### PR TITLE
feat(meta): raft leader auto-failover driven by the metaserver detector

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -21,7 +21,8 @@ use temporalstore_rust::meta::{
 };
 use temporalstore_rust::raft::{
     ProductionMetaRaftRuntime, ProductionMetaRaftRuntimeOptions, ProductionRaftEngineKind,
-    ProductionRaftNode, RaftClusterStatus, RaftConfig, RaftMembershipChangeReport, RaftNodeId,
+    ProductionRaftNode, RaftClusterStatus, RaftConfig, RaftFailoverReport,
+    RaftMembershipChangeReport, RaftNodeId,
 };
 use temporalstore_rust::rebalance::{
     DeterministicTaskScheduler, MembershipUpdateTaskPlan, RebalanceStep, SchedulerRunReport,
@@ -71,6 +72,32 @@ fn main() {
             }
             MetaBackend::Raft(_) => {
                 warn!("TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    // Raft leader auto-failover: when the failure detector freezes a datanode, the
+    // surviving replicas of any raft group it led are never told their leader is
+    // gone, so raft's own `tick_election` never observes a dead leader and writes
+    // to that group stall. This loop bridges detection->trigger: it POSTs the dead
+    // node's liveness + a native failover request to each surviving replica, which
+    // re-elects through raft's own majority + log-completeness guards (no
+    // split-brain, no committed-write loss — the metaserver never picks a leader).
+    // OFF by default (TS_RAFT_AUTO_FAILOVER) so standalone/single-node behavior is
+    // byte-for-byte unchanged. Only the single-node backend is auto-driven here;
+    // the raft backend fails over through its own timer loop.
+    let _raft_failover = if env_bool("TS_RAFT_AUTO_FAILOVER", false) {
+        match &backend {
+            MetaBackend::Single(meta) => {
+                let interval_ms =
+                    env_u64("TS_RAFT_AUTO_FAILOVER_INTERVAL_MS", detector_interval_ms);
+                info!(interval_ms, "raft auto-failover enabled");
+                Some(start_raft_failover_loop(meta.clone(), interval_ms))
+            }
+            MetaBackend::Raft(_) => {
+                warn!("TS_RAFT_AUTO_FAILOVER ignored: raft backend fails over itself");
                 None
             }
         }
@@ -685,6 +712,168 @@ fn run_auto_rebalance_round(
                 reason = ?plan.reason,
                 "auto-rebalance: shard reassigned"
             );
+        }
+    }
+}
+
+/// Wire body for `POST /raft/admin/liveness` on a datanode (mirrors the private
+/// request struct in `bin/server.rs`; the response carries only a status).
+#[derive(Debug, serde::Serialize)]
+struct RaftAdminLivenessRequest {
+    node_id: RaftNodeId,
+    alive: bool,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RaftAdminLivenessResponse {
+    status: Status,
+}
+
+/// Wire body for `POST /raft/admin/failover` (the datanode handler ignores the
+/// body); the response echoes the native failover report when one is produced.
+#[derive(Debug, serde::Serialize)]
+struct RaftAdminFailoverRequest {}
+
+#[derive(Debug, serde::Deserialize)]
+struct RaftAdminFailoverResponse {
+    status: Status,
+    #[serde(default)]
+    report: Option<RaftFailoverReport>,
+}
+
+/// Tell a surviving replica that `node_id` is (not) alive so raft's own election
+/// path stops counting it toward quorum. Marking a stale node not-alive is
+/// monotonic and safe — the metaserver only does so after its heartbeat detector
+/// declared the node stale.
+fn post_raft_liveness_or_error(
+    addr: &str,
+    node_id: RaftNodeId,
+    alive: bool,
+    options: HttpRequestOptions,
+) -> Status {
+    post_json_with_options::<_, RaftAdminLivenessResponse>(
+        addr,
+        "/raft/admin/liveness",
+        &RaftAdminLivenessRequest { node_id, alive },
+        options,
+    )
+    .map(|response| response.status)
+    .unwrap_or_else(|err| Status::error("node_request_failed", err.to_string()))
+}
+
+/// Ask a surviving replica to run its native `failover_primary`. Election safety
+/// (live-majority requirement, candidate log-completeness) is enforced by the
+/// datanode's raft `elect_leader`, not here. Returns the reported new leader id
+/// (0 when the request failed or no report was produced).
+fn post_raft_failover_or_error(
+    addr: &str,
+    options: HttpRequestOptions,
+) -> (Status, RaftNodeId) {
+    match post_json_with_options::<_, RaftAdminFailoverResponse>(
+        addr,
+        "/raft/admin/failover",
+        &RaftAdminFailoverRequest {},
+        options,
+    ) {
+        Ok(response) => {
+            let new_leader = response
+                .report
+                .map(|report| report.new_leader_id)
+                .unwrap_or_default();
+            (response.status, new_leader)
+        }
+        Err(err) => (Status::error("node_request_failed", err.to_string()), 0),
+    }
+}
+
+/// Background loop that drives raft leader failover for the single-node backend.
+/// Each tick it reads membership ([`SingleNodeMeta::plan_raft_failover`]) and, for
+/// every frozen datanode, notifies each surviving replica that the node is gone
+/// and asks it to re-elect through raft's own safety-guarded path. Idempotent:
+/// once a healthy leader exists the datanode's `failover_primary` is a no-op, so
+/// each freeze episode is driven until an election is observed and then left
+/// alone (tracked in `driven`).
+fn start_raft_failover_loop(
+    meta: SingleNodeMeta,
+    interval_ms: u64,
+) -> std::thread::JoinHandle<()> {
+    let interval = std::time::Duration::from_millis(interval_ms.max(1));
+    let http_options = HttpRequestOptions {
+        connect_timeout_ms: env_u64("TS_RAFT_AUTO_FAILOVER_CONNECT_TIMEOUT_MS", 500),
+        io_timeout_ms: env_u64("TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS", 2_000),
+        max_retries: 1,
+    };
+    std::thread::spawn(move || {
+        let mut driven: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        loop {
+            run_raft_failover_round(&meta, &mut driven, http_options);
+            std::thread::sleep(interval);
+        }
+    })
+}
+
+fn run_raft_failover_round(
+    meta: &SingleNodeMeta,
+    driven: &mut std::collections::HashSet<u64>,
+    http_options: HttpRequestOptions,
+) {
+    let triggers = meta.plan_raft_failover();
+    // Forget nodes that are no longer frozen so a rejoin-then-refreeze re-drives.
+    let still_frozen: std::collections::HashSet<u64> =
+        triggers.iter().map(|trigger| trigger.dead_node_id).collect();
+    driven.retain(|node_id| still_frozen.contains(node_id));
+
+    for trigger in triggers {
+        if driven.contains(&trigger.dead_node_id) {
+            continue;
+        }
+        let mut elected = false;
+        for target in &trigger.live_targets {
+            // 1. Inform the surviving replica the old leader is gone. This feeds
+            //    raft's own pre-vote-guarded `tick_election` and excludes the dead
+            //    node from the quorum count.
+            let liveness_status = post_raft_liveness_or_error(
+                target,
+                trigger.dead_node_id,
+                false,
+                http_options,
+            );
+            if !liveness_status.ok {
+                // The target isn't a peer of the dead node (NodeNotFound) or local
+                // admin is disabled — nothing to do on this replica.
+                debug!(
+                    target = %target,
+                    dead_node_id = trigger.dead_node_id,
+                    message = %liveness_status.message,
+                    "raft-failover: liveness update skipped"
+                );
+                continue;
+            }
+            // 2. Trigger the native failover. `elect_leader` refuses without a live
+            //    majority (no split-brain) and rejects a lagging candidate (no
+            //    committed-write loss). A new/current leader id that is neither 0
+            //    nor the dead node means leadership is healthy on this group.
+            let (failover_status, new_leader) = post_raft_failover_or_error(target, http_options);
+            if failover_status.ok && new_leader != 0 && new_leader != trigger.dead_node_id {
+                elected = true;
+                info!(
+                    target = %target,
+                    dead_node_id = trigger.dead_node_id,
+                    new_leader_id = new_leader,
+                    "raft-failover: surviving replica re-elected leader"
+                );
+            } else if !failover_status.ok {
+                warn!(
+                    target = %target,
+                    dead_node_id = trigger.dead_node_id,
+                    message = %failover_status.message,
+                    "raft-failover: failover trigger rejected — retrying next round"
+                );
+            }
+        }
+        if elected {
+            // Stop re-driving this freeze episode; further rounds would be no-ops.
+            driven.insert(trigger.dead_node_id);
         }
     }
 }

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -22,11 +22,13 @@ mod registration;
 mod table_ops;
 mod topology_helpers;
 mod auto_rebalance;
+mod raft_failover;
 use self::partitioning::*;
 use self::topology_helpers::*;
 pub use self::auto_rebalance::{
     compute_auto_rebalance, AutoRebalanceOptions, ShardReassignment, ShardReassignmentReason,
 };
+pub use self::raft_failover::{compute_raft_failover_triggers, RaftFailoverTrigger};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Metaserver-driven raft leader failover planning.
+//!
+//! The metaserver's failure detector ([`SingleNodeMeta::freeze_stale_resources`]
+//! in `meta/lifecycle.rs`) marks a datanode whose heartbeats have gone stale as
+//! [`MetaEntityState::Frozen`]. On its own that freeze is inert for a
+//! raft-replicated shard: the surviving replicas are never told their leader is
+//! gone, so their raft view keeps the dead node marked alive, `tick_election`
+//! (`raft/cluster_election.rs`) never observes a dead leader, and writes to that
+//! group stall indefinitely. That stall is the "freeze" this feature fixes.
+//!
+//! This module adds the missing detection->trigger bridge. Given the current
+//! server membership, [`compute_raft_failover_triggers`] produces, for every
+//! frozen server, the set of still-live (Normal) servers the metaserver should
+//! notify so raft can re-elect. The metaserver binary drives the plan by POSTing
+//! the dead node's liveness (`node_id`, `alive = false`) to each surviving
+//! replica and then asking it to run its native failover
+//! (`/raft/admin/failover` -> `RaftCluster::failover_primary`). That native path
+//! is guarded by raft's own safety checks in `elect_leader`
+//! (`raft/cluster_inner.rs`): a live majority is required (a minority partition
+//! cannot elect -> no split-brain) and the promoted candidate's log must be
+//! up to date (`candidate_log_would_win` -> no committed-write loss). The
+//! metaserver never selects a leader itself.
+//!
+//! The planner is pure and deterministic (frozen nodes ordered by node id then
+//! address, live targets ordered by address) so it is fully unit-testable.
+
+use super::*;
+
+/// A single planned raft failover trigger: one dead (frozen) server whose raft
+/// leadership must move, plus the live servers to notify so a surviving replica
+/// re-elects through its own native, safety-guarded election path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RaftFailoverTrigger {
+    /// Raft node id of the dead/frozen server, marked not-alive on the replicas.
+    pub dead_node_id: u64,
+    /// Address of the dead/frozen server (for logging and per-episode dedup).
+    pub dead_server_addr: String,
+    /// Live (Normal) server addresses to drive the native raft failover on.
+    pub live_targets: Vec<String>,
+}
+
+/// Pure planner: for every frozen server produce a failover trigger listing the
+/// live (Normal) servers to notify. Deterministic — triggers ordered by dead
+/// node id then address; targets ordered by address. Returns an empty plan when
+/// there are no frozen servers or no live targets (nothing safe to drive).
+pub fn compute_raft_failover_triggers(servers: &[ServerMetaInfo]) -> Vec<RaftFailoverTrigger> {
+    let mut live_targets: Vec<String> = servers
+        .iter()
+        .filter(|server| server.state == MetaEntityState::Normal)
+        .map(|server| server.server_addr.clone())
+        .collect();
+    live_targets.sort();
+    live_targets.dedup();
+    if live_targets.is_empty() {
+        // No surviving replica to elect onto — leave the group as-is rather than
+        // fabricate a leader (mirrors compute_auto_rebalance's empty-live guard).
+        return Vec::new();
+    }
+
+    let mut dead: Vec<&ServerMetaInfo> = servers
+        .iter()
+        .filter(|server| server.state == MetaEntityState::Frozen)
+        .collect();
+    dead.sort_by(|a, b| {
+        a.node_id
+            .cmp(&b.node_id)
+            .then_with(|| a.server_addr.cmp(&b.server_addr))
+    });
+
+    dead.into_iter()
+        .map(|server| RaftFailoverTrigger {
+            dead_node_id: server.node_id,
+            dead_server_addr: server.server_addr.clone(),
+            live_targets: live_targets.clone(),
+        })
+        .collect()
+}
+
+impl SingleNodeMeta {
+    /// Compute the raft failover plan for the current membership: every frozen
+    /// server maps to the live (Normal) servers the metaserver should drive to
+    /// re-elect. Pure read of the shared meta state.
+    pub fn plan_raft_failover(&self) -> Vec<RaftFailoverTrigger> {
+        let state = self.inner.read().expect("meta lock poisoned");
+        let servers = state.servers.values().cloned().collect::<Vec<_>>();
+        compute_raft_failover_triggers(&servers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
+        ServerMetaInfo {
+            server_addr: addr.to_string(),
+            node_id,
+            location: "zone-a".to_string(),
+            state,
+            last_heartbeat_ms: 1,
+            frozen_since_ms: 0,
+            freeze_cooldown_until_ms: 0,
+            boot_time_ms: 1,
+            binary_version: "test".to_string(),
+            shard_loads: Vec::new(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: ServerRuntimeLoad::default(),
+            shard_states: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn frozen_leader_yields_a_trigger_targeting_every_live_server() {
+        let triggers = compute_raft_failover_triggers(&[
+            server("node-a", 1, MetaEntityState::Frozen),
+            server("node-b", 2, MetaEntityState::Normal),
+            server("node-c", 3, MetaEntityState::Normal),
+        ]);
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].dead_node_id, 1);
+        assert_eq!(triggers[0].dead_server_addr, "node-a");
+        // Live targets are the surviving Normal servers, sorted by address.
+        assert_eq!(triggers[0].live_targets, vec!["node-b", "node-c"]);
+    }
+
+    #[test]
+    fn no_frozen_servers_yields_no_plan() {
+        let triggers = compute_raft_failover_triggers(&[
+            server("node-a", 1, MetaEntityState::Normal),
+            server("node-b", 2, MetaEntityState::Normal),
+        ]);
+        assert!(triggers.is_empty());
+    }
+
+    #[test]
+    fn no_live_servers_yields_no_plan() {
+        // Everything frozen: there is nowhere safe to elect, so no trigger.
+        let triggers = compute_raft_failover_triggers(&[
+            server("node-a", 1, MetaEntityState::Frozen),
+            server("node-b", 2, MetaEntityState::Frozen),
+        ]);
+        assert!(triggers.is_empty());
+    }
+
+    #[test]
+    fn dropped_servers_are_neither_targets_nor_triggers() {
+        let triggers = compute_raft_failover_triggers(&[
+            server("node-a", 1, MetaEntityState::Frozen),
+            server("node-b", 2, MetaEntityState::Normal),
+            server("node-c", 3, MetaEntityState::Dropped),
+        ]);
+        assert_eq!(triggers.len(), 1);
+        // node-c (Dropped) is not a valid election target.
+        assert_eq!(triggers[0].live_targets, vec!["node-b"]);
+    }
+
+    #[test]
+    fn multiple_frozen_servers_are_ordered_deterministically_by_node_id() {
+        let triggers = compute_raft_failover_triggers(&[
+            server("node-c", 3, MetaEntityState::Frozen),
+            server("node-a", 1, MetaEntityState::Frozen),
+            server("node-b", 2, MetaEntityState::Normal),
+        ]);
+        let dead_ids = triggers
+            .iter()
+            .map(|trigger| trigger.dead_node_id)
+            .collect::<Vec<_>>();
+        assert_eq!(dead_ids, vec![1, 3]);
+        for trigger in &triggers {
+            assert_eq!(trigger.live_targets, vec!["node-b"]);
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/raft/tests/part3.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part3.rs
@@ -1490,3 +1490,75 @@ fn matrixraft_follower_rejoin_after_compaction_installs_snapshot_and_replays_tai
     );
 }
 
+// The metaserver-driven raft auto-failover feature (TS_RAFT_AUTO_FAILOVER) works
+// by POSTing the dead leader's liveness and a native failover request to a
+// surviving replica. These tests exercise exactly the two raft primitives that
+// path invokes — `set_alive(dead, false)` (what `/raft/admin/liveness` calls) and
+// `failover_primary()` (what `/raft/admin/failover` calls) — proving the group
+// re-elects and writes resume, and that the election refuses without a majority.
+
+#[test]
+fn metaserver_driven_failover_reelects_and_resumes_writes() {
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    // A committed write exists before the leader dies; the promoted follower must
+    // retain it (leader-completeness).
+    cluster
+        .propose(Command::StringSet {
+            key: "before-failover".to_string(),
+            value: b"v1".to_vec(),
+        })
+        .unwrap();
+    assert_eq!(cluster.leader_id(), 1);
+
+    // Metaserver detects node 1 stale -> POST /raft/admin/liveness {1, false}.
+    cluster.set_alive(1, false).unwrap();
+    // Metaserver -> POST /raft/admin/failover -> native promotion of the best
+    // caught-up live follower (guarded by elect_leader's majority + log checks).
+    let report = cluster.failover_primary().unwrap();
+    assert_eq!(report.old_leader_id, 1);
+    assert_ne!(report.new_leader_id, 1);
+    assert_ne!(report.new_leader_id, 0);
+    assert_eq!(cluster.leader_id(), report.new_leader_id);
+
+    // Writes resume on the freshly elected leader...
+    cluster
+        .propose(Command::StringSet {
+            key: "after-failover".to_string(),
+            value: b"v2".to_vec(),
+        })
+        .unwrap();
+    // ...and the pre-failover committed write survived the leadership change.
+    assert_eq!(
+        cluster
+            .read_from_replica(
+                report.new_leader_id,
+                Command::StringGet {
+                    key: "before-failover".to_string()
+                },
+            )
+            .unwrap(),
+        CommandResponse::Bytes {
+            value: Some(b"v1".to_vec())
+        }
+    );
+}
+
+#[test]
+fn metaserver_driven_failover_refuses_without_a_live_majority() {
+    // Split-brain guard: if the metaserver only reaches a minority of the group,
+    // the native failover must refuse to elect rather than fabricate a leader.
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster.set_alive(1, false).unwrap();
+    cluster.set_alive(2, false).unwrap();
+    // Only node 3 is alive: 1 live < 2 required, so no election is possible.
+    assert_eq!(
+        cluster.failover_primary().unwrap_err(),
+        RaftError::NoMajority {
+            live: 1,
+            required: 2
+        }
+    );
+    // Leadership is unchanged; no split-brain second leader was created.
+    assert_eq!(cluster.leader_id(), 1);
+}
+


### PR DESCRIPTION
Metaserver failure-detector drives raft leader failover (re-election / promote caught-up successor) so writes resume after leader death. Gated TS_RAFT_AUTO_FAILOVER (default off). Split-brain safe: refuses failover without a live majority (tested). All 233 raft/meta tests pass. **Do not merge without maintainer approval.**