### PR TITLE
test(recovery): pin the recovering-gate read behavior on WAL replay

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -486,4 +486,81 @@ impl TemporalEngine {
             status: Status::ok(),
         }
     }
+
+    /// Test-only: run the publish phase of `load_shard_with` (install newer manifest, load
+    /// the served-index base, publish the shard as `recovering: true`) but STOP before WAL
+    /// replay, leaving the shard parked in the recovery window. Returns the WAL replay
+    /// watermark to hand to `test_finish_recovery`. Reuses the exact real recovery helpers so
+    /// the observed gate behaviour matches production; it only splits the single synchronous
+    /// `load_shard_with` into two steps a single-threaded test can observe between.
+    #[cfg(test)]
+    pub(crate) fn test_publish_recovering_shard(&self, shard_id: ShardId) -> u64 {
+        let installed_manifest_watermark = self
+            .install_latest_manifest_if_newer_on_load(shard_id)
+            .expect("manifest install should succeed in test");
+        let loaded = self.load_index(shard_id, eager_cache_warm_on_load());
+        let replay_watermark = match installed_manifest_watermark {
+            Some(manifest_watermark) => manifest_watermark,
+            None => match &loaded {
+                None => 0,
+                Some(state) => state
+                    .applied_wal_sequence
+                    .unwrap_or_else(|| self.wal_store.stats(shard_id).last_sequence),
+            },
+        };
+        let mut state = loaded.unwrap_or_default();
+        promote_model_maps_to_bucket_index_authority(shard_id, &mut state, 0, u32::MAX);
+        self.infos.write().expect("info lock poisoned").insert(
+            shard_id,
+            ShardInfo {
+                shard_id,
+                loaded: true,
+                table_name: String::new(),
+                shard_uri: String::new(),
+                start_routing_bucket: 0,
+                end_routing_bucket: u32::MAX,
+                readonly: false,
+                load_version: 0,
+                local_node_id: None,
+                membership_version: 0,
+                replica_membership_version: 0,
+                membership_valid: true,
+                replica_node_ids: Vec::new(),
+                leader_node_id: None,
+                recovering: true,
+            },
+        );
+        self.shards
+            .write()
+            .expect("engine lock poisoned")
+            .insert(shard_id, state);
+        self.configs
+            .write()
+            .expect("config lock poisoned")
+            .entry(shard_id)
+            .or_default();
+        self.admissions
+            .write()
+            .expect("admission lock poisoned")
+            .entry(AdmissionScope::Shard(shard_id))
+            .or_default();
+        replay_watermark
+    }
+
+    /// Test-only: finish the recovery started by `test_publish_recovering_shard` by running
+    /// the real WAL replay and then clearing the `recovering` gate, exactly as
+    /// `load_shard_with`'s tail does.
+    #[cfg(test)]
+    pub(crate) fn test_finish_recovery(&self, shard_id: ShardId, watermark: u64) {
+        self.replay_wal_into_shard(shard_id, watermark)
+            .expect("wal replay should succeed in test");
+        if let Some(info) = self
+            .infos
+            .write()
+            .expect("info lock poisoned")
+            .get_mut(&shard_id)
+        {
+            info.recovering = false;
+        }
+    }
 }

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1008,6 +1008,95 @@ fn async_write_survives_restart_via_wal_replay_like_native() {
     );
 }
 
+// Readiness race regression: after a restart with WAL entries not yet reflected in the served
+// index, the shard is published but NOT serving until `replay_wal_into_shard` completes
+// (ShardInfo.recovering gates it). A read that arrives inside that window must NOT observe a
+// false null from the half-reconstructed state -- it must be rejected with a retryable
+// `shard_not_loaded`. Once replay completes the same read must return the recovered value.
+// (The fix commit gated this deliberately without a deterministic test; this pins it.)
+#[test]
+fn read_during_wal_replay_recovery_returns_retryable_not_false_null() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    // async_storage: the write lands in the WAL but page/index materialization is deferred, so
+    // it is absent from the served index until the WAL is replayed on the next load.
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "k".to_string(),
+            value: b"recovered-value".to_vec(),
+        },
+    });
+    assert_eq!(engine.block_store().stats().writes, 0);
+    assert_eq!(engine.write_ahead_log_store().stats(1).writes, 1);
+    drop(engine);
+
+    // Restart, and park the shard in the recovery window: base index loaded (the async write is
+    // NOT in it yet), recovering=true, WAL not yet replayed.
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    let watermark = restarted.test_publish_recovering_shard(1);
+
+    // A read inside the recovery window must be rejected retryably, NOT return a false null.
+    let during = restarted.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "k".to_string(),
+        },
+    });
+    assert!(
+        !during.status.ok,
+        "read during WAL-replay recovery must be rejected, not served from half-built state"
+    );
+    assert_eq!(during.status.code, "shard_not_loaded");
+    assert_eq!(
+        during.response,
+        CommandResponse::Empty,
+        "recovering read must return a retryable error, never a false null (Bytes {{ None }})"
+    );
+
+    // After replay completes and the gate clears, the same read returns the recovered value.
+    restarted.test_finish_recovery(1, watermark);
+    let after = restarted.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "k".to_string(),
+        },
+    });
+    assert!(after.status.ok, "shard must serve once recovery completes");
+    assert_eq!(
+        after.response,
+        CommandResponse::Bytes {
+            value: Some(b"recovered-value".to_vec())
+        },
+        "the WAL-recovered value must be served after recovery completes"
+    );
+}
+
 // Coalesced control-state persistence skips the per-write whole-series page rewrite
 // (write-amplification) and relies on the index snapshot + WAL replay for durability, the
 // same model control_state_changes/fol already use. This MUST stay crash-safe: increments


### PR DESCRIPTION
## Readiness-gate regression test (test-only)

Adds a deterministic regression test pinning the datanode recovery readiness gate: after a restart with WAL entries not yet folded into the served index, a read that arrives while the shard is still recovering (WAL replay in progress) must NOT return a false null from half-reconstructed state -- it is rejected with a retryable `shard_not_loaded`, and returns the WAL-recovered value once replay completes.

The gate itself already exists on `main` (ShardInfo.recovering set before `replay_wal_into_shard` and cleared only after it returns Ok; both the main execute path and the read-only fast path honor it). That fix shipped deliberately without a deterministic test to avoid a flaky concurrency test; this makes it deterministic by splitting the synchronous load into publish-then-replay via two `#[cfg(test)]`-only helpers that reuse the real recovery functions. No production recovery path is modified.

Full single-threaded lib suite: 632 passed, 1 ignored; only the pre-existing `jitter_backoff` flake failing.

**Do not merge without maintainer approval.**