### PR TITLE
storage: retain cross-shard live page slabs during reclaim; apply lazy expiry to feature range reads

### DIFF
--- a/crates/temporalstore-rust/src/data_node/task_execution.rs
+++ b/crates/temporalstore-rust/src/data_node/task_execution.rs
@@ -127,7 +127,15 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
     }
     if status.ok {
         if let Some(retain_from_page_slab_id) = request.retain_page_slabs_from_id {
-            let mut live_page_slab_ids = inner.engine.live_page_slab_ids(request.shard_id);
+            // One engine shares a single page_store across every shard it hosts, so a slab can
+            // hold pages from multiple shards. Retain slabs live in ANY loaded shard, not just
+            // this request's shard; a per-shard live set would delete another shard's live pages.
+            let mut live_page_slab_ids =
+                if crate::engine::cross_shard_reclaim_guard_enabled() {
+                    inner.engine.live_page_slab_ids_all_shards()
+                } else {
+                    inner.engine.live_page_slab_ids(request.shard_id)
+                };
             // Retain any page slab still referenced by a durable bucket-dump manifest. The
             // operator /gc RPC must not delete a slab a retained manifest needs: a lagging
             // follower's replay or a snapshot-install reads it, and deleting it makes the

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -37,6 +37,7 @@ mod command_validation;
 // which previously kept a drifted subset that mis-classified context/control-state writes
 // as reads -> lifecycle-write-barrier bypass + missing dump scheduling).
 pub(crate) use command_validation::{command_object_keys, is_write_command};
+pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 mod storage_bucket_internals;
 mod compaction;
 mod storage_reporting;

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -581,13 +581,25 @@ pub(crate) fn execute_on_shard(
             start_ms,
             end_ms,
             count,
-        } => cached_response(
-            cache,
-            CacheKey::feature_query(shard_id, &key, start_ms, end_ms, count),
-            || {
-                let points = shard
-                    .features
-                    .get(&key)
+        } => {
+            // Apply lazy expiry before serving, matching FeatureAggQuery/SequenceQuery and
+            // every sibling read: a key past its deadline but not yet swept must read empty,
+            // otherwise FeatureQuery and FeatureAggQuery disagree on the same expired key.
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "feature", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::FeaturePoints { points: Vec::new() },
+                    mutated,
+                };
+            }
+            cached_response(
+                cache,
+                CacheKey::feature_query(shard_id, &key, start_ms, end_ms, count),
+                || {
+                    let points = shard
+                        .features
+                        .get(&key)
                     .map(|series| {
                         let mut page_cache = HashMap::new();
                         // feature_append_keeps_oversized_single_timestamped_value_readable:
@@ -612,9 +624,10 @@ pub(crate) fn execute_on_shard(
                             .collect()
                     })
                     .unwrap_or_default();
-                CommandResponse::FeaturePoints { points }
-            },
-        ),
+                    CommandResponse::FeaturePoints { points }
+                },
+            )
+        }
         Command::FeatureQueryFiltered {
             key,
             start_ms,
@@ -622,6 +635,17 @@ pub(crate) fn execute_on_shard(
             count,
             filters,
         } => {
+            // Apply lazy expiry before serving, matching FeatureAggQuery/SequenceQuery and
+            // every sibling read: an expired-but-unswept key must read empty so filtered and
+            // aggregate reads stay consistent with each other on the same key.
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "feature", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::FeaturePoints { points: Vec::new() },
+                    mutated,
+                };
+            }
             let limit = count.unwrap_or(feature_max_size).min(feature_max_size);
             let points = shard
                 .features

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -197,6 +197,29 @@ impl TemporalEngine {
         ids
     }
 
