### PR TITLE
fix(retrieval): make the context pack respect the caller budget symmetrically + de-noise

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -134,6 +134,7 @@ max_candidates_per_node = 1024              # MATRIXARK_MAX_CANDIDATES_PER_NODE 
 max_global_candidates = 2048                # MATRIXARK_MAX_GLOBAL_CANDIDATES  global candidate scan cap
 max_selected_refs = 1000                    # MATRIXARK_MAX_SELECTED_REFS  hard cap on refs in a pack
 budget_fill_policy = "quality_first"        # MATRIXARK_BUDGET_FILL_POLICY  quality_first keeps the pack signal-not-noise
+near_duplicate_overlap_threshold = 0.85     # MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD  drop a candidate whose token-set Jaccard similarity with a higher-ranked already-selected ref is >= this (de-noise now that defaults return more). 1.0 = only token-identical collapses; 0 = disabled.
 max_children_scored_per_parent = 100000     # MATRIXARK_MAX_CHILDREN_SCORED_PER_PARENT  fan-out scoring cap
 # --- cross-session lane (breadth across other sessions) ---
 cross_session_budget_ratio = 0.12           # MATRIXARK_CROSS_SESSION_BUDGET_RATIO  fraction of the pack budget for cross-session refs

--- a/tools/matrixark_http.py
+++ b/tools/matrixark_http.py
@@ -250,7 +250,7 @@ def _agent_hook_call(server: Any, body: Json) -> Json:
         retrieve_args: Json = {
             **args_common,
             "query": str(body.get("query") or text or event)[:500],
-            "max_context_tokens": int(body.get("max_context_tokens") or normalized.get("max_context_tokens") or GATEWAY_DEFAULT_MAX_CONTEXT_TOKENS),
+            "max_context_tokens": int(body.get("max_context_tokens") or normalized.get("max_context_tokens") or body.get("budget") or normalized.get("budget") or GATEWAY_DEFAULT_MAX_CONTEXT_TOKENS),
             "audit_mode": str(body.get("audit_mode") or normalized.get("audit_mode") or "telemetry_only"),
             "audit_sample_rate": float(body.get("audit_sample_rate") or normalized.get("audit_sample_rate") or 0.0),
             "metadata": retrieve_metadata,
@@ -750,6 +750,24 @@ def apply_ingest_route_defaults(path: str, args: Json) -> Json:
     return args
 
 
+def apply_retrieve_budget_alias(args: Json) -> Json:
+    """Alias the client-facing ``budget`` knob onto ``max_context_tokens``.
+
+    The documented public retrieve knob is ``budget``, but the gateway and the
+    ``matrixark_retrieve`` tool read ``max_context_tokens`` -- so ``budget`` was
+    silently ignored. Accept either: ``max_context_tokens`` wins when both are
+    supplied, otherwise a non-empty ``budget`` populates it. Pure apart from
+    mutating the passed args dict.
+    """
+    if not isinstance(args, dict):
+        return args
+    if args.get("max_context_tokens") in (None, ""):
+        budget = args.get("budget")
+        if budget not in (None, ""):
+            args["max_context_tokens"] = budget
+    return args
+
+
 def make_matrixark_http_handler(server: "MatrixArkMcpServer", static_root: Path) -> type[SimpleHTTPRequestHandler]:
     static_root = static_root.resolve()
 
@@ -815,6 +833,8 @@ def make_matrixark_http_handler(server: "MatrixArkMcpServer", static_root: Path)
                     self._write_auth_required(tool_name)
                     return
                 _http_api_key(self.headers, args)
+                if tool_name == "matrixark_retrieve":
+                    apply_retrieve_budget_alias(args)
                 result = server.call_tool(tool_name, args)
                 self._write_json(200, {"status": "ok", "tool": tool_name, "result": result})
             except Exception as exc:

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -126,6 +126,7 @@ ENV_MAP: Dict[str, str] = {
     "retrieval.max_global_candidates": "MATRIXARK_MAX_GLOBAL_CANDIDATES",
     "retrieval.max_selected_refs": "MATRIXARK_MAX_SELECTED_REFS",
     "retrieval.budget_fill_policy": "MATRIXARK_BUDGET_FILL_POLICY",
+    "retrieval.near_duplicate_overlap_threshold": "MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD",
     "retrieval.max_children_scored_per_parent": "MATRIXARK_MAX_CHILDREN_SCORED_PER_PARENT",
     "retrieval.cross_session_budget_ratio": "MATRIXARK_CROSS_SESSION_BUDGET_RATIO",
     "retrieval.cross_session_max_candidates": "MATRIXARK_CROSS_SESSION_MAX_CANDIDATES",

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -89,7 +89,21 @@ MATRIXARK_ALLOW_PYTHON_HOT_CACHE = os.environ.get("MATRIXARK_ALLOW_PYTHON_HOT_CA
 MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER = os.environ.get("MATRIXARK_REQUIRE_NATIVE_CANDIDATE_PREFILTER", "").strip().lower()
 BACKEND_READINESS_CONNECT_TIMEOUT_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_CONNECT_TIMEOUT_MS", "1000"))
 
-DEFAULT_MAX_CONTEXT_TOKENS = int(os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS", "128000"))
+# Single source of truth: reuse the runtime-config default so core and
+# matrixark_mcp_runtime_config agree out-of-the-box (both were previously
+# reading the same env var but with different fallback literals -- 128000 here
+# vs 500000 in runtime_config -- so an operator who set nothing got a 128k
+# ceiling from core paths and a 500k ceiling from runtime-config paths). Both
+# still honour MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS when it is set.
+try:
+    from tools.matrixark_mcp_runtime_config import (
+        DEFAULT_MAX_CONTEXT_TOKENS as _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_mcp_runtime_config import (
+        DEFAULT_MAX_CONTEXT_TOKENS as _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS,
+    )
+DEFAULT_MAX_CONTEXT_TOKENS = _RUNTIME_DEFAULT_MAX_CONTEXT_TOKENS
 CONTEXT_PACK_DEBUG_REFS = os.environ.get("MATRIXARK_CONTEXT_PACK_DEBUG_REFS", "0").strip().lower() in {"1", "true", "yes"}
 AUDIT_DEBUG_PAYLOAD = os.environ.get("MATRIXARK_AUDIT_DEBUG_PAYLOAD", "0").strip().lower() in {"1", "true", "yes"}
 CONTEXT_PACK_DEBUG_LINEAGE = os.environ.get("MATRIXARK_CONTEXT_PACK_DEBUG_LINEAGE", "0").strip().lower() in {"1", "true", "yes"}
@@ -144,6 +158,12 @@ DEFAULT_MAX_CANDIDATES_PER_NODE = int(os.environ.get("MATRIXARK_MAX_CANDIDATES_P
 DEFAULT_MAX_GLOBAL_CANDIDATES = int(os.environ.get("MATRIXARK_MAX_GLOBAL_CANDIDATES", "512"))
 DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "64"))
 DEFAULT_BUDGET_FILL_POLICY = os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "quality_first").strip().lower()
+# Near-duplicate suppression threshold (see matrixark_mcp_runtime_config for the
+# canonical definition). Reused here so the ref-selection path shares one source
+# of truth for the knob.
+DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD = float(
+    os.environ.get("MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD", "0.85")
+)
 DEFAULT_CROSS_SESSION_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_BUDGET_RATIO", "0.12"))
 DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO", "0.20"))
 DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO", "0.20"))

--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -11,6 +11,7 @@ try:  # package path (tools.matrixark_mcp_core)
         DEFAULT_BUDGET_FILL_POLICY,
         DEFAULT_MAX_GLOBAL_CANDIDATES,
         DEFAULT_MAX_SELECTED_REFS,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
         DEFAULT_RETRIEVAL_MIN_SCORE,
         Json,
         candidate_memory_layer_name,
@@ -35,6 +36,7 @@ except ImportError:  # top-level path (matrixark_mcp_core)
         DEFAULT_BUDGET_FILL_POLICY,
         DEFAULT_MAX_GLOBAL_CANDIDATES,
         DEFAULT_MAX_SELECTED_REFS,
+        DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
         DEFAULT_RETRIEVAL_MIN_SCORE,
         Json,
         candidate_memory_layer_name,
@@ -55,7 +57,75 @@ except ImportError:  # top-level path (matrixark_mcp_core)
         tokens,
     )
 
-__all__ = ['dropped_candidate_audit_ref', 'record_dropped_candidate', 'diversify_for_question_type', 'entity_current_state_key', 'prefer_profile_entities_for_current_state', 'is_stale_or_superseded_candidate', 'suppress_profile_shadowed_session_entity_refs', 'select_token_budgeted_refs']
+__all__ = ['dropped_candidate_audit_ref', 'record_dropped_candidate', 'diversify_for_question_type', 'entity_current_state_key', 'prefer_profile_entities_for_current_state', 'is_stale_or_superseded_candidate', 'suppress_profile_shadowed_session_entity_refs', 'normalized_token_set', 'near_duplicate_overlap_ratio', 'clamp_refs_to_token_budget', 'select_token_budgeted_refs']
+
+
+def normalized_token_set(text: str) -> frozenset[str]:
+    """Lower-cased, de-duplicated token set used for near-duplicate detection."""
+    return frozenset(token.lower() for token in tokens(str(text or "")) if token)
+
+
+def near_duplicate_overlap_ratio(candidate_tokens: frozenset[str], selected_tokens: frozenset[str]) -> float:
+    """Jaccard token-set similarity between two refs (|A ∩ B| / |A ∪ B|).
+
+    Jaccard is the near-duplicate metric here (rather than containment) so a
+    short ref whose few tokens merely happen to be a subset of a longer but
+    genuinely different ref is NOT collapsed: near-duplicate requires the two
+    texts to be substantially the same, in both content and size. Ranges 0.0
+    (disjoint) .. 1.0 (identical token sets).
+    """
+    if not candidate_tokens or not selected_tokens:
+        return 0.0
+    intersection = len(candidate_tokens & selected_tokens)
+    if intersection == 0:
+        return 0.0
+    union = len(candidate_tokens | selected_tokens)
+    if union <= 0:
+        return 0.0
+    return intersection / union
+
+
+def clamp_refs_to_token_budget(
+    refs: list[Json],
+    max_context_tokens: int,
+    *,
+    reserved_tokens: int = 0,
+) -> tuple[list[Json], list[Json], int]:
+    """Enforce the token ceiling on an already ranked list of refs.
+
+    ``refs`` must be ordered best-first. Keeps the highest-ranked prefix whose
+    cumulative token estimate fits within ``max_context_tokens - reserved_tokens``
+    and returns ``(kept, trimmed, used_tokens)``. Ceiling-not-target: a short
+    ranked list that already fits is returned unchanged (never padded). At least
+    the single top ref is kept when the list is non-empty so a relevant pack is
+    never emptied by an unusually tight budget. This is the symmetric partner to
+    the in-loop budget check in ``select_token_budgeted_refs`` and is applied to
+    packs assembled outside that loop (e.g. the native backend pack path), which
+    otherwise could return a pack exceeding the caller's budget.
+    """
+    remote_budget = max(0, int(max_context_tokens) - max(0, int(reserved_tokens)))
+    kept: list[Json] = []
+    trimmed: list[Json] = []
+    used_tokens = 0
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        ref_tokens = ref.get("token_count")
+        if ref_tokens is None:
+            ref_tokens = ref.get("token_estimate")
+        if ref_tokens is None:
+            ref_tokens = token_count(str(ref.get("text", "")))
+        try:
+            ref_tokens = max(1, int(ref_tokens))
+        except (TypeError, ValueError):
+            ref_tokens = max(1, token_count(str(ref.get("text", ""))))
+        # Always keep the top ref so a relevant pack is not zeroed by a tight budget.
+        if kept and (remote_budget <= 0 or used_tokens + ref_tokens > remote_budget):
+            trimmed.append(ref)
+            continue
+        kept.append(ref)
+        used_tokens += ref_tokens
+    return kept, trimmed, used_tokens
 
 
 def dropped_candidate_audit_ref(candidate: Json, *, reason: str, token_estimate: int) -> Json:
@@ -325,6 +395,7 @@ def select_token_budgeted_refs(
     max_global_candidates: int | None = None,
     budget_fill_policy: str = DEFAULT_BUDGET_FILL_POLICY,
     duplicate_text_hashes: set[int] | None = None,
+    near_duplicate_overlap_threshold: float = DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD,
     deadline_exceeded: Callable[[], bool] | None = None,
     deadline_reason: str = "deadline_during_pack",
     cross_session_policy: Json | None = None,
@@ -344,6 +415,15 @@ def select_token_budgeted_refs(
     )
     min_score = max(0.0, min(1.0, float(min_score)))
     budget_fill_policy = (budget_fill_policy or DEFAULT_BUDGET_FILL_POLICY).strip().lower()
+    try:
+        near_duplicate_overlap_threshold = float(near_duplicate_overlap_threshold)
+    except (TypeError, ValueError):
+        near_duplicate_overlap_threshold = DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD
+    # <= 0 disables near-dup suppression; > 1 can never trigger (overlap ratio is
+    # bounded at 1.0), so clamp to a sane [0, 1] operating range.
+    near_duplicate_overlap_threshold = max(0.0, min(1.0, near_duplicate_overlap_threshold))
+    near_duplicate_enabled = near_duplicate_overlap_threshold > 0.0
+    selected_token_sets: list[frozenset[str]] = []
     candidates = merge_ranked_paths(
         primary,
         auxiliary,
@@ -655,6 +735,7 @@ def select_token_budgeted_refs(
         "stale": 0,
         "summary": 0,
         "raw_l2": 0,
+        "near_duplicate": 0,
         "cross_session_budget": 0,
         "cross_session_session_cap": 0,
         "cross_session_candidate_cap": 0,
@@ -670,10 +751,12 @@ def select_token_budgeted_refs(
         "estimated_tokens": {
             "over_budget": 0,
             "duplicate": 0,
+            "near_duplicate": 0,
             "low_score": 0,
             "stale": 0,
             "summary": 0,
             "raw_l2": 0,
+            "near_duplicate": 0,
             "cross_session_budget": 0,
             "cross_session_session_cap": 0,
             "cross_session_candidate_cap": 0,
@@ -690,6 +773,7 @@ def select_token_budgeted_refs(
         "reason_descriptions": {
             "over_budget": "candidate was relevant but exceeded the remaining remote context token budget",
             "duplicate": "candidate duplicated local context or an already selected ref",
+            "near_duplicate": "candidate text near-duplicated a higher-ranked already selected ref (token overlap above the configured threshold)",
             "low_score": "candidate score was below the minimum packing threshold",
             "stale": "candidate was stale or superseded for the query policy",
             "summary": "summary text was dropped in favor of denser raw/evidence refs",
@@ -761,6 +845,21 @@ def select_token_budgeted_refs(
             dropped["estimated_tokens"]["stale"] += ref_tokens
             record_dropped_candidate(dropped, candidate, reason="stale", token_estimate=ref_tokens)
             continue
+        # Near-duplicate suppression: drop a candidate whose normalized token set
+        # overlaps an already-selected (strictly higher-ranked, since selection is
+        # in ranked order) ref above the configured threshold, so repetitive refs
+        # do not dilute precision or spend budget on redundant content. The
+        # highest-ranked instance is the one already in `selected`, so it is kept.
+        if near_duplicate_enabled and selected_token_sets:
+            candidate_token_set = normalized_token_set(candidate.get("text", ""))
+            if candidate_token_set and any(
+                near_duplicate_overlap_ratio(candidate_token_set, selected_tokens) >= near_duplicate_overlap_threshold
+                for selected_tokens in selected_token_sets
+            ):
+                dropped["near_duplicate"] += 1
+                dropped["estimated_tokens"]["near_duplicate"] += ref_tokens
+                record_dropped_candidate(dropped, candidate, reason="near_duplicate", token_estimate=ref_tokens)
+                continue
         if remote_budget <= 0 or (selected and used_tokens + ref_tokens > remote_budget):
             dropped["over_budget"] += 1
             dropped["estimated_tokens"]["over_budget"] += ref_tokens
@@ -1031,6 +1130,8 @@ def select_token_budgeted_refs(
             )
             continue
         seen_text_hashes.add(text_hash)
+        if near_duplicate_enabled:
+            selected_token_sets.append(normalized_token_set(candidate.get("text", "")))
         selected.append(
             {
                 **candidate,

--- a/tools/matrixark_mcp_native_retrieve.py
+++ b/tools/matrixark_mcp_native_retrieve.py
@@ -11,6 +11,7 @@ from typing import Any
 try:
     from tools.matrixark_mcp_core import (
         Json,
+        clamp_refs_to_token_budget,
         compact_context_pack_audit_record,
         compact_context_pack_for_serving,
         compact_context_pack_refs,
@@ -25,6 +26,7 @@ try:
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
         Json,
+        clamp_refs_to_token_budget,
         compact_context_pack_audit_record,
         compact_context_pack_for_serving,
         compact_context_pack_refs,
@@ -99,6 +101,27 @@ def try_native_context_pack(
     native_pack.setdefault("remote_context_refs", native_pack.get("selected_refs", []))
     native_pack.setdefault("selected_ref_counts", selected_context_class_counts(native_pack.get("selected_refs", [])))
     selected_refs = native_pack.get("selected_refs", []) if isinstance(native_pack.get("selected_refs"), list) else []
+    # Symmetric budget clamp: the native backend assembles the pack, but a pack
+    # that comes back above max_context_tokens must still be trimmed to the
+    # caller's ceiling (lowest-ranked refs dropped) rather than served over
+    # budget. When the native pack already fits, nothing changes -- and raising
+    # the budget lets the engine return (and this keep) more refs. Ceiling, not
+    # target: an under-budget pack is never padded.
+    selected_refs, over_budget_trimmed_refs, clamped_used_tokens = clamp_refs_to_token_budget(
+        selected_refs, max_context_tokens
+    )
+    if over_budget_trimmed_refs:
+        native_pack["selected_refs"] = selected_refs
+        native_pack["remote_context_refs"] = selected_refs
+        native_pack["selected_ref_counts"] = selected_context_class_counts(selected_refs)
+        native_pack["used_remote_context_tokens"] = clamped_used_tokens
+        native_pack["python_budget_clamp"] = {
+            "applied": True,
+            "max_context_tokens": max_context_tokens,
+            "trimmed_ref_count": len(over_budget_trimmed_refs),
+            "used_remote_context_tokens": clamped_used_tokens,
+            "reason": "native pack exceeded max_context_tokens; trimmed lowest-ranked refs to fit the caller budget",
+        }
     context_pack_id_text = str(native_pack.get("context_pack_id") or stable_hash(f"native:{query}:{selected_refs}:{now_ms()}"))
     native_pack["context_pack_id"] = context_pack_id_text
     if audit_mode == "full" and audit_sample_rate > 0 and (

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -155,6 +155,15 @@ DEFAULT_MAX_CANDIDATES_PER_NODE = int(os.environ.get("MATRIXARK_MAX_CANDIDATES_P
 DEFAULT_MAX_GLOBAL_CANDIDATES = int(os.environ.get("MATRIXARK_MAX_GLOBAL_CANDIDATES", "2048"))
 DEFAULT_MAX_SELECTED_REFS = int(os.environ.get("MATRIXARK_MAX_SELECTED_REFS", "1000"))
 DEFAULT_BUDGET_FILL_POLICY = os.environ.get("MATRIXARK_BUDGET_FILL_POLICY", "quality_first").strip().lower()
+# Near-duplicate suppression in ref selection. A candidate whose token set has a
+# Jaccard similarity >= this ratio with an already-selected (higher-ranked) ref
+# is dropped before packing, so the richer default packs (top_k 24, cross-session
+# cands 200) do not spend budget on repetitive/near-identical refs. Jaccard (not
+# containment) is used so distinct refs that merely share a common prefix are
+# kept. 1.0 == only token-set-identical collapses; <= 0.0 disables entirely.
+DEFAULT_NEAR_DUPLICATE_OVERLAP_THRESHOLD = float(
+    os.environ.get("MATRIXARK_NEAR_DUPLICATE_OVERLAP_THRESHOLD", "0.85")
+)
 
 DEFAULT_CROSS_SESSION_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_BUDGET_RATIO", "0.12"))
 DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO = float(os.environ.get("MATRIXARK_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO", "0.20"))

--- a/tools/test_retrieval_budget_gaps.py
+++ b/tools/test_retrieval_budget_gaps.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Unit tests for the retrieval-budget gap fixes.
+
+Covers the four fixes that make the returned context pack respect the caller's
+budget symmetrically and de-noise it now that defaults return more:
+
+  1. budget-alias      -- the client-facing `budget` knob maps onto
+                          max_context_tokens (max_context_tokens wins if both).
+  2. harmonized-default -- core and runtime-config agree on the 500000 default.
+  3. symmetric-clamp    -- a pack with more-than-budget candidates is trimmed to
+                          <= budget; a small query returns a small pack
+                          (ceiling, not target); raising the budget allows more.
+  4. dedup              -- near-duplicate candidates collapse to the single
+                          highest-ranked instance before packing.
+
+Run from the tools/ directory: ``python3 test_retrieval_budget_gaps.py``.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:  # package path
+    from tools import matrixark_mcp_core as mcp_core
+    from tools import matrixark_mcp_runtime_config as runtime_config
+    from tools import matrixark_http as mcp_http
+except ImportError:  # top-level path (run from tools/)
+    import matrixark_mcp_core as mcp_core
+    import matrixark_mcp_runtime_config as runtime_config
+    import matrixark_http as mcp_http
+
+
+def _fact_candidate(ref_hash: int, text: str, score: float, ref_type: str = "event") -> dict:
+    return {"ref_type": ref_type, "ref_hash": ref_hash, "text": text, "score": score}
+
+
+class RetrieveBudgetAliasTest(unittest.TestCase):
+    """Fix 1: budget -> max_context_tokens alias in the gateway."""
+
+    def test_budget_populates_max_context_tokens(self) -> None:
+        args = {"query": "q", "budget": 42000}
+        mcp_http.apply_retrieve_budget_alias(args)
+        self.assertEqual(42000, args["max_context_tokens"])
+
+    def test_explicit_max_context_tokens_wins_over_budget(self) -> None:
+        args = {"query": "q", "budget": 42000, "max_context_tokens": 9000}
+        mcp_http.apply_retrieve_budget_alias(args)
+        self.assertEqual(9000, args["max_context_tokens"])
+
+    def test_empty_max_context_tokens_falls_back_to_budget(self) -> None:
+        args = {"query": "q", "budget": 7000, "max_context_tokens": None}
+        mcp_http.apply_retrieve_budget_alias(args)
+        self.assertEqual(7000, args["max_context_tokens"])
+
+    def test_no_budget_leaves_args_untouched(self) -> None:
+        args = {"query": "q"}
+        mcp_http.apply_retrieve_budget_alias(args)
+        self.assertNotIn("max_context_tokens", args)
+
+
+class HarmonizedDefaultTest(unittest.TestCase):
+    """Fix 2: core and runtime-config agree on the default ceiling."""
+
+    def test_core_and_runtime_config_agree(self) -> None:
+        self.assertEqual(
+            mcp_core.DEFAULT_MAX_CONTEXT_TOKENS,
+            runtime_config.DEFAULT_MAX_CONTEXT_TOKENS,
+        )
+
+    def test_default_is_500000_out_of_the_box(self) -> None:
+        # Only meaningful when the operator has not overridden the env var.
+        import os
+
+        if os.environ.get("MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS"):
+            self.skipTest("env override set; default value not under test")
+        self.assertEqual(500000, mcp_core.DEFAULT_MAX_CONTEXT_TOKENS)
+
+
+class ClampRefsToTokenBudgetTest(unittest.TestCase):
+    """Fix 3: the symmetric clamp helper used by the native pack path."""
+
+    def _refs(self, counts: list[int]) -> list[dict]:
+        return [
+            {"ref_type": "event", "ref_hash": index, "text": f"ref {index}", "token_count": count}
+            for index, count in enumerate(counts)
+        ]
+
+    def test_over_budget_pack_is_trimmed_to_fit(self) -> None:
+        refs = self._refs([5, 5, 5, 5])  # 20 tokens total, ranked best-first
+        kept, trimmed, used = mcp_core.clamp_refs_to_token_budget(refs, 12)
+        self.assertEqual(2, len(kept))          # 5 + 5 = 10 <= 12; next would be 15 > 12
+        self.assertEqual(2, len(trimmed))
+        self.assertLessEqual(used, 12)
+        self.assertEqual([0, 1], [ref["ref_hash"] for ref in kept])  # highest-ranked kept
+
+    def test_raising_budget_allows_more(self) -> None:
+        refs = self._refs([5, 5, 5, 5])
+        kept_small, _, _ = mcp_core.clamp_refs_to_token_budget(refs, 12)
+        kept_large, trimmed_large, used_large = mcp_core.clamp_refs_to_token_budget(refs, 100)
+        self.assertGreater(len(kept_large), len(kept_small))
+        self.assertEqual(4, len(kept_large))
+        self.assertEqual(0, len(trimmed_large))
+        self.assertEqual(20, used_large)
+
+    def test_under_budget_pack_is_not_padded(self) -> None:
+        refs = self._refs([3, 4])  # 7 tokens, well under budget -- ceiling not target
+        kept, trimmed, used = mcp_core.clamp_refs_to_token_budget(refs, 500000)
+        self.assertEqual(2, len(kept))
+        self.assertEqual([], trimmed)
+        self.assertEqual(7, used)
+
+    def test_top_ref_kept_even_when_over_a_tiny_budget(self) -> None:
+        refs = self._refs([50, 50])
+        kept, trimmed, used = mcp_core.clamp_refs_to_token_budget(refs, 1)
+        self.assertEqual(1, len(kept))          # never zero a relevant pack
+        self.assertEqual(1, len(trimmed))
+
+
+class SymmetricSelectionClampTest(unittest.TestCase):
+    """Fix 3: select_token_budgeted_refs enforces the ceiling both directions."""
+
+    def _distinct_candidates(self, n: int) -> list[dict]:
+        # Distinct texts (no accidental near-dup) so only the budget gates them.
+        words = [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+            "hotel", "india", "juliet", "kilo", "lima", "mike", "november",
+        ]
+        return [
+            _fact_candidate(1000 + i, f"{words[i % len(words)]} distinct fact number {i}", 0.95 - i * 0.01)
+            for i in range(n)
+        ]
+
+    def test_more_than_budget_candidates_trimmed_to_budget(self) -> None:
+        candidates = self._distinct_candidates(12)
+        total_tokens = sum(mcp_core.token_count(c["text"]) for c in candidates)
+        budget = max(1, total_tokens // 4)
+        selected, used_tokens, _dropped = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=budget, auxiliary_quota=0, min_score=0.0
+        )
+        self.assertLessEqual(used_tokens, budget)
+        self.assertGreaterEqual(len(selected), 1)
+        self.assertLess(len(selected), len(candidates))
+
+    def test_small_query_returns_small_pack_not_padded_to_budget(self) -> None:
+        candidates = self._distinct_candidates(2)
+        selected, used_tokens, _dropped = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=500000, auxiliary_quota=0, min_score=0.0
+        )
+        self.assertEqual(2, len(selected))              # ceiling, not target
+        self.assertLess(used_tokens, 100)               # nowhere near 500000
+
+    def test_raising_budget_allows_more_refs(self) -> None:
+        candidates = self._distinct_candidates(12)
+        total_tokens = sum(mcp_core.token_count(c["text"]) for c in candidates)
+        tight, _, _ = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=max(1, total_tokens // 4), auxiliary_quota=0, min_score=0.0
+        )
+        wide, _, _ = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=total_tokens * 4, auxiliary_quota=0, min_score=0.0
+        )
+        self.assertGreater(len(wide), len(tight))
+
+
+class NearDuplicateDedupTest(unittest.TestCase):
+    """Fix 4: near-duplicate suppression in the ref-selection path."""
+
+    def _dup_candidate_set(self) -> list[dict]:
+        # base has 11 unique tokens; the near-dup appends one word -> Jaccard
+        # 11/12 ~= 0.92, above the 0.85 default. A distinct fact stays distinct.
+        base = "the deployment pipeline was migrated to the staging region on friday morning"
+        return [
+            _fact_candidate(1, base, 0.97),                # highest-ranked original
+            _fact_candidate(2, base + " cleanly", 0.95),   # near-duplicate of #1
+            _fact_candidate(3, "quarterly revenue exceeded the forecast by twelve percent", 0.90),
+        ]
+
+    def test_near_duplicates_collapse_to_highest_ranked(self) -> None:
+        candidates = self._dup_candidate_set()
+        selected, _used, dropped = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=500000, auxiliary_quota=0, min_score=0.0
+        )
+        selected_hashes = {ref.get("ref_hash") for ref in selected}
+        self.assertIn(1, selected_hashes)          # highest-ranked original kept
+        self.assertNotIn(2, selected_hashes)       # near-duplicate collapsed away
+        self.assertIn(3, selected_hashes)          # distinct fact kept
+        self.assertEqual(1, dropped["near_duplicate"])
+
+    def test_threshold_zero_disables_dedup(self) -> None:
+        candidates = self._dup_candidate_set()
+        selected, _used, dropped = mcp_core.select_token_budgeted_refs(
+            candidates,
+            [],
+            max_context_tokens=500000,
+            auxiliary_quota=0,
+            min_score=0.0,
+            near_duplicate_overlap_threshold=0.0,
+        )
+        selected_hashes = {ref.get("ref_hash") for ref in selected}
+        self.assertEqual({1, 2, 3}, selected_hashes)
+        self.assertEqual(0, dropped["near_duplicate"])
+
+    def test_distinct_candidates_are_all_kept(self) -> None:
+        candidates = [
+            _fact_candidate(10, "database connection pool exhausted under load", 0.95),
+            _fact_candidate(11, "user preference set to dark theme in settings", 0.94),
+            _fact_candidate(12, "release cut from the stable branch on tuesday", 0.93),
+        ]
+        selected, _used, dropped = mcp_core.select_token_budgeted_refs(
+            candidates, [], max_context_tokens=500000, auxiliary_quota=0, min_score=0.0
+        )
+        self.assertEqual(3, len(selected))
+        self.assertEqual(0, dropped["near_duplicate"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the retrieval-budget gaps in the gateway/packer so the returned context pack respects the caller's budget symmetrically and drops repetitive refs, keeping "return more by default" high-signal.

## Fixes

1. **Wire `budget` -> `max_context_tokens`.** The client-facing `budget` param was silently ignored (the gateway only read `max_context_tokens`). `apply_retrieve_budget_alias` now aliases it in the retrieve request path; `max_context_tokens` wins when both are supplied. (`tools/matrixark_http.py`)
2. **Harmonize the default ceiling.** `matrixark_mcp_core` reused its own `128000` literal while `matrixark_mcp_runtime_config` used `500000`, so the two disagreed out of the box. Core now imports the runtime-config `DEFAULT_MAX_CONTEXT_TOKENS` (single source of truth). (`tools/matrixark_mcp_core.py`)
3. **Symmetric clamp.** New `clamp_refs_to_token_budget` trims the lowest-ranked refs so the final pack token count is `<= max_context_tokens`, applied on the native pack path (which previously could return a pack over budget). The in-loop budget check already fills up to a raised budget. Ceiling, not target: an under-budget pack is never padded. (`tools/matrixark_mcp_core_ref_selection.py`, `tools/matrixark_mcp_native_retrieve.py`)
4. **Near-duplicate dedup.** In the ref-selection path, a candidate whose token-set Jaccard similarity with a higher-ranked already-selected ref is `>=` a configurable threshold (default `0.85`) is dropped before packing, so repetitive refs stop diluting precision now that defaults return more (top_k 24, cross-session candidates 200). Jaccard (not containment) so distinct refs that merely share a prefix are kept. Tunable via `near_duplicate_overlap_threshold` in `[retrieval]`. (`tools/matrixark_mcp_core_ref_selection.py`, `config/temporalstore.toml`, `tools/matrixark_load_config.py`)

## Tests

`tools/test_retrieval_budget_gaps.py` (16 tests): budget-alias precedence, harmonized default, symmetric clamp (over-budget trimmed to fit, small query -> small pack, raising budget allows more, top ref kept under a tiny budget), and near-duplicate collapse keeping the highest-ranked instance. Full `test_matrixark_codex_hook_pipeline`, `test_matrixark_python_module_boundaries`, and `test_matrixark_mcp_backend_policy` suites show zero new failures vs the pre-change baseline.

## Deferred

Empirical before/after default-pack size on live data is deferred: the test cluster is intentionally stopped for cost. Follow-up once it is back up.
