### PR TITLE
feat(deploy): wire centralized config file into systemd start

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,69 @@
+# Deploying the centralized config file
+
+TemporalStore / MatrixArk services read every tunable from one documented file,
+`config/temporalstore.toml`, via a non-invasive launcher (`scripts/with_config.sh`
++ `tools/matrixark_load_config.py`). This directory wires that file into the
+real systemd deployment.
+
+## Canonical layout (on each node, persists on EBS across stop/start)
+
+    /opt/temporalstore/config/temporalstore.toml     # the config file (source of truth)
+    /opt/temporalstore/scripts/with_config.sh        # launcher
+    /opt/temporalstore/tools/matrixark_load_config.py # loader
+    /opt/temporalstore/tools/deploy_config.sh        # applier (this dir)
+
+## How a service reads the config on start
+
+Each unit's `ExecStart` runs THROUGH the launcher:
+
+    ExecStart=/opt/temporalstore/scripts/with_config.sh \
+        /opt/temporalstore/config/temporalstore.toml \
+        <binary> <args>
+
+`with_config.sh` loads the TOML, exports every mapped env var **only if it is not
+already set**, then `exec`s the binary. Precedence is:
+
+    built-in default  <  config file  <  explicit environment variable
+
+Because systemd applies a unit's `Environment=` / `EnvironmentFile=` before
+`ExecStart` runs, any explicit env in the unit is already set when the launcher
+runs and is left untouched — so **env still wins** over the config file. No
+service reader code changes; the existing `os.environ.get` / `std::env::var`
+reads pick the values up unchanged.
+
+The canonical unit files are in `deploy/systemd/*.service` (reference / fresh
+installs). For an already-provisioned cluster, `deploy_config.sh` wraps the
+units in place (see below) without needing to know their exact ExecStart.
+
+## Apply on the NEXT cluster start
+
+The test cluster is normally stopped to save cost (`ts_cluster.sh stop`). On the
+next start, run the applier once per node (control, datanode, extractor):
+
+    ts_cluster.sh start                 # bring instances up
+    # then, on each node (or via ssh from control):
+    sudo /opt/temporalstore/tools/deploy_config.sh --restart
+
+`deploy_config.sh` is idempotent. It:
+
+1. installs the config file + launcher + loader under `/opt/temporalstore`
+   (never clobbers an edited `temporalstore.toml` unless `--force-config`);
+2. for each installed `matrixark-*` unit, writes an idempotent drop-in
+   `/etc/systemd/system/<unit>.service.d/10-with-config.conf` that re-points
+   `ExecStart` through the launcher, preserving the unit's current command +
+   args (read live from systemd);
+3. `daemon-reload` (and `--restart` to restart the wired units now).
+
+After the first apply, the drop-ins persist on EBS, so subsequent starts read
+the config automatically; re-run `deploy_config.sh` only to pick up a changed
+config file or new units (`--force-config` to replace the deployed TOML).
+
+Requirement: `python3` must be present on every node (the loader is a
+stdlib-only script; no third-party TOML library needed).
+
+## Editing the config
+
+Edit `/opt/temporalstore/config/temporalstore.toml` on the node and restart the
+service, or edit `config/temporalstore.toml` in the repo and re-run
+`deploy_config.sh --force-config --restart`. For a one-off override, set the env
+var in the unit (a drop-in `Environment=…`) — it wins over the file.

