### PR TITLE
feat(recovery): snapshot/recovery completeness + O(state) raft snapshot install

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -315,6 +315,20 @@ pub enum BlockStoreBandState {
     Purged,
 }
 
+/// Metadata for a SEALED band whose bytes live in shared storage and are restored lazily.
+/// Passed to [`LocalBlockStore::install_lazy_checkpoint_bands`] so a lazy-restore installs
+/// complete band descriptors before the first on-demand slab fetch.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LazyCheckpointBand {
+    pub page_slab_id: u64,
+    pub physical_bytes: u64,
+    pub logical_bytes: u64,
+    pub first_page_id: Option<u64>,
+    pub last_page_id: Option<u64>,
+    pub created_unix_ms: Option<u64>,
+    pub updated_unix_ms: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockStoreBandDescriptor {
     #[serde(alias = "extent_id", alias = "zone_id")]
@@ -775,6 +789,64 @@ impl LocalBlockStore {
             },
         );
         persist_band_manifest(&inner.root, &inner.bands)?;
+        Ok(())
+    }
+
+    /// Install SEALED band descriptors for the slabs a lazy checkpoint restore backs from shared
+    /// storage. The slab bytes are NOT local yet (they are fetched on demand through the attached
+    /// shared read-through), but a GC/compaction cycle running between restore and the first fetch
+    /// must still see these sealed bands, or it accounts on an incomplete picture and could
+    /// reclaim prematurely. Recording them here makes `band_summary()`/`band_descriptors()`
+    /// complete immediately after restore. Any slab id that is the current active slab, or already
+    /// has a descriptor (e.g. it was fetched or is local), is left untouched. Call AFTER
+    /// [`reserve_lazy_checkpoint_range`] so the reserved slab is the active one and every
+    /// checkpoint slab is correctly sealed.
+    pub fn install_lazy_checkpoint_bands(
+        &self,
+        bands: &[LazyCheckpointBand],
+    ) -> Result<(), BlockStoreError> {
+        let mut inner = self.inner.lock().expect("block store lock poisoned");
+        let root = inner.root.clone();
+        let active = inner.page_slab_id;
+        let mut changed = false;
+        for band in bands {
+            // Never touch the active (reserved) slab — it holds live local writes.
+            if band.page_slab_id == active {
+                continue;
+            }
+            // If the slab is materialized locally (already fetched / a real local slab), its
+            // existing descriptor reflects real on-disk bytes and is authoritative — leave it.
+            if slab_path(&root, band.page_slab_id).exists() {
+                continue;
+            }
+            // Lazily-backed checkpoint slab: install (or replace a fresh-store placeholder — a
+            // freshly opened block store seeds an empty Active descriptor for slab 0, which
+            // `reserve_lazy_checkpoint_range` then seals; that stale empty descriptor must be
+            // overwritten with the checkpoint's real band metadata, not skipped) a complete
+            // SEALED descriptor so accounting is correct before any fetch.
+            let descriptor = BlockStoreBandDescriptor {
+                band_id: band_id_for_slab(band.page_slab_id),
+                page_slab_id: band.page_slab_id,
+                state: BlockStoreBandState::Sealed,
+                physical_bytes: band.physical_bytes,
+                logical_bytes: band.logical_bytes,
+                created_unix_ms: band.created_unix_ms,
+                updated_unix_ms: band.updated_unix_ms,
+                first_page_id: band.first_page_id,
+                last_page_id: band.last_page_id,
+                readable_prefix_physical_bytes: band.physical_bytes,
+                has_corruption: false,
+                first_error_offset: None,
+                first_error: None,
+            };
+            if inner.bands.get(&band.page_slab_id) != Some(&descriptor) {
+                inner.bands.insert(band.page_slab_id, descriptor);
+                changed = true;
+            }
+        }
+        if changed {
+            persist_band_manifest(&inner.root, &inner.bands)?;
+        }
         Ok(())
     }
 

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -107,6 +107,29 @@ pub struct RaftSnapshot {
     #[serde(default)]
     pub external_snapshot_ref: Option<RaftExternalSnapshotRef>,
     pub entries: Vec<RaftLogEntry>,
+    /// S2: opaque engine state image captured at `last_included_index`. When present, install
+    /// reconstructs state from this image (O(state)) instead of replaying `entries`, and `entries`
+    /// is empty. Absent (default) on the classic entry-carrying snapshot, so older peers and the
+    /// gate-off path deserialize unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_image: Option<RaftSnapshotStateImage>,
+}
+
+/// S2: an opaque engine STATE IMAGE — the exported served index plus every referenced page slab —
+/// that reconstructs a shard's applied state without replaying the committed log. Mirrors the
+/// metadata-checkpoint the shared-store recovery path builds (index bytes + slab bytes +
+/// next-page-id), letting a snapshot install run in O(state) rather than O(total history).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RaftSnapshotStateImage {
+    pub index_bytes: Vec<u8>,
+    pub next_page_id: u64,
+    pub slabs: Vec<RaftSnapshotStateImageSlab>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RaftSnapshotStateImageSlab {
+    pub page_slab_id: u64,
+    pub bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -206,6 +229,15 @@ fn raft_leader_ready_barrier_on() -> bool {
 /// majority of granted votes) before promotion, instead of promoting from a local view.
 fn raft_quorum_election_on() -> bool {
     raft_env_flag_on("TS_RAFT_QUORUM_ELECTION")
+}
+
+/// S2: snapshot the engine STATE IMAGE (exported index + page slabs) instead of every committed
+/// log entry. When on, `create_snapshot` captures an opaque image at the leader's applied index
+/// and drops the replayable entries, so a far-behind follower installs in O(state) rather than
+/// replaying O(total history); install reconstructs state from the image. Default OFF -> the
+/// snapshot still carries entries and behavior is byte-identical.
+fn raft_snapshot_state_image_on() -> bool {
+    raft_env_flag_on("TS_RAFT_SNAPSHOT_STATE_IMAGE")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1309,6 +1341,11 @@ pub struct InstallSnapshotChunkRequest {
     pub chunk_index: u64,
     pub chunk_count: u64,
     pub entries: Vec<RaftLogEntry>,
+    /// S2: opaque engine state image, carried on chunk 0 of an image-based snapshot (whose
+    /// `entries` are empty, so it is a single chunk). Default `None` keeps entry-carrying chunks
+    /// and older peers byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_image: Option<RaftSnapshotStateImage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3218,6 +3255,9 @@ struct PendingSnapshotChunks {
     last_included_term: u64,
     last_included_index: u64,
     chunks: Vec<Option<Vec<RaftLogEntry>>>,
+    // S2: opaque engine state image reassembled from the chunk stream (carried on chunk 0 of an
+    // image-based snapshot). `None` for the classic entry-carrying stream.
+    state_image: Option<RaftSnapshotStateImage>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -311,6 +311,7 @@ impl RaftCluster {
                 chunk_index: 0,
                 chunk_count: 1,
                 entries: Vec::new(),
+                state_image: snapshot.state_image.clone(),
             });
             return Ok(chunks);
         }
@@ -327,6 +328,7 @@ impl RaftCluster {
                 chunk_index: chunk_index as u64,
                 chunk_count: chunk_count as u64,
                 entries: entries.to_vec(),
+                state_image: None,
             });
         }
         Ok(chunks)
