### PR TITLE
feat(storage): true single-WAL-barrier durability with base-only recovery (TS_WAL_SINGLE_BARRIER)

### DIFF
--- a/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
@@ -27,7 +27,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+use temporalstore_rust::{
+    Command, CommandResponse, Config, ExecuteRequest, FeaturePoint, SetConfigRequest,
+    TemporalEngine,
+};
 
 fn key_of(i: u64) -> String {
     format!("sbk-{i:010}")
@@ -235,6 +238,132 @@ fn recover(root: PathBuf, keys: u64) {
     }
 }
 
+/// DECISIVE single-barrier case: evict (feature_max_size trim) BEFORE any dump, then crash.
+/// One FeatureAppend of 5 points with feature_max_size=3 keeps the newest 3 in the series but
+/// leaves all 5 physically in the page. The trim decision is config-driven; the config is made
+/// durable + WAL-ordered by the single-barrier config-log. After the crash only the fsync'd WAL
+/// and config-log survive (no dump), so recovery must re-derive the trim and NOT resurrect the
+/// two evicted points.
+fn populate_feature(root: PathBuf) -> ! {
+    let engine = open_engine(&root);
+    engine.load_shard(1);
+    let applied = engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            feature_max_size: 3,
+            ..Config::default()
+        },
+    });
+    assert!(applied.ok, "set_config failed: {applied:?}");
+    let points: Vec<FeaturePoint> = (1..=5u64)
+        .map(|i| FeaturePoint {
+            timestamp_ms: i * 10,
+            value: vec![i as u8],
+        })
+        .collect();
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureAppend {
+            key: "f".to_string(),
+            points,
+        },
+    });
+    assert!(response.status.ok, "feature append ack failed");
+    // No dump: only the fsync'd WAL + config-log are durable.
+    fs::write(durable_lengths_path(&root), "").expect("record durable lengths");
+    std::process::abort();
+}
+
+fn recover_feature(root: PathBuf) {
+    let engine = open_engine(&root);
+    engine.load_shard(1); // forces WAL replay from the durable watermark
+    let got: Vec<u64> = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::FeatureQuery {
+                key: "f".to_string(),
+                start_ms: 0,
+                end_ms: u64::MAX,
+                count: Some(100),
+            },
+        })
+        .response
+    {
+        CommandResponse::FeaturePoints { points } => {
+            points.iter().map(|p| p.timestamp_ms).collect()
+        }
+        other => {
+            eprintln!("unexpected feature query response: {other:?}");
+            std::process::exit(3);
+        }
+    };
+    let expected = vec![30u64, 40, 50];
+    let ok = got == expected;
+    println!(
+        "{{\"feature_timestamps\":{got:?},\"expected\":{expected:?},\"ok\":{ok}}}"
+    );
+    if !ok {
+        std::process::exit(2);
+    }
+}
+
+/// Exactly-once proof for a NON-idempotent command under base-only recovery. Increment one hash
+/// counter `keys` times (each a WAL command), dump halfway, then crash. Base-only replay applies
+/// each post-dump record EXACTLY ONCE (no delta fold that would re-apply the tail on top of the
+/// base), so the recovered counter must equal `keys`, never 2x.
+fn populate_counter(root: PathBuf, keys: u64, flush_at: Option<u64>) -> ! {
+    let engine = open_engine(&root);
+    engine.load_shard(1);
+    for i in 0..keys {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashIncrBy {
+                key: "counter".to_string(),
+                field: "n".to_string(),
+                increment: 1,
+            },
+        });
+        assert!(response.status.ok, "incr ack failed at {i}");
+        if Some(i) == flush_at {
+            engine.flush_shard_index(1);
+            record_durable_slab_lengths(&root);
+        }
+    }
+    if flush_at.is_none() {
+        fs::write(durable_lengths_path(&root), "").expect("record durable lengths");
+    }
+    std::process::abort();
+}
+
+fn recover_counter(root: PathBuf, expected: i64) {
+    let engine = open_engine(&root);
+    engine.load_shard(1); // forces WAL replay from the durable watermark
+    let got: i64 = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashGet {
+                key: "counter".to_string(),
+                field: "n".to_string(),
+            },
+        })
+        .response
+    {
+        CommandResponse::Bytes { value: Some(bytes) } => {
+            String::from_utf8_lossy(&bytes).trim().parse::<i64>().unwrap_or(-1)
+        }
+        other => {
+            eprintln!("unexpected counter response: {other:?}");
+            std::process::exit(3);
+        }
+    };
+    let ok = got == expected;
+    println!("{{\"counter\":{got},\"expected\":{expected},\"ok\":{ok}}}");
+    if !ok {
+        std::process::exit(2);
+    }
+}
+
 fn main() {
     let mut root = None;
     let mut mode = None;
@@ -258,6 +387,12 @@ fn main() {
         Some("populate") => populate(root, keys, flush_at),
         Some("powerloss") => powerloss(root, &scope),
         Some("recover") => recover(root, keys),
-        other => panic!("--mode must be populate|powerloss|recover, got {other:?}"),
+        Some("populate-feature") => populate_feature(root),
+        Some("recover-feature") => recover_feature(root),
+        Some("populate-counter") => populate_counter(root, keys, flush_at),
+        Some("recover-counter") => recover_counter(root, keys as i64),
+        other => panic!(
+            "--mode must be populate|powerloss|recover|populate-feature|recover-feature|populate-counter|recover-counter, got {other:?}"
+        ),
     }
 }

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -960,12 +960,34 @@ pub(crate) fn bulk_relaxed_durability() -> bool {
     )
 }
 
