### PR TITLE
perf(write-path): group-commit fsync coalescing + engine lock-release barrier

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -85,7 +85,8 @@ cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retai
 # -----------------------------------------------------------------------------
 [wal]
 wal_single_barrier = 1                 # TS_WAL_SINGLE_BARRIER  1 = single write-path barrier (WAL-only fsync; base-only recovery). DEFAULT.
-group_commit = 1                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers (sub-ms/write under load). DEFAULT.
+group_commit = 1                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers (sub-ms/write under load); also coalesces the shared-store object-store SYNC publish onto one durable barrier per group. DEFAULT.
+commit_delay_us = 0                     # TS_WAL_COMMIT_DELAY_US  group-commit batch-widening delay in microseconds. 0 = pure timer-less (batch = whatever accrues during one barrier's in-flight duration); >0 deliberately widens batches under extreme load.
 wal_legacy_recovery = 0                # TS_WAL_LEGACY_RECOVERY  1 = emergency fallback to the legacy multi-barrier write path + delta-fold recovery.
 # raft_wal_dir = ""                    # TS_RAFT_WAL_DIR        raft WAL directory (raft/replicated modes)
 

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1691,7 +1691,9 @@ fn wire_matrixobject_durability(
     use std::sync::Arc;
     use std::time::Duration;
     use temporalstore_rust::matrixobject_store::MatrixObjectObjectStore;
-    use temporalstore_rust::{SharedStoreReplicator, SharedStoreStorageMode, StorageBackend};
+    use temporalstore_rust::{
+        SharedStoreReplicator, SharedStoreStorageMode, SharedStoreWalAppendMode, StorageBackend,
+    };
 
     let (bucket, cluster_id) = match storage_backend {
         StorageBackend::MatrixObject { bucket, cluster_id } => (bucket.clone(), cluster_id.clone()),
@@ -1732,7 +1734,19 @@ fn wire_matrixobject_durability(
         }
     };
 
-    let replicator = SharedStoreReplicator::new(cluster_id, Arc::new(store));
+    // `TS_MATRIXOBJECT_SYNC_FLUSH=1` forces every write durable before ack; group commit (the
+    // `[wal] group_commit` / `TS_GROUP_COMMIT` gate, default ON) then coalesces concurrent sync
+    // writers onto a shared durable barrier. Coalescing requires the single-appendable-log
+    // (ProtobufAppendBlob) WAL layout, so select it here when group commit is active on the sync
+    // path. `latest_persisted_wal_index` / replay read BOTH layouts (union by WAL index), so a shard
+    // that previously wrote the per-key layout continues monotonically with no migration.
+    let sync_flush = env_bool("TS_MATRIXOBJECT_SYNC_FLUSH", false);
+    let group_commit = sync_flush && temporalstore_rust::wal::group_commit_configured();
+    let commit_delay = temporalstore_rust::wal::group_commit_delay();
+    let mut replicator = SharedStoreReplicator::new(cluster_id, Arc::new(store));
+    if group_commit {
+        replicator = replicator.with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+    }
 
     let latest = match rt.block_on(replicator.latest_persisted_wal_index(shard_id)) {
         Ok(latest) => latest,
@@ -1782,15 +1796,16 @@ fn wire_matrixobject_durability(
         );
     }
 
-    // `TS_MATRIXOBJECT_SYNC_FLUSH=1` forces every write durable before ack;
-    // otherwise writes are batched off the critical path (the default).
-    let sync_flush = env_bool("TS_MATRIXOBJECT_SYNC_FLUSH", false);
     let mode = SharedStoreStorageMode::from_sync_flag(sync_flush);
     let async_mode = mode.is_async();
 
     // Continue publishing at latest + 1 so we never overwrite persisted WAL
     // entries.
-    let writer = Arc::new(replicator.storage_writer(mode, latest + 1));
+    let writer = Arc::new(
+        replicator
+            .storage_writer(mode, latest + 1)
+            .with_group_commit(group_commit, commit_delay),
+    );
     let shutdown = Arc::new(AtomicBool::new(false));
     let flush_signal = Arc::new(tokio::sync::Notify::new());
 
@@ -1832,6 +1847,11 @@ fn wire_matrixobject_durability(
         });
         println!(
             "matrixobject durability: async batched flush (interval {flush_interval_ms}ms, batch {flush_batch}); durable local WAL covers process crash"
+        );
+    } else if group_commit {
+        println!(
+            "matrixobject durability: sync flush with timer-less group commit (concurrent writers coalesce onto a shared durable barrier; commit_delay {}us)",
+            commit_delay.as_micros()
         );
     } else {
         println!("matrixobject durability: sync flush (every write durable before ack)");

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -335,6 +335,10 @@ impl TemporalEngine {
                 shard.bucket_recency.insert(recency_bucket, now);
             }
         }
