### PR TITLE
test(gateway): lock in per-user isolation within a tenant + document the contract

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -425,6 +425,14 @@ def _apply_identity(args: Json, key: Optional[str], tenant: Optional[str],
     the authenticated key -- rather than trusting the client's `scope` string -- is what isolates one
     tenant's memory (and the `pending_async_event` fallback buffer) from another's.
 
+    The END-USER identity (`user_id`/`session_id`) is a different axis and is NOT server-pinned: the
+    tenant's own backend supplies it per request, so it is PRESERVED from the client `scope` here --
+    only `tenant_id`/`account_id` are (re)written, never `user_id`/`session_id`. That is what keeps
+    two end-users of the SAME tenant on distinct buffer keys (e.g. `alice` cannot read `bob`'s
+    pending/session buffer even under one shared API key). A tenant that wants per-user isolation MUST
+    pass `user_id` (and, for per-session isolation, `session_id`) in `scope`; when both are absent the
+    request legitimately falls back to the tenant-level buffer (`user_id`/`session_id` default to "").
+
     The edge bearer key is forwarded as the backend `api_key` only when
     MATRIXARK_GATEWAY_FORWARD_API_KEY is truthy (default on). Deployments where the edge itself is the
     trust boundary and the backend runs in `dev` access mode set it to 0, so the edge token is not

--- a/tools/test_matrixark_v1_gateway.py
+++ b/tools/test_matrixark_v1_gateway.py
@@ -511,6 +511,49 @@ class EnforcedAuthTest(unittest.TestCase):
         self.assertNotEqual((a_scope["tenant_id"], a_scope["account_id"]),
                             (b_scope["tenant_id"], b_scope["account_id"]))
 
+    @staticmethod
+    def _buffer_key(scope):
+        # Mirrors matrixark_mcp_core_session.session_buffer_key_from_scope (the pending/session
+        # buffer key); kept inline so this stays a pure-Python gateway unit test with no backend import.
+        user_id = str(scope.get("user_id") or "")
+        session_id = str(scope.get("session_id") or user_id or "")
+        return (str(scope.get("account_id") or "acct_local"),
+                str(scope.get("tenant_id") or "tenant_local_agent"), user_id, session_id)
+
+    def test_same_tenant_users_get_distinct_buffer_keys(self):
+        # Two END-USERS of ONE tenant (same API key, same client scope string "cart") must NOT share a
+        # pending/session buffer. The gateway pins tenant_id/account_id from the key but PRESERVES the
+        # client-supplied user_id, so `alice` and `bob` land on distinct buffer keys.
+        drive(self.app, path="/v1/ingest",
+              body={"scope": {"user_id": "alice", "namespace": "cart"}, "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_A}"})
+        drive(self.app, path="/v1/ingest",
+              body={"scope": {"user_id": "bob", "namespace": "cart"}, "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_A}"})
+        a_scope = self.s.calls[0][1]["scope"]
+        b_scope = self.s.calls[1][1]["scope"]
+        # tenant/account pinned from the key (not client text); user_id preserved, never overwritten.
+        self.assertEqual(("tenantA", "acct_a", "alice"),
+                         (a_scope["tenant_id"], a_scope["account_id"], a_scope["user_id"]))
+        self.assertEqual(("tenantA", "acct_a", "bob"),
+                         (b_scope["tenant_id"], b_scope["account_id"], b_scope["user_id"]))
+        # The resulting pending/session buffer keys differ only on the user axis -> no cross-user leak.
+        ka, kb = self._buffer_key(a_scope), self._buffer_key(b_scope)
+        self.assertEqual(("acct_a", "tenantA", "alice", "alice"), ka)
+        self.assertEqual(("acct_a", "tenantA", "bob", "bob"), kb)
+        self.assertNotEqual(ka, kb)
+
+    def test_missing_user_id_falls_back_to_tenant_buffer(self):
+        # Contract: a tenant that omits user_id/session_id legitimately shares one tenant-level buffer.
+        drive(self.app, path="/v1/ingest", body={"scope": {"namespace": "cart"}, "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_A}"})
+        drive(self.app, path="/v1/ingest", body={"scope": {"namespace": "cart"}, "records": [1]},
+              headers={"Authorization": f"Bearer {self.KEY_A}"})
+        k0 = self._buffer_key(self.s.calls[0][1]["scope"])
+        k1 = self._buffer_key(self.s.calls[1][1]["scope"])
+        self.assertEqual(("acct_a", "tenantA", "", ""), k0)
+        self.assertEqual(k0, k1)
+
     def test_dev_mode_still_accepts_demo(self):
         # Enforcement OFF -> legacy behavior: demo key maps to its tenant, request succeeds.
         cfg = gw.GatewayConfig.from_env({"api_keys": {"sk_live_demo": "acme"}, "require_auth": True})


### PR DESCRIPTION
**Please do not merge without maintainer approval.**

Closes the per-user isolation coverage gap in the enforced-mode `/v1` gateway.

### Context
The enforced-mode gateway already pins `tenant_id`/`account_id` from the authenticated API key and preserves the client-supplied `user_id`/`session_id`, so two end-users of the *same* tenant land on distinct session/pending buffer keys `(account_id, tenant_id, user_id, session_id)`. Existing tests only proved the **cross-tenant** axis; nothing pinned the **same-tenant / different-user** case.

### Change (test + docs only, no behavior change)
- `test_same_tenant_users_get_distinct_buffer_keys`: one API key, same client scope string `cart`, `user_id` alice vs bob -> `tenant_id`/`account_id` pinned identically but buffer keys differ on the user axis (alice cannot read bob's buffer under one shared key).
- `test_missing_user_id_falls_back_to_tenant_buffer`: omitting `user_id`/`session_id` legitimately collapses to the tenant-level buffer (documents the contract).
- Docstring in `_apply_identity` documents that `user_id`/`session_id` are the end-user axis, supplied by the tenant backend per request and preserved (never overwritten); a tenant wanting per-user isolation must pass them.

### Verification
38/38 gateway unit tests pass. Live-proven on an enforced test instance against the AWS cluster: alice retrieves her marker; bob (same tenant, same scope) gets an empty pack; cross-tenant gets nothing.