### PR TITLE
perf(engine): incremental delta served-index (O(delta) per-write, gated)

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -324,6 +324,13 @@ impl TemporalEngine {
         }
         if outcome.mutated {
             let object_keys = command_object_keys(&command);
+            // Capture this write's touched keys for the O(delta) index-log append below
+            // (the command is moved into the WAL append before we reach that point).
+            let delta_command_keys = if delta_served_index_enabled() {
+                object_keys.clone()
+            } else {
+                Vec::new()
+            };
             if object_keys.is_empty() {
                 rebuild_bucket_page_ownership(
                     request.shard_id,
@@ -424,11 +431,34 @@ impl TemporalEngine {
                 // dumped-log-id anchor read back on load).
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                let index_bytes = serialize_index(shard);
-                let _ = self
-                    .index_log_store
-                    .append_json(request.shard_id, &index_bytes);
-                let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                if delta_served_index_enabled() {
+                    // Delta path: append ONLY the pages this write changed (O(delta)) to the
+                    // index-log, advancing the index-log sequence and populating the
+                    // served-index delta stream. DO NOT rewrite the whole base index
+                    // (O(store)); the base is materialized at compaction/unload, the funnel
+                    // serves the live in-memory shard between them, and cold reload replays
+                    // the WAL suffix beyond the last materialized anchor.
+                    let items = collect_command_index_items(
+                        shard,
+                        &delta_command_keys,
+                        start_routing_bucket,
+                        end_routing_bucket,
+                    );
+                    let key_states = capture_key_states(shard, &delta_command_keys);
+                    let _ = self.index_log_store.append_delta(
+                        request.shard_id,
+                        items,
+                        key_states,
+                        shard.applied_wal_sequence,
+                        None,
+                    );
+                } else {
+                    let index_bytes = serialize_index(shard);
+                    let _ = self
+                        .index_log_store
+                        .append_json(request.shard_id, &index_bytes);
+                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                }
             }
         }
         ExecuteResponse {
@@ -1077,6 +1107,23 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
+/// Whether the delta / incremental served-index path is enabled. When ON, a write no
+/// longer rewrites the whole `shard-{id}.index.json` (O(store)); the full base snapshot is
+/// materialized only at compaction points (flush / dump / gc / unload) and the in-memory
+/// shard is the authoritative served index, which every reader reaches through
+/// `load_served_index_bytes`. Defaults OFF: the funnel then reads the base file, i.e. the
+/// established per-write-persist behavior, so this gate is behavior-preserving until set.
+pub(super) fn delta_served_index_enabled() -> bool {
+    matches!(
+        std::env::var("MATRIXARK_DELTA_SERVED_INDEX")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 /// Whether the per-command model-map -> bucket-index promotion and first-index
 /// rebuild should be DEFERRED to a single reconstruct pass. True during bulk
 /// backfill (MATRIXARK_BULK_INGEST) and during WAL replay on load: both re-drive
@@ -1106,6 +1153,221 @@ fn eager_cache_warm_on_load() -> bool {
 
 fn serialize_index(shard: &ShardState) -> Vec<u8> {
     serde_json::to_vec(shard).expect("shard index should serialize")
+}
+
+/// Collect the served-index delta items for exactly the object keys a single write
+/// touched. Looks up only the routing buckets those keys map to (never the whole store),
+/// so the result is O(delta): one `IndexItem` per live/tombstoned page currently backing a
+/// touched key. Deleted pages ride as `deleted` tombstones so a fold applies the removal.
+/// Empty when the command has no object keys (e.g. a context rebuild command); the caller
+/// still appends the record so the index-log sequence advances per write.
+fn collect_command_index_items(
+    shard: &ShardState,
+    command_keys: &[String],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> Vec<crate::index_log::IndexItem> {
+    use std::collections::BTreeSet;
+    let keys: BTreeSet<&str> = command_keys.iter().map(String::as_str).collect();
+    if keys.is_empty() {
+        return Vec::new();
+    }
+    let buckets: BTreeSet<u32> = keys
+        .iter()
+        .map(|key| page_routing_bucket(key, start_routing_bucket, end_routing_bucket))
+        .collect();
+    let mut items = Vec::new();
+    for routing_bucket in buckets {
+        let Some(bucket) = shard.bucket_index.bucket_map.get(&routing_bucket) else {
+            continue;
+        };
+        for (page_ref_key, page) in &bucket.page_index {
+            if !keys.contains(page.object_key.as_str()) {
+                continue;
+            }
+            items.push(crate::index_log::IndexItem {
+                kind: crate::index_log::IndexItemKind::Page,
+                routing_bucket,
+                page_ref_key: page_ref_key.clone(),
+                object_key: page.object_key.clone(),
+                model_id: page.model_id.clone(),
+                component: page.component.clone(),
+                object_id: page.object_id,
+                page_id: page.address.page_id.unwrap_or(0),
+                address: Some(page.address.clone()),
+                size: page.address.length,
+                in_log: page.log_backed,
+                deleted: page.deleted,
+            });
+        }
+    }
+    items
+}
+
+/// Capture the authoritative post-write state of the maps that a single page-index entry
+/// cannot reconstruct on reload, for exactly the object keys a write touched (O(delta)):
+///  - packed timestamped series (features + the context timestamped maps): one physical
+///    page holds many timestamps, so an eviction that trims the in-memory membership leaves
+///    the dropped timestamps physically in the page. Pinning the membership here stops
+///    reconstruction-from-pages resurrecting them.
+///  - non-page maps that ride only on the serialized index (TTL expiry, control-state
+///    change/sketch/selection, context nodes/entities/embeddings), which no page entry
+///    encodes.
+/// Each blob is `{"key": ..., "<map>": <value-or-null>}`; a null marks the key absent from
+/// that map (a tombstone). Opaque JSON so the index-log layer stays decoupled from the
+/// concrete `ShardState` field types.
+fn capture_key_states(shard: &ShardState, keys: &[String]) -> Vec<serde_json::Value> {
+    keys.iter()
+        .map(|key| {
+            serde_json::json!({
+                "key": key,
+                "features": shard.features.get(key),
+                "expires_at_ms": shard.expires_at_ms.get(key),
+                "control_state_changes": shard.control_state_changes.get(key),
+                "control_state_change_sketch": shard.control_state_change_sketch.get(key),
+                "control_state_selection": shard.control_state_selection.get(key),
+                "context_nodes": shard.context_nodes.get(key),
+                "context_events": shard.context_events.get(key),
+                "context_indexes": shard.context_indexes.get(key),
+                "context_audits": shard.context_audits.get(key),
+                "context_children": shard.context_children.get(key),
+                "context_summaries": shard.context_summaries.get(key),
+                "context_compressions": shard.context_compressions.get(key),
+                "context_entities": shard.context_entities.get(key),
+                "context_embeddings": shard.context_embeddings.get(key),
+            })
+        })
+        .collect()
+}
+
+/// Apply the captured per-key state blobs back onto a shard (last blob wins per key),
+/// pinning the authoritative membership a write produced. Used on reload after WAL replay
+/// to correct the exact touched keys, so reconstruction from physical pages honors the
+/// evicted/tombstoned membership instead of resurrecting it.
+fn apply_key_states(shard: &mut ShardState, key_states: &[serde_json::Value]) {
+    for blob in key_states {
+        let Some(key) = blob.get("key").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        apply_key_state_field(&mut shard.features, key, blob.get("features"));
+        apply_key_state_field(&mut shard.expires_at_ms, key, blob.get("expires_at_ms"));
+        apply_key_state_field(
+            &mut shard.control_state_changes,
+            key,
+            blob.get("control_state_changes"),
+        );
+        apply_key_state_field(
+            &mut shard.control_state_change_sketch,
+            key,
+            blob.get("control_state_change_sketch"),
+        );
+        apply_key_state_field(
+            &mut shard.control_state_selection,
+            key,
+            blob.get("control_state_selection"),
+        );
+        apply_key_state_field(&mut shard.context_nodes, key, blob.get("context_nodes"));
+        apply_key_state_field(&mut shard.context_events, key, blob.get("context_events"));
+        apply_key_state_field(&mut shard.context_indexes, key, blob.get("context_indexes"));
+        apply_key_state_field(&mut shard.context_audits, key, blob.get("context_audits"));
+        apply_key_state_field(&mut shard.context_children, key, blob.get("context_children"));
+        apply_key_state_field(&mut shard.context_summaries, key, blob.get("context_summaries"));
+        apply_key_state_field(
+            &mut shard.context_compressions,
+            key,
+            blob.get("context_compressions"),
+        );
+        apply_key_state_field(&mut shard.context_entities, key, blob.get("context_entities"));
+        apply_key_state_field(
+            &mut shard.context_embeddings,
+            key,
+            blob.get("context_embeddings"),
+        );
+    }
+}
+
+fn apply_key_state_field<V: serde::de::DeserializeOwned>(
+    map: &mut HashMap<String, V>,
+    key: &str,
+    value: Option<&serde_json::Value>,
+) {
+    match value {
+        Some(value) if !value.is_null() => {
+            if let Ok(parsed) = serde_json::from_value::<V>(value.clone()) {
+                map.insert(key.to_string(), parsed);
+            }
+        }
+        _ => {
+            map.remove(key);
+        }
+    }
+}
+
+/// Apply one delta record's page items to the bucket index, making the delta's view of the
+/// covered object keys authoritative: every existing live page entry for a covered key is
+/// removed first (so an overwrite that relocated or dropped a page does not leave the stale
+/// entry behind), then the delta's live items are inserted at their ORIGINAL recorded
+/// addresses. This is what lets reload reconstruct the exact on-disk page layout without
+/// re-executing the WAL (which would write fresh pages and relocate them to the active
+/// slab). `covered_keys` are the object keys the write touched (from the key-state blobs).
+fn fold_delta_page_items(
+    bucket_index: &mut CoreIndex,
+    covered_keys: &BTreeSet<String>,
+    items: &[crate::index_log::IndexItem],
+) {
+    if !covered_keys.is_empty() {
+        for bucket in bucket_index.bucket_map.values_mut() {
+            bucket
+                .page_index
+                .retain(|_, page| !covered_keys.contains(&page.object_key));
+        }
+    }
+    for item in items {
+        if item.deleted {
+            continue;
+        }
+        let Some(address) = item.address.clone() else {
+            continue;
+        };
+        let bucket = bucket_index
+            .bucket_map
+            .entry(item.routing_bucket)
+            .or_insert_with(|| BucketNode {
+                routing_bucket: item.routing_bucket,
+                meta_loaded: true,
+                in_memory: true,
+                ..BucketNode::default()
+            });
+        bucket.object_index.insert(item.object_id);
+        bucket.page_index.insert(
+            item.page_ref_key.clone(),
+            PageIndex {
+                object_key: item.object_key.clone(),
+                model_id: item.model_id.clone(),
+                component: item.component.clone(),
+                object_id: item.object_id,
+                address,
+                dirty: false,
+                deleted: false,
+                log_backed: item.in_log,
+            },
+        );
+    }
+}
+
+/// Collect the object keys a delta record touched, read from its per-key state blobs.
+fn delta_record_covered_keys(record: &crate::index_log::IndexDeltaRecord) -> BTreeSet<String> {
+    let mut keys: BTreeSet<String> = record
+        .key_states
+        .iter()
+        .filter_map(|blob| blob.get("key").and_then(|value| value.as_str()))
+        .map(str::to_string)
+        .collect();
+    // Fall back to the items' own object keys if a record carried page items but no blobs.
+    for item in &record.items {
+        keys.insert(item.object_key.clone());
+    }
+    keys
 }
 
 thread_local! {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -344,6 +344,10 @@ impl TemporalEngine {
         }
 
         if replayed_through > watermark {
+            // Only the uncaptured tail beyond the reconstructed delta anchor reaches here
+            // (e.g. async writes, which do not append index-log deltas). The delta path's
+            // sync writes were already folded at their original addresses in load_index, so
+            // this reconstruct handles just the replayed tail.
             let index_bytes = {
                 let mut shards = self.shards.write().expect("engine lock poisoned");
                 match shards.get_mut(&shard_id) {
@@ -398,6 +402,21 @@ impl TemporalEngine {
             return UnloadShardResponse {
                 status: Status::error("shard_not_found", "shard is not loaded"),
             };
+        }
+        // Delta path: the per-write base rewrite is deferred, so materialize the current
+        // in-memory index to disk before the shard leaves memory. This keeps a later cold
+        // load (and any consumer that reads shard-{id}.index.json directly) on a current
+        // base. No-op on the default path, where the base is already current per write.
+        if delta_served_index_enabled() {
+            let index_bytes = self
+                .shards
+                .read()
+                .expect("engine lock poisoned")
+                .get(&request.shard_id)
+                .map(serialize_index);
+            if let Some(index_bytes) = index_bytes {
+                let _ = self.persist_index_bytes_durable(request.shard_id, &index_bytes);
+            }
         }
         self.shards
             .write()

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -9,6 +9,35 @@ impl TemporalEngine {
         self.index_dir.join(format!("shard-{shard_id}.index.json"))
     }
 
+    /// The single funnel through which every consumer reads the COMPLETE served index for
+    /// a shard. It always returns a full, current `serialize_index`-shaped byte image of
+    /// the `ShardState`, so callers never see a partial or stale index regardless of the
+    /// delta path.
+    ///
+    /// - Delta path ON, shard loaded, not bulk: serialize the LIVE in-memory shard. This
+    ///   is the authoritative current state and is what makes deferring the per-write base
+    ///   rewrite safe -- readers reconstruct from memory rather than from the on-disk base.
+    /// - Otherwise: read the on-disk base `shard-{id}.index.json`. This is the established
+    ///   behavior (default OFF) and is also the correct source in bulk mode, where the base
+    ///   is deliberately frozen at the last flush anchor while the WAL tail races ahead
+    ///   (serving the live tail there would over-advance the manifest replay watermark).
+    pub(super) fn load_served_index_bytes(
+        &self,
+        shard_id: ShardId,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        if delta_served_index_enabled() && !bulk_ingest_mode() {
+            if let Some(shard) = self
+                .shards
+                .read()
+                .expect("engine lock poisoned")
+                .get(&shard_id)
+            {
+                return Ok(serialize_index(shard));
+            }
+        }
+        fs::read(self.index_path(shard_id))
+    }
+
     pub(super) fn persist_bucket_dump_manifest(
         &self,
         manifest: &BucketDumpManifest,
@@ -104,8 +133,19 @@ impl TemporalEngine {
     }
 
     pub(super) fn load_index(&self, shard_id: ShardId, warm_cache: bool) -> Option<ShardState> {
-        let bytes = fs::read(self.index_path(shard_id)).ok()?;
-        let mut shard = serde_json::from_slice::<ShardState>(&bytes).ok()?;
+        let delta = delta_served_index_enabled();
+        let read = fs::read(self.index_path(shard_id));
+        let base_present = read.is_ok();
+        // Default path: a missing base means nothing to load. Delta path: the base is
+        // materialized only at compaction/unload, so a crash before the first compaction
+        // leaves no base -- start empty and rebuild from the index-log deltas below.
+        if !base_present && !delta {
+            return None;
+        }
+        let mut shard = match read {
+            Ok(bytes) => serde_json::from_slice::<ShardState>(&bytes).ok()?,
+            Err(_) => ShardState::default(),
+        };
         // Thin-layer Sequence fold: a pre-fold on-disk index stored Sequence rows in a
         // separate `sequences` map. Sequence now lives in `features` (same timestamped-KV
         // storage, typed row codec at the API layer), so fold any legacy series forward
@@ -113,6 +153,22 @@ impl TemporalEngine {
         if !shard.sequences.is_empty() {
             for (key, series) in std::mem::take(&mut shard.sequences) {
                 shard.features.entry(key).or_default().extend(series);
+            }
+        }
+        // Delta path: fold the index-log deltas beyond the base snapshot's anchor into the
+        // bucket index (reconstructing the exact on-disk page layout at the ORIGINAL
+        // addresses) and apply the captured per-key non-page state, BEFORE reconcile. This
+        // is what lets a crash reload reconstruct the served index WITHOUT re-executing the
+        // WAL -- re-execution would write fresh pages and relocate them to the active slab,
+        // doubling physical page counts and losing the recorded slab layout.
+        if delta {
+            self.fold_index_log_deltas(shard_id, &mut shard);
+            // ON but no base and nothing to fold -> genuinely nothing persisted yet.
+            if !base_present
+                && shard.bucket_index.bucket_map.is_empty()
+                && shard.applied_wal_sequence.is_none()
+            {
+                return None;
             }
         }
         // Fold disk->memory cache promotion into reconcile's page reads on a warming
@@ -140,6 +196,47 @@ impl TemporalEngine {
         }
         refresh_bucket_runtime_flags(&mut shard);
         Some(shard)
+    }
+
+    /// Fold the append-only index-log deltas onto a (possibly empty) base `ShardState`,
+    /// reconstructing the served index for the delta path. Only deltas with a WAL anchor
+    /// beyond the base snapshot's own anchor are applied -- deltas already captured by the
+    /// base are skipped (their pages may have been relocated/reclaimed by the compaction
+    /// that produced the base). Each delta's page items are re-attached at their ORIGINAL
+    /// addresses (authoritative replace per covered key) and its per-key non-page state is
+    /// applied, then the reconstructed anchor advances so WAL replay re-executes only the
+    /// uncaptured (e.g. async) tail rather than relocating the pages the deltas already pin.
+    fn fold_index_log_deltas(&self, shard_id: ShardId, shard: &mut ShardState) {
+        let records = match self.index_log_store.read_delta_records(shard_id, 0) {
+            Ok(records) => records,
+            Err(_) => return,
+        };
+        if records.is_empty() {
+            return;
+        }
+        let base_anchor = shard.applied_wal_sequence.unwrap_or(0);
+        let mut max_anchor = base_anchor;
+        let mut applied = false;
+        for record in &records {
+            let record_anchor = record.applied_wal_sequence.unwrap_or(0);
+            // A present base already reflects everything at/below its anchor; fold only the
+            // suffix. An absent base (anchor 0) folds the whole log.
+            if base_anchor > 0 && record_anchor <= base_anchor {
+                continue;
+            }
+            let covered = delta_record_covered_keys(record);
+            fold_delta_page_items(&mut shard.bucket_index, &covered, &record.items);
+            apply_key_states(shard, &record.key_states);
+            max_anchor = max_anchor.max(record_anchor);
+            applied = true;
+        }
+        if applied {
+            for bucket in shard.bucket_index.bucket_map.values_mut() {
+                update_bucket_layout(bucket);
+            }
+            shard.bucket_index.rebuild_object_page_lookup();
+            shard.applied_wal_sequence = Some(max_anchor);
+        }
     }
 
     /// Persist the in-memory shard index to disk once (used by bulk backfill

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -23,11 +23,23 @@ impl TemporalEngine {
     }
 
     pub(super) fn storage_recovery_report_without_boundary(&self, shard_id: ShardId) -> StorageRecoveryReport {
-        let index_bytes = self
+        // Durable served-index size. On the default path this is the atomically-written
+        // base file. On the delta path the base is materialized only at compaction, so a
+        // fresh crash-recovered shard has no base file yet -- the durable served index is
+        // the base folded with the index-log deltas, whose reconstructed size we report
+        // (via the served-index funnel) so recovery diagnostics reflect real durable state.
+        let base_index_bytes = self
             .index_path(shard_id)
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or_default();
+        let index_bytes = if base_index_bytes == 0 && delta_served_index_enabled() {
+            self.load_served_index_bytes(shard_id)
+                .map(|bytes| bytes.len() as u64)
+                .unwrap_or_default()
+        } else {
+            base_index_bytes
+        };
         let wal_records = self
             .wal_store
             .scan(shard_id, 0, u64::MAX, u64::MAX)

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1358,6 +1358,19 @@ pub(super) fn rebuild_bucket_first_index(
     start_routing_bucket: u32,
     end_routing_bucket: u32,
 ) {
+    // Preserve tombstone (deleted) object ids across the rebuild. A delete removes the object
+    // from the model maps (strings/hashes/...), so collect_model_live_page_entries no longer
+    // sees it, but the object manager must keep reporting it as a tombstone until GC reclaims
+    // the slot. The deserialize + reconcile load path keeps deleted_object_index; a
+    // promote/rebuild reconstruct (flush or the WAL-replay tail) would otherwise silently drop
+    // it, undercounting objects after a reconstruct-based reload.
+    let prior_deleted_object_index: BTreeMap<u32, ObjectIndex> = shard
+        .bucket_index
+        .bucket_map
+        .iter()
+        .filter(|(_, bucket)| !bucket.deleted_object_index.is_empty())
+        .map(|(routing_bucket, bucket)| (*routing_bucket, bucket.deleted_object_index.clone()))
+        .collect();
     let mut bucket_index = CoreIndex::default();
     for entry in collect_model_live_page_entries(shard) {
         let routing_bucket = entry.address.routing_bucket.unwrap_or_else(|| {
@@ -1401,6 +1414,23 @@ pub(super) fn rebuild_bucket_first_index(
             },
         );
         update_bucket_layout(bucket);
+    }
+    // Re-attach the tombstone ids captured above. Keep them in object_index too so the object
+    // manager's object_count matches the deserialize/reconcile load path (which never dropped
+    // them); a live page entry re-adding the same id is a no-op (BTreeSet).
+    for (routing_bucket, deleted) in prior_deleted_object_index {
+        let bucket = bucket_index
+            .bucket_map
+            .entry(routing_bucket)
+            .or_insert_with(|| BucketNode {
+                routing_bucket,
+                meta_loaded: true,
+                ..BucketNode::default()
+            });
+        for object_id in &deleted {
+            bucket.object_index.insert(*object_id);
+        }
+        bucket.deleted_object_index.extend(deleted);
     }
     bucket_index.rebuild_object_page_lookup();
     shard.bucket_index = bucket_index;

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -11,17 +11,22 @@ impl TemporalEngine {
                 .page_store
                 .read_logical_range(request.page_slab_id, request.offset, request.size)
                 .map_err(|err| err.to_string()),
-            StreamKind::Index => fs::read(self.index_path(request.shard_id))
-                .map_err(|err| err.to_string())
-                .map(|bytes| {
-                    let start = request.offset as usize;
-                    let end = start.saturating_add(request.size as usize).min(bytes.len());
-                    if start >= bytes.len() {
-                        Vec::new()
-                    } else {
-                        bytes[start..end].to_vec()
-                    }
-                }),
+            StreamKind::Index => {
+                // Serve the complete current index through the funnel (live in-memory on
+                // the delta path, base file otherwise), then slice the requested window.
+                // Preserves the original missing-file -> error semantics.
+                self.load_served_index_bytes(request.shard_id)
+                    .map_err(|err| err.to_string())
+                    .map(|bytes| {
+                        let start = request.offset as usize;
+                        let end = start.saturating_add(request.size as usize).min(bytes.len());
+                        if start >= bytes.len() {
+                            Vec::new()
+                        } else {
+                            bytes[start..end].to_vec()
+                        }
+                    })
+            }
             StreamKind::Wal => self
                 .wal_store
                 .read_range(request.shard_id, request.offset, request.size)
@@ -200,6 +205,9 @@ impl TemporalEngine {
         }
         let mut mutated_any = false;
         let mut wal_commands = Vec::new();
+        // Accumulate the object keys every mutating command in the batch touched, for the
+        // single O(delta) index-log append below (delta path). Empty when the flag is off.
+        let mut delta_command_keys: Vec<String> = Vec::new();
         for command in request.commands {
             let write_command = is_write_command(&command);
             if readonly && write_command {
@@ -276,6 +284,9 @@ impl TemporalEngine {
             if outcome.mutated {
                 mutated_any = true;
                 let object_keys = command_object_keys(&command_for_post_write);
+                if delta_served_index_enabled() {
+                    delta_command_keys.extend(object_keys.iter().cloned());
+                }
                 if object_keys.is_empty() {
                     rebuild_bucket_page_ownership(
                         request.shard_id,
@@ -333,11 +344,32 @@ impl TemporalEngine {
                 // single-command path) so shard load replays only records after it.
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                let index_bytes = serialize_index(shard);
-                let _ = self
-                    .index_log_store
-                    .append_json(request.shard_id, &index_bytes);
-                let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                if delta_served_index_enabled() {
+                    // Delta path: append the pages this batch changed (O(delta)) to the
+                    // index-log (advances the sequence + populates the delta stream); defer
+                    // the whole-index base rewrite to the next compaction point (see the
+                    // single-command execute path).
+                    let items = collect_command_index_items(
+                        shard,
+                        &delta_command_keys,
+                        start_routing_bucket,
+                        end_routing_bucket,
+                    );
+                    let key_states = capture_key_states(shard, &delta_command_keys);
+                    let _ = self.index_log_store.append_delta(
+                        request.shard_id,
+                        items,
+                        key_states,
+                        shard.applied_wal_sequence,
+                        None,
+                    );
+                } else {
+                    let index_bytes = serialize_index(shard);
+                    let _ = self
+                        .index_log_store
+                        .append_json(request.shard_id, &index_bytes);
+                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
+                }
             }
         }
         BatchExecuteResponse {
@@ -393,7 +425,11 @@ impl TemporalEngine {
     }
 
     pub fn export_index_bytes(&self, shard_id: ShardId) -> Result<Vec<u8>, std::io::Error> {
-        fs::read(self.index_path(shard_id))
+        // Route through the served-index funnel: on the delta path (and outside bulk) the
+        // authoritative index is the live in-memory shard; otherwise fall back to the base
+        // file, preserving the original missing-file -> Err contract that callers map to a
+        // dump/publish failure status.
+        self.load_served_index_bytes(shard_id)
     }
 
     pub fn publish_shard_index_snapshot(&self, shard_id: ShardId) -> Result<usize, Status> {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -157,10 +157,10 @@ fn control_api_reads_and_scans_index_log_stream() {
     });
     assert!(stream.status.ok);
     let text = String::from_utf8(stream.data).unwrap();
+    // The index-log advances one record per write in both the whole-index and the delta
+    // formats; assert the per-write sequence rather than a format-specific record shape.
     assert!(text.contains("\"sequence\":1"));
     assert!(text.contains("\"sequence\":2"));
-    assert!(text.contains("\"strings\""));
-    assert!(text.contains("\"hashes\""));
 
     let scan = engine.scan_stream(ScanStreamRequest {
         shard_id: 1,
@@ -171,15 +171,19 @@ fn control_api_reads_and_scans_index_log_stream() {
         max_bytes: 8192,
     });
     assert_eq!(scan.records.len(), 2);
+    assert_eq!(engine.index_log_store().stats(1).last_sequence, 2);
 
-    let last_record: crate::index_log::IndexLogRecord =
-        serde_json::from_slice(&scan.records[1].data).unwrap();
-    assert_eq!(last_record.sequence, 2);
+    // Content is asserted over the folded served-index reconstruction (export_index_bytes),
+    // which is the complete, current ShardState in both the whole-index (base-file) and the
+    // delta (live-in-memory) paths -- the index-log itself is a per-write log, not the
+    // authoritative complete image.
+    let served: serde_json::Value =
+        serde_json::from_slice(&engine.export_index_bytes(1).unwrap()).unwrap();
     assert_eq!(
-        last_record.index["hashes"]["h"]["f"]["page_segment_id"],
+        served["hashes"]["h"]["f"]["page_segment_id"],
         serde_json::json!(0)
     );
-    assert_eq!(engine.index_log_store().stats(1).last_sequence, 2);
+    assert!(served["strings"].get("k1").is_some());
 }
 
 #[test]

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -638,7 +638,13 @@ fn partial_compaction_failure_durably_persists_the_consistent_partial_index() {
         },
     });
 
-    let index_before = fs::read(engine.index_path(1)).unwrap();
+    // On the delta served-index path the per-write base rewrite is deferred, so the base file
+    // may not exist yet before the first compaction (the served index is the live shard; a
+    // compaction is what materializes the base). Tolerate an absent base here: the assertion
+    // below still holds -- compaction must durably write the relocated partial index, so
+    // `index_after` differs from an absent/empty `index_before` exactly as it differs from a
+    // per-write-persisted one on the default path.
+    let index_before = fs::read(engine.index_path(1)).unwrap_or_default();
 
     // Corrupt only the newest page slab (k2's): truncate it to empty so k2's page cannot be read.
     let mut slabs = fs::read_dir(&pages)

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::block_store::BlockAddress;
 use crate::types::ShardId;
 
 #[derive(Debug, Error)]
@@ -24,7 +25,132 @@ pub enum IndexLogError {
 pub struct IndexLogRecord {
     pub shard_id: ShardId,
     pub sequence: u64,
+    // Default so a delta-record line (which carries `items`/`meta` but no `index`) still
+    // parses as an IndexLogRecord for the sequence-tail scan (`last_sequence_at`), which
+    // only reads `.sequence`. Whole-index records always carry `index`.
+    #[serde(default)]
     pub index: serde_json::Value,
+}
+
+/// Kind of a single delta item in the append-only served-index log. A write emits a
+/// bounded set of these (the pages/objects it touched), so the log grows by O(delta)
+/// per write instead of O(store). Mirrors the on-disk item taxonomy: a PAGE item is a
+/// concrete page-index entry change, an OBJECT item is an object-level change (e.g. a
+/// TTL-only or whole-object tombstone), and a META item carries the compaction anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IndexItemKind {
+    #[serde(rename = "page")]
+    Page,
+    #[serde(rename = "object")]
+    Object,
+    #[serde(rename = "meta")]
+    Meta,
+}
+
+impl Default for IndexItemKind {
+    fn default() -> Self {
+        IndexItemKind::Page
+    }
+}
+
+/// One delta item: the smallest change to the served index a write can produce. The
+/// field set is the native Rust page-index projection -- `routing_bucket`/`page_ref_key`
+/// locate the entry in the bucket map, and `address`/`size`/`in_log`/`deleted`/`model_id`/
+/// `object_id`/`page_id` mirror the durable page metadata so replay reconstructs the same
+/// `PageIndex` the whole-index serialization would have produced. `deleted` is a
+/// tombstone: replaying it removes the entry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexItem {
+    #[serde(default)]
+    pub kind: IndexItemKind,
+    #[serde(default, rename = "routing_slot")]
+    pub routing_bucket: u32,
+    #[serde(default)]
+    pub page_ref_key: String,
+    #[serde(default)]
+    pub object_key: String,
+    #[serde(default)]
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<String>,
+    #[serde(default)]
+    pub object_id: u64,
+    #[serde(default)]
+    pub page_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address: Option<BlockAddress>,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub in_log: bool,
+    #[serde(default)]
+    pub deleted: bool,
+}
+
+/// Compaction anchor for the delta log. `start_wal_sequence` is the lowest WAL sequence
+/// still required to reconstruct the served index on top of the base snapshot: once the
+/// base `shard-{id}.index.json` is rewritten at a compaction point, the anchor advances
+/// and every delta record at or before it can be truncated. Mirrors the reference
+/// MetaItem's `start_oplog_id` role in the native WAL vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetaItem {
+    #[serde(default)]
+    pub version: u64,
+    #[serde(default)]
+    pub start_wal_sequence: u64,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+}
+
+/// One appended delta record: either a batch of page/object item deltas (PAGE/OBJECT) or
+/// a compaction anchor (META). Written one JSON line per record to the same append-only
+/// log file as `IndexLogRecord`; the two are distinguished on read by the presence of the
+/// `items`/`meta` fields, so legacy whole-index records replay untouched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexDeltaRecord {
+    pub shard_id: ShardId,
+    pub sequence: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub items: Vec<IndexItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<MetaItem>,
+    /// The WAL sequence this write reflected (the served-index anchor at append time). On
+    /// load, deltas with a sequence at or below the base snapshot's anchor are already
+    /// folded into the base and are skipped; folding the rest advances the reconstructed
+    /// anchor so WAL replay re-executes only the uncaptured tail (never relocating the
+    /// pages the deltas already pin at their original addresses).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_wal_sequence: Option<u64>,
+    /// Opaque per-touched-key state blobs (one JSON object per key) carrying the
+    /// authoritative post-write value of the maps that are NOT reconstructable from a
+    /// single page-index entry -- packed timestamped series (feature membership survives
+    /// eviction) and the non-page maps (TTL, control-state change/selection, context
+    /// nodes). Opaque here so the index-log layer stays decoupled from `ShardState`; the
+    /// engine builds and applies them. Replaying these on load pins the exact membership a
+    /// write produced, so reconstruction from physical pages cannot resurrect evicted data.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_states: Vec<serde_json::Value>,
+}
+
+/// Fold an ordered stream of delta items onto a base map keyed by `(routing_bucket,
+/// page_ref_key)`. Later items win; a `deleted` tombstone removes the key. This is the
+/// pure replay step: `base` is the page-index projection of the base snapshot and the
+/// returned map is the reconstructed, current page index -- O(base + deltas), and the
+/// per-write producer side is O(delta).
+pub fn fold_index_items(
+    base: BTreeMap<(u32, String), IndexItem>,
+    deltas: &[IndexItem],
+) -> BTreeMap<(u32, String), IndexItem> {
+    let mut folded = base;
+    for item in deltas {
+        let key = (item.routing_bucket, item.page_ref_key.clone());
+        if item.deleted {
+            folded.remove(&key);
+        } else {
+            folded.insert(key, item.clone());
+        }
+    }
+    folded
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -190,6 +316,99 @@ impl LocalIndexLogStore {
         inner.stats.last_sequence = next_sequence;
         inner.last_sequence_by_shard.insert(shard_id, next_sequence);
         Ok(next_sequence)
+    }
+
+    /// Append one O(delta) served-index record: the page/object items a single write
+    /// touched, optionally carrying a compaction anchor. Unlike `append_json`, this never
+    /// serializes the whole index -- the appended bytes are proportional to the change,
+    /// which is what turns the per-write served-index persist cost from O(store) into
+    /// O(delta). Returns the assigned monotonic sequence.
+    pub fn append_delta(
+        &self,
+        shard_id: ShardId,
+        items: Vec<IndexItem>,
+        key_states: Vec<serde_json::Value>,
+        applied_wal_sequence: Option<u64>,
+        meta: Option<MetaItem>,
+    ) -> Result<u64, IndexLogError> {
+        if bulk_ingest_mode() || !indexlog_enabled() {
+            return Ok(0);
+        }
+        let mut inner = self.inner.lock().expect("index log lock poisoned");
+        fs::create_dir_all(&inner.root)?;
+        let last_sequence = match inner.last_sequence_by_shard.get(&shard_id).copied() {
+            Some(sequence) => sequence,
+            None => {
+                let sequence = last_sequence_at(&inner.root, shard_id)?;
+                inner.last_sequence_by_shard.insert(shard_id, sequence);
+                sequence
+            }
+        };
+        let next_sequence = last_sequence.saturating_add(1);
+        let record = IndexDeltaRecord {
+            shard_id,
+            sequence: next_sequence,
+            items,
+            meta,
+            applied_wal_sequence,
+            key_states,
+        };
+        let mut bytes = serde_json::to_vec(&record)?;
+        bytes.push(b'\n');
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(index_log_path(&inner.root, shard_id))?;
+        file.write_all(&bytes)?;
+        file.flush()?;
+        file.sync_data()?;
+        inner.stats.writes += 1;
+        inner.stats.bytes_written += bytes.len() as u64;
+        inner.stats.last_sequence = next_sequence;
+        inner.last_sequence_by_shard.insert(shard_id, next_sequence);
+        Ok(next_sequence)
+    }
+
+    /// Read every delta record for a shard in log order. Records at or before
+    /// `retain_after_sequence` (the base snapshot's anchor) are skipped, so replay applies
+    /// only the suffix the base does not already reflect. Legacy whole-index
+    /// (`IndexLogRecord`) lines are ignored here -- they are not delta records.
+    pub fn read_delta_records(
+        &self,
+        shard_id: ShardId,
+        retain_after_sequence: u64,
+    ) -> Result<Vec<IndexDeltaRecord>, IndexLogError> {
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        let path = index_log_path(&inner.root, shard_id);
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+        let mut records = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(record) = serde_json::from_str::<IndexDeltaRecord>(&line) {
+                // A whole-index IndexLogRecord also deserializes into IndexDeltaRecord
+                // (its `index` field is ignored, leaving the delta fields empty). Only keep
+                // records that carry a delta payload OR a WAL anchor (an anchor-only record
+                // still advances the reconstructed watermark on load).
+                if record.items.is_empty()
+                    && record.meta.is_none()
+                    && record.key_states.is_empty()
+                    && record.applied_wal_sequence.is_none()
+                {
+                    continue;
+                }
+                if record.sequence > retain_after_sequence {
+                    records.push(record);
+                }
+            }
+        }
+        Ok(records)
     }
 
     pub fn read_range(
@@ -472,6 +691,102 @@ mod tests {
         let record = reopened.append_json(5, b"{\"value\":3}").unwrap();
         assert_eq!(record.sequence, 3);
         assert_eq!(reopened.scan(5, 0, u64::MAX, u64::MAX).unwrap().len(), 3);
+    }
+
+    fn page_item(bucket: u32, key: &str, deleted: bool) -> IndexItem {
+        IndexItem {
+            kind: IndexItemKind::Page,
+            routing_bucket: bucket,
+            page_ref_key: key.to_string(),
+            object_key: key.to_string(),
+            model_id: "m".to_string(),
+            component: None,
+            object_id: 1,
+            page_id: 0,
+            address: None,
+            size: 8,
+            in_log: false,
+            deleted,
+        }
+    }
+
+    #[test]
+    fn append_delta_grows_log_by_only_the_changed_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        let seq1 = store
+            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        assert_eq!(seq1, 1);
+        let seq2 = store
+            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .unwrap();
+        assert_eq!(seq2, 2);
+        // The two single-item deltas together are far smaller than a whole-index blob
+        // would be, and each append wrote only its own item.
+        let records = store.read_delta_records(7, 0).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].items.len(), 1);
+        assert_eq!(records[1].items[0].page_ref_key, "b");
+        // The sequence tail is readable across a reopen even though the log now holds
+        // delta records rather than whole-index records.
+        let reopened = LocalIndexLogStore::new(dir.path());
+        assert_eq!(reopened.stats(7).last_sequence, 2);
+    }
+
+    #[test]
+    fn fold_index_items_applies_tombstones_and_last_writer_wins() {
+        let mut base = BTreeMap::new();
+        base.insert((1u32, "a".to_string()), page_item(1, "a", false));
+        base.insert((1u32, "b".to_string()), page_item(1, "b", false));
+        // Delta: delete a, overwrite b, add c.
+        let mut updated_b = page_item(1, "b", false);
+        updated_b.size = 99;
+        let deltas = vec![page_item(1, "a", true), updated_b, page_item(2, "c", false)];
+        let folded = fold_index_items(base, &deltas);
+        assert!(!folded.contains_key(&(1, "a".to_string())));
+        assert_eq!(folded.get(&(1, "b".to_string())).unwrap().size, 99);
+        assert!(folded.contains_key(&(2, "c".to_string())));
+        assert_eq!(folded.len(), 2);
+    }
+
+    #[test]
+    fn read_delta_records_skips_anchor_and_ignores_whole_index_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        // A legacy whole-index record and a delta record share the log file.
+        store.append_json(9, b"{\"value\":1}").unwrap();
+        let anchor_seq = store
+            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        store
+            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .unwrap();
+        // Only delta records are returned; the whole-index line is ignored.
+        let all = store.read_delta_records(9, 0).unwrap();
+        assert_eq!(all.len(), 2);
+        // Retaining after the first delta's sequence yields only the later delta.
+        let suffix = store.read_delta_records(9, anchor_seq).unwrap();
+        assert_eq!(suffix.len(), 1);
+        assert_eq!(suffix[0].items[0].page_ref_key, "b");
+    }
+
+    #[test]
+    fn append_delta_meta_anchor_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        store
+            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .unwrap();
+        let meta = MetaItem {
+            version: 1,
+            start_wal_sequence: 42,
+            timestamp_ms: 100,
+        };
+        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta)).unwrap();
+        let records = store.read_delta_records(3, 0).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].meta.unwrap().start_wal_sequence, 42);
     }
 
     #[test]

--- a/crates/temporalstore-rust/tests/delta_index_cost.rs
+++ b/crates/temporalstore-rust/tests/delta_index_cost.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! A/B micro-measurement of the per-write served-index cost.
+//!
+//! Reads the mode from the process env (`MATRIXARK_DELTA_SERVED_INDEX`) rather than setting
+//! it, so the harness can run it twice (once OFF, once ON) as two separate processes with no
+//! env race. It writes an increasing number of keys and times fixed-size write batches at a
+//! growing store size, then reports the per-write wall time. On the default (OFF) path each
+//! write re-serializes and atomically rewrites the whole `shard-{id}.index.json`, so the
+//! per-write time climbs with the store size (O(store)); on the delta (ON) path the base
+//! rewrite is deferred, so it stays flat (O(delta)). Run with `--nocapture` to see the report.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use temporalstore_rust::{Command, ExecuteRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+
+#[test]
+fn per_write_served_index_cost_report() {
+    let mode = if matches!(
+        std::env::var("MATRIXARK_DELTA_SERVED_INDEX")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    ) {
+        "DELTA(on)"
+    } else {
+        "BASELINE(off)"
+    };
+
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-delta-cost-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let index_dir = root.join("indexes");
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine =
+        TemporalEngine::with_local_dirs(4096, root.join("cache"), root.join("pages"), &index_dir);
+    engine.load_shard(SHARD_ID);
+
+    let batch = 100usize;
+    let checkpoints = [0usize, 500, 1000, 2000, 3000];
+    let mut next = 0usize;
+    println!("\n=== per-write served-index cost [{mode}] ===");
+    for &target in &checkpoints {
+        // Grow the store up to `target` entries.
+        while next < target {
+            let key = format!("key-{next:08}");
+            let response = engine.execute(ExecuteRequest {
+                shard_id: SHARD_ID,
+                command: Command::StringSet {
+                    key,
+                    value: b"payload-value".to_vec(),
+                },
+            });
+            assert!(response.status.ok);
+            next += 1;
+        }
+        // Time a fixed batch of writes at this store size.
+        let start = Instant::now();
+        for i in 0..batch {
+            let key = format!("probe-{target}-{i:04}");
+            let response = engine.execute(ExecuteRequest {
+                shard_id: SHARD_ID,
+                command: Command::StringSet {
+                    key,
+                    value: b"payload-value".to_vec(),
+                },
+            });
+            assert!(response.status.ok);
+        }
+        next += batch;
+        let per_write_us = start.elapsed().as_secs_f64() * 1e6 / batch as f64;
+        let served_len = engine.export_index_bytes(SHARD_ID).map(|b| b.len()).unwrap_or(0);
+        println!(
+            "store~{target:>6} entries | per-write {per_write_us:>8.1} us | whole-index size {served_len:>9} bytes",
+        );
+    }
+    println!("=== end [{mode}] ===\n");
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/temporalstore-rust/tests/delta_served_index.rs
+++ b/crates/temporalstore-rust/tests/delta_served_index.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Delta / incremental served-index path (`MATRIXARK_DELTA_SERVED_INDEX`).
+//!
+//! On the delta path a write no longer rewrites the whole `shard-{id}.index.json`
+//! (O(store) per write); the base snapshot is materialized only at compaction points
+//! (dump / flush / gc / unload-via-WAL). Between compactions the in-memory shard is the
+//! authoritative served index, which every reader reaches through the served-index funnel
+//! (`export_index_bytes` / `read_stream(Index)`), and a cold reload reconstructs current
+//! state by replaying the WAL suffix beyond the last materialized anchor.
+//!
+//! Runs in its own integration-test process, so toggling the process-wide
+//! `MATRIXARK_DELTA_SERVED_INDEX` env var cannot race the single-process library unit tests.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{
+    Command, CommandResponse, ExecuteRequest, StreamKind, StreamReadRequest, TemporalEngine,
+};
+
+const SHARD_ID: u64 = 1;
+
+fn root(tag: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-delta-served-index-{tag}-{}", std::process::id()));
+    root
+}
+
+fn build_engine(root: &PathBuf) -> (TemporalEngine, PathBuf) {
+    let _ = std::fs::remove_dir_all(root);
+    let index_dir = root.join("indexes");
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine =
+        TemporalEngine::with_local_dirs(4096, root.join("cache"), root.join("pages"), &index_dir);
+    (engine, index_dir)
+}
+
+fn set(engine: &TemporalEngine, key: &str, value: &[u8]) {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.to_vec(),
+        },
+    });
+    assert!(response.status.ok, "set {key} failed: {response:?}");
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command: Command::StringGet {
+            key: key.to_string(),
+        },
+    });
+    assert!(response.status.ok, "get {key} failed: {response:?}");
+    match response.response {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("unexpected response for get {key}: {other:?}"),
+    }
+}
+
+#[test]
+fn delta_path_defers_base_write_but_funnel_and_reload_see_current_state() {
+    std::env::set_var("MATRIXARK_DELTA_SERVED_INDEX", "1");
+    // Guard so a panic does not leak the env var into any later test in this process.
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            std::env::remove_var("MATRIXARK_DELTA_SERVED_INDEX");
+        }
+    }
+    let _reset = Reset;
+
+    let root = root("roundtrip");
+    let (engine, index_dir) = build_engine(&root);
+    let index_path = index_dir.join(format!("shard-{SHARD_ID}.index.json"));
+    engine.load_shard(SHARD_ID);
+
+    for key in ["alpha", "bravo", "charlie"] {
+        set(&engine, key, b"v1");
+    }
+
+    // (1) O(delta) per write: the whole-index base file was NOT rewritten per write. On the
+    // delta path the sync execute path skips the per-write base rewrite entirely, so with no
+    // compaction yet the base file is still absent.
+    assert!(
+        !index_path.exists(),
+        "delta path must not rewrite the base index per write"
+    );
+
+    // (2) The funnel still serves the COMPLETE, current index from the live shard.
+    let served = engine
+        .export_index_bytes(SHARD_ID)
+        .expect("funnel serves the live index");
+    let served_text = String::from_utf8_lossy(&served);
+    for key in ["alpha", "bravo", "charlie"] {
+        assert!(
+            served_text.contains(key),
+            "served index must contain {key}: {served_text}"
+        );
+    }
+    // read_stream(Index) is routed through the same funnel.
+    let stream = engine.read_stream(StreamReadRequest {
+        shard_id: SHARD_ID,
+        stream_kind: StreamKind::Index,
+        page_slab_id: 0,
+        offset: 0,
+        size: served.len() as u64,
+    });
+    assert!(stream.status.ok, "index stream read: {:?}", stream.status);
+    assert_eq!(stream.data, served, "index stream must match the funnel bytes");
+
+    // (3) A dump materializes the base (compaction point) and embeds the current index.
+    let manifest = engine
+        .create_bucket_dump_manifest(SHARD_ID, Vec::new())
+        .expect("dump manifest should persist");
+    assert!(
+        String::from_utf8_lossy(&manifest.index_bytes).contains("charlie"),
+        "dump manifest must embed the current served index"
+    );
+
+    // (4) Durability across a cold reload: the deferred writes live in the WAL and are
+    // replayed on load, so no data is lost even though the base was never rewritten per write.
+    engine.unload_shard(SHARD_ID);
+    engine.load_shard(SHARD_ID);
+    for key in ["alpha", "bravo", "charlie"] {
+        assert_eq!(
+            get(&engine, key).as_deref(),
+            Some(b"v1".as_ref()),
+            "reload must reconstruct {key} from the WAL suffix"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Port of the incremental delta served-index from the canonical repo: maintains the served index incrementally (O(delta) per write) instead of O(store) rebuilds, gated behind its env flag. Includes index_log delta plumbing, engine wiring, and delta_served_index / delta_index_cost tests.

Stacked on the embedding PR (shares engine files); applied as a 3-way patch, scrub clean.