### PR TITLE
feat(wal): default to the single write-path durability barrier; delete legacy multi-barrier paths

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -76,15 +76,17 @@ cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retai
 
 # -----------------------------------------------------------------------------
 # [wal] - write-ahead-log durability barriers (write-path fsync policy)
-# NOTE: several of these flags are a productionization pass away from being
-# consolidated into a single durability mode; kept here as the living source of
-# truth. Defaults are all OFF = maximum durability (every barrier synchronous).
+# CONSOLIDATED: the write path runs a SINGLE synchronous durability barrier (WAL-only
+# fdatasync per write) with base-only recovery, plus group-commit -- both ON by default.
+# Every acked write is still fully durable before its ack returns; the data-page, served-index
+# delta, and band-manifest fsyncs are deferred and reconstructed by base-only WAL replay on
+# recovery. Set wal_legacy_recovery = 1 (the emergency escape hatch) to fall back to the legacy
+# multi-barrier write path + delta-fold recovery without a rebuild.
 # -----------------------------------------------------------------------------
 [wal]
-wal_only_sync = 0                      # TS_WAL_ONLY_SYNC       1 = only the WAL takes a synchronous barrier on ack (defer data-page + index fsync). WILL CONSOLIDATE.
-wal_single_barrier = 0                 # TS_WAL_SINGLE_BARRIER  1 = true single write-path barrier (WAL only; base-only recovery). Implies wal_only_sync. WILL CONSOLIDATE.
-indexlog_defer_sync = 0                # TS_INDEXLOG_DEFER_SYNC  1 = drop the served-index delta-log fsync from the ack path (delta still appended). WILL CONSOLIDATE.
-group_commit = 0                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers. WILL CONSOLIDATE.
+wal_single_barrier = 1                 # TS_WAL_SINGLE_BARRIER  1 = single write-path barrier (WAL-only fsync; base-only recovery). DEFAULT.
+group_commit = 1                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers (sub-ms/write under load). DEFAULT.
+wal_legacy_recovery = 0                # TS_WAL_LEGACY_RECOVERY  1 = emergency fallback to the legacy multi-barrier write path + delta-fold recovery.
 # raft_wal_dir = ""                    # TS_RAFT_WAL_DIR        raft WAL directory (raft/replicated modes)
 
 

--- a/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_single_barrier_crash_harness.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! WAL-replay recovery harness. Exercises the relaxed-durability write path (run with
-//! TS_INDEXLOG_DEFER_SYNC=1 + TS_WAL_ONLY_SYNC=1, where the served-index delta fdatasync is
-//! dropped from the ack path while the WAL + data pages stay durable per write) and, as a
-//! stronger stress, proves the WAL alone is self-sufficient: the WAL record embeds the full
-//! command payload, so startup replay from the last durable watermark rebuilds the served index
-//! and the page state.
+//! WAL-replay recovery harness. Exercises the single write-path durability barrier (the DEFAULT:
+//! only the WAL takes a synchronous fdatasync per write; the data-page fdatasync and the
+//! served-index delta fdatasync are both deferred, and recovery is base-only) and proves the WAL
+//! alone is self-sufficient: the WAL record embeds the full command payload, so startup replay
+//! from the last durable watermark rebuilds the served index and the page state. Set
+//! TS_WAL_LEGACY_RECOVERY=1 to exercise the legacy multi-barrier write path + delta-fold recovery.
 //!
 //! A plain SIGKILL / process::abort preserves the OS page cache, so un-fsync'd bytes survive it
 //! and would not exercise recovery. To faithfully model real power loss this harness also drops

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1032,34 +1032,26 @@ pub(crate) fn bulk_relaxed_durability() -> bool {
     )
 }
 
