### PR TITLE
Restore embedding backfill + retrieve-cap fix (inadvertently reverted by mirror-sync #6)

### DIFF
--- a/crates/temporalstore-rust/src/bin/cb_retrieve.rs
+++ b/crates/temporalstore-rust/src/bin/cb_retrieve.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+//! Experiment-only: retrieve a REAL ContextPack from a context_batch_ingest store.
+//!
+//! Loads the embedded TemporalEngine at --root (same with_local_dirs layout the
+//! bulk backfill bin writes), loads all node_hashes for --session-id from the
+//! agent session index, and runs the SAME `retrieve_context` the live hook uses,
+//! with high fanout caps so recall reflects the whole store (not the hook's
+//! 8-event injection cap). Prints JSON: {query, blocks, tokens, text}.
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+use serde_json::json;
+use temporalstore_rust::{
+    retrieve_context, ContextModelProviderConfig, ContextProviderKind, ContextRetrieveRequest,
+    ContextTier, TemporalEngine,
+};
+
+#[derive(Debug, Deserialize, Default)]
+struct SessionIndex {
+    sessions: BTreeMap<String, Vec<u64>>,
+}
+
+fn stable_hash64(value: &str) -> u64 {
+    let mut h = DefaultHasher::new();
+    value.hash(&mut h);
+    h.finish()
+}
+
+fn arg(flag: &str, default: &str) -> String {
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        if a == flag {
+            return it.next().unwrap_or_else(|| default.to_string());
+        }
+    }
+    default.to_string()
+}
+
+fn main() {
+    let root = PathBuf::from(arg("--root", "/tmp/ts-cb/store"));
+    let agent = arg("--agent-name", "claude");
+    let session = arg("--session-id", "s000");
+    let account = arg("--account-id", "acct_cb");
+    let tenant = arg("--tenant-id", "tenant_cb");
+    let user = arg("--user-id", "cb_user");
+    let query = arg("--query", "");
+    let max_nodes: usize = arg("--max-nodes", "4000").parse().unwrap_or(4000);
+    // When --embed-base-url is set, rank by REAL model embeddings (query vector
+    // comes from the same OpenAI-compatible provider used for the stored node
+    // vectors). Without it, the default mock/deterministic provider is used
+    // (16-dim hash vectors) which is the lexical/recency-only baseline.
+    let embed_base_url = arg("--embed-base-url", "");
+    let embedding_model = arg("--embedding-model", "all-MiniLM-L6-v2");
+    let provider = if embed_base_url.trim().is_empty() {
+        ContextModelProviderConfig::default()
+    } else {
+        let mut provider = ContextModelProviderConfig::default();
+        provider.provider_name = "minilm-local".to_string();
+        provider.provider_kind = ContextProviderKind::OpenAiCompatible;
+        provider.base_url = embed_base_url.clone();
+        provider.api_key_env = String::new();
+        provider.embedding_model = embedding_model.clone();
+        provider.mock_mode = false;
+        provider
+    };
+
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let index_path = root.join(format!("{}-session-index.json", agent));
+    let index: SessionIndex = fs::read_to_string(&index_path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_default();
+    let node_hashes: Vec<u64> = index
+        .sessions
+        .get(&session)
+        .cloned()
+        .unwrap_or_default();
+
+    let tenant_hash = stable_hash64(&format!("{}:{}:{}:{}", account, tenant, user, session));
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(1);
+
+    let emit_blocks = arg("--emit-blocks", "0") == "1";
+
+    // Optional one-shot embedding-lookup probe (diagnostic): query node_l0 refs
+    // directly against this engine/tenant to isolate reload vs retrieve-path.
+    if arg("--probe-embeddings", "0") == "1" {
+        use temporalstore_rust::{
+            context_embedding_ref_hash, Command, CommandResponse, ExecuteRequest,
+        };
+        eprintln!(
+            "probe tenant_hash={} node_count={} first_node={:?} first_ref(FNV)={:?}",
+            tenant_hash,
+            node_hashes.len(),
+            node_hashes.first().copied(),
+            node_hashes
+                .first()
+                .map(|nh| context_embedding_ref_hash(tenant_hash, *nh, "node_l0")),
+        );
+        // (a) node_l0 only, small/large; (b) retrieve's EXACT interleaved shape.
+        for take in [500usize, 900, 1000, 1001, 1100, 2000, 3700] {
+            let refs: Vec<u64> = node_hashes
+                .iter()
+                .take(take)
+                .map(|nh| context_embedding_ref_hash(tenant_hash, *nh, "node_l0"))
+                .collect();
+            let n = refs.len();
+            for lim in [n, 1000usize] {
+                let resp = engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::ContextQueryEmbeddings {
+                        tenant_hash,
+                        ref_hashes: refs.clone(),
+                        limit: Some(lim.max(1)),
+                    },
+                });
+                let found = match resp.response {
+                    CommandResponse::ContextEmbeddings { embeddings } => embeddings.len(),
+                    _ => 0,
+                };
+                eprintln!("probe node_l0-only refs={} limit={} found={}", n, lim, found);
+            }
+        }
+        // Exact retrieve shape: interleaved node_l0/node_l1, limit = len*2.
+        let mut interleaved = Vec::new();
+        for nh in &node_hashes {
+            for label in ["node_l0", "node_l1"] {
+                interleaved.push(context_embedding_ref_hash(tenant_hash, *nh, label));
+            }
+        }
+        let lim = node_hashes.len().saturating_mul(2).max(1);
+        let resp = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddings {
+                tenant_hash,
+                ref_hashes: interleaved.clone(),
+                limit: Some(lim),
+            },
+        });
+        let found = match resp.response {
+            CommandResponse::ContextEmbeddings { embeddings } => embeddings.len(),
+            _ => 0,
+        };
+        eprintln!(
+            "probe interleaved refs={} limit={} found={}",
+            interleaved.len(),
+            lim,
+            found
+        );
+        return;
+    }
+
+    // Run a single retrieve at a given fanout cap and serialize the result.
+    let run_one = |query: &str, cap: usize| -> serde_json::Value {
+        let report = retrieve_context(
+            &engine,
+            ContextRetrieveRequest {
+                shard_id: 1,
+                tenant_hash,
+                node_hashes: node_hashes.clone(),
+                query: query.to_string(),
+                start_time_ms: 0,
+                end_time_ms: now_ms.saturating_add(1),
+                max_events: cap,
+                min_confidence: 0.0,
+                min_importance: 0.0,
+                tiers: vec![ContextTier::L0, ContextTier::L1, ContextTier::L2],
+                max_summary_nodes: cap,
+                max_event_nodes: cap,
+                prefer_current_agent: false,
+                current_agent_scope_key: format!("agent:{}", agent),
+                provider: provider.clone(),
+            },
+        );
+        let mut text = String::new();
+        let mut tokens: u64 = 0;
+        let mut block_list = Vec::new();
+        for b in &report.blocks {
+            tokens += b.estimated_tokens as u64;
+            text.push_str(&b.text);
+            text.push_str("\n\n");
+            block_list.push(json!({
+                "node_hash": b.node_hash,
+                "tokens": b.estimated_tokens,
+                "source_ref": b.source_ref,
+                "text": b.text,
+            }));
+        }
+        let tts = &report.query_understanding_debug.tree_traversal_summary;
+        json!({
+            "query": query,
+            "cap": cap,
+            "session": session,
+            "session_node_count": node_hashes.len(),
+            "ok": report.status.ok,
+            "status_code": report.status.code,
+            "blocks": report.blocks.len(),
+            "tokens": tokens,
+            "query_embedding_dimension": tts.query_embedding_dimension,
+            "summary_embedding_candidate_count": tts.summary_embedding_candidate_count,
+            "summary_embedding_selected_count": tts.summary_embedding_selected_count,
+            "text": if emit_blocks { String::new() } else { text },
+            "block_list": if emit_blocks { serde_json::Value::Array(block_list) } else { serde_json::Value::Null },
+        })
+    };
+
+    // Batch mode: load the engine ONCE and answer many "<cap>\t<query>" lines
+    // from stdin, printing one JSON object per line. This amortizes the ~17s
+    // shard-load cost across a whole sweep. Otherwise run the single --query.
+    if arg("--batch-stdin", "0") == "1" {
+        use std::io::{BufRead, Write};
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        for line in stdin.lock().lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => break,
+            };
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let (cap_str, q) = line.split_once('\t').unwrap_or(("8", line));
+            let cap: usize = cap_str.trim().parse().unwrap_or(8);
+            let value = run_one(q, cap);
+            let _ = writeln!(out, "{}", value);
+            let _ = out.flush();
+        }
+    } else {
+        println!("{}", run_one(&query, max_nodes));
+    }
+}