+    /// Union of live page-slab ids across EVERY shard currently loaded into this engine.
+    ///
+    /// One engine owns a single `page_store` shared by all shards it hosts, and the current
+    /// append cursor + slab counter are global, so two shards' pages can land in the same slab.
+    /// Any slab referenced by *any* loaded shard is live and must not be reclaimed. A single
+    /// shard's live set is therefore an unsafe basis for GC: a slab live only in shard B looks
+    /// stale to shard A's cycle and would be deleted, silently destroying B's committed pages.
+    /// Reclaim must be driven by this union so a slab referenced by any shard is retained.
+    ///
+    /// For a single loaded shard this equals `live_page_slab_ids(that_shard)`, so single-shard
+    /// callers are unaffected.
+    pub fn live_page_slab_ids_all_shards(&self) -> Vec<u64> {
+        let shards = self.shards.read().expect("engine lock poisoned");
+        let mut ids = shards
+            .values()
+            .flat_map(collect_live_page_slab_ids)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
+    }
+
     pub fn sweep_expired_records(
         &self,
         shard_id: ShardId,

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -4,6 +4,24 @@
 //! Storage-manager cycle + merged-dump policy report for TemporalEngine, split from engine.rs.
 use super::*;
 
+/// TS_CROSS_SHARD_RECLAIM_GUARD (default ON): page-slab reclaim retains any slab referenced by
+/// ANY shard loaded into this engine, not only the shard whose cycle is running. One engine
+/// shares a single page_store across all its shards with a global slab cursor, so a slab can hold
+/// committed pages from multiple shards; driving GC off a single shard's live set deletes another
+/// shard's live pages (silent data loss). Set to "0"/"false"/"no"/"off" to restore the legacy
+/// per-shard live set (a kill-switch only; unsafe under multi-shard hosting). For a single loaded
+/// shard the union equals that shard's live set, so single-shard behavior is byte-identical.
+pub(crate) fn cross_shard_reclaim_guard_enabled() -> bool {
+    !matches!(
+        std::env::var("TS_CROSS_SHARD_RECLAIM_GUARD")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
 impl TemporalEngine {
     pub fn run_storage_manager_cycle(
         &self,
@@ -246,9 +264,17 @@ impl TemporalEngine {
                 .max()
                 .unwrap_or_default()
                 .saturating_add(1);
+            // Retain slabs live in ANY shard sharing this engine's page_store, not just the
+            // shard being cycled (see cross_shard_reclaim_guard_enabled): otherwise a slab whose
+            // pages belong to another shard is absent from this shard's live set and gets deleted.
+            let reclaim_live_refs = if cross_shard_reclaim_guard_enabled() {
+                self.live_page_slab_ids_all_shards()
+            } else {
+                plan.live_page_slab_ids.clone()
+            };
             match self.page_store.gc_slabs_before_with_live_refs_policy(
                 retain_from_page_slab_id,
-                plan.live_page_slab_ids.clone(),
+                reclaim_live_refs,
                 // garbage-ratio GC victim selection (reference source): reclaim the
                 // highest-garbage bands first, keeping bands below the garbage floor.
                 // Floor 0 (the default) reclaims every eligible band as before.

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -2946,3 +2946,202 @@ fn storage_lifecycle_plan_matches_delayed_and_limited_dirty_bucket_dump_policy()
     assert!(!explicit.dump_delayed);
     assert_eq!(explicit.selected_dump_buckets, vec![delayed.dirty_buckets[0]]);
 }
+
+// E1 regression: one engine hosts many shards over a SINGLE page_store with a global slab
+// cursor, so two shards' pages can share a slab. Page reclaim used to compute the live set from
+// only the shard whose cycle was running, so a slab holding another shard's committed pages
+// looked like an orphan and was deleted -- silent cross-shard data loss.
+//
+// This test builds exactly that: shard B's page lands in slab 0, the slab is sealed by a roll,
+// shard A's page lands in slab 1, then shard A's storage-manager cycle runs page reclaim. Slab 0
+// is absent from shard A's live set, below the retention floor, and not the current slab, so the
+// legacy per-shard live set deletes it. The fix unions live slab ids across ALL loaded shards, so
+// slab 0 (live in shard B) is retained.
+//
+// FAIL-before / PASS-after is demonstrated with the TS_CROSS_SHARD_RECLAIM_GUARD kill-switch:
+// running this test with TS_CROSS_SHARD_RECLAIM_GUARD=0 reproduces the legacy per-shard behavior
+// and the assertions below fail (slab 0 is moved out of the read path); the default (guard on)
+// passes.
+#[test]
+fn cross_shard_page_reclaim_retains_another_shards_live_slab() {
+    let dir = tempfile::tempdir().unwrap();
+    let pages = dir.path().join("pages");
+    let indexes = dir.path().join("indexes");
+    // Tiny cache so reads hit the slab on disk rather than an in-memory copy.
+    let engine =
+        TemporalEngine::with_local_dirs(16, dir.path().join("cache"), &pages, &indexes);
+    // Two shards hosted by the SAME engine => the SAME page_store + global slab cursor.
+    engine.load_shard(1); // shard A -- runs the reclaim cycle
+    engine.load_shard(2); // shard B -- owns the shared slab's live page
+
+    // Shard B's committed page lands in the current slab (slab 0).
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 2,
+        command: Command::StringSet {
+            key: "shard-b-key".to_string(),
+            value: b"shard-b-committed-value".to_vec(),
+        },
+    });
+    assert!(response.status.ok, "{response:?}");
+
+    // Identify the slab file backing shard B's page (the only .seg under the pages root).
+    let shard_b_slab_path = fs::read_dir(&pages)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.starts_with("page_segment_") && name.ends_with(".seg"))
+                .unwrap_or(false)
+        })
+        .expect("shard B write must create a page slab");
+
+    // Seal slab 0 so future appends go to a fresh slab, then write shard A into slab 1. Slab 0 is
+    // now a non-current slab that is live ONLY in shard B.
+    engine.block_store().roll_slab().unwrap();
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "shard-a-key".to_string(),
+            value: b"shard-a-committed-value".to_vec(),
+        },
+    });
+    assert!(response.status.ok, "{response:?}");
+
+    // Sanity: from shard A's own viewpoint, slab 0 is NOT live (it holds no shard-A pages), which
+    // is precisely why the legacy per-shard reclaim would delete it.
+    assert!(
+        !engine.live_page_slab_ids(1).contains(&0),
+        "slab 0 must be absent from shard A's per-shard live set"
+    );
+    assert!(
+        engine.live_page_slab_ids_all_shards().contains(&0),
+        "slab 0 must be present in the cross-shard union live set"
+    );
+
+    // Run shard A's storage-manager cycle with page reclaim (only). Other stages are off so the
+    // test isolates the reclaim decision.
+    let cycle = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        enable_prepare: true,
+        enable_wal_reclaim: false,
+        enable_evict: false,
+        enable_expire: false,
+        enable_page_reclaim: true,
+        enable_page_compaction: false,
+        enable_index_gc: false,
+        ..StorageManagerCycleRequest::default()
+    });
+    assert!(
+        cycle.errors.is_empty(),
+        "reclaim cycle should not error: {:?}",
+        cycle.errors
+    );
+
+    // Decisive, cache-independent check: shard B's slab file must still be in the read path (the
+    // legacy per-shard reclaim moves it into the delayed-destroy trash, vanishing shard B's data).
+    assert!(
+        shard_b_slab_path.exists(),
+        "shard B's live slab was reclaimed by shard A's cycle -> cross-shard data loss"
+    );
+
+    // Behavioral check: shard B's committed value is still readable after shard A's cycle.
+    let read_back = engine.execute(ExecuteRequest {
+        shard_id: 2,
+        command: Command::StringGet {
+            key: "shard-b-key".to_string(),
+        },
+    });
+    assert_eq!(
+        read_back.response,
+        CommandResponse::Bytes {
+            value: Some(b"shard-b-committed-value".to_vec()),
+        },
+        "shard B's committed value must survive shard A's reclaim cycle"
+    );
+}
+
+// E5 regression: FeatureQuery / FeatureQueryFiltered used to skip lazy expiry, so a key past its
+// deadline but not yet swept read live points from FeatureQuery while FeatureAggQuery (which
+// applies remove_if_expired) read empty -- an inconsistency between two reads of the same key.
+// All feature reads must agree: an expired-but-unswept key reads empty everywhere.
+#[test]
+fn expired_feature_key_reads_empty_consistently_across_feature_reads() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for command in [
+        Command::FeatureAppend {
+            key: "expiring-feature".to_string(),
+            points: vec![FeaturePoint {
+                timestamp_ms: 10,
+                value: b"ten".to_vec(),
+            }],
+        },
+        Command::CommonExpire {
+            key: "expiring-feature".to_string(),
+            ttl_ms: 1,
+        },
+    ] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command,
+        });
+        assert!(response.status.ok, "{response:?}");
+    }
+    // Cross the deadline but run NO sweep: this is the window where lazy expiry must fire.
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let feature_query = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureQuery {
+            key: "expiring-feature".to_string(),
+            start_ms: 0,
+            end_ms: 1000,
+            count: None,
+        },
+    });
+    assert_eq!(
+        feature_query.response,
+        CommandResponse::FeaturePoints { points: Vec::new() },
+        "FeatureQuery must apply lazy expiry and read empty for an expired-but-unswept key"
+    );
+
+    let filtered_query = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureQueryFiltered {
+            key: "expiring-feature".to_string(),
+            start_ms: 0,
+            end_ms: 1000,
+            count: None,
+            filters: Vec::new(),
+        },
+    });
+    assert_eq!(
+        filtered_query.response,
+        CommandResponse::FeaturePoints { points: Vec::new() },
+        "FeatureQueryFiltered must apply lazy expiry and read empty for an expired-but-unswept key"
+    );
+
+    let agg_query = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureAggQuery {
+            key: "expiring-feature".to_string(),
+            start_ms: 0,
+            end_ms: 1000,
+            aggregator: "count".to_string(),
+            count: None,
+        },
+    });
+    assert_eq!(
+        agg_query.response,
+        CommandResponse::Aggregate { value: 0 },
+        "FeatureAggQuery reads empty for an expired key -- the other feature reads must match"
+    );
+}


