### PR TITLE
raft/shared-store: gated replication-safety hardenings (R2-R5, R8, R9)

### DIFF
--- a/crates/temporalstore-rust/src/bin/server/raft_route.rs
+++ b/crates/temporalstore-rust/src/bin/server/raft_route.rs
@@ -505,8 +505,32 @@ fn read_via_server_raft(
         DataRaftReadMode::BoundedStale | DataRaftReadMode::UnsafeAnyReplica => state.local_node_id,
     };
     let cluster = state.runtime.cluster();
-    cluster.check_data_raft_read_policy(target_node_id, state.read_policy)?;
+    let read_index_response = cluster.check_data_raft_read_policy(target_node_id, state.read_policy)?;
+    // R3: the read-index round returns the frontier this read must observe, but the previous
+    // code discarded it and served immediately — so a replica that had COMMITTED but not yet
+    // APPLIED up to that index could answer with stale/half-applied state. Wait for the target
+    // to apply through the returned read_index before serving. Gated so default behavior is
+    // unchanged.
+    if raft_applied_read_safety_enabled() {
+        cluster.wait_for_applied_index(
+            target_node_id,
+            read_index_response.read_index,
+            state.read_policy.read_index_timeout_ms,
+        )?;
+    }
     cluster.read_from_replica(target_node_id, command)