--- a/deploy/systemd/matrixark-datanode.service
+++ b/deploy/systemd/matrixark-datanode.service
@@ -1,0 +1,21 @@
+# Canonical systemd unit for the TemporalStore datanode (Rust engine).
+# Installed to /etc/systemd/system/matrixark-datanode.service on the node.
+#
+# ExecStart runs THROUGH the config launcher (with_config.sh reads the canonical
+# TOML -> exports mapped TS_* / MATRIXARK_* env if-unset -> exec's the binary).
+# Explicit Environment= / EnvironmentFile= still wins (systemd sets them first).
+# Requires python3 on the node for the loader (a stdlib-only script).
+[Unit]
+Description=TemporalStore datanode (Rust engine)
+After=network-online.target matrixark-metaserver.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/temporalstore
+ExecStart=/opt/temporalstore/scripts/with_config.sh /opt/temporalstore/config/temporalstore.toml /opt/temporalstore/bin/matrixark_rust_datanode
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/matrixark-gateway.service
+++ b/deploy/systemd/matrixark-gateway.service
@@ -1,0 +1,23 @@
+# Canonical systemd unit for the MatrixArk /v1 HTTP gateway.
+# Installed to /etc/systemd/system/matrixark-gateway.service on the node.
+#
+# ExecStart runs THROUGH the config launcher: with_config.sh reads the canonical
+# TOML, exports every mapped env var that is not already set, then exec's the
+# gateway. Any Environment= / EnvironmentFile= set below (or in a drop-in) still
+# wins, because systemd applies them before ExecStart runs.
+[Unit]
+Description=MatrixArk /v1 HTTP gateway
+After=network-online.target matrixark-proxy.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/temporalstore/gw
+# Explicit env here (or via a drop-in) overrides the config file (env wins):
+# Environment=MATRIXARK_HTTP_PORT=8080
+ExecStart=/opt/temporalstore/scripts/with_config.sh /opt/temporalstore/config/temporalstore.toml /usr/bin/python3 /opt/temporalstore/gw/tools/matrixark_v1_gateway.py
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/matrixark-metaserver.service
+++ b/deploy/systemd/matrixark-metaserver.service
@@ -1,0 +1,18 @@
+# Canonical systemd unit for the TemporalStore metaserver.
+# Installed to /etc/systemd/system/matrixark-metaserver.service on the node.
+# ExecStart runs THROUGH the config launcher; explicit Environment= still wins.
+# Requires python3 on the node for the loader (a stdlib-only script).
+[Unit]
+Description=TemporalStore metaserver
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/temporalstore
+ExecStart=/opt/temporalstore/scripts/with_config.sh /opt/temporalstore/config/temporalstore.toml /opt/temporalstore/bin/matrixark_rust_metaserver
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/matrixark-proxy.service
+++ b/deploy/systemd/matrixark-proxy.service
@@ -1,0 +1,18 @@
+# Canonical systemd unit for the TemporalStore proxy.
+# Installed to /etc/systemd/system/matrixark-proxy.service on the node.
+# ExecStart runs THROUGH the config launcher; explicit Environment= still wins.
+# Requires python3 on the node for the loader (a stdlib-only script).
+[Unit]
+Description=TemporalStore proxy
+After=network-online.target matrixark-metaserver.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/temporalstore
+ExecStart=/opt/temporalstore/scripts/with_config.sh /opt/temporalstore/config/temporalstore.toml /opt/temporalstore/bin/matrixark_rust_proxy
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/with_config.sh
+++ b/scripts/with_config.sh
@@ -3,18 +3,30 @@
 # with_config.sh - launch a TemporalStore / MatrixArk process with the
 # centralized config file applied to the environment first.
 #
-# It reads config/temporalstore.toml (or $MATRIXARK_CONFIG_FILE, or --config
-# PATH) via tools/matrixark_load_config.py and exports every mapped env var that
-# is NOT already set, then exec's the given command. Precedence:
+# It reads config/temporalstore.toml (or the path given, or
+# $MATRIXARK_CONFIG_FILE) via tools/matrixark_load_config.py and exports every
+# mapped env var that is NOT already set, then exec's the given command.
+# Precedence:
 #
 #     built-in code default  <  config file  <  explicit environment variable
+#
+# Because systemd puts a unit's Environment= / EnvironmentFile= values into the
+# process environment BEFORE ExecStart runs, those explicit env vars are already
+# set when this shim executes, so the loader leaves them untouched (env wins) -
+# precedence is preserved when this is used as a systemd ExecStart wrapper.
 #
 # The gateway and datanode read their existing env-var names unchanged, so this
 # is a non-invasive shim - no reader edits required.
 #
-# Usage:
+# Usage (all three forms work):
+#     with_config.sh <command> [args...]                       # default/env config
+#     with_config.sh /opt/temporalstore/config/temporalstore.toml <command> [args...]
+#     with_config.sh --config /path/temporalstore.toml <command> [args...]
+#
+# Examples:
 #     scripts/with_config.sh python3 tools/matrixark_v1_gateway.py
-#     scripts/with_config.sh --config /etc/matrixark/prod.toml matrixark_rust_datanode
+#     scripts/with_config.sh /opt/temporalstore/config/temporalstore.toml \
+#         /opt/temporalstore/bin/matrixark_rust_datanode
 #     MATRIXARK_TOP_K_PER_LAYER=32 scripts/with_config.sh ...   # env still wins
 # =============================================================================
 set -euo pipefail
@@ -24,13 +36,18 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 LOADER="${REPO_ROOT}/tools/matrixark_load_config.py"
 
 CONFIG_ARGS=()
+# Explicit --config PATH, or a leading positional that is an existing .toml file
+# (matches the ExecStart form `with_config.sh <config.toml> <binary> ...`).
 if [[ "${1:-}" == "--config" ]]; then
   CONFIG_ARGS=(--config "${2:?--config needs a path}")
   shift 2
