### PR TITLE
feat(context): embedding backfill for bulk stores + embedding-dirty drainer

### DIFF
--- a/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
+++ b/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
@@ -43,8 +43,13 @@ use serde_json::{json, Value};
 use temporalstore_rust::{
     ingest_extract_context, BatchExecuteRequest, Command, ContextEvent, ContextExtractRequest,
     ContextIndexRef, ContextIngestExtractRequest, ContextModelProviderConfig, ContextNode,
-    ContextSourceKind, TemporalEngine,
+    ContextSourceKind, ContextSummaryDirtyMarker, TemporalEngine,
 };
+
+// Reason code stamped on embedding-dirty markers written by the raw-first bulk
+// path, distinguishing "embedding deferred at bulk ingest" from a live-path embed
+// failure. Purely diagnostic; the drainer treats any pending marker identically.
+const EMBEDDING_DIRTY_REASON_BULK_DEFERRED: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct SessionIndex {
@@ -322,7 +327,7 @@ fn write_raw_sources(
         return (0, 0, Vec::new());
     }
     let shard_id = sources[0].shard_id;
-    let mut commands = Vec::with_capacity(sources.len().saturating_mul(3));
+    let mut commands = Vec::with_capacity(sources.len().saturating_mul(4));
     let mut node_hashes = Vec::new();
     for source in sources {
         let node_hash = stable_hash64(&format!(
@@ -380,6 +385,22 @@ fn write_raw_sources(
             event_time_ms: timestamp_ms,
             index_ref,
         });
+        // Raw-first bulk ingest stores no embeddings, so mark each node
+        // embedding-dirty. The async embed drainer (MATRIXARK_EMBED_DRAINER) picks
+        // these up and attaches vectors; until then the hybrid retrieve path keeps
+        // them rankable via lexical scoring. This is the ONLY place the bulk path
+        // marks embedding-dirty (the live/extraction path embeds inline and marks
+        // only on failure).
+        commands.push(Command::ContextMarkEmbeddingDirty {
+            tenant_hash,
+            marker: ContextSummaryDirtyMarker {
+                node_hash,
+                event_time_ms: timestamp_ms,
+                reason: EMBEDDING_DIRTY_REASON_BULK_DEFERRED,
+                propagate_depth: 0,
+            },
+            clear: false,
+        });
         node_hashes.push(node_hash);
     }
     let response = engine.batch_execute(BatchExecuteRequest { shard_id, commands });
@@ -392,7 +413,9 @@ fn write_raw_sources(
         .filter(|entry| !entry.status.ok)
         .count();
     if failed_commands > 0 {
-        let failed_rows = failed_commands.div_ceil(3);
+        // Four commands per source: upsert-node, write-event, write-index-ref,
+        // mark-embedding-dirty.
+        let failed_rows = failed_commands.div_ceil(4);
         let accepted = sources.len().saturating_sub(failed_rows) as u64;
         return (accepted, failed_rows as u64, node_hashes);
     }

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -9,10 +9,12 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use temporalstore_rust::context_workflow::{
     context_pipeline_manage_report, context_workflow_state_report, default_context_model_providers,
-    extract_context, ingest_extract_context, inject_context, retrieve_context,
-    ContextExtractRequest, ContextIngestExtractRequest, ContextInjectRequest,
-    ContextModelProviderConfig, ContextRetrieveRequest,
+    embed_drainer_config_from_env, embed_drainer_enabled, extract_context, ingest_extract_context,
+    inject_context, retrieve_context, run_embed_drainer_loop, ContextExtractRequest,
+    ContextIngestExtractRequest, ContextInjectRequest, ContextModelProviderConfig,
+    ContextRetrieveRequest,
 };
+use temporalstore_rust::ContextProviderKind;
 use temporalstore_rust::data_node::{DataNodeLifecycleSnapshot, DataNodeTopologyValidationReport};
 use temporalstore_rust::engine::reports::{StorageManagerCycleReport, StorageManagerCycleRequest};
 use temporalstore_rust::engine::TemporalEngine;
@@ -172,6 +174,40 @@ fn main() {
             max_background_queue_depth: env_usize("TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH", 128),
         },
     );
+
+    // Async embedding drainer (gated by MATRIXARK_EMBED_DRAINER, default off).
+    // Attaches vectors to nodes left embedding-dirty by raw-first bulk ingest or a
+    // live-path embed failure, so a bulk-loaded store becomes semantically
+    // retrievable without slowing ingest. Scans only the pending dirty set
+    // (O(pending)); the interval is a short idle fallback (MATRIXARK_EMBED_DRAINER_INTERVAL_MS).
+    if embed_drainer_enabled() {
+        let drainer_engine = engine.clone();
+        // Provider: a configured OpenAI-compatible embed server (MATRIXARK_EMBED_BASE_URL)
+        // else the default deterministic provider (safe offline; real vectors need a
+        // real server + MATRIXARK_REQUIRE_MODEL_EMBEDDINGS).
+        let provider = match std::env::var("MATRIXARK_EMBED_BASE_URL").ok() {
+            Some(base_url) if !base_url.trim().is_empty() => ContextModelProviderConfig {
+                provider_name: "embed-drainer".to_string(),
+                provider_kind: ContextProviderKind::OpenAiCompatible,
+                base_url,
+                api_key_env: std::env::var("MATRIXARK_EMBED_API_KEY_ENV").unwrap_or_default(),
+                embedding_model: std::env::var("MATRIXARK_EMBEDDING_MODEL")
+                    .unwrap_or_else(|_| "all-MiniLM-L6-v2".to_string()),
+                mock_mode: false,
+                ..ContextModelProviderConfig::default()
+            },
+            _ => ContextModelProviderConfig::default(),
+        };
+        let drainer_config = embed_drainer_config_from_env(shard_id, 0, provider);
+        println!(
+            "embed drainer enabled: shard {shard_id}, batch {}, interval {}ms",
+            drainer_config.batch_size,
+            drainer_config.interval.as_millis()
+        );
+        std::thread::spawn(move || {
+            run_embed_drainer_loop(&drainer_engine, &drainer_config, || false);
+        });
+    }
 
     let location = std::env::var("TS_SERVER_LOCATION").unwrap_or_default();
     let binary_version = env!("CARGO_PKG_VERSION").to_string();

--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -83,6 +83,8 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ContextQueryPackAudit { .. }
         | Command::ContextMarkSummaryDirty { .. }
         | Command::ContextQuerySummaryDirty { .. }
+        | Command::ContextMarkEmbeddingDirty { .. }
+        | Command::ContextQueryEmbeddingDirty { .. }
         | Command::ContextUpsertEntity { .. }
         | Command::ContextGetEntity { .. }
         | Command::ContextQueryEntities { .. }
@@ -184,6 +186,16 @@ pub(super) fn context_command_key(command: &Command) -> Option<String> {
             node_hash,
             ..
         } => Some(context_dirty_key(*tenant_hash, *node_hash)),
+        Command::ContextMarkEmbeddingDirty {
+            tenant_hash,
+            marker,
+            ..
+        } => Some(context_embedding_dirty_key(*tenant_hash, marker.node_hash)),
+        Command::ContextQueryEmbeddingDirty {
+            tenant_hash,
+            node_hash,
+            ..
+        } => Some(context_embedding_dirty_key(*tenant_hash, *node_hash)),
         Command::ContextUpsertEntity {
             tenant_hash,
             entity,
@@ -288,6 +300,10 @@ pub(super) fn context_audit_key(tenant_hash: u64, session_hash: u64) -> String {
 
 pub(super) fn context_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
     format!("ctx:dirty:{tenant_hash}:{node_hash}")
+}
+
+pub(super) fn context_embedding_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
+    format!("ctx:embdirty:{tenant_hash}:{node_hash}")
 }
 
 pub(super) fn context_entity_key(tenant_hash: u64, node_hash: u64, entity_hash: u64) -> String {

--- a/crates/temporalstore-rust/src/client/table_context.rs
+++ b/crates/temporalstore-rust/src/client/table_context.rs
@@ -252,4 +252,84 @@ impl TemporalStoreTable {
             }),
         }
     }
+
+    /// Mark a context node embedding-dirty (its semantic embedding is deferred or
+    /// failed). Independent of the summary-dirty marker.
+    pub fn context_mark_embedding_dirty(
+        &self,
+        tenant_hash: u64,
+        marker: ContextSummaryDirtyMarker,
+    ) -> Result<String, ClientError> {
+        match self
+            .execute(Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker,
+                clear: false,
+            })?
+            .response
+        {
+            CommandResponse::ContextObjectKey { object_key } => Ok(object_key),
+            response => Err(ClientError::UnexpectedResponse {
+                operation: "context_mark_embedding_dirty",
+                response,
+            }),
+        }
+    }
+
+    /// Clear the embedding-dirty marker for a node (called once it is embedded).
+    pub fn context_clear_embedding_dirty(
+        &self,
+        tenant_hash: u64,
+        marker: ContextSummaryDirtyMarker,
+    ) -> Result<String, ClientError> {
+        match self
+            .execute(Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker,
+                clear: true,
+            })?
+            .response
+        {
+            CommandResponse::ContextObjectKey { object_key } => Ok(object_key),
+            response => Err(ClientError::UnexpectedResponse {
+                operation: "context_clear_embedding_dirty",
+                response,
+            }),
+        }
+    }
+
+    /// Query embedding-dirty markers. `node_hash == 0` returns all pending
+    /// embedding-dirty nodes (the drainer's O(pending) scan); a non-zero
+    /// `node_hash` returns the single coalesced entry for that node. Returns the
+    /// markers alongside their per-marker tenant hashes (parallel vector; used by
+    /// the all-pending drain scan, which spans tenants).
+    pub fn context_query_embedding_dirty(
+        &self,
+        tenant_hash: u64,
+        node_hash: u64,
+        start_time_ms: u64,
+        end_time_ms: u64,
+        limit: Option<usize>,
+    ) -> Result<(Vec<ContextSummaryDirtyMarker>, Vec<u64>), ClientError> {
+        match self
+            .execute(Command::ContextQueryEmbeddingDirty {
+                tenant_hash,
+                node_hash,
+                start_time_ms,
+                end_time_ms,
+                limit,
+            })?
+            .response
+        {
+            CommandResponse::ContextEmbeddingDirtyMarkers {
+                markers,
+                tenant_hashes,
+                ..
+            } => Ok((markers, tenant_hashes)),
+            response => Err(ClientError::UnexpectedResponse {
+                operation: "context_query_embedding_dirty",
+                response,
+            }),
+        }
+    }
 }

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -15,7 +15,44 @@ use serde_json::Value;
 /// fully scored instead of silently falling back to lexical ranking.
 const CONTEXT_EMBEDDING_QUERY_CHUNK: usize = 1000;
 
+/// Reason code stamped on an embedding-dirty marker written by the live extraction
+/// path when the inline embedding call fails (after any fallback provider). Purely
+/// diagnostic; the drainer treats every pending marker identically. Distinct from
+/// the bulk-ingest deferral reason (2, see context_batch_ingest.rs).
+const EMBEDDING_DIRTY_REASON_LIVE_FAILURE: u32 = 3;
+
+/// Raw lexical-relevance score at/above which a node is treated as a full-strength
+/// lexical match, mapped to `LEXICAL_MATCH_MICROS`. Scores below scale linearly.
+/// A topic-phrase hit alone already contributes 1000 in `context_relevance_score_plan`.
+const LEXICAL_SCORE_SATURATION: i64 = 1_000;
+/// Micros a saturated lexical match maps to. Kept below the 1_000_000 ceiling a
+/// perfect cosine match reaches so that, in a MIXED store, a strong semantic
+/// (embedded) match still outranks a purely lexical one, while un-embedded nodes
+/// remain rankable (never a flat 0) instead of collapsing to recency order.
+const LEXICAL_MATCH_MICROS: i64 = 500_000;
+
+/// Hybrid lexical fallback for un-embedded nodes in `retrieve_context`
+/// (`MATRIXARK_CONTEXT_HYBRID_LEXICAL`, default ON). When enabled, a node with no
+/// stored summary embedding is scored by query/text lexical overlap instead of the
+/// flat 0 it used to get, so a freshly bulk-loaded store returns relevant results
+/// before the embed drainer catches up. Embedded-node scoring is unchanged.
+fn context_hybrid_lexical_enabled() -> bool {
+    std::env::var("MATRIXARK_CONTEXT_HYBRID_LEXICAL")
+        .ok()
+        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
+}
+
+/// Map a raw lexical-relevance score into the same micros scale cosine similarity
+/// uses (`context_embedding_similarity_micros`), so lexical and cosine node scores
+/// merge into one ranking. 0 stays 0 (no overlap => not surfaced by lexical).
+fn lexical_score_to_micros(raw: u32) -> i64 {
+    let raw = (raw as i64).min(LEXICAL_SCORE_SATURATION);
+    raw.saturating_mul(LEXICAL_MATCH_MICROS) / LEXICAL_SCORE_SATURATION
+}
+
 mod query;
+mod embed_drainer;
 mod resource;
 mod benchmark;
 mod model_provider;
