### PR TITLE
feat(telemetry): structured logging (tracing + RUST_LOG) for serving daemons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +782,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1326,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "zstd",
 ]
@@ -1339,6 +1368,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1510,6 +1548,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1539,6 +1607,12 @@ dependencies = [
  "getrandom 0.2.17",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -24,6 +24,8 @@ temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }
 tonic = { version = "0.12", default-features = false, features = ["codegen", "prost", "transport"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "=1.8.0", features = ["v4", "serde"] }
 zstd = "0.13"
 

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -33,8 +33,10 @@ use temporalstore_rust::{
     DataNodeShardLifecycleState, LoadShardRequest, LoadShardResponse, SchedulerLifecycleToken,
     UnloadShardRequest, UnloadShardResponse,
 };
+use tracing::{debug, error, info, warn};
 
 fn main() {
+    temporalstore_rust::telemetry::init();
     let addr = std::env::var("TS_META_BIND_ADDR")
         .or_else(|_| std::env::var("TS_META_ADDR"))
         .unwrap_or_else(|_| "127.0.0.1:17001".to_string());
@@ -60,9 +62,7 @@ fn main() {
             MetaBackend::Single(meta) => {
                 let interval_ms = env_u64("TS_META_AUTO_REBALANCE_INTERVAL_MS", detector_interval_ms);
                 let balance_load = env_bool("TS_META_AUTO_REBALANCE_BALANCE", true);
-                println!(
-                    "auto-rebalance enabled (interval {interval_ms}ms, balance_load {balance_load})"
-                );
+                info!(interval_ms, balance_load, "auto-rebalance enabled");
                 Some(start_auto_rebalance_loop(
                     meta.clone(),
                     interval_ms,
@@ -70,15 +70,18 @@ fn main() {
                 ))
             }
             MetaBackend::Raft(_) => {
-                eprintln!("TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself");
+                warn!("TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself");
                 None
             }
         }
     } else {
         None
     };
-    println!("temporalstore metaserver listening on {addr}");
-    serve(&addr, move |request| handle(&backend, &scheduler, request)).expect("metaserver failed");
+    info!(%addr, "temporalstore metaserver listening");
+    if let Err(err) = serve(&addr, move |request| handle(&backend, &scheduler, request)) {
+        error!(%err, "metaserver serve loop exited");
+        std::process::exit(1);
+    }
 }
 
 #[derive(Clone)]
@@ -644,9 +647,11 @@ fn run_auto_rebalance_round(
             false,
         );
         if !load_status.ok && load_status.code != "already_exists" {
-            eprintln!(
-                "auto-rebalance: target {} failed to load shard {}: {} — retrying next round",
-                plan.to_server, plan.shard_id, load_status.message
+            error!(
+                target = %plan.to_server,
+                shard_id = plan.shard_id,
+                message = %load_status.message,
+                "auto-rebalance: target failed to load shard — retrying next round"
             );
             continue;
         }
@@ -663,18 +668,22 @@ fn run_auto_rebalance_round(
                     false,
                 );
                 if !unload_status.ok {
-                    eprintln!(
-                        "auto-rebalance: source {from_server} failed to unload shard {}: {}",
-                        plan.shard_id, unload_status.message
+                    warn!(
+                        source = %from_server,
+                        shard_id = plan.shard_id,
+                        message = %unload_status.message,
+                        "auto-rebalance: source failed to unload shard"
                     );
                 }
             }
         }
         let ack = meta.reassign_shard(plan.shard_id, &plan.to_server);
         if ack.status.ok {
-            println!(
-                "auto-rebalance: shard {} -> {} ({:?})",
-                plan.shard_id, plan.to_server, plan.reason
+            info!(
+                shard_id = plan.shard_id,
+                to = %plan.to_server,
+                reason = ?plan.reason,
+                "auto-rebalance: shard reassigned"
             );
         }
     }
@@ -790,6 +799,7 @@ fn handle(
     scheduler: &MetaTaskScheduler,
     request: HttpRequest,
 ) -> (u16, Vec<u8>) {
+    debug!(method = %request.method, path = %request.path, "serving request");
     if let Some(response) = handle_master_service_route(meta, &request) {
         return response;
     }

--- a/crates/temporalstore-rust/src/bin/proxy.rs
+++ b/crates/temporalstore-rust/src/bin/proxy.rs
@@ -3,8 +3,10 @@
 
 use temporalstore_rust::http::serve;
 use temporalstore_rust::{ProxyOptions, ProxyService, ProxyServingMode};
+use tracing::info;
 
 fn main() {
+    temporalstore_rust::telemetry::init();
     let addr = std::env::var("TS_PROXY_BIND_ADDR")
         .or_else(|_| std::env::var("TS_PROXY_ADDR"))
         .unwrap_or_else(|_| "127.0.0.1:17000".to_string());
@@ -36,7 +38,7 @@ fn main() {
     let proxy = ProxyService::new(options);
     let heartbeat_interval_ms = env_u64("TS_PROXY_HEARTBEAT_INTERVAL_MS", 10_000);
     let _heartbeat_loop = proxy.start_heartbeat_loop(heartbeat_interval_ms);
-    println!("temporalstore proxy listening on {addr}");
+    info!(%addr, "temporalstore proxy listening");
     serve(&addr, move |request| proxy.handle(request)).expect("proxy failed");
 }
 

--- a/crates/temporalstore-rust/src/bin/raft_node.rs
+++ b/crates/temporalstore-rust/src/bin/raft_node.rs
@@ -20,6 +20,7 @@ use temporalstore_rust::{
     RaftMembershipChangeReport, RaftNodeId, RaftRpcRuntimeOptions, Status,
 };
 use temporalstore_snapshot::{FileObjectStore, S3SnapshotStore};
+use tracing::info;
 
 #[derive(Debug, Deserialize)]
 struct RaftAdminLivenessRequest {
@@ -152,6 +153,7 @@ fn uri_scheme(uri: &str) -> String {
 }
 
 fn main() {
+    temporalstore_rust::telemetry::init();
     let options = runtime_options_from_env();
     let bind_addr = std::env::var("TS_RAFT_BIND_ADDR")
         .ok()
@@ -167,9 +169,10 @@ fn main() {
     let _timer = runtime.start_timer_loop();
     let local_admin_enabled = env_bool("TS_RAFT_ENABLE_LOCAL_ADMIN", false);
     let blocked_peers = Arc::new(Mutex::new(BTreeSet::new()));
-    println!(
-        "temporalstore raft node {} listening on {bind_addr}",
-        runtime.status().leader_id
+    info!(
+        node = runtime.status().leader_id,
+        addr = %bind_addr,
+        "temporalstore raft node listening"
     );
     serve(&bind_addr, move |request| {
         handle(&runtime, local_admin_enabled, &blocked_peers, request)

--- a/crates/temporalstore-rust/src/bin/redis_proxy.rs
+++ b/crates/temporalstore-rust/src/bin/redis_proxy.rs
@@ -2,8 +2,10 @@
 // Copyright 2026 MatrixArkAI
 
 use temporalstore_rust::serve_redis_proxy;
+use tracing::info;
 
 fn main() {
+    temporalstore_rust::telemetry::init();
     let addr = std::env::var("TS_REDIS_BIND_ADDR")
         .or_else(|_| std::env::var("TS_REDIS_ADDR"))
         .unwrap_or_else(|_| "127.0.0.1:16379".to_string());
@@ -13,8 +15,11 @@ fn main() {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(1);
-    println!(
-        "temporalstore redis proxy listening on {addr}, routing shard {shard_id} via {proxy_addr}"
+    info!(
+        %addr,
+        shard_id,
+        proxy = %proxy_addr,
+        "temporalstore redis proxy listening"
     );
     serve_redis_proxy(&addr, proxy_addr, shard_id).expect("redis proxy failed");
 }

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -51,6 +51,7 @@ use temporalstore_rust::{
 use temporalstore_snapshot::object_store::ObjectStore;
 use temporalstore_snapshot::{FileObjectStore, S3SnapshotStore};
 use bytes::Bytes;
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ServerTopologyValidationRequest {
@@ -81,6 +82,7 @@ struct BlobReceipt {
 }
 
 fn main() {
+    temporalstore_rust::telemetry::init();
     let addr = std::env::var("TS_SERVER_BIND_ADDR")
         .or_else(|_| std::env::var("TS_SERVER_ADDR"))
         .unwrap_or_else(|_| "127.0.0.1:17002".to_string());
@@ -131,35 +133,37 @@ fn main() {
         let startup_load = startup_load_shard_request(shard_id, node_id);
         let load_response = engine.load_shard_with(startup_load);
         if !load_response.status.ok {
-            eprintln!(
-                "startup shard load failed for shard {shard_id}: {}",
-                load_response.status.message
+            error!(
+                shard_id,
+                message = %load_response.status.message,
+                "startup shard load failed"
             );
         }
     } else {
-        println!("join-empty datanode: awaiting metaserver shard placement");
+        info!("join-empty datanode: awaiting metaserver shard placement");
     }
     // Resolve the distributed storage/replication backend for this node:
     // matrixobject shared storage when detected, else a configured shared object
     // store, else raft replication (the default when nothing is configured).
     let storage_backend = temporalstore_rust::StorageBackendConfig::from_env().resolve();
-    println!(
-        "storage backend: {} (replication {:?})",
-        storage_backend.describe(),
-        storage_backend.replication_mode()
+    info!(
+        backend = %storage_backend.describe(),
+        replication = ?storage_backend.replication_mode(),
+        "resolved storage backend"
     );
     // Construct the shared object store early so a broken shared-storage config
     // fails fast at startup rather than on the first write.
     match storage_backend.build_shared_object_store() {
-        Ok(Some(_shared_store)) => println!(
-            "shared-storage backend ready: {} — shard durability served by shared storage",
-            storage_backend.describe()
+        Ok(Some(_shared_store)) => info!(
+            backend = %storage_backend.describe(),
+            "shared-storage backend ready — shard durability served by shared storage"
         ),
         Ok(None) => {}
         Err(err) => {
-            eprintln!(
-                "configured storage backend {} is unusable: {err}",
-                storage_backend.describe()
+            error!(
+                backend = %storage_backend.describe(),
+                %err,
+                "configured storage backend is unusable"
             );
             std::process::exit(1);
         }
@@ -211,8 +215,10 @@ fn main() {
         _ => !(meta_addr_is_real || env_bool("TS_DISTRIBUTED", false)),
     };
     if standalone {
-        println!(
-            "standalone datanode: no metaserver — serving shard {shard_id} locally at {advertised_addr}"
+        info!(
+            shard_id,
+            addr = %advertised_addr,
+            "standalone datanode: no metaserver — serving shard locally"
         );
     } else {
         let server_registration = RegisterServerRequest {
@@ -223,16 +229,17 @@ fn main() {
         };
         match post_json::<_, AckResponse>(&meta_addr, "/servers/register", &server_registration) {
             Ok(response) if response.status.ok => {
-                println!("registered server {advertised_addr} with metaserver {meta_addr}");
+                info!(server = %advertised_addr, meta = %meta_addr, "registered server with metaserver");
             }
             Ok(response) => {
-                eprintln!(
-                    "metaserver rejected server registration: {}",
-                    response.status.message
+                warn!(
+                    server = %advertised_addr,
+                    message = %response.status.message,
+                    "metaserver rejected server registration"
                 );
             }
             Err(err) => {
-                eprintln!("failed to register server {advertised_addr}: {err}");
+                warn!(server = %advertised_addr, %err, "failed to register server");
             }
         }
 
@@ -244,16 +251,17 @@ fn main() {
             match post_json::<_, RegisterShardResponse>(&meta_addr, "/register_shard", &registration)
             {
                 Ok(response) if response.status.ok => {
-                    println!("registered shard {shard_id} with metaserver {meta_addr}");
+                    info!(shard_id, meta = %meta_addr, "registered shard with metaserver");
                 }
                 Ok(response) => {
-                    eprintln!(
-                        "metaserver rejected registration: {}",
-                        response.status.message
+                    warn!(
+                        shard_id,
+                        message = %response.status.message,
+                        "metaserver rejected shard registration"
                     );
                 }
                 Err(err) => {
-                    eprintln!("failed to register shard {shard_id}: {err}");
+                    warn!(shard_id, %err, "failed to register shard");
                 }
             }
         }
@@ -292,9 +300,10 @@ fn main() {
             match &storage_backend {
                 StorageBackend::SharedPath { root, cluster_id } => {
                     let store = Arc::new(FileObjectStore::new(root.clone()));
-                    println!(
-                        "shard data movement enabled: shared-storage checkpoints at {} (cluster {cluster_id})",
-                        root.display()
+                    info!(
+                        checkpoints = %root.display(),
+                        cluster = %cluster_id,
+                        "shard data movement enabled: shared-storage checkpoints"
                     );
                     Some(Arc::new(SharedStoreReplicator::new(
                         cluster_id.clone(),
@@ -302,9 +311,9 @@ fn main() {
                     )))
                 }
                 other => {
-                    eprintln!(
-                        "TS_AUTO_REBALANCE_DATA_MOVE set but backend {} is not a shared path — data movement disabled",
-                        other.describe()
+                    warn!(
+                        backend = %other.describe(),
+                        "TS_AUTO_REBALANCE_DATA_MOVE set but backend is not a shared path — data movement disabled"
                     );
                     None
                 }
@@ -313,7 +322,7 @@ fn main() {
             None
         };
 
-    println!("temporalstore server listening on {addr}");
+    info!(%addr, "temporalstore server listening");
     // Streaming pre-handler: owns `/blob/<key>` and moves bytes straight between
     // the socket and the object store (no full-body buffering). Everything else
     // is Declined and falls through to the buffered handler below.
@@ -322,7 +331,7 @@ fn main() {
     let handler_replicator = shard_replicator.clone();
     let handler_block_runtime = Arc::clone(&blob_runtime);
     let stream_chunk_bytes = blob_chunk_bytes;
-    serve_with_stream_handler(
+    if let Err(err) = serve_with_stream_handler(
         &addr,
         move |head, transfer| {
             handle_blob_stream(
@@ -334,6 +343,7 @@ fn main() {
             )
         },
         move |request| {
+        debug!(method = %request.method, path = %request.path, "serving request");
         if let Some(response) = handle_ping_route(&request) {
             return response;
         }
@@ -790,8 +800,10 @@ fn main() {
             _ => json_response(404, &Status::error("not_found", "unknown server route")),
         }
         },
-    )
-    .expect("server failed");
+    ) {
+        error!(%err, "server serve loop exited");
+        std::process::exit(1);
+    }
 }
 
 fn handle_ping_route(request: &HttpRequest) -> Option<(u16, Vec<u8>)> {
@@ -942,13 +954,15 @@ fn replay_shard_from_shared(
     match runtime.block_on(replicator.replay_wal(shard_id, 0, engine)) {
         Ok(report) => {
             if report.applied > 0 {
-                println!(
-                    "replayed shard {shard_id} from shared storage: {} records (through wal_index {})",
-                    report.applied, report.last_wal_index
+                info!(
+                    shard_id,
+                    records = report.applied,
+                    wal_index = report.last_wal_index,
+                    "replayed shard from shared storage"
                 );
             }
         }
-        Err(err) => eprintln!("no shared-storage data replayed for shard {shard_id}: {err}"),
+        Err(err) => warn!(shard_id, %err, "no shared-storage data replayed for shard"),
     }
 }
 

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -26,6 +26,7 @@ pub mod sdk;
 pub mod shared_store;
 pub mod storage_backend;
 pub mod storage_config;
+pub mod telemetry;
 pub mod types;
 pub mod wal;
 

--- a/crates/temporalstore-rust/src/telemetry.rs
+++ b/crates/temporalstore-rust/src/telemetry.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Process-wide structured-logging (tracing) initialization for the TemporalStore
+//! serving daemons.
+//!
+//! [`init`] installs a `tracing_subscriber` fmt subscriber whose level filter is
+//! read from the `RUST_LOG` environment variable, falling back to `info` when the
+//! variable is unset or unparseable. It is idempotent and safe to call from every
+//! daemon `main`: the subscriber is installed at most once, and a pre-existing
+//! global subscriber is left untouched.
+//!
+//! Logging cost on the serving hot path is near zero at the default `info` level.
+//! `debug!`/`trace!` events compile to a cheap static level check that short-
+//! circuits before any argument formatting, so per-request instrumentation stays
+//! disabled unless `RUST_LOG` explicitly enables it.
+
+use std::sync::Once;
+
+use tracing_subscriber::EnvFilter;
+
+static INIT: Once = Once::new();
+
+/// Initialize the global tracing subscriber exactly once.
+///
+/// Reads `RUST_LOG` via [`EnvFilter`], defaulting to `info` when it is absent or
+/// invalid. Subsequent calls are no-ops, and if another component already
+/// installed a global subscriber this leaves it in place (the install is done
+/// with `try_init`, whose error is ignored).
+pub fn init() {
+    INIT.call_once(|| {
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        // `try_init` returns an error (rather than panicking) when a global
+        // subscriber is already set; ignore it so daemons can init freely.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .try_init();
+    });
+}


### PR DESCRIPTION
…daemons

Port of the logging layer from the canonical repo. The crate had no logging framework; the long-running daemons emitted a few ad-hoc eprintln!/println! only.

- add tracing + tracing-subscriber (env-filter, fmt)
- new src/telemetry.rs: idempotent init() (std::sync::Once) reading RUST_LOG via EnvFilter (default "info"), installed with try_init so a pre-existing global subscriber is left intact; near-zero disabled-level cost on hot paths
- call telemetry::init() at the top of every serving-daemon main (server, metaserver, raft_node, proxy, redis_proxy)
- convert daemon startup/lifecycle/registration prints to leveled events (info!/warn!/error!) with structured fields; per-request logs are debug! (disabled at default info -> no perf impact)

Logging-only change (applied as a 3-way patch onto the mirror tree); one-shot CLI/harness tools keep stdout as their intended output. cargo build --bins green.