### PR TITLE
storage: drop the index-log delta fdatasync from the write path (TS_INDEXLOG_DEFER_SYNC)

### DIFF
--- a/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! WAL-replay recovery harness. Exercises the relaxed-durability write path (run with
+//! TS_INDEXLOG_DEFER_SYNC=1 + TS_WAL_ONLY_SYNC=1, where the served-index delta fdatasync is
+//! dropped from the ack path while the WAL + data pages stay durable per write) and, as a
+//! stronger stress, proves the WAL alone is self-sufficient: the WAL record embeds the full
+//! command payload, so startup replay from the last durable watermark rebuilds the served index
+//! and the page state.
+//!
+//! A plain SIGKILL / process::abort preserves the OS page cache, so un-fsync'd bytes survive it
+//! and would not exercise recovery. To faithfully model real power loss this harness also drops
+//! state (up to and including the pages, beyond what the relaxed mode actually defers), then
+//! asserts that every acked write is reconstructed by WAL replay.
+//!
+//! Modes:
+//!   populate   --root R --keys N [--flush-at F]
+//!                write keys 0..N (each ack'd); at write F force a durable dump
+//!                (flush_shard_index) and record the durable page-slab lengths; then abort.
+//!   powerloss  --root R --scope <wipe-nondurable|truncate-tail|torn-tail>
+//!                simulate loss of the never-fsync'd state.
+//!   recover    --root R --keys N
+//!                load the shard (forces WAL replay) and assert every acked key is present
+//!                with the exact value; print a JSON report.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+
+fn key_of(i: u64) -> String {
+    format!("sbk-{i:010}")
+}
+fn value_of(i: u64) -> Vec<u8> {
+    // Non-trivial, sequence-dependent payload so a stale/duplicate page cannot pass.
+    format!("sbv-{i:010}-{}", "x".repeat(48)).into_bytes()
+}
+
+fn open_engine(root: &Path) -> TemporalEngine {
+    TemporalEngine::with_local_dirs(
+        256,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    )
+}
+
+fn write_key(engine: &TemporalEngine, i: u64) {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: key_of(i),
+            value: value_of(i),
+        },
+    });
+    assert!(response.status.ok, "ack failed for {i}: {}", response.status.message);
+}
+
+fn read_key(engine: &TemporalEngine, i: u64) -> Option<Vec<u8>> {
+    match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet { key: key_of(i) },
+        })
+        .response
+    {
+        CommandResponse::Bytes { value: Some(bytes) } => Some(bytes),
+        _ => None,
+    }
+}
+
+fn durable_lengths_path(root: &Path) -> PathBuf {
+    root.join("durable_lengths.txt")
+}
+
+fn record_durable_slab_lengths(root: &Path) {
+    let pages = root.join("pages");
+    let mut lines = String::new();
+    if let Ok(entries) = fs::read_dir(&pages) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("seg") {
+                if let Ok(meta) = fs::metadata(&path) {
+                    lines.push_str(&format!(
+                        "{}\t{}\n",
+                        path.file_name().unwrap().to_string_lossy(),
+                        meta.len()
+                    ));
+                }
+            }
+        }
+    }
+    fs::write(durable_lengths_path(root), lines).expect("record durable lengths");
+}
+
+fn populate(root: PathBuf, keys: u64, flush_at: Option<u64>) -> ! {
+    let engine = open_engine(&root);
+    engine.load_shard(1);
+    for i in 0..keys {
+        write_key(&engine, i);
+        if Some(i) == flush_at {
+            // Background threshold dump: fsync pages + persist the anchored base index, then
+            // record the durable frontier (post-dump slab lengths) for the power-loss step.
+            engine.flush_shard_index(1);
+            record_durable_slab_lengths(&root);
+        }
+    }
+    if flush_at.is_none() {
+        // No dump happened: nothing but the WAL is durable. Record empty frontier.
+        fs::write(durable_lengths_path(&root), "").expect("record durable lengths");
+    }
+    // Abrupt process loss AFTER the acks (page/index fsyncs were deferred).
+    std::process::abort();
+}
+
+fn powerloss(root: PathBuf, scope: &str) {
+    match scope {
+        // No dump occurred: the ONLY durable state is the fsync'd WAL. Drop everything else,
+        // exactly as a power cut would drop the never-fsync'd pages + served index.
+        "wipe-nondurable" => {
+            let _ = fs::remove_dir_all(root.join("pages"));
+            let _ = fs::remove_dir_all(root.join("indexes").join("indexlogs"));
+            // Drop any base index snapshot (only the WAL survives a power cut here).
+            if let Ok(entries) = fs::read_dir(root.join("indexes")) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if name.starts_with("shard-") && name.ends_with(".index.json") {
+                        let _ = fs::remove_file(entry.path());
+                    }
+                }
+            }
+            assert!(
+                root.join("indexes").join("wals").exists(),
+                "WAL must survive a power cut -- it is the single durable barrier"
+            );
+        }
+        // A dump made pages durable up to the recorded frontier; the post-dump tail pages were
+        // appended but never fsync'd. Truncate each slab back to its recorded durable length,
+        // modelling loss of exactly the un-synced tail. The (durable) base index + WAL remain.
+        "truncate-tail" => {
+            let lengths = fs::read_to_string(durable_lengths_path(&root)).unwrap_or_default();
+            let mut durable: std::collections::HashMap<String, u64> = Default::default();
+            for line in lengths.lines() {
+                if let Some((name, len)) = line.split_once('\t') {
+                    durable.insert(name.to_string(), len.parse().unwrap_or(0));
+                }
+            }
+            if let Ok(entries) = fs::read_dir(root.join("pages")) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("seg") {
+                        continue;
+                    }
+                    let name = path.file_name().unwrap().to_string_lossy().to_string();
+                    let keep = durable.get(&name).copied().unwrap_or(0);
+                    let cur = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    if cur > keep {
+                        let f = fs::OpenOptions::new().write(true).open(&path).unwrap();
+                        f.set_len(keep).expect("truncate un-synced slab tail");
+                    }
+                }
+            }
+        }
+        // Realistic power loss for the index-log-defer-sync (3->2) mode: the ONLY relaxation is
+        // the deferred delta-log fdatasync, so the loss it can cause is an un-synced delta tail.
+        // Drop the entire delta index-log (worst case) while the durable pages + WAL + base index
+        // remain. Recovery must fold the (durable) base + replay the WAL tail to restore every
+        // acked write; the durable pages are never referenced through a lost delta.
+        "drop-indexlog" => {
+            let _ = fs::remove_dir_all(root.join("indexes").join("indexlogs"));
+        }
+        // A page write was torn by the crash: lop a few bytes off the newest slab (partial
+        // record). Reconcile-on-open must drop the torn record and replay must rebuild it.
+        "torn-tail" => {
+            let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
+            if let Ok(entries) = fs::read_dir(root.join("pages")) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("seg") {
+                        continue;
+                    }
+                    let m = fs::metadata(&path).and_then(|m| m.modified()).ok();
+                    if let Some(m) = m {
+                        if newest.as_ref().map(|(_, t)| m > *t).unwrap_or(true) {
+                            newest = Some((path, m));
+                        }
+                    }
+                }
+            }
+            if let Some((path, _)) = newest {
+                let len = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                if len > 7 {
+                    let f = fs::OpenOptions::new().write(true).open(&path).unwrap();
+                    f.set_len(len - 7).expect("tear newest slab tail");
+                }
+            }
+        }
+        other => panic!("unknown powerloss scope {other}"),
+    }
+}
+
+#[derive(Serialize)]
+struct RecoverReport {
+    keys: u64,
+    recovered: u64,
+    missing: Vec<u64>,
+    mismatched: Vec<u64>,
+    ok: bool,
+}
+
+fn recover(root: PathBuf, keys: u64) {
+    let engine = open_engine(&root);
+    engine.load_shard(1); // forces WAL replay from the durable watermark
+    let mut missing = Vec::new();
+    let mut mismatched = Vec::new();
+    let mut recovered = 0u64;
+    for i in 0..keys {
+        match read_key(&engine, i) {
+            Some(v) if v == value_of(i) => recovered += 1,
+            Some(_) => mismatched.push(i),
+            None => missing.push(i),
+        }
+    }
+    let report = RecoverReport {
+        keys,
+        recovered,
+        ok: missing.is_empty() && mismatched.is_empty(),
+        missing,
+        mismatched,
+    };
+    println!("{}", serde_json::to_string(&report).expect("serialize report"));
+    if !report.ok {
+        std::process::exit(2);
+    }
+}
+
+fn main() {
+    let mut root = None;
+    let mut mode = None;
+    let mut keys = 0u64;
+    let mut flush_at: Option<u64> = None;
+    let mut scope = String::new();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--root" => root = args.next().map(PathBuf::from),
+            "--mode" => mode = args.next(),
+            "--keys" => keys = args.next().and_then(|s| s.parse().ok()).unwrap_or(0),
+            "--flush-at" => flush_at = args.next().and_then(|s| s.parse().ok()),
+            "--scope" => scope = args.next().unwrap_or_default(),
+            other => panic!("unknown argument {other}"),
+        }
+    }
+    let root = root.expect("--root required");
+    fs::create_dir_all(&root).expect("create root");
+    match mode.as_deref() {
+        Some("populate") => populate(root, keys, flush_at),
+        Some("powerloss") => powerloss(root, &scope),
+        Some("recover") => recover(root, keys),
+        other => panic!("--mode must be populate|powerloss|recover, got {other:?}"),
+    }
+}

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -231,6 +231,29 @@ fn indexlog_wal_only_sync() -> bool {
     )
 }
 