### PR DESCRIPTION
Two storage-correctness fixes from a parity audit.

## E1 — cross-shard slab reclaim deletes another shard live pages (silent data loss)
One engine owns a single page_store shared by every shard it hosts, with a global slab cursor, so two shards pages can land in the same slab. Page reclaim computed the live set from only the shard whose storage-manager cycle was running, so a slab holding another shard committed pages looked like an orphan and was deleted -- vanishing that shard durable pages with no error.

Fix: reclaim now unions live page-slab ids across ALL loaded shards (live_page_slab_ids_all_shards) so a slab referenced by any shard is retained. Applied to both the storage-manager reclaim cycle and the operator gc RPC path. Gated by TS_CROSS_SHARD_RECLAIM_GUARD (default ON); for a single loaded shard the union equals that shard live set, so single-shard behavior is byte-identical. The kill-switch restores the legacy per-shard set.

## E5 — FeatureQuery/FeatureQueryFiltered skip lazy expiry (read inconsistency)
Those two reads skipped lazy expiry while every sibling read (FeatureAggQuery, SequenceQuery, StringGet, ...) applied remove_if_expired, so an expired-but-unswept key returned live points from FeatureQuery but empty from FeatureAggQuery. Both range reads now apply remove_if_expired atop the arm, matching the siblings.

## Tests
- cross_shard_page_reclaim_retains_another_shards_live_slab: hosts two shards sharing a slab, runs shard A reclaim cycle, asserts shard B slab survives. Fails with TS_CROSS_SHARD_RECLAIM_GUARD=0 (reproduces the loss), passes by default.
- expired_feature_key_reads_empty_consistently_across_feature_reads: an expired-but-unswept key reads empty from FeatureQuery, FeatureQueryFiltered, and FeatureAggQuery.