--- a/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
+++ b/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+//! Additive embed-backfill for `raw_first` bulk-ingested context stores.
+//!
+//! `context_batch_ingest` with `MATRIXARK_BACKFILL_RAW_FIRST=1` stores raw
+//! ContextNode/ContextEvent/source-index rows fast but **defers embeddings** --
+//! and no runnable extraction pass existed to attach them. Without embeddings the
+//! retrieve path (`retrieve_context`) has nothing to rank by cosine, so focused
+//! semantic recall on a large bulk store degrades to lexical/recency fallback
+//! (~0% needle recall at scale).
+//!
+//! This bin closes that gap WITHOUT touching live ingest: it opens an existing
+//! `with_local_dirs` store, enumerates the context nodes recorded in the agent
+//! session index, reads each node's stored event text, batches those texts to a
+//! real OpenAI-compatible embedding provider (e.g. a local MiniLM
+//! `/v1/embeddings` server), and persists the `ctx:embedding:{tenant}:{ref}`
+//! entries under the exact `node_l0` ref-hash the retrieve path reads
+//! (`context_embedding_ref_hash`). It reuses the engine's own provider path
+//! (`context_backfill_embeddings`) so batching, `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS`
+//! enforcement, and response validation are identical to live extraction.
+//!
+//! Identity flags mirror `cb_retrieve`/the live hook so the derived tenant_hash
+//! matches what retrieval uses. Example:
+//!   MATRIXARK_REQUIRE_MODEL_EMBEDDINGS=1 context_embed_backfill \
+//!     --root /tmp/ts-cb-lin/1350000/store --agent-name claude \
+//!     --account-id acct_cb --tenant-id tenant_cb --user-id cb_user \
+//!     --embed-base-url http://127.0.0.1:18099/v1 \
+//!     --embedding-model all-MiniLM-L6-v2
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+use serde_json::json;
+use temporalstore_rust::{
+    context_backfill_embeddings, context_embedding_ref_hash, BatchExecuteRequest, Command,
+    CommandResponse, ContextEmbedding, ContextModelProviderConfig, ContextProviderKind,
+    ExecuteRequest, TemporalEngine,
+};
+
+#[derive(Debug, Deserialize, Default)]
+struct SessionIndex {
+    sessions: BTreeMap<String, Vec<u64>>,
+}
+
+fn stable_hash64(value: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn arg(flag: &str, default: &str) -> String {
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        if a == flag {
+            return it.next().unwrap_or_else(|| default.to_string());
+        }
+    }
+    default.to_string()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(1)
+}
+
+fn main() {
+    let root = PathBuf::from(arg("--root", "/tmp/ts-cb/store"));
+    let agent = arg("--agent-name", "claude");
+    let account = arg("--account-id", "acct_cb");
+    let tenant = arg("--tenant-id", "tenant_cb");
+    let user = arg("--user-id", "cb_user");
+    let only_session = arg("--session-id", "");
+    let base_url = arg("--embed-base-url", "http://127.0.0.1:18099/v1");
+    let embedding_model = arg("--embedding-model", "all-MiniLM-L6-v2");
+    let batch: usize = arg("--batch", "64").parse().unwrap_or(64);
+    let max_events: usize = arg("--max-events", "4").parse().unwrap_or(4);
+    let verify_only = arg("--verify", "0") == "1";
+
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let index_path = root.join(format!("{}-session-index.json", agent));
+    let index: SessionIndex = fs::read_to_string(&index_path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_default();
+
+    let mut provider = ContextModelProviderConfig::default();
+    provider.provider_name = "minilm-local".to_string();
+    provider.provider_kind = ContextProviderKind::OpenAiCompatible;
+    provider.base_url = base_url.clone();
+    provider.api_key_env = String::new();
+    provider.embedding_model = embedding_model.clone();
+    provider.mock_mode = false;
+
+    let sessions: Vec<String> = if only_session.trim().is_empty() {
+        index.sessions.keys().cloned().collect()
+    } else {
+        vec![only_session.clone()]
+    };
+
+    if verify_only {
+        // Fresh-load verification: for the first N nodes of each session, query
+        // the node_l0 embedding straight from the reloaded store and count hits.
+        let n_probe = 20usize;
+        for session in &sessions {
+            let node_hashes = index.sessions.get(session).cloned().unwrap_or_default();
+            let tenant_hash =
+                stable_hash64(&format!("{}:{}:{}:{}", account, tenant, user, session));
+            let probe: Vec<u64> = node_hashes.iter().take(n_probe).copied().collect();
+            let ref_hashes: Vec<u64> = probe
+                .iter()
+                .map(|nh| context_embedding_ref_hash(tenant_hash, *nh, "node_l0"))
+                .collect();
+            let resp = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextQueryEmbeddings {
+                    tenant_hash,
+                    ref_hashes: ref_hashes.clone(),
+                    limit: Some(ref_hashes.len().max(1)),
+                },
+            });
+            let (found, dim) = if let CommandResponse::ContextEmbeddings { embeddings } =
+                resp.response
+            {
+                let d = embeddings.first().map(|e| e.vector.len()).unwrap_or(0);
+                (embeddings.len(), d)
+            } else {
+                (0, 0)
+            };
+            println!(
+                "{}",
+                json!({
+                    "verify": true,
+                    "session": session,
+                    "tenant_hash": tenant_hash,
+                    "probed": probe.len(),
+                    "found": found,
+                    "vector_dim": dim,
+                    "first_node_hash": probe.first().copied(),
+                    "first_ref_hash": ref_hashes.first().copied(),
+                })
+            );
+        }
+        return;
+    }
+
+    let started = Instant::now();
+    let mut total_nodes = 0u64;
+    let mut embedded = 0u64;
+    let mut empty_text = 0u64;
+    let mut failed = 0u64;
+    let updated_at_ms = now_ms();
+
+    for session in &sessions {
+        let node_hashes = index.sessions.get(session).cloned().unwrap_or_default();
+        if node_hashes.is_empty() {
+            continue;
+        }
+        let tenant_hash =
+            stable_hash64(&format!("{}:{}:{}:{}", account, tenant, user, session));
+        let end_time_ms = updated_at_ms.saturating_add(1);
+
+        // Collect (node_hash, text) by reading each node's stored events.
+        let mut pending: Vec<(u64, String)> = Vec::with_capacity(node_hashes.len());
+        for node_hash in &node_hashes {
+            total_nodes += 1;
+            let resp = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextQueryEvents {
+                    tenant_hash,
+                    node_hash: *node_hash,
+                    start_time_ms: 0,
+                    end_time_ms,
+                    limit: Some(max_events.max(1)),
+                    current_valid_only: false,
+                    as_of_ms: 0,
+                    kinds: Vec::new(),
+                    statuses: Vec::new(),
+                    min_confidence: 0.0,
+                    min_importance: 0.0,
+                },
+            });
+            let text = if let CommandResponse::ContextEvents { events, .. } = resp.response {
+                // Use the richest (longest) event text for this node.
+                events
+                    .into_iter()
+                    .map(|e| e.text)
+                    .max_by_key(|t| t.len())
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            if text.trim().is_empty() {
+                empty_text += 1;
+                continue;
+            }
+            pending.push((*node_hash, text));
+        }
+
+        // Batch-embed and upsert node_l0 embeddings under the retrieve-path key.
+        for chunk in pending.chunks(batch.max(1)) {
+            let texts: Vec<&str> = chunk.iter().map(|(_, t)| t.as_str()).collect();
+            let vectors = match context_backfill_embeddings(&provider, &texts) {
+                Ok(v) => v,
+                Err(status) => {
+                    eprintln!(
+                        "embedding batch failed (session {}): {} / {}",
+                        session, status.code, status.message
+                    );
+                    failed += chunk.len() as u64;
+                    continue;
+                }
+            };
+            if vectors.len() != chunk.len() {
+                eprintln!(
+                    "embedding count mismatch (session {}): {} vectors for {} inputs",
+                    session,
+                    vectors.len(),
+                    chunk.len()
+                );
+                failed += chunk.len() as u64;
+                continue;
+            }
+            let mut commands = Vec::with_capacity(chunk.len());
+            for ((node_hash, _), vector) in chunk.iter().zip(vectors.into_iter()) {
+                let embedding = ContextEmbedding {
+                    ref_hash: context_embedding_ref_hash(tenant_hash, *node_hash, "node_l0"),
+                    level: 1,
+                    model_hash: stable_hash64(&format!("embedding_model:{}", embedding_model)),
+                    vector,
+                    updated_at_ms,
+                };
+                commands.push(Command::ContextUpsertEmbedding {
+                    tenant_hash,
+                    embedding,
+                });
+            }
+            let response = engine.batch_execute(BatchExecuteRequest {
+                shard_id: 1,
+                commands,
+            });
+            let ok = response.responses.iter().filter(|r| r.status.ok).count();
+            let bad = response.responses.len().saturating_sub(ok);
+            embedded += ok as u64;
+            failed += bad as u64;
+        }
+        eprintln!(
+            "  session {} -> nodes {} embedded {} ({:.0} node/s cumulative)",
+            session,
+            node_hashes.len(),
+            embedded,
+            embedded as f64 / started.elapsed().as_secs_f64().max(0.001)
+        );
+    }
+
+    // Persist the shard index once so the upserted embeddings survive reload.
+    engine.flush_shard_index(1);
+
+    let report = json!({
+        "status": "ok",
+        "root": root.display().to_string(),
+        "index_path": index_path.display().to_string(),
+        "base_url": base_url,
+        "embedding_model": embedding_model,
+        "sessions": sessions.len(),
+        "total_nodes": total_nodes,
+        "embedded": embedded,
+        "empty_text": empty_text,
+        "failed": failed,
+        "seconds": started.elapsed().as_secs_f64(),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).expect("report should serialize")
+    );
+}

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -8,6 +8,13 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Max ref_hashes per ContextQueryEmbeddings command. Must not exceed the
+/// engine's CONTEXT_MAX_LIMIT (engine/constants.rs), which command validation
+/// enforces by rejecting larger requests. Retrieval chunks its summary-embedding
+/// lookups at this size so a namespace with more nodes than the cap is still
+/// fully scored instead of silently falling back to lexical ranking.
+const CONTEXT_EMBEDDING_QUERY_CHUNK: usize = 1000;
+
 mod query;
 mod resource;
 mod benchmark;