+/// TS_INDEXLOG_DEFER_SYNC: drop the served-index delta-log fdatasync from the synchronous
+/// write/ack path. The delta record is still APPENDED (so the served-index stream and every
+/// consumer of it -- gc / reclaim / manifest / reconcile / cold reload -- are unchanged); only
+/// its fdatasync is deferred. Combined with TS_WAL_ONLY_SYNC this takes the ack path from three
+/// synchronous barriers (WAL + data-page + index-log) to two: the WAL and the data pages stay
+/// durable per write, so no index reference can dangle at an un-synced page, and the durable WAL
+/// rebuilds any lost index-log delta tail on replay. Default OFF.
+///
+/// NOTE: this stops at two barriers on purpose. Eviction / expiry / compaction decisions are
+/// recorded ONLY in the served-index delta, not in the WAL, so a pure WAL replay would resurrect
+/// points a background op had removed. Reaching one barrier requires making those served-index-
+/// only mutations WAL-reconstructable first; that is a separate, larger change.
+fn indexlog_defer_sync() -> bool {
+    matches!(
+        std::env::var("TS_INDEXLOG_DEFER_SYNC")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 impl LocalIndexLogStore {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root = root.into();
@@ -384,7 +407,13 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        file.sync_data()?;
+        // Ack-path delta append. Under TS_INDEXLOG_DEFER_SYNC the record is written but its
+        // fdatasync is deferred: the WAL + data pages are still durable per write, so the lost
+        // delta tail is rebuilt by WAL replay and no page reference dangles. This drops the
+        // index-log fdatasync from the write critical path (three barriers -> two).
+        if !indexlog_defer_sync() {
+            file.sync_data()?;
+        }
         inner.stats.writes += 1;
         inner.stats.bytes_written += bytes.len() as u64;
         inner.stats.last_sequence = next_sequence;

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! WAL-replay recovery under TS_INDEXLOG_DEFER_SYNC (the index-log delta fdatasync is dropped
+//! from the ack path; the WAL + data pages stay durable per write). After a crash, EVERY acked
+//! write must be reconstructed -- the WAL is self-sufficient (it embeds the full command
+//! payload), so even if the deferred-fsync index-log tail AND, as a stronger stress, the pages
+//! are lost to a simulated power cut, replay rebuilds every key. Each phase runs in its own
+//! subprocess so the durability-mode env var never leaks into the rest of the suite.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_wal_single_barrier_crash_harness")
+}
+
+fn populate(root: &str, keys: &str, flush_at: Option<&str>) {
+    let mut cmd = Command::new(bin());
+    cmd.env("TS_INDEXLOG_DEFER_SYNC", "1")
+        .env("TS_WAL_ONLY_SYNC", "1")
+        .env("TS_GROUP_COMMIT", "1")
+        .args(["--mode", "populate", "--root", root, "--keys", keys]);
+    if let Some(f) = flush_at {
+        cmd.args(["--flush-at", f]);
+    }
+    let out = cmd.output().expect("populate should run");
+    assert!(
+        !out.status.success(),
+        "populate must end in an abrupt abort (crash simulation)"
+    );
+}
+
+fn powerloss(root: &str, scope: &str) {
+    let out = Command::new(bin())
+        .env("TS_INDEXLOG_DEFER_SYNC", "1")
+        .args(["--mode", "powerloss", "--root", root, "--scope", scope])
+        .output()
+        .expect("powerloss should run");
+    assert!(
+        out.status.success(),
+        "powerloss failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn recover_ok(root: &str, keys: &str) {
+    let out = Command::new(bin())
+        .env("TS_INDEXLOG_DEFER_SYNC", "1")
+        .env("TS_WAL_ONLY_SYNC", "1")
+        .args(["--mode", "recover", "--root", root, "--keys", keys])
+        .output()
+        .expect("recover should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "recover reported data loss: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("\"ok\":true"),
+        "recover report not ok: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"missing\":[]") && stdout.contains("\"mismatched\":[]"),
+        "recover lost or corrupted acked writes: {stdout}"
+    );
+}
+
+#[test]
+fn deferred_indexlog_loss_never_drops_an_ack_after_a_dump() {
+    // The mode's ONLY relaxation is the deferred delta-log fdatasync, so its worst-case loss is
+    // the whole un-synced delta log. A dump anchors a durable base at key 150; the post-dump
+    // deltas (151..) are then lost. The durable pages + WAL replay from the base watermark must
+    // still restore every acked write.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate(root, "300", Some("150"));
+    powerloss(root, "drop-indexlog");
+    recover_ok(root, "300");
+}
+
+#[test]
+fn deferred_indexlog_loss_never_drops_an_ack_without_a_dump() {
+    // No dump: the entire delta log is lost and there is no base index. Recovery replays the whole
+    // WAL from zero and rebuilds every key.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate(root, "300", None);
+    powerloss(root, "drop-indexlog");
+    recover_ok(root, "300");
+}
+
+#[test]
+fn wal_is_self_sufficient_when_all_non_wal_state_is_wiped() {
+    // Strongest stress (beyond what the mode actually defers): drop the pages AND the served index
+    // AND the delta log; only the fsync'd WAL remains. The WAL embeds the full command payload, so
+    // replay rebuilds every acked write from scratch.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate(root, "300", None);
+    powerloss(root, "wipe-nondurable");
+    recover_ok(root, "300");
+}


### PR DESCRIPTION
**Do not merge without maintainer approval.**

Drops the served-index delta-log `fdatasync` from the synchronous write/ack path, behind a new default-OFF env flag `TS_INDEXLOG_DEFER_SYNC`. Combined with `TS_WAL_ONLY_SYNC` this takes the ack path from three synchronous durability barriers (WAL + data-page + index-log) down to two.

**Why safe:** the delta record is still *appended* per write (so the served-index stream and every consumer — gc / reclaim / manifest / reconcile / cold reload — are unchanged); only its fdatasync is deferred. The WAL and the data pages stay durable per write, so no index reference can dangle at an un-synced page, and the durable WAL rebuilds any lost delta tail on replay.

**Why it stops at two barriers (not one):** eviction / expiry / compaction decisions are recorded only in the served-index delta, not in the WAL, so a pure WAL replay resurrects points a background op had removed. Reaching a single barrier requires making those served-index-only mutations WAL-reconstructable first — a separate, larger change (noted in a code TODO).

**Verification (local):**
- strace, standalone datanode: 3.00 → 2.00 fdatasync per write; WAL still written, reads correct.
- storage lib subset (dump/gc/reclaim/compaction/manifest/reconcile/recovery) with the flag ON: zero new failures vs baseline.
- WAL-replay recovery harness + `tests/wal_single_barrier_recovery.rs`: after an abrupt crash + loss of the deferred delta-log (and, as a stress, all non-WAL state), every acked write is reconstructed.

Default OFF; when off the write path is byte-for-byte unchanged.