### PR TITLE
chore(oss): fix OSS-readiness CI (restore readiness doc, neutralize p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,21 +268,21 @@ python3 tools/run_temporalstore_unified_tests.py --validate-only
 
 ## Status & evidence
 
-Apache-2.0. Production-readiness claims should be read from passing readiness reports, not this
-README alone:
+Apache-2.0. The project's production-readiness claims should be read from passing readiness
+reports, not this README alone:
 
 - [Benchmarks: token & quality vs full local replay](docs/benchmarks/README.md)
 - [Context Management on TemporalStore](docs/context_management_on_temporalstore.md) ·
   [technical blog](docs/blog_context_management_temporalstore.md)
 - Deploy: [Windows Docker](docs/windows_docker_install.md) · [Linux](docs/linux_deploy.md) · [macOS](docs/macos_deploy.md)
 
-Out of scope unless separately re-added: alternate wire-protocol compatibility and live external object-store (S3) integration.
+Out of scope unless separately re-added: alternate wire-protocol compatibility (no brpc/thrift wire-compatible clone) and live external object-store (S3) integration.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md). New product-behavior tests
-should reference a shared corpus case with `shared-corpus: <case_id>`; Rust-only implementation
-tests should be marked `rust-internal: <reason>`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md). Contributions target the
+`rust-main` branch. New product-behavior tests should reference a shared corpus case with
+`shared-corpus: <case_id>`; Rust-only implementation tests should be marked `rust-internal: <reason>`.
 
 ## License
 

--- a/docs/open_source_readiness.md
+++ b/docs/open_source_readiness.md
@@ -1,0 +1,73 @@
+# Open Source Readiness
+
+Last validated: 2026-06-23
+
+This page records the repository-level open-source readiness contract for the
+Rust TemporalStore worktree.
+
+## Required Public Files
+
+- `README.md`
+- `crates/temporalstore-rust/README.md`
+- `LICENSE`
+- `NOTICE`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `CODE_OF_CONDUCT.md`
+- `.gitignore`
+
+CI is intentionally tracked as a follow-up publishing step when the pushing
+credential has GitHub `workflow` scope. The repository-level validator does not
+require `.github/workflows/*` because GitHub rejects workflow updates from
+tokens without that scope.
+
+## Scope Statement
+
+Rust TemporalStore is open-source ready as a Rust-native implementation path.
+The Rust repo should not imply that it is a brpc/thrift wire-compatible clone or
+a byte-for-byte reference storage-layout clone.
+
+The Rust crate README and crate-level rustdoc now make the Raft library contract
+explicit: TemporalRaft/raft-rs is the production process path, local Raft models
+are test-only fixtures, and production readiness requires spawned process
+evidence with independent WAL/snapshot stores.
+
+Current Rust compatibility positioning:
+
+- Reference implementation behavior parity is tracked through shared tests,
+  migration corpus, harness reports, and readiness docs.
+- Rust public surfaces are Rust APIs, HTTP/JSON, RESP, tonic/gRPC, Codex MCP,
+  and harness contracts.
+- brpc/thrift compatibility remains explicitly out of scope for Rust.
+- live object store/S3 production integration remains explicitly out of scope
+  until re-scoped and security-reviewed.
+
+## Validation
+
+Run:
+
+```bash
+python3 tools/validate_open_source_readiness.py
+cargo fmt --all -- --check
+python3 tools/run_temporalstore_unified_tests.py --validate-only
+```
+
+The open-source readiness validator checks required files, license alignment,
+scope language, generated-output ignore rules, absence of tracked local Codex
+hook config, and absence of personal absolute checkout paths. Add the CI
+workflow with a credential that has `workflow` scope, then run the same
+validation commands in that workflow.
+
+## Release Hygiene
+
+Before publishing or accepting external contributions:
+
+- keep secrets out of git
+- keep generated build outputs out of git
+- keep third-party dependency caches out of git
+- keep `.codex/` local-only; publish hook templates in docs instead of tracked
+  machine-specific hook files
+- use placeholders such as `<repo-root>` and `<reference-temporalstore-checkout>`
+  in docs instead of absolute local paths
+- keep production-readiness claims tied to evidence
+- update readiness docs when scope changes

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -18,7 +18,7 @@
     "matrixark_home": {
       "type": "string",
       "title": "TemporalStore checkout path",
-      "description": "Absolute path to your TemporalStore repo (the directory containing tools/matrixark_claude_hook.sh and tools/run_matrixark_mcp_server.sh). Example: /root/src/github-services/TemporalStore",
+      "description": "Absolute path to your TemporalStore repo (the directory containing tools/matrixark_claude_hook.sh and tools/run_matrixark_mcp_server.sh). Example: <repo-root>/TemporalStore",
       "required": true
     }
   }