@@ -398,6 +400,7 @@ impl RaftCluster {
                 last_included_term: request.last_included_term,
                 last_included_index: request.last_included_index,
                 chunks: vec![None; request.chunk_count as usize],
+                state_image: None,
             });
         if pending.shard_id != request.shard_id
             || pending.last_included_term != request.last_included_term
@@ -425,6 +428,10 @@ impl RaftCluster {
             ));
         }
         let duplicate_chunk = pending.chunks[request.chunk_index as usize].is_some();
+        // S2: the state image rides on chunk 0; retain it for the reassembled snapshot.
+        if request.state_image.is_some() {
+            pending.state_image = request.state_image.clone();
+        }
         pending.chunks[request.chunk_index as usize] = Some(request.entries);
         let received_chunks = pending
             .chunks
@@ -466,6 +473,7 @@ impl RaftCluster {
             .pending_snapshots
             .remove(&key)
             .expect("complete pending snapshot must exist");
+        let state_image = pending.state_image;
         let entries = pending
             .chunks
             .into_iter()
@@ -480,6 +488,7 @@ impl RaftCluster {
                 last_included_index: request.last_included_index,
                 external_snapshot_ref: None,
                 entries,
+                state_image,
             },
         );
         {
@@ -534,6 +543,55 @@ impl RaftCluster {
             .get(&inner.leader_id)
             .filter(|node| node.alive && node.role == RaftRole::Leader)
             .ok_or(RaftError::LeaderUnavailable)?;
+        // S2: capture an opaque engine STATE IMAGE at the leader's applied index instead of the
+        // full committed entry log, so a far-behind follower installs in O(state). Gated OFF by
+        // default. Any failure to build the image falls through to the classic entry-carrying
+        // snapshot below, so the gate can never make snapshotting worse.
+        if raft_snapshot_state_image_on() && leader.applied_index > 0 {
+            let shard_id = inner.shard_id;
+            let watermark = leader.applied_index;
+            let image = (|| -> Option<RaftSnapshotStateImage> {
+                let index_bytes = leader.engine.export_index_bytes(shard_id).ok()?;
+                let block_store = leader.engine.block_store();
+                let mut slabs = Vec::new();
+                for page_slab_id in block_store.slab_ids().ok()? {
+                    let bytes = block_store.read_slab(page_slab_id).ok()?;
+                    slabs.push(RaftSnapshotStateImageSlab {
+                        page_slab_id,
+                        bytes,
+                    });
+                }
+                Some(RaftSnapshotStateImage {
+                    index_bytes,
+                    next_page_id: block_store.next_page_id(),
+                    slabs,
+                })
+            })();
+            if let Some(image) = image {
+                // Term AT the applied watermark, derived from the log/installed snapshot (entries
+                // are dropped, so it cannot come from entries.last()).
+                let last_included_term = leader
+                    .log
+                    .iter()
+                    .find(|entry| entry.index == watermark)
+                    .map(|entry| entry.term)
+                    .or_else(|| {
+                        leader.installed_snapshot.as_ref().and_then(|snap| {
+                            (snap.last_included_index == watermark)
+                                .then_some(snap.last_included_term)
+                        })
+                    })
+                    .unwrap_or(leader.current_term);
+                return Ok(RaftSnapshot {
+                    shard_id,
+                    last_included_term,
+                    last_included_index: watermark,
+                    external_snapshot_ref: None,
+                    entries: Vec::new(),
+                    state_image: Some(image),
+                });
+            }
+        }
         let mut entries_by_index = BTreeMap::new();
         if let Some(snapshot) = &leader.installed_snapshot {
             for entry in snapshot
@@ -562,6 +620,7 @@ impl RaftCluster {
             last_included_index: leader.commit_index,
             external_snapshot_ref: None,
             entries,
+            state_image: None,
         })
     }
 
@@ -778,12 +837,28 @@ impl RaftCluster {
             }
 
             let engine = TemporalEngine::default();
-            engine.load_shard(shard_id);
-            for entry in &snapshot.entries {
-                engine.execute_durable(ExecuteRequest {
-                    shard_id: entry.shard_id,
-                    command: entry.command.clone(),
-                });
+            if let Some(image) = &snapshot.state_image {
+                // S2: reconstruct state from the opaque image (index + slabs) in O(state) — no
+                // full-history entry replay. Mirrors the shared-store lazy restore: install slabs,
+                // install the served index base, then load the shard so the index is read in.
+                let block_store = engine.block_store();
+                for slab in &image.slabs {
+                    block_store
+                        .install_slab(slab.page_slab_id, &slab.bytes)
+                        .map_err(|err| RaftError::SnapshotEncoding(err.to_string()))?;
+                }
+                engine
+                    .install_index_bytes(shard_id, &image.index_bytes)
+                    .map_err(|err| RaftError::SnapshotEncoding(err.to_string()))?;
+                engine.load_shard(shard_id);
+            } else {
+                engine.load_shard(shard_id);
+                for entry in &snapshot.entries {
+                    engine.execute_durable(ExecuteRequest {
+                        shard_id: entry.shard_id,
+                        command: entry.command.clone(),
+                    });
+                }
             }
 
             node.engine = engine;
@@ -815,8 +890,15 @@ impl RaftCluster {
                     .retain(|entry| entry.index > snapshot.last_included_index);
             }
             node.applied.clear();
-            node.applied
-                .extend(snapshot.entries.iter().map(|entry| entry.index));
+            if snapshot.state_image.is_some() {
+                // The image carries no entries, so seed the applied set from the covered index
+                // range (mirrors the existing snapshot-install applied-set fill in raft.rs), so
+                // `applied_index`-derived accounting stays consistent with the entry-carrying path.
+                node.applied.extend(1..=snapshot.last_included_index);
+            } else {
+                node.applied
+                    .extend(snapshot.entries.iter().map(|entry| entry.index));
+            }
             node.applied_index = snapshot.last_included_index;
             node.max_applied_index = node.max_applied_index.max(snapshot.last_included_index);
             node.installed_snapshot = Some(snapshot);

--- a/crates/temporalstore-rust/src/raft/tests/part1.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part1.rs
@@ -1208,6 +1208,7 @@ fn install_snapshot_clears_stale_vote_on_term_raise() {
                         value: b"v".to_vec(),
                     },
                 }],