+}
+
+/// R3 gate mirror for the server read path (see `raft::raft_applied_read_safety_on`).
+fn raft_applied_read_safety_enabled() -> bool {
+    matches!(
+        std::env::var("TS_RAFT_APPLIED_READ_SAFETY")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 fn command_response(

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -164,6 +164,50 @@ pub const DATA_RAFT_CODEC_VERSION: u32 = 1;
 const DATA_RAFT_LOG_HEADER_LEN: usize = 56;
 const DATA_RAFT_COMMAND_HEADER_LEN: usize = 40;
 
+/// Read a boolean gate env var (`1`/`true`/`yes`/`on`). Every replication-safety hardening in
+/// this module is gated OFF by default so the shipped behavior stays byte-identical until the
+/// operator opts in; the gated tests set the flag explicitly.
+fn raft_env_flag_on(name: &str) -> bool {
+    matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// R8: §7 snapshot-install boundary-term truncation. When on, a snapshot install whose
+/// boundary entry does not term-match the local log discards the ENTIRE log instead of
+/// retaining a possibly-divergent tail.
+fn raft_snapshot_boundary_truncate_on() -> bool {
+    raft_env_flag_on("TS_RAFT_SNAPSHOT_BOUNDARY_TRUNCATE")
+}
+
+/// R9: durably persist the incremented term + a self-vote before advertising a RequestVote.
+fn raft_persist_vote_before_request_on() -> bool {
+    raft_env_flag_on("TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST")
+}
+
+/// R3: gate reads on `applied_index` (reject/await unapplied-but-committed state) rather than
+/// bounding on commit-lag alone.
+fn raft_applied_read_safety_on() -> bool {
+    raft_env_flag_on("TS_RAFT_APPLIED_READ_SAFETY")
+}
+
+/// R4: after an election, withhold read-index/lease reads until the new leader has committed a
+/// no-op entry in its own term (leader-ready barrier).
+fn raft_leader_ready_barrier_on() -> bool {
+    raft_env_flag_on("TS_RAFT_LEADER_READY_BARRIER")
+}
+
+/// R5: require a durable per-term quorum RequestVote round (a candidate must collect a
+/// majority of granted votes) before promotion, instead of promoting from a local view.
+fn raft_quorum_election_on() -> bool {
+    raft_env_flag_on("TS_RAFT_QUORUM_ELECTION")
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DataRaftLogCodecEntry {
     pub shard_id: ShardId,
@@ -3202,6 +3246,12 @@ pub enum RaftError {
         applied_index: u64,
         target_index: u64,
         timeout_ms: u64,
+    },
+    #[error("replica {replica_id} has committed but not applied up to the read frontier: applied={replica_applied_index}, required={required_index}")]
+    ReplicaApplyLagging {
+        replica_id: RaftNodeId,
+        replica_applied_index: u64,
+        required_index: u64,
     },
     #[error("snapshot shard mismatch: snapshot={snapshot_shard_id}, cluster={cluster_shard_id}")]
     SnapshotShardMismatch {

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -462,6 +462,9 @@ impl RaftClusterInner {
     }
 
     pub(super) fn elect_leader(&mut self, node_id: RaftNodeId) -> Result<(), RaftError> {
+        if raft_quorum_election_on() {
+            return self.elect_leader_quorum_round(node_id);
+        }
         if self.config.prohibits_election {
             for node in self.nodes.values_mut() {
                 node.pipeline_state.election_rejections =
@@ -516,6 +519,125 @@ impl RaftClusterInner {
                 Some(node_id)
             } else {
                 None
+            };
+        }
+        self.election_elapsed_tick = 0;
+        self.renew_leader_lease();
+        Ok(())
+    }
+
+    /// R5: promote `node_id` only after a DURABLE per-term quorum RequestVote round grants it a
+    /// majority — instead of promoting from a local snapshot. This mirrors the receiver rules
+    /// already implemented in `receive_vote_request` (single vote per term via `voted_for`,
+    /// leader-completeness log-freshness), but drives them across every voter and gates
+    /// promotion on the collected grant count. A partitioned candidate whose granting voters
+    /// fall short of majority cannot elect, so two disjoint partitions can never each promote a
+    /// leader for the same term.
+    fn elect_leader_quorum_round(&mut self, node_id: RaftNodeId) -> Result<(), RaftError> {
+        if self.config.prohibits_election {
+            for node in self.nodes.values_mut() {
+                node.pipeline_state.election_rejections =
+                    node.pipeline_state.election_rejections.saturating_add(1);
+            }
+            return Err(RaftError::ElectionProhibited);
+        }
+        if let Some((live, required)) = self.joint_majority_failure() {
+            return Err(RaftError::NoMajority { live, required });
+        }
+        if !self
+            .nodes
+            .get(&node_id)
+            .map(|node| node.alive && node.replica_role.can_be_leader())
+            .unwrap_or(false)
+        {
+            return Err(RaftError::NodeNotFound(node_id));
+        }
+
+        let election_term = self
+            .nodes
+            .values()
+            .map(|node| node.current_term)
+            .max()
+            .unwrap_or_default()
+            .saturating_add(1);
+        let (candidate_last_index, candidate_last_term) = {
+            let candidate = self
+                .nodes
+                .get(&node_id)
+                .ok_or(RaftError::NodeNotFound(node_id))?;
+            let last_index = node_last_log_or_snapshot_index(candidate);
+            let last_term =
+                node_term_at_log_or_snapshot_index(candidate, last_index).unwrap_or_default();
+            (last_index, last_term)
+        };
+
+        // Candidate durably records its own term bump + self-vote first.
+        {
+            let candidate = self
+                .nodes
+                .get_mut(&node_id)
+                .ok_or(RaftError::NodeNotFound(node_id))?;
+            candidate.current_term = election_term;
+            candidate.voted_for = Some(node_id);
+        }
+        let required = self.required_majority();
+        let mut grants = 1usize; // self-vote
+
+        let voter_ids: Vec<RaftNodeId> = self
+            .nodes
+            .values()
+            .filter(|node| node.replica_role.participates_in_quorum() && node.id != node_id)
+            .map(|node| node.id)
+            .collect();
+        for voter_id in voter_ids {
+            let node = self
+                .nodes
+                .get_mut(&voter_id)
+                .ok_or(RaftError::NodeNotFound(voter_id))?;
+            // A partitioned / unreachable voter cannot respond to the RequestVote — it observes
+            // the higher term (so it cannot later grant a stale one) but does not grant here.
+            if !node.alive {
+                node.current_term = node.current_term.max(election_term);
+                continue;
+            }
+            let already_voted_other = node.current_term == election_term
+                && node.voted_for.is_some()
+                && node.voted_for != Some(node_id);
+            let voter_last_index = node_last_log_or_snapshot_index(node);
+            let voter_last_term =
+                node_term_at_log_or_snapshot_index(node, voter_last_index).unwrap_or_default();
+            let candidate_log_up_to_date = (candidate_last_term, candidate_last_index)
+                >= (voter_last_term, voter_last_index);
+            if !already_voted_other && candidate_log_up_to_date {
+                node.current_term = election_term;
+                node.voted_for = Some(node_id);
+                node.role = RaftRole::Follower;
+                grants += 1;
+            } else {
+                node.current_term = node.current_term.max(election_term);
+                node.pipeline_state.election_rejections =
+                    node.pipeline_state.election_rejections.saturating_add(1);
+            }
+        }
+
+        if grants < required {
+            // Did not collect a durable quorum — do NOT promote. Leave the cluster leaderless
+            // for this attempt rather than installing a minority "leader".
+            if let Some(candidate) = self.nodes.get_mut(&node_id) {
+                candidate.role = RaftRole::Follower;
+            }
+            return Err(RaftError::NoMajority {
+                live: grants,
+                required,
+            });
+        }
+
+        self.leader_id = node_id;
+        for node in self.nodes.values_mut() {
+            node.role = if node.id == node_id {
+                RaftRole::Leader
+            } else {
+                RaftRole::Follower
             };
         }
         self.election_elapsed_tick = 0;
@@ -579,6 +701,31 @@ impl RaftClusterInner {
             .get(&self.leader_id)
             .map(|node| node.commit_index)
             .unwrap_or_default()
+    }
+
+    /// R4 leader-ready barrier: has the current leader committed an entry in its OWN term? Until
+    /// it has, a freshly elected leader must not serve read-index/lease reads, because it cannot
+    /// yet know the true commit point of its predecessors' terms (Raft §5.4.2 — the reason a new
+    /// leader commits a no-op). A committed current-term entry (in the log or folded into an
+    /// installed snapshot) discharges the barrier.
+    pub(super) fn leader_has_committed_current_term(&self) -> bool {
+        let Some(leader) = self.nodes.get(&self.leader_id) else {
+            return false;
+        };
+        let term = leader.current_term;
+        let committed_in_log = leader
+            .log
+            .iter()
+            .any(|entry| entry.term == term && entry.index <= leader.commit_index);
+        let committed_in_snapshot = leader
+            .installed_snapshot
+            .as_ref()
+            .map(|snapshot| {
+                snapshot.last_included_term == term
+                    && snapshot.last_included_index <= leader.commit_index
+            })
+            .unwrap_or(false);
+        committed_in_log || committed_in_snapshot
     }
 
     pub(super) fn voting_node_ids(&self) -> Vec<RaftNodeId> {

--- a/crates/temporalstore-rust/src/raft/cluster_read_status.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_read_status.rs
@@ -55,6 +55,17 @@ impl RaftCluster {
                 leader_commit_index,
             });
         }
+        // R3: committed is not the right freshness bar — a replica can hold
+        // commit_index == leader_commit while its state machine has only applied a prefix of
+        // that (applied_index < commit_index), which would serve HALF-APPLIED state as fresh.
+        // Gate the read on applied_index reaching the leader's committed frontier.
+        if raft_applied_read_safety_on() && node.applied_index < leader_commit_index {
+            return Err(RaftError::ReplicaApplyLagging {
+                replica_id: node_id,
+                replica_applied_index: node.applied_index,
+                required_index: leader_commit_index,
+            });
+        }
         Ok(node
             .engine
             .execute(ExecuteRequest {
@@ -114,6 +125,27 @@ impl RaftCluster {
                 .read_safety_state
                 .lease_read_requests
                 .saturating_add(1);
+        }
+        // R4: withhold read-index/lease reads on a leader that has not yet committed an entry in
+        // its own term. A leader freshly elected (or one that has just superseded a partitioned
+        // predecessor) has not established its commit point until it commits in-term, so serving
+        // now risks returning stale linearizable state.
+        if raft_leader_ready_barrier_on()
+            && node_id == inner.leader_id
+            && !inner.leader_has_committed_current_term()
+        {
+            inner.read_safety_state.read_index_rejected = inner
+                .read_safety_state
+                .read_index_rejected
+                .saturating_add(1);
+            if lease_read {
+                inner.read_safety_state.lease_read_rejected = inner
+                    .read_safety_state
+                    .lease_read_rejected
+                    .saturating_add(1);
+            }
+            inner.persist_configured_wal()?;
+            return Err(RaftError::LeaderUnavailable);
         }
         let status = inner.status();
         let Some(node) = inner.nodes.get(&node_id) else {
@@ -602,5 +634,22 @@ impl RaftCluster {
             .get(&node_id)
             .ok_or(RaftError::NodeNotFound(node_id))?
             .commit_index)
+    }
+
+    /// Test-only: rewind a node's `applied_index` (below its `commit_index`) to reproduce a
+    /// replica that has COMMITTED but not yet APPLIED a prefix — the R3 half-applied read case.
+    #[cfg(test)]
+    pub(crate) fn set_applied_index_for_test(
+        &self,
+        node_id: RaftNodeId,
+        applied_index: u64,
+    ) -> Result<(), RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let node = inner
+            .nodes
+            .get_mut(&node_id)
+            .ok_or(RaftError::NodeNotFound(node_id))?;
+        node.applied_index = applied_index;
+        Ok(())
     }
 }

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -538,6 +538,37 @@ impl RaftCluster {
         candidate_id: RaftNodeId,
         target_id: RaftNodeId,
     ) -> Result<VoteRequest, RaftError> {
+        // R9: a candidate must durably persist its incremented term and a self-vote BEFORE it
+        // advertises the RequestVote, else a crash-restart could re-issue the same term without
+        // remembering it already voted for itself (double-vote in one term). Under the gate we
+        // take a write lock, bump `current_term`, record `voted_for = self`, and fsync the WAL
+        // before returning the request.
+        if raft_persist_vote_before_request_on() {
+            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+            let shard_id = inner.shard_id;
+            let (election_term, last_log_index, last_log_term) = {
+                let candidate = inner
+                    .nodes
+                    .get_mut(&candidate_id)
+                    .ok_or(RaftError::NodeNotFound(candidate_id))?;
+                candidate.current_term = candidate.current_term.saturating_add(1);
+                candidate.voted_for = Some(candidate_id);
+                let last_log_index = node_last_log_or_snapshot_index(candidate);
+                let last_log_term =
+                    node_term_at_log_or_snapshot_index(candidate, last_log_index).unwrap_or_default();
+                (candidate.current_term, last_log_index, last_log_term)
+            };
+            inner.persist_configured_wal()?;
+            return Ok(VoteRequest {
+                rpc: None,
+                shard_id,
+                term: election_term,
+                candidate_id,
+                target_id,
+                last_log_index,
+                last_log_term,
+            });
+        }
         let inner = self.inner.read().expect("raft cluster lock poisoned");
         let candidate = inner
             .nodes

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -797,8 +797,23 @@ impl RaftCluster {
             }
             node.current_term = node.current_term.max(snapshot.last_included_term);
             node.commit_index = snapshot.last_included_index;
-            node.log
-                .retain(|entry| entry.index > snapshot.last_included_index);
+            // R8 (§7): only retain the log tail past the snapshot boundary if the local entry
+            // AT the boundary index term-matches the snapshot. If it is absent or from a
+            // divergent term, the entries following it may belong to an uncommitted, superseded
+            // branch — discard the entire log rather than fold a divergent tail onto the
+            // snapshot's state.
+            let boundary_matches = node
+                .log
+                .iter()
+                .find(|entry| entry.index == snapshot.last_included_index)
+                .map(|entry| entry.term == snapshot.last_included_term)
+                .unwrap_or(false);
+            if raft_snapshot_boundary_truncate_on() && !boundary_matches {
+                node.log.clear();
+            } else {
+                node.log
+                    .retain(|entry| entry.index > snapshot.last_included_index);
+            }
             node.applied.clear();
             node.applied
                 .extend(snapshot.entries.iter().map(|entry| entry.index));

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2101,4 +2101,135 @@ fn wal_recovery_rejects_ahead_of_storage_apply_fence() {
     );
 }
 
+/// Sets an env gate for the duration of a test and removes it on drop (even on panic), so a
+/// gated-behavior test never leaks its flag into the rest of the single-threaded suite.
+struct EnvFlagGuard {
+    name: &'static str,
+}
+
+impl EnvFlagGuard {
+    fn set(name: &'static str) -> Self {
+        std::env::set_var(name, "1");
+        Self { name }
+    }
+}
+
+impl Drop for EnvFlagGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.name);
+    }
+}
+
+/// R3: a replica whose state machine has only APPLIED a prefix of what it has COMMITTED must
+/// not answer a follower read with that half-applied state as if it were fresh.
+#[test]
+fn r3_replica_with_applied_below_commit_does_not_serve_unapplied_as_fresh() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_APPLIED_READ_SAFETY");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v1".to_vec(),
+        })
+        .unwrap();
+    // All voters have committed AND applied index 1 at this point.
+    assert_eq!(cluster.commit_index(3).unwrap(), 1);
+
+    // Simulate replica 3 having committed index 1 but only applied through 0 (apply lag).
+    cluster.set_applied_index_for_test(3, 0).unwrap();
+
+    // The read is rejected because applied_index (0) is below the leader's committed frontier.
+    let err = cluster
+        .read_from_replica(
+            3,
+            Command::StringGet {
+                key: "k".to_string(),
+            },
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            RaftError::ReplicaApplyLagging {
+                replica_id: 3,
+                replica_applied_index: 0,
+                required_index: 1,
+            }
+        ),
+        "expected ReplicaApplyLagging, got {err:?}"
+    );
+
+    // Once apply catches up to the committed frontier, the read is served normally.
+    cluster.set_applied_index_for_test(3, 1).unwrap();
+    assert_eq!(
+        cluster
+            .read_from_replica(
+                3,
+                Command::StringGet {
+                    key: "k".to_string(),
+                },
+            )
+            .unwrap(),
+        CommandResponse::Bytes {
+            value: Some(b"v1".to_vec())
+        }
+    );
+}
+
+/// R5: promotion goes through a durable per-term quorum vote round. A candidate that can only
+/// collect a minority of grants (its peers are partitioned away) cannot elect itself, so two
+/// disjoint partitions can never both promote a leader.
+#[test]
+fn r5_quorum_election_requires_majority_and_minority_cannot_elect() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_QUORUM_ELECTION");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+
+    // Healthy quorum: node 2 collects a majority of grants and is promoted.
+    cluster.elect_leader(2).unwrap();
+    assert_eq!(cluster.leader_id(), 2);
+    let status = cluster.hard_state(2).unwrap();
+    assert_eq!(status.voted_for, Some(2));
+
+    // Partition away a majority: only node 1 remains reachable.
+    cluster.set_alive(2, false).unwrap();
+    cluster.set_alive(3, false).unwrap();
+    let err = cluster.elect_leader(1).unwrap_err();
+    assert!(
+        matches!(err, RaftError::NoMajority { live: 1, required: 2 }),
+        "a minority partition must not elect, got {err:?}"
+    );
+    // The lone reachable node did NOT install itself as leader.
+    assert_ne!(cluster.leader_id(), 1);
+}
+
+/// R4: a freshly elected leader must not serve a linearizable read-index until it has committed
+/// an entry in its own term — otherwise it could answer with stale state predating its
+/// leadership (the case a partitioned/just-superseded leader falls into).
+#[test]
+fn r4_new_leader_withholds_linearizable_read_until_committed_in_term() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_LEADER_READY_BARRIER");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+
+    // Promote node 2 to a new term. It has not yet committed anything in that term.
+    cluster.elect_leader(2).unwrap();
+    assert_eq!(cluster.leader_id(), 2);
+
+    // The linearizable read-index is withheld: the leader is not yet ready.
+    let err = cluster.read_index(2).unwrap_err();
+    assert!(
+        matches!(err, RaftError::LeaderUnavailable),
+        "a not-yet-ready leader must withhold read-index, got {err:?}"
+    );
+
+    // Committing a write in the new term discharges the barrier; reads are then served.
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+    let response = cluster.read_index(2).unwrap();
+    assert_eq!(response.leader_id, 2);
+}
+
 

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -42,6 +42,21 @@ pub enum SharedStoreReplicationError {
     CheckpointNotFound(ShardId),
     #[error("replicated command failed at WAL index {wal_index}: {status:?}")]
     ApplyFailed { wal_index: u64, status: Status },
+    /// The durable single-writer fence rejected this operation: a newer owner (higher
+    /// load_version) holds the shard lease, so this (stale) writer must ABORT rather than
+    /// double-append to the shared WAL. Maps [`ObjectStoreError::ConditionFailed`].
+    #[error("shared-store fence rejected write: {detail}")]
+    StoreConditionFailed { detail: String },
+    /// A lease acquisition was refused because the object store already holds a lease at an
+    /// equal-or-higher load_version — this writer's ownership claim is stale.
+    #[error(
+        "shared-store lease for shard {shard_id} held at load_version {current} >= attempted {attempted}"
+    )]
+    StaleOwnership {
+        shard_id: ShardId,
+        current: u64,
+        attempted: u64,
+    },
     #[error("WAL replay gap: expected index {expected}, got {actual}")]
     ReplayGap { expected: u64, actual: u64 },
     #[error(