-/// TS_WAL_ONLY_SYNC: on the live path, defer the per-record data-page fdatasync and
+/// TS_WAL_ONLY_SYNC / TS_WAL_SINGLE_BARRIER: on the live path, defer the per-record
 /// extent-manifest persist to sync_durable()/slab-seal (WAL replay re-materializes pages
 /// on recovery; the manifest is reconciled from disk on open). Default OFF.
 pub(crate) fn page_wal_only_sync() -> bool {
+    ["TS_WAL_ONLY_SYNC", "TS_WAL_SINGLE_BARRIER"].iter().any(|name| {
+        matches!(
+            std::env::var(name)
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase()
+                .as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// TS_WAL_SINGLE_BARRIER: the true single-barrier mode also defers the per-write data-page
+/// fdatasync -- the last non-WAL synchronous barrier. This is safe ONLY because the flag also
+/// switches recovery to base-only replay: reload trusts only the durable dump checkpoint (whose
+/// `flush_shard_index` fsyncs every page BEFORE advancing the watermark) and re-derives every
+/// post-watermark page by replaying the WAL tail exactly once. A page that was written but never
+/// fsync'd is therefore rebuilt from its WAL command, never left as a dangling reference. The
+/// deferred page still becomes durable at the next dump (`sync_durable` fsyncs the active slab;
+/// a rolled slab is fsync'd at roll). Deliberately NOT enabled by the legacy TS_WAL_ONLY_SYNC,
+/// which does not change recovery trust.
+pub(crate) fn page_wal_single_barrier() -> bool {
     matches!(
-        std::env::var("TS_WAL_ONLY_SYNC")
+        std::env::var("TS_WAL_SINGLE_BARRIER")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -95,7 +95,10 @@ impl LocalBlockStore {
         //    fsync + rename EVERY record -- barriers 5/6) to sync_durable()/slab-seal. SAFE
         //    even with pages kept durable: the manifest is band/GC metadata reconstructed
         //    by reconcile-on-open from the durable page records, never a read dependency.
-        let defer_data_sync = bulk_relaxed_durability();
+        // Under the true single-barrier mode the data-page fdatasync is also deferred;
+        // base-only recovery re-derives every post-dump page by WAL replay, so a never-fsync'd
+        // page is rebuilt from its WAL command rather than left dangling.
+        let defer_data_sync = bulk_relaxed_durability() || page_wal_single_barrier();
         let defer_manifest = bulk_relaxed_durability() || page_wal_only_sync();
         if !defer_data_sync {
             file.sync_data()?;
@@ -219,8 +222,10 @@ impl LocalBlockStore {
         // The batch already amortizes the data barrier across all its records (one
         // sync_data for the whole batch). Keep that data barrier on the live path (durable
         // pages); only the extent-manifest persist is deferred under TS_WAL_ONLY_SYNC
-        // (reconciled on open), matching the single-append path.
-        let defer_data_sync = bulk_relaxed_durability();
+        // (reconciled on open), matching the single-append path. Under the true single-barrier
+        // mode the data-page fdatasync is also deferred; base-only recovery re-derives every
+        // post-dump page by WAL replay, so a never-fsync'd page is rebuilt, never left dangling.
+        let defer_data_sync = bulk_relaxed_durability() || page_wal_single_barrier();
         let defer_manifest = bulk_relaxed_durability() || page_wal_only_sync();
         if let Some(mut current) = file {
             current.flush()?;

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -452,13 +452,22 @@ impl TemporalEngine {
                         shard.applied_wal_sequence,
                         None,
                     );
-                } else {
+                } else if !wal_single_barrier() {
                     let index_bytes = serialize_index(shard);
                     let _ = self
                         .index_log_store
                         .append_json(request.shard_id, &index_bytes);
                     let _ = self.persist_index_bytes(request.shard_id, &index_bytes);
                 }
+                // Single-barrier mode (base-only recovery): the per-write base-index rewrite
+                // above is DEFERRED. It would otherwise advance the on-disk base watermark (and
+                // its page references) to the latest write while the data-page fdatasync is
+                // deferred, so a crash would leave the durable base pointing past the durable
+                // page frontier -- recovery would then trust a watermark whose pages were never
+                // synced and silently drop them. Instead the base index is materialized ONLY by
+                // the durable dump/flush path (which fsyncs every page BEFORE advancing its
+                // watermark), so base-only recovery never trusts a watermark or page reference
+                // beyond the durable frontier; the WAL (already synced above) re-derives the tail.
             }
         }
         ExecuteResponse {
@@ -635,8 +644,79 @@ impl TemporalEngine {
         if request.config.version == current.version {
             return Status::ok();
         }
+        let applied = request.config.clone();
         configs.insert(request.shard_id, request.config);
+        // Drop the config lock before touching the WAL/disk so the durable append never runs
+        // under the config mutex.
+        drop(configs);
+        // Single-barrier durability: config-driven trims (feature_max_size) are re-derived by
+        // WAL-tail replay on recovery, so the config must be durable and ordered relative to the
+        // WAL. Stamp this change with the current WAL frontier -- it is effective for every write
+        // with a strictly greater sequence -- and fsync it. Config changes are rare admin ops, so
+        // this extra barrier is off the per-write hot path. Off the flag this is a no-op and the
+        // config path is byte-for-byte unchanged.
+        if wal_single_barrier() {
+            let after_seq = self.wal_store.stats(request.shard_id).last_sequence;
+            if let Err(err) = self.append_config_log_entry(request.shard_id, after_seq, &applied) {
+                tracing::warn!(
+                    shard_id = request.shard_id,
+                    error = %err,
+                    "failed to persist single-barrier config-log entry"
+                );
+            }
+        }
         Status::ok()
+    }
+
+    /// Durable, WAL-sequence-ordered config-log path for a shard (single-barrier mode).
+    pub(super) fn config_log_path(&self, shard_id: ShardId) -> PathBuf {
+        self.index_dir
+            .join(format!("shard-{shard_id}.configlog.jsonl"))
+    }
+
+    /// Append one config-log entry `{after_seq, config}` and fsync it. `after_seq` is the WAL
+    /// sequence the config became effective AFTER (it applies to writes with sequence >
+    /// after_seq). Append-only + fsync'd so a crash cannot lose an acked config change.
+    pub(super) fn append_config_log_entry(
+        &self,
+        shard_id: ShardId,
+        after_seq: u64,
+        config: &Config,
+    ) -> std::io::Result<()> {
+        use std::io::Write as _;
+        std::fs::create_dir_all(&self.index_dir)?;
+        let entry = ConfigLogEntry {
+            after_seq,
+            config: config.clone(),
+        };
+        let mut bytes = serde_json::to_vec(&entry)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        bytes.push(b'\n');
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.config_log_path(shard_id))?;
+        file.write_all(&bytes)?;
+        file.flush()?;
+        file.sync_data()?;
+        Ok(())
+    }
+
+    /// Read the config-log entries for a shard, sorted by ascending `after_seq` (stable). Empty
+    /// when the shard has no config-log (no single-barrier config change was ever persisted).
+    pub(super) fn config_log_entries(&self, shard_id: ShardId) -> Vec<ConfigLogEntry> {
+        let path = self.config_log_path(shard_id);
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(_) => return Vec::new(),
+        };
+        let mut entries: Vec<ConfigLogEntry> = contents
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .filter_map(|line| serde_json::from_str::<ConfigLogEntry>(line).ok())
+            .collect();
+        entries.sort_by_key(|entry| entry.after_seq);
+        entries
     }
 
     pub fn get_config(&self, shard_id: ShardId) -> GetConfigResponse {
@@ -1463,14 +1543,53 @@ fn atomic_write_bytes_synced(path: &Path, bytes: &[u8], sync: bool) -> Result<()
 /// barrier; the served-index checkpoint write is issued but its fsync is deferred to the
 /// background flush / OS writeback (reconstructable from the WAL on recovery). Default OFF.
 pub(super) fn wal_only_sync() -> bool {
+    env_flag_on("TS_WAL_ONLY_SYNC") || wal_single_barrier()
+}
+
+/// TS_WAL_SINGLE_BARRIER: the true SINGLE write-path durability barrier. Only the WAL takes a
+/// synchronous fdatasync per write (1.00/write); the data-page fdatasync, the served-index
+/// delta-log fdatasync, the band-manifest persist, and the base-index sync are all deferred.
+/// Correctness rests on the WAL + the durable dump checkpoint being a COMPLETE source of truth:
+///  - config changes (feature_max_size etc.) become durable and WAL-sequence-ordered via a
+///    per-shard config-log, so replay re-derives config-driven eviction (trims) at the exact
+///    frontier they took effect (see `append_config_log_entry` / `config_log_entries`). Without
+///    this, WAL-only replay re-executed feature appends with the default config and resurrected
+///    evicted points.
+///  - expiry (TTL) resolves against the leader timestamp captured in each WAL record (replay
+///    clock) and applies lazily; compaction is background + non-destructive to logical
+///    membership -- both already WAL-re-derivable.
+///  - the durable dump/flush path fsyncs every data page BEFORE it materializes the base index
+///    and advances its watermark, so every page at/below the base watermark is durable. Recovery
+///    is BASE-ONLY: it trusts only that durable base/manifest checkpoint (never the un-synced
+///    per-write base rewrite or served-index delta, which may reference pages that were never
+///    fsync'd), then replays the WAL tail from the watermark, re-deriving every post-dump page
+///    EXACTLY ONCE. A page written but never fsync'd is rebuilt from its WAL command rather than
+///    left dangling -- no page loss, no double-apply.
+/// Default OFF; when off the write and load paths are byte-for-byte unchanged.
+pub(super) fn wal_single_barrier() -> bool {
+    env_flag_on("TS_WAL_SINGLE_BARRIER")
+}
+
+fn env_flag_on(name: &str) -> bool {
     matches!(
-        std::env::var("TS_WAL_ONLY_SYNC")
+        std::env::var(name)
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
         "1" | "true" | "yes" | "on"
     )
+}
+
+/// One durable config-log entry: the shard config `config`, effective for every WAL write with
+/// sequence strictly greater than `after_seq`. Written under single-barrier mode so WAL-tail
+/// replay re-derives config-driven eviction (feature_max_size trims) at the exact frontier the
+/// change took effect, rather than replaying with a lost/default config and resurrecting or
+/// dropping points.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(super) struct ConfigLogEntry {
+    pub after_seq: u64,
+    pub config: Config,
 }
 
 fn next_temp_counter() -> u64 {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -131,32 +131,78 @@ impl TemporalEngine {
                 status: Status::error("already_exists", "shard already exists"),
             };
         }
-        // If the latest durable dump manifest is newer than the served index, install
-        // it as the load base first (recovers data already dumped into a manifest and
-        // then WAL-GC'd): the dumped index is restored first, then
-        // startup load replays the WAL on top.
-        let installed_manifest_watermark =
-            match self.install_latest_manifest_if_newer_on_load(request.shard_id) {
-                Ok(watermark) => watermark,
-                // An index-load failure is fatal. A newer durable manifest
-                // that will not install means the served snapshot + (possibly reclaimed)
-                // WAL cannot be trusted to hold the records it covers -- refuse the load.
-                Err(status) => return LoadShardResponse { status },
+        let (loaded, replay_watermark) = if wal_single_barrier() {
+            // SINGLE-BARRIER RECOVERY TRUST (base-only). The data-page + delta fdatasyncs and
+            // the per-write base rewrite are all deferred, so neither the served-index delta nor
+            // the un-synced base rewrite can be trusted -- they may reference pages that were
+            // never fsync'd. Recover ONLY from durable checkpoints:
+            //  * the base index snapshot, materialized durably (fsync) at the last dump/flush --
+            //    that path fsyncs every page BEFORE advancing its watermark, so every page
+            //    at/below the base watermark is on disk; and
+            //  * the latest durable dump manifest, if newer than the base file.
+            // Then replay the WAL tail from that durable watermark, re-deriving every page written
+            // after it (a lost un-synced page is rebuilt, never left dangling) and, via the
+            // config-log, re-applying config-driven eviction at the exact frontier. The delta is
+            // deliberately NOT folded (load_index_base_only), so each tail record is applied
+            // EXACTLY ONCE -- no double-apply of non-idempotent commands (counters, appends).
+            let base_only =
+                self.load_index_base_only(request.shard_id, eager_cache_warm_on_load());
+            let base_watermark = base_only
+                .as_ref()
+                .and_then(|state| state.applied_wal_sequence)
+                .unwrap_or(0);
+            match latest_bucket_dump_manifest_at(&self.index_dir, request.shard_id) {
+                Some(manifest) if manifest.wal_sequence > base_watermark => {
+                    // A durable dump is newer than the base file (base not materialized at that
+                    // dump). Use the manifest's embedded durable index as the recovery base. Read
+                    // it directly (not install_bucket_dump_manifest) so the stale-manifest guard --
+                    // which refuses to install a manifest older than the delta-advanced index-log
+                    // sequence -- cannot block trusting the durable checkpoint over the un-synced
+                    // delta.
+                    match serde_json::from_slice::<ShardState>(&manifest.index_bytes) {
+                        Ok(mut restored) => {
+                            rebuild_bucket_page_ownership(
+                                request.shard_id,
+                                &mut restored,
+                                0,
+                                u32::MAX,
+                            );
+                            (Some(restored), manifest.wal_sequence)
+                        }
+                        Err(_) => (base_only, base_watermark),
+                    }
+                }
+                _ => (base_only, base_watermark),
+            }
+        } else {
+            // If the latest durable dump manifest is newer than the served index, install
+            // it as the load base first (recovers data already dumped into a manifest and
+            // then WAL-GC'd): the dumped index is restored first, then
+            // startup load replays the WAL on top.
+            let installed_manifest_watermark =
+                match self.install_latest_manifest_if_newer_on_load(request.shard_id) {
+                    Ok(watermark) => watermark,
+                    // An index-load failure is fatal. A newer durable manifest
+                    // that will not install means the served snapshot + (possibly reclaimed)
+                    // WAL cannot be trusted to hold the records it covers -- refuse the load.
+                    Err(status) => return LoadShardResponse { status },
+                };
+            let loaded = self.load_index(request.shard_id, eager_cache_warm_on_load());
+            // WAL replay watermark, from the dumped-log id read on startup load:
+            // installed manifest -> its wal_sequence; no index
+            // file -> 0 (fresh/async-only shard, replay whole retained WAL); anchored index
+            // -> its anchor; unanchored (pre-field) index -> current last_sequence (replay
+            // nothing, safe upgrade).
+            let replay_watermark = match installed_manifest_watermark {
+                Some(manifest_watermark) => manifest_watermark,
+                None => match &loaded {
+                    None => 0,
+                    Some(state) => state
+                        .applied_wal_sequence
+                        .unwrap_or_else(|| self.wal_store.stats(request.shard_id).last_sequence),
+                },
             };
-        let loaded = self.load_index(request.shard_id, eager_cache_warm_on_load());
-        // WAL replay watermark, from the dumped-log id read on startup load:
-        // installed manifest -> its wal_sequence; no index
-        // file -> 0 (fresh/async-only shard, replay whole retained WAL); anchored index
-        // -> its anchor; unanchored (pre-field) index -> current last_sequence (replay
-        // nothing, safe upgrade).
-        let replay_watermark = match installed_manifest_watermark {
-            Some(manifest_watermark) => manifest_watermark,
-            None => match &loaded {
-                None => 0,
-                Some(state) => state
-                    .applied_wal_sequence
-                    .unwrap_or_else(|| self.wal_store.stats(request.shard_id).last_sequence),
-            },
+            (loaded, replay_watermark)
         };
         let mut state = loaded.unwrap_or_default();
         promote_model_maps_to_bucket_index_authority(
@@ -202,6 +248,19 @@ impl TemporalEngine {
             .expect("config lock poisoned")
             .entry(request.shard_id)
             .or_default();
+        // Single-barrier mode: config is not carried in the served-index checkpoint, so restore
+        // the last durably-logged config before replay. This covers the no-replay path (a clean
+        // dump with nothing to tail-replay) and post-restart client writes; the replay loop below
+        // overrides it with the WAL-sequence-ordered config while re-driving historical records,
+        // then restores the latest again. No-op (and byte-for-byte unchanged) off the flag.
+        if wal_single_barrier() {
+            if let Some(entry) = self.config_log_entries(request.shard_id).into_iter().last() {
+                self.configs
+                    .write()
+                    .expect("config lock poisoned")
+                    .insert(request.shard_id, entry.config);
+            }
+        }
         self.admissions
             .write()
             .expect("admission lock poisoned")
@@ -307,6 +366,20 @@ impl TemporalEngine {
         }
         pending.sort_by_key(|record| record.sequence);
 
+        // Single-barrier mode: replay config-driven eviction (feature_max_size trims) with the
+        // config that was effective at each record's WAL frontier. An entry stamped `after_seq`
+        // is effective for records with sequence > after_seq, so before executing a record we
+        // apply every not-yet-applied config entry with `after_seq < record.sequence`. This
+        // re-derives the exact historical trim -- no resurrection (default config would skip the
+        // trim) and no over-trim/loss (the latest config applied to an older record). Empty (and
+        // inert) off the flag.
+        let config_log: Vec<ConfigLogEntry> = if wal_single_barrier() {
+            self.config_log_entries(shard_id)
+        } else {
+            Vec::new()
+        };
+        let mut config_cursor = 0usize;
+
         let _guard = WalReplayGuard::enter();
         let mut expected = watermark.saturating_add(1);
         let mut replayed_through = watermark;
@@ -323,6 +396,15 @@ impl TemporalEngine {
                         record.sequence
                     ),
                 ));
+            }
+            while config_cursor < config_log.len()
+                && config_log[config_cursor].after_seq < record.sequence
+            {
+                self.configs
+                    .write()
+                    .expect("config lock poisoned")
+                    .insert(shard_id, config_log[config_cursor].config.clone());
+                config_cursor += 1;
             }
             // Resolve TTL deadlines / event times against the LEADER's timestamp
             // captured when this record was written, not the (later) restart clock, so
@@ -341,6 +423,16 @@ impl TemporalEngine {
             }
             replayed_through = record.sequence;
             expected = expected.saturating_add(1);
+        }
+        // Restore the latest config for post-recovery client writes: any config entries stamped
+        // at/after the last replayed sequence (future-effective changes) were intentionally not
+        // applied above.
+        while config_cursor < config_log.len() {
+            self.configs
+                .write()
+                .expect("config lock poisoned")
+                .insert(shard_id, config_log[config_cursor].config.clone());
+            config_cursor += 1;
         }
 
         if replayed_through > watermark {
@@ -379,8 +471,17 @@ impl TemporalEngine {
                     None => None,
                 }
             };
+            // Single-barrier mode: DO NOT persist the reconstructed base index here. The pages
+            // this replay just re-derived are not yet fsync'd (the data-page barrier is deferred),
+            // so writing a base index anchored at `replayed_through` would again advance the
+            // durable base watermark past the durable page frontier -- a second crash would then
+            // trust it and drop the un-synced replayed tail. The base index is advanced ONLY by
+            // the durable dump/flush path (which fsyncs pages first); until then every reload
+            // re-derives the tail from the WAL (the documented base-only re-derivation tradeoff).
             if let Some(index_bytes) = index_bytes {
-                let _ = self.persist_index_bytes(shard_id, &index_bytes);
+                if !wal_single_barrier() {
+                    let _ = self.persist_index_bytes(shard_id, &index_bytes);
+                }
             }
         }
         Ok(())

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -133,13 +133,37 @@ impl TemporalEngine {
     }
 
     pub(super) fn load_index(&self, shard_id: ShardId, warm_cache: bool) -> Option<ShardState> {
-        let delta = delta_served_index_enabled();
+        self.load_index_inner(shard_id, warm_cache, delta_served_index_enabled())
+    }
+
+    /// Load ONLY the durable base snapshot, WITHOUT folding the served-index delta. Used by
+    /// single-barrier recovery: under the flag the delta-log fdatasync and the per-write base
+    /// rewrite are deferred, so neither the served-index delta nor the un-synced base rewrite can
+    /// be trusted -- they may reference pages that were never fsync'd. The base index file is
+    /// materialized ONLY by the durable dump/flush path (which fsyncs every page before advancing
+    /// its watermark), so it is a durable checkpoint at its own watermark; the WAL tail beyond it
+    /// is re-derived by replaying each record exactly once (no delta fold means no double-apply of
+    /// non-idempotent commands).
+    pub(super) fn load_index_base_only(
+        &self,
+        shard_id: ShardId,
+        warm_cache: bool,
+    ) -> Option<ShardState> {
+        self.load_index_inner(shard_id, warm_cache, false)
+    }
+
+    fn load_index_inner(
+        &self,
+        shard_id: ShardId,
+        warm_cache: bool,
+        fold_deltas: bool,
+    ) -> Option<ShardState> {
         let read = fs::read(self.index_path(shard_id));
         let base_present = read.is_ok();
-        // Default path: a missing base means nothing to load. Delta path: the base is
-        // materialized only at compaction/unload, so a crash before the first compaction
-        // leaves no base -- start empty and rebuild from the index-log deltas below.
-        if !base_present && !delta {
+        // No fold: a missing base means nothing to load. Fold path: the base is materialized
+        // only at compaction/unload, so a crash before the first compaction leaves no base --
+        // start empty and rebuild from the index-log deltas below.
+        if !base_present && !fold_deltas {
             return None;
         }
         let mut shard = match read {
@@ -161,7 +185,7 @@ impl TemporalEngine {
         // is what lets a crash reload reconstruct the served index WITHOUT re-executing the
         // WAL -- re-execution would write fresh pages and relocate them to the active slab,
         // doubling physical page counts and losing the recorded slab layout.
-        if delta {
+        if fold_deltas {
             self.fold_index_log_deltas(shard_id, &mut shard);
             // ON but no base and nothing to fold -> genuinely nothing persisted yet.
             if !base_present

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -218,17 +218,19 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
-/// TS_WAL_ONLY_SYNC: defer the ack-path index-log fsync (WAL replay is the durable
-/// recovery source). Default OFF.
+/// TS_WAL_ONLY_SYNC / TS_WAL_SINGLE_BARRIER: defer the ack-path index-log fsync (WAL replay is
+/// the durable recovery source). Default OFF.
 fn indexlog_wal_only_sync() -> bool {
-    matches!(
-        std::env::var("TS_WAL_ONLY_SYNC")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    ["TS_WAL_ONLY_SYNC", "TS_WAL_SINGLE_BARRIER"].iter().any(|name| {
+        matches!(
+            std::env::var(name)
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase()
+                .as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 /// TS_INDEXLOG_DEFER_SYNC: drop the served-index delta-log fdatasync from the synchronous

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -66,6 +66,163 @@ fn recover_ok(root: &str, keys: &str) {
     );
 }
 
+// TS_WAL_SINGLE_BARRIER helpers: the TRUE single barrier (per-write data-page fdatasync also
+// deferred) with base-only recovery. Each phase runs in its own subprocess so the mode env never
+// leaks into the rest of the suite.
+fn populate_sb(root: &str, keys: &str, flush_at: Option<&str>) {
+    let mut cmd = Command::new(bin());
+    cmd.env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "populate", "--root", root, "--keys", keys]);
+    if let Some(f) = flush_at {
+        cmd.args(["--flush-at", f]);
+    }
+    let out = cmd.output().expect("populate_sb should run");
+    assert!(
+        !out.status.success(),
+        "populate_sb must end in an abrupt abort (crash simulation)"
+    );
+}
+
+fn powerloss_sb(root: &str, scope: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "powerloss", "--root", root, "--scope", scope])
+        .output()
+        .expect("powerloss_sb should run");
+    assert!(
+        out.status.success(),
+        "powerloss_sb failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn recover_sb_ok(root: &str, keys: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "recover", "--root", root, "--keys", keys])
+        .output()
+        .expect("recover_sb should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("\"ok\":true"),
+        "single-barrier recover reported data loss: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("\"missing\":[]") && stdout.contains("\"mismatched\":[]"),
+        "single-barrier recover lost or corrupted an acked write: {stdout}"
+    );
+}
+
+#[test]
+fn single_barrier_data_page_loss_after_dump_rebuilds_from_wal() {
+    // THE data-page kill-point case for the true single barrier. The per-write data-page fdatasync
+    // is deferred, so pages become durable only at the dump. A dump at key 150 fsyncs pages 0..150
+    // and anchors the watermark; writes 151..300 then append pages that are NEVER fsync'd. Model a
+    // real power cut of exactly those un-synced page tails (truncate each slab back to its recorded
+    // post-dump durable length). Base-only recovery replays 151..300 from the dump watermark and
+    // rebuilds every lost page from its WAL command -> zero data loss.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate_sb(root, "300", Some("150"));
+    powerloss_sb(root, "truncate-tail");
+    recover_sb_ok(root, "300");
+}
+
+fn populate_counter_sb(root: &str, incrs: &str, flush_at: Option<&str>) {
+    let mut cmd = Command::new(bin());
+    cmd.env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "populate-counter", "--root", root, "--keys", incrs]);
+    if let Some(f) = flush_at {
+        cmd.args(["--flush-at", f]);
+    }
+    let out = cmd.output().expect("populate-counter should run");
+    assert!(!out.status.success(), "populate-counter must abort");
+}
+
+fn recover_counter_sb_ok(root: &str, expected: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "recover-counter", "--root", root, "--keys", expected])
+        .output()
+        .expect("recover-counter should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("\"ok\":true"),
+        "counter mis-applied on recovery (double-apply or loss): stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn single_barrier_non_idempotent_counter_applies_exactly_once() {
+    // A hash counter incremented 200 times, dumped at 100, then crashed with the un-synced tail
+    // pages lost. Base-only recovery replays 101..200 from the dump watermark EXACTLY ONCE (no
+    // delta fold that would re-apply the tail on top of the base), so the counter must be exactly
+    // 200 -- not doubled to 300, and not short.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate_counter_sb(root, "200", Some("100"));
+    powerloss_sb(root, "truncate-tail");
+    recover_counter_sb_ok(root, "200");
+}
+
+#[test]
+fn single_barrier_full_page_loss_no_dump_rebuilds_from_wal() {
+    // No dump: every data page is un-synced. Wipe all non-WAL state (pages + served index + delta);
+    // only the fsync'd WAL survives. Base-only replay from 0 rebuilds all 300 keys.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate_sb(root, "300", None);
+    powerloss_sb(root, "wipe-nondurable");
+    recover_sb_ok(root, "300");
+}
+
+fn populate_feature_sb(root: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_SINGLE_BARRIER", "1")
+        .env("TS_GROUP_COMMIT", "1")
+        .args(["--mode", "populate-feature", "--root", root])
+        .output()
+        .expect("populate-feature should run");
+    assert!(
+        !out.status.success(),
+        "populate-feature must end in an abrupt abort (crash simulation)"
+    );
+}
+
+fn recover_feature_sb_ok(root: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_SINGLE_BARRIER", "1")
+        .args(["--mode", "recover-feature", "--root", root])
+        .output()
+        .expect("recover-feature should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("\"ok\":true"),
+        "single-barrier feature recovery failed: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("\"feature_timestamps\":[30, 40, 50]"),
+        "recovery resurrected/lost feature points: {stdout}"
+    );
+}
+
+#[test]
+fn single_barrier_evict_then_crash_before_dump_does_not_resurrect() {
+    // THE decisive single-barrier case: a config-driven feature_max_size trim (eviction) happens,
+    // then the process is lost BEFORE any dump -- so the trim is recorded only in memory, never in
+    // a served-index checkpoint. Only the fsync'd WAL + config-log survive the power cut. Recovery
+    // must re-derive the trim from the WAL-ordered config-log and keep exactly the newest 3 points
+    // (no resurrection of the 2 evicted points, no loss of an acked point).
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate_feature_sb(root);
+    powerloss_sb(root, "wipe-nondurable");
+    recover_feature_sb_ok(root);
+}
+
 #[test]
 fn deferred_indexlog_loss_never_drops_an_ack_after_a_dump() {
     // The mode's ONLY relaxation is the deferred delta-log fdatasync, so its worst-case loss is


### PR DESCRIPTION
## Summary

Completes the write-path durability barrier reduction to a **true single WAL barrier**, gated behind `TS_WAL_SINGLE_BARRIER` (default **OFF**; when off the write and load paths are byte-for-byte unchanged). Under the flag only the WAL takes a synchronous `fdatasync` per write (**1.00 fdatasync/write**); the data-page `fdatasync`, the served-index delta-log `fdatasync`, the band-manifest persist, and the per-write base-index rewrite are all deferred.

Correctness rests on the WAL + the durable dump checkpoint being a complete source of truth:

- **WAL-ordered config-log** makes config-driven eviction (the `feature_max_size` trim) reconstructable. Previously the trim lived only in the served-index delta and the shard config was neither logged nor persisted, so a pure WAL-tail replay re-executed feature appends with the default config and resurrected the evicted points. `set_config` now appends `{after_seq, config}` to a durable, WAL-sequence-ordered per-shard config-log and fsyncs it (config changes are rare admin ops, off the per-write hot path). Recovery restores the config effective at each record's WAL frontier before re-executing it, so replay re-derives the exact historical trim.
- **Expiry** resolves against the leader timestamp captured per WAL record and applies lazily; **compaction** is background and non-destructive to logical membership — both already WAL-re-derivable.
- **Watermark-bounded base-only recovery** makes deferring the data-page `fdatasync` safe. The durable dump/flush path fsyncs every data page *before* it materializes the base index and advances its watermark, so every page at/below the base watermark is on disk. On reload under the flag, recovery trusts **only** that durable checkpoint (the base snapshot, or the latest durable dump manifest if newer) — never the un-synced per-write base rewrite or the served-index delta, which may reference pages that were never fsync'd. It then replays the WAL tail from the durable watermark, re-deriving every post-dump page from its WAL command **exactly once** (the delta is not folded, so no double-apply of non-idempotent commands). A page written but never fsync'd is rebuilt, never left as a dangling reference.

## Mirror-specific data-safety fix

This mirror advanced the on-disk base index (its watermark **and** its page references) on **every write** via the default served-index-persist path. Combined with a deferred data-page `fdatasync`, that would leave the durable base pointing past pages that were never synced, so a crash would silently drop them (a naive port loses data here: a dump-based crash recovers a counter as `None` and drops post-dump keys). The fix keeps the invariant that base-only recovery never trusts a watermark or page reference beyond the durable page frontier: **under the flag the per-write base rewrite is deferred** (both in the ack path and in the post-replay reconstruct), so the base index is materialized only by the durable dump/flush path. The base watermark and its page references therefore never exceed the durable frontier. This is proven stable across a *recursive* crash-before-dump (a second recovery still restores every key).

## Verification (flag on)

Crash harness models real power loss by dropping every non-fsync'd byte; each phase runs in its own subprocess so the mode env never leaks.

- `single_barrier_data_page_loss_after_dump_rebuilds_from_wal` — dump at 150, write 151..300 (pages never fsync'd), truncate each slab to its recorded post-dump durable length, recover → `{"recovered":300,"missing":[],"mismatched":[],"ok":true}`.
- `single_barrier_non_idempotent_counter_applies_exactly_once` — a hash counter +1 ×200, dump at 100, lose the un-synced tail → `{"counter":200,"ok":true}` (not `None`, not doubled).
- `single_barrier_full_page_loss_no_dump_rebuilds_from_wal` — no dump, wipe all non-WAL state → base-only replay from 0 rebuilds all 300 keys.
- `single_barrier_evict_then_crash_before_dump_does_not_resurrect` — config-log re-derives the trim, no resurrection.
- `strace`: **1.00 fdatasync/write** under the flag (WAL only), vs 2.05 default.
- Full library suite unchanged with the flag off (default).

## Tradeoff (disclosed, not a data-loss bug)

Base-only recovery re-derives every post-dump page by replaying the WAL, so on reload the page store transiently holds re-written pages (GC reclaims the extra stale pages). A page store cannot be concurrently shared and re-written across two live engine instances under the flag; a correct restore/failover (old engine stopped, new engine loads) has a single active writer and is unaffected. Single-engine crash recovery loses nothing.

---

**Please do not merge without maintainer approval.** This changes durability-critical recovery behavior (behind a default-off flag) and should get a maintainer review before landing.