+                state_image: None,
             },
         )
         .unwrap();

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2232,4 +2232,130 @@ fn r4_new_leader_withholds_linearizable_read_until_committed_in_term() {
     assert_eq!(response.leader_id, 2);
 }
 
+/// S2: with the state-image gate on, a snapshot carries an opaque engine STATE IMAGE instead of
+/// the full committed entry log, and a far-behind follower reconstructs complete state from that
+/// image alone (O(state)) — no per-entry replay of the whole history.
+#[test]
+fn s2_state_image_snapshot_installs_without_replaying_full_entry_log() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    for i in 0..16 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("k{i}"),
+                value: format!("v{i}").into_bytes(),
+            })
+            .unwrap();
+    }
+
+    let snapshot = cluster.create_snapshot().unwrap();
+    assert!(
+        snapshot.entries.is_empty(),
+        "state-image snapshot must NOT carry the full committed entry log"
+    );
+    let image = snapshot
+        .state_image
+        .as_ref()
+        .expect("state-image snapshot must carry an engine image");
+    assert!(!image.index_bytes.is_empty(), "image must include the served index");
+
+    // Far-behind follower installs from the image and serves every key correctly.
+    cluster.install_snapshot(3, snapshot).unwrap();
+    let inner = cluster.inner.read().expect("raft cluster lock poisoned");
+    let shard_id = inner.shard_id;
+    let node3 = inner.nodes.get(&3).expect("follower 3 exists");
+    for i in 0..16 {
+        assert_eq!(
+            node3
+                .engine
+                .execute(ExecuteRequest {
+                    shard_id,
+                    command: Command::StringGet {
+                        key: format!("k{i}"),
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(format!("v{i}").into_bytes())
+            },
+            "follower must reconstruct key k{i} from the state image"
+        );
+    }
+}
+
+/// S2: the state image travels through the chunked install path (it rides chunk 0 of a
+/// single-chunk, empty-entries stream) and the follower installs from it end-to-end.
+#[test]
+fn s2_state_image_snapshot_travels_through_chunk_stream() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    for i in 0..8 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("k{i}"),
+                value: format!("v{i}").into_bytes(),
+            })
+            .unwrap();
+    }
+
+    let chunks = cluster.build_install_snapshot_chunks(3, 4).unwrap();
+    assert_eq!(
+        chunks.len(),
+        1,
+        "an image snapshot has empty entries, so it is a single chunk"
+    );
+    assert!(
+        chunks[0].state_image.is_some(),
+        "the state image must ride the chunk stream"
+    );
+    let response = cluster
+        .receive_install_snapshot_chunk(chunks[0].clone())
+        .unwrap();
+    assert!(response.snapshot_complete, "single-chunk install must complete");
+
+    let inner = cluster.inner.read().expect("raft cluster lock poisoned");
+    let shard_id = inner.shard_id;
+    let node3 = inner.nodes.get(&3).expect("follower 3 exists");
+    for i in 0..8 {
+        assert_eq!(
+            node3
+                .engine
+                .execute(ExecuteRequest {
+                    shard_id,
+                    command: Command::StringGet {
+                        key: format!("k{i}"),
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(format!("v{i}").into_bytes())
+            },
+        );
+    }
+}
+
+/// S2 gate OFF (default): the snapshot still carries the committed entry log and no state image,
+/// so behavior is byte-identical to before.
+#[test]
+fn s2_snapshot_gate_off_still_carries_entries_and_no_image() {
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    for i in 0..4 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("k{i}"),
+                value: format!("v{i}").into_bytes(),
+            })
+            .unwrap();
+    }
+    let snapshot = cluster.create_snapshot().unwrap();
+    assert!(
+        snapshot.state_image.is_none(),
+        "gate off must not attach a state image"
+    );
+    assert!(
+        !snapshot.entries.is_empty(),
+        "gate off must still carry the committed entry log"
+    );
+}
+
 

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -15,7 +15,7 @@ use temporalstore_snapshot::object_store::{
 };
 use thiserror::Error;
 
