### PR TITLE
feat(gateway): proactively materialize streaming ingests via a background loop

### DIFF
--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -79,6 +79,7 @@ try:
         MatrixArkServerRequestPolicyMixin,
     )
     from tools.matrixark_mcp_schemas import TOOLS
+    from tools.matrixark_mcp_stream_materialize import flush_due_scopes
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
         MATRIXARK_ALLOW_LOCAL_BACKEND,
@@ -132,6 +133,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         MatrixArkServerRequestPolicyMixin,
     )
     from matrixark_mcp_schemas import TOOLS
+    from matrixark_mcp_stream_materialize import flush_due_scopes
 
 
 __all__ = [
@@ -163,6 +165,20 @@ __all__ = [
     "select_token_budgeted_refs",
     "validate_mcp_backend_policy",
 ]
+
+
+# Background stream-materializer: proactively drains SCHEDULED idle-commit tasks so a
+# plain (non-finalized) streaming ingest becomes retrievable on its own after a short
+# debounce, instead of waiting for a retrieve-time flush to happen to run. The loop drains
+# a per-scope registry (populated at ingest time) with the SAME backend-native flush the
+# retrieve path uses (`pre_retrieval_idle_commit_flush` over the rust-native, SCOPED
+# `idle_commit_task_records`) -- never Python `read_all`, and never a full-store scan. It is
+# started per worker process and wired into the gateway lifespan (see
+# matrixark_v1_gateway.create_v1_app / the ASGI lifespan handler). 0 disables the loop.
+STREAM_MATERIALIZE_INTERVAL_MS = int(os.environ.get("MATRIXARK_STREAM_MATERIALIZE_INTERVAL_MS", "1500"))
+# Hard cap on tracked pending scopes so a slow/stuck backend cannot grow the registry without
+# bound; the durable scheduled-task record + retrieve-time flush remain the backstop.
+STREAM_MATERIALIZE_MAX_SCOPES = int(os.environ.get("MATRIXARK_STREAM_MATERIALIZE_MAX_SCOPES", "20000"))
 
 
 try:
@@ -255,6 +271,13 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         self._summary_thread: threading.Thread | None = None
         self._summary_refresh_interval_s = max(0.0, SUMMARY_REFRESH_INTERVAL_MS / 1000.0)
         self._summary_refresh_limit = max(1, SUMMARY_REFRESH_LIMIT)
+        self._stream_materialize_worker_started = False
+        self._stream_materialize_stop = threading.Event()
+        self._stream_materialize_thread: threading.Thread | None = None
+        self._stream_materialize_interval_s = max(0.0, STREAM_MATERIALIZE_INTERVAL_MS / 1000.0)
+        # scope_key -> (scope_dict, due_ms). Populated at ingest time; drained by the loop.
+        self._stream_materialize_registry: dict[str, tuple[Json, int]] = {}
+        self._stream_materialize_registry_lock = threading.Lock()
         self._operation_backpressure_timeout_ms = max(0, int(os.environ.get("MATRIXARK_BACKPRESSURE_TIMEOUT_MS", "100")))
         self._retrieve_shed_cooldown_ms = max(0, int(os.environ.get("MATRIXARK_RETRIEVE_SHED_COOLDOWN_MS", "0")))
         self._retrieve_shed_until_perf = 0.0
@@ -291,10 +314,87 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
                 self.metrics.observe_operation("summary_refresh", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
                 _mcp_debug_log(f"matrixark summary refresh loop failed: {exc}")
 
+    def ensure_stream_materialize_worker(self) -> None:
+        """Start the background stream-materializer loop (idempotent, per-process).
+
+        Modelled on `_ensure_summary_worker`. The gateway calls this once per uvicorn worker
+        (from `create_v1_app` and on ASGI `lifespan.startup`); the loop proactively drains
+        SCHEDULED idle-commit tasks so non-finalized streaming ingests become retrievable on
+        their own. It is a no-op when the interval is 0 or the backend adapter cannot serve the
+        native `idle_commit_task_records` scan (so we never fall back to Python `read_all`).
+        """
+        if self._stream_materialize_worker_started or self._stream_materialize_interval_s <= 0:
+            return
+        if not callable(getattr(self.adapter, "idle_commit_task_records", None)):
+            _mcp_debug_log("matrixark stream materializer skipped: adapter lacks native idle_commit_task_records")
+            return
+        self._stream_materialize_worker_started = True
+        self._stream_materialize_stop.clear()
+        self._stream_materialize_thread = threading.Thread(
+            target=self._stream_materialize_loop, name="matrixark-stream-materializer", daemon=True
+        )
+        self._stream_materialize_thread.start()
+        _mcp_debug_log(f"matrixark stream materializer started interval_ms={STREAM_MATERIALIZE_INTERVAL_MS}")
+
+    def register_stream_materialize_scope(self, scope: Json, due_ms: int) -> None:
+        """Record a scope whose streaming-ingest debounce should be flushed by the loop.
+
+        Called by the gateway right after a plain (non-finalize) `/v1/ingest`. Each scope is
+        owned by the worker process that handled the ingest, so the loop only ever runs cheap
+        SCOPED flushes and no cross-worker coordination is needed. Losing an entry (worker
+        crash) is safe: the durable scheduled-task record + retrieve-time flush still commit it.
+        """
+        if not self._stream_materialize_worker_started:
+            return
+        try:
+            key = json.dumps(scope or {}, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            key = str(scope)
+        with self._stream_materialize_registry_lock:
+            registry = self._stream_materialize_registry
+            existing = registry.get(key)
+            # Keep the EARLIEST due time so an idle scope is not perpetually deferred.
+            if existing is None or int(due_ms) < int(existing[1]):
+                registry[key] = (scope or {}, int(due_ms))
+            if len(registry) > STREAM_MATERIALIZE_MAX_SCOPES:
+                oldest = min(registry, key=lambda k: registry[k][1])
+                registry.pop(oldest, None)
+
+    def _stream_materialize_loop(self) -> None:
+        while not self._stream_materialize_stop.wait(self._stream_materialize_interval_s):
+            try:
+                now = now_ms()
+                with self._stream_materialize_registry_lock:
+                    due_keys = [k for k, (_scope, due_ms) in self._stream_materialize_registry.items() if due_ms <= now]
+                    due_scopes = [self._stream_materialize_registry.pop(k)[0] for k in due_keys]
+                if not due_scopes:
+                    continue
+                started_perf = time.perf_counter()
+                result = flush_due_scopes(self.adapter, due_scopes)
+                self.metrics.observe_operation("stream_materialize", "ok", (time.perf_counter() - started_perf) * 1000.0)
+                committed = int(result.get("committed_event_count") or 0)
+                if committed:
+                    self.access.append_audit(
+                        "context.stream_materialize.background",
+                        {"account_id": "system", "tenant_id": "system", "user_id": "stream_materializer"},
+                        status="ok",
+                        details={
+                            "committed_event_count": committed,
+                            "due_scope_count": int(result.get("due_scope_count") or 0),
+                            "interval_ms": STREAM_MATERIALIZE_INTERVAL_MS,
+                        },
+                    )
+            except Exception as exc:
+                self.metrics.observe_operation("stream_materialize", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
+                _mcp_debug_log(f"matrixark stream materialize loop failed: {exc}")
+
     def close(self, *, timeout_s: float = 5.0) -> None:
         self._summary_stop.set()
+        self._stream_materialize_stop.set()
         if self._summary_thread is not None:
             self._summary_thread.join(timeout=max(0.0, timeout_s))
+        if self._stream_materialize_thread is not None:
+            self._stream_materialize_thread.join(timeout=max(0.0, timeout_s))
         adapter_close = getattr(self.adapter, "close", None)
         if callable(adapter_close):
             adapter_close(timeout_s=timeout_s)

--- a/tools/matrixark_mcp_stream_materialize.py
+++ b/tools/matrixark_mcp_stream_materialize.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Background stream-materializer flush.
+
+Proactively drains SCHEDULED idle-commit tasks so a plain (non-finalized) streaming
+ingest becomes retrievable on its own after a short debounce, instead of waiting for a
+client retrieve to happen to run the flush. It calls the SAME backend-native flush the
+retrieve path uses (`pre_retrieval_idle_commit_flush` over the rust-native
+`idle_commit_task_records` scan) -- never Python `read_all`, which is intentionally
+disabled on the production rust adapter.
+
+Draining is driven by a per-scope registry populated at ingest time (see
+`MatrixArkMcpServer.register_stream_materialize_scope`), so each flush is a cheap SCOPED
+native scan. A broad, cross-scope scan (`scope={}`) is deliberately avoided: it is a
+full-store scan that saturates the shared backend proxy.
+
+The thread lifecycle lives on `MatrixArkMcpServer` (mirroring the summary worker); this
+module holds the per-flush logic so the MCP entrypoint stays small.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from tools.matrixark_mcp_core import Json, _mcp_debug_log
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import Json, _mcp_debug_log  # type: ignore
+
+
+def flush_due_scopes(adapter: Any, due_scopes: list[Json]) -> Json:
+    """Flush each due scope through the canonical native idle-commit flush.
+
+    `due_scopes` are the scopes whose streaming-ingest debounce has elapsed. Each is drained
+    with a SCOPED native scan (the exact path the retrieve endpoint uses). Idempotent: a
+    already-resolved task is skipped inside the flush and `session_commit` dedupes by cutoff,
+    so re-flushing a quiet scope is a cheap no-op.
+    """
+    if not due_scopes:
+        return {"status": "ok", "due_scope_count": 0, "flushed": 0, "committed_event_count": 0}
+    idle_task_records = getattr(adapter, "idle_commit_task_records", None)
+    if not callable(idle_task_records):
+        return {"status": "unavailable", "reason": "idle_commit_task_records_missing"}
+    try:
+        from tools.matrixark_mcp_retrieve_request import pre_retrieval_idle_commit_flush
+    except ModuleNotFoundError:  # Direct script execution from tools/.
+        from matrixark_mcp_retrieve_request import pre_retrieval_idle_commit_flush
+
+    _mcp_debug_log(
+        f"matrixark stream materializer draining due_scope_count={len(due_scopes)} "
+        "via native idle_commit_task_records (scoped)"
+    )
+    flushed = 0
+    committed_events = 0
+    for scope in due_scopes:
+        outcome = pre_retrieval_idle_commit_flush(adapter, {}, {}, scope=scope or {})
+        flushed += 1
+        if isinstance(outcome, dict):
+            committed_events += int(outcome.get("committed_event_count") or 0)
+    return {
+        "status": "ok",
+        "due_scope_count": len(due_scopes),
+        "flushed": flushed,
+        "committed_event_count": committed_events,
+    }

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -85,6 +85,11 @@ _DEFAULTS = {
     "direct_backend": False,
     "direct_backend_url": "http://127.0.0.1:17000",
     "direct_pool_size": 64,
+    # Streaming-ingest debounce: a plain (non-finalize) /v1/ingest schedules a native
+    # idle-commit task with this deadline so the background materializer can drain it and
+    # the ingest becomes retrievable on its own. Must be > 0 (0 would commit inline and
+    # defeat the debounce); <= 0 disables scheduling (retrieve-time flush still applies).
+    "stream_idle_commit_timeout_ms": 1000,
 }
 
 # route -> (tool name, rate-limit class). "__mcp__" is dispatched through mcp_http_dispatch.
@@ -278,6 +283,9 @@ class GatewayConfig:
             ),
             direct_pool_size=num("MATRIXARK_GATEWAY_DIRECT_POOL", "direct_pool_size", int),
             direct_connection_factory=overrides.get("direct_connection_factory"),
+            stream_idle_commit_timeout_ms=num(
+                "MATRIXARK_STREAM_IDLE_COMMIT_TIMEOUT_MS", "stream_idle_commit_timeout_ms", int
+            ),
         )
 
 
@@ -853,6 +861,31 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
     direct_client = _build_direct_client(cfg) if cfg.direct_backend else None
 
     async def app(scope: Json, receive: Callable, send: Callable) -> None:
+        # ASGI lifespan: start the background stream-materializer on startup (so a non-finalized
+        # streaming ingest becomes retrievable on its own) and stop it cleanly on shutdown. Started
+        # per uvicorn worker process; idempotent with the eager start in create_v1_app().
+        if scope.get("type") == "lifespan":
+            while True:
+                message = await receive()
+                mtype = message.get("type")
+                if mtype == "lifespan.startup":
+                    try:
+                        ensure = getattr(server, "ensure_stream_materialize_worker", None)
+                        if callable(ensure):
+                            ensure()
+                    except Exception:  # never block startup on the materializer
+                        pass
+                    await send({"type": "lifespan.startup.complete"})
+                elif mtype == "lifespan.shutdown":
+                    try:
+                        close = getattr(server, "close", None)
+                        if callable(close):
+                            close()
+                    except Exception:
+                        pass
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+            return
         if scope.get("type") != "http":
             return
 
@@ -960,6 +993,16 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 n_records=n_records, n_messages=n_messages)
 
         apply_ingest_route_defaults("/api/ingest" if tool == "matrixark_ingest" else path, args)
+        # A plain (non-finalize) streaming ingest schedules a backend-native idle-commit task so
+        # the gateway's background materializer can drain it and make the ingest retrievable on
+        # its own -- without waiting for a client retrieve. A finalize ingest extracts inline
+        # below, so it is left alone. Callers keep control by passing idle_commit_timeout_ms.
+        if (
+            tool == "matrixark_ingest"
+            and not _finalize_requested(parsed, args)
+            and cfg.stream_idle_commit_timeout_ms > 0
+        ):
+            args.setdefault("idle_commit_timeout_ms", cfg.stream_idle_commit_timeout_ms)
         _apply_identity(args, key, tenant, account)
 
         try:
@@ -995,6 +1038,17 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 except Exception as exc:  # extraction failure must NOT lose the durable ingest
                     out["finalized"] = False
                     out["extraction_error"] = str(exc)
+            elif args.get("idle_commit_timeout_ms"):
+                # Plain streaming ingest: register the scope so the gateway's background
+                # materializer drains its scheduled idle-commit after the debounce, making the
+                # ingest retrievable without a client retrieve. Best-effort: the durable
+                # scheduled-task record + retrieve-time flush remain the backstop.
+                register = getattr(server, "register_stream_materialize_scope", None)
+                if callable(register):
+                    try:
+                        register(args.get("scope"), int(time.time() * 1000) + int(args.get("idle_commit_timeout_ms") or 0))
+                    except Exception:
+                        pass
             return await _json(send, 202, out, rl_headers)
         return await _json(send, 200, _ok_body(result), rl_headers)
 
@@ -1044,7 +1098,17 @@ def create_v1_app() -> Callable[..., Awaitable[None]]:
 
     Mirrors `matrixark_asgi.create_app` for `uvicorn matrixark_v1_gateway:application`.
     """
-    return make_v1_app(_build_server_from_env(), GatewayConfig.from_env())
+    server = _build_server_from_env()
+    app = make_v1_app(server, GatewayConfig.from_env())
+    # Eager per-process start so the background materializer runs even under ASGI servers that
+    # never drive the lifespan protocol. Idempotent with the lifespan.startup start above.
+    ensure = getattr(server, "ensure_stream_materialize_worker", None)
+    if callable(ensure):
+        try:
+            ensure()
+        except Exception:
+            pass
+    return app
 
 
 _LAZY_APP: Optional[Callable[..., Awaitable[None]]] = None


### PR DESCRIPTION
Streaming `/v1/ingest` (no `finalize:true`) now becomes retrievable on its own after a short debounce, via a background materializer loop wired into the gateway ASGI lifespan that drains scheduled idle-commit tasks through the backend-native flush (per-scope registry -> cheap scoped scans; never a full-store scan, never Python read_all). `finalize:true`, normal 202 ingest, and health are unchanged. Verified on a live cluster.

**do not merge without maintainer approval.**