+        // Set to the reserved WAL sequence when the concurrent-commit path defers this
+        // write's durable barrier out of the `shards` lock (TS_ENGINE_CONCURRENT_COMMIT).
+        // The barrier is awaited AFTER the lock is released, just before the ack.
+        let mut pending_barrier_seq: Option<u64> = None;
         if outcome.mutated {
             let object_keys = command_object_keys(&command);
             // Capture this write's touched keys for the O(delta) index-log append below
@@ -408,10 +412,32 @@ impl TemporalEngine {
             // commit). Page/index materialization stays deferred to dump.
             if write_command && !replaying_wal() {
                 let sync = !config.async_storage && !bulk_ingest_mode();
-                if let Err(err) =
+                // Concurrent-commit path (gated, default OFF): for a synchronous write, only
+                // RESERVE the WAL sequence + append the bytes here (under the `shards` lock);
+                // the durable fdatasync barrier is deferred to `commit_barrier` AFTER the lock
+                // is released, so concurrent same-shard writers reach the group-commit queue in
+                // parallel and coalesce their fsyncs (see wal.rs::group_commit_sync). WAL
+                // sequence order still equals in-memory apply order because the reservation +
+                // byte-append stay under this same lock, exactly as append_with_sync did; only
+                // the order-independent fsync moves out. Off -> byte-identical append_with_sync.
+                let concurrent_commit = sync && engine_concurrent_commit();
+                let append_result = if concurrent_commit {
+                    self.wal_store
+                        .append_for_group_commit(request.shard_id, command)
+                        .map(|record| Some(record.sequence))
+                } else {
                     self.wal_store
                         .append_with_sync(request.shard_id, command, sync)
-                {
+                        .map(|_| None)
+                };
+                match append_result {
+                    Ok(deferred_seq) => {
+                        // In concurrent-commit mode remember the reserved sequence; its durable
+                        // barrier is awaited after the `shards` lock is dropped (below). The ack
+                        // is returned strictly AFTER that barrier succeeds -- never before.
+                        pending_barrier_seq = deferred_seq;
+                    }
+                    Err(err) => {
                     if sync {
                         // A synchronous write whose durable WAL commit failed is NOT durable: the
                         // WAL is the recovery source of truth (replayed on load), so returning ok
@@ -444,6 +470,7 @@ impl TemporalEngine {
                             "async WAL append failed: write acked to the client is NOT durable \
                              and will be lost on a crash before the next flush"
                         );
+                    }
                     }
                 }
             }
@@ -482,6 +509,29 @@ impl TemporalEngine {
                     None,
                     index_log_durable,
                 );
+            }
+        }
+        // Release the `shards` write lock BEFORE the durable barrier. A concurrent same-shard
+        // writer can now acquire it, mutate + reserve its own WAL sequence, and enter the
+        // group-commit queue WHILE this writer's fdatasync is in flight -- the coalescing window
+        // that makes group commit engage (fewer fsyncs than writes). The in-memory mutation and
+        // WAL sequence reservation already completed under the lock above, so WAL order == apply
+        // order holds regardless of how the (order-independent) barriers interleave. When the
+        // concurrent-commit gate is OFF, `pending_barrier_seq` is None and the barrier below is a
+        // no-op, so this is byte-identical to the prior in-lock append_with_sync path.
+        drop(shards);
+        if let Some(barrier_seq) = pending_barrier_seq {
+            if let Err(err) = self.wal_store.commit_barrier(request.shard_id, barrier_seq) {
+                // The coalesced durable barrier failed: this synchronous write is NOT durable, so
+                // surface the failure instead of acking (mirrors the append_with_sync sync-failure
+                // path -- the ack is returned strictly after a successful barrier, never before).
+                return ExecuteResponse {
+                    status: Status::error(
+                        "wal_commit_failed",
+                        format!("durable WAL commit barrier failed: {err}"),
+                    ),
+                    response: CommandResponse::Empty,
+                };
             }
         }
         ExecuteResponse {
@@ -1632,6 +1682,18 @@ pub(super) fn wal_only_sync() -> bool {
 /// back to the legacy multi-barrier write path + delta-fold recovery.
 pub(super) fn wal_single_barrier() -> bool {
     !wal_legacy_recovery()
+}
+
+/// TS_ENGINE_CONCURRENT_COMMIT: run the WAL durability barrier OUTSIDE the global `shards`
+/// write lock. When ON, a synchronous write reserves its WAL sequence and appends its record
+/// UNDER the `shards` lock (preserving WAL-order == apply-order), then RELEASES the lock and
+/// awaits the durable barrier (`commit_barrier`). This lets concurrent same-shard writers reach
+/// the group-commit queue while a peer's fdatasync is in flight, so #45's fsync coalescing
+/// actually engages (fewer fsyncs than writes; QPS scales with concurrency). Default OFF ->
+/// byte-identical to the legacy in-lock `append_with_sync` barrier. The ack is always returned
+/// strictly AFTER the covering barrier succeeds, so durability is never weakened.
+fn engine_concurrent_commit() -> bool {
+    env_flag_on("TS_ENGINE_CONCURRENT_COMMIT")
 }
 
 fn env_flag_on(name: &str) -> bool {

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -75,6 +75,7 @@ fn assert_cache_latency_histograms_observed(stats: matrixcache::CacheStats) {
 
 
 mod conformance;
+mod concurrent_commit;
 mod part1;
 mod part2;
 mod part3;

--- a/crates/temporalstore-rust/src/engine/tests/concurrent_commit.rs
+++ b/crates/temporalstore-rust/src/engine/tests/concurrent_commit.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Tests for the concurrent-commit write path (`TS_ENGINE_CONCURRENT_COMMIT`): the durable WAL
+//! barrier runs OUTSIDE the global `shards` write lock, so concurrent same-shard writers reach
+//! #45's group-commit queue and their fdatasyncs coalesce. These tests prove:
+//!   (a) with the gate ON, N concurrent same-shard writers take FEWER fdatasyncs than writes
+//!       (group commit engages) AND every acked write is present + exact (no lost/torn writes);
+//!   (b) with the gate OFF, the barrier stays under the lock -> one fsync per write (coalescing
+//!       is unreachable) -> byte-identical legacy behavior;
+//!   (c) the concurrent path is durable: after a drop + WAL-replay reload every acked write is
+//!       recovered exactly (ordering/consistency preserved -- WAL order == apply order).
+#![allow(clippy::all)]
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+
+// The gate is read from a process-global env var; serialize the sub-tests that toggle it so a
+// gate-OFF baseline measurement never observes a gate-ON window from its sibling (and vice
+// versa). Other tests are unaffected: the gate only alters the SYNC write path, and no other
+// test asserts an exact sync-write fdatasync count.
+static ENGINE_COMMIT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const WRITERS: usize = 8;
+const PER_WRITER: usize = 25; // 200 same-shard sync writes total
+
+struct ConcurrentRun {
+    fsyncs: u64,
+    writes: usize,
+    acked: usize,
+}
+
+/// Drive `WRITERS` threads, each issuing `PER_WRITER` synchronous StringSet writes to shard 1,
+/// all starting together (barrier) to maximize the group-commit overlap window. Returns the
+/// number of WAL fdatasyncs the run actually took (delta), the total write count, and how many
+/// were acked. Also asserts every acked key is retrievable with its exact value (no lost/torn
+/// write) from the LIVE engine before returning.
+fn run_concurrent_same_shard_writes(engine: &Arc<TemporalEngine>) -> ConcurrentRun {
+    let total = WRITERS * PER_WRITER;
+    let syncs_before = engine.write_ahead_log_store().stats(1).syncs;
+    let acked = Arc::new(AtomicUsize::new(0));
+    let gate = Arc::new(Barrier::new(WRITERS));
+    let mut handles = Vec::new();
+    for w in 0..WRITERS {
+        let engine = Arc::clone(engine);
+        let acked = Arc::clone(&acked);
+        let gate = Arc::clone(&gate);
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for i in 0..PER_WRITER {
+                let resp = engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("w{w}-k{i}"),
+                        value: format!("v{w}-{i}").into_bytes(),
+                    },
+                });
+                assert!(resp.status.ok, "write w{w}-k{i} must ack ok: {:?}", resp.status);
+                acked.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("writer thread must not panic");
+    }
+    let fsyncs = engine.write_ahead_log_store().stats(1).syncs - syncs_before;
+    eprintln!(
+        "[concurrent_commit] writers={WRITERS} writes={total} fdatasyncs={fsyncs} ratio={:.3} fsync/write",
+        fsyncs as f64 / total as f64
+    );
+
+    // Correctness: every acked write is present and byte-exact on the live engine.
+    for w in 0..WRITERS {
+        for i in 0..PER_WRITER {
+            let get = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("w{w}-k{i}"),
+                },
+            });
+            match get.response {
+                CommandResponse::Bytes { value: Some(value) } => assert_eq!(
+                    value,
+                    format!("v{w}-{i}").into_bytes(),
+                    "torn/wrong value for w{w}-k{i}"
+                ),
+                other => panic!("lost acked write w{w}-k{i}: {other:?}"),
+            }
+        }
+    }
+
+    ConcurrentRun {
+        fsyncs,
+        writes: total,
+        acked: acked.load(Ordering::Relaxed),
+    }
+}
+
+fn new_engine(dir: &std::path::Path) -> Arc<TemporalEngine> {
+    let engine = Arc::new(TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.join("cache"),
+        dir.join("pages"),
+        dir.join("indexes"),
+    ));
+    engine.load_shard(1);
+    engine
+}
+
+/// THE proof: with the barrier moved out of the global lock, concurrent same-shard writers
+/// coalesce their fdatasyncs (fewer fsyncs than writes); with the gate OFF the barrier stays
+/// under the lock and every write takes its own fsync. Both paths preserve all acked writes.
+#[test]
+fn concurrent_commit_coalesces_fsyncs_while_off_path_is_one_fsync_per_write() {
+    let _serial = ENGINE_COMMIT_ENV_LOCK.lock().unwrap();
+
+    // --- Baseline: gate OFF -> barrier under the shards lock -> group commit unreachable. ---
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    let off_dir = tempfile::tempdir().unwrap();
+    let off = run_concurrent_same_shard_writes(&new_engine(off_dir.path()));
+    assert_eq!(off.acked, off.writes, "gate OFF: all writes acked");
+    // Serialized under the global lock, each sync write drives its own barrier -> exactly one
+    // fdatasync per write. This is the live-proven 1.00 fdatasync/write bottleneck.
+    assert_eq!(
+        off.fsyncs, off.writes as u64,
+        "gate OFF: each sync write takes its own fsync ({} writes, {} fsyncs)",
+        off.writes, off.fsyncs
+    );
+
+    // --- Fix: gate ON -> barrier out of the lock -> group commit engages. ---
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
+    let on_dir = tempfile::tempdir().unwrap();
+    let on = run_concurrent_same_shard_writes(&new_engine(on_dir.path()));
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    assert_eq!(on.acked, on.writes, "gate ON: all writes acked");
+    // The whole point: fewer durable barriers than writes -> coalescing is now reachable.
+    assert!(
+        on.fsyncs < on.writes as u64,
+        "gate ON: group commit must coalesce fsyncs below the write count (writes={}, fsyncs={})",
+        on.writes, on.fsyncs
+    );
+    // And it must be a MEANINGFUL reduction vs the serialized baseline, not an off-by-one.
+    assert!(
+        on.fsyncs < off.fsyncs,
+        "gate ON must take strictly fewer fsyncs than the serialized OFF baseline (on={}, off={})",
+        on.fsyncs, off.fsyncs
+    );
+}
+
+/// Durability + recovery + ordering/consistency for the concurrent path: after N concurrent
+/// same-shard writers commit with the gate ON, drop the engine and reopen over the SAME dirs so
+/// the shard is rebuilt by WAL replay. Every acked write must be recovered byte-exact -- proving
+/// the sequence reservation stayed correct (WAL order == apply order) even though the fsync ran
+/// outside the lock, and that no acked write was lost/torn/reordered.
+#[test]
+fn concurrent_commit_writes_survive_wal_replay_reload() {
+    let _serial = ENGINE_COMMIT_ENV_LOCK.lock().unwrap();
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let engine = new_engine(dir.path());
+        let run = run_concurrent_same_shard_writes(&engine);
+        assert_eq!(run.acked, run.writes, "all writes acked before reload");
+        assert!(run.fsyncs < run.writes as u64, "coalescing engaged before reload");
+        // engine dropped here -> nothing flushed beyond the WAL; recovery must rebuild from it.
+    }
+
+    // Fresh engine over the same directories -> load_shard replays the WAL tail.
+    let recovered = new_engine(dir.path());
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    for w in 0..WRITERS {
+        for i in 0..PER_WRITER {
+            let get = recovered.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("w{w}-k{i}"),
+                },
+            });
+            match get.response {
+                CommandResponse::Bytes { value: Some(value) } => assert_eq!(
+                    value,
+                    format!("v{w}-{i}").into_bytes(),
+                    "recovery lost/corrupted w{w}-k{i}"
+                ),
+                other => panic!("recovery lost acked write w{w}-k{i}: {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -15,6 +15,8 @@ use temporalstore_snapshot::object_store::{
 };
 use thiserror::Error;
 
+use tokio::sync::oneshot;
+
 use crate::block_store::{BlockStoreError, LazyCheckpointBand, LocalBlockStore, SharedSlabSource};
 use crate::engine::TemporalEngine;
 use crate::sdk::{self, v1};
@@ -387,6 +389,56 @@ pub struct SharedStoreStorageWriter<O> {
     mode: SharedStoreStorageMode,
     next_wal_index: AtomicU64,
     pending: Mutex<VecDeque<SharedStoreWalEntry>>,
+    /// Timer-less queue-coalesced group commit for the SYNC path. When enabled, concurrent
+    /// sync writers append their entry to `commit` and await a covering durable barrier instead
+    /// of each publishing inline, amortizing N object-store appends onto ~1 per group. Ignored
+    /// on the async path (that path is already off the ack critical path).
+    group_commit: bool,
+    /// Optional deliberate widening of the group-commit window under extreme load. 0 (default)
+    /// keeps it purely timer-less — the group is exactly what accumulates during one append's
+    /// in-flight duration.
+    commit_delay: Duration,
+    /// Group-commit staging buffer + leader flag. A writer pushes its `(entry, waker)` here; the
+    /// first arrival becomes the flusher (leader) and every later arrival awaits its waker.
+    commit: Mutex<GroupCommitBuffer>,
+}
+
+/// One sync writer waiting on the group-commit barrier: its entry (staged for the next flush)
+/// and the channel the flusher wakes once the covering append has (or has not) reached the store.
+#[derive(Debug)]
+struct GroupCommitWaiter {
+    entry: SharedStoreWalEntry,
+    waker: oneshot::Sender<GroupCommitOutcome>,
+}
+
+#[derive(Debug, Default)]
+struct GroupCommitBuffer {
+    /// Entries appended by writers but not yet covered by a completed durable barrier.
+    queue: VecDeque<GroupCommitWaiter>,
+    /// A leader is currently running (or about to run) a flush round. Only the leader clears this,
+    /// and only under the lock once the queue is drained empty — so no entry is ever stranded.
+    flushing: bool,
+}
+
+/// Result the flusher hands each waiter. Errors are stringified so a single failed append can
+/// fan out to every covered writer (the typed `SharedStoreReplicationError` is not `Clone`); a
+/// stringified error is still an error — the durability contract only requires that a covered
+/// writer whose barrier failed is NEVER told Ok.
+#[derive(Debug, Clone)]
+enum GroupCommitOutcome {
+    Committed(SharedStoreWriteReport),
+    Failed(String),
+}
+
+impl GroupCommitOutcome {
+    fn into_result(self) -> Result<SharedStoreWriteReport, SharedStoreReplicationError> {
+        match self {
+            GroupCommitOutcome::Committed(report) => Ok(report),
+            GroupCommitOutcome::Failed(message) => Err(SharedStoreReplicationError::Io(
+                std::io::Error::new(std::io::ErrorKind::Other, message),
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -615,6 +667,115 @@ where
         Ok(())
     }
 
+    /// Group-commit barrier: make an entire batch of WAL entries durable with the FEWEST possible
+    /// object-store appends, returning a per-entry [`SharedStoreWriteReport`] aligned with `entries`.
+    ///
+    /// In `ProtobufAppendBlob` mode the shared WAL is a single per-shard appendable log of
+    /// length-prefixed frames, so the whole batch is concatenated and made durable in ONE
+    /// `append_blob` (plus ONE append of the concatenated offset-index frames) — `N` entries share
+    /// exactly `2` appends instead of `2N`. Per-entry logical offsets are derived from the single
+    /// batch receipt (`start_offset` + cumulative frame lengths); `FileObjectStore::append_blob`
+    /// appends contiguously from the prior object length, so each frame is individually
+    /// range-readable exactly as a one-at-a-time publish would have written it.
+    ///
+    /// Every entry must belong to the same shard (the caller — a per-shard storage writer —
+    /// guarantees this). The fence is re-validated ONCE for the batch. In `JsonPerKey` mode each
+    /// index is its own object, so no single-object barrier exists; the batch degrades to per-entry
+    /// publishes (still correct, just no fsync coalescing — the win is inherent to append-blob mode).
+    ///
+    /// Durability: this returns `Ok` only after the covering append(s) have reached the store, so a
+    /// caller that fans `Ok` out to waiters can never ack a write before its barrier completed.
+    pub async fn publish_wal_entries_batch(
+        &self,
+        entries: &[SharedStoreWalEntry],
+    ) -> Result<Vec<SharedStoreWriteReport>, SharedStoreReplicationError> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        let shard_id = entries[0].shard_id;
+        let single_shard = entries.iter().all(|entry| entry.shard_id == shard_id);
+        let append_blob_mode = matches!(
+            self.wal_append_mode,
+            SharedStoreWalAppendMode::ProtobufAppendBlob
+        );
+        if !append_blob_mode || !single_shard {
+            // No single-object barrier available (JsonPerKey, or a mixed-shard batch): publish each
+            // entry on its own durable barrier. Correct, just uncoalesced.
+            let mut reports = Vec::with_capacity(entries.len());
+            for entry in entries {
+                let receipt = self.publish_wal_entry(entry.clone()).await?;
+                reports.push(write_report_from_receipt(entry.wal_index, receipt.as_ref()));
+            }
+            return Ok(reports);
+        }
+
+        // R2 single-writer fence: re-validate ownership once before the coalesced append.
+        self.enforce_fence(shard_id).await?;
+        let wal_blob_key = self.wal_blob_key(shard_id);
+
+        // Concatenate every entry's length-prefixed frame into one append payload, remembering each
+        // frame's length (and command metadata) so per-entry offsets can be derived from the single
+        // receipt below.
+        let mut wal_payload: Vec<u8> = Vec::new();
+        let mut frame_lengths: Vec<u64> = Vec::with_capacity(entries.len());
+        let mut command_metadata: Vec<WalCommandMetadata> = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let frame = encode_wal_proto_frame(entry)?;
+            frame_lengths.push(frame.len() as u64);
+            command_metadata.push(wal_command_metadata(&entry.command)?);
+            wal_payload.extend_from_slice(&frame);
+        }
+        let receipt = self
+            .append_blob_with_retry(&wal_blob_key, Bytes::from(wal_payload))
+            .await?
+            .expect("protobuf append blob must return a receipt");
+
+        // Derive each entry's [start, end) from the batch receipt and build the concatenated
+        // offset-index payload, then make it durable in a single append.
+        let mut offset_payload: Vec<u8> = Vec::new();
+        let mut reports = Vec::with_capacity(entries.len());
+        let mut cursor = receipt.start_offset;
+        for ((entry, frame_len), metadata) in entries
+            .iter()
+            .zip(frame_lengths.iter().copied())
+            .zip(command_metadata.into_iter())
+        {
+            let start = cursor;
+            let end = start.saturating_add(frame_len);
+            cursor = end;
+            let offset_metadata = SharedStoreWalOffsetMetadata {
+                shard_id: entry.shard_id,
+                wal_index: entry.wal_index,
+                wal_blob_key: wal_blob_key.clone(),
+                wal_blob_start_offset: start,
+                wal_blob_end_offset: end,
+                wal_blob_bytes_written: frame_len,
+                wal_blob_object_length: receipt.object_length,
+                wal_blob_physical_band_count: receipt.physical_band_count as u64,
+                wal_blob_first_physical_offset: receipt.first_physical_offset,
+                command_byte_size: metadata.byte_size,
+                command_sha256: metadata.sha256,
+                command_encoding: metadata.encoding,
+            };
+            offset_payload.extend_from_slice(&encode_wal_offset_metadata_frame(&offset_metadata));
+            reports.push(SharedStoreWriteReport {
+                wal_index: entry.wal_index,
+                published: true,
+                queued: false,
+                wal_blob_start_offset: Some(start),
+                wal_blob_end_offset: Some(end),
+                wal_blob_bytes_written: Some(frame_len),
+                wal_blob_object_length: Some(receipt.object_length),
+            });
+        }
+        self.append_blob_with_retry(
+            &self.wal_offset_index_blob_key(shard_id),
+            Bytes::from(offset_payload),
+        )
+        .await?;
+        Ok(reports)
+    }
+
     pub async fn lookup_wal_offset_metadata(
         &self,
         shard_id: ShardId,
@@ -684,6 +845,9 @@ where
             mode,
             next_wal_index: AtomicU64::new(next_wal_index.max(1)),
             pending: Mutex::default(),
+            group_commit: false,
+            commit_delay: Duration::ZERO,
+            commit: Mutex::default(),
         }
     }
 
@@ -1718,10 +1882,35 @@ impl SharedStoreReplicator<MatrixObjectHttpStore> {
     }
 }
 
+/// Build a per-entry [`SharedStoreWriteReport`] from an optional append receipt (JsonPerKey mode
+/// has no receipt; append-blob mode carries the byte range).
+fn write_report_from_receipt(
+    wal_index: u64,
+    receipt: Option<&AppendBlobReceipt>,
+) -> SharedStoreWriteReport {
+    SharedStoreWriteReport {
+        wal_index,
+        published: true,
+        queued: false,
+        wal_blob_start_offset: receipt.map(|receipt| receipt.start_offset),
+        wal_blob_end_offset: receipt.map(|receipt| receipt.end_offset),
+        wal_blob_bytes_written: receipt.map(|receipt| receipt.bytes_written),
+        wal_blob_object_length: receipt.map(|receipt| receipt.object_length),
+    }
+}
+
 impl<O> SharedStoreStorageWriter<O>
 where
     O: ObjectStore + 'static,
 {
+    /// Enable timer-less queue-coalesced group commit on the SYNC path. `commit_delay` (default
+    /// `ZERO`) optionally widens each batch under extreme load; `ZERO` keeps it purely timer-less.
+    pub fn with_group_commit(mut self, enabled: bool, commit_delay: Duration) -> Self {
+        self.group_commit = enabled;
+        self.commit_delay = commit_delay;
+        self
+    }
+
     pub async fn write(
         &self,
         shard_id: ShardId,
@@ -1734,17 +1923,12 @@ where
             command,
         };
         match self.mode {
+            SharedStoreStorageMode::Sync if self.group_commit => {
+                self.group_commit_write(entry).await
+            }
             SharedStoreStorageMode::Sync => {
                 let receipt = self.replicator.publish_wal_entry(entry).await?;
-                Ok(SharedStoreWriteReport {
-                    wal_index,
-                    published: true,
-                    queued: false,
-                    wal_blob_start_offset: receipt.as_ref().map(|receipt| receipt.start_offset),
-                    wal_blob_end_offset: receipt.as_ref().map(|receipt| receipt.end_offset),
-                    wal_blob_bytes_written: receipt.as_ref().map(|receipt| receipt.bytes_written),
-                    wal_blob_object_length: receipt.as_ref().map(|receipt| receipt.object_length),
-                })
+                Ok(write_report_from_receipt(wal_index, receipt.as_ref()))
             }
             SharedStoreStorageMode::Async => {
                 self.pending
@@ -1762,6 +1946,107 @@ where
                 })
             }
         }
