### PR TITLE
docs(readme): lead with the three open Rust crates; fix private-repo refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ token-budgeted **ContextPack** retrieval, exact serving-time **feature aggregate
 **control state** (caps, quotas, pacing) — all from one temporal index. It runs locally with
 one Docker command and scales out to a replicated, shared-storage cluster.
 
+**Three open Apache-2.0 repositories — free for anyone to use.**
+[TemporalStore](https://github.com/matrixarkai/TemporalStore) (this repo — the engine) ·
+[MatrixCache](https://github.com/matrixarkai/MatrixCache) (multi-layer cache) ·
+[MatrixRaft](https://github.com/matrixarkai/MatrixRaft) (Rust Raft consensus).
+Depend on them as **Rust crates**, run the server with one Docker command, or talk to it
+over RESP / gRPC / HTTP / MCP — see [Use it as a Rust library](#use-it-as-a-rust-library).
+
 ---
 
 ## What you get
@@ -137,7 +144,7 @@ turn, plus recall/remember tools.
 ### Claude Code (marketplace plugin)
 
 ```text
-/plugin marketplace add bjmeetsfo/TemporalStore
+/plugin marketplace add matrixarkai/TemporalStore
 /plugin install matrixark-memory@temporalstore
 ```
 

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 description = "Rust-native TemporalStore engine, storage, client/proxy, and production Raft readiness surfaces."
 readme = "README.md"
-repository = "https://github.com/bjmeetsfo/TemporalStore"
-homepage = "https://github.com/bjmeetsfo/TemporalStore"
+repository = "https://github.com/matrixarkai/TemporalStore"
+homepage = "https://github.com/matrixarkai/TemporalStore"
 keywords = ["temporalstore", "database", "storage", "raft", "memory"]
 categories = ["database-implementations", "data-structures"]
 


### PR DESCRIPTION
…references

- add a top-of-README callout: three open Apache-2.0 repositories (TemporalStore, MatrixCache, MatrixRaft), free for anyone to use as Rust crates / Docker / RESP- gRPC-HTTP-MCP, linking the "Use it as a Rust library" section
- fix the Claude Code plugin install to reference the public repo (matrixarkai/TemporalStore, not the private canonical repo)
- point the crate's Cargo.toml repository/homepage at the public repo so people who `cargo add` it land on the right place

Docs/metadata only; open_source_ready: true; readiness tokens intact.