### PR TITLE
Extend lazy shared-store read-through to range/streaming reads

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1800,6 +1800,73 @@ mod tests {
     }
 
     #[test]
+    fn read_range_and_logical_range_drive_shared_slab_read_through() {
+        // Reference-parity lazy recovery must cover band-report / streaming reads too:
+        // read_range and read_logical_range on a metadata-only restored node must pull a
+        // not-yet-fetched checkpoint slab from shared storage on first access (previously
+        // they hit a local File::open miss instead of the shared read-through).
+        #[derive(Debug)]
+        struct OneSlabSource {
+            page_slab_id: u64,
+            bytes: Vec<u8>,
+        }
+        impl SharedSlabSource for OneSlabSource {
+            fn fetch_slab(&self, page_slab_id: u64) -> Result<Option<Vec<u8>>, BlockStoreError> {
+                Ok((page_slab_id == self.page_slab_id).then(|| self.bytes.clone()))
+            }
+        }
+
+        // Producer writes a real slab; capture its raw bytes to serve lazily to fresh nodes.
+        let producer_dir = tempfile::tempdir().unwrap();
+        let producer = LocalBlockStore::new(producer_dir.path());
+        producer.append(b"abc").unwrap();
+        producer.append(b"def").unwrap();
+        let raw = producer.read_slab(0).unwrap();
+        drop(producer);
+
+        // read_range: fresh node, slab absent locally, shared source attached.
+        let range_dir = tempfile::tempdir().unwrap();
+        let range_node = LocalBlockStore::new(range_dir.path());
+        range_node.attach_shared_slab_source(Arc::new(OneSlabSource {
+            page_slab_id: 0,
+            bytes: raw.clone(),
+        }));
+        assert!(
+            !range_node.slab_ids().unwrap().contains(&0),
+            "slab must not be installed before the range read"
+        );
+        assert_eq!(range_node.stats().shared_slab_fetches, 0);
+        let raw_prefix = range_node.read_range(0, 0, 3).unwrap();
+        assert_eq!(
+            range_node.stats().shared_slab_fetches, 1,
+            "read_range must fetch the missing slab exactly once"
+        );
+        assert_eq!(raw_prefix.len(), 3);
+        assert_eq!(raw, range_node.read_slab(0).unwrap());
+        // Cached now: a second range read must not re-fetch.
+        let _ = range_node.read_range(0, 0, 3).unwrap();
+        assert_eq!(
+            range_node.stats().shared_slab_fetches, 1,
+            "cached slab: no re-fetch"
+        );
+
+        // read_logical_range: independent fresh node so its fetch count starts at 0.
+        let logical_dir = tempfile::tempdir().unwrap();
+        let logical_node = LocalBlockStore::new(logical_dir.path());
+        logical_node.attach_shared_slab_source(Arc::new(OneSlabSource {
+            page_slab_id: 0,
+            bytes: raw.clone(),
+        }));
+        assert_eq!(logical_node.stats().shared_slab_fetches, 0);
+        let logical = logical_node.read_logical_range(0, 1, 4).unwrap();
+        assert_eq!(
+            logical_node.stats().shared_slab_fetches, 1,
+            "read_logical_range must fetch the missing slab exactly once"
+        );
+        assert_eq!(logical, b"bcde");
+    }
+
+    #[test]
     fn compressed_page_records_round_trip_and_remain_logical() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -44,6 +44,9 @@ impl LocalBlockStore {
         offset: u64,
         size: u64,
     ) -> Result<Vec<u8>, BlockStoreError> {
+        // Reference-parity lazy recovery: drive the shared-store read-through for band-report /
+        // streaming reads too, so a not-yet-fetched checkpoint slab is pulled + cached on demand.
+        self.ensure_slab_present(page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         let path = slab_path(&inner.root, page_slab_id);
         let mut file = File::open(path)?;
@@ -62,6 +65,9 @@ impl LocalBlockStore {
         offset: u64,
         size: u64,
     ) -> Result<Vec<u8>, BlockStoreError> {
+        // Reference-parity lazy recovery: drive the shared-store read-through for band-report /
+        // streaming reads too, so a not-yet-fetched checkpoint slab is pulled + cached on demand.
+        self.ensure_slab_present(page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
         let path = slab_path(&inner.root, page_slab_id);
         let slab = fs::read(path)?;


### PR DESCRIPTION
Completes increment 1's reference-parity lazy recovery on the shared-filesystem (SharedPath) backend.

**What**: `ensure_slab_present` (the shared-store read-through: on a local slab miss, fetch the slab from shared storage by address, verify checksum, cache, count) was wired into `read()`/`read_slab()` but **not** `read_range()`/`read_logical_range()`. A band-report or streaming read of a checkpoint slab not yet fetched after a metadata-only restore therefore hit a local `File::open` miss instead of the read-through. This adds `ensure_slab_present` at the top of both range paths (before taking the block-store lock, matching `read()`).

**Why it's safe**: no-op when the slab is local or no shared source is attached (fully backward compatible); identical lock ordering to the existing `read()` path.

**Test**: `read_range_and_logical_range_drive_shared_slab_read_through` — a fresh node with only a shared slab source (no local slab) drives exactly one fetch per range path and serves correct bytes; a cached read does not re-fetch.

**Base**: stacks on merged PR #23 (increment 1). Validated on bjmeetsfo: block_store + shared_store lazy tests 37/0; full lib build clean.