### PR TITLE
fix(durability): safe write-path defaults, atomic batches, durable config + hot-page reads

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -44,6 +44,7 @@ mod hashing;
 mod bucket_store;
 mod control_rollup;
 mod hll;
+mod hot_page_spill;
 mod state;
 
 // shared-corpus: storage_bucket_first_physical_index storage_object_manager_bucketstore_runtime_authority storage_model_layout_compaction_policies storage_merged_dump_load_lifecycle storage_object_manager_cold_hot_reload storage_page_address_disk_cache_shared_store_fallback
@@ -422,6 +423,19 @@ impl TemporalEngine {
                             ),
                             response: CommandResponse::Empty,
                         };
+                    } else {
+                        // Async / bulk mode is a fire-and-forget commit, so an append error does
+                        // NOT fail the command (the ack path is intentionally best-effort here).
+                        // But it must never be swallowed silently: a dropped async append means
+                        // the recovery source of truth is missing this write, so surface it in the
+                        // logs (with the failing shard) so operators can see acked-but-undurable
+                        // writes instead of discovering them only as post-crash data loss.
+                        tracing::error!(
+                            shard_id = request.shard_id,
+                            error = %err,
+                            "async WAL append failed: write acked to the client is NOT durable \
+                             and will be lost on a crash before the next flush"
+                        );
                     }
                 }
             }