--- a/tools/measure_claude_prompt_memory_breakdown.py
+++ b/tools/measure_claude_prompt_memory_breakdown.py
@@ -24,8 +24,8 @@ TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(TOOLS))
 import run_local_context_token_quality_sweep as S  # noqa: E402
 
-CLAUDE_ROOT = Path("/mnt/c/Users/Deeproute/.claude/projects")
-CODEX_ROOT = Path("/mnt/c/Users/Deeproute/.codex/sessions")
+CLAUDE_ROOT = Path(S.default_claude_root())
+CODEX_ROOT = Path(S.default_codex_root())
 WORKING_BUDGET = 4000          # working-turn managed budget (fill with relevant refs)
 BASELINE_WINDOW = 128000       # let full local replay use the whole window (uncapped-ish)
 

--- a/tools/run_deep_thread.py
+++ b/tools/run_deep_thread.py
@@ -82,8 +82,8 @@ def main():
     args = ap.parse_args()
 
     roles = {"user", "assistant"}
-    claude = S.iter_claude_events(Path("/mnt/c/Users/Deeproute/.claude/projects"), 200, 400, roles)
-    codex = S.iter_codex_events(Path("/mnt/c/Users/Deeproute/.codex/sessions"), 200, 400, roles)
+    claude = S.iter_claude_events(Path(S.default_claude_root()), 200, 400, roles)
+    codex = S.iter_codex_events(Path(S.default_codex_root()), 200, 400, roles)
     corpus = sorted(claude + codex, key=lambda e: e.timestamp_ms)
     segments = S.build_segments(corpus, 10)
     entities = S.build_entities(corpus, 18)

--- a/tools/run_floor_followup.py
+++ b/tools/run_floor_followup.py
@@ -60,8 +60,8 @@ def main() -> int:
     args = ap.parse_args()
 
     roles = {"user", "assistant"}
-    claude = S.iter_claude_events(Path("/mnt/c/Users/Deeproute/.claude/projects"), 200, 400, roles)
-    codex = S.iter_codex_events(Path("/mnt/c/Users/Deeproute/.codex/sessions"), 200, 400, roles)
+    claude = S.iter_claude_events(Path(S.default_claude_root()), 200, 400, roles)
+    codex = S.iter_codex_events(Path(S.default_codex_root()), 200, 400, roles)
     events = sorted(claude + codex, key=lambda e: e.timestamp_ms)
     segments = S.build_segments(events, 10)
     entities = S.build_entities(events, 18)

--- a/tools/run_floor_inertness.py
+++ b/tools/run_floor_inertness.py
@@ -24,8 +24,8 @@ BUDGETS = [3000, 8000, 30000, 100000, 300000]
 
 def main() -> int:
     roles = {"user", "assistant"}
-    claude = S.iter_claude_events(Path("/mnt/c/Users/Deeproute/.claude/projects"), 200, 400, roles)
-    codex = S.iter_codex_events(Path("/mnt/c/Users/Deeproute/.codex/sessions"), 200, 400, roles)
+    claude = S.iter_claude_events(Path(S.default_claude_root()), 200, 400, roles)
+    codex = S.iter_codex_events(Path(S.default_codex_root()), 200, 400, roles)
     events = sorted(claude + codex, key=lambda e: e.timestamp_ms)
     segments = S.build_segments(events, 10)
     entities = S.build_entities(events, 18)

--- a/tools/run_local_context_token_quality_sweep.py
+++ b/tools/run_local_context_token_quality_sweep.py
@@ -36,6 +36,20 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 
+def default_claude_root() -> str:
+    """Local Claude Code transcript root; override with MATRIXARK_CLAUDE_ROOT."""
+    return os.environ.get(
+        "MATRIXARK_CLAUDE_ROOT", os.path.expanduser("~/.claude/projects")
+    )
+
+
+def default_codex_root() -> str:
+    """Local Codex rollout session root; override with MATRIXARK_CODEX_ROOT."""
+    return os.environ.get(
+        "MATRIXARK_CODEX_ROOT", os.path.expanduser("~/.codex/sessions")
+    )
+
+
 # --------------------------------------------------------------------------------------
 # Query set tuned to this user's real history, each with objective expected key terms.
 # --------------------------------------------------------------------------------------
@@ -645,8 +659,8 @@ def make_reader(kind: str, args: argparse.Namespace):
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--codex-root", default="/mnt/c/Users/Deeproute/.codex/sessions")
-    ap.add_argument("--claude-root", default="/mnt/c/Users/Deeproute/.claude/projects")
+    ap.add_argument("--codex-root", default=default_codex_root())
+    ap.add_argument("--claude-root", default=default_claude_root())
     ap.add_argument("--max-sessions", type=int, default=40)
     ap.add_argument("--max-msgs", type=int, default=120)
     ap.add_argument("--segment-size", type=int, default=10)