@@ -33,6 +70,10 @@ pub use ingest::{ingest_extract_context, ingest_resource_skill_context, validate
 pub(crate) use model_provider::*;
 pub use model_provider::context_backfill_embeddings;
 pub use query::context_embedding_ref_hash;
+pub use embed_drainer::{
+    drain_embedding_dirty_once, embed_drainer_config_from_env, embed_drainer_enabled,
+    run_embed_drainer_loop, EmbedDrainReport, EmbedDrainerConfig,
+};
 pub use skill::{
     context_skill_registry_from_parsed, parse_context_skill_markdown,
     select_context_skills_for_retrieval, update_context_skill_registry,
@@ -1560,65 +1601,91 @@ pub(crate) fn extract_context_gated(
         embedding_inputs.push(("node_l1", node_hash, 2, l1.as_str()));
     }
     embedding_inputs.push(("event_text", event_id_hash, 3, request.body.as_str()));
-    let (embedding_vectors, embedding_generation) =
-        match context_embeddings_for_extract(&provider, &embedding_inputs) {
-            Ok(value) => value,
-            Err(status) => {
-                if let Some(fallback) = provider.fallback_provider.as_deref() {
-                    let fallback = normalize_provider(fallback.clone());
-                    match context_embeddings_for_extract(&fallback, &embedding_inputs) {
-                        Ok((vectors, mut report)) => {
-                            report.fallback_used = true;
-                            report.provider_name = format!(
-                                "{}+fallback:{}",
-                                provider.provider_name, report.provider_name
-                            );
-                            (vectors, report)
-                        }
-                        Err(fallback_status) => {
-                            return empty_extract_report(
-                                fallback_status,
-                                provider,
-                                request.tenant_hash,
-                                request.timestamp_ms,
-                            );
-                        }
-                    }
-                } else {
-                    return empty_extract_report(
-                        status,
-                        provider,
-                        request.tenant_hash,
-                        request.timestamp_ms,
-                    );
-                }
+    // Compute embeddings, trying the fallback provider on error. On total failure
+    // the behavior depends on `context_embed_defer_on_failure()`: the default is to
+    // DEFER (persist the node/event/summaries without vectors and mark the node
+    // embedding-dirty so the async drainer attaches vectors later, keeping it
+    // lexically rankable meanwhile); the fail-closed path aborts the extract.
+    let embed_outcome = match context_embeddings_for_extract(&provider, &embedding_inputs) {
+        Ok(value) => Ok(value),
+        Err(status) => {
+            if let Some(fallback) = provider.fallback_provider.as_deref() {
+                let fallback = normalize_provider(fallback.clone());
+                context_embeddings_for_extract(&fallback, &embedding_inputs).map(
+                    |(vectors, mut report)| {
+                        report.fallback_used = true;
+                        report.provider_name = format!(
+                            "{}+fallback:{}",
+                            provider.provider_name, report.provider_name
+                        );
+                        (vectors, report)
+                    },
+                )
+            } else {
+                Err(status)
             }
-        };
-    let embedding_l0 = ContextEmbedding {
-        ref_hash: context_embedding_ref_hash(request.tenant_hash, node_hash, "node_l0"),
-        level: 1,
-        model_hash: context_embedding_model_hash(&provider.model),
-        vector: embedding_vectors[0].clone(),
-        updated_at_ms: timestamp_ms,
+        }
     };
-    let embedding_l1 = if emit_l1 {
-        Some(ContextEmbedding {
-            ref_hash: context_embedding_ref_hash(request.tenant_hash, node_hash, "node_l1"),
-            level: 2,
-            model_hash: context_embedding_model_hash(&provider.model),
-            vector: embedding_vectors[1].clone(),
-            updated_at_ms: timestamp_ms,
-        })
+    let (embedding_vectors, embedding_generation, embedding_deferred) = match embed_outcome {
+        Ok((vectors, report)) => (vectors, report, false),
+        Err(status) => {
+            if !context_embed_defer_on_failure() {
+                return empty_extract_report(
+                    status,
+                    provider,
+                    request.tenant_hash,
+                    request.timestamp_ms,
+                );
+            }
+            (Vec::new(), ContextEmbeddingGenerationReport::default(), true)
+        }
+    };
+    // Embedding upsert commands are built only when embeddings actually succeeded;
+    // when deferred we skip them and mark the node embedding-dirty instead.
+    let embedding_commands: Vec<Command> = if embedding_deferred {
+        Vec::new()
     } else {
-        None
-    };
-    let event_vector_index = if emit_l1 { 2 } else { 1 };
-    let embedding_event = ContextEmbedding {
-        ref_hash: context_embedding_ref_hash(request.tenant_hash, event_id_hash, "event_text"),
-        level: 3,
-        model_hash: context_embedding_model_hash(&provider.model),
-        vector: embedding_vectors[event_vector_index].clone(),
-        updated_at_ms: timestamp_ms,
+        let embedding_l0 = ContextEmbedding {
+            ref_hash: context_embedding_ref_hash(request.tenant_hash, node_hash, "node_l0"),
+            level: 1,
+            model_hash: context_embedding_model_hash(&provider.model),
+            vector: embedding_vectors[0].clone(),
+            updated_at_ms: timestamp_ms,
+        };
+        let embedding_l1 = if emit_l1 {
+            Some(ContextEmbedding {
+                ref_hash: context_embedding_ref_hash(request.tenant_hash, node_hash, "node_l1"),
+                level: 2,
+                model_hash: context_embedding_model_hash(&provider.model),
+                vector: embedding_vectors[1].clone(),
+                updated_at_ms: timestamp_ms,
+            })
+        } else {
+            None
+        };
+        let event_vector_index = if emit_l1 { 2 } else { 1 };
+        let embedding_event = ContextEmbedding {
+            ref_hash: context_embedding_ref_hash(request.tenant_hash, event_id_hash, "event_text"),
+            level: 3,
+            model_hash: context_embedding_model_hash(&provider.model),
+            vector: embedding_vectors[event_vector_index].clone(),
+            updated_at_ms: timestamp_ms,
+        };
+        let mut embedding_commands = vec![Command::ContextUpsertEmbedding {
+            tenant_hash: request.tenant_hash,
+            embedding: embedding_l0,
+        }];
+        if let Some(embedding_l1) = embedding_l1 {
+            embedding_commands.push(Command::ContextUpsertEmbedding {
+                tenant_hash: request.tenant_hash,
+                embedding: embedding_l1,
+            });
+        }
+        embedding_commands.push(Command::ContextUpsertEmbedding {
+            tenant_hash: request.tenant_hash,
+            embedding: embedding_event,
+        });
+        embedding_commands
     };
 
     let mut commands = vec![
@@ -1650,27 +1717,29 @@ pub(crate) fn extract_context_gated(
             summary: summary_l0,
         },
     ];
-    // L1 summary + embedding are written only when L1 was emitted (see `emit_l1`).
+    // L1 summary is written only when L1 was emitted (see `emit_l1`).
     if let Some(summary_l1) = summary_l1 {
         commands.push(Command::ContextUpsertSummary {
             tenant_hash: request.tenant_hash,
             summary: summary_l1,
         });
     }
-    commands.push(Command::ContextUpsertEmbedding {
-        tenant_hash: request.tenant_hash,
-        embedding: embedding_l0,
-    });
-    if let Some(embedding_l1) = embedding_l1 {
-        commands.push(Command::ContextUpsertEmbedding {
+    if embedding_deferred {
+        // Live-path embed failed: persist the node without vectors and mark it
+        // embedding-dirty so the async drainer retries. Happy path marks nothing.
+        commands.push(Command::ContextMarkEmbeddingDirty {
             tenant_hash: request.tenant_hash,
-            embedding: embedding_l1,
+            marker: ContextSummaryDirtyMarker {
+                node_hash,
+                event_time_ms: timestamp_ms,
+                reason: EMBEDDING_DIRTY_REASON_LIVE_FAILURE,
+                propagate_depth: 0,
+            },
+            clear: false,
         });
     }
-    commands.push(Command::ContextUpsertEmbedding {
-        tenant_hash: request.tenant_hash,
-        embedding: embedding_event,
-    });
+    // Embedding upserts (empty when deferred).
+    commands.extend(embedding_commands);
     for command in commands {
         let response = engine.execute_durable(ExecuteRequest {
             shard_id: request.shard_id,
@@ -1826,6 +1895,50 @@ pub fn retrieve_context(
             }
         }
     }
+    // Hybrid lexical fallback: nodes with NO stored summary embedding used to score
+    // a flat 0 here (missing-embedding -> unwrap_or_default), so a freshly
+    // bulk-loaded (un-embedded) store collapsed to recency order and lost focused
+    // recall. Instead, load those un-embedded candidates and score them by
+    // query/text lexical overlap, normalized into the same micros scale as cosine.
+    // Embedded nodes keep their cosine score untouched, so when every node is
+    // embedded this pass does nothing and behavior is identical to before.
+    let mut prefetched_nodes = BTreeMap::<u64, ContextNode>::new();
+    let mut lexical_scores_by_node = BTreeMap::<u64, i64>::new();
+    if context_hybrid_lexical_enabled() {
+        let unembedded: Vec<u64> = node_hashes
+            .iter()
+            .copied()
+            .filter(|node_hash| {
+                summary_scores_by_node
+                    .get(node_hash)
+                    .map(|(_, found)| *found == 0)
+                    .unwrap_or(true)
+            })
+            .collect();
+        if !unembedded.is_empty() {
+            for chunk in unembedded.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
+                if chunk.is_empty() {
+                    continue;
+                }
+                let nodes_response = engine.execute(ExecuteRequest {
+                    shard_id: request.shard_id,
+                    command: Command::ContextGetNodes {
+                        tenant_hash: request.tenant_hash,
+                        node_hashes: chunk.to_vec(),
+                    },
+                });
+                if let CommandResponse::ContextNodes { nodes } = nodes_response.response {
+                    for node in nodes {
+                        let text = format!("{} {} {}", node.canonical_name, node.l0, node.l1_ref);
+                        let lexical = context_relevance_score_plan(&query_plan, &text);
+                        lexical_scores_by_node
+                            .insert(node.node_hash, lexical_score_to_micros(lexical));
+                        prefetched_nodes.insert(node.node_hash, node);
+                    }
+                }
+            }
+        }
+    }
     let mut summary_scores = node_hashes
         .iter()
         .map(|node_hash| {
@@ -1833,6 +1946,17 @@ pub fn retrieve_context(
                 .get(node_hash)
                 .copied()
                 .unwrap_or_default();
+            // Embedded node (found > 0): cosine score, exactly as before. Otherwise
+            // fall back to the hybrid lexical score (0 when there was no overlap or
+            // hybrid is disabled) so un-embedded nodes are still rankable.
+            let best_score = if found > 0 {
+                best_score
+            } else {
+                lexical_scores_by_node
+                    .get(node_hash)
+                    .copied()
+                    .unwrap_or(best_score)
+            };
             (*node_hash, best_score, found, 0u32, 0u64)
         })
         .collect::<Vec<_>>();
@@ -1856,7 +1980,6 @@ pub fn retrieve_context(
         .min(summary_node_limit.max(1))
         .min(query_aware_event_limit);
     let rerank_node_limit = summary_node_limit.min(summary_scores.len());
-    let mut prefetched_nodes = BTreeMap::<u64, ContextNode>::new();
     let rerank_node_hashes = summary_scores
         .iter()
         .take(rerank_node_limit)

--- a/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
+++ b/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Async batched embedding drainer.
+//!
+//! Raw-first bulk ingest (`context_batch_ingest` with
+//! `MATRIXARK_BACKFILL_RAW_FIRST=1`) and the live extraction path on embed failure
+//! both store context nodes WITHOUT vectors and mark them embedding-dirty
+//! (`ctx:embdirty:{tenant}:{node}`). This drainer is the background worker that
+//! closes the gap: it queries only the pending embedding-dirty set (O(pending), a
+//! bounded scan of the in-memory dirty index, NOT a corpus scan), reads each dirty
+//! node's event text, batch-embeds it through the SAME provider path live
+//! extraction uses (`context_backfill_embeddings`), upserts the `node_l0`
+//! embedding under the exact ref-hash the retrieve path reads, then clears the
+//! embedding-dirty marker for every node it embedded.
+//!
+//! It is event-driven-ish: while pending work exists it drains back-to-back with
+//! no sleep, so ingest bursts clear quickly; only when the pending set is empty
+//! does it sleep for a short fallback interval (an empty dirty set costs one empty
+//! query). Gated OFF by default via `MATRIXARK_EMBED_DRAINER`.
+
+use std::time::Duration;
+
+use super::*;
+use crate::types::BatchExecuteRequest;
+
+/// A timestamp comfortably in the future but well within the context timeline's
+/// valid range (`u64::MAX / CONTEXT_TIMELINE_FANOUT`), used as the query window's
+/// upper bound so every pending marker overlaps.
+const EMBED_DRAINER_MAX_TIME_MS: u64 = 9_000_000_000_000;
+
+/// Configuration for a single drain pass / the drain loop.
+#[derive(Debug, Clone)]
+pub struct EmbedDrainerConfig {
+    /// Shard to drain (single-shard local/resident engine).
+    pub shard_id: ShardId,
+    /// Tenant filter for the pending scan: 0 = all tenants on the shard (the
+    /// normal setting, since bulk-ingest tenant hashes are per-session), or a
+    /// specific tenant to scope the drain.
+    pub tenant_hash: u64,
+    /// Provider used to compute embeddings (mock/deterministic works offline).
+    pub provider: ContextModelProviderConfig,
+    /// Embedding batch size (>= 1; the task calls for >= 64 per call).
+    pub batch_size: usize,
+    /// Max pending nodes processed per pass (bounds one drain's work + memory).
+    pub max_nodes_per_pass: usize,
+    /// Max events read per node when picking the text to embed.
+    pub max_events_per_node: usize,
+    /// Idle fallback interval between passes when nothing was pending.
+    pub interval: Duration,
+}
+
+impl Default for EmbedDrainerConfig {
+    fn default() -> Self {
+        Self {
+            shard_id: 1,
+            tenant_hash: 0,
+            provider: ContextModelProviderConfig::default(),
+            batch_size: 64,
+            max_nodes_per_pass: 512,
+            max_events_per_node: 4,
+            interval: Duration::from_millis(1500),
+        }
+    }
+}
+
+/// Outcome of one drain pass.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EmbedDrainReport {
+    /// Pending markers returned by the O(pending) query this pass.
+    pub pending_scanned: usize,
+    /// Nodes whose embedding was upserted successfully.
+    pub embedded: usize,
+    /// Embedding-dirty markers cleared (== embedded, minus any clear failures).
+    pub cleared: usize,
+    /// Dirty nodes skipped because they had no event text to embed. These are
+    /// still cleared so the drainer does not spin on them forever.
+    pub empty_text: usize,
+    /// Nodes whose embedding batch failed (left dirty for a later pass).
+    pub failed: usize,
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(default)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Whether the background drainer is enabled (`MATRIXARK_EMBED_DRAINER`, default off).
+pub fn embed_drainer_enabled() -> bool {
+    env_bool("MATRIXARK_EMBED_DRAINER", false)
+}
+
+/// Build an [`EmbedDrainerConfig`] from environment, given the target shard and a
+/// provider (identity/base-url is the caller's concern, mirroring the backfill bin).
+pub fn embed_drainer_config_from_env(
+    shard_id: ShardId,
+    tenant_hash: u64,
+    provider: ContextModelProviderConfig,
+) -> EmbedDrainerConfig {
+    let d = EmbedDrainerConfig::default();
+    EmbedDrainerConfig {
+        shard_id,
+        tenant_hash,
+        provider,
+        batch_size: env_usize("MATRIXARK_EMBED_DRAINER_BATCH", d.batch_size).max(1),
+        max_nodes_per_pass: env_usize(
+            "MATRIXARK_EMBED_DRAINER_MAX_NODES_PER_PASS",
+            d.max_nodes_per_pass,
+        )
+        .max(1),
+        max_events_per_node: env_usize(
+            "MATRIXARK_EMBED_DRAINER_MAX_EVENTS",
+            d.max_events_per_node,
+        )
+        .max(1),
+        interval: Duration::from_millis(env_u64(
+            "MATRIXARK_EMBED_DRAINER_INTERVAL_MS",
+            d.interval.as_millis() as u64,
+        )),
+    }
+}
+
+/// Read the text to embed for a node: the longest stored event text (matches the
+/// backfill bin and gives the richest signal).
+fn node_embed_text(engine: &TemporalEngine, config: &EmbedDrainerConfig, tenant_hash: u64, node_hash: u64) -> String {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: config.shard_id,
+        command: Command::ContextQueryEvents {
+            tenant_hash,
+            node_hash,
+            start_time_ms: 0,
+            end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+            limit: Some(config.max_events_per_node.max(1)),
+            current_valid_only: false,
+            as_of_ms: 0,
+            kinds: Vec::new(),
+            statuses: Vec::new(),
+            min_confidence: 0.0,
+            min_importance: 0.0,
+        },
+    });
+    match response.response {
+        CommandResponse::ContextEvents { events, .. } => events
+            .into_iter()
+            .map(|event| event.text)
+            .max_by_key(|text| text.len())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+/// Clear the embedding-dirty marker for a node (write path). Returns true on ok.
+fn clear_marker(
+    engine: &TemporalEngine,
+    config: &EmbedDrainerConfig,
+    tenant_hash: u64,
+    node_hash: u64,
+    event_time_ms: u64,
+) -> bool {
+    engine
+        .execute_durable(ExecuteRequest {
+            shard_id: config.shard_id,
+            command: Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker: ContextSummaryDirtyMarker {
+                    node_hash,
+                    event_time_ms: event_time_ms.max(1),
+                    reason: 0,
+                    propagate_depth: 0,
+                },
+                clear: true,
+            },
+        })
+        .status
+        .ok
+}
+
+/// Run a single drain pass: query pending -> read text -> batch embed -> upsert ->
+/// clear. Pure with respect to time (no sleeping); returns what it did so it is
+/// unit-testable and O(pending).
+pub fn drain_embedding_dirty_once(
+    engine: &TemporalEngine,
+    config: &EmbedDrainerConfig,
+) -> EmbedDrainReport {
+    let mut report = EmbedDrainReport::default();
+
+    // 1) O(pending) scan of the embedding-dirty index (all tenants when tenant==0).
+    let query = engine.execute(ExecuteRequest {
+        shard_id: config.shard_id,
+        command: Command::ContextQueryEmbeddingDirty {
+            tenant_hash: config.tenant_hash,
+            node_hash: 0,
+            start_time_ms: 0,
+            end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+            limit: Some(config.max_nodes_per_pass.max(1)),
+        },
+    });
+    let (markers, tenant_hashes) = match query.response {
+        CommandResponse::ContextEmbeddingDirtyMarkers {
+            markers,
+            tenant_hashes,
+            ..
+        } => (markers, tenant_hashes),
+        _ => return report,
+    };
+    report.pending_scanned = markers.len();
+    if markers.is_empty() {
+        return report;
+    }
+
+    // 2) Collect (tenant, node, event_time, text). Nodes with no text are cleared
+    //    immediately so the drainer does not re-scan them every pass.
+    struct Pending {
+        tenant_hash: u64,
+        node_hash: u64,
+        event_time_ms: u64,
+        text: String,
+    }
+    let mut pending: Vec<Pending> = Vec::with_capacity(markers.len());
+    for (index, marker) in markers.iter().enumerate() {
+        let tenant_hash = tenant_hashes
+            .get(index)
+            .copied()
+            .filter(|value| *value != 0)
+            .unwrap_or(config.tenant_hash);
+        if tenant_hash == 0 {
+            // No tenant recoverable (shouldn't happen for embedding-dirty entries).
+            report.failed += 1;
+            continue;
+        }
+        let text = node_embed_text(engine, config, tenant_hash, marker.node_hash);
+        if text.trim().is_empty() {
+            report.empty_text += 1;
+            if clear_marker(engine, config, tenant_hash, marker.node_hash, marker.event_time_ms) {
+                report.cleared += 1;
+            }
+            continue;
+        }
+        pending.push(Pending {
+            tenant_hash,
+            node_hash: marker.node_hash,
+            event_time_ms: marker.event_time_ms,
+            text,
+        });
+    }
+
+    // 3) Batch-embed (>= batch_size per call) and upsert node_l0 vectors, then
+    //    clear the markers for the nodes that embedded successfully.
+    let model_hash = context_embedding_model_hash(&config.provider.embedding_model);
+    let updated_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(1)
+        .max(1);
+    for chunk in pending.chunks(config.batch_size.max(1)) {
+        let texts: Vec<&str> = chunk.iter().map(|item| item.text.as_str()).collect();
+        let vectors = match context_backfill_embeddings(&config.provider, &texts) {
+            Ok(vectors) if vectors.len() == chunk.len() => vectors,
+            _ => {
+                // Leave this chunk dirty for a later pass.
+                report.failed += chunk.len();
+                continue;
+            }
+        };
+        let commands: Vec<Command> = chunk
+            .iter()
+            .zip(vectors.into_iter())
+            .map(|(item, vector)| Command::ContextUpsertEmbedding {
+                tenant_hash: item.tenant_hash,
+                embedding: ContextEmbedding {
+                    ref_hash: context_embedding_ref_hash(item.tenant_hash, item.node_hash, "node_l0"),
+                    level: 1,
+                    model_hash,
+                    vector,
+                    updated_at_ms,
+                },
+            })
+            .collect();
+        let response = engine.batch_execute(BatchExecuteRequest {
+            shard_id: config.shard_id,
+            commands,
+        });
+        for (item, entry) in chunk.iter().zip(response.responses.iter()) {
+            if entry.status.ok {
+                report.embedded += 1;
+                if clear_marker(
+                    engine,
+                    config,
+                    item.tenant_hash,
+                    item.node_hash,
+                    item.event_time_ms,
+                ) {
+                    report.cleared += 1;
+                }
+            } else {
+                report.failed += 1;
+            }
+        }
+    }
+    report
+}
+
+/// Run the drain loop until `should_stop` returns true. Drains back-to-back while
+/// pending work exists; sleeps `config.interval` only when a pass found nothing.
+pub fn run_embed_drainer_loop<F: Fn() -> bool>(
+    engine: &TemporalEngine,
+    config: &EmbedDrainerConfig,
+    should_stop: F,
+) {
+    while !should_stop() {
+        let report = drain_embedding_dirty_once(engine, config);
+        // If the pass did real work and may have more queued, loop immediately;
+        // only back off when the pending set was empty this pass.
+        if report.pending_scanned == 0 {
+            std::thread::sleep(config.interval);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drainer_engine() -> TemporalEngine {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Leak the tempdir so the store outlives the test body (engine holds paths).
+        std::mem::forget(dir);
+        engine
+    }
+
+    fn seed_raw_node(engine: &TemporalEngine, tenant_hash: u64, node_hash: u64, text: &str) {
+        let ok = engine
+            .execute_durable(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextUpsertNode {
+                    tenant_hash,
+                    node: ContextNode {
+                        node_hash,
+                        parent_hash: 0,
+                        kind: 0,
+                        canonical_name: format!("node-{node_hash}"),
+                        l0: text.to_string(),
+                        status: 1,
+                        last_event_time_ms: 1_000,
+                        summary_dirty: true,
+                        l1_ref: String::new(),
+                        raw_metadata_ref: format!("src://{node_hash}"),
+                    },
+                },
+            })
+            .status
+            .ok;
+        assert!(ok);
+        let ok = engine
+            .execute_durable(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextWriteEvent {
+                    tenant_hash,
+                    node_hash,
+                    event: ContextEvent {
+                        event_id_hash: node_hash.wrapping_mul(7).max(1),
+                        event_time_ms: 1_000,
+                        ingestion_time_ms: 1_000,
+                        kind: 0,
+                        event_type: 1,
+                        actor_hash: 1,
+                        status: 1,
+                        valid_until_ms: 0,
+                        confidence: 1.0,
+                        importance: 1.0,
+                        text: text.to_string(),
+                        source_ref: String::new(),
+                        related_node_hashes: Vec::new(),
+                        compact_attrs: Vec::new(),
+                    },
+                    first_write_only: false,
+                    cold_storage: false,
+                },
+            })
+            .status
+            .ok;
+        assert!(ok);
+        // Mark it embedding-dirty (as raw-first bulk ingest would).
+        let ok = engine
+            .execute_durable(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextMarkEmbeddingDirty {
+                    tenant_hash,
+                    marker: ContextSummaryDirtyMarker {
+                        node_hash,
+                        event_time_ms: 1_000,
+                        reason: 2,
+                        propagate_depth: 0,
+                    },
+                    clear: false,
+                },
+            })
+            .status
+            .ok;
+        assert!(ok);
+    }
+
+    fn count_pending(engine: &TemporalEngine) -> usize {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddingDirty {
+                tenant_hash: 0,
+                node_hash: 0,
+                start_time_ms: 0,
+                end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+                limit: Some(1000),
+            },
+        });
+        match response.response {
+            CommandResponse::ContextEmbeddingDirtyMarkers { markers, .. } => markers.len(),
+            _ => 0,
+        }
+    }
+
+    fn has_embedding(engine: &TemporalEngine, tenant_hash: u64, node_hash: u64) -> bool {
+        let ref_hash = context_embedding_ref_hash(tenant_hash, node_hash, "node_l0");
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddings {
+                tenant_hash,
+                ref_hashes: vec![ref_hash],
+                limit: Some(1),
+            },
+        });
+        match response.response {
+            CommandResponse::ContextEmbeddings { embeddings } => {
+                embeddings.iter().any(|e| !e.vector.is_empty())
+            }
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn embedding_dirty_marker_mark_query_clear_round_trip() {
+        let engine = drainer_engine();
+        let tenant_hash = 7;
+        let node_hash = 42;
+        // Independent of summary-dirty: marking embedding-dirty does not create a
+        // summary-dirty marker.
+        engine.execute_durable(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker: ContextSummaryDirtyMarker {
+                    node_hash,
+                    event_time_ms: 500,
+                    reason: 2,
+                    propagate_depth: 0,
+                },
+                clear: false,
+            },
+        });
+        // Per-node query surfaces exactly one marker.
+        let per_node = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddingDirty {
+                tenant_hash,
+                node_hash,
+                start_time_ms: 0,
+                end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+                limit: Some(10),
+            },
+        });
+        match per_node.response {
+            CommandResponse::ContextEmbeddingDirtyMarkers { markers, .. } => {
+                assert_eq!(markers.len(), 1);
+                assert_eq!(markers[0].node_hash, node_hash);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        // Summary-dirty is untouched (independence).
+        let summary = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQuerySummaryDirty {
+                tenant_hash,
+                node_hash,
+                start_time_ms: 0,
+                end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+                limit: Some(10),
+            },
+        });
+        match summary.response {
+            CommandResponse::ContextSummaryDirtyMarkers { markers, .. } => {
+                assert!(markers.is_empty(), "embedding-dirty must not set summary-dirty");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        // All-pending scan (tenant 0) returns it with its tenant hash.
+        let all = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddingDirty {
+                tenant_hash: 0,
+                node_hash: 0,
+                start_time_ms: 0,
+                end_time_ms: EMBED_DRAINER_MAX_TIME_MS,
+                limit: Some(10),
+            },
+        });
+        match all.response {
+            CommandResponse::ContextEmbeddingDirtyMarkers {
+                markers,
+                tenant_hashes,
+                ..
+            } => {
+                assert_eq!(markers.len(), 1);
+                assert_eq!(tenant_hashes, vec![tenant_hash]);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        // Clear removes it.
+        engine.execute_durable(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker: ContextSummaryDirtyMarker {
+                    node_hash,
+                    event_time_ms: 500,
+                    reason: 0,
+                    propagate_depth: 0,
+                },
+                clear: true,
+            },
+        });
+        assert_eq!(count_pending(&engine), 0);
+    }
+
+    #[test]
+    fn drainer_embeds_all_pending_and_clears_markers() {
+        let engine = drainer_engine();
+        // Two tenants, several nodes each: exercises the all-tenant pending scan.
+        let nodes: [(u64, u64, &str); 5] = [
+            (100, 1, "checkout payment failed with a risk score spike"),
+            (100, 2, "deployment rollout paused after latency regression"),
+            (100, 3, "user updated notification preference to email"),
+            (200, 4, "database migration added a new index column"),
+            (200, 5, "incident timeline: outage then recovery"),
+        ];
+        for (tenant, node, text) in nodes {
+            seed_raw_node(&engine, tenant, node, text);
+        }
+        assert_eq!(count_pending(&engine), 5);
+
+        let config = EmbedDrainerConfig {
+            batch_size: 64,
+            ..EmbedDrainerConfig::default()
+        };
+        let report = drain_embedding_dirty_once(&engine, &config);
+        assert_eq!(report.pending_scanned, 5);
+        assert_eq!(report.embedded, 5);
+        assert_eq!(report.cleared, 5);
+        assert_eq!(report.failed, 0);
+
+        // Every node now has an embedding and no marker remains.
+        for (tenant, node, _) in nodes {
+            assert!(has_embedding(&engine, tenant, node), "node {node} not embedded");
+        }
+        assert_eq!(count_pending(&engine), 0);
+
+        // A second pass is a no-op (empty pending set) -> O(pending) drains to zero.
+        let report2 = drain_embedding_dirty_once(&engine, &config);
+        assert_eq!(report2.pending_scanned, 0);
+        assert_eq!(report2.embedded, 0);
+    }
+
+    #[test]
+    fn drainer_pass_is_bounded_by_pending_not_corpus() {
+        let engine = drainer_engine();
+        // Seed nodes but only mark a couple embedding-dirty: the pass must scan
+        // only the pending set, not every node.
+        for node in 1..=6u64 {
+            // Node + event without marking dirty.
+            engine.execute_durable(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextUpsertNode {
+                    tenant_hash: 9,
+                    node: ContextNode {
+                        node_hash: node,
+                        parent_hash: 0,
+                        kind: 0,
+                        canonical_name: format!("n{node}"),
+                        l0: format!("body text for node {node}"),
+                        status: 1,
+                        last_event_time_ms: 1_000,
+                        summary_dirty: false,
+                        l1_ref: String::new(),
+                        raw_metadata_ref: String::new(),
+                    },
+                },
+            });
+        }
+        // Mark just two of them dirty (with events).
+        seed_raw_node(&engine, 9, 100, "only this one is pending");
+        seed_raw_node(&engine, 9, 101, "and this one too");
+        assert_eq!(count_pending(&engine), 2);
+
+        let report = drain_embedding_dirty_once(&engine, &EmbedDrainerConfig::default());
+        assert_eq!(report.pending_scanned, 2, "must scan only pending, not corpus");
+        assert_eq!(report.embedded, 2);
+        assert_eq!(count_pending(&engine), 0);
+    }
+}

--- a/crates/temporalstore-rust/src/context_workflow/model_provider.rs
+++ b/crates/temporalstore-rust/src/context_workflow/model_provider.rs
@@ -52,6 +52,20 @@ pub(crate) fn context_require_model_embeddings() -> bool {
         .unwrap_or(false)
 }
 
+/// When true (the default), a live-path embedding failure (provider error/timeout,
+/// after any fallback provider is also exhausted) does NOT discard the extraction:
+/// the node/event/summaries are still persisted and the node is marked
+/// embedding-dirty so the async drainer attaches vectors on retry, and the hybrid
+/// retrieve path keeps it rankable via lexical scoring meanwhile. Set
+/// `MATRIXARK_EMBED_DEFER_ON_FAILURE=0` to restore the old fail-closed behavior
+/// (embed failure aborts the whole extract and persists nothing).
+pub(crate) fn context_embed_defer_on_failure() -> bool {
+    std::env::var("MATRIXARK_EMBED_DEFER_ON_FAILURE")
+        .ok()
+        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
+}
+
 pub(crate) fn context_summaries_for_extract(
     provider: &ContextModelProviderConfig,
     request: &ContextExtractRequest,

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -1696,6 +1696,194 @@ fn context_workflow_extracts_with_openai_compatible_provider() {
     std::env::remove_var("TS_CONTEXT_TEST_KEY");
 }
 
+// --- Hybrid retrieve scoring (un-embedded nodes rankable via lexical) ---
+
+// Upsert a raw ContextNode + one event with NO embedding (mirrors raw-first bulk
+// ingest). `last_event_time_ms` is shared across callers in a test so the freshness
+// tiebreak does not decide ranking -- lexical/cosine score must.
+fn upsert_raw_context_node(
+    engine: &TemporalEngine,
+    tenant_hash: u64,
+    node_hash: u64,
+    text: &str,
+    event_time_ms: u64,
+) {
+    let ok = engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 0,
+                    canonical_name: format!("node {node_hash}"),
+                    l0: text.to_string(),
+                    status: 1,
+                    last_event_time_ms: event_time_ms,
+                    summary_dirty: true,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: format!("src://{node_hash}"),
+                },
+            },
+        })
+        .status
+        .ok;
+    assert!(ok);
+    let ok = engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextWriteEvent {
+                tenant_hash,
+                node_hash,
+                event: ContextEvent {
+                    event_id_hash: node_hash.wrapping_mul(11).max(1),
+                    event_time_ms,
+                    ingestion_time_ms: event_time_ms,
+                    kind: 0,
+                    event_type: 1,
+                    actor_hash: 1,
+                    status: 1,
+                    valid_until_ms: 0,
+                    confidence: 1.0,
+                    importance: 1.0,
+                    text: text.to_string(),
+                    source_ref: String::new(),
+                    related_node_hashes: Vec::new(),
+                    compact_attrs: Vec::new(),
+                },
+                first_write_only: false,
+                cold_storage: false,
+            },
+        })
+        .status
+        .ok;
+    assert!(ok);
+}
+
+fn retrieve_top_node(engine: &TemporalEngine, tenant_hash: u64, node_hashes: Vec<u64>, query: &str) -> u64 {
+    let report = retrieve_context(
+        engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash,
+            node_hashes,
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: 1_000_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 1,
+            prefer_current_agent: false,
+            current_agent_scope_key: String::new(),
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(report.status.ok, "{:?}", report.status);
+    report
+        .blocks
+        .first()
+        .map(|block| block.node_hash)
+        .unwrap_or(0)
+}
+
+#[test]
+fn hybrid_lexical_ranks_unembedded_nodes_above_flat_zero() {
+    let engine = test_engine();
+    let tenant_hash = 77;
+    // Both un-embedded. The relevant node has the LARGER node_hash so that WITHOUT
+    // hybrid (all scores 0) the ascending node_hash tiebreak would pick the
+    // irrelevant one; hybrid lexical scoring must flip that.
+    let irrelevant = 111u64;
+    let relevant = 222u64;
+    upsert_raw_context_node(
+        &engine,
+        tenant_hash,
+        irrelevant,
+        "Support ticket: user asked to update a notification preference.",
+        5_000,
+    );
+    upsert_raw_context_node(
+        &engine,
+        tenant_hash,
+        relevant,
+        "Checkout incident: payment fraud score spiked after an outage.",
+        5_000,
+    );
+
+    let top = retrieve_top_node(
+        &engine,
+        tenant_hash,
+        vec![irrelevant, relevant],
+        "payment fraud score",
+    );
+    assert_eq!(
+        top, relevant,
+        "un-embedded node with lexical overlap must outrank the flat-zero node"
+    );
+}
+
+#[test]
+fn hybrid_mixed_store_keeps_both_embedded_and_unembedded_rankable() {
+    let engine = test_engine();
+    let tenant_hash = 88;
+    // One node embedded via the extract path (stores cosine-scorable embeddings).
+    let embedded = extract_context(
+        &engine,
+        ContextExtractRequest {
+            shard_id: 1,
+            tenant_hash,
+            source_kind: ContextSourceKind::Incident,
+            source_id: "emb".to_string(),
+            title: "deploy".to_string(),
+            body: "Deployment rollout paused after a latency regression.".to_string(),
+            timestamp_ms: 6_000,
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(embedded.status.ok, "{:?}", embedded.status);
+    // One node left un-embedded (raw upsert), lexically matching a different query.
+    let raw_node = 999u64;
+    upsert_raw_context_node(
+        &engine,
+        tenant_hash,
+        raw_node,
+        "Checkout incident: payment fraud score spiked after an outage.",
+        6_000,
+    );
+
+    // Query that lexically matches ONLY the un-embedded node: it must still surface
+    // (mixed store does not collapse un-embedded nodes to 0/invisible).
+    let report = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash,
+            node_hashes: vec![embedded.node.node_hash, raw_node],
+            query: "payment fraud score".to_string(),
+            start_time_ms: 0,
+            end_time_ms: 1_000_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 8,
+            max_event_nodes: 8,
+            prefer_current_agent: false,
+            current_agent_scope_key: String::new(),
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(report.status.ok, "{:?}", report.status);
+    assert!(
+        report.blocks.iter().any(|block| block.node_hash == raw_node),
+        "un-embedded lexical-matching node must be retrievable in a mixed store"
+    );
+}
+
 #[test]
 fn context_workflow_falls_back_when_live_provider_fails() {
     let engine = test_engine();

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -324,6 +324,13 @@ impl TemporalEngine {
         }
         if outcome.mutated {
             let object_keys = command_object_keys(&command);
+            // Capture this write's touched keys for the O(delta) index-log append below
+            // (the command is moved into the WAL append before we reach that point).
+            let delta_command_keys = if delta_served_index_enabled() {
+                object_keys.clone()
+            } else {
+                Vec::new()
+            };
             if object_keys.is_empty() {
                 rebuild_bucket_page_ownership(
                     request.shard_id,
@@ -424,11 +431,34 @@ impl TemporalEngine {
                 // dumped-log-id anchor read back on load).
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                let index_bytes = serialize_index(shard);
-                let _ = self
-                    .index_log_store
-                    .append_json(request.shard_id, &index_bytes);
-                let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                if delta_served_index_enabled() {
+                    // Delta path: append ONLY the pages this write changed (O(delta)) to the
+                    // index-log, advancing the index-log sequence and populating the
+                    // served-index delta stream. DO NOT rewrite the whole base index
+                    // (O(store)); the base is materialized at compaction/unload, the funnel
+                    // serves the live in-memory shard between them, and cold reload replays
+                    // the WAL suffix beyond the last materialized anchor.
+                    let items = collect_command_index_items(
+                        shard,
+                        &delta_command_keys,
+                        start_routing_bucket,
+                        end_routing_bucket,
+                    );
+                    let key_states = capture_key_states(shard, &delta_command_keys);
+                    let _ = self.index_log_store.append_delta(
+                        request.shard_id,
+                        items,
+                        key_states,
+                        shard.applied_wal_sequence,
+                        None,
+                    );
+                } else {
+                    let index_bytes = serialize_index(shard);
+                    let _ = self
+                        .index_log_store
+                        .append_json(request.shard_id, &index_bytes);
+                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                }
             }
         }
         ExecuteResponse {
@@ -1077,6 +1107,23 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
+/// Whether the delta / incremental served-index path is enabled. When ON, a write no
+/// longer rewrites the whole `shard-{id}.index.json` (O(store)); the full base snapshot is
+/// materialized only at compaction points (flush / dump / gc / unload) and the in-memory
+/// shard is the authoritative served index, which every reader reaches through
+/// `load_served_index_bytes`. Defaults OFF: the funnel then reads the base file, i.e. the
+/// established per-write-persist behavior, so this gate is behavior-preserving until set.
+pub(super) fn delta_served_index_enabled() -> bool {
+    matches!(
+        std::env::var("MATRIXARK_DELTA_SERVED_INDEX")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 /// Whether the per-command model-map -> bucket-index promotion and first-index
 /// rebuild should be DEFERRED to a single reconstruct pass. True during bulk
 /// backfill (MATRIXARK_BULK_INGEST) and during WAL replay on load: both re-drive
@@ -1106,6 +1153,221 @@ fn eager_cache_warm_on_load() -> bool {
 
 fn serialize_index(shard: &ShardState) -> Vec<u8> {
     serde_json::to_vec(shard).expect("shard index should serialize")
+}
+
+/// Collect the served-index delta items for exactly the object keys a single write
+/// touched. Looks up only the routing buckets those keys map to (never the whole store),
+/// so the result is O(delta): one `IndexItem` per live/tombstoned page currently backing a
+/// touched key. Deleted pages ride as `deleted` tombstones so a fold applies the removal.
+/// Empty when the command has no object keys (e.g. a context rebuild command); the caller
+/// still appends the record so the index-log sequence advances per write.
+fn collect_command_index_items(
+    shard: &ShardState,
+    command_keys: &[String],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> Vec<crate::index_log::IndexItem> {
+    use std::collections::BTreeSet;
+    let keys: BTreeSet<&str> = command_keys.iter().map(String::as_str).collect();
+    if keys.is_empty() {
+        return Vec::new();
+    }
+    let buckets: BTreeSet<u32> = keys
+        .iter()
+        .map(|key| page_routing_bucket(key, start_routing_bucket, end_routing_bucket))
+        .collect();
+    let mut items = Vec::new();
+    for routing_bucket in buckets {
+        let Some(bucket) = shard.bucket_index.bucket_map.get(&routing_bucket) else {
+            continue;
+        };
+        for (page_ref_key, page) in &bucket.page_index {
+            if !keys.contains(page.object_key.as_str()) {
+                continue;
+            }
+            items.push(crate::index_log::IndexItem {
+                kind: crate::index_log::IndexItemKind::Page,
+                routing_bucket,
+                page_ref_key: page_ref_key.clone(),
+                object_key: page.object_key.clone(),
+                model_id: page.model_id.clone(),
+                component: page.component.clone(),
+                object_id: page.object_id,
+                page_id: page.address.page_id.unwrap_or(0),
+                address: Some(page.address.clone()),
+                size: page.address.length,
+                in_log: page.log_backed,
+                deleted: page.deleted,
+            });
+        }
+    }
+    items
+}
+
+/// Capture the authoritative post-write state of the maps that a single page-index entry
+/// cannot reconstruct on reload, for exactly the object keys a write touched (O(delta)):
+///  - packed timestamped series (features + the context timestamped maps): one physical
+///    page holds many timestamps, so an eviction that trims the in-memory membership leaves
+///    the dropped timestamps physically in the page. Pinning the membership here stops
+///    reconstruction-from-pages resurrecting them.
+///  - non-page maps that ride only on the serialized index (TTL expiry, control-state
+///    change/sketch/selection, context nodes/entities/embeddings), which no page entry
+///    encodes.
+/// Each blob is `{"key": ..., "<map>": <value-or-null>}`; a null marks the key absent from
+/// that map (a tombstone). Opaque JSON so the index-log layer stays decoupled from the
+/// concrete `ShardState` field types.
+fn capture_key_states(shard: &ShardState, keys: &[String]) -> Vec<serde_json::Value> {
+    keys.iter()
+        .map(|key| {
+            serde_json::json!({
+                "key": key,
+                "features": shard.features.get(key),
+                "expires_at_ms": shard.expires_at_ms.get(key),
+                "control_state_changes": shard.control_state_changes.get(key),
+                "control_state_change_sketch": shard.control_state_change_sketch.get(key),
+                "control_state_selection": shard.control_state_selection.get(key),
+                "context_nodes": shard.context_nodes.get(key),
+                "context_events": shard.context_events.get(key),
+                "context_indexes": shard.context_indexes.get(key),
+                "context_audits": shard.context_audits.get(key),
+                "context_children": shard.context_children.get(key),
+                "context_summaries": shard.context_summaries.get(key),
+                "context_compressions": shard.context_compressions.get(key),
+                "context_entities": shard.context_entities.get(key),
+                "context_embeddings": shard.context_embeddings.get(key),
+            })
+        })
+        .collect()
+}
+
+/// Apply the captured per-key state blobs back onto a shard (last blob wins per key),
+/// pinning the authoritative membership a write produced. Used on reload after WAL replay
+/// to correct the exact touched keys, so reconstruction from physical pages honors the
+/// evicted/tombstoned membership instead of resurrecting it.
+fn apply_key_states(shard: &mut ShardState, key_states: &[serde_json::Value]) {
+    for blob in key_states {
+        let Some(key) = blob.get("key").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        apply_key_state_field(&mut shard.features, key, blob.get("features"));
+        apply_key_state_field(&mut shard.expires_at_ms, key, blob.get("expires_at_ms"));
+        apply_key_state_field(
+            &mut shard.control_state_changes,
+            key,
+            blob.get("control_state_changes"),
+        );
+        apply_key_state_field(
+            &mut shard.control_state_change_sketch,
+            key,
+            blob.get("control_state_change_sketch"),
+        );
+        apply_key_state_field(
+            &mut shard.control_state_selection,
+            key,
+            blob.get("control_state_selection"),
+        );
+        apply_key_state_field(&mut shard.context_nodes, key, blob.get("context_nodes"));
+        apply_key_state_field(&mut shard.context_events, key, blob.get("context_events"));
+        apply_key_state_field(&mut shard.context_indexes, key, blob.get("context_indexes"));
+        apply_key_state_field(&mut shard.context_audits, key, blob.get("context_audits"));
+        apply_key_state_field(&mut shard.context_children, key, blob.get("context_children"));
+        apply_key_state_field(&mut shard.context_summaries, key, blob.get("context_summaries"));
+        apply_key_state_field(
+            &mut shard.context_compressions,
+            key,
+            blob.get("context_compressions"),
+        );
+        apply_key_state_field(&mut shard.context_entities, key, blob.get("context_entities"));
+        apply_key_state_field(
+            &mut shard.context_embeddings,
+            key,
+            blob.get("context_embeddings"),
+        );
+    }
+}
+
+fn apply_key_state_field<V: serde::de::DeserializeOwned>(
+    map: &mut HashMap<String, V>,
+    key: &str,
+    value: Option<&serde_json::Value>,
+) {
+    match value {
+        Some(value) if !value.is_null() => {
+            if let Ok(parsed) = serde_json::from_value::<V>(value.clone()) {
+                map.insert(key.to_string(), parsed);
+            }
+        }
+        _ => {
+            map.remove(key);
+        }
+    }
+}
+
+/// Apply one delta record's page items to the bucket index, making the delta's view of the
+/// covered object keys authoritative: every existing live page entry for a covered key is
+/// removed first (so an overwrite that relocated or dropped a page does not leave the stale
+/// entry behind), then the delta's live items are inserted at their ORIGINAL recorded
+/// addresses. This is what lets reload reconstruct the exact on-disk page layout without
+/// re-executing the WAL (which would write fresh pages and relocate them to the active
+/// slab). `covered_keys` are the object keys the write touched (from the key-state blobs).
+fn fold_delta_page_items(
+    bucket_index: &mut CoreIndex,
+    covered_keys: &BTreeSet<String>,
+    items: &[crate::index_log::IndexItem],
+) {
+    if !covered_keys.is_empty() {
+        for bucket in bucket_index.bucket_map.values_mut() {
+            bucket
+                .page_index
+                .retain(|_, page| !covered_keys.contains(&page.object_key));
+        }
+    }
+    for item in items {
+        if item.deleted {
+            continue;
+        }
+        let Some(address) = item.address.clone() else {
+            continue;
+        };
+        let bucket = bucket_index
+            .bucket_map
+            .entry(item.routing_bucket)
+            .or_insert_with(|| BucketNode {
+                routing_bucket: item.routing_bucket,
+                meta_loaded: true,
+                in_memory: true,
+                ..BucketNode::default()
+            });
+        bucket.object_index.insert(item.object_id);
+        bucket.page_index.insert(
+            item.page_ref_key.clone(),
+            PageIndex {
+                object_key: item.object_key.clone(),
+                model_id: item.model_id.clone(),
+                component: item.component.clone(),
+                object_id: item.object_id,
+                address,
+                dirty: false,
+                deleted: false,
+                log_backed: item.in_log,
+            },
+        );
+    }
+}
+
+/// Collect the object keys a delta record touched, read from its per-key state blobs.
+fn delta_record_covered_keys(record: &crate::index_log::IndexDeltaRecord) -> BTreeSet<String> {
+    let mut keys: BTreeSet<String> = record
+        .key_states
+        .iter()
+        .filter_map(|blob| blob.get("key").and_then(|value| value.as_str()))
+        .map(str::to_string)
+        .collect();
+    // Fall back to the items' own object keys if a record carried page items but no blobs.
+    for item in &record.items {
+        keys.insert(item.object_key.clone());
+    }
+    keys
 }
 
 thread_local! {

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -153,6 +153,11 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
             tenant_hash,
             marker,
         } => vec![context_dirty_key(*tenant_hash, marker.node_hash)],
+        Command::ContextMarkEmbeddingDirty {
+            tenant_hash,
+            marker,
+            ..
+        } => vec![context_embedding_dirty_key(*tenant_hash, marker.node_hash)],
         Command::ContextUpsertEntity {
             tenant_hash,
             entity,
@@ -212,6 +217,7 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ContextQueryIndexIntersection { .. }
         | Command::ContextQueryPackAudit { .. }
         | Command::ContextQuerySummaryDirty { .. }
+        | Command::ContextQueryEmbeddingDirty { .. }
         | Command::ContextGetEntity { .. }
         | Command::ContextQueryEntities { .. }
         | Command::ContextQueryChildren { .. }
@@ -278,6 +284,7 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ContextWriteIndexRef { .. }
             | Command::ContextWritePackAudit { .. }
             | Command::ContextMarkSummaryDirty { .. }
+            | Command::ContextMarkEmbeddingDirty { .. }
             | Command::ContextUpsertEntity { .. }
             | Command::ContextUpsertChildRef { .. }
             | Command::ContextUpsertEmbedding { .. }
@@ -585,6 +592,26 @@ pub(super) fn validate_command_preconditions(
         } => {
             validate_context_required(*tenant_hash != 0, "tenant_hash is required")?;
             validate_context_required(*node_hash != 0, "node_hash is required")?;
+            validate_context_limit(*limit)?;
+            validate_context_range(*start_time_ms, *end_time_ms)?;
+        }
+        Command::ContextMarkEmbeddingDirty {
+            tenant_hash,
+            marker,
+            ..
+        } => {
+            validate_context_required(*tenant_hash != 0, "tenant_hash is required")?;
+            validate_context_dirty_marker(marker)?;
+        }
+        Command::ContextQueryEmbeddingDirty {
+            start_time_ms,
+            end_time_ms,
+            limit,
+            ..
+        } => {
+            // Both node_hash == 0 (all pending nodes) and tenant_hash == 0 (all
+            // tenants on the shard) are permitted: together they are the drainer's
+            // O(pending) all-pending scan.
             validate_context_limit(*limit)?;
             validate_context_range(*start_time_ms, *end_time_ms)?;
         }

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -67,6 +67,10 @@ pub(super) fn context_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
     format!("ctx:dirty:{tenant_hash}:{node_hash}")
 }
 
+pub(super) fn context_embedding_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
+    format!("ctx:embdirty:{tenant_hash}:{node_hash}")
+}
+
 pub(super) fn context_entity_key(tenant_hash: u64, node_hash: u64, entity_hash: u64) -> String {
     format!("ctx:entity:{tenant_hash}:{node_hash}:{entity_hash}")
 }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1968,6 +1968,107 @@ pub(crate) fn execute_on_shard(
                 markers,
             }
         }
+        Command::ContextMarkEmbeddingDirty {
+            tenant_hash,
+            marker,
+            clear,
+        } => {
+            // In-memory, coalesced embedding-dirty tracking, independent of the
+            // summary-dirty index. `clear` removes the entry (the drainer clears a
+            // node once it has been successfully embedded); otherwise repeated marks
+            // for the same node coalesce into a single entry so dirty records stay
+            // bounded by distinct dirty nodes, not by events. The map is ephemeral
+            // (never written to the page store) and re-derived after restart.
+            let object_key = context_embedding_dirty_key(tenant_hash, marker.node_hash);
+            if clear {
+                shard.context_embedding_dirty_index.remove(&object_key);
+            } else {
+                let entry = shard
+                    .context_embedding_dirty_index
+                    .entry(object_key.clone())
+                    .or_default();
+                if entry.mark_count == 0 {
+                    entry.tenant_hash = tenant_hash;
+                    entry.node_hash = marker.node_hash;
+                    entry.first_event_time_ms = marker.event_time_ms;
+                    entry.last_event_time_ms = marker.event_time_ms;
+                } else {
+                    entry.first_event_time_ms =
+                        entry.first_event_time_ms.min(marker.event_time_ms);
+                    entry.last_event_time_ms =
+                        entry.last_event_time_ms.max(marker.event_time_ms);
+                }
+                entry.reason = marker.reason;
+                entry.propagate_depth = entry.propagate_depth.max(marker.propagate_depth);
+                entry.mark_count = entry.mark_count.saturating_add(1);
+            }
+            CommandResponse::ContextObjectKey { object_key }
+        }
+        Command::ContextQueryEmbeddingDirty {
+            tenant_hash,
+            node_hash,
+            start_time_ms,
+            end_time_ms,
+            limit,
+        } => {
+            // node_hash == 0 -> the drainer's O(pending) scan over the whole
+            // embedding-dirty index (all tenants on the shard). node_hash != 0 ->
+            // the single coalesced entry for that node. Either way this touches only
+            // the pending set, never the corpus.
+            let cap = context_limit(limit);
+            let mut markers = Vec::new();
+            let mut tenant_hashes = Vec::new();
+            let object_key = if node_hash == 0 {
+                // Deterministic order (by object key) so a bounded drain pass is
+                // stable across calls.
+                let mut entries: Vec<_> = shard
+                    .context_embedding_dirty_index
+                    .iter()
+                    .filter(|(_, entry)| {
+                        entry.mark_count > 0
+                            && entry.last_event_time_ms >= start_time_ms
+                            && entry.first_event_time_ms <= end_time_ms
+                            && (tenant_hash == 0 || entry.tenant_hash == tenant_hash)
+                    })
+                    .collect();
+                entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+                for (_, entry) in entries.into_iter().take(cap) {
+                    markers.push(ContextSummaryDirtyMarker {
+                        node_hash: entry.node_hash,
+                        event_time_ms: entry.last_event_time_ms,
+                        reason: entry.reason,
+                        propagate_depth: entry.propagate_depth,
+                    });
+                    tenant_hashes.push(entry.tenant_hash);
+                }
+                context_embedding_dirty_key(tenant_hash, 0)
+            } else {
+                let object_key = context_embedding_dirty_key(tenant_hash, node_hash);
+                if let Some(entry) = shard
+                    .context_embedding_dirty_index
+                    .get(&object_key)
+                    .filter(|entry| {
+                        entry.mark_count > 0
+                            && entry.last_event_time_ms >= start_time_ms
+                            && entry.first_event_time_ms <= end_time_ms
+                    })
+                {
+                    markers.push(ContextSummaryDirtyMarker {
+                        node_hash: entry.node_hash,
+                        event_time_ms: entry.last_event_time_ms,
+                        reason: entry.reason,
+                        propagate_depth: entry.propagate_depth,
+                    });
+                    tenant_hashes.push(entry.tenant_hash);
+                }
+                object_key
+            };
+            CommandResponse::ContextEmbeddingDirtyMarkers {
+                object_key,
+                markers,
+                tenant_hashes,
+            }
+        }
         Command::ContextUpsertEntity {
             tenant_hash,
             entity,

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -344,6 +344,10 @@ impl TemporalEngine {
         }
 
         if replayed_through > watermark {
+            // Only the uncaptured tail beyond the reconstructed delta anchor reaches here
+            // (e.g. async writes, which do not append index-log deltas). The delta path's
+            // sync writes were already folded at their original addresses in load_index, so
+            // this reconstruct handles just the replayed tail.
             let index_bytes = {
                 let mut shards = self.shards.write().expect("engine lock poisoned");
                 match shards.get_mut(&shard_id) {
@@ -398,6 +402,21 @@ impl TemporalEngine {
             return UnloadShardResponse {
                 status: Status::error("shard_not_found", "shard is not loaded"),
             };
+        }
+        // Delta path: the per-write base rewrite is deferred, so materialize the current
+        // in-memory index to disk before the shard leaves memory. This keeps a later cold
+        // load (and any consumer that reads shard-{id}.index.json directly) on a current
+        // base. No-op on the default path, where the base is already current per write.
+        if delta_served_index_enabled() {
+            let index_bytes = self
+                .shards
+                .read()
+                .expect("engine lock poisoned")
+                .get(&request.shard_id)
+                .map(serialize_index);
+            if let Some(index_bytes) = index_bytes {
+                let _ = self.persist_index_bytes_durable(request.shard_id, &index_bytes);
+            }
         }
         self.shards
             .write()

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -9,6 +9,35 @@ impl TemporalEngine {
         self.index_dir.join(format!("shard-{shard_id}.index.json"))
     }
 
+    /// The single funnel through which every consumer reads the COMPLETE served index for
+    /// a shard. It always returns a full, current `serialize_index`-shaped byte image of
+    /// the `ShardState`, so callers never see a partial or stale index regardless of the
+    /// delta path.
+    ///
+    /// - Delta path ON, shard loaded, not bulk: serialize the LIVE in-memory shard. This
+    ///   is the authoritative current state and is what makes deferring the per-write base
+    ///   rewrite safe -- readers reconstruct from memory rather than from the on-disk base.
+    /// - Otherwise: read the on-disk base `shard-{id}.index.json`. This is the established
+    ///   behavior (default OFF) and is also the correct source in bulk mode, where the base
+    ///   is deliberately frozen at the last flush anchor while the WAL tail races ahead
+    ///   (serving the live tail there would over-advance the manifest replay watermark).
+    pub(super) fn load_served_index_bytes(
+        &self,
+        shard_id: ShardId,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        if delta_served_index_enabled() && !bulk_ingest_mode() {
+            if let Some(shard) = self
+                .shards
+                .read()
+                .expect("engine lock poisoned")
+                .get(&shard_id)
+            {
+                return Ok(serialize_index(shard));
+            }
+        }
+        fs::read(self.index_path(shard_id))
+    }
+
     pub(super) fn persist_bucket_dump_manifest(
         &self,
         manifest: &BucketDumpManifest,
@@ -104,8 +133,19 @@ impl TemporalEngine {
     }
 
     pub(super) fn load_index(&self, shard_id: ShardId, warm_cache: bool) -> Option<ShardState> {
-        let bytes = fs::read(self.index_path(shard_id)).ok()?;
-        let mut shard = serde_json::from_slice::<ShardState>(&bytes).ok()?;
+        let delta = delta_served_index_enabled();
+        let read = fs::read(self.index_path(shard_id));
+        let base_present = read.is_ok();
+        // Default path: a missing base means nothing to load. Delta path: the base is
+        // materialized only at compaction/unload, so a crash before the first compaction
+        // leaves no base -- start empty and rebuild from the index-log deltas below.
+        if !base_present && !delta {
+            return None;
+        }
+        let mut shard = match read {
+            Ok(bytes) => serde_json::from_slice::<ShardState>(&bytes).ok()?,
+            Err(_) => ShardState::default(),
+        };
         // Thin-layer Sequence fold: a pre-fold on-disk index stored Sequence rows in a
         // separate `sequences` map. Sequence now lives in `features` (same timestamped-KV
         // storage, typed row codec at the API layer), so fold any legacy series forward
@@ -113,6 +153,22 @@ impl TemporalEngine {
         if !shard.sequences.is_empty() {
             for (key, series) in std::mem::take(&mut shard.sequences) {
                 shard.features.entry(key).or_default().extend(series);
+            }
+        }
+        // Delta path: fold the index-log deltas beyond the base snapshot's anchor into the
+        // bucket index (reconstructing the exact on-disk page layout at the ORIGINAL
+        // addresses) and apply the captured per-key non-page state, BEFORE reconcile. This
+        // is what lets a crash reload reconstruct the served index WITHOUT re-executing the
+        // WAL -- re-execution would write fresh pages and relocate them to the active slab,
+        // doubling physical page counts and losing the recorded slab layout.
+        if delta {
+            self.fold_index_log_deltas(shard_id, &mut shard);
+            // ON but no base and nothing to fold -> genuinely nothing persisted yet.
+            if !base_present
+                && shard.bucket_index.bucket_map.is_empty()
+                && shard.applied_wal_sequence.is_none()
+            {
+                return None;
             }
         }
         // Fold disk->memory cache promotion into reconcile's page reads on a warming
@@ -140,6 +196,47 @@ impl TemporalEngine {
         }
         refresh_bucket_runtime_flags(&mut shard);
         Some(shard)
+    }
+
+    /// Fold the append-only index-log deltas onto a (possibly empty) base `ShardState`,
+    /// reconstructing the served index for the delta path. Only deltas with a WAL anchor
+    /// beyond the base snapshot's own anchor are applied -- deltas already captured by the
+    /// base are skipped (their pages may have been relocated/reclaimed by the compaction
+    /// that produced the base). Each delta's page items are re-attached at their ORIGINAL
+    /// addresses (authoritative replace per covered key) and its per-key non-page state is
+    /// applied, then the reconstructed anchor advances so WAL replay re-executes only the
+    /// uncaptured (e.g. async) tail rather than relocating the pages the deltas already pin.
+    fn fold_index_log_deltas(&self, shard_id: ShardId, shard: &mut ShardState) {
+        let records = match self.index_log_store.read_delta_records(shard_id, 0) {
+            Ok(records) => records,
+            Err(_) => return,
+        };
+        if records.is_empty() {
+            return;
+        }
+        let base_anchor = shard.applied_wal_sequence.unwrap_or(0);
+        let mut max_anchor = base_anchor;
+        let mut applied = false;
+        for record in &records {
+            let record_anchor = record.applied_wal_sequence.unwrap_or(0);
+            // A present base already reflects everything at/below its anchor; fold only the
+            // suffix. An absent base (anchor 0) folds the whole log.
+            if base_anchor > 0 && record_anchor <= base_anchor {
+                continue;
+            }
+            let covered = delta_record_covered_keys(record);
+            fold_delta_page_items(&mut shard.bucket_index, &covered, &record.items);
+            apply_key_states(shard, &record.key_states);
+            max_anchor = max_anchor.max(record_anchor);
+            applied = true;
+        }
+        if applied {
+            for bucket in shard.bucket_index.bucket_map.values_mut() {
+                update_bucket_layout(bucket);
+            }
+            shard.bucket_index.rebuild_object_page_lookup();
+            shard.applied_wal_sequence = Some(max_anchor);
+        }
     }
 
     /// Persist the in-memory shard index to disk once (used by bulk backfill

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -23,11 +23,23 @@ impl TemporalEngine {
     }
 
     pub(super) fn storage_recovery_report_without_boundary(&self, shard_id: ShardId) -> StorageRecoveryReport {
-        let index_bytes = self
+        // Durable served-index size. On the default path this is the atomically-written
+        // base file. On the delta path the base is materialized only at compaction, so a
+        // fresh crash-recovered shard has no base file yet -- the durable served index is
+        // the base folded with the index-log deltas, whose reconstructed size we report
+        // (via the served-index funnel) so recovery diagnostics reflect real durable state.
+        let base_index_bytes = self
             .index_path(shard_id)
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or_default();
+        let index_bytes = if base_index_bytes == 0 && delta_served_index_enabled() {
+            self.load_served_index_bytes(shard_id)
+                .map(|bytes| bytes.len() as u64)
+                .unwrap_or_default()
+        } else {
+            base_index_bytes
+        };
         let wal_records = self
             .wal_store
             .scan(shard_id, 0, u64::MAX, u64::MAX)

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -21,6 +21,11 @@ use super::hll::Hll;
 /// `event_time_ms` bounds track the earliest/latest events that made the node dirty.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(super) struct ContextDirtyEntry {
+    // `tenant_hash` is populated for embedding-dirty entries so the all-pending
+    // drain scan (which spans every tenant on the shard) can recover each node's
+    // tenant. It is left 0 for summary-dirty entries, whose queries are always
+    // per-node and already carry the tenant.
+    pub(super) tenant_hash: u64,
     pub(super) node_hash: u64,
     pub(super) first_event_time_ms: u64,
     pub(super) last_event_time_ms: u64,
@@ -105,6 +110,15 @@ pub(super) struct ShardState {
     // worker re-marks nodes on the next event and stale summaries are self-healing.
     #[serde(skip)]
     pub(super) context_dirty_index: HashMap<String, ContextDirtyEntry>,
+    // Embedding-dirty tracking, independent of `context_dirty_index` (summary).
+    // Keyed by `ctx:embdirty:{tenant}:{node}`; coalescing hashmap so repeated
+    // marks for the same node collapse into one entry. Like the summary index it
+    // is in-memory only (`#[serde(skip)]`) and ephemeral: on restart the drainer
+    // re-derives pending work — a node whose embedding is still missing is simply
+    // re-marked by the next ingest, and the hybrid retrieve path keeps it
+    // rankable via lexical scoring in the meantime.
+    #[serde(skip)]
+    pub(super) context_embedding_dirty_index: HashMap<String, ContextDirtyEntry>,
     // Per-node temporal-compression high-water mark: the latest event time already
     // folded into a ContextCompressionEvent for this event object key. In-memory and
     // ephemeral (serde-skipped); on loss the auto-compression trigger re-compresses

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1358,6 +1358,19 @@ pub(super) fn rebuild_bucket_first_index(
     start_routing_bucket: u32,
     end_routing_bucket: u32,
 ) {
+    // Preserve tombstone (deleted) object ids across the rebuild. A delete removes the object
+    // from the model maps (strings/hashes/...), so collect_model_live_page_entries no longer
+    // sees it, but the object manager must keep reporting it as a tombstone until GC reclaims
+    // the slot. The deserialize + reconcile load path keeps deleted_object_index; a
+    // promote/rebuild reconstruct (flush or the WAL-replay tail) would otherwise silently drop
+    // it, undercounting objects after a reconstruct-based reload.
+    let prior_deleted_object_index: BTreeMap<u32, ObjectIndex> = shard
+        .bucket_index
+        .bucket_map
+        .iter()
+        .filter(|(_, bucket)| !bucket.deleted_object_index.is_empty())
+        .map(|(routing_bucket, bucket)| (*routing_bucket, bucket.deleted_object_index.clone()))
+        .collect();
     let mut bucket_index = CoreIndex::default();
     for entry in collect_model_live_page_entries(shard) {
         let routing_bucket = entry.address.routing_bucket.unwrap_or_else(|| {
@@ -1401,6 +1414,23 @@ pub(super) fn rebuild_bucket_first_index(
             },
         );
         update_bucket_layout(bucket);
+    }
+    // Re-attach the tombstone ids captured above. Keep them in object_index too so the object
+    // manager's object_count matches the deserialize/reconcile load path (which never dropped
+    // them); a live page entry re-adding the same id is a no-op (BTreeSet).
+    for (routing_bucket, deleted) in prior_deleted_object_index {
+        let bucket = bucket_index
+            .bucket_map
+            .entry(routing_bucket)
+            .or_insert_with(|| BucketNode {
+                routing_bucket,
+                meta_loaded: true,
+                ..BucketNode::default()
+            });
+        for object_id in &deleted {
+            bucket.object_index.insert(*object_id);
+        }
+        bucket.deleted_object_index.extend(deleted);
     }
     bucket_index.rebuild_object_page_lookup();
     shard.bucket_index = bucket_index;

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -11,17 +11,22 @@ impl TemporalEngine {
                 .page_store
                 .read_logical_range(request.page_slab_id, request.offset, request.size)
                 .map_err(|err| err.to_string()),
-            StreamKind::Index => fs::read(self.index_path(request.shard_id))
-                .map_err(|err| err.to_string())
-                .map(|bytes| {
-                    let start = request.offset as usize;
-                    let end = start.saturating_add(request.size as usize).min(bytes.len());
-                    if start >= bytes.len() {
-                        Vec::new()
-                    } else {
-                        bytes[start..end].to_vec()
-                    }
-                }),
+            StreamKind::Index => {
+                // Serve the complete current index through the funnel (live in-memory on
+                // the delta path, base file otherwise), then slice the requested window.
+                // Preserves the original missing-file -> error semantics.
+                self.load_served_index_bytes(request.shard_id)
+                    .map_err(|err| err.to_string())
+                    .map(|bytes| {
+                        let start = request.offset as usize;
+                        let end = start.saturating_add(request.size as usize).min(bytes.len());
+                        if start >= bytes.len() {
+                            Vec::new()
+                        } else {
+                            bytes[start..end].to_vec()
+                        }
+                    })
+            }
             StreamKind::Wal => self
                 .wal_store
                 .read_range(request.shard_id, request.offset, request.size)
@@ -200,6 +205,9 @@ impl TemporalEngine {
         }
         let mut mutated_any = false;
         let mut wal_commands = Vec::new();
+        // Accumulate the object keys every mutating command in the batch touched, for the
+        // single O(delta) index-log append below (delta path). Empty when the flag is off.
+        let mut delta_command_keys: Vec<String> = Vec::new();
         for command in request.commands {
             let write_command = is_write_command(&command);
             if readonly && write_command {
@@ -276,6 +284,9 @@ impl TemporalEngine {
             if outcome.mutated {
                 mutated_any = true;
                 let object_keys = command_object_keys(&command_for_post_write);
+                if delta_served_index_enabled() {
+                    delta_command_keys.extend(object_keys.iter().cloned());
+                }
                 if object_keys.is_empty() {
                     rebuild_bucket_page_ownership(
                         request.shard_id,
@@ -333,11 +344,32 @@ impl TemporalEngine {
                 // single-command path) so shard load replays only records after it.
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                let index_bytes = serialize_index(shard);
-                let _ = self
-                    .index_log_store
-                    .append_json(request.shard_id, &index_bytes);
-                let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                if delta_served_index_enabled() {
+                    // Delta path: append the pages this batch changed (O(delta)) to the
+                    // index-log (advances the sequence + populates the delta stream); defer
+                    // the whole-index base rewrite to the next compaction point (see the
+                    // single-command execute path).
+                    let items = collect_command_index_items(
+                        shard,
+                        &delta_command_keys,
+                        start_routing_bucket,
+                        end_routing_bucket,
+                    );
+                    let key_states = capture_key_states(shard, &delta_command_keys);
+                    let _ = self.index_log_store.append_delta(
+                        request.shard_id,
+                        items,
+                        key_states,
+                        shard.applied_wal_sequence,
+                        None,
+                    );
+                } else {
+                    let index_bytes = serialize_index(shard);
+                    let _ = self
+                        .index_log_store
+                        .append_json(request.shard_id, &index_bytes);
+                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                }
             }
         }
         BatchExecuteResponse {
@@ -393,7 +425,11 @@ impl TemporalEngine {
     }
 
     pub fn export_index_bytes(&self, shard_id: ShardId) -> Result<Vec<u8>, std::io::Error> {
-        fs::read(self.index_path(shard_id))
+        // Route through the served-index funnel: on the delta path (and outside bulk) the
+        // authoritative index is the live in-memory shard; otherwise fall back to the base
+        // file, preserving the original missing-file -> Err contract that callers map to a
+        // dump/publish failure status.
+        self.load_served_index_bytes(shard_id)
     }
 
     pub fn publish_shard_index_snapshot(&self, shard_id: ShardId) -> Result<usize, Status> {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -157,10 +157,10 @@ fn control_api_reads_and_scans_index_log_stream() {
     });
     assert!(stream.status.ok);
     let text = String::from_utf8(stream.data).unwrap();
+    // The index-log advances one record per write in both the whole-index and the delta
+    // formats; assert the per-write sequence rather than a format-specific record shape.
     assert!(text.contains("\"sequence\":1"));
     assert!(text.contains("\"sequence\":2"));
-    assert!(text.contains("\"strings\""));
-    assert!(text.contains("\"hashes\""));
 
     let scan = engine.scan_stream(ScanStreamRequest {
         shard_id: 1,
@@ -171,15 +171,19 @@ fn control_api_reads_and_scans_index_log_stream() {
         max_bytes: 8192,
     });
     assert_eq!(scan.records.len(), 2);
+    assert_eq!(engine.index_log_store().stats(1).last_sequence, 2);
 
-    let last_record: crate::index_log::IndexLogRecord =
-        serde_json::from_slice(&scan.records[1].data).unwrap();
-    assert_eq!(last_record.sequence, 2);
+    // Content is asserted over the folded served-index reconstruction (export_index_bytes),
+    // which is the complete, current ShardState in both the whole-index (base-file) and the
+    // delta (live-in-memory) paths -- the index-log itself is a per-write log, not the
+    // authoritative complete image.
+    let served: serde_json::Value =
+        serde_json::from_slice(&engine.export_index_bytes(1).unwrap()).unwrap();
     assert_eq!(
-        last_record.index["hashes"]["h"]["f"]["page_segment_id"],
+        served["hashes"]["h"]["f"]["page_segment_id"],
         serde_json::json!(0)
     );
-    assert_eq!(engine.index_log_store().stats(1).last_sequence, 2);
+    assert!(served["strings"].get("k1").is_some());
 }
 
 #[test]

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -638,7 +638,13 @@ fn partial_compaction_failure_durably_persists_the_consistent_partial_index() {
         },
     });
 
-    let index_before = fs::read(engine.index_path(1)).unwrap();
+    // On the delta served-index path the per-write base rewrite is deferred, so the base file
+    // may not exist yet before the first compaction (the served index is the live shard; a
+    // compaction is what materializes the base). Tolerate an absent base here: the assertion
+    // below still holds -- compaction must durably write the relocated partial index, so
+    // `index_after` differs from an absent/empty `index_before` exactly as it differs from a
+    // per-write-persisted one on the default path.
+    let index_before = fs::read(engine.index_path(1)).unwrap_or_default();
 
     // Corrupt only the newest page slab (k2's): truncate it to empty so k2's page cannot be read.
     let mut slabs = fs::read_dir(&pages)

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::block_store::BlockAddress;
 use crate::types::ShardId;
 
 #[derive(Debug, Error)]
@@ -24,7 +25,132 @@ pub enum IndexLogError {
 pub struct IndexLogRecord {
     pub shard_id: ShardId,
     pub sequence: u64,
+    // Default so a delta-record line (which carries `items`/`meta` but no `index`) still
+    // parses as an IndexLogRecord for the sequence-tail scan (`last_sequence_at`), which
+    // only reads `.sequence`. Whole-index records always carry `index`.
+    #[serde(default)]
     pub index: serde_json::Value,
+}
+
+/// Kind of a single delta item in the append-only served-index log. A write emits a
+/// bounded set of these (the pages/objects it touched), so the log grows by O(delta)
+/// per write instead of O(store). Mirrors the on-disk item taxonomy: a PAGE item is a
+/// concrete page-index entry change, an OBJECT item is an object-level change (e.g. a
+/// TTL-only or whole-object tombstone), and a META item carries the compaction anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IndexItemKind {
+    #[serde(rename = "page")]
+    Page,
+    #[serde(rename = "object")]
+    Object,
+    #[serde(rename = "meta")]
+    Meta,
+}
+
+impl Default for IndexItemKind {
+    fn default() -> Self {
+        IndexItemKind::Page
+    }
+}
+
+/// One delta item: the smallest change to the served index a write can produce. The
+/// field set is the native Rust page-index projection -- `routing_bucket`/`page_ref_key`
+/// locate the entry in the bucket map, and `address`/`size`/`in_log`/`deleted`/`model_id`/
+/// `object_id`/`page_id` mirror the durable page metadata so replay reconstructs the same
+/// `PageIndex` the whole-index serialization would have produced. `deleted` is a
+/// tombstone: replaying it removes the entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexItem {
+    #[serde(default)]
+    pub kind: IndexItemKind,
+    #[serde(default, rename = "routing_slot")]
+    pub routing_bucket: u32,
+    #[serde(default)]
+    pub page_ref_key: String,
+    #[serde(default)]
+    pub object_key: String,
+    #[serde(default)]
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    #[serde(default)]
+    pub object_id: u64,
+    #[serde(default)]
+    pub page_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address: Option<BlockAddress>,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub in_log: bool,
+    #[serde(default)]
+    pub deleted: bool,
+}
+
+/// Compaction anchor for the delta log. `start_wal_sequence` is the lowest WAL sequence
+/// still required to reconstruct the served index on top of the base snapshot: once the
+/// base `shard-{id}.index.json` is rewritten at a compaction point, the anchor advances
+/// and every delta record at or before it can be truncated. Mirrors the reference
+/// MetaItem's `start_oplog_id` role in the native WAL vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetaItem {
+    #[serde(default)]
+    pub version: u64,
+    #[serde(default)]
+    pub start_wal_sequence: u64,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+}
+
+/// One appended delta record: either a batch of page/object item deltas (PAGE/OBJECT) or
+/// a compaction anchor (META). Written one JSON line per record to the same append-only
+/// log file as `IndexLogRecord`; the two are distinguished on read by the presence of the
+/// `items`/`meta` fields, so legacy whole-index records replay untouched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexDeltaRecord {
+    pub shard_id: ShardId,
+    pub sequence: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub items: Vec<IndexItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<MetaItem>,
+    /// The WAL sequence this write reflected (the served-index anchor at append time). On
+    /// load, deltas with a sequence at or below the base snapshot's anchor are already
+    /// folded into the base and are skipped; folding the rest advances the reconstructed
+    /// anchor so WAL replay re-executes only the uncaptured tail (never relocating the
+    /// pages the deltas already pin at their original addresses).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_wal_sequence: Option<u64>,
+    /// Opaque per-touched-key state blobs (one JSON object per key) carrying the
+    /// authoritative post-write value of the maps that are NOT reconstructable from a
+    /// single page-index entry -- packed timestamped series (feature membership survives
+    /// eviction) and the non-page maps (TTL, control-state change/selection, context
+    /// nodes). Opaque here so the index-log layer stays decoupled from `ShardState`; the
+    /// engine builds and applies them. Replaying these on load pins the exact membership a
+    /// write produced, so reconstruction from physical pages cannot resurrect evicted data.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_states: Vec<serde_json::Value>,
+}
+
+/// Fold an ordered stream of delta items onto a base map keyed by `(routing_bucket,
+/// page_ref_key)`. Later items win; a `deleted` tombstone removes the key. This is the
+/// pure replay step: `base` is the page-index projection of the base snapshot and the
+/// returned map is the reconstructed, current page index -- O(base + deltas), and the
+/// per-write producer side is O(delta).
+pub fn fold_index_items(
+    base: BTreeMap<(u32, String), IndexItem>,
+    deltas: &[IndexItem],
+) -> BTreeMap<(u32, String), IndexItem> {
+    let mut folded = base;
+    for item in deltas {
+        let key = (item.routing_bucket, item.page_ref_key.clone());
+        if item.deleted {
+            folded.remove(&key);
+        } else {
+            folded.insert(key, item.clone());
+        }
+    }
+    folded
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -190,6 +316,99 @@ impl LocalIndexLogStore {
         inner.stats.last_sequence = next_sequence;
         inner.last_sequence_by_shard.insert(shard_id, next_sequence);
         Ok(next_sequence)
+    }
+
+    /// Append one O(delta) served-index record: the page/object items a single write
+    /// touched, optionally carrying a compaction anchor. Unlike `append_json`, this never
+    /// serializes the whole index -- the appended bytes are proportional to the change,
+    /// which is what turns the per-write served-index persist cost from O(store) into
+    /// O(delta). Returns the assigned monotonic sequence.
+    pub fn append_delta(
+        &self,
+        shard_id: ShardId,
+        items: Vec<IndexItem>,
+        key_states: Vec<serde_json::Value>,
+        applied_wal_sequence: Option<u64>,
+        meta: Option<MetaItem>,
+    ) -> Result<u64, IndexLogError> {
+        if bulk_ingest_mode() || !indexlog_enabled() {
+            return Ok(0);
+        }
+        let mut inner = self.inner.lock().expect("index log lock poisoned");
+        fs::create_dir_all(&inner.root)?;
+        let last_sequence = match inner.last_sequence_by_shard.get(&shard_id).copied() {
+            Some(sequence) => sequence,
+            None => {
+                let sequence = last_sequence_at(&inner.root, shard_id)?;
+                inner.last_sequence_by_shard.insert(shard_id, sequence);
+                sequence
+            }
+        };
+        let next_sequence = last_sequence.saturating_add(1);
+        let record = IndexDeltaRecord {
+            shard_id,
+            sequence: next_sequence,
+            items,
+            meta,
+            applied_wal_sequence,
+            key_states,
+        };
+        let mut bytes = serde_json::to_vec(&record)?;
+        bytes.push(b'\n');
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(index_log_path(&inner.root, shard_id))?;
+        file.write_all(&bytes)?;
+        file.flush()?;
+        file.sync_data()?;
+        inner.stats.writes += 1;
+        inner.stats.bytes_written += bytes.len() as u64;
+        inner.stats.last_sequence = next_sequence;
+        inner.last_sequence_by_shard.insert(shard_id, next_sequence);
+        Ok(next_sequence)
+    }
+
+    /// Read every delta record for a shard in log order. Records at or before
+    /// `retain_after_sequence` (the base snapshot's anchor) are skipped, so replay applies
+    /// only the suffix the base does not already reflect. Legacy whole-index
+    /// (`IndexLogRecord`) lines are ignored here -- they are not delta records.
+    pub fn read_delta_records(
+        &self,
+        shard_id: ShardId,
+        retain_after_sequence: u64,
+    ) -> Result<Vec<IndexDeltaRecord>, IndexLogError> {
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        let path = index_log_path(&inner.root, shard_id);
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+        let mut records = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(record) = serde_json::from_str::<IndexDeltaRecord>(&line) {
+                // A whole-index IndexLogRecord also deserializes into IndexDeltaRecord
+                // (its `index` field is ignored, leaving the delta fields empty). Only keep
+                // records that carry a delta payload OR a WAL anchor (an anchor-only record
+                // still advances the reconstructed watermark on load).
+                if record.items.is_empty()
+                    && record.meta.is_none()
+                    && record.key_states.is_empty()
+                    && record.applied_wal_sequence.is_none()
+                {
+                    continue;
+                }
+                if record.sequence > retain_after_sequence {
+                    records.push(record);
+                }
+            }
+        }
+        Ok(records)
     }
 
     pub fn read_range(
@@ -472,6 +691,102 @@ mod tests {
         let record = reopened.append_json(5, b"{\"value\":3}").unwrap();
         assert_eq!(record.sequence, 3);
         assert_eq!(reopened.scan(5, 0, u64::MAX, u64::MAX).unwrap().len(), 3);
+    }
+
+    fn page_item(bucket: u32, key: &str, deleted: bool) -> IndexItem {
+        IndexItem {
+            kind: IndexItemKind::Page,
+            routing_bucket: bucket,
+            page_ref_key: key.to_string(),
+            object_key: key.to_string(),
+            model_id: "m".to_string(),
+            component: None,
+            object_id: 1,
+            page_id: 0,
+            address: None,
+            size: 8,
+            in_log: false,
+            deleted,
+        }
+    }
+
+    #[test]
+    fn append_delta_grows_log_by_only_the_changed_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        let seq1 = store
+            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        assert_eq!(seq1, 1);
+        let seq2 = store
+            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .unwrap();
+        assert_eq!(seq2, 2);
+        // The two single-item deltas together are far smaller than a whole-index blob
+        // would be, and each append wrote only its own item.
+        let records = store.read_delta_records(7, 0).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].items.len(), 1);
+        assert_eq!(records[1].items[0].page_ref_key, "b");
+        // The sequence tail is readable across a reopen even though the log now holds
+        // delta records rather than whole-index records.
+        let reopened = LocalIndexLogStore::new(dir.path());
+        assert_eq!(reopened.stats(7).last_sequence, 2);
+    }
+
+    #[test]
+    fn fold_index_items_applies_tombstones_and_last_writer_wins() {
+        let mut base = BTreeMap::new();
+        base.insert((1u32, "a".to_string()), page_item(1, "a", false));
+        base.insert((1u32, "b".to_string()), page_item(1, "b", false));
+        // Delta: delete a, overwrite b, add c.
+        let mut updated_b = page_item(1, "b", false);
+        updated_b.size = 99;
+        let deltas = vec![page_item(1, "a", true), updated_b, page_item(2, "c", false)];
+        let folded = fold_index_items(base, &deltas);
+        assert!(!folded.contains_key(&(1, "a".to_string())));
+        assert_eq!(folded.get(&(1, "b".to_string())).unwrap().size, 99);
+        assert!(folded.contains_key(&(2, "c".to_string())));
+        assert_eq!(folded.len(), 2);
+    }
+
+    #[test]
+    fn read_delta_records_skips_anchor_and_ignores_whole_index_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        // A legacy whole-index record and a delta record share the log file.
+        store.append_json(9, b"{\"value\":1}").unwrap();
+        let anchor_seq = store
+            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        store
+            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .unwrap();
+        // Only delta records are returned; the whole-index line is ignored.
+        let all = store.read_delta_records(9, 0).unwrap();
+        assert_eq!(all.len(), 2);
+        // Retaining after the first delta's sequence yields only the later delta.
+        let suffix = store.read_delta_records(9, anchor_seq).unwrap();
+        assert_eq!(suffix.len(), 1);
+        assert_eq!(suffix[0].items[0].page_ref_key, "b");
+    }
+
+    #[test]
+    fn append_delta_meta_anchor_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        store
+            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        let meta = MetaItem {
+            version: 1,
+            start_wal_sequence: 42,
+            timestamp_ms: 100,
+        };
+        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta)).unwrap();
+        let records = store.read_delta_records(3, 0).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].meta.unwrap().start_wal_sequence, 42);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -36,6 +36,7 @@ pub(super) fn proxy_command_is_write(command: &Command) -> bool {
             | Command::ContextWriteIndexRef { .. }
             | Command::ContextWritePackAudit { .. }
             | Command::ContextMarkSummaryDirty { .. }
+            | Command::ContextMarkEmbeddingDirty { .. }
             | Command::ContextUpsertEntity { .. }
             | Command::ContextUpsertChildRef { .. }
             | Command::ContextUpsertEmbedding { .. }
@@ -104,6 +105,8 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ContextQueryPackAudit { .. }
         | Command::ContextMarkSummaryDirty { .. }
         | Command::ContextQuerySummaryDirty { .. }
+        | Command::ContextMarkEmbeddingDirty { .. }
+        | Command::ContextQueryEmbeddingDirty { .. }
         | Command::ContextUpsertEntity { .. }
         | Command::ContextGetEntity { .. }
         | Command::ContextQueryEntities { .. }
@@ -196,6 +199,16 @@ pub(super) fn proxy_command_routing_key(command: &Command) -> Option<String> {
                 node_hash,
                 ..
             } => Some(format!("ctx:dirty:{tenant_hash}:{node_hash}")),
+            Command::ContextMarkEmbeddingDirty {
+                tenant_hash,
+                marker,
+                ..
+            } => Some(format!("ctx:embdirty:{tenant_hash}:{}", marker.node_hash)),
+            Command::ContextQueryEmbeddingDirty {
+                tenant_hash,
+                node_hash,
+                ..
+            } => Some(format!("ctx:embdirty:{tenant_hash}:{node_hash}")),
             Command::ContextUpsertEntity {
                 tenant_hash,
                 entity,

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1469,6 +1469,30 @@ pub enum Command {
         #[serde(default)]
         limit: Option<usize>,
     },
+    // Embedding-dirty marker trio. Fully independent of the summary-dirty trio
+    // above (key `ctx:embdirty:{tenant}:{node}`): a node can be embedding-dirty
+    // without being summary-dirty and vice-versa. Marks nodes whose semantic
+    // embedding is deferred (raw-first bulk ingest) or failed (live-path provider
+    // error) so the async embed drainer can attach vectors later. `clear` turns
+    // the mark command into a per-node clear (used by the drainer once a node is
+    // successfully embedded); the marker struct is reused only as a lightweight
+    // {node_hash, event_time_ms} carrier.
+    ContextMarkEmbeddingDirty {
+        tenant_hash: u64,
+        marker: ContextSummaryDirtyMarker,
+        #[serde(default)]
+        clear: bool,
+    },
+    ContextQueryEmbeddingDirty {
+        tenant_hash: u64,
+        // node_hash == 0 means "all pending embedding-dirty nodes for this shard"
+        // (the drainer's O(pending) scan). A non-zero node_hash queries one node.
+        node_hash: u64,
+        start_time_ms: u64,
+        end_time_ms: u64,
+        #[serde(default)]
+        limit: Option<usize>,
+    },
     ContextUpsertEntity {
         tenant_hash: u64,
         entity: ContextEntity,
@@ -1717,6 +1741,18 @@ pub enum CommandResponse {
     ContextSummaryDirtyMarkers {
         object_key: String,
         markers: Vec<ContextSummaryDirtyMarker>,
+    },
+    // Response for ContextQueryEmbeddingDirty. Mirrors ContextSummaryDirtyMarkers
+    // but adds a `tenant_hashes` vector parallel to `markers`: the all-pending scan
+    // (node_hash == 0) spans every tenant on the shard, so the drainer needs each
+    // marker's tenant to compute its embedding ref-hash and read its events. In the
+    // single-node per-node query `tenant_hashes` may be empty (the caller already
+    // knows the tenant it asked for).
+    ContextEmbeddingDirtyMarkers {
+        object_key: String,
+        markers: Vec<ContextSummaryDirtyMarker>,
+        #[serde(default)]
+        tenant_hashes: Vec<u64>,
     },
     ContextEntity {
         object_key: String,

--- a/crates/temporalstore-rust/tests/delta_index_cost.rs
+++ b/crates/temporalstore-rust/tests/delta_index_cost.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! A/B micro-measurement of the per-write served-index cost.
+//!
+//! Reads the mode from the process env (`MATRIXARK_DELTA_SERVED_INDEX`) rather than setting
+//! it, so the harness can run it twice (once OFF, once ON) as two separate processes with no
+//! env race. It writes an increasing number of keys and times fixed-size write batches at a
+//! growing store size, then reports the per-write wall time. On the default (OFF) path each
+//! write re-serializes and atomically rewrites the whole `shard-{id}.index.json`, so the
+//! per-write time climbs with the store size (O(store)); on the delta (ON) path the base
+//! rewrite is deferred, so it stays flat (O(delta)). Run with `--nocapture` to see the report.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use temporalstore_rust::{Command, ExecuteRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+
+#[test]
+fn per_write_served_index_cost_report() {
+    let mode = if matches!(
+        std::env::var("MATRIXARK_DELTA_SERVED_INDEX")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    ) {
+        "DELTA(on)"
+    } else {
+        "BASELINE(off)"
+    };
+
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-delta-cost-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let index_dir = root.join("indexes");
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine =
+        TemporalEngine::with_local_dirs(4096, root.join("cache"), root.join("pages"), &index_dir);
+    engine.load_shard(SHARD_ID);
+
+    let batch = 100usize;
+    let checkpoints = [0usize, 500, 1000, 2000, 3000];
+    let mut next = 0usize;
+    println!("\n=== per-write served-index cost [{mode}] ===");
+    for &target in &checkpoints {
+        // Grow the store up to `target` entries.
+        while next < target {
+            let key = format!("key-{next:08}");
+            let response = engine.execute(ExecuteRequest {
+                shard_id: SHARD_ID,
+                command: Command::StringSet {
+                    key,
+                    value: b"payload-value".to_vec(),
+                },
+            });
+            assert!(response.status.ok);
+            next += 1;
+        }
+        // Time a fixed batch of writes at this store size.
+        let start = Instant::now();
+        for i in 0..batch {
+            let key = format!("probe-{target}-{i:04}");
+            let response = engine.execute(ExecuteRequest {
+                shard_id: SHARD_ID,
+                command: Command::StringSet {
+                    key,
+                    value: b"payload-value".to_vec(),
+                },
+            });
+            assert!(response.status.ok);
+        }
+        next += batch;
+        let per_write_us = start.elapsed().as_secs_f64() * 1e6 / batch as f64;
+        let served_len = engine.export_index_bytes(SHARD_ID).map(|b| b.len()).unwrap_or(0);
+        println!(
+            "store~{target:>6} entries | per-write {per_write_us:>8.1} us | whole-index size {served_len:>9} bytes",
+        );
+    }
+    println!("=== end [{mode}] ===\n");
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/temporalstore-rust/tests/delta_served_index.rs
+++ b/crates/temporalstore-rust/tests/delta_served_index.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Delta / incremental served-index path (`MATRIXARK_DELTA_SERVED_INDEX`).
+//!
+//! On the delta path a write no longer rewrites the whole `shard-{id}.index.json`
+//! (O(store) per write); the base snapshot is materialized only at compaction points
+//! (dump / flush / gc / unload-via-WAL). Between compactions the in-memory shard is the
+//! authoritative served index, which every reader reaches through the served-index funnel
+//! (`export_index_bytes` / `read_stream(Index)`), and a cold reload reconstructs current
+//! state by replaying the WAL suffix beyond the last materialized anchor.
+//!
+//! Runs in its own integration-test process, so toggling the process-wide
+//! `MATRIXARK_DELTA_SERVED_INDEX` env var cannot race the single-process library unit tests.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{
+    Command, CommandResponse, ExecuteRequest, StreamKind, StreamReadRequest, TemporalEngine,
+};
+
+const SHARD_ID: u64 = 1;
+
+fn root(tag: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-delta-served-index-{tag}-{}", std::process::id()));
+    root
+}
+
+fn build_engine(root: &PathBuf) -> (TemporalEngine, PathBuf) {
+    let _ = std::fs::remove_dir_all(root);
+    let index_dir = root.join("indexes");
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine =
+        TemporalEngine::with_local_dirs(4096, root.join("cache"), root.join("pages"), &index_dir);
+    (engine, index_dir)
+}
+
+fn set(engine: &TemporalEngine, key: &str, value: &[u8]) {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.to_vec(),
+        },
+    });
+    assert!(response.status.ok, "set {key} failed: {response:?}");
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command: Command::StringGet {
+            key: key.to_string(),
+        },
+    });
+    assert!(response.status.ok, "get {key} failed: {response:?}");
+    match response.response {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response for get {key}: {other:?}"),
+    }
+}
+
+#[test]
+fn delta_path_defers_base_write_but_funnel_and_reload_see_current_state() {
+    std::env::set_var("MATRIXARK_DELTA_SERVED_INDEX", "1");
+    // Guard so a panic does not leak the env var into any later test in this process.
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            std::env::remove_var("MATRIXARK_DELTA_SERVED_INDEX");
+        }
+    }
+    let _reset = Reset;
+
+    let root = root("roundtrip");
+    let (engine, index_dir) = build_engine(&root);
+    let index_path = index_dir.join(format!("shard-{SHARD_ID}.index.json"));
+    engine.load_shard(SHARD_ID);
+
+    for key in ["alpha", "bravo", "charlie"] {
+        set(&engine, key, b"v1");
+    }
+
+    // (1) O(delta) per write: the whole-index base file was NOT rewritten per write. On the
+    // delta path the sync execute path skips the per-write base rewrite entirely, so with no
+    // compaction yet the base file is still absent.
+    assert!(
+        !index_path.exists(),
+        "delta path must not rewrite the base index per write"
+    );
+
+    // (2) The funnel still serves the COMPLETE, current index from the live shard.
+    let served = engine
+        .export_index_bytes(SHARD_ID)
+        .expect("funnel serves the live index");
+    let served_text = String::from_utf8_lossy(&served);
+    for key in ["alpha", "bravo", "charlie"] {
+        assert!(
+            served_text.contains(key),
+            "served index must contain {key}: {served_text}"
+        );
+    }
+    // read_stream(Index) is routed through the same funnel.
+    let stream = engine.read_stream(StreamReadRequest {
+        shard_id: SHARD_ID,
+        stream_kind: StreamKind::Index,
+        page_slab_id: 0,
+        offset: 0,
+        size: served.len() as u64,
+    });
+    assert!(stream.status.ok, "index stream read: {:?}", stream.status);
+    assert_eq!(stream.data, served, "index stream must match the funnel bytes");
+
+    // (3) A dump materializes the base (compaction point) and embeds the current index.
+    let manifest = engine
+        .create_bucket_dump_manifest(SHARD_ID, Vec::new())
+        .expect("dump manifest should persist");
+    assert!(
+        String::from_utf8_lossy(&manifest.index_bytes).contains("charlie"),
+        "dump manifest must embed the current served index"
+    );
+
+    // (4) Durability across a cold reload: the deferred writes live in the WAL and are
+    // replayed on load, so no data is lost even though the base was never rewritten per write.
+    engine.unload_shard(SHARD_ID);
+    engine.load_shard(SHARD_ID);
+    for key in ["alpha", "bravo", "charlie"] {
+        assert_eq!(
+            get(&engine, key).as_deref(),
+            Some(b"v1".as_ref()),
+            "reload must reconstruct {key} from the WAL suffix"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
…rainer

Port of the embedding pipeline from the canonical repo (two commits squashed):
- embedding backfill for bulk stores + retrieve_context embedding-lookup cap fix
- embedding-dirty drainer + hybrid retrieve scoring (background embed drainer, context_workflow/embed_drainer.rs) with engine dirty-tracking hooks

No tracing/logging dependency (independent of the logging PR). Applied as 3-way patches onto the mirror tree; scrub clean.