@@ -247,6 +262,45 @@ pub struct SharedStoreReplicator<O> {
     object_store: Arc<O>,
     retry_policy: SharedStoreRetryPolicy,
     wal_append_mode: SharedStoreWalAppendMode,
+    /// Durable single-writer fence. When set (and `TS_SHARED_STORE_FENCE` is on), every WAL
+    /// append and checkpoint publish first re-validates that this writer's `load_version`
+    /// still owns the shard lease in the object store, aborting a superseded stale owner
+    /// before it can double-append.
+    fence: Option<ShardFenceConfig>,
+}
+
+/// Ownership token carried by a fenced replicator: the `load_version` (monotonic ownership
+/// epoch) this writer believes it holds, plus a human-readable owner tag for diagnostics.
+#[derive(Debug, Clone)]
+struct ShardFenceConfig {
+    load_version: u64,
+    /// Retained for diagnostics / future lease-holder attribution; the fence decision keys on
+    /// `load_version` alone.
+    #[allow(dead_code)]
+    owner: String,
+}
+
+/// Durable lease object persisted in the shared object store, keyed by cluster+shard. The
+/// `load_version` is the fence token: a writer may only install a lease strictly greater than
+/// the currently stored one, and may only append while the stored value still equals its own.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ShardLease {
+    load_version: u64,
+    owner: String,
+}
+
+/// `TS_SHARED_STORE_FENCE`: gate for the durable single-writer fence (R2). Default OFF so the
+/// shared-store write path is byte-identical to the pre-fence behavior unless explicitly
+/// enabled.
+fn shared_store_fence_enabled() -> bool {
+    matches!(
+        std::env::var("TS_SHARED_STORE_FENCE")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 impl<O> Clone for SharedStoreReplicator<O> {
@@ -256,6 +310,7 @@ impl<O> Clone for SharedStoreReplicator<O> {
             object_store: Arc::clone(&self.object_store),
             retry_policy: self.retry_policy,
             wal_append_mode: self.wal_append_mode,
+            fence: self.fence.clone(),
         }
     }
 }
@@ -333,6 +388,7 @@ where
             object_store,
             retry_policy: SharedStoreRetryPolicy::default(),
             wal_append_mode: SharedStoreWalAppendMode::default(),
+            fence: None,
         }
     }
 