@@ -649,21 +663,23 @@ impl TemporalEngine {
         // Drop the config lock before touching the WAL/disk so the durable append never runs
         // under the config mutex.
         drop(configs);
-        // Single-barrier durability: config-driven trims (feature_max_size) are re-derived by
-        // WAL-tail replay on recovery, so the config must be durable and ordered relative to the
-        // WAL. Stamp this change with the current WAL frontier -- it is effective for every write
-        // with a strictly greater sequence -- and fsync it. Config changes are rare admin ops, so
-        // this extra barrier is off the per-write hot path. Off the flag this is a no-op and the
-        // config path is byte-for-byte unchanged.
-        if wal_single_barrier() {
-            let after_seq = self.wal_store.stats(request.shard_id).last_sequence;
-            if let Err(err) = self.append_config_log_entry(request.shard_id, after_seq, &applied) {
-                tracing::warn!(
-                    shard_id = request.shard_id,
-                    error = %err,
-                    "failed to persist single-barrier config-log entry"
-                );
-            }
+        // Durably log the config so it survives reload REGARDLESS of barrier mode. Runtime config
+        // (feature_max_size + the representation-changing extend gate flags: control_rollup /
+        // coalesce / distinct_sketch) is NOT carried in the served-index checkpoint, so without a
+        // durable config-log a reload defaults `Config` and silently resets these -- which for the
+        // representation flags can misread already-written data. Stamp the change with the current
+        // WAL frontier (effective for every write with a strictly greater sequence) and fsync it.
+        // Config changes are rare admin ops, so this barrier is off the per-write hot path. In
+        // single-barrier mode WAL-tail replay additionally re-derives config-driven trims at this
+        // exact frontier; in every other mode the last entry is simply restored as the live config
+        // on load (see load_shard_with / replay_wal_into_shard).
+        let after_seq = self.wal_store.stats(request.shard_id).last_sequence;
+        if let Err(err) = self.append_config_log_entry(request.shard_id, after_seq, &applied) {
+            tracing::warn!(
+                shard_id = request.shard_id,
+                error = %err,
+                "failed to persist config-log entry"
+            );
         }
         Status::ok()
     }
@@ -2179,6 +2195,19 @@ fn read_page_bytes(
         address.routing_bucket);
     if let Ok(Some(bytes)) = cache.get(&cache_key) {
         return Some(bytes);
+    }
+    // Log-backed hot page (synthetic address, no block-store file): a cache miss here would read
+    // as MISSING for an acked async write. If it was spilled to a real slab on eviction, resolve
+    // the redirect and read the durable copy. On a genuine miss (never spilled, or spill failed)
+    // this falls through to the normal read below, which returns None -- the WAL still holds the
+    // value and a reload replays it.
+    if address.page_slab_id == HOT_PAGE_SLAB_ID {
+        if let Some(real_address) = hot_page_spill::lookup_spilled(shard_id, address.offset) {
+            if let Ok(bytes) = page_store.read(&real_address) {
+                let _ = cache.put(cache_key, bytes.clone());
+                return Some(bytes);
+            }
+        }
     }
     let bytes = page_store.read(address).ok()?;
     let _ = cache.put(cache_key, bytes.clone());

--- a/crates/temporalstore-rust/src/engine/hot_page_spill.rs
+++ b/crates/temporalstore-rust/src/engine/hot_page_spill.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Durable read-by-address fallback for log-backed hot pages.
+//!
+//! Under `async_storage`, a freshly written value is served only from the in-memory cache tier
+//! at a SYNTHETIC page address (`page_slab_id == HOT_PAGE_SLAB_ID`); it is not written to the
+//! block store, so it exists on disk only as its WAL record. That has two costs:
+//!
+//!   1. Correctness -- if the memory-only entry is evicted before the next dump/flush
+//!      materializes it, a read misses the cache and `page_store.read(synthetic_address)` finds
+//!      no file, so the acked write reads back as MISSING (looks deleted). Only a full reload
+//!      (WAL replay) would recover it.
+//!   2. Memory footprint -- hot pages are a primary consumer of the DRAM tier because their only
+//!      residence is memory.
+//!
+//! This module fixes both by SPILLING a hot page to a real slab exactly when it is evicted from
+//! the cache: an eviction handler writes the evicted bytes to the durable block store and records
+//! a redirect from the synthetic address to the real one. Reads consult the redirect on a
+//! hot-address cache miss and read the real slab, so an evicted hot page is never read-as-missing.
+//! Because the eviction moves the bytes out of DRAM (to the block store / SSD-backed slab) and
+//! keeps only a tiny redirect entry, steady-state RSS drops as well.
+//!
+//! The redirect map is purely live-path state: on crash/reload the WAL is the source of truth and
+//! re-derives every hot page from scratch, so the map is never persisted. It is bounded by
+//! clearing a shard's entries on unload.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use matrixcache::{CacheEvictionRecord, MultiLayerCache};
+
+use crate::block_store::{BlockAddress, LocalBlockStore};
+use crate::types::ShardId;
+
+use super::constants::HOT_PAGE_SLAB_ID;
+
+/// TS_HOT_PAGE_SPILL: spill evicted hot pages to a real slab + serve the durable read-by-address
+/// fallback. Default ON -- it is strictly additive (adds a durable fallback + frees DRAM) and
+/// fixes an acked-write-reads-as-missing bug. Set to a falsey value to restore the prior
+/// memory-only behavior (evicted hot pages read as missing until reload).
+pub(super) fn spill_enabled() -> bool {
+    !matches!(
+        std::env::var("TS_HOT_PAGE_SPILL")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+fn redirects() -> &'static Mutex<HashMap<(ShardId, u64), BlockAddress>> {
+    static REDIRECTS: OnceLock<Mutex<HashMap<(ShardId, u64), BlockAddress>>> = OnceLock::new();
+    REDIRECTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The synthetic hot-page cache key's record_key, i.e. `segment-{HOT_PAGE_SLAB_ID:020}`.
+fn hot_page_record_key() -> String {
+    format!("segment-{HOT_PAGE_SLAB_ID:020}")
+}
+
+/// Parse `(offset, routing_bucket)` out of a hot-page cache key selector. Selector forms produced
+/// for a hot page are `slot-{routing}:{offset}:{length}` or `{offset}:{length}`; the offset is the
+/// second-to-last colon-separated component and any leading `slot-{n}` carries the routing bucket.
+fn parse_hot_selector(selector: &str) -> Option<(u64, Option<u32>)> {
+    let parts: Vec<&str> = selector.split(':').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let offset: u64 = parts[parts.len() - 2].parse().ok()?;
+    let routing_bucket = parts
+        .first()
+        .and_then(|head| head.strip_prefix("slot-"))
+        .and_then(|slot| slot.parse::<u32>().ok());
+    Some((offset, routing_bucket))
+}
+
+/// Install the eviction handler that spills this engine's evicted hot pages to ITS block store.
+///
+/// Registered per engine cache (not process-globally): every engine owns its own cache + block
+/// store, and a spilled page's real address is only valid within the block store it was written
+/// to. A process-wide handler capturing one engine's block store would misroute another engine's
+/// spills (their real slab lives in a different store). `register_eviction_callback` replaces the
+/// cache's callback, so a cache used 1:1 with an engine ends up with the correct store; the shared
+/// redirect map stays coherent because hot-page offsets are globally unique (one process-wide
+/// atomic), so an engine only ever looks up offsets it minted itself.
+pub(super) fn install_spill_handler(cache: &MultiLayerCache, block_store: &LocalBlockStore) {
+    if !spill_enabled() {
+        return;
+    }
+    let block_store = block_store.clone();
+    let hot_record_key = hot_page_record_key();
+    cache.register_eviction_callback(move |record: CacheEvictionRecord| {
+        spill_evicted_hot_page(&block_store, &hot_record_key, record);
+    });
+}
+
+fn spill_evicted_hot_page(
+    block_store: &LocalBlockStore,
+    hot_record_key: &str,
+    record: CacheEvictionRecord,
+) {
+    if record.key.namespace != "page" || record.key.record_key != hot_record_key {
+        return;
+    }
+    let Some((offset, routing_bucket)) = parse_hot_selector(&record.key.selector) else {
+        return;
+    };
+    let shard_id = record.key.shard_id;
+    // Already spilled (e.g. an earlier memory eviction, now re-evicted from a lower tier): the
+    // existing redirect still points at valid durable bytes, so skip the redundant write.
+    if redirects()
+        .lock()
+        .map(|map| map.contains_key(&(shard_id, offset)))
+        .unwrap_or(false)
+    {
+        return;
+    }
+    // Write the evicted bytes to a real slab. object_id is not needed for read-by-address
+    // (reads resolve on slab+offset+length), so we only preserve the routing bucket.
+    match block_store.append_with_page_metadata(&record.value, None, routing_bucket) {
+        Ok(real_address) => {
+            if let Ok(mut map) = redirects().lock() {
+                map.insert((shard_id, offset), real_address);
+            }
+        }
+        Err(err) => {
+            // The value is still recoverable from the WAL on reload; log so an operator can see a
+            // hot page that failed to spill (it will read-as-missing until reload).
+            tracing::error!(
+                shard_id,
+                offset,
+                error = %err,
+                "failed to spill evicted hot page to a durable slab"
+            );
+        }
+    }
+}
+
+/// Look up the real slab address a spilled hot page was written to, if any. Keyed by the synthetic
+/// address's `(shard_id, offset)`.
+pub(super) fn lookup_spilled(shard_id: ShardId, offset: u64) -> Option<BlockAddress> {
+    redirects()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&(shard_id, offset)).cloned())
+}
+
+/// Drop a shard's redirect entries (called on unload) so the map stays bounded across a shard's
+/// load/unload lifecycle.
+pub(super) fn clear_shard(shard_id: ShardId) {
+    if let Ok(mut map) = redirects().lock() {
+        map.retain(|(entry_shard, _), _| *entry_shard != shard_id);
+    }
+}

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -26,6 +26,10 @@ impl TemporalEngine {
         let index_dir = index_dir.into();
         let wal_store = LocalWriteAheadLogStore::new(index_dir.join("wals"));
         let index_log_store = LocalIndexLogStore::new(index_dir.join("indexlogs"));
+        // Install the durable read-by-address fallback for log-backed hot pages: an eviction
+        // handler spills an evicted hot page to a real slab (freeing DRAM + preventing the acked
+        // write from reading back as missing). Idempotent + a no-op when disabled.
+        hot_page_spill::install_spill_handler(&cache, &block_store);
         Self {
             shards: Arc::default(),
             cache,
@@ -248,18 +252,17 @@ impl TemporalEngine {
             .expect("config lock poisoned")
             .entry(request.shard_id)
             .or_default();
-        // Single-barrier mode: config is not carried in the served-index checkpoint, so restore
-        // the last durably-logged config before replay. This covers the no-replay path (a clean
+        // Config is not carried in the served-index checkpoint, so restore the last durably-logged
+        // config before replay REGARDLESS of barrier mode. This covers the no-replay path (a clean
         // dump with nothing to tail-replay) and post-restart client writes; the replay loop below
         // overrides it with the WAL-sequence-ordered config while re-driving historical records,
-        // then restores the latest again. No-op (and byte-for-byte unchanged) off the flag.
-        if wal_single_barrier() {
-            if let Some(entry) = self.config_log_entries(request.shard_id).into_iter().last() {
-                self.configs
-                    .write()
-                    .expect("config lock poisoned")
-                    .insert(request.shard_id, entry.config);
-            }
+        // then restores the latest again. Without this, a reload defaults `Config` and silently
+        // resets feature_max_size + the representation-changing extend gate flags.
+        if let Some(entry) = self.config_log_entries(request.shard_id).into_iter().last() {
+            self.configs
+                .write()
+                .expect("config lock poisoned")
+                .insert(request.shard_id, entry.config);
         }
         self.admissions
             .write()
@@ -365,19 +368,27 @@ impl TemporalEngine {
             return Ok(());
         }
         pending.sort_by_key(|record| record.sequence);
+        // Drop a trailing atomic batch that never reached its durability barrier. A batch is
+        // written as N contiguously-sequenced records sharing one batch_id, buffered, then made
+        // durable by a SINGLE barrier; a crash before that barrier can leave a partial suffix on
+        // disk. Because the engine assigns the batch a contiguous sequence block and serializes
+        // writes, an incomplete batch is always the WAL tail, so truncating it preserves strict
+        // sequence continuity for everything before it -- and guarantees the batch is applied
+        // all-or-nothing (never a double-applied durable prefix on retry).
+        truncate_trailing_incomplete_batch(&mut pending);
+        if pending.is_empty() {
+            return Ok(());
+        }
 
-        // Single-barrier mode: replay config-driven eviction (feature_max_size trims) with the
-        // config that was effective at each record's WAL frontier. An entry stamped `after_seq`
-        // is effective for records with sequence > after_seq, so before executing a record we
-        // apply every not-yet-applied config entry with `after_seq < record.sequence`. This
-        // re-derives the exact historical trim -- no resurrection (default config would skip the
-        // trim) and no over-trim/loss (the latest config applied to an older record). Empty (and
-        // inert) off the flag.
-        let config_log: Vec<ConfigLogEntry> = if wal_single_barrier() {
-            self.config_log_entries(shard_id)
-        } else {
-            Vec::new()
-        };
+        // Replay config-driven eviction (feature_max_size trims) with the config that was
+        // effective at each record's WAL frontier. An entry stamped `after_seq` is effective for
+        // records with sequence > after_seq, so before executing a record we apply every
+        // not-yet-applied config entry with `after_seq < record.sequence`. This re-derives the
+        // exact historical trim -- no resurrection (default config would skip the trim) and no
+        // over-trim/loss (the latest config applied to an older record). Runs in every barrier
+        // mode now that the config-log is persisted unconditionally; empty (and inert) for a
+        // shard that never had a config change logged.
+        let config_log: Vec<ConfigLogEntry> = self.config_log_entries(shard_id);
         let mut config_cursor = 0usize;
 
         let _guard = WalReplayGuard::enter();
@@ -535,6 +546,10 @@ impl TemporalEngine {
             .write()
             .expect("admission lock poisoned")
             .remove(&AdmissionScope::Shard(request.shard_id));
+        // Drop this shard's hot-page spill redirects: on the next load the WAL replay re-derives
+        // the hot pages (and re-spills them as needed), so the live-path redirect map stays
+        // bounded across load/unload cycles.
+        hot_page_spill::clear_shard(request.shard_id);
         UnloadShardResponse {
             status: Status::ok(),
         }
@@ -663,5 +678,116 @@ impl TemporalEngine {
         {
             info.recovering = false;
         }
+    }
+}
+
+/// Truncate a trailing atomic batch that is missing its commit marker.
+///
+/// `pending` is the sorted, contiguous WAL tail about to be replayed. The last record is
+/// inspected: if it carries batch framing (`batch_id` + `batch_size`) and the batch is not fully
+/// present -- fewer than `batch_size` records for that id, or the terminal `batch_index ==
+/// batch_size` commit marker is absent -- every record of that trailing batch is dropped. A
+/// complete batch (all records present, commit marker last) is kept; a non-batch tail record is
+/// left untouched. Interior batches are always complete (an incomplete batch can only be the
+/// crash tail), so this never opens a hole before a surviving record.
+fn truncate_trailing_incomplete_batch(pending: &mut Vec<WriteAheadLogRecord>) {
+    let Some(last) = pending.last() else {
+        return;
+    };
+    let Some((batch_id, batch_size)) = last
+        .metadata
+        .as_ref()
+        .and_then(|meta| meta.batch_id.zip(meta.batch_size))
+    else {
+        return;
+    };
+    // Walk back over the contiguous run of records sharing this batch id.
+    let mut first_index = pending.len();
+    let mut count = 0u32;
+    let mut commit_marker_present = false;
+    for (index, record) in pending.iter().enumerate().rev() {
+        let record_batch = record.metadata.as_ref().and_then(|meta| meta.batch_id);
+        if record_batch != Some(batch_id) {
+            break;
+        }
+        first_index = index;
+        count = count.saturating_add(1);
+        if record
+            .metadata
+            .as_ref()
+            .and_then(|meta| meta.batch_index)
+            == Some(batch_size)
+        {
+            commit_marker_present = true;
+        }
+    }
+    if count < batch_size || !commit_marker_present {
+        pending.truncate(first_index);
+    }
+}
+
+#[cfg(test)]
+mod batch_truncation_tests {
+    use super::truncate_trailing_incomplete_batch;
+    use crate::types::Command;
+    use crate::wal::{WriteAheadLogRecord, WriteAheadLogRecordMetadata};
+
+    fn rec(seq: u64, batch: Option<(u64, u32, u32)>) -> WriteAheadLogRecord {
+        let command = Command::StringSet {
+            key: format!("k{seq}"),
+            value: Vec::new(),
+        };
+        let mut metadata = WriteAheadLogRecordMetadata::single_command(&command);
+        if let Some((id, size, index)) = batch {
+            metadata.batch_id = Some(id);
+            metadata.batch_size = Some(size);
+            metadata.batch_index = Some(index);
+        }
+        WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: seq,
+            command,
+            metadata: Some(metadata),
+        }
+    }
+
+    #[test]
+    fn keeps_complete_trailing_batch() {
+        let mut pending = vec![rec(1, None), rec(2, Some((7, 2, 1))), rec(3, Some((7, 2, 2)))];
+        truncate_trailing_incomplete_batch(&mut pending);
+        assert_eq!(pending.len(), 3);
+    }
+
+    #[test]
+    fn drops_incomplete_trailing_batch_missing_commit_marker() {
+        // batch id 7 has size 3 but only indexes 1 and 2 persisted (commit marker 3 lost to a
+        // crash before the barrier) -> the whole batch is dropped, all-or-nothing.
+        let mut pending = vec![rec(1, None), rec(2, Some((7, 3, 1))), rec(3, Some((7, 3, 2)))];
+        truncate_trailing_incomplete_batch(&mut pending);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].sequence, 1);
+    }
+
+    #[test]
+    fn keeps_non_batch_tail() {
+        let mut pending = vec![rec(1, None), rec(2, None)];
+        truncate_trailing_incomplete_batch(&mut pending);
+        assert_eq!(pending.len(), 2);
+    }
+
+    #[test]
+    fn keeps_complete_batch_before_non_batch_tail() {
+        let mut pending = vec![rec(1, Some((7, 2, 1))), rec(2, Some((7, 2, 2))), rec(3, None)];
+        truncate_trailing_incomplete_batch(&mut pending);
+        assert_eq!(pending.len(), 3);
+    }
+
+    #[test]
+    fn drops_single_persisted_record_of_larger_batch() {
+        // Only the first record of a 3-record batch survived the crash.
+        let mut pending = vec![rec(1, None), rec(2, Some((9, 3, 1)))];
+        truncate_trailing_incomplete_batch(&mut pending);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].sequence, 1);
     }
 }

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -326,16 +326,39 @@ impl TemporalEngine {
         }
         if mutated_any {
             refresh_bucket_runtime_flags(shard);
-            // Every
-            // write records a WAL entry before any page is written.
-            // async_storage only changes whether the commit BLOCKS: sync -> fsync,
-            // async (or bulk backfill) -> buffered, no fsync (a fire-and-forget
-            // commit). Mirrors the single-command execute path.
+            // Every write records a WAL entry before any page is written. async_storage only
+            // changes whether the commit BLOCKS: sync -> fsync, async (or bulk backfill) ->
+            // buffered, no fsync (a fire-and-forget commit).
+            //
+            // The batch is logged as ONE crash-atomic group: all commands are appended under a
+            // single batch id and made durable by a SINGLE barrier (not a per-command fsync
+            // loop). A crash mid-batch therefore leaves an incomplete trailing batch that replay
+            // drops wholesale -- so a retry never double-applies a durable PREFIX of the batch,
+            // which for a non-idempotent / time-unspecified command (FeatureAppend occur_time=0 ->
+            // a fresh now on each apply) would otherwise duplicate points.
             let sync = !config.async_storage && !bulk_ingest_mode();
-            for command in wal_commands {
-                let _ = self
-                    .wal_store
-                    .append_with_sync(request.shard_id, command, sync);
+            if let Err(err) =
+                self.wal_store
+                    .append_batch_atomic(request.shard_id, wal_commands, sync)
+            {
+                if sync {
+                    // A durable batch commit that failed is not durable; surface it rather than
+                    // acking undurable writes (mirrors the single-command execute path).
+                    return BatchExecuteResponse {
+                        status: Status::error(
+                            "wal_commit_failed",
+                            format!("durable WAL batch commit failed: {err}"),
+                        ),
+                        responses,
+                    };
+                } else {
+                    tracing::error!(
+                        shard_id = request.shard_id,
+                        error = %err,
+                        "async WAL batch append failed: acked writes are NOT durable and will be \
+                         lost on a crash before the next flush"
+                    );
+                }
             }
             // Page/index materialization stays deferred to the background dump in
             // async and bulk modes (index_log/persist already no-op under bulk).

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -865,6 +865,222 @@ fn async_storage_string_write_stays_on_hot_memory_path() {
 }
 
 #[test]
+fn async_hot_page_survives_memory_eviction_via_spill() {
+    // Regression for the log-backed hot-page read-as-missing bug (gap P1): under async_storage a
+    // write lives ONLY in the memory tier at a synthetic hot-page address. If the memory-only
+    // entry is evicted before the next dump, a read used to miss the cache, hit a non-existent
+    // slab file, and return value:None for an ACKED write. The eviction handler now spills the
+    // evicted hot page to a real slab and a hot-address cache miss resolves the redirect, so the
+    // value survives eviction on the live path (no reload needed).
+    let dir = tempfile::tempdir().unwrap();
+    // Deliberately tiny memory tier so the flood below forces capacity eviction of the target.
+    let engine = TemporalEngine::with_local_dirs(
+        2048,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+
+    // Async write -> memory-only hot page, nothing in the block store yet.
+    let target_value = b"durable-async-value-that-must-survive-eviction".to_vec();
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: "target".to_string(),
+                    value: target_value.clone(),
+                },
+            })
+            .status
+            .ok
+    );
+    assert_eq!(engine.block_store().stats().writes, 0);
+
+    // Flood the memory tier with far more async hot pages than it can hold, forcing the target's
+    // page to be evicted (and spilled to a real slab by the eviction handler).
+    for i in 0..400 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("filler-{i}"),
+                value: vec![b'x'; 96],
+            },
+        });
+    }
+
+    // At least one hot page must have spilled to a durable slab (proves the handler fired).
+    assert!(
+        engine.block_store().stats().writes > 0,
+        "evicted hot pages must spill to a durable slab"
+    );
+
+    // Drop EVERY cache tier for the shard so the only surviving copy of the target is the durable
+    // spilled slab (plus the WAL). This defeats the cache's own cross-tier retention and forces
+    // the read to resolve through the hot-page spill redirect -- the path this fix adds.
+    let _ = engine.cache().invalidate_shard(1);
+
+    let reads_before = engine.block_store().stats().reads;
+    // The acked write must still read back as its value -- resolved via the spill redirect + a
+    // durable slab read, NOT as value:None.
+    let read = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "target".to_string(),
+        },
+    });
+    assert_eq!(
+        read.response,
+        CommandResponse::Bytes {
+            value: Some(target_value)
+        },
+        "an acked async write must not read as missing after its hot page is evicted"
+    );
+    // The value came from the durable spilled slab, confirming the redirect fallback was used.
+    assert!(
+        engine.block_store().stats().reads > reads_before,
+        "the evicted target must be served from the durable spilled slab"
+    );
+}
+
+fn set_async_config(engine: &TemporalEngine, shard_id: ShardId) {
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+}
+
+#[test]
+fn atomic_batch_survives_restart_when_complete() {
+    // Positive control for gap E3: a fully-persisted atomic batch replays in full on restart.
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1024 * 1024, dir.path().join("cache-a"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    set_async_config(&engine, 1);
+    let batch = engine.batch_execute(BatchExecuteRequest {
+        shard_id: 1,
+        commands: vec![
+            Command::StringSet { key: "b0".to_string(), value: b"v0".to_vec() },
+            Command::StringSet { key: "b1".to_string(), value: b"v1".to_vec() },
+            Command::StringSet { key: "b2".to_string(), value: b"v2".to_vec() },
+        ],
+    });
+    assert!(batch.status.ok);
+    drop(engine);
+
+    let restarted =
+        TemporalEngine::with_local_dirs(1024 * 1024, dir.path().join("cache-b"), &page_dir, &index_dir);
+    restarted.load_shard(1);
+    for (key, value) in [("b0", "v0"), ("b1", "v1"), ("b2", "v2")] {
+        let read = restarted.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet { key: key.to_string() },
+        });
+        assert_eq!(
+            read.response,
+            CommandResponse::Bytes { value: Some(value.as_bytes().to_vec()) },
+            "complete batch key {key} must survive restart"
+        );
+    }
+}
+
+#[test]
+fn atomic_batch_is_all_or_nothing_when_commit_marker_lost() {
+    // Gap E3: a crash between the batch's buffered appends and its single durability barrier can
+    // leave a partial suffix on disk. Simulate that by dropping the batch's final (commit-marker)
+    // WAL line; on restart the WHOLE batch must be discarded -- never a partially-applied prefix
+    // that a retry would double-apply.
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1024 * 1024, dir.path().join("cache-a"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    set_async_config(&engine, 1);
+    // A standalone durable write before the batch, to prove only the batch is dropped.
+    assert!(engine
+        .execute_durable(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet { key: "keep".to_string(), value: b"kept".to_vec() },
+        })
+        .status
+        .ok);
+    let batch = engine.batch_execute(BatchExecuteRequest {
+        shard_id: 1,
+        commands: vec![
+            Command::StringSet { key: "b0".to_string(), value: b"v0".to_vec() },
+            Command::StringSet { key: "b1".to_string(), value: b"v1".to_vec() },
+            Command::StringSet { key: "b2".to_string(), value: b"v2".to_vec() },
+        ],
+    });
+    assert!(batch.status.ok);
+    drop(engine);
+
+    // Simulate the lost commit marker: drop the last WAL line (batch_index == batch_size).
+    let wal_path = index_dir.join("wals").join("shard-1.wal.jsonl");
+    let contents = std::fs::read_to_string(&wal_path).expect("wal file should exist");
+    let mut lines: Vec<&str> = contents.lines().collect();
+    assert!(lines.len() >= 4, "expected keep + 3 batch records, got {}", lines.len());
+    lines.pop(); // drop the batch commit-marker record
+    let mut truncated = lines.join("\n");
+    truncated.push('\n');
+    std::fs::write(&wal_path, truncated).expect("rewrite wal");
+
+    let restarted =
+        TemporalEngine::with_local_dirs(1024 * 1024, dir.path().join("cache-b"), &page_dir, &index_dir);
+    restarted.load_shard(1);
+
+    // The pre-batch durable write survives.
+    assert_eq!(
+        restarted
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet { key: "keep".to_string() },
+            })
+            .response,
+        CommandResponse::Bytes { value: Some(b"kept".to_vec()) }
+    );
+    // No member of the incomplete batch is applied -- not even the durable prefix (b0, b1).
+    for key in ["b0", "b1", "b2"] {
+        assert_eq!(
+            restarted
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet { key: key.to_string() },
+                })
+                .response,
+            CommandResponse::Bytes { value: None },
+            "incomplete-batch key {key} must NOT be applied"
+        );
+    }
+}
+
+
+#[test]
 fn durable_execute_overrides_async_storage_for_raft_local_file_path() {
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -2193,10 +2193,15 @@ fn open_engine(request: &RecordLogRequest) -> Result<TemporalEngine, String> {
         shard_id: DEFAULT_SHARD_ID,
         config: Config {
             version: 2,
+            // Inherit the durable engine-library default (async_storage=false, i.e. every
+            // write is fsync-committed to the WAL before it is acked). The async path buffers
+            // the WAL with no barrier, so a crash before the next flush drops an acked write --
+            // that must never be the deployed front-door default. Async is opt-in only, via an
+            // explicit truthy MATRIXARK_RUST_PROXY_ASYNC_STORAGE.
             async_storage: env::var("MATRIXARK_RUST_PROXY_ASYNC_STORAGE")
                 .ok()
                 .and_then(|value| value.parse::<bool>().ok())
-                .unwrap_or(true),
+                .unwrap_or(false),
             ..Config::default()
         },
     });

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -37,6 +37,19 @@ pub struct WriteAheadLogRecordMetadata {
     pub version: u32,
     pub timestamp_ms: u64,
     pub items: Vec<WriteAheadLogItemMetadata>,
+    // Atomic-batch framing (all three set together, or all absent for a standalone write). A
+    // batch of N commands is written as N contiguously-sequenced records sharing one `batch_id`,
+    // buffered and made durable by a SINGLE barrier after the last record. `batch_index` is
+    // 1-based; the record with `batch_index == batch_size` is the commit marker. Replay drops a
+    // trailing batch that is missing its commit marker (a crash between the buffered appends and
+    // the barrier), so a partially-persisted batch is never applied -- all-or-nothing. Absent
+    // (skipped in JSON) for every non-batch record, so standalone-write WALs are byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_size: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_index: Option<u32>,
 }
 
 impl WriteAheadLogRecordMetadata {
@@ -45,6 +58,9 @@ impl WriteAheadLogRecordMetadata {
             version: WRITE_AHEAD_LOG_FORMAT_VERSION,
             timestamp_ms: current_time_ms(),
             items: vec![WriteAheadLogItemMetadata::from_command(command)],
+            batch_id: None,
+            batch_size: None,
+            batch_index: None,
         }
     }
 }
