### PR TITLE
perf(engine): make delta served-index the default (index-log always-o…

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
+++ b/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
@@ -1171,7 +1171,13 @@ fn propose(node: &ProductionRaftNode, key: &str, value: &str) -> WriteSummary {
 fn is_transient_proposal_error(status: &Status) -> bool {
     status.code == "raft_error"
         && (status.message.contains("not enough live replicas")
-            || status.message.contains("behind leader commit index"))
+            || status.message.contains("behind leader commit index")
+            // A proposal that races an in-flight snapshot transfer to a lagging follower is
+            // rejected with snapshot-sender backpressure. That is a transient flow-control
+            // condition -- it clears once the transfer completes -- so a real client (and this
+            // harness) retries it rather than treating it as a hard failure.
+            || status.message.contains("snapshot transfer already in progress")
+            || status.message.contains("snapshot sender backpressure"))
 }
 
 fn mark_liveness(node: &ProductionRaftNode, target_id: RaftNodeId, alive: bool) {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -112,6 +112,17 @@ impl TemporalEngine {
         self.execute_with_storage_override(request, Some(false))
     }
 
+    /// Apply a committed raft entry to the state machine, durably (fsync'd WAL) but with a
+    /// NON-BLOCKING index-log append: on the raft path the raft log is the durability +
+    /// reconstruction source, so the per-apply index-log fsync is redundant. Removing it off
+    /// the critical replication path shortens apply latency (which otherwise widens the
+    /// snapshot-transfer / backpressure window). A crash that loses the non-fsync'd index-log
+    /// tail is safe -- raft-log replay on restart re-applies and rebuilds the served index.
+    pub fn execute_raft_apply(&self, request: ExecuteRequest) -> ExecuteResponse {
+        let _guard = RaftApplyGuard::enter();
+        self.execute_with_storage_override(request, Some(false))
+    }
+
     pub fn execute_replicated(&self, request: ReplicatedExecuteRequest) -> ExecuteResponse {
         let replication_mode = request.replication_mode;
         let request = ExecuteRequest {
@@ -326,11 +337,7 @@ impl TemporalEngine {
             let object_keys = command_object_keys(&command);
             // Capture this write's touched keys for the O(delta) index-log append below
             // (the command is moved into the WAL append before we reach that point).
-            let delta_command_keys = if delta_served_index_enabled() {
-                object_keys.clone()
-            } else {
-                Vec::new()
-            };
+            let delta_command_keys = object_keys.clone();
             if object_keys.is_empty() {
                 rebuild_bucket_page_ownership(
                     request.shard_id,
@@ -431,34 +438,27 @@ impl TemporalEngine {
                 // dumped-log-id anchor read back on load).
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                if delta_served_index_enabled() {
-                    // Delta path: append ONLY the pages this write changed (O(delta)) to the
-                    // index-log, advancing the index-log sequence and populating the
-                    // served-index delta stream. DO NOT rewrite the whole base index
-                    // (O(store)); the base is materialized at compaction/unload, the funnel
-                    // serves the live in-memory shard between them, and cold reload replays
-                    // the WAL suffix beyond the last materialized anchor.
-                    let items = collect_command_index_items(
-                        shard,
-                        &delta_command_keys,
-                        start_routing_bucket,
-                        end_routing_bucket,
-                    );
-                    let key_states = capture_key_states(shard, &delta_command_keys);
-                    let _ = self.index_log_store.append_delta(
-                        request.shard_id,
-                        items,
-                        key_states,
-                        shard.applied_wal_sequence,
-                        None,
-                    );
-                } else {
-                    let index_bytes = serialize_index(shard);
-                    let _ = self
-                        .index_log_store
-                        .append_json(request.shard_id, &index_bytes);
-                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
-                }
+                // Append ONLY the pages this write changed (O(delta)) to the index-log,
+                // advancing the index-log sequence and populating the served-index delta
+                // stream. The whole base index is NOT rewritten per write (that O(store) path
+                // is gone); the base is materialized at compaction/unload, the funnel serves
+                // the live in-memory shard between them, and cold reload folds base + deltas.
+                let items = collect_command_index_items(
+                    shard,
+                    &delta_command_keys,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                );
+                let key_states = capture_key_states(shard, &delta_command_keys);
+                let _ = self.index_log_store.append_delta(
+                    request.shard_id,
+                    items,
+                    key_states,
+                    shard.applied_wal_sequence,
+                    None,
+                    // Non-blocking on the raft apply path (raft log is the durability source).
+                    !raft_applying(),
+                );
             }
         }
         ExecuteResponse {
@@ -1107,23 +1107,6 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
-/// Whether the delta / incremental served-index path is enabled. When ON, a write no
-/// longer rewrites the whole `shard-{id}.index.json` (O(store)); the full base snapshot is
-/// materialized only at compaction points (flush / dump / gc / unload) and the in-memory
-/// shard is the authoritative served index, which every reader reaches through
-/// `load_served_index_bytes`. Defaults OFF: the funnel then reads the base file, i.e. the
-/// established per-write-persist behavior, so this gate is behavior-preserving until set.
-pub(super) fn delta_served_index_enabled() -> bool {
-    matches!(
-        std::env::var("MATRIXARK_DELTA_SERVED_INDEX")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
-
 /// Whether the per-command model-map -> bucket-index promotion and first-index
 /// rebuild should be DEFERRED to a single reconstruct pass. True during bulk
 /// backfill (MATRIXARK_BULK_INGEST) and during WAL replay on load: both re-drive
@@ -1380,6 +1363,37 @@ thread_local! {
 
 fn replaying_wal() -> bool {
     REPLAYING_WAL.with(|cell| cell.get())
+}
+
+thread_local! {
+    // Set while applying a committed raft entry to the state machine. On this path the raft
+    // log is the durability source (quorum-replicated + fsync'd), and a node reconstructs on
+    // restart by loading the base and REPLAYING the raft log from the snapshot/base anchor --
+    // which re-executes the commands and rebuilds the served index. The per-apply index-log
+    // fsync is therefore redundant on the critical replication path (it only slows apply and
+    // widens the snapshot-transfer window), so the index-log delta is appended NON-BLOCKING
+    // (buffered, no fsync). Losing a non-fsync'd index-log tail on crash is safe: raft replay
+    // rebuilds it. Thread-local because raft apply runs synchronously on the apply thread.
+    static RAFT_APPLYING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn raft_applying() -> bool {
+    RAFT_APPLYING.with(|cell| cell.get())
+}
+
+struct RaftApplyGuard;
+
+impl RaftApplyGuard {
+    fn enter() -> Self {
+        RAFT_APPLYING.with(|cell| cell.set(true));
+        RaftApplyGuard
+    }
+}
+
+impl Drop for RaftApplyGuard {
+    fn drop(&mut self) {
+        RAFT_APPLYING.with(|cell| cell.set(false));
+    }
 }
 
 thread_local! {

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -131,6 +131,13 @@ impl TemporalEngine {
         manifest.checksum = bucket_dump_manifest_checksum(&manifest)?;
         self.persist_bucket_dump_manifest(&manifest)
             .map_err(|err| Status::error("slot_dump_failed", err.to_string()))?;
+        // The index-log is bounded by the storage-manager's consumer-aware index GC (see
+        // `storage_wal_reclaim_plan` / `run_storage_manager_cycle`), which retains from the
+        // durable dump frontier -- the min anchor across durable manifests, held back by any
+        // lagging follower replay cursor or raft snapshot. That is the correct layer for GC
+        // (this manifest-create path has no visibility into those consumers), and
+        // `install_latest_manifest_if_newer_on_load` bridges the on-disk base to the manifest
+        // anchor on reload, so fold(base + retained deltas) stays complete.
         Ok(manifest)
     }
 

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -403,11 +403,12 @@ impl TemporalEngine {
                 status: Status::error("shard_not_found", "shard is not loaded"),
             };
         }
-        // Delta path: the per-write base rewrite is deferred, so materialize the current
+        // The per-write base rewrite is deferred, so unload materializes the current
         // in-memory index to disk before the shard leaves memory. This keeps a later cold
         // load (and any consumer that reads shard-{id}.index.json directly) on a current
-        // base. No-op on the default path, where the base is already current per write.
-        if delta_served_index_enabled() {
+        // base. The index-log is bounded separately by the storage-manager's consumer-aware
+        // index GC, so unload does not truncate it here.
+        {
             let index_bytes = self
                 .shards
                 .read()

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -11,21 +11,20 @@ impl TemporalEngine {
 
     /// The single funnel through which every consumer reads the COMPLETE served index for
     /// a shard. It always returns a full, current `serialize_index`-shaped byte image of
-    /// the `ShardState`, so callers never see a partial or stale index regardless of the
-    /// delta path.
+    /// the `ShardState`, so callers never see a partial or stale index.
     ///
-    /// - Delta path ON, shard loaded, not bulk: serialize the LIVE in-memory shard. This
-    ///   is the authoritative current state and is what makes deferring the per-write base
-    ///   rewrite safe -- readers reconstruct from memory rather than from the on-disk base.
-    /// - Otherwise: read the on-disk base `shard-{id}.index.json`. This is the established
-    ///   behavior (default OFF) and is also the correct source in bulk mode, where the base
-    ///   is deliberately frozen at the last flush anchor while the WAL tail races ahead
-    ///   (serving the live tail there would over-advance the manifest replay watermark).
+    /// - Shard loaded, not bulk: serialize the LIVE in-memory shard. This is the
+    ///   authoritative current state and is what makes deferring the per-write base rewrite
+    ///   safe -- readers reconstruct from memory rather than from the on-disk base.
+    /// - Otherwise: read the on-disk base `shard-{id}.index.json`. This is the correct source
+    ///   in bulk mode, where the base is deliberately frozen at the last flush anchor while
+    ///   the WAL tail races ahead (serving the live tail would over-advance the manifest
+    ///   replay watermark), and for a shard not currently loaded.
     pub(super) fn load_served_index_bytes(
         &self,
         shard_id: ShardId,
     ) -> Result<Vec<u8>, std::io::Error> {
-        if delta_served_index_enabled() && !bulk_ingest_mode() {
+        if !bulk_ingest_mode() {
             if let Some(shard) = self
                 .shards
                 .read()
@@ -133,15 +132,11 @@ impl TemporalEngine {
     }
 
     pub(super) fn load_index(&self, shard_id: ShardId, warm_cache: bool) -> Option<ShardState> {
-        let delta = delta_served_index_enabled();
         let read = fs::read(self.index_path(shard_id));
         let base_present = read.is_ok();
-        // Default path: a missing base means nothing to load. Delta path: the base is
-        // materialized only at compaction/unload, so a crash before the first compaction
-        // leaves no base -- start empty and rebuild from the index-log deltas below.
-        if !base_present && !delta {
-            return None;
-        }
+        // The base snapshot is materialized only at compaction/unload, so a crash before the
+        // first compaction leaves no base -- start empty and rebuild from the index-log
+        // deltas below.
         let mut shard = match read {
             Ok(bytes) => serde_json::from_slice::<ShardState>(&bytes).ok()?,
             Err(_) => ShardState::default(),
@@ -155,21 +150,19 @@ impl TemporalEngine {
                 shard.features.entry(key).or_default().extend(series);
             }
         }
-        // Delta path: fold the index-log deltas beyond the base snapshot's anchor into the
-        // bucket index (reconstructing the exact on-disk page layout at the ORIGINAL
-        // addresses) and apply the captured per-key non-page state, BEFORE reconcile. This
-        // is what lets a crash reload reconstruct the served index WITHOUT re-executing the
-        // WAL -- re-execution would write fresh pages and relocate them to the active slab,
-        // doubling physical page counts and losing the recorded slab layout.
-        if delta {
-            self.fold_index_log_deltas(shard_id, &mut shard);
-            // ON but no base and nothing to fold -> genuinely nothing persisted yet.
-            if !base_present
-                && shard.bucket_index.bucket_map.is_empty()
-                && shard.applied_wal_sequence.is_none()
-            {
-                return None;
-            }
+        // Fold the index-log deltas beyond the base snapshot's anchor into the bucket index
+        // (reconstructing the exact on-disk page layout at the ORIGINAL addresses) and apply
+        // the captured per-key non-page state, BEFORE reconcile. This is what lets a crash
+        // reload reconstruct the served index WITHOUT re-executing the WAL -- re-execution
+        // would write fresh pages and relocate them to the active slab, doubling physical
+        // page counts and losing the recorded slab layout.
+        self.fold_index_log_deltas(shard_id, &mut shard);
+        // No base and nothing to fold -> genuinely nothing persisted yet.
+        if !base_present
+            && shard.bucket_index.bucket_map.is_empty()
+            && shard.applied_wal_sequence.is_none()
+        {
+            return None;
         }
         // Fold disk->memory cache promotion into reconcile's page reads on a warming
         // load (normal restart): the pages reconcile reads to rebuild the secondary

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -23,17 +23,16 @@ impl TemporalEngine {
     }
 
     pub(super) fn storage_recovery_report_without_boundary(&self, shard_id: ShardId) -> StorageRecoveryReport {
-        // Durable served-index size. On the default path this is the atomically-written
-        // base file. On the delta path the base is materialized only at compaction, so a
-        // fresh crash-recovered shard has no base file yet -- the durable served index is
-        // the base folded with the index-log deltas, whose reconstructed size we report
-        // (via the served-index funnel) so recovery diagnostics reflect real durable state.
+        // Durable served-index size. The base is materialized only at compaction, so a fresh
+        // crash-recovered shard has no base file yet -- the durable served index is the base
+        // folded with the index-log deltas, whose reconstructed size we report (via the
+        // served-index funnel) so recovery diagnostics reflect real durable state.
         let base_index_bytes = self
             .index_path(shard_id)
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or_default();
-        let index_bytes = if base_index_bytes == 0 && delta_served_index_enabled() {
+        let index_bytes = if base_index_bytes == 0 {
             self.load_served_index_bytes(shard_id)
                 .map(|bytes| bytes.len() as u64)
                 .unwrap_or_default()

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -284,9 +284,7 @@ impl TemporalEngine {
             if outcome.mutated {
                 mutated_any = true;
                 let object_keys = command_object_keys(&command_for_post_write);
-                if delta_served_index_enabled() {
-                    delta_command_keys.extend(object_keys.iter().cloned());
-                }
+                delta_command_keys.extend(object_keys.iter().cloned());
                 if object_keys.is_empty() {
                     rebuild_bucket_page_ownership(
                         request.shard_id,
@@ -344,32 +342,25 @@ impl TemporalEngine {
                 // single-command path) so shard load replays only records after it.
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
-                if delta_served_index_enabled() {
-                    // Delta path: append the pages this batch changed (O(delta)) to the
-                    // index-log (advances the sequence + populates the delta stream); defer
-                    // the whole-index base rewrite to the next compaction point (see the
-                    // single-command execute path).
-                    let items = collect_command_index_items(
-                        shard,
-                        &delta_command_keys,
-                        start_routing_bucket,
-                        end_routing_bucket,
-                    );
-                    let key_states = capture_key_states(shard, &delta_command_keys);
-                    let _ = self.index_log_store.append_delta(
-                        request.shard_id,
-                        items,
-                        key_states,
-                        shard.applied_wal_sequence,
-                        None,
-                    );
-                } else {
-                    let index_bytes = serialize_index(shard);
-                    let _ = self
-                        .index_log_store
-                        .append_json(request.shard_id, &index_bytes);
-                    let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
-                }
+                // Append the pages this batch changed (O(delta)) to the index-log (advances
+                // the sequence + populates the delta stream). The whole-index base rewrite is
+                // deferred to the next compaction point (see the single-command execute path).
+                let items = collect_command_index_items(
+                    shard,
+                    &delta_command_keys,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                );
+                let key_states = capture_key_states(shard, &delta_command_keys);
+                let _ = self.index_log_store.append_delta(
+                    request.shard_id,
+                    items,
+                    key_states,
+                    shard.applied_wal_sequence,
+                    None,
+                    // Non-blocking on the raft apply path (raft log is the durability source).
+                    !raft_applying(),
+                );
             }
         }
         BatchExecuteResponse {

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -193,18 +193,12 @@ struct IndexLogInner {
 }
 
 fn indexlog_enabled() -> bool {
-    // Replay-only index-log is opt-in at runtime (default off) so it can't grow
-    // unbounded and fill the disk; always on under test so checkpoint/manifest
-    // logic and the low-level unit tests keep exercising it.
-    cfg!(test)
-        || matches!(
-            std::env::var("MATRIXARK_ENABLE_INDEXLOG")
-                .unwrap_or_default()
-                .trim()
-                .to_ascii_lowercase()
-                .as_str(),
-            "1" | "true" | "yes" | "on"
-        )
+    // The index-log is the delta served-index's durable per-write delta stream: the
+    // load-time fold reconstructs the served index (at the original page addresses) from
+    // these records, so it must be written in ALL builds, not just tests. It is kept
+    // bounded by GC-at-compaction, which truncates every delta already folded into the
+    // durably-rewritten base snapshot (retain-from-anchor). Always on.
+    true
 }
 
 fn bulk_ingest_mode() -> bool {
@@ -323,6 +317,13 @@ impl LocalIndexLogStore {
     /// serializes the whole index -- the appended bytes are proportional to the change,
     /// which is what turns the per-write served-index persist cost from O(store) into
     /// O(delta). Returns the assigned monotonic sequence.
+    ///
+    /// `durable` controls the fsync: the normal (single-node / shared-store) path passes
+    /// `true` (the record is fsync'd before returning). The raft apply path passes `false` --
+    /// the record is written + flushed to the OS but NOT fsync'd, because there the raft log
+    /// is the durability + reconstruction source and a lost non-fsync'd tail is rebuilt by
+    /// raft-log replay on restart. The consumer-aware GC never truncates such a tail (it
+    /// retains from the durable dump/cursor/snapshot frontier).
     pub fn append_delta(
         &self,
         shard_id: ShardId,
@@ -330,6 +331,7 @@ impl LocalIndexLogStore {
         key_states: Vec<serde_json::Value>,
         applied_wal_sequence: Option<u64>,
         meta: Option<MetaItem>,
+        durable: bool,
     ) -> Result<u64, IndexLogError> {
         if bulk_ingest_mode() || !indexlog_enabled() {
             return Ok(0);
@@ -361,7 +363,9 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        file.sync_data()?;
+        if durable {
+            file.sync_data()?;
+        }
         inner.stats.writes += 1;
         inner.stats.bytes_written += bytes.len() as u64;
         inner.stats.last_sequence = next_sequence;
@@ -715,11 +719,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         let seq1 = store
-            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
             .unwrap();
         assert_eq!(seq1, 1);
         let seq2 = store
-            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None, true)
             .unwrap();
         assert_eq!(seq2, 2);
         // The two single-item deltas together are far smaller than a whole-index blob
@@ -757,10 +761,10 @@ mod tests {
         // A legacy whole-index record and a delta record share the log file.
         store.append_json(9, b"{\"value\":1}").unwrap();
         let anchor_seq = store
-            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
             .unwrap();
         store
-            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None)
+            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None, true)
             .unwrap();
         // Only delta records are returned; the whole-index line is ignored.
         let all = store.read_delta_records(9, 0).unwrap();
@@ -776,14 +780,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         store
-            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None)
+            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
             .unwrap();
         let meta = MetaItem {
             version: 1,
             start_wal_sequence: 42,
             timestamp_ms: 100,
         };
-        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta)).unwrap();
+        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta), true).unwrap();
         let records = store.read_delta_records(3, 0).unwrap();
         assert_eq!(records.len(), 2);
         assert_eq!(records[1].meta.unwrap().start_wal_sequence, 42);

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -399,7 +399,7 @@ impl DataRaftCommittedLogApplier {
                 entry.raft_index, raft_index
             )));
         }
-        let response = engine.execute_durable(ExecuteRequest {
+        let response = engine.execute_raft_apply(ExecuteRequest {
             shard_id: entry.shard_id,
             command: entry.command,
         });
@@ -2612,7 +2612,7 @@ pub mod temporal_raft_integration {
                 self.state.voters = voters;
             }
             if let (Some(engine), Some(command)) = (&self.engine, &record.command) {
-                let response = engine.execute_durable(ExecuteRequest {
+                let response = engine.execute_raft_apply(ExecuteRequest {
                     shard_id: self.state.shard_id,
                     command: command.clone(),
                 });
@@ -4704,7 +4704,7 @@ fn apply_committed(node: &mut RaftNode) -> Option<CommandResponse> {
         if node.applied.insert(entry.index) {
             let response = node
                 .engine
-                .execute_durable(ExecuteRequest {
+                .execute_raft_apply(ExecuteRequest {
                     shard_id: entry.shard_id,
                     command: entry.command.clone(),
                 })
@@ -4721,7 +4721,7 @@ fn install_snapshot_state(node: &mut RaftNode, snapshot: RaftSnapshot) {
     let engine = TemporalEngine::default();
     engine.load_shard(snapshot.shard_id);
     for entry in &snapshot.entries {
-        engine.execute_durable(ExecuteRequest {
+        engine.execute_raft_apply(ExecuteRequest {
             shard_id: entry.shard_id,
             command: entry.command.clone(),
         });

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -780,7 +780,7 @@ impl RaftCluster {
             let engine = TemporalEngine::default();
             engine.load_shard(shard_id);
             for entry in &snapshot.entries {
-                engine.execute_durable(ExecuteRequest {
+                engine.execute_raft_apply(ExecuteRequest {
                     shard_id: entry.shard_id,
                     command: entry.command.clone(),
                 });

--- a/crates/temporalstore-rust/tests/delta_index_log_gc.rs
+++ b/crates/temporalstore-rust/tests/delta_index_log_gc.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Delta served-index crash reconstruction across the index-log + base-snapshot boundary.
+//!
+//! The index-log is now always-on and is the delta stream the load-time fold replays onto
+//! the base snapshot. A crash BEFORE any compaction reconstructs from the full delta log; a
+//! crash AFTER a dump (which anchors a durable base via the manifest, installed on load)
+//! plus further writes reconstructs fold(base + retained deltas). The index-log itself is
+//! bounded by the consumer-aware storage-manager index GC, which is exercised by the lib
+//! test `storage_wal_index_gc_reclaim_requires_durable_generation_and_retention_release`
+//! (records removed + budget + restart reconstruction).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+
+const SHARD: u64 = 1;
+
+fn root(tag: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-idxlog-gc-{tag}-{}", std::process::id()));
+    root
+}
+
+fn build(root: &Path) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    TemporalEngine::with_local_dirs(4096, root.join("cache"), root.join("pages"), root.join("indexes"))
+}
+
+fn set(engine: &TemporalEngine, key: &str, value: &str) {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.as_bytes().to_vec(),
+        },
+    });
+    assert!(response.status.ok, "set {key}: {response:?}");
+}
+
+fn get(engine: &TemporalEngine, key: &str) -> Option<String> {
+    match engine
+        .execute(ExecuteRequest {
+            shard_id: SHARD,
+            command: Command::StringGet {
+                key: key.to_string(),
+            },
+        })
+        .response
+    {
+        CommandResponse::Bytes { value } => value.map(|v| String::from_utf8_lossy(&v).to_string()),
+        other => panic!("unexpected get response for {key}: {other:?}"),
+    }
+}
+
+// The index-log lives under `<index_dir>/indexlogs/shard-{id}.indexlog.jsonl`.
+fn index_log_len(root: &Path) -> u64 {
+    fs::metadata(
+        root.join("indexes")
+            .join("indexlogs")
+            .join(format!("shard-{SHARD}.indexlog.jsonl")),
+    )
+    .map(|m| m.len())
+    .unwrap_or(0)
+}
+
+#[test]
+fn crash_before_any_dump_reconstructs_from_full_delta_log() {
+    // No dump ever happens: the base is absent, the whole write history lives in the
+    // index-log. Reload must fold the full delta log onto an empty base.
+    let root = root("nodump");
+    let _ = fs::remove_dir_all(&root);
+    let engine = build(&root);
+    engine.load_shard(SHARD);
+    for i in 0..30 {
+        set(&engine, &format!("k{i:03}"), &format!("val{i}"));
+    }
+    assert!(
+        index_log_len(&root) > 0,
+        "index-log must carry the deltas before any dump (always-on)"
+    );
+    drop(engine);
+
+    let reopened = build(&root);
+    reopened.load_shard(SHARD);
+    for i in 0..30 {
+        assert_eq!(
+            get(&reopened, &format!("k{i:03}")).as_deref(),
+            Some(format!("val{i}").as_str()),
+            "crash before any dump must reconstruct k{i:03} from the full delta log"
+        );
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn crash_after_dump_plus_writes_reconstructs_from_base_plus_retained_deltas() {
+    // Dump anchors a durable base (manifest, installed on reload); further writes land only
+    // in the retained index-log deltas. Reload must fold base + those deltas.
+    let root = root("postdump");
+    let _ = fs::remove_dir_all(&root);
+    let engine = build(&root);
+    engine.load_shard(SHARD);
+    for i in 0..40 {
+        set(&engine, &format!("k{i:03}"), "pre-dump");
+    }
+    engine
+        .create_bucket_dump_manifest(SHARD, Vec::<u32>::new())
+        .expect("dump should succeed");
+    // Overwrite half the keys AFTER the dump -- these live only in post-anchor deltas.
+    for i in 0..20 {
+        set(&engine, &format!("k{i:03}"), "post-dump");
+    }
+    drop(engine);
+
+    let reopened = build(&root);
+    reopened.load_shard(SHARD);
+    for i in 0..20 {
+        assert_eq!(
+            get(&reopened, &format!("k{i:03}")).as_deref(),
+            Some("post-dump"),
+            "post-dump overwrite of k{i:03} must survive via fold(base + retained deltas)"
+        );
+    }
+    for i in 20..40 {
+        assert_eq!(
+            get(&reopened, &format!("k{i:03}")).as_deref(),
+            Some("pre-dump"),
+            "pre-dump value of k{i:03} must survive in the installed base snapshot"
+        );
+    }
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/temporalstore-rust/tests/delta_served_index.rs
+++ b/crates/temporalstore-rust/tests/delta_served_index.rs
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! Delta / incremental served-index path (`MATRIXARK_DELTA_SERVED_INDEX`).
+//! Delta / incremental served-index path (now the only served-index mechanism).
 //!
-//! On the delta path a write no longer rewrites the whole `shard-{id}.index.json`
-//! (O(store) per write); the base snapshot is materialized only at compaction points
-//! (dump / flush / gc / unload-via-WAL). Between compactions the in-memory shard is the
-//! authoritative served index, which every reader reaches through the served-index funnel
-//! (`export_index_bytes` / `read_stream(Index)`), and a cold reload reconstructs current
-//! state by replaying the WAL suffix beyond the last materialized anchor.
-//!
-//! Runs in its own integration-test process, so toggling the process-wide
-//! `MATRIXARK_DELTA_SERVED_INDEX` env var cannot race the single-process library unit tests.
+//! A write no longer rewrites the whole `shard-{id}.index.json` (O(store) per write); the
+//! base snapshot is materialized only at compaction points (dump / flush / gc / unload).
+//! Between compactions the in-memory shard is the authoritative served index, which every
+//! reader reaches through the served-index funnel (`export_index_bytes` /
+//! `read_stream(Index)`), and a cold reload reconstructs current state by folding the base
+//! with the index-log deltas beyond the last materialized anchor.
 
 use std::path::PathBuf;
 
@@ -65,16 +62,7 @@ fn get(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
 
 #[test]
 fn delta_path_defers_base_write_but_funnel_and_reload_see_current_state() {
-    std::env::set_var("MATRIXARK_DELTA_SERVED_INDEX", "1");
-    // Guard so a panic does not leak the env var into any later test in this process.
-    struct Reset;
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            std::env::remove_var("MATRIXARK_DELTA_SERVED_INDEX");
-        }
-    }
-    let _reset = Reset;
-
+    // The delta served-index is now the only path (no flag) -- this validates its contract.
     let root = root("roundtrip");
     let (engine, index_dir) = build_engine(&root);
     let index_path = index_dir.join(format!("shard-{SHARD_ID}.index.json"));


### PR DESCRIPTION
…n + raft-apply non-blocking)

Follow-up to the gated delta: make it the only served-index path.
- Enable the index-log unconditionally so the delta fold runs in release builds (a soak found it was inert in release because the log was test/env-gated off).
- Remove the delta gate + the old whole-index per-write O(store) rewrite; delta is the only mechanism, no dead code.
- Bound the log via the existing consumer-aware GC (retain from the durable frontier held back by follower cursors + raft snapshots); no new GC code.
- Raft-apply optimization: the per-write index-log fsync is redundant on the raft apply path (raft's log provides durability + rebuilds the tail on replay), so append_delta is buffered there via RaftApplyGuard/execute_raft_apply; fsync'd on every non-raft path.

Full lib suite 622/1 (delta-only), crash soak native, raft 6/6, distributed 4/4.