-/// TS_WAL_ONLY_SYNC / TS_WAL_SINGLE_BARRIER: on the live path, defer the per-record
-/// extent-manifest persist to sync_durable()/slab-seal (WAL replay re-materializes pages
-/// on recovery; the manifest is reconciled from disk on open). Default OFF.
+/// On the live path, defer the per-record extent-manifest persist to sync_durable()/slab-seal
+/// (the manifest is reconciled from disk on open). Single-barrier default; restored to a
+/// synchronous persist only under the TS_WAL_LEGACY_RECOVERY escape hatch. Moves in lockstep
+/// with `page_wal_single_barrier` (the intermediate "manifest-only" relaxation is gone).
 pub(crate) fn page_wal_only_sync() -> bool {
-    ["TS_WAL_ONLY_SYNC", "TS_WAL_SINGLE_BARRIER"].iter().any(|name| {
-        matches!(
-            std::env::var(name)
-                .unwrap_or_default()
-                .trim()
-                .to_ascii_lowercase()
-                .as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    page_wal_single_barrier()
 }
 
-/// TS_WAL_SINGLE_BARRIER: the true single-barrier mode also defers the per-write data-page
-/// fdatasync -- the last non-WAL synchronous barrier. This is safe ONLY because the flag also
-/// switches recovery to base-only replay: reload trusts only the durable dump checkpoint (whose
-/// `flush_shard_index` fsyncs every page BEFORE advancing the watermark) and re-derives every
-/// post-watermark page by replaying the WAL tail exactly once. A page that was written but never
-/// fsync'd is therefore rebuilt from its WAL command, never left as a dangling reference. The
-/// deferred page still becomes durable at the next dump (`sync_durable` fsyncs the active slab;
-/// a rolled slab is fsync'd at roll). Deliberately NOT enabled by the legacy TS_WAL_ONLY_SYNC,
-/// which does not change recovery trust.
+/// The single-barrier default also defers the per-write data-page fdatasync -- the last non-WAL
+/// synchronous barrier. This is safe ONLY because the default also switches recovery to base-only
+/// replay: reload trusts only the durable dump checkpoint (whose `flush_shard_index` fsyncs every
+/// page BEFORE advancing the watermark) and re-derives every post-watermark page by replaying the
+/// WAL tail exactly once. A page that was written but never fsync'd is therefore rebuilt from its
+/// WAL command, never left as a dangling reference. The deferred page still becomes durable at the
+/// next dump (`sync_durable` fsyncs the active slab; a rolled slab is fsync'd at roll). Restored to
+/// a synchronous per-write data-page fdatasync (with delta-fold recovery) only under the
+/// TS_WAL_LEGACY_RECOVERY escape hatch.
 pub(crate) fn page_wal_single_barrier() -> bool {
-    matches!(
-        std::env::var("TS_WAL_SINGLE_BARRIER")
+    !matches!(
+        std::env::var("TS_WAL_LEGACY_RECOVERY")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -220,11 +220,11 @@ impl LocalBlockStore {
             addresses.push(address);
         }
         // The batch already amortizes the data barrier across all its records (one
-        // sync_data for the whole batch). Keep that data barrier on the live path (durable
-        // pages); only the extent-manifest persist is deferred under TS_WAL_ONLY_SYNC
-        // (reconciled on open), matching the single-append path. Under the true single-barrier
-        // mode the data-page fdatasync is also deferred; base-only recovery re-derives every
-        // post-dump page by WAL replay, so a never-fsync'd page is rebuilt, never left dangling.
+        // sync_data for the whole batch). Under the single-barrier default both the data-page
+        // fdatasync and the extent-manifest persist are deferred (the manifest is reconciled on
+        // open); base-only recovery re-derives every post-dump page by WAL replay, so a
+        // never-fsync'd page is rebuilt, never left dangling. Under the TS_WAL_LEGACY_RECOVERY
+        // escape hatch both barriers stay synchronous on the live path (delta-fold recovery).
         let defer_data_sync = bulk_relaxed_durability() || page_wal_single_barrier();
         let defer_manifest = bulk_relaxed_durability() || page_wal_only_sync();
         if let Some(mut current) = file {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1580,11 +1580,21 @@ fn sync_parent_dir(path: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-/// TS_WAL_ONLY_SYNC: on the write/ack path, only the WAL takes a synchronous durability
-/// barrier; the served-index checkpoint write is issued but its fsync is deferred to the
-/// background flush / OS writeback (reconstructable from the WAL on recovery). Default OFF.
+/// TS_WAL_LEGACY_RECOVERY: emergency escape hatch. When set, the engine falls back to the
+/// legacy multi-barrier write path (WAL + data-page + served-index delta all fsync'd on the ack
+/// path) AND delta-fold recovery. Default OFF -> the single write-path durability barrier
+/// (WAL-only fsync) + base-only recovery is the DEFAULT. This exists solely so an operator can
+/// revert the default in the field without a rebuild; steady state runs single-barrier.
+pub(super) fn wal_legacy_recovery() -> bool {
+    env_flag_on("TS_WAL_LEGACY_RECOVERY")
+}
+
+/// On the write/ack path only the WAL takes a synchronous durability barrier; the served-index
+/// checkpoint write is issued but its fsync is deferred to the background flush / OS writeback
+/// (reconstructable from the WAL on recovery). Implied by the single-barrier default; disabled
+/// only by the TS_WAL_LEGACY_RECOVERY escape hatch.
 pub(super) fn wal_only_sync() -> bool {
-    env_flag_on("TS_WAL_ONLY_SYNC") || wal_single_barrier()
+    wal_single_barrier()
 }
 
 /// TS_WAL_SINGLE_BARRIER: the true SINGLE write-path durability barrier. Only the WAL takes a
@@ -1606,9 +1616,10 @@ pub(super) fn wal_only_sync() -> bool {
 ///    fsync'd), then replays the WAL tail from the watermark, re-deriving every post-dump page
 ///    EXACTLY ONCE. A page written but never fsync'd is rebuilt from its WAL command rather than
 ///    left dangling -- no page loss, no double-apply.
-/// Default OFF; when off the write and load paths are byte-for-byte unchanged.
+/// Default ON (the productionized write/recovery path). Set TS_WAL_LEGACY_RECOVERY=1 to fall
+/// back to the legacy multi-barrier write path + delta-fold recovery.
 pub(super) fn wal_single_barrier() -> bool {
-    env_flag_on("TS_WAL_SINGLE_BARRIER")
+    !wal_legacy_recovery()
 }
 
 fn env_flag_on(name: &str) -> bool {

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -353,7 +353,7 @@ impl TemporalEngine {
             return Ok(());
         }
         fs::create_dir_all(&self.index_dir)?;
-        // Ack-path served-index checkpoint. Under TS_WAL_ONLY_SYNC the durable barrier is
+        // Ack-path served-index checkpoint. Under the single-barrier default the durable barrier is
         // deferred (content + rename still issued): the WAL is durably synced before ack
         // and replay-on-load rebuilds the served index from it, so a stale-on-crash index
         // only costs a longer WAL replay, never an acked write. This is the served-index

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -598,8 +598,8 @@ impl TemporalEngine {
             .filter(|policy| policy.layout_aware_rewrite_required)
             .count();
         // Durability barrier BEFORE publishing the base index that names the relocated pages.
-        // Under deferred-fsync modes (bulk / page_wal_single_barrier / TS_WAL_ONLY_SYNC ->
-        // append.rs defer_data_sync) compaction relocates pages fsync-deferred, so the moved
+        // Under deferred-fsync modes (bulk / page_wal_single_barrier -> append.rs
+        // defer_data_sync) compaction relocates pages fsync-deferred, so the moved
         // bytes may still be in the page cache. Persisting a base index that references them
         // and crashing before the next barrier would leave dangling references at an un-synced
         // slab (compaction does not advance applied_wal_sequence, so WAL replay does not

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3358,9 +3358,47 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
         readonly: false,
         table_name: String::new(),
     });
-    assert!(
-        !response.status.ok,
-        "a corrupt interior index-log delta must refuse the load, not be silently skipped: {:?}",
-        response.status
-    );
+    if crate::engine::wal_single_barrier() {
+        // Base-only single-barrier recovery (the DEFAULT) never folds the served-index delta:
+        // it re-derives state from the durable base checkpoint + WAL replay (+ config-log),
+        // which is a COMPLETE source of truth (evictions/removals are WAL/config-log
+        // re-derivable, not delta-only). A corrupt delta is therefore never parsed and cannot
+        // cause a silent skip of a delta-only removal -- so the load must SUCCEED and reconstruct
+        // the EXACT logical state. We prove no silent loss by reading every acked key back at its
+        // written value (a strictly stronger guarantee than the original binary refuse/accept),
+        // so this generalization preserves the test's protection rather than weakening it. The
+        // delta-fold refuse-on-corruption path is still asserted below under the legacy escape
+        // hatch (and covered by the subprocess crash harness's drop-indexlog cases).
+        assert!(
+            response.status.ok,
+            "base-only recovery ignores the un-folded delta and must load: {:?}",
+            response.status
+        );
+        for key in ["alpha", "beta", "gamma"] {
+            let got = restarted.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: key.to_string(),
+                },
+            });
+            assert!(
+                got.status.ok,
+                "read of {key} must succeed after base-only recovery: {:?}",
+                got.status
+            );
+            assert_eq!(
+                got.response,
+                CommandResponse::Bytes {
+                    value: Some(b"v".to_vec())
+                },
+                "base-only recovery must preserve the exact value for {key} (no silent loss)"
+            );
+        }
+    } else {
+        assert!(
+            !response.status.ok,
+            "a corrupt interior index-log delta must refuse the load, not be silently skipped: {:?}",
+            response.status
+        );
+    }
 }

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -231,36 +231,30 @@ fn bulk_ingest_mode() -> bool {
     )
 }
 
-/// TS_WAL_ONLY_SYNC / TS_WAL_SINGLE_BARRIER: defer the ack-path index-log fsync (WAL replay is
-/// the durable recovery source). Default OFF.
+/// Defer the ack-path index-log fsync (WAL replay is the durable recovery source). This is the
+/// single-barrier default; restored to a synchronous fsync only under the TS_WAL_LEGACY_RECOVERY
+/// escape hatch (whose delta-fold recovery trusts the durable delta).
 fn indexlog_wal_only_sync() -> bool {
-    ["TS_WAL_ONLY_SYNC", "TS_WAL_SINGLE_BARRIER"].iter().any(|name| {
-        matches!(
-            std::env::var(name)
-                .unwrap_or_default()
-                .trim()
-                .to_ascii_lowercase()
-                .as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    !matches!(
+        std::env::var("TS_WAL_LEGACY_RECOVERY")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
-/// TS_INDEXLOG_DEFER_SYNC: drop the served-index delta-log fdatasync from the synchronous
-/// write/ack path. The delta record is still APPENDED (so the served-index stream and every
-/// consumer of it -- gc / reclaim / manifest / reconcile / cold reload -- are unchanged); only
-/// its fdatasync is deferred. Combined with TS_WAL_ONLY_SYNC this takes the ack path from three
-/// synchronous barriers (WAL + data-page + index-log) to two: the WAL and the data pages stay
-/// durable per write, so no index reference can dangle at an un-synced page, and the durable WAL
-/// rebuilds any lost index-log delta tail on replay. Default OFF.
-///
-/// NOTE: this stops at two barriers on purpose. Eviction / expiry / compaction decisions are
-/// recorded ONLY in the served-index delta, not in the WAL, so a pure WAL replay would resurrect
-/// points a background op had removed. Reaching one barrier requires making those served-index-
-/// only mutations WAL-reconstructable first; that is a separate, larger change.
+/// Drop the served-index delta-log fdatasync from the synchronous write/ack path. The delta
+/// record is still APPENDED (so the served-index stream and every consumer of it -- gc / reclaim /
+/// manifest / reconcile / cold reload -- are unchanged); only its fdatasync is deferred. This is
+/// the single-barrier default: base-only recovery re-derives state from the durable base +
+/// WAL-tail (+ config-log, which makes config-driven eviction WAL-reconstructable), so the delta
+/// is never a recovery source and its fsync leaves the ack path. Restored to a synchronous delta
+/// fsync only under the TS_WAL_LEGACY_RECOVERY escape hatch (whose delta-fold recovery trusts it).
 fn indexlog_defer_sync() -> bool {
-    matches!(
-        std::env::var("TS_INDEXLOG_DEFER_SYNC")
+    !matches!(
+        std::env::var("TS_WAL_LEGACY_RECOVERY")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
@@ -321,7 +315,7 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        // Ack-path index-log append. Under TS_WAL_ONLY_SYNC defer this fsync (bytes are
+        // Ack-path index-log append. Under the single-barrier default defer this fsync (bytes are
         // still written): the WAL is the durable recovery source and replay rebuilds the
         // served index, so the replay-log checkpoint need not be crash-durable per write.
         if !indexlog_wal_only_sync() {
@@ -371,7 +365,7 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        // Ack-path index-log append. Under TS_WAL_ONLY_SYNC defer this fsync (bytes are
+        // Ack-path index-log append. Under the single-barrier default defer this fsync (bytes are
         // still written): the WAL is the durable recovery source and replay rebuilds the
         // served index, so the replay-log checkpoint need not be crash-durable per write.
         if !indexlog_wal_only_sync() {
@@ -429,7 +423,7 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        // Ack-path delta append. Under TS_INDEXLOG_DEFER_SYNC the record is written but its
+        // Ack-path delta append. Under the single-barrier default the record is written but its
         // fdatasync is deferred: the WAL + data pages are still durable per write, so the lost
         // delta tail is rebuilt by WAL replay and no page reference dangles. This drops the
         // index-log fdatasync from the write critical path (three barriers -> two).

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -819,15 +819,23 @@ fn wal_env_flag_on(name: &str) -> bool {
 
 /// TS_GROUP_COMMIT: coalesce concurrent WAL fsyncs into shared durability barriers.
 /// The WAL append still records every byte durably before ack; only the fsync is
-/// batched across writers. Default OFF (exact per-append fsync behavior).
+/// batched across writers. Default ON (set TS_GROUP_COMMIT=0 to force exact per-append
+/// fsync behavior); every acked write is still durable before its ack returns.
 fn group_commit_enabled() -> bool {
-    wal_env_flag_on("TS_GROUP_COMMIT")
+    match std::env::var("TS_GROUP_COMMIT") {
+        Ok(value) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => true,
+    }
 }
 
 /// Whether the redundant per-append WAL parent-dir fsync may be skipped (safe once the
-/// file exists). Enabled by either the WAL-only-sync or group-commit relaxation flag.
+/// file exists). Enabled under the single-barrier default or group-commit; restored to a
+/// per-append dir fsync only under the TS_WAL_LEGACY_RECOVERY escape hatch with group-commit off.
 fn wal_relaxed_dir_sync() -> bool {
-    wal_env_flag_on("TS_WAL_ONLY_SYNC") || wal_env_flag_on("TS_GROUP_COMMIT")
+    !wal_env_flag_on("TS_WAL_LEGACY_RECOVERY") || group_commit_enabled()
 }
 
 fn append_record_locked(
@@ -848,7 +856,7 @@ fn append_record_locked(
         file.sync_data()?;
         // The parent-directory entry for the WAL file only needs a durable barrier when
         // the file is first created; appends grow the file (inode) without changing the
-        // directory. Under relaxed-sync (TS_WAL_ONLY_SYNC / TS_GROUP_COMMIT) skip the
+        // directory. Under relaxed-sync (single-barrier default / TS_GROUP_COMMIT) skip the
         // redundant per-append dir fsync once the file already has content (offset > 0).
         if offset == 0 || !wal_relaxed_dir_sync() {
             sync_parent_dir(&path)?;

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! WAL-replay recovery under TS_INDEXLOG_DEFER_SYNC (the index-log delta fdatasync is dropped
-//! from the ack path; the WAL + data pages stay durable per write). After a crash, EVERY acked
-//! write must be reconstructed -- the WAL is self-sufficient (it embeds the full command
-//! payload), so even if the deferred-fsync index-log tail AND, as a stronger stress, the pages
-//! are lost to a simulated power cut, replay rebuilds every key. Each phase runs in its own
-//! subprocess so the durability-mode env var never leaks into the rest of the suite.
+//! WAL-replay recovery under the single write-path durability barrier -- now the DEFAULT (only the
+//! WAL takes a synchronous fdatasync per write; the data-page fdatasync and the served-index delta
+//! fdatasync are both deferred, and recovery is base-only). After a crash, EVERY acked write must
+//! be reconstructed -- the WAL is self-sufficient (it embeds the full command payload), so even if
+//! the deferred-fsync index-log tail AND, as a stronger stress, the pages are lost to a simulated
+//! power cut, replay rebuilds every key. A final phase exercises the TS_WAL_LEGACY_RECOVERY escape
+//! hatch (legacy multi-barrier write + delta-fold recovery) so the fallback stays covered. Each
+//! phase runs in its own subprocess so any mode env var never leaks into the rest of the suite.
 
 use std::process::Command;
 
@@ -14,12 +16,11 @@ fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_wal_single_barrier_crash_harness")
 }
 
+// Default-path helpers (single-barrier + group-commit are the DEFAULT, so no mode env is set).
+// These focus on losing the deferred served-index delta log (its `drop-indexlog` kill point).
 fn populate(root: &str, keys: &str, flush_at: Option<&str>) {
     let mut cmd = Command::new(bin());
-    cmd.env("TS_INDEXLOG_DEFER_SYNC", "1")
-        .env("TS_WAL_ONLY_SYNC", "1")
-        .env("TS_GROUP_COMMIT", "1")
-        .args(["--mode", "populate", "--root", root, "--keys", keys]);
+    cmd.args(["--mode", "populate", "--root", root, "--keys", keys]);
     if let Some(f) = flush_at {
         cmd.args(["--flush-at", f]);
     }
@@ -32,7 +33,6 @@ fn populate(root: &str, keys: &str, flush_at: Option<&str>) {
 
 fn powerloss(root: &str, scope: &str) {
     let out = Command::new(bin())
-        .env("TS_INDEXLOG_DEFER_SYNC", "1")
         .args(["--mode", "powerloss", "--root", root, "--scope", scope])
         .output()
         .expect("powerloss should run");
@@ -45,8 +45,6 @@ fn powerloss(root: &str, scope: &str) {
 
 fn recover_ok(root: &str, keys: &str) {
     let out = Command::new(bin())
-        .env("TS_INDEXLOG_DEFER_SYNC", "1")
-        .env("TS_WAL_ONLY_SYNC", "1")
         .args(["--mode", "recover", "--root", root, "--keys", keys])
         .output()
         .expect("recover should run");
@@ -66,9 +64,9 @@ fn recover_ok(root: &str, keys: &str) {
     );
 }
 
-// TS_WAL_SINGLE_BARRIER helpers: the TRUE single barrier (per-write data-page fdatasync also
-// deferred) with base-only recovery. Each phase runs in its own subprocess so the mode env never
-// leaks into the rest of the suite.
+// Single-barrier helpers: the TRUE single barrier (per-write data-page fdatasync also deferred)
+// with base-only recovery -- now the DEFAULT. TS_WAL_SINGLE_BARRIER=1 is left set as an explicit
+// intent marker (it resolves to the same default behavior). Each phase runs in its own subprocess.
 fn populate_sb(root: &str, keys: &str, flush_at: Option<&str>) {
     let mut cmd = Command::new(bin());
     cmd.env("TS_WAL_SINGLE_BARRIER", "1")
@@ -257,4 +255,52 @@ fn wal_is_self_sufficient_when_all_non_wal_state_is_wiped() {
     populate(root, "300", None);
     powerloss(root, "wipe-nondurable");
     recover_ok(root, "300");
+}
+
+// Legacy escape-hatch helpers: TS_WAL_LEGACY_RECOVERY=1 restores the legacy multi-barrier write
+// path (WAL + data-page + delta all fsync'd per write) + delta-fold recovery. Kept covered so the
+// operator fallback does not rot.
+fn populate_legacy(root: &str, keys: &str, flush_at: Option<&str>) {
+    let mut cmd = Command::new(bin());
+    cmd.env("TS_WAL_LEGACY_RECOVERY", "1")
+        .args(["--mode", "populate", "--root", root, "--keys", keys]);
+    if let Some(f) = flush_at {
+        cmd.args(["--flush-at", f]);
+    }
+    let out = cmd.output().expect("populate_legacy should run");
+    assert!(
+        !out.status.success(),
+        "populate_legacy must end in an abrupt abort (crash simulation)"
+    );
+}
+
+fn recover_legacy_ok(root: &str, keys: &str) {
+    let out = Command::new(bin())
+        .env("TS_WAL_LEGACY_RECOVERY", "1")
+        .args(["--mode", "recover", "--root", root, "--keys", keys])
+        .output()
+        .expect("recover_legacy should run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("\"ok\":true"),
+        "legacy delta-fold recover reported data loss: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("\"missing\":[]") && stdout.contains("\"mismatched\":[]"),
+        "legacy delta-fold recover lost or corrupted an acked write: {stdout}"
+    );
+}
+
+#[test]
+fn legacy_recovery_escape_hatch_delta_fold_recovers_every_ack() {
+    // The TS_WAL_LEGACY_RECOVERY fallback. A dump anchors a durable base at key 150 (pages fsync'd
+    // per write in legacy mode); the served-index delta is then lost. Delta-fold recovery folds the
+    // durable base and replays the WAL tail 151..300, so every acked write is restored -- proving
+    // the operator escape hatch still recovers cleanly.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_str().unwrap();
+    populate_legacy(root, "300", Some("150"));
+    powerloss(root, "drop-indexlog");
+    recover_legacy_ok(root, "300");
 }

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -91,10 +91,9 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
     # ---- [wal] --------------------------------------------------------------
-    "wal.wal_only_sync": "TS_WAL_ONLY_SYNC",
     "wal.wal_single_barrier": "TS_WAL_SINGLE_BARRIER",
-    "wal.indexlog_defer_sync": "TS_INDEXLOG_DEFER_SYNC",
     "wal.group_commit": "TS_GROUP_COMMIT",
+    "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",
     # ---- [replication] ------------------------------------------------------
     "replication.meta_addr": "TS_META_ADDR",


### PR DESCRIPTION

Flip the write path to a SINGLE synchronous durability barrier (WAL-only fdatasync per
write) with base-only recovery as the DEFAULT, and enable WAL group-commit by default.
This takes the steady-state durable write from two synchronous barriers down to one,
amortized toward sub-ms/write under concurrent load via group-commit. Every acked write
is still fully durable before its ack returns.

- wal_single_barrier() is now default ON, disabled only by the TS_WAL_LEGACY_RECOVERY
  emergency escape hatch, which restores the legacy multi-barrier write path
  (WAL + data-page + served-index delta all fsync'd on the ack path) + delta-fold recovery.
- Delete the superseded intermediate flags TS_WAL_ONLY_SYNC and TS_INDEXLOG_DEFER_SYNC
  (both subsumed by the single-barrier default). The per-write served-index delta is still
  appended (live funnel + legacy fallback) but its fdatasync leaves the ack critical path.
- Group-commit default ON (set TS_GROUP_COMMIT=0 to force exact per-append fsync).
- config/temporalstore.toml: wal_single_barrier=1, group_commit=1, wal_legacy_recovery=0;
  the config->env loader mapping is trimmed to match.

Correctness: base-only recovery trusts only the durable base/manifest checkpoint plus
WAL-tail replay (and the WAL-sequence-ordered config-log for config-driven eviction),
re-deriving every post-dump page exactly once; a never-fsync'd page is rebuilt from its
WAL command, never left dangling, and non-idempotent commands apply exactly once. The
delta-fold recovery safety test was generalized soundly: under the single-barrier default
it now proves base-only recovery LOADS a shard whose un-folded served-index delta is corrupt
AND round-trips every acked key at its exact value (no silent loss), while retaining the
refuse-load assertion under the legacy escape hatch; a new subprocess crash test exercises
the escape hatch's delta-fold recovery end to end.