@@ -349,6 +405,7 @@ where
                 backoff_ms: retry_policy.backoff_ms,
             },
             wal_append_mode: SharedStoreWalAppendMode::default(),
+            fence: None,
         }
     }
 
@@ -357,10 +414,121 @@ where
         self
     }
 
+    /// Attach a durable single-writer fence: this replicator (and every storage writer it
+    /// spawns) claims `load_version` for its shard leases. Combine with
+    /// [`acquire_shard_lease`](Self::acquire_shard_lease) to install the lease and with
+    /// `TS_SHARED_STORE_FENCE=1` to enforce re-validation on every append/checkpoint.
+    pub fn with_fence(mut self, load_version: u64, owner: impl Into<String>) -> Self {
+        self.fence = Some(ShardFenceConfig {
+            load_version,
+            owner: owner.into(),
+        });
+        self
+    }
+
+    fn lease_key(&self, shard_id: ShardId) -> String {
+        format!("leases/{}/shard_{}.lease", self.cluster_id, shard_id)
+    }
+
+    /// Durably claim ownership of `shard_id` at `load_version` via a store compare-and-set.
+    /// Succeeds only if the currently persisted lease is absent or holds a strictly lower
+    /// load_version; a stale writer (equal-or-lower load_version) is rejected with
+    /// [`SharedStoreReplicationError::StaleOwnership`], and a lost CAS race with
+    /// [`SharedStoreReplicationError::StoreConditionFailed`]. This is the ONLY way a writer
+    /// becomes the fenced owner — it does not mutate in-memory state, so ownership is decided
+    /// by the durable store, not a local view.
+    pub async fn acquire_shard_lease(
+        &self,
+        shard_id: ShardId,
+        load_version: u64,
+        owner: impl Into<String>,
+    ) -> Result<(), SharedStoreReplicationError> {
+        let key = self.lease_key(shard_id);
+        let current_bytes = match self.object_store.get(&key).await {
+            Ok(bytes) => Some(bytes),
+            Err(ObjectStoreError::NotFound(_)) => None,
+            Err(err) => return Err(err.into()),
+        };
+        if let Some(bytes) = &current_bytes {
+            let current: ShardLease = serde_json::from_slice(bytes)?;
+            if current.load_version >= load_version {
+                return Err(SharedStoreReplicationError::StaleOwnership {
+                    shard_id,
+                    current: current.load_version,
+                    attempted: load_version,
+                });
+            }
+        }
+        let lease = ShardLease {
+            load_version,
+            owner: owner.into(),
+        };
+        let new_bytes = Bytes::from(serde_json::to_vec(&lease)?);
+        match self
+            .object_store
+            .compare_and_swap(&key, current_bytes, new_bytes)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::ConditionFailed { detail, .. }) => {
+                Err(SharedStoreReplicationError::StoreConditionFailed { detail })
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Re-read the durable lease and confirm it still records `load_version`. Any other value
+    /// (a newer owner took over) or a missing lease is a fence breach → StoreConditionFailed.
+    pub async fn validate_shard_lease(
+        &self,
+        shard_id: ShardId,
+        load_version: u64,
+    ) -> Result<(), SharedStoreReplicationError> {
+        let key = self.lease_key(shard_id);
+        let bytes = match self.object_store.get(&key).await {
+            Ok(bytes) => bytes,
+            Err(ObjectStoreError::NotFound(_)) => {
+                return Err(SharedStoreReplicationError::StoreConditionFailed {
+                    detail: format!("shard {shard_id} lease missing; ownership not held"),
+                });
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let current: ShardLease = serde_json::from_slice(&bytes)?;
+        if current.load_version != load_version {
+            return Err(SharedStoreReplicationError::StoreConditionFailed {
+                detail: format!(
+                    "shard {shard_id} lease held by load_version {} (owner {}), not {}",
+                    current.load_version, current.owner, load_version
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    /// Fence check invoked on every WAL append + checkpoint publish. A no-op unless a fence is
+    /// configured AND `TS_SHARED_STORE_FENCE` is enabled, so the default write path is
+    /// unchanged. When active it re-validates the durable lease, aborting a superseded writer.
+    async fn enforce_fence(
+        &self,
+        shard_id: ShardId,
+    ) -> Result<(), SharedStoreReplicationError> {
+        let Some(fence) = &self.fence else {
+            return Ok(());
+        };
+        if !shared_store_fence_enabled() {
+            return Ok(());
+        }
+        self.validate_shard_lease(shard_id, fence.load_version).await
+    }
+
     pub async fn publish_wal_entry(
         &self,
         entry: SharedStoreWalEntry,
     ) -> Result<Option<AppendBlobReceipt>, SharedStoreReplicationError> {
+        // R2 single-writer fence: re-validate ownership before appending to the shared WAL so
+        // a partitioned-but-alive stale owner is rejected rather than double-appending.
+        self.enforce_fence(entry.shard_id).await?;
         if matches!(
             self.wal_append_mode,
             SharedStoreWalAppendMode::ProtobufAppendBlob
@@ -540,6 +708,9 @@ where
         engine: &TemporalEngine,
         block_store: &LocalBlockStore,
     ) -> Result<SharedStoreCheckpointManifest, SharedStoreReplicationError> {
+        // R2 single-writer fence: a checkpoint publish is a durable-frontier advance, so a
+        // superseded stale owner must be rejected here just as on a WAL append.
+        self.enforce_fence(shard_id).await?;
         let checkpoint_id = uuid::Uuid::new_v4().to_string();
         let prefix = self.checkpoint_prefix(shard_id, &checkpoint_id);
         let index_key = format!("{prefix}index/shard.index.json");
@@ -2880,6 +3051,90 @@ mod tests {
                 CommandResponse::Bytes { value: Some(value) }
             );
         }
+    }
+
+    /// R2: a durable, cross-owner single-writer fence. Proves rejection happens at the STORE
+    /// layer (a superseded stale owner cannot double-append to the shared WAL), not merely via
+    /// an in-memory load_version check.
+    #[tokio::test]
+    async fn r2_stale_load_version_writer_is_rejected_at_store_layer() {
+        std::env::set_var("TS_SHARED_STORE_FENCE", "1");
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(FileObjectStore::new(dir.path().join("objects")));
+        let shard: ShardId = 7;
+
+        // Owner A claims the shard at load_version 1 and writes successfully.
+        let repl_a = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone()).with_fence(1, "A");
+        repl_a.acquire_shard_lease(shard, 1, "A").await.unwrap();
+        let writer_a = repl_a.storage_writer(SharedStoreStorageMode::Sync, 1);
+        writer_a
+            .write(
+                shard,
+                Command::StringSet {
+                    key: "k".to_string(),
+                    value: b"from-a".to_vec(),
+                },
+            )
+            .await
+            .expect("owner A write should succeed while it holds the lease");
+
+        // A newer owner B takes over at a strictly higher load_version 2.
+        let repl_b = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone()).with_fence(2, "B");
+        repl_b.acquire_shard_lease(shard, 2, "B").await.unwrap();
+
+        // The stale owner A is now fenced OUT: its next WAL append is rejected at the store
+        // layer, so it cannot double-append and corrupt the shared WAL.
+        let err = writer_a
+            .write(
+                shard,
+                Command::StringSet {
+                    key: "k".to_string(),
+                    value: b"stale-a".to_vec(),
+                },
+            )
+            .await
+            .expect_err("stale owner A must be rejected after being superseded");
+        assert!(
+            matches!(err, SharedStoreReplicationError::StoreConditionFailed { .. }),
+            "expected fence rejection, got {err:?}"
+        );
+
+        // Owner B, holding the current lease, still writes fine.
+        let writer_b = repl_b.storage_writer(SharedStoreStorageMode::Sync, 2);
+        writer_b
+            .write(
+                shard,
+                Command::StringSet {
+                    key: "k".to_string(),
+                    value: b"from-b".to_vec(),
+                },
+            )
+            .await
+            .expect("current owner B write should succeed");
+
+        // A stale ownership claim (equal-or-lower load_version) cannot acquire the lease.
+        let repl_c = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone()).with_fence(1, "C");
+        let acquire_err = repl_c
+            .acquire_shard_lease(shard, 1, "C")
+            .await
+            .expect_err("a stale load_version must not be able to acquire the lease");
+        assert!(
+            matches!(acquire_err, SharedStoreReplicationError::StaleOwnership { .. }),
+            "expected StaleOwnership, got {acquire_err:?}"
+        );
+
+        // The underlying store CAS is itself fenced: a wrong `expected` is rejected.
+        let cas_err = store
+            .compare_and_swap(
+                "leases/probe.lease",
+                Some(Bytes::from_static(b"never-written")),
+                Bytes::from_static(b"new"),
+            )
+            .await
+            .expect_err("CAS with a mismatched expected value must fail");
+        assert!(matches!(cas_err, ObjectStoreError::ConditionFailed { .. }));
+
+        std::env::remove_var("TS_SHARED_STORE_FENCE");
     }
 
     #[derive(Debug)]

--- a/crates/temporalstore-snapshot/src/object_store.rs
+++ b/crates/temporalstore-snapshot/src/object_store.rs
@@ -25,6 +25,12 @@ pub enum ObjectStoreError {
     Http(String),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+    /// A durable compare-and-set precondition failed: the object either did not hold the
+    /// expected bytes (lost a race / stale owner) or the backend does not support a fenced
+    /// conditional put. This is the single-writer FENCE signal — callers MUST treat it as a
+    /// hard abort, never a retryable transient error.
+    #[error("object store condition failed for {key}: {detail}")]
+    ConditionFailed { key: String, detail: String },
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize)]
@@ -63,6 +69,26 @@ pub trait ObjectStore: Send + Sync {
             self.put(key, bytes.clone()).await?;
         }
         Ok(())
+    }
+    /// Durable compare-and-set: atomically replace the object at `key` with `new` iff its
+    /// current contents exactly equal `expected` (`None` meaning "the object must not exist").
+    /// This is the substrate for a single-writer fence/lease: a stale owner that has been
+    /// superseded observes a value it does not expect and is rejected with
+    /// [`ObjectStoreError::ConditionFailed`]. The default implementation is FAIL-CLOSED — it
+    /// refuses rather than performing an unfenced read-modify-write — so a backend without a
+    /// real atomic conditional put can never silently degrade the fence to a racy no-op.
+    /// Overridden with a real cross-process atomic CAS by [`FileObjectStore`].
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected: Option<Bytes>,
+        new: Bytes,
+    ) -> Result<(), ObjectStoreError> {
+        let _ = (expected, new);
+        Err(ObjectStoreError::ConditionFailed {
+            key: key.to_string(),
+            detail: "compare_and_swap unsupported by this object store backend".to_string(),
+        })
     }
     async fn get(&self, key: &str) -> Result<Bytes, ObjectStoreError>;
     async fn get_range(
@@ -599,6 +625,46 @@ impl ObjectStore for FileObjectStore {
         })
     }
 
+    /// Cross-process atomic compare-and-set. Mutual exclusion is provided by an atomic
+    /// `mkdir` of a per-key lock directory (POSIX `mkdir` fails if the directory already
+    /// exists, and this atomicity holds over a shared filesystem too), so a concurrent
+    /// writer on another host cannot interleave its read-compare-write with ours. Inside the
+    /// lock we read the current object, reject with [`ObjectStoreError::ConditionFailed`] if
+    /// it does not exactly equal `expected`, then durably (`sync_all`) install `new`.
+    async fn compare_and_swap(
+        &self,
+        key: &str,
+        expected: Option<Bytes>,
+        new: Bytes,
+    ) -> Result<(), ObjectStoreError> {
+        let path = self.resolve(key)?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let lock_path = {
+            let mut p = path.clone().into_os_string();
+            p.push(".caslock");
+            PathBuf::from(p)
+        };
+        let _guard = CasLockGuard::acquire(lock_path).await?;
+        let current = match tokio::fs::read(&path).await {
+            Ok(bytes) => Some(Bytes::from(bytes)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => return Err(ObjectStoreError::Io(err)),
+        };
+        if current.as_deref() != expected.as_deref() {
+            return Err(ObjectStoreError::ConditionFailed {
+                key: key.to_string(),
+                detail: "current object contents do not match expected fence value".to_string(),
+            });
+        }
+        let mut file = tokio::fs::File::create(&path).await?;
+        file.write_all(&new).await?;
+        file.flush().await?;
+        file.sync_all().await?;
+        Ok(())
+    }
+
     async fn get(&self, key: &str) -> Result<Bytes, ObjectStoreError> {
         let path = self.resolve(key)?;
         match tokio::fs::read(path).await {
@@ -633,6 +699,40 @@ impl ObjectStore for FileObjectStore {
 
     fn uri(&self, key: &str) -> String {
         format!("{}://{}", self.uri_scheme, key)
+    }
+}
+
+/// RAII cross-process lock backed by an atomic `mkdir`. Acquisition spins on `create_dir`
+/// (which fails atomically with `AlreadyExists` while another holder owns it) up to a bounded
+/// deadline; the directory is removed on drop so the lock is released even on the error path.
+struct CasLockGuard {
+    lock_path: PathBuf,
+}
+
+impl CasLockGuard {
+    async fn acquire(lock_path: PathBuf) -> Result<Self, ObjectStoreError> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            match tokio::fs::create_dir(&lock_path).await {
+                Ok(()) => return Ok(Self { lock_path }),
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(ObjectStoreError::ConditionFailed {
+                            key: lock_path.to_string_lossy().to_string(),
+                            detail: "timed out acquiring compare-and-swap lock".to_string(),
+                        });
+                    }
+                    tokio::time::sleep(Duration::from_millis(2)).await;
+                }
+                Err(err) => return Err(ObjectStoreError::Io(err)),
+            }
+        }
+    }
+}
+
+impl Drop for CasLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.lock_path);
     }
 }
 


