### PR TITLE
fix(recovery): close round-2 fault-tolerance / silent-data-loss gaps on the default recovery path

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -47,7 +47,6 @@ use temporalstore_rust::{
     RaftFailoverReport, RaftMembershipChangeReport, RaftNodeId, RaftRpcRuntimeOptions,
     RequestController, ScanStreamRequest, SchedulerLifecycleToken, SetConfigRequest,
     SharedStoreReplicationError, SharedStoreReplicator, SharedStoreWalEntry, StorageBackend,
-    WriteAheadLogRecord,
     BucketDumpManifest, StorageCacheInvalidateBucketRequest, StorageLifecycleRequest,
     StorageProductionReadinessRequest, StreamReadRequest, UnloadShardRequest,
 };
@@ -1070,7 +1069,7 @@ fn publish_shard_checkpoint(
     let mut published = 0usize;
     let mut last_wal_index = 0u64;
     for (_offset, line) in records {
-        let record: WriteAheadLogRecord = match serde_json::from_slice(&line) {
+        let record = match temporalstore_rust::wal::decode_wal_line(&line) {
             Ok(record) => record,
             Err(err) => {
                 return PublishShardCheckpointResponse {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1548,12 +1548,36 @@ fn atomic_write_bytes_synced(path: &Path, bytes: &[u8], sync: bool) -> Result<()
             file.sync_all()?;
         }
         drop(file);
-        fs::rename(&temp_path, path)
+        fs::rename(&temp_path, path)?;
+        if sync {
+            // The rename is only crash-durable once the PARENT DIRECTORY entry is fsync'd:
+            // sync_all above makes the temp file's data+inode durable, but the rename that
+            // publishes it under `path` is a directory mutation that can still be lost on a
+            // crash. This backs the dump manifest (the durable WAL-reclaim watermark), the
+            // base index, and the install markers -- if the rename is not durable, a dump can
+            // let WAL-GC truncate the WAL to the manifest watermark, then a crash loses the
+            // manifest directory entry while the reclaimed WAL is already gone = permanent
+            // acked-write loss. Every other durable writer (wal.rs, index_log.rs,
+            // block_store) already syncs the parent dir here.
+            sync_parent_dir(path)?;
+        }
+        Ok(())
     })();
     if write_result.is_err() {
         let _ = fs::remove_file(&temp_path);
     }
     write_result
+}
+
+/// Make the atomic-rename that published `path` crash-durable by fsync'ing the parent
+/// directory entry (mirrors `wal::sync_parent_dir` / `index_log::sync_parent_dir`).
+fn sync_parent_dir(path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = File::open(parent) {
+            dir.sync_all()?;
+        }
+    }
+    Ok(())
 }
 
 /// TS_WAL_ONLY_SYNC: on the write/ack path, only the WAL takes a synchronous durability

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -191,7 +191,13 @@ impl TemporalEngine {
                     // WAL cannot be trusted to hold the records it covers -- refuse the load.
                     Err(status) => return LoadShardResponse { status },
                 };
-            let loaded = self.load_index(request.shard_id, eager_cache_warm_on_load());
+            // Fold-aware load: a corrupt served-index delta log is fatal here. Silently
+            // folding a holed delta prefix would advance the anchor past a removal/eviction
+            // recorded only in the delta -> silent loss. Refuse the load instead.
+            let loaded = match self.load_index_checked(request.shard_id, eager_cache_warm_on_load()) {
+                Ok(loaded) => loaded,
+                Err(status) => return LoadShardResponse { status },
+            };
             // WAL replay watermark, from the dumped-log id read on startup load:
             // installed manifest -> its wal_sequence; no index
             // file -> 0 (fresh/async-only shard, replay whole retained WAL); anchored index
@@ -355,15 +361,39 @@ impl TemporalEngine {
         shard_id: ShardId,
         watermark: u64,
     ) -> Result<(), Status> {
+        // A corrupt / unreadable WAL scan is DATA LOSS, not "nothing to replay": swallowing it
+        // to Ok(()) would load the shard from the stale base index only, silently discarding
+        // the committed WAL tail and defeating the caller's refuse-load-on-DataLoss guard. An
+        // absent WAL file is the only "nothing to replay" case, and `scan` already returns an
+        // empty vec for it (never an error), so any Err here is a genuine failure -> abort.
         let records = match self.wal_store.scan(shard_id, 0, u64::MAX, u64::MAX) {
             Ok(records) => records,
-            Err(_) => return Ok(()),
+            Err(err) => {
+                return Err(Status::error(
+                    "wal_scan_failed",
+                    format!(
+                        "WAL scan failed during recovery for shard {shard_id}; refusing load rather than serving a truncated prefix: {err}"
+                    ),
+                ));
+            }
         };
-        let mut pending: Vec<WriteAheadLogRecord> = records
-            .into_iter()
-            .filter_map(|(_, line)| serde_json::from_slice::<WriteAheadLogRecord>(&line).ok())
-            .filter(|record| record.sequence > watermark)
-            .collect();
+        // Decode each record through the integrity-verifying framing decoder and PROPAGATE a
+        // failure (a value-preserving bit-flip surfaces as `Corruption`) instead of dropping
+        // the record via `.ok()`, which would silently truncate the replayed tail.
+        let mut pending: Vec<WriteAheadLogRecord> = Vec::new();
+        for (_, line) in records {
+            let record = crate::wal::decode_wal_line(&line).map_err(|err| {
+                Status::error(
+                    "wal_record_corruption",
+                    format!(
+                        "WAL record integrity failure during recovery for shard {shard_id}; refusing load: {err}"
+                    ),
+                )
+            })?;
+            if record.sequence > watermark {
+                pending.push(record);
+            }
+        }
         if pending.is_empty() {
             return Ok(());
         }

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -133,6 +133,22 @@ impl TemporalEngine {
     }
 
     pub(super) fn load_index(&self, shard_id: ShardId, warm_cache: bool) -> Option<ShardState> {
+        // Tolerant wrapper for probe/report callers (manifest-anchor probe, recovery reports):
+        // a corrupt index-log delta yields None here. The authoritative load path
+        // (`load_shard_with`) calls `load_index_checked` instead so it can REFUSE the load on
+        // corruption rather than silently serving a base-only prefix.
+        self.load_index_inner(shard_id, warm_cache, delta_served_index_enabled())
+            .ok()
+            .flatten()
+    }
+
+    /// Fold-aware load that surfaces a corrupt served-index delta as `Err` so the caller can
+    /// refuse the load. Used by the authoritative recovery path.
+    pub(super) fn load_index_checked(
+        &self,
+        shard_id: ShardId,
+        warm_cache: bool,
+    ) -> Result<Option<ShardState>, Status> {
         self.load_index_inner(shard_id, warm_cache, delta_served_index_enabled())
     }
 
@@ -149,7 +165,10 @@ impl TemporalEngine {
         shard_id: ShardId,
         warm_cache: bool,
     ) -> Option<ShardState> {
+        // base_only never folds the delta log, so this never fails on delta corruption.
         self.load_index_inner(shard_id, warm_cache, false)
+            .ok()
+            .flatten()
     }
 
     fn load_index_inner(
@@ -157,17 +176,20 @@ impl TemporalEngine {
         shard_id: ShardId,
         warm_cache: bool,
         fold_deltas: bool,
-    ) -> Option<ShardState> {
+    ) -> Result<Option<ShardState>, Status> {
         let read = fs::read(self.index_path(shard_id));
         let base_present = read.is_ok();
         // No fold: a missing base means nothing to load. Fold path: the base is materialized
         // only at compaction/unload, so a crash before the first compaction leaves no base --
         // start empty and rebuild from the index-log deltas below.
         if !base_present && !fold_deltas {
-            return None;
+            return Ok(None);
         }
         let mut shard = match read {
-            Ok(bytes) => serde_json::from_slice::<ShardState>(&bytes).ok()?,
+            Ok(bytes) => match serde_json::from_slice::<ShardState>(&bytes) {
+                Ok(shard) => shard,
+                Err(_) => return Ok(None),
+            },
             Err(_) => ShardState::default(),
         };
         // Thin-layer Sequence fold: a pre-fold on-disk index stored Sequence rows in a
@@ -186,13 +208,13 @@ impl TemporalEngine {
         // WAL -- re-execution would write fresh pages and relocate them to the active slab,
         // doubling physical page counts and losing the recorded slab layout.
         if fold_deltas {
-            self.fold_index_log_deltas(shard_id, &mut shard);
+            self.fold_index_log_deltas(shard_id, &mut shard)?;
             // ON but no base and nothing to fold -> genuinely nothing persisted yet.
             if !base_present
                 && shard.bucket_index.bucket_map.is_empty()
                 && shard.applied_wal_sequence.is_none()
             {
-                return None;
+                return Ok(None);
             }
         }
         // Fold disk->memory cache promotion into reconcile's page reads on a warming
@@ -219,7 +241,7 @@ impl TemporalEngine {
             }
         }
         refresh_bucket_runtime_flags(&mut shard);
-        Some(shard)
+        Ok(Some(shard))
     }
 
     /// Fold the append-only index-log deltas onto a (possibly empty) base `ShardState`,
@@ -230,13 +252,24 @@ impl TemporalEngine {
     /// addresses (authoritative replace per covered key) and its per-key non-page state is
     /// applied, then the reconstructed anchor advances so WAL replay re-executes only the
     /// uncaptured (e.g. async) tail rather than relocating the pages the deltas already pin.
-    fn fold_index_log_deltas(&self, shard_id: ShardId, shard: &mut ShardState) {
+    fn fold_index_log_deltas(&self, shard_id: ShardId, shard: &mut ShardState) -> Result<(), Status> {
+        // Propagate a corrupt/holed delta stream instead of silently folding a prefix. A
+        // silently-skipped delta advances the reconstructed anchor past a removal/eviction that
+        // lives ONLY in the delta (not the WAL), so it is recovered from neither source -- a
+        // silent loss / dangling ref. The caller (load_shard_with) refuses the load on Err.
         let records = match self.index_log_store.read_delta_records(shard_id, 0) {
             Ok(records) => records,
-            Err(_) => return,
+            Err(err) => {
+                return Err(Status::error(
+                    "index_log_delta_corruption",
+                    format!(
+                        "served-index delta log for shard {shard_id} is corrupt; refusing load: {err}"
+                    ),
+                ));
+            }
         };
         if records.is_empty() {
-            return;
+            return Ok(());
         }
         let base_anchor = shard.applied_wal_sequence.unwrap_or(0);
         let mut max_anchor = base_anchor;
@@ -261,6 +294,7 @@ impl TemporalEngine {
             shard.bucket_index.rebuild_object_page_lookup();
             shard.applied_wal_sequence = Some(max_anchor);
         }
+        Ok(())
     }
 
     /// Persist the in-memory shard index to disk once (used by bulk backfill

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -597,6 +597,22 @@ impl TemporalEngine {
             .iter()
             .filter(|policy| policy.layout_aware_rewrite_required)
             .count();
+        // Durability barrier BEFORE publishing the base index that names the relocated pages.
+        // Under deferred-fsync modes (bulk / page_wal_single_barrier / TS_WAL_ONLY_SYNC ->
+        // append.rs defer_data_sync) compaction relocates pages fsync-deferred, so the moved
+        // bytes may still be in the page cache. Persisting a base index that references them
+        // and crashing before the next barrier would leave dangling references at an un-synced
+        // slab (compaction does not advance applied_wal_sequence, so WAL replay does not
+        // re-derive them) = permanent silent loss. The partial-failure path above already
+        // syncs here; the success path must too. Unconditional, matching that path.
+        self.page_store.sync_durable().map_err(|barrier| {
+            Status::error(
+                "page_compaction_failed",
+                format!(
+                    "durability barrier failed before publishing the compacted base index: {barrier}"
+                ),
+            )
+        })?;
         let index_bytes = serde_json::to_vec_pretty(shard)
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
         self.persist_index_bytes(shard_id, &index_bytes)

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -775,7 +775,11 @@ impl TemporalEngine {
         let removable_records_before_budget = records
             .iter()
             .filter_map(|(_, bytes)| {
-                serde_json::from_slice::<crate::index_log::IndexLogRecord>(bytes).ok()
+                // Decode the integrity framing (accepts legacy unframed records too) before
+                // reading the sequence; a corrupt line is simply not counted here (this is a
+                // GC-pressure metric, not the recovery path).
+                let payload = crate::log_framing::decode_line(bytes).ok()?;
+                serde_json::from_slice::<crate::index_log::IndexLogRecord>(payload).ok()
             })
             .filter(|record| record.sequence < wal_plan.retain_from_index_log_sequence)
             .count();

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -28,6 +28,33 @@ impl TemporalEngine {
         request: StorageManagerCycleRequest,
     ) -> StorageManagerCycleReport {
         let cycle_started_unix_ms = now_ms();
+        // Short-circuit while the shard is RECOVERING (WAL replay in progress). The cycle
+        // mutates shard state (eviction / page + WAL reclaim / compaction); a GC or compaction
+        // round interleaved with an in-flight replay would observe a half-reconstructed bucket
+        // index and could mis-reclaim a page that is still live -> silent durable loss. The
+        // synchronous POST /load path calls load_shard_with directly (it never registers in
+        // running_shards), so `recovering` is the reliable, path-independent guard: it is set
+        // for the whole replay window by both the async and the synchronous load. A recovering
+        // shard yields an inert (no-op) report; the next cycle after recovery runs normally.
+        if self
+            .infos
+            .read()
+            .expect("info lock poisoned")
+            .get(&request.shard_id)
+            .map(|info| info.recovering)
+            .unwrap_or(false)
+        {
+            return StorageManagerCycleReport {
+                shard_id: request.shard_id,
+                dry_run: request.dry_run,
+                completed: false,
+                errors: vec![format!(
+                    "storage manager cycle skipped for shard {}: recovery (WAL replay) is in progress; GC/compaction must not interleave with replay",
+                    request.shard_id
+                )],
+                ..StorageManagerCycleReport::default()
+            };
+        }
         let native_stage_order = [
             "prepare",
             "reclaim_wal",

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3145,3 +3145,222 @@ fn expired_feature_key_reads_empty_consistently_across_feature_reads() {
         "FeatureAggQuery reads empty for an expired key -- the other feature reads must match"
     );
 }
+
+// RN2: a storage-manager cycle must be an inert no-op while the shard is RECOVERING (WAL
+// replay in progress). A GC/compaction/reclaim round interleaved with an in-flight replay
+// would observe a half-reconstructed bucket index and could mis-reclaim a still-live page.
+#[test]
+fn storage_manager_cycle_is_a_noop_while_shard_is_recovering() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    for i in 0..4 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{i}"),
+                value: b"v".to_vec(),
+            },
+        });
+        assert!(response.status.ok, "{response:?}");
+    }
+    drop(engine);
+
+    // Restart and park the shard in the recovery window (recovering=true, replay not yet run).
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    let watermark = restarted.test_publish_recovering_shard(1);
+    let wal_before = restarted.write_ahead_log_store().stats(1).last_sequence;
+
+    let report = restarted.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        max_dump_buckets_per_round: 16,
+        min_undumped_wal_records: 0,
+        warm_cache: true,
+        enable_wal_reclaim: true,
+        enable_page_reclaim: true,
+        enable_page_compaction: true,
+        enable_index_gc: true,
+        ..StorageManagerCycleRequest::default()
+    });
+    assert!(
+        !report.completed,
+        "a storage-manager cycle must not complete while the shard is recovering: {report:?}"
+    );
+    assert!(
+        report.stages.is_empty(),
+        "a recovering cycle must build no stages (it returns early before any mutation)"
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|error| error.contains("recovering") || error.contains("recovery")),
+        "the skip reason must name recovery: {:?}",
+        report.errors
+    );
+    // The WAL tail is untouched (nothing reclaimed), and recovery still completes normally.
+    assert_eq!(
+        restarted.write_ahead_log_store().stats(1).last_sequence,
+        wal_before,
+        "no WAL record may be reclaimed during recovery"
+    );
+    restarted.test_finish_recovery(1, watermark);
+    let after = restarted.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "k0".to_string(),
+        },
+    });
+    assert!(after.status.ok, "the shard serves once recovery completes");
+}
+
+// F4: a corrupt / unreadable WAL scan on load is DATA LOSS, not "nothing to replay". The load
+// must refuse rather than silently serving the stale base index (dropping the committed WAL
+// tail). A value-preserving bit-flip in a committed, newline-terminated record exercises this.
+#[test]
+fn corrupt_wal_scan_refuses_load_rather_than_truncating() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    for key in ["keepme", "corruptme"] {
+        assert!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: key.to_string(),
+                        value: b"v".to_vec(),
+                    },
+                })
+                .status
+                .ok
+        );
+    }
+    drop(engine);
+
+    let wal_path = index_dir.join("wals").join("shard-1.wal.jsonl");
+    let mut bytes = std::fs::read(&wal_path).unwrap();
+    let position = bytes
+        .windows(9)
+        .position(|window| window == b"corruptme")
+        .expect("the second WAL record is present");
+    bytes[position + 1] = b'0'; // "corruptme" -> "c0rruptme": still valid JSON, wrong digest
+    std::fs::write(&wal_path, &bytes).unwrap();
+
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    let response = restarted.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(
+        !response.status.ok,
+        "a corrupt WAL scan must refuse the load, not serve a truncated prefix: {:?}",
+        response.status
+    );
+}
+
+// F3: a corrupt INTERIOR served-index delta record must abort the load, not be silently
+// skipped (a skipped delta loses a removal/eviction recorded only there -> resurrection or
+// dangling ref).
+#[test]
+fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    for key in ["alpha", "beta", "gamma"] {
+        assert!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: key.to_string(),
+                        value: b"v".to_vec(),
+                    },
+                })
+                .status
+                .ok
+        );
+    }
+    drop(engine);
+
+    let index_log_path = index_dir
+        .join("indexlogs")
+        .join("shard-1.indexlog.jsonl");
+    let contents = std::fs::read(&index_log_path).unwrap();
+    let mut lines: Vec<Vec<u8>> = contents
+        .split(|&byte| byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| line.to_vec())
+        .collect();
+    assert!(
+        lines.len() >= 2,
+        "the write path must have appended index-log delta records"
+    );
+    // Corrupt an interior record (not the tail) so it is committed corruption, not a torn tail.
+    lines[0] = b"corrupt-not-a-record".to_vec();
+    let mut rebuilt = Vec::new();
+    for line in &lines {
+        rebuilt.extend_from_slice(line);
+        rebuilt.push(b'\n');
+    }
+    std::fs::write(&index_log_path, &rebuilt).unwrap();
+
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    let response = restarted.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(
+        !response.status.ok,
+        "a corrupt interior index-log delta must refuse the load, not be silently skipped: {:?}",
+        response.status
+    );
+}

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -19,6 +19,19 @@ pub enum IndexLogError {
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+    /// A committed, newline-terminated served-index-log record failed its per-record
+    /// integrity envelope (framing length / SHA-256 digest) or violated delta
+    /// sequence-continuity. Surfaced as data loss so the load aborts instead of silently
+    /// skipping a delta (an eviction/removal recorded ONLY in the delta -- not the WAL --
+    /// would otherwise be lost, resurrecting the removed point or dangling its page ref).
+    #[error("index-log record integrity error: {0}")]
+    Corruption(String),
+}
+
+impl From<crate::log_framing::FramingError> for IndexLogError {
+    fn from(err: crate::log_framing::FramingError) -> Self {
+        IndexLogError::Corruption(err.0)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -299,8 +312,9 @@ impl LocalIndexLogStore {
             sequence: next_sequence,
             index: serde_json::from_slice(index_bytes)?,
         };
-        let mut bytes = serde_json::to_vec(&record)?;
-        bytes.push(b'\n');
+        // Frame the record with a length + SHA-256 digest (crate::log_framing) so a later
+        // value-preserving bit-flip in this committed line is detected on read.
+        let bytes = crate::log_framing::encode_line(&serde_json::to_vec(&record)?);
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -340,13 +354,17 @@ impl LocalIndexLogStore {
             }
         };
         let next_sequence = last_sequence.saturating_add(1);
-        let mut bytes = Vec::with_capacity(index_bytes.len().saturating_add(96));
+        // Build the JSON payload (no trailing newline) by splicing the pre-serialized index
+        // bytes in directly (avoids re-parsing/re-encoding the whole index), then frame it
+        // with a length + SHA-256 digest (crate::log_framing) for per-record integrity.
+        let mut payload = Vec::with_capacity(index_bytes.len().saturating_add(96));
         write!(
-            &mut bytes,
+            &mut payload,
             "{{\"shard_id\":{shard_id},\"sequence\":{next_sequence},\"index\":"
         )?;
-        bytes.extend_from_slice(index_bytes);
-        bytes.extend_from_slice(b"}\n");
+        payload.extend_from_slice(index_bytes);
+        payload.push(b'}');
+        let bytes = crate::log_framing::encode_line(&payload);
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -401,8 +419,10 @@ impl LocalIndexLogStore {
             applied_wal_sequence,
             key_states,
         };
-        let mut bytes = serde_json::to_vec(&record)?;
-        bytes.push(b'\n');
+        // Frame the delta record with a length + SHA-256 digest (crate::log_framing) so a
+        // value-preserving bit-flip (e.g. a flipped `deleted` flag or page address) in this
+        // committed line is detected on read rather than replayed as truth on recovery.
+        let bytes = crate::log_framing::encode_line(&serde_json::to_vec(&record)?);
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -440,26 +460,46 @@ impl LocalIndexLogStore {
         let file = File::open(&path)?;
         let reader = BufReader::new(file);
         let mut records = Vec::new();
+        let mut last_sequence = 0_u64;
         for line in reader.lines() {
             let line = line?;
             if line.trim().is_empty() {
                 continue;
             }
-            if let Ok(record) = serde_json::from_str::<IndexDeltaRecord>(&line) {
-                // A whole-index IndexLogRecord also deserializes into IndexDeltaRecord
-                // (its `index` field is ignored, leaving the delta fields empty). Only keep
-                // records that carry a delta payload OR a WAL anchor (an anchor-only record
-                // still advances the reconstructed watermark on load).
-                if record.items.is_empty()
-                    && record.meta.is_none()
-                    && record.key_states.is_empty()
-                    && record.applied_wal_sequence.is_none()
-                {
-                    continue;
-                }
-                if record.sequence > retain_after_sequence {
-                    records.push(record);
-                }
+            // PROPAGATE decode/parse failures instead of silently skipping the line. Silently
+            // dropping an unparseable interior delta record and continuing the fold advances
+            // the reconstructed anchor past it, so an eviction/removal recorded ONLY in that
+            // delta (not the WAL) is recovered from neither source = silent loss / dangling
+            // ref. `decode_line` also verifies the per-record integrity envelope, so a
+            // value-preserving bit-flip surfaces here as `Corruption`. Consistent with the
+            // scan / last_sequence_at path, which already treats interior corruption as fatal.
+            let payload = crate::log_framing::decode_line(line.as_bytes())?;
+            let record: IndexDeltaRecord = serde_json::from_slice(payload)?;
+            // Enforce delta sequence-continuity: sequences are assigned strictly monotonically
+            // across ALL appended records (whole-index and delta share one counter), and GC
+            // only truncates a leading prefix, so in file order each record's sequence must be
+            // strictly greater than the previous. A drop below or duplicate means a lost /
+            // reordered / corrupted record -- refuse rather than fold a holed delta stream.
+            if record.sequence <= last_sequence {
+                return Err(IndexLogError::Corruption(format!(
+                    "index-log delta sequence continuity violation: record sequence {} is not greater than previous {}",
+                    record.sequence, last_sequence
+                )));
+            }
+            last_sequence = record.sequence;
+            // A whole-index IndexLogRecord also deserializes into IndexDeltaRecord (its `index`
+            // field is ignored, leaving the delta fields empty). Only keep records that carry a
+            // delta payload OR a WAL anchor (an anchor-only record still advances the
+            // reconstructed watermark on load).
+            if record.items.is_empty()
+                && record.meta.is_none()
+                && record.key_states.is_empty()
+                && record.applied_wal_sequence.is_none()
+            {
+                continue;
+            }
+            if record.sequence > retain_after_sequence {
+                records.push(record);
             }
         }
         Ok(records)
@@ -491,9 +531,13 @@ impl LocalIndexLogStore {
         max_bytes: u64,
     ) -> Result<Vec<(u64, Vec<u8>)>, IndexLogError> {
         let mut inner = self.inner.lock().expect("index log lock poisoned");
-        let _ = last_sequence_at(&inner.root, shard_id)?;
         let path = index_log_path(&inner.root, shard_id);
-        let mut file = File::open(path)?;
+        if !path.exists() {
+            inner.stats.scans += 1;
+            return Ok(Vec::new());
+        }
+        let _ = last_sequence_at(&inner.root, shard_id)?;
+        let mut file = File::open(&path)?;
         file.seek(SeekFrom::Start(start_offset))?;
         let mut reader = BufReader::new(file);
         let mut offset = start_offset;
@@ -558,14 +602,23 @@ impl LocalIndexLogStore {
                 continue;
             }
             records_before += 1;
-            let record: IndexLogRecord = serde_json::from_str(&line)?;
+            // Preserve the exact on-disk payload for retained records so a delta record is not
+            // silently re-encoded as a whole-index record (which would drop its items/meta).
+            // Decode verifies the integrity envelope; the retained raw payload is re-framed on
+            // write-out below.
+            let payload = crate::log_framing::decode_line(line.as_bytes())?;
+            let record: IndexLogRecord = serde_json::from_slice(payload)?;
             if record.sequence < retain_from_sequence {
                 removable_records_before_budget = removable_records_before_budget.saturating_add(1);
             }
             if record.sequence >= retain_from_sequence
                 || (max_entries_per_round > 0 && removed_this_round >= max_entries_per_round)
             {
-                retained.push(record);
+                // Retain the EXACT decoded payload, not a re-serialized IndexLogRecord: a delta
+                // record also parses as IndexLogRecord (its delta fields are dropped), so
+                // re-encoding the parsed struct would silently destroy retained delta items on
+                // a GC round. Re-frame the untouched payload on write-out below.
+                retained.push(payload.to_vec());
             } else {
                 removed_this_round = removed_this_round.saturating_add(1);
             }
@@ -574,9 +627,8 @@ impl LocalIndexLogStore {
         let temp_path = path.with_extension("jsonl.tmp");
         {
             let mut temp = File::create(&temp_path)?;
-            for record in &retained {
-                serde_json::to_writer(&mut temp, record)?;
-                temp.write_all(b"\n")?;
+            for payload in &retained {
+                temp.write_all(&crate::log_framing::encode_line(payload))?;
             }
             temp.flush()?;
             temp.sync_all()?;
@@ -647,10 +699,12 @@ fn last_sequence_at(root: &Path, shard_id: ShardId) -> Result<u64, IndexLogError
         // it as end-of-log would set_len the file down to the last parseable record -- silently
         // dropping durable index-log records after the corrupt one AND rewinding the sequence
         // counter (the next append reuses a sequence that dump manifests already reference).
-        // Surface it as an error (index-log replay returns DataLoss on a hole / CRC
+        // Surface it as an error (index-log replay returns DataLoss on a hole / digest
         // mismatch, never trims). A genuine torn tail lacks the trailing '\n' (break above).
-        // Mirrors the WAL fix in wal.rs::last_wal_sequence_at.
-        let record = serde_json::from_slice::<IndexLogRecord>(&line)?;
+        // `decode_line` verifies the per-record length + SHA-256 envelope (crate::log_framing)
+        // and accepts legacy unframed records unchanged. Mirrors wal.rs::last_wal_sequence_at.
+        let payload = crate::log_framing::decode_line(&line)?;
+        let record = serde_json::from_slice::<IndexLogRecord>(payload)?;
         last = last.max(record.sequence);
         good_offset = offset;
     }
@@ -718,7 +772,8 @@ mod tests {
         assert_eq!(sequence, 1);
         let rows = store.scan(5, 0, u64::MAX, u64::MAX).unwrap();
         assert_eq!(rows.len(), 1);
-        let record: IndexLogRecord = serde_json::from_slice(&rows[0].1).unwrap();
+        let payload = crate::log_framing::decode_line(&rows[0].1).unwrap();
+        let record: IndexLogRecord = serde_json::from_slice(payload).unwrap();
         assert_eq!(record.shard_id, 5);
         assert_eq!(record.sequence, 1);
         assert_eq!(record.index, serde_json::json!({"value": 1}));
@@ -873,5 +928,99 @@ mod tests {
             reopened.scan(5, 0, u64::MAX, u64::MAX).is_err(),
             "interior index-log corruption must be fatal, not silently truncated"
         );
+    }
+
+    #[test]
+    fn read_delta_records_propagates_interior_delta_corruption() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        for key in ["a", "b", "c"] {
+            store
+                .append_delta(5, vec![page_item(1, key, false)], Vec::new(), Some(1), None)
+                .unwrap();
+        }
+        drop(store);
+        // Corrupt the 2nd delta record in place, keeping it newline-terminated with the 3rd
+        // intact after it. Previously read_delta_records `if let Ok(..)` SILENTLY SKIPPED such
+        // a line and folded on -- losing a removal/eviction recorded only in that delta. It
+        // must now propagate the error and abort.
+        let path = index_log_path(dir.path(), 5);
+        let contents = std::fs::read(&path).unwrap();
+        let mut lines: Vec<Vec<u8>> = contents
+            .split(|&byte| byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| line.to_vec())
+            .collect();
+        assert_eq!(lines.len(), 3);
+        lines[1] = b"corrupt-not-a-record".to_vec();
+        let mut rebuilt = Vec::new();
+        for line in &lines {
+            rebuilt.extend_from_slice(line);
+            rebuilt.push(b'\n');
+        }
+        std::fs::write(&path, &rebuilt).unwrap();
+        let reopened = LocalIndexLogStore::new(dir.path());
+        assert!(
+            reopened.read_delta_records(5, 0).is_err(),
+            "an interior delta record that fails to decode must abort, not be silently skipped"
+        );
+    }
+
+    #[test]
+    fn read_delta_records_enforces_sequence_continuity() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        for (index, key) in ["a", "b", "c"].iter().enumerate() {
+            store
+                .append_delta(
+                    5,
+                    vec![page_item(1, key, false)],
+                    Vec::new(),
+                    Some(index as u64 + 1),
+                    None,
+                )
+                .unwrap();
+        }
+        drop(store);
+        // Reorder the (valid, framed) records so their sequences read 1, 3, 2 -- a continuity
+        // violation that means a record was lost/reordered. Each line is individually valid
+        // (correct digest), so this exercises the sequence-continuity guard, not the checksum.
+        let path = index_log_path(dir.path(), 5);
+        let contents = std::fs::read(&path).unwrap();
+        let lines: Vec<Vec<u8>> = contents
+            .split(|&byte| byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| line.to_vec())
+            .collect();
+        assert_eq!(lines.len(), 3);
+        let mut rebuilt = Vec::new();
+        for index in [0usize, 2, 1] {
+            rebuilt.extend_from_slice(&lines[index]);
+            rebuilt.push(b'\n');
+        }
+        std::fs::write(&path, &rebuilt).unwrap();
+        let reopened = LocalIndexLogStore::new(dir.path());
+        match reopened.read_delta_records(5, 0) {
+            Err(IndexLogError::Corruption(_)) => {}
+            other => panic!("out-of-order delta sequences must be a Corruption error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_unframed_index_log_still_loads_after_upgrade() {
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-upgrade whole-index records: raw single-line JSON, no framing.
+        let path = index_log_path(dir.path(), 8);
+        let raw = b"{\"shard_id\":8,\"sequence\":1,\"index\":{\"v\":1}}\n{\"shard_id\":8,\"sequence\":2,\"index\":{\"v\":2}}\n";
+        std::fs::write(&path, raw).unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        assert_eq!(store.stats(8).last_sequence, 2);
+        assert_eq!(store.scan(8, 0, u64::MAX, u64::MAX).unwrap().len(), 2);
+        // A new append is framed; the mixed file still loads and continues the sequence.
+        let record = store.append_json(8, b"{\"v\":3}").unwrap();
+        assert_eq!(record.sequence, 3);
+        let reopened = LocalIndexLogStore::new(dir.path());
+        assert_eq!(reopened.scan(8, 0, u64::MAX, u64::MAX).unwrap().len(), 3);
+        assert_eq!(reopened.stats(8).last_sequence, 3);
     }
 }

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod engine;
 pub mod http;
 pub mod index_log;
 pub mod ingestion;
+pub(crate) mod log_framing;
 #[cfg(feature = "matrixobject")]
 pub mod matrixobject_store;
 pub mod meta;

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Per-record integrity framing for the append-only JSON logs (WAL + served-index log).
+//!
+//! Historically each log record was a bare single-line JSON document terminated by `\n`.
+//! A value-preserving bit-flip -- a flipped digit in a sequence/ttl, a flipped byte inside
+//! a base64 value -- parses cleanly and would replay as truth on the default recovery path.
+//! Framing wraps each line with a magic prefix, the payload length, and a truncated SHA-256
+//! digest of the payload, so a silent corruption of an otherwise-complete committed record
+//! is detected on read and surfaced as data loss rather than applied.
+//!
+//! Backward compatibility: a legacy unframed record is a serialized JSON object, so it
+//! always begins with `{`. A framed record begins with [`FRAME_MAGIC`]. [`decode_line`]
+//! detects the framing by that prefix and, for a legacy record, treats the whole line as the
+//! payload -- so a WAL / index-log written before this change still loads unchanged. New
+//! writes are framed; the two coexist in one file across an upgrade (and across a GC rewrite,
+//! which re-emits every retained record framed).
+//!
+//! Framed line layout (single line, `\n`-terminated on disk):
+//! `#tsf1 <payload_len> <digest_hex> <payload_json>\n`
+//! The payload JSON is compact serde output, so it contains neither a literal `\n` (line
+//! boundary) nor is its boundary ambiguous: the first two space-delimited fields after the
+//! magic are the length and digest, and everything after the third space is the payload
+//! (which may itself contain spaces inside JSON string values).
+
+use sha2::{Digest, Sha256};
+
+/// ASCII framing prefix, including the trailing space that delimits the fields after it.
+/// Chosen so it can never collide with a legacy record: a serialized JSON object always
+/// starts with `{`, never `#`.
+pub(crate) const FRAME_MAGIC: &[u8] = b"#tsf1 ";
+
+/// Number of leading SHA-256 bytes retained in the framed digest. 8 bytes (a 64-bit digest,
+/// 16 hex chars) is ample to catch accidental corruption of a committed record.
+const DIGEST_BYTES: usize = 8;
+
+/// Integrity failure discovered while decoding a framed log line. Carried into the WAL /
+/// index-log error types (as their `Corruption` variant) so the recovery path surfaces it as
+/// data loss and refuses the load rather than silently applying or skipping the record.
+#[derive(Debug, Clone)]
+pub(crate) struct FramingError(pub String);
+
+impl std::fmt::Display for FramingError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "log record integrity error: {}", self.0)
+    }
+}
+
+impl std::error::Error for FramingError {}
+
+fn digest_hex(payload: &[u8]) -> String {
+    let full = Sha256::digest(payload);
+    hex::encode(&full[..DIGEST_BYTES])
+}
+
+/// Encode `payload` (a single-line JSON document with NO trailing newline) as a framed,
+/// newline-terminated log line.
+pub(crate) fn encode_line(payload: &[u8]) -> Vec<u8> {
+    let digest = digest_hex(payload);
+    let header = format!("#tsf1 {} {} ", payload.len(), digest);
+    let mut out = Vec::with_capacity(header.len() + payload.len() + 1);
+    out.extend_from_slice(header.as_bytes());
+    out.extend_from_slice(payload);
+    out.push(b'\n');
+    out
+}
+
+/// Decode one raw log line (as read by a `\n`-delimited reader; a trailing newline is
+/// optional and stripped) into its JSON payload bytes, verifying the integrity envelope when
+/// present. A legacy unframed record is returned as-is (minus any trailing newline). A framed
+/// record whose declared length or digest does not match its payload is COMMITTED corruption
+/// and returns `Err`.
+pub(crate) fn decode_line(line: &[u8]) -> Result<&[u8], FramingError> {
+    let line = strip_trailing_newline(line);
+    if !line.starts_with(FRAME_MAGIC) {
+        // Legacy unframed record (or a blank line): the whole line is the payload.
+        return Ok(line);
+    }
+    let rest = &line[FRAME_MAGIC.len()..];
+    let (len_field, rest) = split_once_space(rest)
+        .ok_or_else(|| FramingError("framed record missing length field".to_string()))?;
+    let (digest_field, payload) = split_once_space(rest)
+        .ok_or_else(|| FramingError("framed record missing digest field".to_string()))?;
+    let declared_len: usize = std::str::from_utf8(len_field)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| FramingError("framed record has an unparseable length field".to_string()))?;
+    if declared_len != payload.len() {
+        return Err(FramingError(format!(
+            "framed record length mismatch: declared {declared_len}, actual {}",
+            payload.len()
+        )));
+    }
+    let actual = digest_hex(payload);
+    if actual.as_bytes() != digest_field {
+        return Err(FramingError(format!(
+            "framed record checksum mismatch: declared {}, actual {actual}",
+            String::from_utf8_lossy(digest_field)
+        )));
+    }
+    Ok(payload)
+}
+
+fn strip_trailing_newline(line: &[u8]) -> &[u8] {
+    if line.last() == Some(&b'\n') {
+        &line[..line.len() - 1]
+    } else {
+        line
+    }
+}
+
+fn split_once_space(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
+    bytes
+        .iter()
+        .position(|&byte| byte == b' ')
+        .map(|index| (&bytes[..index], &bytes[index + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framed_round_trip_recovers_exact_payload() {
+        let payload = br#"{"shard_id":5,"sequence":42,"value":"a b c"}"#;
+        let framed = encode_line(payload);
+        assert!(framed.ends_with(b"\n"));
+        assert!(framed.starts_with(FRAME_MAGIC));
+        assert_eq!(decode_line(&framed).unwrap(), payload);
+    }
+
+    #[test]
+    fn legacy_unframed_line_is_returned_as_payload() {
+        let legacy = b"{\"shard_id\":5,\"sequence\":1}\n";
+        assert_eq!(decode_line(legacy).unwrap(), &legacy[..legacy.len() - 1]);
+        // Without a trailing newline too.
+        let legacy_no_nl = b"{\"shard_id\":5}";
+        assert_eq!(decode_line(legacy_no_nl).unwrap(), legacy_no_nl);
+    }
+
+    #[test]
+    fn value_preserving_bitflip_in_framed_payload_is_detected() {
+        let payload = br#"{"shard_id":5,"sequence":42}"#;
+        let mut framed = encode_line(payload);
+        // Flip a digit in the payload's sequence so it STILL parses as valid JSON but no
+        // longer matches the framed digest.
+        let position = framed
+            .windows(3)
+            .position(|window| window == b":42")
+            .expect("payload contains :42")
+            + 2;
+        framed[position] = b'9'; // 42 -> 49, still valid JSON
+        let decoded = decode_line(&framed);
+        assert!(
+            decoded.is_err(),
+            "a value-preserving bit-flip must fail the framed checksum"
+        );
+    }
+
+    #[test]
+    fn truncated_length_field_is_rejected() {
+        let payload = br#"{"a":1}"#;
+        let mut framed = encode_line(payload);
+        // Corrupt the declared length so it no longer matches the payload length.
+        let magic_len = FRAME_MAGIC.len();
+        framed[magic_len] = b'9';
+        assert!(decode_line(&framed).is_err());
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -21,6 +21,27 @@ pub enum WriteAheadLogError {
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
+    /// A committed, newline-terminated record failed its per-record integrity envelope (the
+    /// length or CRC/SHA-256 digest did not match the payload). This is silent value-loss --
+    /// a bit-flip that still parses as JSON -- so recovery surfaces it as data loss and
+    /// refuses to trust the record rather than replaying the corrupted value.
+    #[error("wal record integrity error: {0}")]
+    Corruption(String),
+}
+
+impl From<crate::log_framing::FramingError> for WriteAheadLogError {
+    fn from(err: crate::log_framing::FramingError) -> Self {
+        WriteAheadLogError::Corruption(err.0)
+    }
+}
+
+/// Decode one raw WAL line (framed or legacy-unframed) into a [`WriteAheadLogRecord`],
+/// verifying the per-record integrity envelope when present. Used by every WAL reader
+/// (`last_wal_sequence_at`, `scan` consumers, GC, `info`) so a value-preserving bit-flip in a
+/// committed record surfaces as `Corruption` instead of replaying as truth.
+pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
+    let payload = crate::log_framing::decode_line(line)?;
+    Ok(serde_json::from_slice::<WriteAheadLogRecord>(payload)?)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -505,9 +526,16 @@ impl LocalWriteAheadLogStore {
         max_bytes: u64,
     ) -> Result<Vec<(u64, Vec<u8>)>, WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
-        let _ = last_wal_sequence_at(&inner.root, shard_id)?;
         let path = write_ahead_log_path(&inner.root, shard_id);
-        let mut file = File::open(path)?;
+        // An absent WAL file is "nothing to scan", not an error. Distinguishing it here lets
+        // recovery treat a missing WAL as "nothing to replay" while still surfacing a genuine
+        // scan/decode failure (corruption) as data loss (see engine::lifecycle replay).
+        if !path.exists() {
+            inner.stats.scans += 1;
+            return Ok(Vec::new());
+        }
+        let _ = last_wal_sequence_at(&inner.root, shard_id)?;
+        let mut file = File::open(&path)?;
         file.seek(SeekFrom::Start(start_offset))?;
         let mut reader = BufReader::new(file);
         let mut offset = start_offset;
@@ -599,7 +627,7 @@ impl LocalWriteAheadLogStore {
                 continue;
             }
             records_before += 1;
-            let record: WriteAheadLogRecord = serde_json::from_str(&line)?;
+            let record = decode_wal_line(line.as_bytes())?;
             if record.sequence >= effective_retain {
                 retained.push(record);
             }
@@ -609,8 +637,8 @@ impl LocalWriteAheadLogStore {
         {
             let mut temp = File::create(&temp_path)?;
             for record in &retained {
-                serde_json::to_writer(&mut temp, record)?;
-                temp.write_all(b"\n")?;
+                // Re-emit each retained record framed so the integrity envelope survives GC.
+                temp.write_all(&crate::log_framing::encode_line(&serde_json::to_vec(record)?))?;
             }
             temp.flush()?;
             temp.sync_all()?;
@@ -661,7 +689,7 @@ impl LocalWriteAheadLogStore {
             if line.trim().is_empty() {
                 continue;
             }
-            let record: WriteAheadLogRecord = serde_json::from_str(&line)?;
+            let record = decode_wal_line(line.as_bytes())?;
             if start_sequence == 0 {
                 start_sequence = record.sequence;
             }
@@ -809,8 +837,10 @@ fn append_record_locked(
 ) -> Result<WriteAheadLogAppendReport, WriteAheadLogError> {
     let path = write_ahead_log_path(&inner.root, record.shard_id);
     let offset = path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
-    let mut bytes = serde_json::to_vec(record)?;
-    bytes.push(b'\n');
+    // Frame the record with a length + SHA-256 digest so a later value-preserving bit-flip in
+    // this committed line is detected on read (see `crate::log_framing`). Offsets/stats below
+    // use the real byte length, so framing is transparent to the append report and replication.
+    let bytes = crate::log_framing::encode_line(&serde_json::to_vec(record)?);
     let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
     file.write_all(&bytes)?;
     if sync {
@@ -866,15 +896,17 @@ fn last_wal_sequence_at(root: &Path, shard_id: ShardId) -> Result<u64, WriteAhea
             good_offset = offset;
             continue;
         }
-        // A fully newline-terminated line that fails to parse is COMMITTED corruption, not a
+        // A fully newline-terminated line that fails to decode is COMMITTED corruption, not a
         // torn tail: WAL records are single-line JSON with no embedded newline, so a complete
-        // (\n-terminated) line is a complete write. Surface it as an error instead of breaking
-        // -- treating interior corruption as end-of-log would set_len the file down to the last
-        // parseable record, silently dropping every durable record after the corrupt one and
-        // defeating the strict replay-continuity DataLoss guard (ReplayWal returns
-        // DataLoss on a CRC failure / hole rather than trimming). A genuine torn tail lacks the
-        // trailing '\n' and is still handled by the break above.
-        let record = serde_json::from_slice::<WriteAheadLogRecord>(&line)?;
+        // (\n-terminated) line is a complete write. `decode_wal_line` verifies the per-record
+        // length + SHA-256 digest envelope (crate::log_framing) and returns `Corruption` on a
+        // value-preserving bit-flip; a legacy unframed record still decodes as before. Surface
+        // it as an error instead of breaking -- treating interior corruption as end-of-log
+        // would set_len the file down to the last good record, silently dropping every durable
+        // record after the corrupt one and defeating the strict replay-continuity DataLoss
+        // guard (ReplayWal refuses the load on a digest failure / hole rather than trimming). A
+        // genuine torn tail lacks the trailing '\n' and is still handled by the break above.
+        let record = decode_wal_line(&line)?;
         last = last.max(record.sequence);
         good_offset = offset;
     }
@@ -1133,6 +1165,91 @@ mod tests {
             restarted.scan(1, 0, u64::MAX, u64::MAX).is_err(),
             "interior WAL corruption must be fatal, not silently truncated to the last good record"
         );
+    }
+
+    #[test]
+    fn framed_wal_bitflip_that_still_parses_json_is_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        store
+            .append(
+                1,
+                Command::StringSet {
+                    key: "alpha".to_string(),
+                    value: b"one".to_vec(),
+                },
+            )
+            .unwrap();
+        store
+            .append(
+                1,
+                Command::StringSet {
+                    key: "target".to_string(),
+                    value: b"two".to_vec(),
+                },
+            )
+            .unwrap();
+        drop(store);
+        // Flip one byte inside the second record's key ("target" -> "tbrget"): the framed line
+        // stays VALID JSON but no longer matches its per-record SHA-256 digest. Without framing
+        // this would replay as truth; with it, the committed corruption is fatal.
+        let path = write_ahead_log_path(dir.path(), 1);
+        let mut bytes = std::fs::read(&path).unwrap();
+        let position = bytes
+            .windows(6)
+            .position(|window| window == b"target")
+            .expect("second record contains the target key");
+        bytes[position + 1] = b'b';
+        std::fs::write(&path, &bytes).unwrap();
+        let reopened = LocalWriteAheadLogStore::new(dir.path());
+        let scanned = reopened.scan(1, 0, u64::MAX, u64::MAX);
+        match scanned {
+            Err(WriteAheadLogError::Corruption(_)) => {}
+            other => panic!("expected a Corruption error from a value-preserving bit-flip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_unframed_wal_still_loads_after_upgrade() {
+        let dir = tempfile::tempdir().unwrap();
+        // Simulate a pre-upgrade on-disk WAL: raw single-line JSON records, no framing.
+        let path = write_ahead_log_path(dir.path(), 3);
+        let make = |sequence: u64, key: &str| WriteAheadLogRecord {
+            shard_id: 3,
+            sequence,
+            command: Command::StringSet {
+                key: key.to_string(),
+                value: b"v".to_vec(),
+            },
+            metadata: None,
+        };
+        let mut raw = serde_json::to_vec(&make(1, "k1")).unwrap();
+        raw.push(b'\n');
+        raw.extend_from_slice(&serde_json::to_vec(&make(2, "k2")).unwrap());
+        raw.push(b'\n');
+        std::fs::write(&path, &raw).unwrap();
+
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        // The legacy (unframed) records still load: sequence tail + scan see both.
+        assert_eq!(store.stats(3).last_sequence, 2);
+        let rows = store.scan(3, 0, u64::MAX, u64::MAX).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(decode_wal_line(&rows[0].1).unwrap().sequence, 1);
+        assert_eq!(decode_wal_line(&rows[1].1).unwrap().sequence, 2);
+        // A new append is framed and continues the sequence; the mixed file still loads.
+        let appended = store
+            .append(
+                3,
+                Command::StringSet {
+                    key: "k3".to_string(),
+                    value: b"v".to_vec(),
+                },
+            )
+            .unwrap();
+        assert_eq!(appended.sequence, 3);
+        let reopened = LocalWriteAheadLogStore::new(dir.path());
+        assert_eq!(reopened.scan(3, 0, u64::MAX, u64::MAX).unwrap().len(), 3);
+        assert_eq!(reopened.stats(3).last_sequence, 3);
     }
 
     // rust-internal: verifies Rust WAL alias exports remain wired to the local mutation log API.


### PR DESCRIPTION
## Round-2 fault-tolerance / silent-data-loss fixes on the default recovery path

Six independent correctness gaps, all silent data-loss / corruption on the **default** recovery path. They share the persistence / WAL / index-log files, so they land together.

- **F1** `atomic_write_bytes_synced` now fsyncs the **parent directory** after the rename when `sync=true` (`engine.rs`). Backs the dump manifest (durable WAL-reclaim watermark), base index and install markers: without a durable directory entry a dump could let WAL-GC truncate the WAL to the manifest watermark, then a crash loses the manifest dir entry while the reclaimed WAL is already gone = permanent acked-write loss.
- **F2** Per-record integrity framing for the append-only JSON logs (new `log_framing.rs`; `wal.rs`, `index_log.rs`). Each WAL / served-index-log line is framed with a length + truncated SHA-256 digest; readers verify it and surface `Corruption` on a value-preserving bit-flip (a flipped digit/byte that still parses as JSON) instead of replaying it as truth. **Backward-compatible**: a legacy unframed record begins with `{`, a framed one with a magic prefix, so a pre-upgrade WAL / index-log still loads (the two coexist across an upgrade, and a GC rewrite re-emits retained records framed). The inaccurate "CRC guard" comments are made accurate. (The dump manifest already carries a verified checksum + `index_sha256`; the standalone base-index at-rest checksum is left as a documented follow-up — it is atomic+durable already, so only media bit-rot is uncovered.)
- **F3** `read_delta_records` now **propagates** a decode/parse failure instead of silently skipping the line, and enforces strict delta sequence-continuity (`index_log.rs`). A silently skipped delta advances the reconstructed anchor past a removal/eviction recorded only in the delta (not the WAL) = silent loss / dangling ref. `fold_index_log_deltas` and `load_index_inner` propagate the error and `load_shard_with` **refuses** the load.
- **F4** WAL replay no longer swallows a corrupt/unreadable scan error into `Ok(())` (`lifecycle.rs`). `scan()` returns an empty vec for an absent WAL (the only "nothing to replay" case), so any `Err` is genuine data loss → abort the load rather than serve the stale base index and silently drop the committed WAL tail. Records decode through the integrity-verifying decoder and failures propagate.
- **RN1** The compaction **success** path now takes the page-durability barrier (`page_store.sync_durable`) before publishing the base index that names the relocated pages (`recovery_sweep_compact.rs`), matching the barrier the partial-failure path already had. Under deferred-fsync modes a crash after writing the naming index but before the next barrier left dangling references at an un-synced slab.
- **RN2** `run_storage_manager_cycle` short-circuits to an inert no-op while the shard is `recovering` (`storage_manager_cycle.rs`). A GC/compaction/reclaim round interleaved with an in-flight WAL replay could observe a half-reconstructed bucket index and mis-reclaim a live page. The `recovering` gate is path-independent (covers both the async load and the synchronous `POST /load`).

### Tests
`log_framing` round-trip + bit-flip + legacy detection; WAL framed-bit-flip-is-fatal + legacy-unframed-still-loads; index-log interior-corruption-propagates + sequence-continuity + legacy-still-loads; engine-level corrupt-WAL-refuses-load (F4), corrupt-index-log-delta-refuses-load (F3), and storage-manager-cycle-no-op-while-recovering (RN2). New tests pass; full single-threaded lib suite shows zero new failures vs baseline.

> Note: `cargo check --tests` on this branch surfaces one **pre-existing** failure on the mirror's main — a non-exhaustive `match` on `CommandResponse::ContextEmbeddingDirtyMarkers` in `tests/unified_temporalstore_corpus.rs` — which is unrelated to this change (that file and `types.rs` are untouched here).
