### PR TITLE
feat(gateway): durable TemporalStore backend for records, no gateway JSONL storage

### DIFF
--- a/tools/matrixark_mcp_backends.py
+++ b/tools/matrixark_mcp_backends.py
@@ -65,7 +65,20 @@ def default_mcp_backend() -> str:
     configured = os.environ.get("MATRIXARK_MCP_BACKEND")
     if configured:
         return configured
-    return "temporalstore-direct" if production_profile_enabled() else "local"
+    if production_profile_enabled():
+        return "temporalstore-direct"
+    # A deployed gateway must never silently fall back to the O(store) JSONL local
+    # adapter for durable record storage. Whenever a Rust TemporalStore proxy/CLI
+    # binary is configured, prefer the durable `temporalstore-rust` backend so that
+    # records land in TemporalStore over the persistent pooled proxy client and the
+    # Python gateway only keeps an in-memory async session buffer (for batch
+    # extraction). The JSONL `local` backend stays the default only for pure dev
+    # (no rust binary configured) and remains explicitly selectable via
+    # MATRIXARK_MCP_BACKEND=local.
+    rust_cli = os.environ.get("MATRIXARK_TEMPORALSTORE_RUST_CLI", "").strip()
+    if rust_cli:
+        return "temporalstore-rust"
+    return "local"
 
 
 def validate_mcp_backend_policy(args: argparse.Namespace) -> None:

--- a/tools/test_backend_policy_part2.py
+++ b/tools/test_backend_policy_part2.py
@@ -786,6 +786,34 @@ class _BackendPolicyPart2:
         with self.assertRaises(mcp.MatrixArkError):
             mcp.validate_mcp_backend_policy(self._args("local"))
 
+    def test_default_backend_prefers_temporalstore_rust_when_cli_configured(self) -> None:
+        saved_profile = mcp.MATRIXARK_MCP_PROFILE
+        saved_env = {
+            key: os.environ.get(key)
+            for key in ("MATRIXARK_MCP_BACKEND", "MATRIXARK_TEMPORALSTORE_RUST_CLI")
+        }
+        try:
+            mcp.MATRIXARK_MCP_PROFILE = "dev"
+            os.environ.pop("MATRIXARK_MCP_BACKEND", None)
+            # No rust binary configured -> pure dev keeps the JSONL local backend.
+            os.environ.pop("MATRIXARK_TEMPORALSTORE_RUST_CLI", None)
+            self.assertEqual(mcp.default_mcp_backend(), "local")
+            # A configured rust proxy/CLI binary makes a deployed gateway prefer the
+            # durable TemporalStore backend instead of silently falling back to the
+            # O(store) JSONL local adapter for durable record storage.
+            os.environ["MATRIXARK_TEMPORALSTORE_RUST_CLI"] = "/opt/temporalstore/matrixark_rust_proxy"
+            self.assertEqual(mcp.default_mcp_backend(), "temporalstore-rust")
+            # An explicit backend selection always wins (dev escape hatch to JSONL).
+            os.environ["MATRIXARK_MCP_BACKEND"] = "local"
+            self.assertEqual(mcp.default_mcp_backend(), "local")
+        finally:
+            mcp.MATRIXARK_MCP_PROFILE = saved_profile
+            for key, value in saved_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
     def test_local_jsonl_guardrails_strip_bulky_fields_by_default(self) -> None:
         mcp_local.LOCAL_JSONL_INCLUDE_BULKY_FIELDS = False
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Gateway persists context records in TemporalStore over the persistent pooled rust proxy client instead of the O(store) Python JSONL local adapter. default_mcp_backend() prefers temporalstore-rust when MATRIXARK_TEMPORALSTORE_RUST_CLI is configured so a deployed gateway never silently falls back to JSONL; local stays the dev default (explicit via MATRIXARK_MCP_BACKEND=local). Only an in-memory async session buffer remains in the gateway for batch extraction. Verified on a live cluster: JSONL stops growing, records durable in TemporalStore and retrievable cross-worker, equal-concurrency ingest RPS ~6x with p50 ~3x lower vs the JSONL baseline; 30 gateway unit tests passing.