### PR DESCRIPTION
## Replication-safety hardenings (R2–R5, R8, R9)

Durable, hard-gated safety fixes to the raft / shared-store replication subsystem. **Every change defaults OFF** behind a named env gate, so shipped/default behavior is byte-identical until an operator opts in. Each gate has a focused test.

| Gate | Env flag | Fix |
|---|---|---|
| **R2** single-writer fence | `TS_SHARED_STORE_FENCE` | Fail-closed compare-and-set on the object store (real cross-process atomic CAS for the file backend via an atomic-mkdir lock). Shared-store writers carry a `load_version` lease, acquire it via CAS, and re-validate on every WAL append + checkpoint publish — a superseded stale owner is rejected (`StoreConditionFailed`) instead of double-appending. |
| **R3** applied-index reads | `TS_RAFT_APPLIED_READ_SAFETY` | `read_from_replica` rejects a replica whose `applied_index` is below the leader's committed frontier; the server read path waits for apply through the returned read-index before serving. No half-applied state served as fresh. |
| **R4** post-election barrier | `TS_RAFT_LEADER_READY_BARRIER` | A freshly elected leader withholds read-index / lease reads until it has committed an entry in its own term. |
| **R5** quorum election | `TS_RAFT_QUORUM_ELECTION` | Promotion requires collecting a majority of durable per-term vote grants (one vote per term, leader-completeness log check) instead of promoting from a local view; a minority partition cannot elect. |
| **R8** snapshot boundary truncate | `TS_RAFT_SNAPSHOT_BOUNDARY_TRUNCATE` | Snapshot install discards the whole log when the boundary entry does not term-match the snapshot, instead of retaining a divergent tail. |
| **R9** persist vote before request | `TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST` | A candidate durably persists its incremented term + self-vote before advertising a RequestVote. |

### Tests
- New gate tests `r2_…`, `r3_…`, `r4_…`, `r5_…` all pass.
- `raft::` + `shared_store::` suites: **182 passed / 0 failed**; snapshot crate **8/8**; no new failures in touched modules.

### Deferred (with precise TODO)
- **R6** — membership through the raft log via a `Command::ConfigChange` entry (applied on commit).
- **R7** — learner catch-up on the topology membership path (route through `add_learner_with_auto_promote`).
- **R2 networked backend** — the enterprise object-store backend still needs a conditional-put; the default trait CAS is fail-closed, so that path stays safe/blocked until then.

These are larger multi-process changes, deliberately left for a follow-up so this safety-focused subset lands correct and isolated.