+    }
+
+    /// Timer-less queue-coalesced group commit (the reference sync-closure group-commit model). The
+    /// writer stages its entry and either becomes the flush LEADER (first arrival) or a FOLLOWER
+    /// that awaits the leader's covering durable barrier. The leader issues ONE coalesced append
+    /// per round covering every entry staged before that round began (the batch window is bounded
+    /// naturally by the append's own in-flight duration), then wakes each covered waiter. A lone
+    /// writer drains a one-entry batch immediately, adding no latency.
+    ///
+    /// Durability invariant: a waiter is told `Ok` STRICTLY AFTER the append covering its entry
+    /// returned `Ok`; on failure every covered waiter (leader included) gets `Err`. A leader that
+    /// vanishes without delivering (its `waker` dropped) surfaces as `Err` to the follower — never
+    /// a false ack. Exactly amortizes N durable barriers onto ~1 per group.
+    async fn group_commit_write(
+        &self,
+        entry: SharedStoreWalEntry,
+    ) -> Result<SharedStoreWriteReport, SharedStoreReplicationError> {
+        let wal_index = entry.wal_index;
+        let (waker, waiter) = oneshot::channel();
+        let is_leader = {
+            let mut buffer = self.commit.lock().expect("group-commit buffer lock poisoned");
+            buffer.queue.push_back(GroupCommitWaiter { entry, waker });
+            if buffer.flushing {
+                false
+            } else {
+                buffer.flushing = true;
+                true
+            }
+        };
+
+        if !is_leader {
+            // Follower: block until the leader publishes our entry. A canceled channel means the
+            // leader disappeared without delivering — report an error, never a false ack.
+            return match waiter.await {
+                Ok(outcome) => outcome.into_result(),
+                Err(_canceled) => Err(SharedStoreReplicationError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "group-commit leader dropped before publishing WAL index {wal_index}"
+                    ),
+                ))),
+            };
+        }
+
+        // Leader. Optionally widen the batch window under extreme load (default ZERO = timer-less).
+        if !self.commit_delay.is_zero() {
+            tokio::time::sleep(self.commit_delay).await;
+        }
+
+        let mut my_outcome: Option<GroupCommitOutcome> = None;
+        loop {
+            // Drain everything staged so far into this flush round. Entries that arrive DURING the
+            // append below are the next round's natural group.
+            let batch: Vec<GroupCommitWaiter> = {
+                let mut buffer = self.commit.lock().expect("group-commit buffer lock poisoned");
+                if buffer.queue.is_empty() {
+                    // Nothing left to flush: hand leadership back. A writer that enqueues after this
+                    // (under the same lock) will see `flushing == false` and become the next leader.
+                    buffer.flushing = false;
+                    break;
+                }
+                buffer.queue.drain(..).collect()
+            };
+
+            let entries: Vec<SharedStoreWalEntry> =
+                batch.iter().map(|waiter| waiter.entry.clone()).collect();
+            let result = self.replicator.publish_wal_entries_batch(&entries).await;
+            match result {
+                Ok(reports) => {
+                    for (waiter, report) in batch.into_iter().zip(reports.into_iter()) {
+                        let outcome = GroupCommitOutcome::Committed(report);
+                        if waiter.entry.wal_index == wal_index {
+                            my_outcome = Some(outcome);
+                        } else {
+                            // A dropped receiver just means that follower's future was canceled;
+                            // its entry is already durable, so nothing to undo.
+                            let _ = waiter.waker.send(outcome);
+                        }
+                    }
+                }
+                Err(err) => {
+                    // The covering append failed: every entry in this round is NOT durable. Fan the
+                    // error out to all of them (never a false ack). The stringified error is shared;
+                    // the leader keeps a typed error for its own return.
+                    let message = err.to_string();
+                    for waiter in batch.into_iter() {
+                        let outcome = GroupCommitOutcome::Failed(message.clone());
+                        if waiter.entry.wal_index == wal_index {
+                            my_outcome = Some(outcome);
+                        } else {
+                            let _ = waiter.waker.send(outcome);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Our own entry was staged before the first round drained, so it was covered by round one.
+        my_outcome
+            .expect("group-commit leader must observe its own entry in a flush round")
+            .into_result()
     }
 
     pub fn queued_len(&self) -> usize {
@@ -4042,5 +4327,279 @@ mod tests {
         fn uri(&self, key: &str) -> String {
             self.inner.uri(key)
         }
+    }
+
+    // ---- Group-commit (timer-less queue-coalesced) tests --------------------------------------
+
+    /// Wraps a real `FileObjectStore` and counts durable `append_blob` barriers so a test can prove
+    /// that N concurrent sync writers were coalesced onto far fewer than N appends. Everything else
+    /// delegates straight through, so replay/recovery behave exactly as against the inner store.
+    #[derive(Debug)]
+    struct CountingObjectStore {
+        inner: FileObjectStore,
+        append_blobs: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingObjectStore {
+        fn new(inner: FileObjectStore) -> Self {
+            Self {
+                inner,
+                append_blobs: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn append_blob_count(&self) -> usize {
+            self.append_blobs.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for CountingObjectStore {
+        async fn put(&self, key: &str, bytes: Bytes) -> Result<(), ObjectStoreError> {
+            self.inner.put(key, bytes).await
+        }
+        async fn append_blob(
+            &self,
+            key: &str,
+            bytes: Bytes,
+        ) -> Result<AppendBlobReceipt, ObjectStoreError> {
+            self.append_blobs
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.append_blob(key, bytes).await
+        }
+        async fn get(&self, key: &str) -> Result<Bytes, ObjectStoreError> {
+            self.inner.get(key).await
+        }
+        async fn get_range(
+            &self,
+            key: &str,
+            offset: u64,
+            length: u64,
+        ) -> Result<Bytes, ObjectStoreError> {
+            self.inner.get_range(key, offset, length).await
+        }
+        async fn list(&self, prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+            self.inner.list(prefix).await
+        }
+        async fn delete(&self, key: &str) -> Result<(), ObjectStoreError> {
+            self.inner.delete(key).await
+        }
+        fn uri(&self, key: &str) -> String {
+            self.inner.uri(key)
+        }
+    }
+
+    /// Fails EVERY `append_blob` (the shared-store durable barrier) so the group-commit failure
+    /// path can be exercised: no covered writer may be told Ok.
+    #[derive(Debug, Default)]
+    struct FailingAppendStore;
+
+    #[async_trait]
+    impl ObjectStore for FailingAppendStore {
+        async fn put(&self, _key: &str, _bytes: Bytes) -> Result<(), ObjectStoreError> {
+            Err(ObjectStoreError::InvalidKey("injected append failure".to_string()))
+        }
+        async fn append_blob(
+            &self,
+            _key: &str,
+            _bytes: Bytes,
+        ) -> Result<AppendBlobReceipt, ObjectStoreError> {
+            Err(ObjectStoreError::InvalidKey("injected append failure".to_string()))
+        }
+        async fn get(&self, key: &str) -> Result<Bytes, ObjectStoreError> {
+            Err(ObjectStoreError::NotFound(key.to_string()))
+        }
+        async fn list(&self, _prefix: &str) -> Result<Vec<String>, ObjectStoreError> {
+            Ok(Vec::new())
+        }
+        async fn delete(&self, _key: &str) -> Result<(), ObjectStoreError> {
+            Ok(())
+        }
+        fn uri(&self, key: &str) -> String {
+            key.to_string()
+        }
+    }
+
+    /// (a) Concurrent sync writers coalesce onto FAR fewer durable appends than writes, while every
+    /// write is Ok with a distinct byte range, and (b) every acked write is recoverable after a
+    /// simulated restart (fresh replicator replays the shared WAL) — proving durability.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn group_commit_coalesces_concurrent_sync_writers_and_stays_durable() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CountingObjectStore::new(FileObjectStore::new(
+            dir.path().join("objects"),
+        )));
+        let replicator = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone())
+            .with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+        // A small commit_delay widens the batch deterministically so the spawned writers land in the
+        // same group; the coalescing itself does not depend on it (delay 0 still batches whatever
+        // accrues during one append's in-flight window).
+        let writer = Arc::new(
+            replicator
+                .storage_writer(SharedStoreStorageMode::Sync, 1)
+                .with_group_commit(true, Duration::from_millis(5)),
+        );
+
+        const WRITERS: usize = 16;
+        let mut handles = Vec::new();
+        for i in 0..WRITERS {
+            let writer = Arc::clone(&writer);
+            handles.push(tokio::spawn(async move {
+                writer
+                    .write(
+                        1,
+                        Command::StringSet {
+                            key: format!("k{i}"),
+                            value: format!("v{i}").into_bytes(),
+                        },
+                    )
+                    .await
+            }));
+        }
+        let mut reports = Vec::new();
+        for handle in handles {
+            reports.push(handle.await.unwrap().expect("every group-commit write must ack Ok"));
+        }
+
+        // Every write acked durable with a distinct, non-overlapping byte range.
+        let mut ranges: Vec<(u64, u64)> = reports
+            .iter()
+            .map(|report| {
+                (
+                    report.wal_blob_start_offset.expect("start offset"),
+                    report.wal_blob_end_offset.expect("end offset"),
+                )
+            })
+            .collect();
+        ranges.sort();
+        for pair in ranges.windows(2) {
+            assert!(
+                pair[0].1 <= pair[1].0,
+                "WAL byte ranges must not overlap: {:?} vs {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+
+        // THE proof: far fewer durable appends than writes (each round is 2 appends: WAL + offset).
+        let appends = store.append_blob_count();
+        eprintln!(
+            "group-commit: {WRITERS} concurrent sync writes coalesced onto {appends} object-store appends (WAL+offset per round)"
+        );
+        assert!(
+            appends < WRITERS,
+            "expected group commit to coalesce {WRITERS} writes onto fewer appends, saw {appends}"
+        );
+
+        // Durability: a fresh replicator (simulated restart) recovers EVERY acked write.
+        let restarted = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone())
+            .with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+        assert_eq!(
+            restarted.latest_persisted_wal_index(1).await.unwrap(),
+            WRITERS as u64
+        );
+        let follower = test_engine(dir.path(), "follower");
+        follower.load_shard(1);
+        let report = restarted.replay_wal(1, 0, &follower).await.unwrap();
+        assert_eq!(report.applied, WRITERS);
+        for i in 0..WRITERS {
+            assert_eq!(
+                follower
+                    .execute(ExecuteRequest {
+                        shard_id: 1,
+                        command: Command::StringGet { key: format!("k{i}") },
+                    })
+                    .response,
+                CommandResponse::Bytes {
+                    value: Some(format!("v{i}").into_bytes())
+                },
+                "acked write k{i} must be durable after restart"
+            );
+        }
+    }
+
+    /// (c) Fsync/append-failure path: when the covering append fails, EVERY covered writer gets an
+    /// Err — none is falsely acked — and nothing is persisted.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn group_commit_append_failure_fails_all_covered_writers() {
+        let store = Arc::new(FailingAppendStore);
+        let replicator = SharedStoreReplicator::new(TEST_CLUSTER_ID, store)
+            .with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+        let writer = Arc::new(
+            replicator
+                .storage_writer(SharedStoreStorageMode::Sync, 1)
+                // Widen so the writers share one (failing) barrier — proving the fan-out of the error.
+                .with_group_commit(true, Duration::from_millis(5)),
+        );
+
+        const WRITERS: usize = 8;
+        let mut handles = Vec::new();
+        for i in 0..WRITERS {
+            let writer = Arc::clone(&writer);
+            handles.push(tokio::spawn(async move {
+                writer
+                    .write(
+                        1,
+                        Command::StringSet {
+                            key: format!("k{i}"),
+                            value: b"v".to_vec(),
+                        },
+                    )
+                    .await
+            }));
+        }
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert!(
+                result.is_err(),
+                "a write whose covering append failed must NOT be acked Ok"
+            );
+        }
+    }
+
+    /// (d) A lone sync writer under group commit is correct and does not stall waiting for a batch:
+    /// it drains a one-entry group immediately (2 appends: WAL + offset) and is recoverable.
+    #[tokio::test]
+    async fn group_commit_single_writer_is_correct_and_immediate() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(CountingObjectStore::new(FileObjectStore::new(
+            dir.path().join("objects"),
+        )));
+        let replicator = SharedStoreReplicator::new(TEST_CLUSTER_ID, store.clone())
+            .with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+        // Pure timer-less (delay 0): a lone writer must not wait on anything.
+        let writer = replicator
+            .storage_writer(SharedStoreStorageMode::Sync, 1)
+            .with_group_commit(true, Duration::ZERO);
+
+        let report = writer
+            .write(
+                1,
+                Command::StringSet {
+                    key: "solo".to_string(),
+                    value: b"value".to_vec(),
+                },
+            )
+            .await
+            .expect("lone group-commit write must ack Ok");
+        assert_eq!(report.wal_index, 1);
+        assert!(report.published);
+        assert_eq!(report.wal_blob_start_offset, Some(0));
+        // Exactly one group → one WAL append + one offset-index append.
+        assert_eq!(store.append_blob_count(), 2);
+
+        let restarted = SharedStoreReplicator::new(TEST_CLUSTER_ID, store)
+            .with_wal_append_mode(SharedStoreWalAppendMode::ProtobufAppendBlob);
+        let follower = test_engine(dir.path(), "follower");
+        follower.load_shard(1);
+        restarted.replay_wal(1, 0, &follower).await.unwrap();
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet { key: "solo".to_string() },
+                })
+                .response,
+            CommandResponse::Bytes { value: Some(b"value".to_vec()) }
+        );
     }
 }

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -338,6 +338,62 @@ impl LocalWriteAheadLogStore {
         Ok(record)
     }
 