@@ -24,6 +31,8 @@ pub(crate) use benchmark::*;
 pub use reports::*;
 pub use ingest::{ingest_extract_context, ingest_resource_skill_context, validate_resource_skill_secondary_indexes};
 pub(crate) use model_provider::*;
+pub use model_provider::context_backfill_embeddings;
+pub use query::context_embedding_ref_hash;
 pub use skill::{
     context_skill_registry_from_parsed, parse_context_skill_markdown,
     select_context_skills_for_retrieval, update_context_skill_registry,
@@ -1784,13 +1793,25 @@ pub fn retrieve_context(
         }
     }
     let mut summary_scores_by_node = BTreeMap::<u64, (i64, usize)>::new();
-    if !summary_ref_hashes.is_empty() {
+    // The engine caps a single ContextQueryEmbeddings at CONTEXT_MAX_LIMIT
+    // ref_hashes -- command validation REJECTS a larger request outright rather
+    // than truncating it. A large (bulk-ingested) namespace has many more nodes
+    // than that, so the summary-embedding pass MUST chunk its lookups: sending
+    // all node_hashes*2 ref_hashes in one command silently fails, leaving every
+    // node at score 0 and collapsing retrieval to the lexical/recency fallback
+    // (0% focused recall at scale). Chunk at the cap so every node is scored.
+    for chunk in summary_ref_hashes.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
+        if chunk.is_empty() {
+            continue;
+        }
+        let chunk_refs = chunk.to_vec();
+        let chunk_len = chunk_refs.len();
         let embeddings = engine.execute(ExecuteRequest {
             shard_id: request.shard_id,
             command: Command::ContextQueryEmbeddings {
                 tenant_hash: request.tenant_hash,
-                ref_hashes: summary_ref_hashes,
-                limit: Some(node_hashes.len().saturating_mul(2).max(1)),
+                ref_hashes: chunk_refs,
+                limit: Some(chunk_len.max(1)),
             },
         });
         if let CommandResponse::ContextEmbeddings { embeddings } = embeddings.response {

--- a/crates/temporalstore-rust/src/context_workflow/model_provider.rs
+++ b/crates/temporalstore-rust/src/context_workflow/model_provider.rs
@@ -86,6 +86,30 @@ pub(crate) fn context_summaries_for_extract(
     }
 }
 
+/// Backfill helper: compute REAL model embeddings for a batch of already-stored
+/// context node/event texts, reusing the exact provider path the live extract
+/// path uses -- request batching, `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS`
+/// enforcement, and response shape/finiteness validation. Returns one vector per
+/// input text, in the same order.
+///
+/// This exists so an out-of-band embed-backfill (the `context_embed_backfill`
+/// bin) can attach semantic vectors to `raw_first` bulk stores WITHOUT rerunning
+/// summary extraction or changing live-ingest behavior.
+pub fn context_backfill_embeddings(
+    provider: &ContextModelProviderConfig,
+    texts: &[&str],
+) -> Result<Vec<Vec<f32>>, Status> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let inputs: Vec<(&str, u64, u32, &str)> = texts
+        .iter()
+        .map(|text| ("node_l0", 0u64, 1u32, *text))
+        .collect();
+    let (vectors, _report) = context_embeddings_for_extract(provider, &inputs)?;
+    Ok(vectors)
+}
+
 pub(crate) fn context_embeddings_for_extract(
     provider: &ContextModelProviderConfig,
     inputs: &[(&str, u64, u32, &str)],

--- a/crates/temporalstore-rust/src/context_workflow/query.rs
+++ b/crates/temporalstore-rust/src/context_workflow/query.rs
@@ -1164,7 +1164,11 @@ pub(super) fn context_embedding_model_hash(model: &str) -> u64 {
     }
 }
 
