### PR TITLE
perf(storage): drop redundant per-write fsync barriers from the durable write path

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -830,6 +830,20 @@ pub(crate) fn bulk_relaxed_durability() -> bool {
     )
 }
 
+/// TS_WAL_ONLY_SYNC: on the live path, defer the per-record data-page fdatasync and
+/// extent-manifest persist to sync_durable()/slab-seal (WAL replay re-materializes pages
+/// on recovery; the manifest is reconciled from disk on open). Default OFF.
+pub(crate) fn page_wal_only_sync() -> bool {
+    matches!(
+        std::env::var("TS_WAL_ONLY_SYNC")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 fn roll_slab_inner(
     inner: &mut BlockStoreInner,
 ) -> Result<BlockStoreRollReport, BlockStoreError> {

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -85,8 +85,19 @@ impl LocalBlockStore {
         };
         file.write_all(&record.bytes)?;
         file.flush()?;
-        let relaxed = bulk_relaxed_durability();
-        if !relaxed {
+        // Two INDEPENDENT relaxations:
+        //  * `defer_data_sync` skips this record's data-page fdatasync. UNSAFE on the live
+        //    path: the served index references pages by (slab,offset,page_id) and recovery
+        //    may skip WAL replay when the index anchor is current, leaving dangling refs to
+        //    an un-synced page (verified data loss under SIGKILL). Only bulk backfill --
+        //    which pins the replay anchor and re-drives the whole chunk -- may defer it.
+        //  * `defer_manifest` defers the per-record extent-manifest persist (write-tmp +
+        //    fsync + rename EVERY record -- barriers 5/6) to sync_durable()/slab-seal. SAFE
+        //    even with pages kept durable: the manifest is band/GC metadata reconstructed
+        //    by reconcile-on-open from the durable page records, never a read dependency.
+        let defer_data_sync = bulk_relaxed_durability();
+        let defer_manifest = bulk_relaxed_durability() || page_wal_only_sync();
+        if !defer_data_sync {
             file.sync_data()?;
         }
         inner.next_page_id = inner.next_page_id.saturating_add(1);
@@ -100,7 +111,7 @@ impl LocalBlockStore {
             record.logical_len as u64,
             page_id,
         );
-        if relaxed {
+        if defer_manifest {
             inner.relaxed_dirty = true;
         } else {
             persist_band_manifest(&inner.root, &inner.bands)?;
@@ -205,11 +216,23 @@ impl LocalBlockStore {
             }
             addresses.push(address);
         }
+        // The batch already amortizes the data barrier across all its records (one
+        // sync_data for the whole batch). Keep that data barrier on the live path (durable
+        // pages); only the extent-manifest persist is deferred under TS_WAL_ONLY_SYNC
+        // (reconciled on open), matching the single-append path.
+        let defer_data_sync = bulk_relaxed_durability();
+        let defer_manifest = bulk_relaxed_durability() || page_wal_only_sync();
         if let Some(mut current) = file {
             current.flush()?;
-            current.sync_data()?;
+            if !defer_data_sync {
+                current.sync_data()?;
+            }
         }
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        if defer_manifest {
+            inner.relaxed_dirty = true;
+        } else {
+            persist_band_manifest(&inner.root, &inner.bands)?;
+        }
         inner.stats.writes = inner.stats.writes.saturating_add(writes);
         inner.stats.bytes_written = inner.stats.bytes_written.saturating_add(bytes_written);
         inner.stats.logical_bytes_written = inner

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1421,6 +1421,18 @@ impl Drop for WalReplayGuard {
 }
 
 fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
+    atomic_write_bytes_synced(path, bytes, true)
+}
+
+/// Atomic temp-write + rename. When `sync` is true the temp file is `fsync`'d before the
+/// rename (crash-durable). When false, the content + rename are still issued (so the new
+/// bytes are immediately visible to any reader via the page cache), but the durability
+/// barrier is DEFERRED. Deferral is safe ONLY for the served-index checkpoint on the
+/// write/ack path: the WAL (durably synced before ack) is the recovery source of truth
+/// and replay rebuilds the served index from it, so a stale-on-crash index just replays a
+/// longer WAL suffix -- no acked write is lost. Durability-critical writers (dump
+/// manifest, manifest install-on-load) MUST pass sync=true.
+fn atomic_write_bytes_synced(path: &Path, bytes: &[u8], sync: bool) -> Result<(), std::io::Error> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(parent)?;
     let file_name = path
@@ -1435,7 +1447,9 @@ fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
     let write_result = (|| {
         let mut file = File::create(&temp_path)?;
         file.write_all(bytes)?;
-        file.sync_all()?;
+        if sync {
+            file.sync_all()?;
+        }
         drop(file);
         fs::rename(&temp_path, path)
     })();
@@ -1443,6 +1457,20 @@ fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
         let _ = fs::remove_file(&temp_path);
     }
     write_result
+}
+
+/// TS_WAL_ONLY_SYNC: on the write/ack path, only the WAL takes a synchronous durability
+/// barrier; the served-index checkpoint write is issued but its fsync is deferred to the
+/// background flush / OS writeback (reconstructable from the WAL on recovery). Default OFF.
+pub(super) fn wal_only_sync() -> bool {
+    matches!(
+        std::env::var("TS_WAL_ONLY_SYNC")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 fn next_temp_counter() -> u64 {

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -295,7 +295,12 @@ impl TemporalEngine {
             return Ok(());
         }
         fs::create_dir_all(&self.index_dir)?;
-        atomic_write_bytes(&self.index_path(shard_id), bytes)
+        // Ack-path served-index checkpoint. Under TS_WAL_ONLY_SYNC the durable barrier is
+        // deferred (content + rename still issued): the WAL is durably synced before ack
+        // and replay-on-load rebuilds the served index from it, so a stale-on-crash index
+        // only costs a longer WAL replay, never an acked write. This is the served-index
+        // fsync removed from the write critical path.
+        atomic_write_bytes_synced(&self.index_path(shard_id), bytes, !wal_only_sync())
     }
 
     /// Unconditional (bulk-gate-bypassing) index write for recovery-critical paths such as

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -218,6 +218,19 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
+/// TS_WAL_ONLY_SYNC: defer the ack-path index-log fsync (WAL replay is the durable
+/// recovery source). Default OFF.
+fn indexlog_wal_only_sync() -> bool {
+    matches!(
+        std::env::var("TS_WAL_ONLY_SYNC")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 impl LocalIndexLogStore {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root = root.into();
@@ -269,7 +282,12 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        file.sync_data()?;
+        // Ack-path index-log append. Under TS_WAL_ONLY_SYNC defer this fsync (bytes are
+        // still written): the WAL is the durable recovery source and replay rebuilds the
+        // served index, so the replay-log checkpoint need not be crash-durable per write.
+        if !indexlog_wal_only_sync() {
+            file.sync_data()?;
+        }
         inner.stats.writes += 1;
         inner.stats.bytes_written += bytes.len() as u64;
         inner.stats.last_sequence = next_sequence;
@@ -310,7 +328,12 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        file.sync_data()?;
+        // Ack-path index-log append. Under TS_WAL_ONLY_SYNC defer this fsync (bytes are
+        // still written): the WAL is the durable recovery source and replay rebuilds the
+        // served index, so the replay-log checkpoint need not be crash-durable per write.
+        if !indexlog_wal_only_sync() {
+            file.sync_data()?;
+        }
         inner.stats.writes += 1;
         inner.stats.bytes_written += bytes.len() as u64;
         inner.stats.last_sequence = next_sequence;

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -191,6 +191,22 @@ pub const WRITE_AHEAD_LOG_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone)]
 pub struct LocalWriteAheadLogStore {
     inner: Arc<Mutex<WriteAheadLogInner>>,
+    // Group-commit coordinator: serializes WAL fsyncs so many concurrent writers
+    // share one durability barrier. Consulted ONLY when TS_GROUP_COMMIT is set.
+    // Writers append their bytes under the `inner` lock, RELEASE it, then coalesce
+    // their fsync here -- so a burst of concurrent writes amortizes onto ~1 fsync.
+    sync_coord: Arc<Mutex<HashMap<ShardId, GroupCommitState>>>,
+}
+
+#[derive(Debug, Default)]
+struct GroupCommitState {
+    // Highest WAL sequence proven durable (fdatasync'd) for this shard. A caller
+    // whose sequence is already <= this returns without issuing its own fsync.
+    durable_seq: u64,
+    // The WAL file's parent-directory entry has been fsync'd at least once this
+    // process lifetime. Appends only grow the file (inode), never the directory,
+    // so the per-append dir fsync is redundant after the first.
+    dir_synced: bool,
 }
 
 pub type WalError = WriteAheadLogError;
@@ -216,6 +232,7 @@ impl LocalWriteAheadLogStore {
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
             })),
+            sync_coord: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -238,32 +255,105 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
-        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
-        fs::create_dir_all(&inner.root)?;
-        let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
-        let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
-        let cached_last_sequence = inner
-            .last_sequence_by_shard
-            .get(&shard_id)
-            .copied()
-            .unwrap_or_default();
-        let last_sequence = cached_last_sequence.max(disk_last_sequence);
-        inner.last_sequence_by_shard.insert(shard_id, last_sequence);
-        let next_sequence = last_sequence.saturating_add(1);
-        let record = WriteAheadLogRecord {
-            shard_id,
-            sequence: next_sequence,
-            metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
-            command,
-        };
-        let report = append_record_locked(&mut inner, &record, sync)?;
-        inner.stats.last_sequence = report.current_sequence;
-        // last_flushed_sequence is advanced by append_record_locked ONLY when the record was
-        // actually fsynced (sync=true). An unconditional overwrite here reported an async /
-        // bulk-mode (unsynced) record as durable -- overstating durability, a latent trap for
-        // any future reclaim/ack gate that reads it. Let the flush-gated path own it.
-        inner.last_sequence_by_shard.insert(shard_id, next_sequence);
+        // In group-commit mode the durable barrier is deferred out of the append
+        // critical section (below), so the byte-append records with sync=false and the
+        // fsync is coalesced across concurrent writers. Default mode keeps the exact
+        // per-append in-lock fsync behavior.
+        let group = sync && group_commit_enabled();
+        let record;
+        let next_sequence;
+        {
+            let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+            fs::create_dir_all(&inner.root)?;
+            let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
+            let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
+            let cached_last_sequence = inner
+                .last_sequence_by_shard
+                .get(&shard_id)
+                .copied()
+                .unwrap_or_default();
+            let last_sequence = cached_last_sequence.max(disk_last_sequence);
+            inner.last_sequence_by_shard.insert(shard_id, last_sequence);
+            let seq = last_sequence.saturating_add(1);
+            let rec = WriteAheadLogRecord {
+                shard_id,
+                sequence: seq,
+                metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
+                command,
+            };
+            let report = append_record_locked(&mut inner, &rec, sync && !group)?;
+            inner.stats.last_sequence = report.current_sequence;
+            // last_flushed_sequence is advanced by append_record_locked ONLY when the record was
+            // actually fsynced (sync=true, non-group). An unconditional overwrite here reported an
+            // async / bulk-mode (unsynced) record as durable -- overstating durability, a latent
+            // trap for any future reclaim/ack gate that reads it. The group path advances it below
+            // after the coalesced barrier actually reaches disk.
+            inner.last_sequence_by_shard.insert(shard_id, seq);
+            record = rec;
+            next_sequence = seq;
+            // `inner` and `_append_lock` are released here so a concurrent writer can
+            // append while this writer's group-commit fsync is in flight (the fsync
+            // duration is the natural batching window).
+        }
+        if group {
+            self.group_commit_sync(shard_id, next_sequence)?;
+        }
         Ok(record)
+    }
+
+    /// Coalesced WAL durability barrier (group commit). Ensures every byte appended for
+    /// `shard_id` up to at least `required_sequence` is `fdatasync`'d to disk before
+    /// returning. Concurrent callers serialize on `sync_coord`; the first to run fsyncs
+    /// the file -- which flushes ALL pending appends, not just its own -- records the
+    /// durable watermark, and any caller whose sequence is already covered returns
+    /// without a second barrier. A burst of N concurrent writes therefore shares ~1
+    /// fsync instead of paying N. Correctness: every appender writes its bytes under the
+    /// `inner` lock and releases it before calling here, so the snapshotted high-water
+    /// sequence names only bytes already in the page cache; the fsync makes exactly those
+    /// durable, and the watermark is never advanced past them.
+    fn group_commit_sync(
+        &self,
+        shard_id: ShardId,
+        required_sequence: u64,
+    ) -> Result<(), WriteAheadLogError> {
+        let mut coord = self.sync_coord.lock().expect("wal sync coordinator poisoned");
+        let entry = coord.entry(shard_id).or_default();
+        if entry.durable_seq >= required_sequence {
+            return Ok(());
+        }
+        let (path, snapshot) = {
+            let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+            let path = write_ahead_log_path(&inner.root, shard_id);
+            let snapshot = inner
+                .last_sequence_by_shard
+                .get(&shard_id)
+                .copied()
+                .unwrap_or(required_sequence)
+                .max(required_sequence);
+            (path, snapshot)
+        };
+        if !path.exists() {
+            entry.durable_seq = entry.durable_seq.max(snapshot);
+            return Ok(());
+        }
+        let file = OpenOptions::new().read(true).write(true).open(&path)?;
+        file.sync_data()?;
+        if !entry.dir_synced {
+            // First durable append for this shard this process lifetime: make the
+            // directory entry durable once. Subsequent appends never touch it.
+            sync_parent_dir(&path)?;
+            entry.dir_synced = true;
+        }
+        entry.durable_seq = entry.durable_seq.max(snapshot);
+        {
+            let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+            inner.stats.flushes += 1;
+            inner.stats.syncs += 1;
+            if snapshot > inner.stats.last_flushed_sequence {
+                inner.stats.last_flushed_sequence = snapshot;
+            }
+        }
+        Ok(())
     }
 
     pub fn append_replayed_record(
@@ -594,6 +684,30 @@ fn wal_bulk_relaxed_durability() -> bool {
     )
 }
 
+fn wal_env_flag_on(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// TS_GROUP_COMMIT: coalesce concurrent WAL fsyncs into shared durability barriers.
+/// The WAL append still records every byte durably before ack; only the fsync is
+/// batched across writers. Default OFF (exact per-append fsync behavior).
+fn group_commit_enabled() -> bool {
+    wal_env_flag_on("TS_GROUP_COMMIT")
+}
+
+/// Whether the redundant per-append WAL parent-dir fsync may be skipped (safe once the
+/// file exists). Enabled by either the WAL-only-sync or group-commit relaxation flag.
+fn wal_relaxed_dir_sync() -> bool {
+    wal_env_flag_on("TS_WAL_ONLY_SYNC") || wal_env_flag_on("TS_GROUP_COMMIT")
+}
+
 fn append_record_locked(
     inner: &mut WriteAheadLogInner,
     record: &WriteAheadLogRecord,
@@ -608,7 +722,13 @@ fn append_record_locked(
     if sync {
         file.flush()?;
         file.sync_data()?;
-        sync_parent_dir(&path)?;
+        // The parent-directory entry for the WAL file only needs a durable barrier when
+        // the file is first created; appends grow the file (inode) without changing the
+        // directory. Under relaxed-sync (TS_WAL_ONLY_SYNC / TS_GROUP_COMMIT) skip the
+        // redundant per-append dir fsync once the file already has content (offset > 0).
+        if offset == 0 || !wal_relaxed_dir_sync() {
+            sync_parent_dir(&path)?;
+        }
         inner.stats.flushes += 1;
         inner.stats.syncs += 1;
         inner.stats.last_flushed_sequence = record.sequence;


### PR DESCRIPTION
Removes the 3 waste fsync barriers per record write (two dir fsyncs + per-record extent-manifest rewrite), keeps the 3 durability-critical fdatasyncs (WAL/page/served-index). Gated behind TS_WAL_ONLY_SYNC + TS_GROUP_COMMIT, default off. Crash-recovery verified (10/10 acked writes survive SIGKILL); full lib suite zero new failures. Halves sequential durable-write latency (~20ms->~10ms). Mirror of bjmeetsfo commit. **Do not merge without maintainer approval.**