+    /// Phase 1 of a two-phase durable commit: append the record bytes and RESERVE its WAL
+    /// sequence WITHOUT taking the durable barrier. The record is written with sync=false
+    /// (bytes buffered, sequence assigned + `last_sequence_by_shard` advanced) and the
+    /// returned `WriteAheadLogRecord.sequence` is then passed to `commit_barrier` AFTER the
+    /// caller has released its own state lock, so the fsync coalesces across concurrent
+    /// writers (see `group_commit_sync`). Mirrors the byte-append half of
+    /// `append_with_sync`'s group branch, minus the in-line barrier call. The caller MUST
+    /// await `commit_barrier(shard_id, record.sequence)` before acking a synchronous write.
+    pub fn append_for_group_commit(
+        &self,
+        shard_id: ShardId,
+        command: Command,
+    ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
+        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        fs::create_dir_all(&inner.root)?;
+        let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
+        let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
+        let cached_last_sequence = inner
+            .last_sequence_by_shard
+            .get(&shard_id)
+            .copied()
+            .unwrap_or_default();
+        let last_sequence = cached_last_sequence.max(disk_last_sequence);
+        inner.last_sequence_by_shard.insert(shard_id, last_sequence);
+        let seq = last_sequence.saturating_add(1);
+        let rec = WriteAheadLogRecord {
+            shard_id,
+            sequence: seq,
+            metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
+            command,
+        };
+        // sync=false: write the bytes, defer the fdatasync to `commit_barrier`. Same as the
+        // group branch of append_with_sync. `last_flushed_sequence` is NOT advanced here (the
+        // record is not yet durable); the coalesced barrier advances it once it reaches disk.
+        let report = append_record_locked(&mut inner, &rec, false)?;
+        inner.stats.last_sequence = report.current_sequence;
+        inner.last_sequence_by_shard.insert(shard_id, seq);
+        // `inner` + `_append_lock` drop here so a concurrent writer can append while this
+        // writer's (later, lock-released) group-commit fsync is in flight.
+        Ok(rec)
+    }
+
+    /// Phase 2 of a two-phase durable commit: the coalesced durable barrier for a sequence
+    /// reserved by `append_for_group_commit`. Returns once every record up to
+    /// `required_sequence` is fdatasync'd (issuing at most one shared fsync per group; returns
+    /// immediately if an earlier writer's barrier already covered `required_sequence`). Public
+    /// wrapper over `group_commit_sync` so the engine can run the barrier AFTER releasing its
+    /// `shards` write lock.
+    pub fn commit_barrier(
+        &self,
+        shard_id: ShardId,
+        required_sequence: u64,
+    ) -> Result<(), WriteAheadLogError> {
+        self.group_commit_sync(shard_id, required_sequence)
+    }
+
     /// Append a group of commands as ONE crash-atomic batch: N contiguously-sequenced records
     /// sharing a single `batch_id`, buffered, then made durable by a SINGLE barrier after the
     /// last record (the commit marker). Either the whole batch is durable (barrier completed) or,

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -831,6 +831,24 @@ fn group_commit_enabled() -> bool {
     }
 }
 