@@ -299,6 +315,76 @@ impl LocalWriteAheadLogStore {
             self.group_commit_sync(shard_id, next_sequence)?;
         }
         Ok(record)
+    }
+
+    /// Append a group of commands as ONE crash-atomic batch: N contiguously-sequenced records
+    /// sharing a single `batch_id`, buffered, then made durable by a SINGLE barrier after the
+    /// last record (the commit marker). Either the whole batch is durable (barrier completed) or,
+    /// on a crash before the barrier, the trailing partial batch is dropped on replay -- so a
+    /// retry never double-applies a durable prefix of a non-idempotent / time-unspecified command
+    /// (e.g. FeatureAppend occur_time=0). `sync=false` skips the barrier (async / bulk mode: the
+    /// whole batch is buffered and lost-or-kept together, still all-or-nothing).
+    ///
+    /// Records are assigned a contiguous sequence block under a single `inner`-lock hold, so no
+    /// other writer can interleave a record into the middle of the batch (the engine also
+    /// serializes writes through its shard lock). A single command takes the standalone
+    /// `append_with_sync` path (no batch framing, byte-identical WAL).
+    pub fn append_batch_atomic(
+        &self,
+        shard_id: ShardId,
+        commands: Vec<Command>,
+        sync: bool,
+    ) -> Result<Vec<WriteAheadLogRecord>, WriteAheadLogError> {
+        if commands.len() <= 1 {
+            let mut records = Vec::with_capacity(commands.len());
+            if let Some(command) = commands.into_iter().next() {
+                records.push(self.append_with_sync(shard_id, command, sync)?);
+            }
+            return Ok(records);
+        }
+        let batch_id = next_batch_id();
+        let batch_size = commands.len() as u32;
+        let mut records = Vec::with_capacity(commands.len());
+        let last_sequence;
+        {
+            let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+            fs::create_dir_all(&inner.root)?;
+            let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
+            let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
+            let cached_last_sequence = inner
+                .last_sequence_by_shard
+                .get(&shard_id)
+                .copied()
+                .unwrap_or_default();
+            let mut seq = cached_last_sequence.max(disk_last_sequence);
+            for (index, command) in commands.into_iter().enumerate() {
+                seq = seq.saturating_add(1);
+                let mut metadata = WriteAheadLogRecordMetadata::single_command(&command);
+                metadata.batch_id = Some(batch_id);
+                metadata.batch_size = Some(batch_size);
+                metadata.batch_index = Some(index as u32 + 1);
+                let rec = WriteAheadLogRecord {
+                    shard_id,
+                    sequence: seq,
+                    metadata: Some(metadata),
+                    command,
+                };
+                // Buffer every record (sync=false); the single durability barrier below covers
+                // the whole batch. append_record_locked keeps last_flushed_sequence honest -- it
+                // only advances on an actual fsync, which happens once, after the loop.
+                let report = append_record_locked(&mut inner, &rec, false)?;
+                inner.stats.last_sequence = report.current_sequence;
+                records.push(rec);
+            }
+            inner.last_sequence_by_shard.insert(shard_id, seq);
+            last_sequence = seq;
+        }
+        if sync {
+            // One coalesced fdatasync makes the entire buffered batch durable. Reusing the
+            // group-commit barrier keeps the durable-watermark bookkeeping consistent.
+            self.group_commit_sync(shard_id, last_sequence)?;
+        }
+        Ok(records)
     }
 
     /// Coalesced WAL durability barrier (group commit). Ensures every byte appended for
