### PR TITLE
feat(gateway): enforced-mode per-tenant API keys with hashed keystore + scope isolation

### DIFF
--- a/tools/matrixark_provision_api_key.py
+++ b/tools/matrixark_provision_api_key.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Mint a per-tenant MatrixArk Cloud API key for the enforced-mode `/v1` gateway.
+
+The key is returned in PLAINTEXT exactly once (on stdout); only its sha256 hash is persisted, in an
+append-only JSONL keystore whose records reuse the backend credential-store shape
+(`record_type="matrixark_api_key"`, the same fields `matrixark_access.create_api_key` writes). The
+gateway loads this store via `MATRIXARK_API_KEYS_HASHED_FILE` and, in enforced mode
+(`MATRIXARK_AUTH_ENFORCED=1`), resolves a presented Bearer key to `{tenant_id, account_id}` by
+hash -- never trusting client-supplied scope text.
+
+    python3 matrixark_provision_api_key.py --tenant-id tenantA --account-id acct_a \
+        --store /opt/temporalstore/gw/keys/api_keys_hashed.jsonl
+
+Revoke a key by re-appending a record with the same `api_key_hash` and `--status revoked` (the
+gateway keeps the last active record per hash).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import sys
+import time
+
+try:  # reuse the backend hashing + key-mint primitives when importable
+    try:
+        from tools.matrixark_mcp_core_identity import make_api_key, secret_hash  # type: ignore
+    except ImportError:
+        from matrixark_mcp_core_identity import make_api_key, secret_hash  # type: ignore
+except Exception:  # pragma: no cover - self-contained fallback (identical algorithm)
+    import hashlib
+
+    def secret_hash(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    def make_api_key(prefix: str = "mk_test") -> str:
+        return f"{prefix}_{secrets.token_urlsafe(32)}"
+
+
+_DEFAULT_SCOPES = [
+    "context:ingest",
+    "context:retrieve",
+    "context:feedback",
+    "context:replay",
+]
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _default_store() -> str:
+    return (
+        os.environ.get("MATRIXARK_API_KEYS_HASHED_FILE")
+        or "/opt/temporalstore/gw/keys/api_keys_hashed.jsonl"
+    )
+
+
+def mint(args: argparse.Namespace) -> dict:
+    api_key = make_api_key(args.prefix)
+    api_key_hash = secret_hash(api_key)
+    api_key_id = f"key_{api_key_hash[:24]}"
+    record = {
+        "record_type": "matrixark_api_key",
+        "api_key_id": api_key_id,
+        "api_key_hash": api_key_hash,
+        "account_id": args.account_id,
+        "tenant_id": args.tenant_id,
+        "scopes": sorted(set(args.scopes or _DEFAULT_SCOPES)),
+        "role": args.role,
+        "display_name": args.display_name or f"{args.tenant_id} key",
+        "allowed_user_ids": sorted(set(args.allowed_user_ids or [])),
+        "status": args.status,
+        "expires_at_ms": args.expires_at_ms,
+        "created_at_ms": _now_ms(),
+    }
+    store = args.store or _default_store()
+    os.makedirs(os.path.dirname(store), exist_ok=True)
+    with open(store, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    return {
+        "status": "created" if args.status == "active" else args.status,
+        "api_key": api_key,  # plaintext -- shown ONCE, never persisted
+        "api_key_id": api_key_id,
+        "api_key_hash": api_key_hash,
+        "tenant_id": args.tenant_id,
+        "account_id": args.account_id,
+        "scopes": record["scopes"],
+        "store": store,
+        "warning": "Store api_key now. MatrixArk only persists its hash.",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Mint a per-tenant MatrixArk Cloud API key.")
+    parser.add_argument("--tenant-id", dest="tenant_id", required=True)
+    parser.add_argument("--account-id", dest="account_id", default="acct_local")
+    parser.add_argument("--prefix", default="sk_live")
+    parser.add_argument("--role", default="service")
+    parser.add_argument("--display-name", dest="display_name", default="")
+    parser.add_argument("--status", default="active", choices=["active", "revoked"])
+    parser.add_argument("--expires-at-ms", dest="expires_at_ms", type=int, default=None)
+    parser.add_argument("--scope", dest="scopes", action="append", help="repeatable MatrixArk scope")
+    parser.add_argument(
+        "--allowed-user-id", dest="allowed_user_ids", action="append",
+        help="repeatable; restrict the key to these user_ids",
+    )
+    parser.add_argument("--store", default="", help="JSONL keystore path (hashed records only)")
+    args = parser.parse_args(argv)
+    result = mint(args)
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -44,6 +44,20 @@ except ImportError:  # Direct script execution from tools/.
     from matrixark_asgi import make_asgi_app, _api_key  # type: ignore
     from matrixark_http import apply_ingest_route_defaults, mcp_http_dispatch  # type: ignore
 
+# Key hashing: reuse the backend's `secret_hash` (sha256 hex) so a key minted by the provisioner /
+# backend credential store verifies identically at the edge. Falls back to a self-contained sha256
+# so the gateway keeps importing cleanly even where the backend identity module is unavailable.
+try:  # pragma: no cover - trivial import shim
+    try:
+        from tools.matrixark_mcp_core_identity import secret_hash as _secret_hash  # type: ignore
+    except ImportError:
+        from matrixark_mcp_core_identity import secret_hash as _secret_hash  # type: ignore
+except Exception:  # pragma: no cover
+    import hashlib as _hashlib
+
+    def _secret_hash(value: str) -> str:
+        return _hashlib.sha256(value.encode("utf-8")).hexdigest()
+
 Json = dict[str, Any]
 
 # ---- defaults (all overridable via env or the `config` dict) -----------------------------------
@@ -51,6 +65,7 @@ _MIB = 1024 * 1024
 _GIB = 1024 * 1024 * 1024
 _DEFAULTS = {
     "require_auth": True,
+    "enforced": False,
     "ingest_rps": 5000.0,
     "ingest_burst": 10000.0,
     "retrieve_rps": 6000.0,
@@ -123,6 +138,72 @@ def _parse_api_keys(env: Any, overrides: Json) -> dict[str, str]:
     return keys
 
 
+def _parse_hashed_keys(env: Any, overrides: Json) -> dict[str, Json]:
+    """Enforced-mode keystore: ``{api_key_hash -> {"tenant_id", "account_id"}}``.
+
+    Keys are stored HASHED, never plaintext. The store is provisioned by
+    ``matrixark_provision_api_key.py`` (which reuses the backend ``secret_hash`` and the
+    ``matrixark_api_key`` record shape). Two source shapes are accepted from
+    ``MATRIXARK_API_KEYS_HASHED_FILE``:
+
+      * JSONL of ``matrixark_api_key`` records (same fields the backend credential store writes:
+        ``record_type``/``api_key_hash``/``account_id``/``tenant_id``/``status``/``expires_at_ms``).
+      * a plain JSON object ``{"<sha256hex>": {"tenant_id": ..., "account_id": ...}}``.
+
+    ``overrides["hashed_api_keys"]`` (a dict) short-circuits for tests. Inactive/expired records are
+    skipped. The last active record for a given hash wins.
+    """
+    if isinstance(overrides.get("hashed_api_keys"), dict):
+        return {str(k): dict(v) if isinstance(v, dict) else {"tenant_id": str(v)}
+                for k, v in overrides["hashed_api_keys"].items()}
+    path = str(env.get("MATRIXARK_API_KEYS_HASHED_FILE", "") or "").strip()
+    out: dict[str, Json] = {}
+    if not path or not os.path.exists(path):
+        return out
+    now = int(time.time() * 1000)
+
+    def _add(hash_hex: str, tenant_id: str, account_id: str) -> None:
+        if hash_hex and tenant_id:
+            out[hash_hex] = {"tenant_id": tenant_id, "account_id": account_id or "acct_local"}
+
+    with open(path, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    stripped = text.strip()
+    if stripped.startswith("{") and '"api_key_hash"' not in stripped:
+        # plain JSON object form.
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError:
+            data = {}
+        if isinstance(data, dict):
+            for hash_hex, value in data.items():
+                if isinstance(value, dict):
+                    _add(str(hash_hex), str(value.get("tenant_id") or ""), str(value.get("account_id") or ""))
+                else:
+                    _add(str(hash_hex), str(value), "")
+        return out
+    # JSONL of records (append-only credential-store shape).
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict) or record.get("record_type") not in (None, "matrixark_api_key"):
+            continue
+        if str(record.get("status", "active")) != "active":
+            out.pop(str(record.get("api_key_hash") or ""), None)
+            continue
+        expires_at_ms = record.get("expires_at_ms")
+        if isinstance(expires_at_ms, int) and expires_at_ms <= now:
+            continue
+        _add(str(record.get("api_key_hash") or ""), str(record.get("tenant_id") or ""),
+             str(record.get("account_id") or ""))
+    return out
+
+
 class GatewayConfig:
     """Resolved gateway configuration (env + optional overrides)."""
 
@@ -130,6 +211,8 @@ class GatewayConfig:
         for name, value in _DEFAULTS.items():
             setattr(self, name, fields.get(name, value))
         self.api_keys: dict[str, str] = fields.get("api_keys", {})
+        # Enforced-mode hashed keystore: {api_key_hash -> {tenant_id, account_id}}.
+        self.hashed_keys: dict[str, Json] = fields.get("hashed_keys", {})
         # Datanode blob target, parsed for the http.client proxy.
         parsed = urlparse(str(self.datanode_url))
         self.blob_scheme = parsed.scheme or "http"
@@ -158,9 +241,14 @@ class GatewayConfig:
 
         return cls(
             api_keys=_parse_api_keys(env, overrides),
+            hashed_keys=_parse_hashed_keys(env, overrides),
             require_auth=_env_bool(
                 overrides.get("require_auth", env.get("MATRIXARK_REQUIRE_AUTH")),
                 _DEFAULTS["require_auth"],
+            ),
+            enforced=_env_bool(
+                overrides.get("enforced", env.get("MATRIXARK_AUTH_ENFORCED")),
+                _DEFAULTS["enforced"],
             ),
             ingest_rps=num("MATRIXARK_RL_INGEST_RPS", "ingest_rps", float),
             ingest_burst=num("MATRIXARK_RL_INGEST_BURST", "ingest_burst", float),
@@ -283,28 +371,56 @@ class _RateLimiter:
 # ================================================================================================
 # Auth + tenant isolation
 # ================================================================================================
-def _authorize(headers: list[Tuple[bytes, bytes]], cfg: GatewayConfig) -> Tuple[bool, Optional[str], Optional[str]]:
-    """Return (allowed, api_key, tenant). Unknown/missing key -> (False, ...) unless auth disabled."""
+def _authorize(headers: list[Tuple[bytes, bytes]],
+               cfg: GatewayConfig) -> Tuple[bool, Optional[str], Optional[str], Optional[str]]:
+    """Resolve the Bearer key to a tenant identity.
+
+    Returns ``(allowed, api_key, tenant_id, account_id)``.
+
+    ENFORCED mode (``MATRIXARK_AUTH_ENFORCED=1``): EVERY /v1 request must carry a Bearer key whose
+    sha256 hash is present in the provisioned hashed keystore. A missing, unknown, or revoked key --
+    and the legacy demo key ``sk_live_demo`` (which is never hashed into the enforced store) -- is
+    rejected. The identity ``{tenant_id, account_id}`` is taken from the stored record, NEVER from
+    client-supplied free text, so two tenants cannot collide on a shared scope string.
+
+    DEV/unenforced mode (default): unchanged legacy behavior -- the plaintext ``api_keys`` env map is
+    honored and, when ``require_auth`` is off, anonymous requests are allowed. This keeps existing dev
+    flows (the demo key) working when enforcement is off.
+    """
     key = _api_key(headers)
+    if cfg.enforced:
+        if not key:
+            return False, None, None, None
+        record = cfg.hashed_keys.get(_secret_hash(key))
+        if record:
+            return True, key, str(record.get("tenant_id") or ""), str(record.get("account_id") or "") or None
+        return False, None, None, None
+    # ---- dev / unenforced (legacy) --------------------------------------------------------------
     if key and key in cfg.api_keys:
-        return True, key, cfg.api_keys[key]
+        return True, key, cfg.api_keys[key], None
     if not cfg.require_auth:  # local/dev: anonymous is allowed.
-        return True, key, (cfg.api_keys.get(key) if key else None) or "anonymous"
-    return False, None, None
+        return True, key, (cfg.api_keys.get(key) if key else None) or "anonymous", None
+    return False, None, None, None
 
 
-def _apply_identity(args: Json, key: Optional[str], tenant: Optional[str]) -> Json:
-    """Inject identity and namespace-isolate `scope` under the tenant.
+def _apply_identity(args: Json, key: Optional[str], tenant: Optional[str],
+                    account: Optional[str] = None) -> Json:
+    """Inject identity and namespace-isolate `scope` under the tenant (and account).
 
     The shared backend access manager validates `scope` as an OBJECT (dict) for *every* backend
-    (`optional_object(args, "scope")`), so the tenant is injected as `scope["tenant_id"]`. Injecting
-    a bare tenant *string* (the previous behavior) made the backend reject every ingest/retrieve with
-    "scope must be an object" — a 100% failure that the unit tests missed by using a fake server.
+    (`optional_object(args, "scope")`), so the tenant is injected as `scope["tenant_id"]` (and the
+    resolved `scope["account_id"]`). Injecting a bare tenant *string* (an earlier behavior) made the
+    backend reject every ingest/retrieve with "scope must be an object".
+
+    The tenant identity is authoritative: the session/pending buffer key derives from
+    `(account_id, tenant_id, user_id, session_id)`, so pinning both `tenant_id` and `account_id` from
+    the authenticated key -- rather than trusting the client's `scope` string -- is what isolates one
+    tenant's memory (and the `pending_async_event` fallback buffer) from another's.
 
     The edge bearer key is forwarded as the backend `api_key` only when
     MATRIXARK_GATEWAY_FORWARD_API_KEY is truthy (default on). Deployments where the edge itself is the
-    trust boundary and the backend runs in `dev` access mode (so it does not expect scoped MatrixArk
-    keys) set it to 0, so the edge token is not misread as a backend credential.
+    trust boundary and the backend runs in `dev` access mode set it to 0, so the edge token is not
+    misread as a backend credential.
     """
     if key and _env_bool(os.environ.get("MATRIXARK_GATEWAY_FORWARD_API_KEY"), True):
         args["api_key"] = key
@@ -312,21 +428,30 @@ def _apply_identity(args: Json, key: Optional[str], tenant: Optional[str]) -> Js
         args["tenant"] = tenant
         scope = args.get("scope")
         if isinstance(scope, dict):
-            scope.setdefault("tenant_id", tenant)
+            scope["tenant_id"] = tenant
+            if account:
+                scope["account_id"] = account
         elif isinstance(scope, str) and scope:
             label = scope if (scope == tenant or scope.startswith(tenant + "/")) else f"{tenant}/{scope}"
-            args["scope"] = {"tenant_id": tenant, "namespace": label}
+            new_scope: Json = {"tenant_id": tenant, "namespace": label}
+            if account:
+                new_scope["account_id"] = account
+            args["scope"] = new_scope
         else:
-            args["scope"] = {"tenant_id": tenant}
+            new_scope = {"tenant_id": tenant}
+            if account:
+                new_scope["account_id"] = account
+            args["scope"] = new_scope
     return args
 
 
-def _isolate_key(key_str: str, tenant: Optional[str]) -> str:
+def _isolate_key(key_str: str, tenant: Optional[str], account: Optional[str] = None) -> str:
     if not tenant:
         return key_str
-    if key_str == tenant or key_str.startswith(tenant + "/"):
+    prefix = f"{account}/{tenant}" if account else tenant
+    if key_str == prefix or key_str.startswith(prefix + "/"):
         return key_str
-    return f"{tenant}/{key_str}"
+    return f"{prefix}/{key_str}"
 
 
 # ================================================================================================
@@ -406,14 +531,15 @@ def _finalize_requested(parsed: Json, args: Json) -> bool:
 # Blob proxy (streamed, bounded memory)
 # ================================================================================================
 async def _blob_put(scope: Json, receive: Callable, send: Callable, method: str,
-                    cfg: GatewayConfig, key_str: str, tenant: Optional[str]) -> None:
+                    cfg: GatewayConfig, key_str: str, tenant: Optional[str],
+                    account: Optional[str] = None) -> None:
     hmap = _headers_map(scope)
     cl_raw = hmap.get("content-length")
     declared = int(cl_raw) if cl_raw and cl_raw.isdigit() else None
     if declared is not None and declared > cfg.max_blob_bytes:
         return await _json(send, 413, {"error": "payload_too_large"})
 
-    dkey = _isolate_key(key_str, tenant)
+    dkey = _isolate_key(key_str, tenant, account)
     conn = cfg.blob_connection_factory(cfg)
     chunked = declared is None
 
@@ -468,8 +594,9 @@ async def _blob_put(scope: Json, receive: Callable, send: Callable, method: str,
     return await _json(send, out_status, receipt)
 
 
-async def _blob_get(send: Callable, cfg: GatewayConfig, key_str: str, tenant: Optional[str]) -> None:
-    dkey = _isolate_key(key_str, tenant)
+async def _blob_get(send: Callable, cfg: GatewayConfig, key_str: str, tenant: Optional[str],
+                    account: Optional[str] = None) -> None:
+    dkey = _isolate_key(key_str, tenant, account)
     conn = cfg.blob_connection_factory(cfg)
 
     def _start() -> Any:
@@ -751,7 +878,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
 
         # ---- blob (auth + concurrent-stream cap, streamed) ----------------------------------
         if path.startswith("/v1/blob/"):
-            allowed, key, tenant = _authorize(scope.get("headers", []), cfg)
+            allowed, key, tenant, account = _authorize(scope.get("headers", []), cfg)
             if not allowed:
                 return await _json(send, 401, {"error": "unauthorized"})
             key_str = path[len("/v1/blob/"):]
@@ -761,9 +888,9 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 429, {"error": "rate_limited"}, [(b"retry-after", b"1")])
             try:
                 if method in ("PUT", "POST"):
-                    return await _blob_put(scope, receive, send, method, cfg, key_str, tenant)
+                    return await _blob_put(scope, receive, send, method, cfg, key_str, tenant, account)
                 if method == "GET":
-                    return await _blob_get(send, cfg, key_str, tenant)
+                    return await _blob_get(send, cfg, key_str, tenant, account)
                 return await _json(send, 405, {"error": "method_not_allowed"})
             finally:
                 limiter.blob_release()
@@ -776,7 +903,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         if method != "POST":
             return await _json(send, 405, {"error": "method_not_allowed"})
 
-        allowed, key, tenant = _authorize(scope.get("headers", []), cfg)
+        allowed, key, tenant, account = _authorize(scope.get("headers", []), cfg)
         if not allowed:
             return await _json(send, 401, {"error": "unauthorized"})
 
@@ -827,13 +954,13 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         # the flag is off, control falls through to the byte-for-byte-unchanged MCP path below.
         if direct_client is not None and tool in (
                 "matrixark_ingest", "matrixark_retrieve", "matrixark_session_commit"):
-            _apply_identity(args, key, tenant)  # scope object only; proxy does the hashing
+            _apply_identity(args, key, tenant, account)  # scope object only; proxy does the hashing
             return await _dispatch_direct(
                 direct_client, cfg, tool, parsed, args, send, rl_headers,
                 n_records=n_records, n_messages=n_messages)
 
         apply_ingest_route_defaults("/api/ingest" if tool == "matrixark_ingest" else path, args)
-        _apply_identity(args, key, tenant)
+        _apply_identity(args, key, tenant, account)
 
         try:
             result = await asyncio.wait_for(
@@ -856,7 +983,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             # extraction NOW; a plain streaming message buffers and extracts later on commit/timeout.
             if _finalize_requested(parsed, args):
                 commit_args = {"scope": args.get("scope")}
-                _apply_identity(commit_args, key, tenant)
+                _apply_identity(commit_args, key, tenant, account)
                 try:
                     out["extraction"] = await asyncio.wait_for(
                         asyncio.to_thread(server.call_tool, "matrixark_session_commit", commit_args),

--- a/tools/test_matrixark_v1_gateway.py
+++ b/tools/test_matrixark_v1_gateway.py
@@ -456,5 +456,69 @@ def _extract_streamed_body(conn):
     return out
 
 
+class EnforcedAuthTest(unittest.TestCase):
+    """MATRIXARK_AUTH_ENFORCED=1: hashed per-tenant keys, demo rejected, tenant identity pinned."""
+
+    KEY_A = "sk_live_tenantA_secret"
+    KEY_B = "sk_live_tenantB_secret"
+
+    def setUp(self):
+        self.s = _FakeServer()
+        hashed = {
+            gw._secret_hash(self.KEY_A): {"tenant_id": "tenantA", "account_id": "acct_a"},
+            gw._secret_hash(self.KEY_B): {"tenant_id": "tenantB", "account_id": "acct_b"},
+        }
+        self.cfg = gw.GatewayConfig.from_env({"enforced": True, "hashed_api_keys": hashed})
+        self.app = gw.make_v1_app(self.s, self.cfg)
+
+    def test_missing_key_rejected(self):
+        st, _, _ = drive(self.app, path="/v1/retrieve", body={"query": "x"})
+        self.assertEqual(401, st)
+        self.assertEqual([], self.s.calls)
+
+    def test_bad_key_rejected(self):
+        st, _, _ = drive(self.app, path="/v1/retrieve", body={"query": "x"},
+                         headers={"Authorization": "Bearer nope"})
+        self.assertEqual(401, st)
+
+    def test_demo_key_rejected_when_enforced(self):
+        st, _, _ = drive(self.app, path="/v1/ingest", body={"records": [1]},
+                         headers={"Authorization": "Bearer sk_live_demo"})
+        self.assertEqual(401, st)
+        self.assertEqual([], self.s.calls)
+
+    def test_valid_key_pins_tenant_and_account(self):
+        st, _, body = drive(self.app, path="/v1/ingest",
+                            body={"scope": "cart", "records": [{"t": "a"}]},
+                            headers={"Authorization": f"Bearer {self.KEY_A}"})
+        self.assertEqual(202, st)
+        scope = json.loads(body)["scope"]
+        self.assertEqual("tenantA", scope["tenant_id"])
+        self.assertEqual("acct_a", scope["account_id"])
+        self.assertEqual("tenantA", self.s.calls[0][1]["tenant"])
+
+    def test_two_tenants_get_distinct_scope_identity(self):
+        # Same client scope string ("cart") must resolve to different tenant identities -> the
+        # session/pending buffer key (account_id, tenant_id, ...) cannot collide across tenants.
+        drive(self.app, path="/v1/ingest", body={"scope": "cart", "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_A}"})
+        drive(self.app, path="/v1/ingest", body={"scope": "cart", "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_B}"})
+        a_scope = self.s.calls[0][1]["scope"]
+        b_scope = self.s.calls[1][1]["scope"]
+        self.assertEqual(("tenantA", "acct_a"), (a_scope["tenant_id"], a_scope["account_id"]))
+        self.assertEqual(("tenantB", "acct_b"), (b_scope["tenant_id"], b_scope["account_id"]))
+        self.assertNotEqual((a_scope["tenant_id"], a_scope["account_id"]),
+                            (b_scope["tenant_id"], b_scope["account_id"]))
+
+    def test_dev_mode_still_accepts_demo(self):
+        # Enforcement OFF -> legacy behavior: demo key maps to its tenant, request succeeds.
+        cfg = gw.GatewayConfig.from_env({"api_keys": {"sk_live_demo": "acme"}, "require_auth": True})
+        app = gw.make_v1_app(self.s, cfg)
+        st, _, _ = drive(app, path="/v1/ingest", body={"records": [1]},
+                         headers={"Authorization": "Bearer sk_live_demo"})
+        self.assertEqual(202, st)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hardens the /v1 Cloud API gateway so tenants can safely share a cluster.

- `MATRIXARK_AUTH_ENFORCED=1` gate. In enforced mode every /v1 request must carry a Bearer key whose sha256 hash is in the provisioned keystore; missing/unknown/revoked keys and the legacy demo key are rejected 401. Dev/unenforced mode keeps the existing plaintext `api_keys` map + anonymous behavior, so current dev flows are unchanged.
- The key resolves to a `{tenant_id, account_id}` identity taken from the stored record (never client-supplied free text), pinned into the backend `scope` object. The session/pending buffer key derives from `(account_id, tenant_id, user_id, session_id)`, so two tenants using the same `scope` string can no longer collide on one shared buffer (closes the cross-scope pending_async_event leak).
- Keys are stored HASHED only. `matrixark_provision_api_key.py` mints a per-tenant key, returns the plaintext once, and appends a hashed record reusing the backend credential-store shape.
- Tests: enforced rejects (missing/bad/demo), tenant identity pinning, two-tenant scope isolation, dev-mode demo backward-compat. 36/36 gateway tests pass.

**Do not merge without maintainer approval.**