-use crate::block_store::{BlockStoreError, LocalBlockStore, SharedSlabSource};
+use crate::block_store::{BlockStoreError, LazyCheckpointBand, LocalBlockStore, SharedSlabSource};
 use crate::engine::TemporalEngine;
 use crate::sdk::{self, v1};
 use crate::types::{Command, ExecuteRequest, ShardId, Status};
@@ -40,6 +40,13 @@ pub enum SharedStoreReplicationError {
     },
     #[error("no shared-store checkpoint found for shard {0}")]
     CheckpointNotFound(ShardId),
+    #[error(
+        "checkpoint for shard {shard_id} references live slab {page_slab_id} that was not uploaded; refusing to publish a manifest that would lose durable pages"
+    )]
+    CheckpointSlabNotDurable {
+        shard_id: ShardId,
+        page_slab_id: u64,
+    },
     #[error("replicated command failed at WAL index {wal_index}: {status:?}")]
     ApplyFailed { wal_index: u64, status: Status },
     /// The durable single-writer fence rejected this operation: a newer owner (higher
@@ -124,6 +131,21 @@ pub struct SharedStorePageSlab {
     pub key: String,
     pub byte_size: u64,
     pub sha256: String,
+    // Per-slab SEALED-band metadata carried so a lazy restore can install complete band
+    // descriptors (physical/logical bytes + page-id range) BEFORE the first on-demand slab
+    // fetch, keeping GC/compaction accounting from under-counting sealed shared bands between
+    // restore and first fetch. All default so older manifests (without these fields) still load;
+    // `byte_size` above is the slab's physical byte size.
+    #[serde(default)]
+    pub logical_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_page_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_page_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_unix_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_unix_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -711,6 +733,12 @@ where
         // R2 single-writer fence: a checkpoint publish is a durable-frontier advance, so a
         // superseded stale owner must be rejected here just as on a WAL append.
         self.enforce_fence(shard_id).await?;
+        // Durability barrier: fsync any bulk-deferred page bytes and persist the band manifest
+        // BEFORE capturing the slab set, mirroring the local dump path which fsyncs pages+WAL
+        // before recording slab ids. Without this a relaxed (bulk) writer could enumerate a slab
+        // whose tail bytes are not yet on disk, uploading a torn page or racing a not-yet-durable
+        // slab into the checkpoint.
+        block_store.sync_durable()?;
         let checkpoint_id = uuid::Uuid::new_v4().to_string();
         let prefix = self.checkpoint_prefix(shard_id, &checkpoint_id);
         let index_key = format!("{prefix}index/shard.index.json");
@@ -719,19 +747,51 @@ where
             .put(&index_key, Bytes::from(index.clone()))
             .await?;
 
+        // Snapshot the local band descriptors so each uploaded slab carries its sealed-band
+        // metadata (logical bytes + page-id range) into the manifest for restore-time install.
+        let band_by_slab: BTreeMap<u64, _> = block_store
+            .band_descriptors()
+            .into_iter()
+            .map(|band| (band.page_slab_id, band))
+            .collect();
         let mut page_slabs = Vec::new();
+        let mut uploaded_slab_ids = std::collections::BTreeSet::new();
         for page_slab_id in block_store.slab_ids()? {
             let bytes = block_store.read_slab(page_slab_id)?;
             let key = format!("{prefix}page_segments/page_segment_{page_slab_id:020}.seg");
             self.object_store
                 .put(&key, Bytes::from(bytes.clone()))
                 .await?;
+            uploaded_slab_ids.insert(page_slab_id);
+            let band = band_by_slab.get(&page_slab_id);
             page_slabs.push(SharedStorePageSlab {
                 page_slab_id,
                 key,
                 byte_size: bytes.len() as u64,
                 sha256: sha256_hex(&bytes),
+                logical_bytes: band.map(|band| band.logical_bytes).unwrap_or(0),
+                first_page_id: band.and_then(|band| band.first_page_id),
+                last_page_id: band.and_then(|band| band.last_page_id),
+                created_unix_ms: band.and_then(|band| band.created_unix_ms),
+                updated_unix_ms: band.and_then(|band| band.updated_unix_ms),
             });
+        }
+
+        // Completeness barrier: every slab the served index actually references must be covered by
+        // an uploaded slab before the manifest is written, so a restore never resolves a live page
+        // to a slab that is absent from the checkpoint. The synthetic in-memory hot-page slab
+        // (u64::MAX) is folded into the exported index, not a durable slab, so it is excluded.
+        const HOT_PAGE_SLAB_ID: u64 = u64::MAX;
+        for referenced in engine.live_page_slab_ids(shard_id) {
+            if referenced == HOT_PAGE_SLAB_ID {
+                continue;
+            }
+            if !uploaded_slab_ids.contains(&referenced) {
+                return Err(SharedStoreReplicationError::CheckpointSlabNotDurable {
+                    shard_id,
+                    page_slab_id: referenced,
+                });
+            }
         }
 
         let manifest = SharedStoreCheckpointManifest {
@@ -1510,6 +1570,24 @@ impl SharedStoreReplicator<FileObjectStore> {
         // and new writes never overwrite a slab still served lazily from shared storage.
         if !manifest.page_slabs.is_empty() {
             block_store.reserve_lazy_checkpoint_range(max_slab_id, manifest.next_page_id)?;
+            // Install SEALED band descriptors for the lazily-backed checkpoint slabs so
+            // GC/compaction accounting is complete immediately after restore, before the first
+            // on-demand fetch materializes any slab locally. Runs AFTER the reserve so the freshly
+            // reserved slab stays the active band and every checkpoint slab is sealed.
+            let lazy_bands: Vec<LazyCheckpointBand> = manifest
+                .page_slabs
+                .iter()
+                .map(|slab| LazyCheckpointBand {
+                    page_slab_id: slab.page_slab_id,
+                    physical_bytes: slab.byte_size,
+                    logical_bytes: slab.logical_bytes,
+                    first_page_id: slab.first_page_id,
+                    last_page_id: slab.last_page_id,
+                    created_unix_ms: slab.created_unix_ms,
+                    updated_unix_ms: slab.updated_unix_ms,
+                })
+                .collect();
+            block_store.install_lazy_checkpoint_bands(&lazy_bands)?;
         }
         Ok(manifest)
     }
@@ -2244,6 +2322,145 @@ mod tests {
                 value: Some(b"wal-value".to_vec())
             }
         );
+    }
+
+    #[tokio::test]
+    async fn s4_publish_checkpoint_covers_every_index_referenced_slab() {
+        // S4 completeness barrier: every slab the served index references must be uploaded and
+        // recorded in the manifest before it is written, so a restore never resolves a live page
+        // to a slab absent from the checkpoint.
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        for i in 0..8 {
+            primary.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("k{i}"),
+                    value: vec![b'v'; 512],
+                },
+            });
+        }
+        let (_store, replicator) = test_shared_store(dir.path());
+        let manifest = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .unwrap();
+        let manifest_slab_ids: std::collections::BTreeSet<u64> =
+            manifest.page_slabs.iter().map(|s| s.page_slab_id).collect();
+        for referenced in primary.live_page_slab_ids(1) {
+            if referenced == u64::MAX {
+                continue;
+            }
+            assert!(
+                manifest_slab_ids.contains(&referenced),
+                "index-referenced slab {referenced} must be covered by the checkpoint manifest"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn s4_publish_checkpoint_rejects_referenced_slab_not_durable() {
+        // S4: if the served index references a slab that is NOT present as a durable/uploaded
+        // slab, publish must FAIL rather than write a manifest that would lose those pages.
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "before".to_string(),
+                value: b"snapshot-value".to_vec(),
+            },
+        });
+        // The write landed in on-disk slab 0 and the index references it.
+        assert!(primary.live_page_slab_ids(1).contains(&0));
+        // Simulate a lost/never-durable slab: remove slab 0 from disk so slab_ids() no longer
+        // enumerates it while the in-memory index still references it.
+        let slab0 = dir
+            .path()
+            .join("primary-pages")
+            .join("page_segment_00000000000000000000.seg");
+        std::fs::remove_file(&slab0).unwrap();
+        assert!(!primary.block_store().slab_ids().unwrap().contains(&0));
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        let err = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .expect_err("publish must reject a checkpoint that would drop a referenced slab");
+        assert!(
+            matches!(
+                err,
+                SharedStoreReplicationError::CheckpointSlabNotDurable {
+                    shard_id: 1,
+                    page_slab_id: 0
+                }
+            ),
+            "expected CheckpointSlabNotDurable, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn s3_lazy_restore_installs_complete_sealed_band_descriptors_before_any_fetch() {
+        // S3: after a lazy metadata restore, the sealed-band descriptors for the checkpoint's
+        // lazily-backed slabs are installed immediately, so GC/compaction accounting is complete
+        // BEFORE the first on-demand slab fetch (previously they under-counted until a fetch).
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "before".to_string(),
+                value: b"snapshot-value".to_vec(),
+            },
+        });
+        let primary_band = primary
+            .block_store()
+            .band_descriptors()
+            .into_iter()
+            .find(|b| b.page_slab_id == 0)
+            .expect("primary must have a band for slab 0");
+        assert!(primary_band.logical_bytes > 0);
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        let manifest = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .unwrap();
+        let slab0 = manifest
+            .page_slabs
+            .iter()
+            .find(|s| s.page_slab_id == 0)
+            .expect("manifest must record slab 0");
+        assert_eq!(slab0.logical_bytes, primary_band.logical_bytes);
+
+        let follower = test_engine(dir.path(), "follower");
+        replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+            .unwrap();
+
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);
+        assert!(
+            !follower.block_store().slab_ids().unwrap().contains(&0),
+            "checkpoint slab 0 must not be materialized locally yet"
+        );
+        let follower_band = follower
+            .block_store()
+            .band_descriptors()
+            .into_iter()
+            .find(|b| b.page_slab_id == 0)
+            .expect("restore must install a band descriptor for the lazily-backed slab 0");
+        assert_eq!(follower_band.state, crate::block_store::BlockStoreBandState::Sealed);
+        assert_eq!(follower_band.logical_bytes, primary_band.logical_bytes);
+        assert_eq!(follower_band.physical_bytes, slab0.byte_size);
+        assert!(
+            follower.block_store().zone_summary().sealed_bands >= 1,
+            "sealed shared band must be counted before any lazy fetch"
+        );
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Snapshot / recovery: completeness, durability, and O(state) raft snapshot install