@@ -671,6 +757,14 @@ fn lock_file_exclusive(_file: &File) -> Result<(), std::io::Error> {
 #[cfg(not(unix))]
 fn unlock_file(_file: &File) -> Result<(), std::io::Error> {
     Ok(())
+}
+
+/// Process-unique atomic-batch identifier. Only needs to disambiguate concurrently-live batches
+/// within one WAL replay window (a monotonic counter is more than enough); it is never persisted
+/// as a stable key across restarts.
+fn next_batch_id() -> u64 {
+    static BATCH_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    BATCH_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 fn wal_bulk_relaxed_durability() -> bool {


### PR DESCRIPTION
Four write-path parity fixes from a durability + memory-footprint audit. Each is gated or default-safe where behavior changes.

## Proxy write default (live data-loss)
The front-door proxy defaulted writes to async fire-and-forget, so an unset deployment acked writes whose log append was only buffered — a crash before the next flush lost them. Default the proxy to the durable engine default; async is now explicit opt-in. Async log-append errors are logged (with the failing shard) instead of silently swallowed.

## Hot-page durability + memory footprint
Under async storage a value lived only in the memory tier at a synthetic address; if it was evicted before the next dump, a read missed the cache, hit a non-existent slab, and returned `None` for an acked write — and hot pages were a primary DRAM consumer. A per-engine cache eviction handler now spills an evicted hot page to a real slab and records a synthetic→real redirect; a hot-address cache miss resolves the redirect and reads the durable copy. Evicted hot pages therefore survive on the live path (no reload) and their bytes leave DRAM. Gated `TS_HOT_PAGE_SPILL` (default on); redirects cleared on unload.

## Batch crash-atomicity
A batch appended each command as a separate log record (one barrier each), so a crash mid-loop persisted a partial batch that a retry double-applied for non-idempotent / time-unspecified commands. The batch is now one crash-atomic group: contiguously sequenced records under a single durability barrier, with the terminal record as the commit marker. Replay drops a trailing batch missing its marker, so a batch is applied all-or-nothing. Batch metadata fields are `Option`/skip-if-none, so standalone-write logs are byte-identical.

## Config durability across reload
Config-log persist + restore were gated on the single-barrier flag, so in the default barrier mode a reload defaulted `Config` and silently reset `feature_max_size` + the representation-changing extend gate flags — which can misread already-written data. Persist + restore the config-log unconditionally so runtime config survives reload in every barrier mode.

## Tests
- Hot-page: async write + forced memory eviction + all-tier cache drop → GET still returns the value from the spilled slab.
- Batch: restart after dropping the commit-marker record asserts none of the batch applied; a complete batch replays in full; unit coverage of the trailing-batch truncation.

Full single-threaded lib suite green apart from the pre-existing `data_node` jitter_backoff flake.