--- a/tools/run_multiturn_3arm.py
+++ b/tools/run_multiturn_3arm.py
@@ -87,8 +87,8 @@ def _pack_breakdown(pack: dict) -> dict:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Multi-turn 3-arm token/quality experiment.")
-    ap.add_argument("--codex-root", default="/mnt/c/Users/Deeproute/.codex/sessions")
-    ap.add_argument("--claude-root", default="/mnt/c/Users/Deeproute/.claude/projects")
+    ap.add_argument("--codex-root", default=S.default_codex_root())
+    ap.add_argument("--claude-root", default=S.default_claude_root())
     ap.add_argument("--max-sessions", type=int, default=200)
     ap.add_argument("--max-msgs", type=int, default=400)
     ap.add_argument("--reader-base-url", default="http://127.0.0.1:11434/v1")

--- a/tools/test_backfill_tool_leaning.py
+++ b/tools/test_backfill_tool_leaning.py
@@ -68,27 +68,27 @@ class ToolLeaningTest(unittest.TestCase):
             self.assertEqual("/tmp/dedicated-codex-root", B.agent_root("codex"))
 
     def test_windows_home_from_path_uses_active_profile(self):
-        with patch.object(B.os.path, "isdir", lambda p: p == "/mnt/c/Users/Deeproute"):
+        with patch.object(B.os.path, "isdir", lambda p: p == "/mnt/d/Users/testuser"):
             self.assertEqual(
-                "/mnt/c/Users/Deeproute",
-                B._windows_home_from_path("/mnt/c/Users/Deeproute/Documents/Codex/task"),
+                "/mnt/d/Users/testuser",
+                B._windows_home_from_path("/mnt/d/Users/testuser/Documents/Codex/task"),
             )
 
     def test_homes_prefers_pwd_profile_before_sorted_discovery(self):
         existing = {
-            "/mnt/c/Users",
-            "/mnt/c/Users/CodexSandboxOffline",
-            "/mnt/c/Users/CodexSandboxOffline/.codex",
-            "/mnt/c/Users/Deeproute",
-            "/mnt/c/Users/Deeproute/.codex",
-            "/mnt/c/Users/Deeproute/.claude",
+            "/mnt/d/Users",
+            "/mnt/d/Users/CodexSandboxOffline",
+            "/mnt/d/Users/CodexSandboxOffline/.codex",
+            "/mnt/d/Users/testuser",
+            "/mnt/d/Users/testuser/.codex",
+            "/mnt/d/Users/testuser/.claude",
             "/root",
         }
-        with patch.dict(os.environ, {"PWD": "/mnt/c/Users/Deeproute/Documents/Codex/task"}, clear=True):
-            with patch.object(B.os, "getcwd", return_value="/root/src/github-services/TemporalStore"):
+        with patch.dict(os.environ, {"PWD": "/mnt/d/Users/testuser/Documents/Codex/task"}, clear=True):
+            with patch.object(B.os, "getcwd", return_value="/root/work/github-services/TemporalStore"):
                 with patch.object(B.os.path, "isdir", lambda p: p in existing):
-                    with patch.object(B.os, "listdir", return_value=["CodexSandboxOffline", "Deeproute"]):
-                        self.assertEqual(("/mnt/c/Users/Deeproute", "/tmp"), B._homes())
+                    with patch.object(B.os, "listdir", return_value=["CodexSandboxOffline", "testuser"]):
+                        self.assertEqual(("/mnt/d/Users/testuser", "/tmp"), B._homes())
 
     def test_emit_jsonl_streams_local_codex_and_claude_context(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
…rivate paths, README tokens)

Lands the OSS-readiness fix that was stranded when #4 merged before it. The validate_open_source_readiness.py gate was red on main for three pre-existing reasons; this makes it green:

- Restore docs/open_source_readiness.md (removed in an earlier docs prune, still required by the validator). Recovered and reworded to neutral language (reference implementation, object store) so it is scrub-clean while keeping the three tokens the validator requires.
- Neutralize local/private path markers the validator rejects: plugin.json example path -> <repo-root>; the benchmark tools derive Codex/Claude roots from MATRIXARK_CODEX_ROOT / MATRIXARK_CLAUDE_ROOT (falling back to ~/.codex, ~/.claude) instead of hardcoded home paths; test fixture strings use neutral placeholders. Tool behavior preserved (12/12 fixture tests pass, --help/import ok).
- Add the README tokens the validator requires (rust-main branch, no brpc/thrift, production-readiness claims).

validate_open_source_readiness.py -> open_source_ready: true; py_compile clean.