Closes three snapshot/recovery gaps (S2/S3/S4). All always-on changes are additive and covered by new tests; the S2 perf change is gated OFF by default and byte-identical until opted in.

### S4 — checkpoint durability + completeness barrier
`SharedStoreReplicator::publish_checkpoint` now:
- calls `block_store.sync_durable()` **before** enumerating slabs (fsyncs bulk-deferred page bytes + persists the band manifest), mirroring the local dump path — a relaxed/bulk writer can no longer race a not-yet-durable slab into a checkpoint; and
- refuses to write the manifest unless **every index-referenced (non-hot) slab was actually uploaded**, via a new `SharedStoreReplicationError::CheckpointSlabNotDurable`. A checkpoint can no longer silently drop durable pages.

### S3 — complete band accounting on lazy restore
The checkpoint manifest now carries **per-slab sealed-band metadata** (logical bytes + page-id range). On a lazy metadata restore, `LocalBlockStore::install_lazy_checkpoint_bands` installs complete **SEALED** descriptors for the lazily-backed slabs immediately, so `zone_summary()` / `band_descriptors()` are complete **before the first on-demand fetch**. Previously GC/compaction accounting under-counted sealed shared bands between restore and first fetch (risking premature reclaim). Manifest fields are `#[serde(default)]`, so older manifests still load.

### S2 — O(state) raft snapshot install (gated: `TS_RAFT_SNAPSHOT_STATE_IMAGE`, default off)
`create_snapshot` can capture an opaque engine **state image** (exported served index + page slabs + next-page-id) at the leader's applied index and drop the replayable committed entries. A far-behind follower then installs in **O(state)** instead of replaying **O(total history)**: `install_snapshot` reconstructs from the image (install slabs + install index base + load shard) and seeds the applied set from the covered range. The image also rides the chunked install stream (chunk 0 of a single-chunk, empty-entries snapshot). With the gate off, snapshots still carry the entry log and behavior is byte-identical.

### Tests
Six new tests:
- S4: every index-referenced slab is covered; publish rejects a referenced-but-non-durable slab.
- S3: sealed band descriptors are complete immediately after restore, before any lazy fetch.
- S2: far-behind follower reconstructs full state from the image with no entry log; state image travels the chunk stream; gate-off parity (entries carried, no image).

Full single-threaded lib suite: green apart from the pre-existing `jitter_backoff` flake (0 new failures).