-pub(super) fn context_embedding_ref_hash(tenant_hash: u64, ref_hash: u64, level: &str) -> u64 {
+/// Derive the object-key ref-hash under which a context embedding is stored/read
+/// (`ctx:embedding:{tenant_hash}:{ref_hash}`). Public so out-of-band tooling
+/// (e.g. the `context_embed_backfill` bin) can attach embeddings under the exact
+/// key the retrieve path reads, without duplicating the label formula.
+pub fn context_embedding_ref_hash(tenant_hash: u64, ref_hash: u64, level: &str) -> u64 {
     stable_hash64(&format!("ctx-embedding:{tenant_hash}:{ref_hash}:{level}"))
 }
 

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -39,7 +39,8 @@ pub use client::{
     TemporalStoreClient, TemporalStorePipeline, TemporalStoreTable,
 };
 pub use context_workflow::{
-    context_pipeline_manage_report, context_pipeline_parity_evidence,
+    context_backfill_embeddings, context_embedding_ref_hash, context_pipeline_manage_report,
+    context_pipeline_parity_evidence,
     context_resource_chunk_embedding, context_skill_registry_from_parsed,
     context_workflow_state_report, default_context_model_providers, extract_context,
     ingest_extract_context, ingest_resource_skill_context, inject_context,

--- a/tools/context_minilm_embed_server.py
+++ b/tools/context_minilm_embed_server.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Tiny OpenAI-compatible /v1/embeddings server wrapping the cached
+sentence-transformers/all-MiniLM-L6-v2 model. Stdlib HTTP only (no flask).
+
+POST /v1/embeddings  {"model": "...", "input": "text" | ["t1","t2",...]}
+  -> {"object":"list","data":[{"object":"embedding","index":i,"embedding":[...]}],
+      "model": "...","usage":{...}}
+
+Run detached; prints the bound port to stdout as: LISTENING <port>
+"""
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from sentence_transformers import SentenceTransformer
+
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+print("loading model...", file=sys.stderr, flush=True)
+_MODEL = SentenceTransformer(MODEL_NAME)
+_LOCK = threading.Lock()
+print("model loaded", file=sys.stderr, flush=True)
+
+
+def embed(texts):
+    with _LOCK:
+        vecs = _MODEL.encode(
+            texts, normalize_embeddings=False, convert_to_numpy=True
+        )
+    return [[float(x) for x in row] for row in vecs]
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        if not self.path.rstrip("/").endswith("/embeddings"):
+            self._send(404, {"error": "not found"})
+            return
+        try:
+            n = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(n) or b"{}")
+        except Exception as exc:  # noqa: BLE001
+            self._send(400, {"error": str(exc)})
+            return
+        model = payload.get("model", MODEL_NAME)
+        inp = payload.get("input", [])
+        if isinstance(inp, str):
+            inp = [inp]
+        inp = ["" if t is None else str(t) for t in inp]
+        try:
+            vectors = embed(inp) if inp else []
+        except Exception as exc:  # noqa: BLE001
+            self._send(500, {"error": str(exc)})
+            return
+        data = [
+            {"object": "embedding", "index": i, "embedding": v}
+            for i, v in enumerate(vectors)
+        ]
+        self._send(
+            200,
+            {
+                "object": "list",
+                "data": data,
+                "model": model,
+                "usage": {"prompt_tokens": 0, "total_tokens": 0},
+            },
+        )
+
+    def do_GET(self):
+        # health check
+        self._send(200, {"status": "ok", "model": MODEL_NAME})
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    bound = server.server_address[1]
+    print("LISTENING %d" % bound, flush=True)
+    with open("/tmp/minilm_embed_server.port", "w") as fh:
+        fh.write(str(bound))
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…ext embedding-lookup cap

Bulk ingest with MATRIXARK_BACKFILL_RAW_FIRST=1 stores raw ContextNode/ContextEvent rows fast but defers embeddings, and no runnable pass existed to attach them -- so focused semantic retrieval over a large bulk store fell back to lexical/recency (~0% needle recall at scale). Two additive changes fix this end to end:

1. New bin `context_embed_backfill`: opens a with_local_dirs store, enumerates the session-index nodes, reads each node's stored event text, batch-embeds via a real OpenAI-compatible provider, and upserts `ctx:embedding:{tenant}:{ref}` under the node_l0 ref-hash the retrieve path reads. Reuses the engine provider path (context_backfill_embeddings, a thin pub wrapper over context_embeddings_for_extract) so batching + MATRIXARK_REQUIRE_MODEL_EMBEDDINGS enforcement match live extraction. Live ingest is unchanged. Adds tools/context_minilm_embed_server.py (stdlib OpenAI-compatible /v1/embeddings wrapping all-MiniLM-L6-v2) for a local endpoint.

2. Engine fix in retrieve_context: it built node_hashes.len()*2 ref_hashes and queried them in a single ContextQueryEmbeddings, which command validation rejects above CONTEXT_MAX_LIMIT (1000) rather than truncating -- so any namespace >~500 nodes got an error, every node scored 0, and retrieval silently fell back to lexical/recency. Now chunked at the engine cap with merged scores so every node is scored. For <=1000 refs it is a single chunk, identical to before.

Verified end-to-end on a 3,700-node raw_first bulk store via the real retrieve_context: focused needle recall goes 0% -> 100% at small K (the answer node ranks #1). cb_retrieve gains --embed-base-url/--embedding-model and a batch-stdin sweep for the before/after.