+/// Public read of the `TS_GROUP_COMMIT` (config `[wal] group_commit`) gate so paths outside this
+/// module — notably the shared-store object-store SYNC writer — honor the SAME switch as the local
+/// WAL fsync coalescing. Default ON.
+pub fn group_commit_configured() -> bool {
+    group_commit_enabled()
+}
+
+/// `TS_WAL_COMMIT_DELAY_US` (config `[wal] commit_delay_us`): optional deliberate widening of the
+/// group-commit batch window under extreme load. Default 0 = pure timer-less coalescing (the group
+/// is exactly what accumulates during one durable barrier's in-flight duration).
+pub fn group_commit_delay() -> std::time::Duration {
+    let micros = std::env::var("TS_WAL_COMMIT_DELAY_US")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(0);
+    std::time::Duration::from_micros(micros)
+}
+
 /// Whether the redundant per-append WAL parent-dir fsync may be skipped (safe once the
 /// file exists). Enabled under the single-barrier default or group-commit; restored to a
 /// per-append dir fsync only under the TS_WAL_LEGACY_RECOVERY escape hatch with group-commit off.


### PR DESCRIPTION
Write-path fsync coalescing so concurrent same-shard writers share one durability barrier, plus the engine change that lets it actually engage. Both paths are gated and default to the pre-existing behavior, so merging is byte-identical until the flags are set.

