### PR TITLE
feat(storage): reference-parity lazy recovery on the shared-filesystem backend

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -46,7 +46,8 @@ use temporalstore_rust::{
     ProductionRaftRuntime, ProductionRaftRuntimeOptions, RaftConfig, RaftControlLeadershipRequest,
     RaftFailoverReport, RaftMembershipChangeReport, RaftNodeId, RaftRpcRuntimeOptions,
     RequestController, ScanStreamRequest, SchedulerLifecycleToken, SetConfigRequest,
-    SharedStoreReplicator, SharedStoreWalEntry, StorageBackend, WriteAheadLogRecord,
+    SharedStoreReplicationError, SharedStoreReplicator, SharedStoreWalEntry, StorageBackend,
+    WriteAheadLogRecord,
     BucketDumpManifest, StorageCacheInvalidateBucketRequest, StorageLifecycleRequest,
     StorageProductionReadinessRequest, StreamReadRequest, UnloadShardRequest,
 };
@@ -987,14 +988,42 @@ fn replay_shard_from_shared(
     let Some(replicator) = replicator else {
         return;
     };
-    match runtime.block_on(replicator.replay_wal(shard_id, 0, engine)) {
+    // Reference-parity lazy recovery: when a shared checkpoint exists, install the served
+    // index + a lazy slab address map (no slab bytes) and replay only the WAL tail
+    // after the checkpoint. Old pages are read lazily through the block store's
+    // shared read-through on first access. With no checkpoint, fall back to the
+    // full WAL replay from 0 (backward compatible with WAL-only mirrors).
+    let after_wal_index =
+        match runtime.block_on(replicator.restore_index_and_page_addresses(
+            shard_id,
+            engine,
+            &engine.block_store(),
+        )) {
+            Ok(manifest) => {
+                info!(
+                    shard_id,
+                    checkpoint_id = %manifest.checkpoint_id,
+                    checkpoint_wal_index = manifest.checkpoint_wal_index,
+                    page_slabs = manifest.page_slabs.len(),
+                    "restored shard index and lazy page addresses from shared checkpoint"
+                );
+                manifest.checkpoint_wal_index
+            }
+            Err(SharedStoreReplicationError::CheckpointNotFound(_)) => 0,
+            Err(err) => {
+                warn!(shard_id, %err, "shared checkpoint restore failed; replaying full shared WAL");
+                0
+            }
+        };
+    match runtime.block_on(replicator.replay_wal(shard_id, after_wal_index, engine)) {
         Ok(report) => {
             if report.applied > 0 {
                 info!(
                     shard_id,
                     records = report.applied,
                     wal_index = report.last_wal_index,
-                    "replayed shard from shared storage"
+                    after_wal_index,
+                    "replayed shard WAL tail from shared storage"
                 );
             }
         }
@@ -1068,10 +1097,30 @@ fn publish_shard_checkpoint(
         published += 1;
         last_wal_index = record.sequence;
     }
+    // Publish a real metadata+slab checkpoint at the current last-applied WAL index so
+    // a future owner can lazily restore (index + slab addresses) and replay only the
+    // WAL tail after this index, rather than replaying the full history. Reuses the
+    // shared WAL mirrored above for the tail.
+    let checkpoint = match runtime.block_on(replicator.publish_checkpoint(
+        shard_id,
+        last_wal_index,
+        engine,
+        &engine.block_store(),
+    )) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            return PublishShardCheckpointResponse {
+                status: Status::error("publish_checkpoint_failed", err.to_string()),
+                checkpoint_id: None,
+                page_slab_count: published,
+                checkpoint_wal_index: last_wal_index,
+            };
+        }
+    };
     PublishShardCheckpointResponse {
         status: Status::ok(),
-        checkpoint_id: None,
-        page_slab_count: published,
+        checkpoint_id: Some(checkpoint.checkpoint_id),
+        page_slab_count: checkpoint.page_slabs.len(),
         checkpoint_wal_index: last_wal_index,
     }
 }

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -127,6 +127,23 @@ pub struct BlockStoreStats {
     pub compressed_records_read: u64,
     #[serde(default)]
     pub compression_bytes_saved: u64,
+    /// Slabs fetched on-demand from a shared-storage read-through source (reference-parity
+    /// lazy recovery). Each shared slab is fetched at most once, only when a read
+    /// misses it locally; a nonzero count proves recovery did not install every slab
+    /// up front.
+    #[serde(default)]
+    pub shared_slab_fetches: u64,
+}
+
+/// Lazy read-through source for slabs that live only in shared storage after a
+/// metadata-only (index + address map) recovery on the shared-filesystem backend.
+/// On a local slab miss the block store asks the source for exactly that slab's
+/// bytes, caches them locally, then serves the read, so old pages are read lazily
+/// by address rather than eagerly installed at recovery time. Implementations
+/// resolve a slab id to its shared object and return its verified bytes, or `None`
+/// when the slab is not part of the recovered checkpoint.
+pub trait SharedSlabSource: Send + Sync + std::fmt::Debug {
+    fn fetch_slab(&self, page_slab_id: u64) -> Result<Option<Vec<u8>>, BlockStoreError>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -590,6 +607,10 @@ struct BlockStoreInner {
     bands: BTreeMap<u64, BlockStoreBandDescriptor>,
     band_manifest_reconciled_on_open: bool,
     stats: BlockStoreStats,
+    // Optional shared-storage read-through (reference-parity lazy recovery): set by
+    // attach_shared_slab_source() after a metadata-only restore. When present, a
+    // read that misses a slab locally fetches it from here, caches it, then serves.
+    shared_slab_source: Option<Arc<dyn SharedSlabSource>>,
 }
 
 impl LocalBlockStore {
@@ -670,8 +691,117 @@ impl LocalBlockStore {
                 bands,
                 band_manifest_reconciled_on_open,
                 stats: BlockStoreStats::default(),
+                shared_slab_source: None,
             })),
         }