+elif [[ "${1:-}" == *.toml && -f "${1:-}" ]]; then
+  CONFIG_ARGS=(--config "$1")
+  shift 1
 fi
 
 if [[ $# -eq 0 ]]; then
-  echo "usage: with_config.sh [--config PATH] <command> [args...]" >&2
+  echo "usage: with_config.sh [--config PATH | PATH.toml] <command> [args...]" >&2
   exit 2
 fi
 

--- a/tools/deploy_config.sh
+++ b/tools/deploy_config.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_config.sh - install the centralized config file + launcher on a node
+# and wire the running systemd units to read it ON START. Idempotent.
+#
+# Run this ONCE per node on the NEXT cluster start (the instances persist
+# /opt/temporalstore on EBS across stop/start, so this only needs re-running
+# when the config file or units change). It:
+#
+#   1. copies config/temporalstore.toml, scripts/with_config.sh and
+#      tools/matrixark_load_config.py from this repo checkout into the canonical
+#      /opt/temporalstore tree (never overwrites an existing edited config
+#      unless --force-config is given);
+#   2. for each installed matrixark-* unit, writes an idempotent drop-in that
+#      re-points ExecStart THROUGH the launcher, preserving the unit's current
+#      command + args (read live from systemd) so nothing else changes;
+#   3. daemon-reload (and --restart to restart the wired units now).
+#
+# Precedence is preserved: systemd applies a unit's Environment= /
+# EnvironmentFile= before ExecStart, so with_config.sh sees those as already-set
+# and does not override them (explicit env wins over the config file).
+#
+# Usage (on the node, as root):
+#   sudo /opt/temporalstore/tools/deploy_config.sh [--src <repo>] [--force-config] [--restart]
+#   sudo tools/deploy_config.sh                 # from a repo checkout
+# =============================================================================
+set -euo pipefail
+
+PREFIX="/opt/temporalstore"
+CONF_DST="${PREFIX}/config/temporalstore.toml"
+DROPIN_NAME="10-with-config.conf"
+UNITS=(matrixark-metaserver matrixark-proxy matrixark-datanode matrixark-gateway)
+
+src=""
+force_config=0
+do_restart=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src) src="${2:?}"; shift 2 ;;
+    --force-config) force_config=1; shift ;;
+    --restart) do_restart=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve the repo checkout this script ships in (…/tools/deploy_config.sh).
+if [[ -z "$src" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  src="$(cd "${script_dir}/.." && pwd)"
+fi
+
+echo "[deploy-config] source repo: ${src}"
+for f in config/temporalstore.toml scripts/with_config.sh tools/matrixark_load_config.py; do
+  [[ -f "${src}/${f}" ]] || { echo "[deploy-config] MISSING ${src}/${f}" >&2; exit 1; }
+done
+
+# --- 1. place config + launcher + loader under /opt/temporalstore -------------
+install -d "${PREFIX}/config" "${PREFIX}/scripts" "${PREFIX}/tools"
+install -m 0755 "${src}/scripts/with_config.sh"        "${PREFIX}/scripts/with_config.sh"
+install -m 0755 "${src}/tools/matrixark_load_config.py" "${PREFIX}/tools/matrixark_load_config.py"
+# also drop a copy of this deploy script so it can be re-run from the node.
+install -m 0755 "${src}/tools/deploy_config.sh"        "${PREFIX}/tools/deploy_config.sh" 2>/dev/null || true
+if [[ -f "$CONF_DST" && "$force_config" -eq 0 ]]; then
+  echo "[deploy-config] keeping existing ${CONF_DST} (use --force-config to replace)"
+else
+  install -m 0644 "${src}/config/temporalstore.toml" "$CONF_DST"
+  echo "[deploy-config] installed ${CONF_DST}"
+fi
+
+# --- 2. wire each installed unit's ExecStart through the launcher -------------
+wired=0
+for unit in "${UNITS[@]}"; do
+  # only touch units systemd actually knows about on this node.
+  if ! systemctl cat "${unit}.service" >/dev/null 2>&1; then
+    continue
+  fi
+  cur="$(systemctl show -p ExecStart --value "${unit}.service" 2>/dev/null || true)"
+  [[ -z "$cur" ]] && { echo "[deploy-config] ${unit}: no ExecStart, skipping"; continue; }
+  # extract the real command line from: { path=… ; argv[]=<cmd> ; ignore_errors=… }
+  argv="$(printf '%s' "$cur" | sed -n 's/.*argv\[\]=\(.*\) ; ignore_errors.*/\1/p')"
+  [[ -z "$argv" ]] && argv="$(printf '%s' "$cur" | sed -n 's/.*argv\[\]=\(.*\) ;.*/\1/p')"
+  [[ -z "$argv" ]] && { echo "[deploy-config] ${unit}: could not parse ExecStart, skipping"; continue; }
+  if printf '%s' "$argv" | grep -q "with_config.sh"; then
+    echo "[deploy-config] ${unit}: already wired, skipping"
+    continue
+  fi
+  dropin_dir="/etc/systemd/system/${unit}.service.d"
+  install -d "$dropin_dir"
+  {
+    echo "# Route ExecStart through the config launcher (managed by deploy_config.sh)."
+    echo "# Original command is preserved; env still wins over the config file."
+    echo "[Service]"
+    echo "ExecStart="
+    echo "ExecStart=${PREFIX}/scripts/with_config.sh ${CONF_DST} ${argv}"
+  } > "${dropin_dir}/${DROPIN_NAME}"
+  echo "[deploy-config] ${unit}: wired -> ${dropin_dir}/${DROPIN_NAME}"
+  wired=$((wired + 1))
+done
+
+# --- 3. reload (+ optional restart) ------------------------------------------
+systemctl daemon-reload
+echo "[deploy-config] daemon-reload done (${wired} unit(s) newly wired)"
+if [[ "$do_restart" -eq 1 ]]; then
+  for unit in "${UNITS[@]}"; do
+    systemctl cat "${unit}.service" >/dev/null 2>&1 || continue
+    systemctl restart "${unit}.service" && echo "[deploy-config] restarted ${unit}"
+  done
+fi
+echo "[deploy-config] done. Services will read ${CONF_DST} on (next) start."

--- a/tools/install_linux_temporalstore.sh
+++ b/tools/install_linux_temporalstore.sh
@@ -240,6 +240,16 @@ for name in matrixark_rust_metaserver matrixark_rust_datanode matrixark_rust_pro
   printf '%s -> %s\n' "$name" "$bin_dir/$name"
 done
 
+step "Install centralized config + launcher"
+mkdir -p "$install_dir/config" "$install_dir/scripts" "$install_dir/tools"
+install -m 0755 "$repo/scripts/with_config.sh" "$install_dir/scripts/with_config.sh"
+install -m 0755 "$repo/tools/matrixark_load_config.py" "$install_dir/tools/matrixark_load_config.py"
+if [[ -f "$install_dir/config/temporalstore.toml" ]]; then
+  echo "keeping existing $install_dir/config/temporalstore.toml"
+else
+  install -m 0644 "$repo/config/temporalstore.toml" "$install_dir/config/temporalstore.toml"
+fi
+
 write_env_file() {
   cat > "$install_dir/temporalstore.env" <<EOF
 TEMPORALSTORE_INSTALL_DIR=$install_dir
@@ -268,7 +278,7 @@ Description=Rust TemporalStore metaserver
 
 [Service]
 EnvironmentFile=$install_dir/temporalstore.env
-ExecStart=$bin_dir/matrixark_rust_metaserver
+ExecStart=$install_dir/scripts/with_config.sh $install_dir/config/temporalstore.toml $bin_dir/matrixark_rust_metaserver
 Restart=on-failure
 RestartSec=2
 
@@ -282,7 +292,7 @@ After=temporalstore-rust-metaserver.service
 
 [Service]
 EnvironmentFile=$install_dir/temporalstore.env
-ExecStart=$bin_dir/matrixark_rust_datanode
+ExecStart=$install_dir/scripts/with_config.sh $install_dir/config/temporalstore.toml $bin_dir/matrixark_rust_datanode
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
Stacked on #29 (the config file + loader). Wires the last mile so a node coming up actually reads `config/temporalstore.toml`.

- Canonical on-node path `/opt/temporalstore/config/temporalstore.toml` (persists on EBS), launcher at `/opt/temporalstore/scripts/with_config.sh`.
- `scripts/with_config.sh` now also accepts the config path as a leading positional, matching the ExecStart form `with_config.sh <config.toml> <binary> <args>`.
- `deploy/systemd/*.service`: canonical unit templates whose ExecStart runs through the launcher. Precedence preserved: systemd applies `Environment=`/`EnvironmentFile=` before ExecStart, so explicit env is already set and the launcher does not override it (env wins).
- `tools/deploy_config.sh`: idempotent node applier that installs the config+launcher and writes a drop-in re-pointing each `matrixark-*` unit's ExecStart through the launcher, preserving its current command (read live from systemd).
- `tools/install_linux_temporalstore.sh`: install the config+launcher and route the user-mode units through the launcher.
- `deploy/README.md`: canonical path + next-start step.

Requires python3 on every node (loader is stdlib-only). No reader code changed.