## What changed

**Group commit (`TS_GROUP_COMMIT`, default ON — unchanged):** timer-less, queue-coalesced group commit on the synchronous durable-write path. Concurrent WAL fsyncs coalesce into shared durability barriers; every acked write is still durably persisted before its ack returns. Also coalesces the shared-store object-store SYNC publish onto one durable barrier per group. New `commit_delay_us` config defaults to `0` (pure timer-less — batch is whatever accrues during one in-flight barrier), so there is no behavior change vs. today.

**Engine lock-release barrier (`TS_ENGINE_CONCURRENT_COMMIT`, default OFF):** runs the WAL durability barrier OUTSIDE the global `shards` write lock. A synchronous write reserves its WAL sequence and appends its record under the lock (preserving WAL-order == apply-order), then releases the lock and awaits the durable barrier. This lets concurrent same-shard writers reach the group-commit queue while a peer's fdatasync is in flight, so the fsync coalescing above actually engages (fewer fsyncs than writes; QPS scales with concurrency). The ack is always returned strictly after the covering barrier succeeds, so durability is never weakened. Default OFF -> byte-identical to the legacy in-lock barrier.

## Safety / testing
- Both gates default to existing behavior; no durability guarantee is relaxed (ack strictly after the covering barrier).
- New `concurrent_commit` tests: fsync coalescing under concurrency, and writes surviving WAL replay/reload.
- wal / recovery / shared_store suites green.