+    }
+
+    /// Attach a shared-storage read-through source (reference-parity lazy recovery). After a
+    /// metadata-only restore installs the served index and a slab address map, this
+    /// lets a later read fetch a missing old slab on demand from shared storage,
+    /// cache it locally, and serve it — instead of installing every slab up front.
+    pub fn attach_shared_slab_source(&self, source: Arc<dyn SharedSlabSource>) {
+        self.inner
+            .lock()
+            .expect("block store lock poisoned")
+            .shared_slab_source = Some(source);
+    }
+
+    pub fn has_shared_slab_source(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("block store lock poisoned")
+            .shared_slab_source
+            .is_some()
+    }
+
+    /// The next free page id this store would assign on the next append. Recorded in a
+    /// shared checkpoint so a lazy restore can advance the fresh owner's counter past it.
+    pub fn next_page_id(&self) -> u64 {
+        self.inner
+            .lock()
+            .expect("block store lock poisoned")
+            .next_page_id
+    }
+
+    /// Reserve the slab-id (and page-id) range consumed by a lazily-restored checkpoint
+    /// so replayed/new appends land in a FRESH slab beyond it, never overwriting a slab
+    /// that is still served on-demand from shared storage. Mirrors the reference recovery
+    /// model where old pages stay addressable in shared storage while new writes roll
+    /// forward. Called right after attaching the shared read-through on a fresh owner.
+    pub fn reserve_lazy_checkpoint_range(
+        &self,
+        through_slab_id: u64,
+        next_page_id_floor: u64,
+    ) -> Result<(), BlockStoreError> {
+        let mut inner = self.inner.lock().expect("block store lock poisoned");
+        fs::create_dir_all(&inner.root)?;
+        let existing_max = slab_ids_at(&inner.root)?.into_iter().max();
+        let new_slab_id = through_slab_id
+            .max(inner.page_slab_id)
+            .max(existing_max.unwrap_or_default())
+            .saturating_add(1);
+        let path = slab_path(&inner.root, new_slab_id);
+        let file = File::create(&path)?;
+        file.sync_all()?;
+        sync_parent_dir(&path)?;
+        inner.page_slab_id = new_slab_id;
+        inner.write_offset = 0;
+        inner.next_page_id = inner.next_page_id.max(next_page_id_floor);
+        let now = now_unix_ms();
+        // Any previously-active local band is now sealed; the reserved slab is active.
+        for band in inner.bands.values_mut() {
+            if band.state == BlockStoreBandState::Active {
+                band.state = BlockStoreBandState::Sealed;
+                band.updated_unix_ms = Some(now);
+            }
+        }
+        inner.bands.insert(
+            new_slab_id,
+            BlockStoreBandDescriptor {
+                band_id: band_id_for_slab(new_slab_id),
+                page_slab_id: new_slab_id,
+                state: BlockStoreBandState::Active,
+                physical_bytes: 0,
+                logical_bytes: 0,
+                created_unix_ms: Some(now),
+                updated_unix_ms: Some(now),
+                first_page_id: None,
+                last_page_id: None,
+                readable_prefix_physical_bytes: 0,
+                has_corruption: false,
+                first_error_offset: None,
+                first_error: None,
+            },
+        );
+        persist_band_manifest(&inner.root, &inner.bands)?;
+        Ok(())
+    }
+
+    /// Ensure `page_slab_id` is present locally, fetching it from the shared
+    /// read-through source (if any) on a local miss, caching it, and counting the
+    /// on-demand fetch. A no-op when the slab already exists locally or no source is
+    /// attached; in the latter case the normal read path surfaces the miss.
+    fn ensure_slab_present(&self, page_slab_id: u64) -> Result<(), BlockStoreError> {
+        let (root, source) = {
+            let inner = self.inner.lock().expect("block store lock poisoned");
+            (inner.root.clone(), inner.shared_slab_source.clone())
+        };
+        if slab_path(&root, page_slab_id).exists() {
+            return Ok(());
+        }
+        let Some(source) = source else {
+            return Ok(());
+        };
+        if let Some(bytes) = source.fetch_slab(page_slab_id)? {
+            self.install_slab(page_slab_id, &bytes)?;
+            self.inner
+                .lock()
+                .expect("block store lock poisoned")
+                .stats
+                .shared_slab_fetches += 1;
+        }
+        Ok(())
     }
 
     pub fn roll_slab(&self) -> Result<BlockStoreRollReport, BlockStoreError> {

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -6,6 +6,9 @@ use super::*;
 
 impl LocalBlockStore {
     pub fn read(&self, address: &BlockAddress) -> Result<Vec<u8>, BlockStoreError> {
+        // Reference-parity lazy recovery: if this slab lives only in shared storage after a
+        // metadata-only restore, fetch + cache it before serving the read.
+        self.ensure_slab_present(address.page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         let path = slab_path(&inner.root, address.page_slab_id);
         let mut file = File::open(path)?;
@@ -72,6 +75,7 @@ impl LocalBlockStore {
     }
 
     pub fn read_slab(&self, page_slab_id: u64) -> Result<Vec<u8>, BlockStoreError> {
+        self.ensure_slab_present(page_slab_id)?;
         let root = self
             .inner
             .lock()

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -32,7 +32,7 @@ pub mod wal;
 
 pub use block_store::{
     BlockAddress, BlockStoreBandDescriptor, BlockStoreBandState, BlockStoreBandSummary,
-    BlockStoreOptions, BlockStoreSlabReport, BlockStoreStats, LocalBlockStore,
+    BlockStoreOptions, BlockStoreSlabReport, BlockStoreStats, LocalBlockStore, SharedSlabSource,
 };
 pub use client::{
     crc64_jones, key_is_dropped_by_percent, shard_id_for_key, bucket_id_for_key, stable_key_hash,
@@ -200,8 +200,8 @@ pub use matrixobject_store::MatrixObjectObjectStore;
 pub use shared_store::{
     ReplayReport, SharedStoreCheckpointManifest, SharedStoreFlushReport, SharedStoreGcReport,
     SharedStoreWalEntry, SharedStoreWalObject, SharedStorePageSlab, SharedStoreReplayCursor,
-    SharedStoreReplicationError, SharedStoreReplicator, SharedStoreRetryPolicy,
-    SharedStoreWalAppendMode,
+    SharedPathSlabSource, SharedStoreReplicationError, SharedStoreReplicator,
+    SharedStoreRetryPolicy, SharedStoreWalAppendMode,
     SharedStoreStorageMode, SharedStoreStorageWriter, SharedStoreWriteReport,
 };
 pub use storage_backend::{

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -10,10 +10,12 @@ use bytes::Bytes;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use temporalstore_snapshot::object_store::{AppendBlobReceipt, ObjectStore, ObjectStoreError};
+use temporalstore_snapshot::object_store::{
+    AppendBlobReceipt, FileObjectStore, ObjectStore, ObjectStoreError,
+};
 use thiserror::Error;
 
-use crate::block_store::{BlockStoreError, LocalBlockStore};
+use crate::block_store::{BlockStoreError, LocalBlockStore, SharedSlabSource};
 use crate::engine::TemporalEngine;
 use crate::sdk::{self, v1};
 use crate::types::{Command, ExecuteRequest, ShardId, Status};
@@ -122,6 +124,12 @@ pub struct SharedStoreCheckpointManifest {
     pub index_sha256: String,
     #[serde(alias = "page_segments")]
     pub page_slabs: Vec<SharedStorePageSlab>,
+    /// Next free block page id at checkpoint time. A lazy restore advances the fresh
+    /// owner's page-id counter past this floor so replayed/new writes never reuse a
+    /// page id that a lazily-fetched checkpoint slab still carries. Defaults to 0 for
+    /// manifests written before this field existed (backward compatible).
+    #[serde(default)]
+    pub next_page_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -565,6 +573,7 @@ where
             index_byte_size: index.len() as u64,
             index_sha256: sha256_hex(&index),
             page_slabs,
+            next_page_id: block_store.next_page_id(),
         };
         self.object_store
             .put(
@@ -1216,6 +1225,125 @@ where
     }
 }
 
+/// One slab's location + integrity in a shared-storage checkpoint: the object key to
+/// read it from and the checksum to verify it against before caching it locally.
+#[derive(Debug, Clone)]
+struct SharedSlabAddress {
+    key: String,
+    byte_size: u64,
+    sha256: String,
+}
+
+/// Lazy read-through source backing reference-parity recovery on the shared-filesystem
+/// (`FileObjectStore`) backend. Holds the checkpoint's slab address map (slab id ->
+/// shared object key) with no slab bytes, and resolves each slab on demand to a
+/// synchronous filesystem read of the shared store, verifying the checkpoint
+/// checksum before returning the bytes. The block store installs (caches) the
+/// returned bytes locally, so each shared slab is fetched at most once and only when
+/// a read actually needs it — never eagerly at recovery time.
+#[derive(Debug)]
+pub struct SharedPathSlabSource {
+    object_store: Arc<FileObjectStore>,
+    slabs: BTreeMap<u64, SharedSlabAddress>,
+}
+
+impl SharedPathSlabSource {
+    fn new(object_store: Arc<FileObjectStore>, slabs: BTreeMap<u64, SharedSlabAddress>) -> Self {
+        Self {
+            object_store,
+            slabs,
+        }
+    }
+
+    /// Number of slabs this source can serve lazily (i.e. the checkpoint's slab
+    /// count). Useful for asserting that recovery installed an address map, not bytes.
+    pub fn slab_count(&self) -> usize {
+        self.slabs.len()
+    }
+}
+
+impl SharedSlabSource for SharedPathSlabSource {
+    fn fetch_slab(&self, page_slab_id: u64) -> Result<Option<Vec<u8>>, BlockStoreError> {
+        let Some(address) = self.slabs.get(&page_slab_id) else {
+            return Ok(None);
+        };
+        let path = self.object_store.object_path(&address.key).map_err(|err| {
+            BlockStoreError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                err.to_string(),
+            ))
+        })?;
+        let bytes = std::fs::read(&path)?;
+        // Parity with restore_checkpoint: reject a corrupt shared slab before caching it.
+        let actual = sha256_hex(&bytes);
+        if bytes.len() as u64 != address.byte_size || actual != address.sha256 {
+            return Err(BlockStoreError::ChecksumMismatch {
+                page_slab_id,
+                offset: 0,
+                length: address.byte_size,
+                expected: address.sha256.clone(),
+                actual,
+            });
+        }
+        Ok(Some(bytes))
+    }
+}
+
+impl SharedStoreReplicator<FileObjectStore> {
+    /// Reference-parity LAZY restore for the shared-filesystem backend: install the served
+    /// INDEX and a per-slab shared address map WITHOUT downloading any slab bytes.
+    /// Old (pre-checkpoint) pages are then read lazily through [`SharedPathSlabSource`]
+    /// on the first read that needs them. The caller replays only the WAL tail after
+    /// `manifest.checkpoint_wal_index`, so recovery cost is O(index + recent WAL),
+    /// not O(full history + all slabs). Returns `CheckpointNotFound` when no
+    /// checkpoint exists so the caller can fall back to a full WAL replay.
+    pub async fn restore_index_and_page_addresses(
+        &self,
+        shard_id: ShardId,
+        engine: &TemporalEngine,
+        block_store: &LocalBlockStore,
+    ) -> Result<SharedStoreCheckpointManifest, SharedStoreReplicationError> {
+        let manifest = self
+            .list_checkpoints(shard_id)
+            .await?
+            .pop()
+            .ok_or(SharedStoreReplicationError::CheckpointNotFound(shard_id))?;
+        let index = self.object_store.get(&manifest.index_key).await?;
+        verify_checksum(
+            &manifest.index_key,
+            &index,
+            manifest.index_byte_size,
+            &manifest.index_sha256,
+        )?;
+        engine.install_index_bytes(manifest.shard_id, &index)?;
+
+        let mut slabs = BTreeMap::new();
+        let mut max_slab_id = 0u64;
+        for slab in &manifest.page_slabs {
+            max_slab_id = max_slab_id.max(slab.page_slab_id);
+            slabs.insert(
+                slab.page_slab_id,
+                SharedSlabAddress {
+                    key: slab.key.clone(),
+                    byte_size: slab.byte_size,
+                    sha256: slab.sha256.clone(),
+                },
+            );
+        }
+        let source = Arc::new(SharedPathSlabSource::new(
+            Arc::clone(&self.object_store),
+            slabs,
+        ));
+        block_store.attach_shared_slab_source(source);
+        // Roll local appends past the checkpoint's slab/page-id range so replayed WAL-tail
+        // and new writes never overwrite a slab still served lazily from shared storage.
+        if !manifest.page_slabs.is_empty() {
+            block_store.reserve_lazy_checkpoint_range(max_slab_id, manifest.next_page_id)?;
+        }
+        Ok(manifest)
+    }
+}
+
 impl<O> SharedStoreStorageWriter<O>
 where
     O: ObjectStore + 'static,
@@ -1820,6 +1948,248 @@ mod tests {
                 .response,
             CommandResponse::Bytes {
                 value: Some(b"wal-value".to_vec())
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_store_lazy_restore_reads_old_page_on_demand() {
+        // Reference-parity lazy recovery: a fresh node with ONLY shared storage restores the
+        // served index + a slab ADDRESS map (no slab bytes), replays the WAL tail, and
+        // fetches an old (pre-checkpoint) slab ON DEMAND the first time a read needs it.
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "before".to_string(),
+                value: b"snapshot-value".to_vec(),
+            },
+        });
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        // Publish a real metadata+slab checkpoint at WAL index 1, then a WAL tail entry.
+        let manifest = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .unwrap();
+        assert!(
+            !manifest.page_slabs.is_empty(),
+            "checkpoint must upload the slab bytes so a lazy owner can fetch them"
+        );
+        replicator
+            .publish_wal_entry(SharedStoreWalEntry {
+                shard_id: 1,
+                wal_index: 2,
+                command: Command::StringSet {
+                    key: "after".to_string(),
+                    value: b"wal-value".to_vec(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // Fresh owner: no local slabs at all.
+        let follower = test_engine(dir.path(), "follower");
+        assert!(follower.block_store().slab_ids().unwrap().is_empty());
+
+        // Lazy restore: index + address map only, NO slab bytes installed up front.
+        let restored = replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+            .unwrap();
+        assert_eq!(restored.checkpoint_wal_index, 1);
+        assert!(
+            follower.block_store().has_shared_slab_source(),
+            "restore must attach a shared read-through source"
+        );
+        // Proof of laziness: the only local slab is the reserved (empty) append slab;
+        // the checkpoint's slab 0 was NOT installed, and nothing was fetched yet.
+        assert!(
+            !follower.block_store().slab_ids().unwrap().contains(&0),
+            "checkpoint slab 0 must not be installed eagerly"
+        );
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);
+
+        follower.load_shard(1);
+        // Replay only the WAL tail after the checkpoint index: applies exactly "after".
+        let report = replicator
+            .replay_wal(1, restored.checkpoint_wal_index, &follower)
+            .await
+            .unwrap();
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.last_wal_index, 2);
+        // The tail write did not touch any pre-checkpoint slab, so still no lazy fetch.
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);
+
+        // Reading the OLD key triggers exactly ONE on-demand slab fetch and is correct.
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "before".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"snapshot-value".to_vec())
+            }
+        );
+        assert_eq!(
+            follower.block_store().stats().shared_slab_fetches,
+            1,
+            "reading one old key must fetch exactly one slab on demand (not all slabs up front)"
+        );
+
+        // The fetched slab is now cached locally; a second read does NOT re-fetch.
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "before".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"snapshot-value".to_vec())
+            }
+        );
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 1);
+
+        // The WAL-tail value is served from the reserved local slab.
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "after".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"wal-value".to_vec())
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_store_lazy_restore_replays_only_wal_tail() {
+        // WAL-tail replay is O(recent): applied count == number of post-checkpoint
+        // records, not the full history.
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "before".to_string(),
+                value: b"snapshot-value".to_vec(),
+            },
+        });
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        let manifest = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .unwrap();
+        assert_eq!(manifest.checkpoint_wal_index, 1);
+
+        // Three post-checkpoint tail records.
+        for (wal_index, key) in [(2u64, "k2"), (3, "k3"), (4, "k4")] {
+            replicator
+                .publish_wal_entry(SharedStoreWalEntry {
+                    shard_id: 1,
+                    wal_index,
+                    command: Command::StringSet {
+                        key: key.to_string(),
+                        value: key.as_bytes().to_vec(),
+                    },
+                })
+                .await
+                .unwrap();
+        }
+
+        let follower = test_engine(dir.path(), "follower");
+        let restored = replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+            .unwrap();
+        follower.load_shard(1);
+        let report = replicator
+            .replay_wal(1, restored.checkpoint_wal_index, &follower)
+            .await
+            .unwrap();
+        assert_eq!(
+            report.applied, 3,
+            "replay applies only the 3 post-checkpoint records, not the full history"
+        );
+        assert_eq!(report.last_wal_index, 4);
+        for key in ["k2", "k3", "k4"] {
+            assert_eq!(
+                follower
+                    .execute(ExecuteRequest {
+                        shard_id: 1,
+                        command: Command::StringGet {
+                            key: key.to_string()
+                        },
+                    })
+                    .response,
+                CommandResponse::Bytes {
+                    value: Some(key.as_bytes().to_vec())
+                }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn shared_store_lazy_restore_no_checkpoint_falls_back_to_full_replay() {
+        // Backward compatible: with no checkpoint published, the lazy restore reports
+        // CheckpointNotFound and the caller replays the full shared WAL from 0.
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, replicator) = test_shared_store(dir.path());
+        for (wal_index, key, value) in [
+            (1u64, "a", b"1".to_vec()),
+            (2, "b", b"2".to_vec()),
+        ] {
+            replicator
+                .publish_wal_entry(SharedStoreWalEntry {
+                    shard_id: 1,
+                    wal_index,
+                    command: Command::StringSet {
+                        key: key.to_string(),
+                        value,
+                    },
+                })
+                .await
+                .unwrap();
+        }
+
+        let follower = test_engine(dir.path(), "follower");
+        follower.load_shard(1);
+        let after = match replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+        {
+            Err(SharedStoreReplicationError::CheckpointNotFound(_)) => 0,
+            other => panic!("expected CheckpointNotFound, got {other:?}"),
+        };
+        assert!(!follower.block_store().has_shared_slab_source());
+        let report = replicator.replay_wal(1, after, &follower).await.unwrap();
+        assert_eq!(report.applied, 2);
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "a".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"1".to_vec())
             }
         );
     }


### PR DESCRIPTION
…m backend

Port of bjmeetsfo increment (merged there): a node recovering a shard from the shared FileObjectStore installs the served index + a per-slab shared address map (no bytes) and replays only the WAL tail after the checkpoint, then reads old pages lazily by address (verified checksum, cached, counted) on first access — recovery O(index + recent WAL) instead of O(full history + all slabs). Falls back to full replay when no checkpoint. matrixobject path unchanged.

Adds SharedSlabSource read-through + SharedPathSlabSource + restore_index_and_ page_addresses + reserve_lazy_checkpoint_range; manifest.next_page_id (serde default). Tests: lazy on-demand fetch, WAL-tail-only (O(recent)), no-checkpoint fallback. Validated on bjmeetsfo (shared_store+block_store 49/0).