### PR TITLE
feat(storage): gated manifest-parity catalog fold into the index-log (TS_INDEX_CATALOG_FOLD)

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -72,6 +72,8 @@ page_store_compression_enabled = 0     # TS_PAGE_STORE_COMPRESSION_ENABLED  1 = 
 page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    compression level (algorithm-dependent)
 page_store_compression_min_bytes = 4096  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
 cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retain slabs referenced by ANY loaded shard during GC (safe default; 0 = legacy per-shard, unsafe under multi-shard hosting)
+index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence
+# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference parity) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.
 
 
 # -----------------------------------------------------------------------------

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1264,6 +1264,79 @@ mod tests {
     }
 
     #[test]
+    fn per_append_does_not_reserialize_the_band_manifest_on_the_default_path() {
+        // MANIFEST-PARITY FOLD no-O(n) proof: on the default single-barrier path the per-append
+        // band-manifest full re-serialize (the measured O(n) aging driver -- ~961 B rewritten per
+        // write, growing with the band count) is OFF the write path. Appending many records must
+        // NOT rewrite `page_extent_manifest.json` each time; the catalog is deferred and made
+        // durable in one shot at sync_durable()/seal. Proven by the manifest file bytes staying
+        // byte-identical across a burst of appends, then changing exactly once at sync_durable.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        let manifest = band_manifest_path(dir.path());
+        // Land one append so the manifest exists at a known state, then snapshot it.
+        store.append(b"seed").unwrap();
+        store.sync_durable().unwrap();
+        let after_seed = std::fs::read(&manifest).unwrap();
+        // A burst of appends: NONE of them may rewrite the manifest (deferred off the write path).
+        for i in 0..200u32 {
+            store.append(format!("record-{i}").as_bytes()).unwrap();
+        }
+        assert_eq!(
+            std::fs::read(&manifest).unwrap(),
+            after_seed,
+            "the band manifest must NOT be re-serialized per append on the default path"
+        );
+        // The deferred catalog materializes in one shot; now it reflects the burst (bytes grew).
+        store.sync_durable().unwrap();
+        assert_ne!(
+            std::fs::read(&manifest).unwrap(),
+            after_seed,
+            "sync_durable must materialize the deferred catalog exactly once"
+        );
+    }
+
+    #[test]
+    fn zone_catalog_folds_bands_and_install_reconstructs_lifecycle() {
+        // MANIFEST-PARITY FOLD round-trip at the block-store layer: project the band catalog into
+        // the durable ZoneInfo subset, then reconstruct the band lifecycle from that projection
+        // with the band-manifest file deleted -- proving the folded catalog is a lossless source
+        // of the durable band state (diagnostics are recomputed from the slab separately).
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        store.append(b"a").unwrap();
+        // Seal the first band by rolling to a new active slab.
+        store.roll_slab().unwrap();
+        store.append(b"b").unwrap();
+        store.sync_durable().unwrap();
+        let zones = store.zone_catalog(7);
+        // Two bands: the sealed first slab and the active second slab.
+        assert_eq!(zones.len(), 2);
+        assert!(zones.iter().any(|z| z.state == crate::index_log::ZoneState::Sealed));
+        assert!(zones.iter().any(|z| z.state == crate::index_log::ZoneState::Active));
+        assert!(zones.iter().all(|z| z.version == 7));
+        // Delete the band-manifest file so the reopened store has no cached catalog file; it
+        // reconstructs bands from the durable slabs (reconcile-on-open), then we install the
+        // folded catalog on top. The lifecycle states must match the pre-crash projection.
+        let reopened = LocalBlockStore::new(dir.path());
+        std::fs::remove_file(band_manifest_path(dir.path())).ok();
+        let changed = reopened.install_zone_catalog(&zones).unwrap();
+        let recovered = reopened.zone_catalog(0);
+        let state_of = |slab: u64, zs: &[crate::index_log::ZoneInfo]| {
+            zs.iter().find(|z| z.page_slab_id == slab).map(|z| z.state)
+        };
+        for zone in &zones {
+            assert_eq!(
+                state_of(zone.page_slab_id, &recovered),
+                Some(zone.state),
+                "band {} lifecycle must reconstruct from the folded catalog",
+                zone.page_slab_id
+            );
+        }
+        let _ = changed;
+    }
+
+    #[test]
     fn gc_slabs_removes_old_non_current_slabs() {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -5,6 +5,26 @@
 
 use super::*;
 
+/// Map a band descriptor's lifecycle state to the index-log `ZoneState` (1:1). Kept a free fn
+/// so both directions of the MANIFEST-PARITY FOLD conversion share one mapping.
+fn band_state_to_zone_state(state: BlockStoreBandState) -> crate::index_log::ZoneState {
+    match state {
+        BlockStoreBandState::Active => crate::index_log::ZoneState::Active,
+        BlockStoreBandState::Sealed => crate::index_log::ZoneState::Sealed,
+        BlockStoreBandState::DelayedDestroy => crate::index_log::ZoneState::DelayedDestroy,
+        BlockStoreBandState::Purged => crate::index_log::ZoneState::Purged,
+    }
+}
+
+fn zone_state_to_band_state(state: crate::index_log::ZoneState) -> BlockStoreBandState {
+    match state {
+        crate::index_log::ZoneState::Active => BlockStoreBandState::Active,
+        crate::index_log::ZoneState::Sealed => BlockStoreBandState::Sealed,
+        crate::index_log::ZoneState::DelayedDestroy => BlockStoreBandState::DelayedDestroy,
+        crate::index_log::ZoneState::Purged => BlockStoreBandState::Purged,
+    }
+}
+
 impl LocalBlockStore {
     pub fn band_descriptors(&self) -> Vec<BlockStoreBandDescriptor> {
         self.inner
@@ -14,6 +34,101 @@ impl LocalBlockStore {
             .values()
             .cloned()
             .collect()
+    }
+
+    /// MANIFEST-PARITY FOLD: project the in-memory band catalog into the DURABLE `ZoneInfo`
+    /// subset the reference keeps in `IndexLog.MetaItem.zones`. Only the durable fields ride in
+    /// the fold; the band descriptor's diagnostic fields (readable_prefix / corruption / errors)
+    /// are deliberately dropped -- they are recomputed on load by scanning the slab, exactly as
+    /// the reference does not persist them. `zone_version` stamps every entry so a folded anchor
+    /// carries a monotonically-versioned snapshot.
+    pub fn zone_catalog(&self, zone_version: u64) -> Vec<crate::index_log::ZoneInfo> {
+        self.inner
+            .lock()
+            .expect("block store lock poisoned")
+            .bands
+            .values()
+            .map(|band| crate::index_log::ZoneInfo {
+                page_slab_id: band.page_slab_id,
+                state: band_state_to_zone_state(band.state),
+                physical_bytes: band.physical_bytes,
+                logical_bytes: band.logical_bytes,
+                created_unix_ms: band.created_unix_ms,
+                updated_unix_ms: band.updated_unix_ms,
+                first_page_id: band.first_page_id,
+                last_page_id: band.last_page_id,
+                version: zone_version,
+            })
+            .collect()
+    }
+
+    /// MANIFEST-PARITY FOLD recovery: seed the band catalog from a folded `ZoneInfo` snapshot
+    /// recovered from the index-log MetaItem. Applied on load AFTER the block store has already
+    /// reconciled from durable pages (reconcile stays authoritative for on-disk physical bytes
+    /// and diagnostics), so this only RESTORES the catalog fields a pure disk scan cannot infer:
+    /// the exact lifecycle state, the creation/update timestamps, the logical byte count, and the
+    /// first/last page-id range. It never deletes a band reconcile found on disk and never
+    /// downgrades physical bytes below what the slab actually holds -- so it cannot lose durable
+    /// state; it is a metadata refinement layered on the lossless disk-derived catalog. Persists
+    /// the merged manifest once. Returns whether anything changed.
+    pub fn install_zone_catalog(
+        &self,
+        zones: &[crate::index_log::ZoneInfo],
+    ) -> Result<bool, BlockStoreError> {
+        let mut inner = self.inner.lock().expect("block store lock poisoned");
+        let active = inner.page_slab_id;
+        let mut changed = false;
+        for zone in zones {
+            let state = zone_state_to_band_state(zone.state);
+            match inner.bands.get_mut(&zone.page_slab_id) {
+                Some(band) => {
+                    let before = band.clone();
+                    // Never override the live ACTIVE slab's disk-derived state (it holds the open
+                    // write frontier); for every other slab adopt the folded lifecycle state.
+                    if zone.page_slab_id != active {
+                        band.state = state;
+                    }
+                    band.created_unix_ms = band.created_unix_ms.or(zone.created_unix_ms);
+                    if band.updated_unix_ms.is_none() {
+                        band.updated_unix_ms = zone.updated_unix_ms;
+                    }
+                    if band.logical_bytes == 0 {
+                        band.logical_bytes = zone.logical_bytes;
+                    }
+                    band.first_page_id = band.first_page_id.or(zone.first_page_id);
+                    band.last_page_id = band.last_page_id.or(zone.last_page_id);
+                    changed |= *band != before;
+                }
+                None => {
+                    // A band the disk scan did not surface (e.g. a purged/reclaimed slab with no
+                    // live file): install it from the fold so accounting/GC see the full history.
+                    inner.bands.insert(
+                        zone.page_slab_id,
+                        BlockStoreBandDescriptor {
+                            band_id: band_id_for_slab(zone.page_slab_id),
+                            page_slab_id: zone.page_slab_id,
+                            state,
+                            physical_bytes: zone.physical_bytes,
+                            logical_bytes: zone.logical_bytes,
+                            created_unix_ms: zone.created_unix_ms,
+                            updated_unix_ms: zone.updated_unix_ms,
+                            first_page_id: zone.first_page_id,
+                            last_page_id: zone.last_page_id,
+                            readable_prefix_physical_bytes: zone.physical_bytes,
+                            has_corruption: false,
+                            first_error_offset: None,
+                            first_error: None,
+                        },
+                    );
+                    changed = true;
+                }
+            }
+        }
+        if changed {
+            let root = inner.root.clone();
+            persist_band_manifest(&root, &inner.bands)?;
+        }
+        Ok(changed)
     }
 
     pub fn band_summary(&self) -> BlockStoreBandSummary {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -214,6 +214,21 @@ impl TemporalEngine {
             };
             (loaded, replay_watermark)
         };
+        // MANIFEST-PARITY FOLD recovery (gate on only): seed the band catalog from the folded
+        // `MetaItem.zones` anchor recovered from the index-log. This is applied AFTER the block
+        // store already reconciled its catalog from the durable pages on open, so it only
+        // RESTORES the catalog fields a pure disk scan cannot infer (exact lifecycle state,
+        // creation/update timestamps, logical byte count, page-id range) and installs bands for
+        // reclaimed slabs with no live file. It never deletes a reconciled band and never lowers
+        // physical bytes below the slab's real size, so it cannot lose durable state -- it is a
+        // metadata refinement over the lossless disk-derived catalog, making the per-write
+        // band-manifest file unnecessary as the catalog's source of truth. Off, this is skipped
+        // entirely (byte-identical).
+        if crate::index_log::index_catalog_fold_enabled() {
+            if let Ok(Some(meta)) = self.index_log_store.latest_zone_catalog(request.shard_id) {
+                let _ = self.page_store.install_zone_catalog(&meta.zones);
+            }
+        }
         let mut state = loaded.unwrap_or_default();
         promote_model_maps_to_bucket_index_authority(
             request.shard_id,

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -339,6 +339,94 @@ impl TemporalEngine {
         let _ = atomic_write_bytes(&self.index_path(shard_id), &index_bytes);
     }
 
+    /// MANIFEST-PARITY FOLD threshold check: dump the index catalog when the undumped index-log
+    /// gap has crossed `index_dump_oplog_gap_bytes` (reference `storage_dump_index_meta_oplog_gap`
+    /// cadence). No-op with the `TS_INDEX_CATALOG_FOLD` gate off, so the background cycle is
+    /// byte-identical when the fold is not enabled. Returns whether a dump fired.
+    pub fn maybe_dump_index_catalog(&self, shard_id: ShardId) -> bool {
+        if !crate::index_log::index_catalog_fold_enabled() {
+            return false;
+        }
+        let gap = crate::storage_config::index_dump_oplog_gap_bytes();
+        let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
+        if !crate::index_log::should_dump_index_catalog(undumped, gap) {
+            return false;
+        }
+        self.dump_index_catalog(shard_id)
+    }
+
+    /// Test-only variant of `maybe_dump_index_catalog` taking an explicit gap, so a test can drive
+    /// both the below-threshold (no dump) and above-threshold (dump) branches deterministically
+    /// without mutating the process-wide gap env mid-test.
+    #[cfg(test)]
+    pub fn maybe_dump_index_catalog_with_gap_for_test(&self, shard_id: ShardId, gap_bytes: u64) -> bool {
+        if !crate::index_log::index_catalog_fold_enabled() {
+            return false;
+        }
+        let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
+        if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
+            return false;
+        }
+        self.dump_index_catalog(shard_id)
+    }
+
+    /// MANIFEST-PARITY FOLD dump: materialize the durable base index, fold the band/zone catalog
+    /// into an index-log `MetaItem` anchor (reference `IndexLog.MetaItem.zones` parity), and
+    /// advance the dumped watermark -- the batched, threshold-driven replacement for the per-write
+    /// band-manifest persist. No-op with the gate off. Ordering is single-barrier safe: pages +
+    /// WAL are fsynced, then the base index is written durably, then the folded anchor is fsync'd,
+    /// and only THEN is the dumped watermark advanced. A crash at any earlier point leaves the
+    /// watermark unadvanced, so the next cycle re-dumps rather than trusting a partial dump -- the
+    /// catalog is never lost, only (harmlessly) re-materialized. Returns whether a dump completed.
+    pub fn dump_index_catalog(&self, shard_id: ShardId) -> bool {
+        if !crate::index_log::index_catalog_fold_enabled() {
+            return false;
+        }
+        // 1. Make deferred data pages + the band manifest + the WAL durable BEFORE materializing
+        //    the dump, so nothing the anchor references is un-fsynced. Bail (without advancing the
+        //    watermark) if the barrier fails; the next cycle retries.
+        if self.page_store.sync_durable().is_err() || self.wal_store.flush(shard_id).is_err() {
+            return false;
+        }
+        // 2. Serialize + durably write the base served index (collapses the legacy per-write
+        //    whole-index rewrite into this threshold dump). Also read the WAL anchor the index
+        //    reflects for the folded MetaItem.
+        let (index_bytes, anchor) = {
+            let shards = self.shards.read().expect("engine lock poisoned");
+            match shards.get(&shard_id) {
+                Some(shard) => (serialize_index(shard), shard.applied_wal_sequence.unwrap_or(0)),
+                None => return false,
+            }
+        };
+        if self.persist_index_bytes_durable(shard_id, &index_bytes).is_err() {
+            return false;
+        }
+        // 3. Fold the band/zone catalog into a MetaItem anchor and append it durably to the
+        //    index-log. This is the reference's "dump the zone catalog into the index log" step:
+        //    after it, the band catalog is recoverable from the durable log, so the per-write
+        //    band-manifest file stops being the source of truth.
+        let zone_version = anchor;
+        let zones = self.page_store.zone_catalog(zone_version);
+        let meta = crate::index_log::MetaItem {
+            version: 1,
+            start_wal_sequence: anchor,
+            timestamp_ms: now_ms(),
+            zone_version,
+            zones,
+        };
+        if self
+            .index_log_store
+            .append_delta(shard_id, Vec::new(), Vec::new(), Some(anchor), Some(meta), true)
+            .is_err()
+        {
+            return false;
+        }
+        // 4. The base + folded anchor are durable; advance the dumped watermark so the undumped
+        //    gap resets and the next threshold is measured from here.
+        self.index_log_store.mark_catalog_dumped(shard_id);
+        true
+    }
+
     pub(super) fn persist_index_bytes(&self, shard_id: ShardId, bytes: &[u8]) -> Result<(), std::io::Error> {
         // Bulk backfill defers the served-index rewrite to flush_shard_index()
         // (turns O(n^2) per-record persistence into one write per batch).

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -947,6 +947,16 @@ impl TemporalEngine {
                 + pressure_signals.raft_snapshot_retention_blockers,
         );
 
+        // MANIFEST-PARITY FOLD threshold dump (gate on only, never on a dry run): if the undumped
+        // index-log gap has crossed `index_dump_oplog_gap_bytes`, materialize the base index +
+        // fold the band/zone catalog into an index-log anchor here, in the background cycle --
+        // mirroring the reference's background `StorageManager` dump-on-oplog-gap cadence, never
+        // per write. No-op with the gate off, so the cycle stays byte-identical when the fold is
+        // not enabled.
+        if !request.dry_run {
+            self.maybe_dump_index_catalog(request.shard_id);
+        }
+
         let production_parity_slice = errors.is_empty()
             && native_stage_order
                 .iter()

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2043,6 +2043,233 @@ fn reconcile_does_not_resurrect_evicted_feature_points_on_reload() {
     );
 }
 
+/// Sets an env gate for the duration of a test and removes it on drop (even on panic), so a
+/// gated-behavior test never leaks its flag into the rest of the suite.
+struct FoldEnvGuard {
+    names: Vec<&'static str>,
+}
+
+impl FoldEnvGuard {
+    fn set(pairs: &[(&'static str, &str)]) -> Self {
+        let names = pairs.iter().map(|(name, _)| *name).collect();
+        for (name, value) in pairs {
+            std::env::set_var(name, value);
+        }
+        Self { names }
+    }
+}
+
+impl Drop for FoldEnvGuard {
+    fn drop(&mut self) {
+        for name in &self.names {
+            std::env::remove_var(name);
+        }
+    }
+}
+
+fn write_string(engine: &TemporalEngine, key: &str, value: &[u8]) {
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.to_vec(),
+        },
+    });
+}
+
+fn read_string(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
+    match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: key.to_string(),
+            },
+        })
+        .response
+    {
+        CommandResponse::Bytes { value } => value,
+        other => panic!("expected Bytes, got {other:?}"),
+    }
+}
+
+#[test]
+fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() {
+    // MANIFEST-PARITY FOLD cadence: with a tiny oplog gap, a threshold dump fires once the
+    // undumped index-log has grown past it, folding the band/zone catalog into an index-log
+    // MetaItem anchor; below the gap nothing is dumped. Mirrors the reference
+    // storage_dump_index_meta_oplog_gap background cadence -- never a per-write dump.
+    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1 << 20, dir.path().join("cache"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    write_string(&engine, "k0", b"v0");
+    // A gap far larger than the current index-log must NOT dump.
+    assert!(
+        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX),
+        "no dump below the threshold"
+    );
+    assert!(
+        engine.index_log_store().latest_zone_catalog(1).unwrap().is_none(),
+        "no folded catalog before any dump"
+    );
+    // A gap of 1 byte crosses immediately: exactly one dump fires and folds the catalog.
+    for i in 0..8 {
+        write_string(&engine, &format!("k{i}"), b"value");
+    }
+    assert!(
+        engine.maybe_dump_index_catalog_with_gap_for_test(1, 1),
+        "dump fires once the undumped gap crosses the threshold"
+    );
+    let catalog = engine.index_log_store().latest_zone_catalog(1).unwrap();
+    let catalog = catalog.expect("a folded band/zone catalog must be durable after the dump");
+    assert!(
+        !catalog.zones.is_empty(),
+        "the dump must fold at least the active band into the anchor"
+    );
+    // The watermark advanced: the undumped gap reset, so an immediate re-check does not re-dump.
+    assert!(
+        !engine.maybe_dump_index_catalog_with_gap_for_test(1, u64::MAX),
+        "the dumped watermark advanced; no immediate re-dump"
+    );
+}
+
+#[test]
+fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
+    // MANIFEST-PARITY FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
+    // file, reload -- every acked key must survive AND the band lifecycle must reconstruct from
+    // the folded index-log MetaItem, proving the fold is a lossless catalog source.
+    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1 << 20, dir.path().join("cache-a"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    for i in 0..50 {
+        write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
+    }
+    assert!(engine.dump_index_catalog(1), "explicit dump must complete");
+    let folded = engine
+        .index_log_store()
+        .latest_zone_catalog(1)
+        .unwrap()
+        .expect("catalog folded");
+    drop(engine);
+    // Delete the band-manifest file: the catalog must come back from the index-log fold, not the
+    // per-write file.
+    let manifest = page_dir.join("page_extent_manifest.json");
+    if manifest.exists() {
+        std::fs::remove_file(&manifest).unwrap();
+    }
+    let restarted = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+    for i in 0..50 {
+        assert_eq!(
+            read_string(&restarted, &format!("key-{i}")),
+            Some(format!("val-{i}").into_bytes()),
+            "every acked key must survive reload after the manifest fold"
+        );
+    }
+    // The folded lifecycle states are present in the reconstructed catalog.
+    let recovered = restarted.block_store().zone_catalog(0);
+    for zone in &folded.zones {
+        assert!(
+            recovered.iter().any(|z| z.page_slab_id == zone.page_slab_id),
+            "band {} must be present after reload from the fold",
+            zone.page_slab_id
+        );
+    }
+}
+
+#[test]
+fn manifest_fold_on_does_not_resurrect_evicted_feature_points_on_reload() {
+    // The #22 resurrection trap must still hold with the fold ON: the fold touches the band
+    // catalog (M1), NOT the per-write served-index delta / key_states nor the WAL config-log, so
+    // config-driven feature_max_size eviction stays durable and does not resurrect on reload.
+    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    feature_max_size: 3,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::FeatureAppend {
+            key: "f".to_string(),
+            points: (1..=5)
+                .map(|i| FeaturePoint {
+                    timestamp_ms: i * 10,
+                    value: vec![i as u8],
+                })
+                .collect(),
+        },
+    });
+    let live_timestamps = |engine: &TemporalEngine| -> Vec<u64> {
+        match engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::FeatureQuery {
+                    key: "f".to_string(),
+                    start_ms: 0,
+                    end_ms: u64::MAX,
+                    count: Some(100),
+                },
+            })
+            .response
+        {
+            CommandResponse::FeaturePoints { points } => {
+                points.iter().map(|point| point.timestamp_ms).collect()
+            }
+            other => panic!("expected FeaturePoints, got {other:?}"),
+        }
+    };
+    // Fold a catalog dump into the mix so the reload exercises the fold recovery path.
+    assert!(engine.dump_index_catalog(1));
+    let before = live_timestamps(&engine);
+    assert!(
+        before.contains(&50) && !before.contains(&10),
+        "trim keeps the newest, drops the oldest: {before:?}"
+    );
+    drop(engine);
+    let restarted = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+    assert_eq!(
+        live_timestamps(&restarted),
+        before,
+        "the fold must not resurrect config-evicted feature points on reload"
+    );
+}
+
 #[test]
 fn hash_incrby_rejects_non_integer_and_overflow_like_native() {
     let engine = TemporalEngine::default();

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -100,12 +100,60 @@ pub struct IndexItem {
     pub deleted: bool,
 }
 
+/// Band/zone lifecycle state folded into the index-log MetaItem. 1:1 with
+/// `block_store::BlockStoreBandState` and with the reference `IndexLog.ZoneState`
+/// (INIT/CREATED/FROZEN/RECYCLED): Active==CREATED, Sealed==FROZEN, DelayedDestroy/Purged
+/// cover the RECYCLED grace. Serialized snake_case so it round-trips with the band manifest's
+/// own state enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZoneState {
+    Active,
+    Sealed,
+    DelayedDestroy,
+    Purged,
+}
+
+/// One band/zone catalog entry folded into the index-log MetaItem, mirroring the reference
+/// `IndexLog.MetaItem.zones` (`map<uint32,ZoneInfo>`). Carries the DURABLE catalog fields the
+/// band descriptor tracks -- lifecycle state, byte counts, timestamps, page-id range, version.
+/// The band descriptor's DIAGNOSTIC fields (readable_prefix_physical_bytes / has_corruption /
+/// first_error*) are intentionally ABSENT: they are recomputed on load by scanning the slab
+/// (`inspect_slab`, driven by `rebuild_band_manifest_at` / reconcile-on-open), exactly as the
+/// reference does not persist them. So this is the lossless durable projection of a band.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZoneInfo {
+    #[serde(alias = "zone_id")]
+    pub page_slab_id: u64,
+    pub state: ZoneState,
+    #[serde(alias = "total_bytes")]
+    pub physical_bytes: u64,
+    #[serde(default)]
+    pub logical_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_unix_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_unix_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_page_id: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_page_id: Option<u64>,
+    #[serde(default)]
+    pub version: u64,
+}
+
 /// Compaction anchor for the delta log. `start_wal_sequence` is the lowest WAL sequence
 /// still required to reconstruct the served index on top of the base snapshot: once the
 /// base `shard-{id}.index.json` is rewritten at a compaction point, the anchor advances
 /// and every delta record at or before it can be truncated. Mirrors the reference
 /// MetaItem's `start_oplog_id` role in the native WAL vocabulary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `zones` folds the band/zone catalog into the anchor (reference `MetaItem.zones` parity). It
+/// is populated ONLY at a threshold dump, and ONLY when the `TS_INDEX_CATALOG_FOLD` gate is on;
+/// with the gate off it is always empty and (via `skip_serializing_if`) not serialized, so an
+/// anchor record is byte-identical to the pre-fold record. Legacy anchors without `zones`
+/// deserialize to an empty catalog and replay unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetaItem {
     #[serde(default)]
     pub version: u64,
@@ -113,6 +161,10 @@ pub struct MetaItem {
     pub start_wal_sequence: u64,
     #[serde(default)]
     pub timestamp_ms: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub zones: Vec<ZoneInfo>,
+    #[serde(default)]
+    pub zone_version: u64,
 }
 
 /// One appended delta record: either a batch of page/object item deltas (PAGE/OBJECT) or
@@ -203,6 +255,12 @@ struct IndexLogInner {
     root: PathBuf,
     stats: IndexLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
+    /// MANIFEST-PARITY FOLD: the index-log byte length recorded at the last catalog dump, per
+    /// shard. `undumped_len_since_dump` subtracts this from the current on-disk length to get the
+    /// undumped gap that drives the threshold-dump cadence (reference `UnDumpLength`). Reset to 0
+    /// on process restart, so the first post-restart cycle may dump once -- harmless (a dump only
+    /// materializes durable state that is already recoverable).
+    last_dumped_len_by_shard: HashMap<ShardId, u64>,
 }
 
 fn indexlog_enabled() -> bool {
@@ -239,7 +297,89 @@ fn indexlog_wal_only_sync() -> bool {
     )
 }
 
+/// MANIFEST-PARITY FOLD gate (default OFF, byte-identical when off). When on, the band/zone
+/// catalog is folded into the index-log `MetaItem.zones` at a threshold dump (reference
+/// `IndexLog.MetaItem.zones` parity) and the per-write band-manifest file stops being the
+/// catalog's source of truth (it is reconstructed on load from the durable pages + the folded
+/// anchor). Off, none of that fold code runs: no `zones` are ever captured (so anchor records
+/// serialize identically), and recovery/persistence take the existing paths unchanged. Ships
+/// dark; flips on after the crash-recovery suite is green.
+pub fn index_catalog_fold_enabled() -> bool {
+    matches!(
+        std::env::var("TS_INDEX_CATALOG_FOLD")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Threshold decision for the background catalog/index dump, mirroring the reference
+/// `storage_dump_index_meta_oplog_gap` gate (`ShouldDelayDumpOplog` compares the undumped
+/// oplog length against the 1 MiB gap). `undumped_bytes` is the served-index-log growth since
+/// the last dumped watermark; when it crosses `gap_bytes` the dump fires. A zero gap disables
+/// the cadence (never dump on threshold) so an operator can pin dumps to compaction/unload only.
+pub fn should_dump_index_catalog(undumped_bytes: u64, gap_bytes: u64) -> bool {
+    gap_bytes > 0 && undumped_bytes >= gap_bytes
+}
+
 impl LocalIndexLogStore {
+    /// On-disk byte length of a shard's index-log file (0 if absent). Used as the "undumped
+    /// length" signal for the threshold-dump cadence: the growth of this file since the last
+    /// dumped watermark is the native analog of the reference `OpLogger::UnDumpLength()`.
+    pub fn log_len_bytes(&self, shard_id: ShardId) -> u64 {
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        index_log_path(&inner.root, shard_id)
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0)
+    }
+
+    /// Undumped index-log length for a shard: the on-disk byte growth since the last catalog
+    /// dump (`mark_catalog_dumped`). This is the native analog of the reference
+    /// `OpLogger::UnDumpLength()` and is the signal compared against `index_dump_oplog_gap_bytes`
+    /// to decide a threshold dump. A shard never dumped this process (or freshly restarted)
+    /// reports the whole current length.
+    pub fn undumped_len_since_dump(&self, shard_id: ShardId) -> u64 {
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        let current = index_log_path(&inner.root, shard_id)
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let dumped = inner
+            .last_dumped_len_by_shard
+            .get(&shard_id)
+            .copied()
+            .unwrap_or(0);
+        current.saturating_sub(dumped)
+    }
+
+    /// Record that a catalog dump captured the shard's index-log up to its current on-disk
+    /// length, resetting the undumped gap to 0. Called by the engine ONLY after the dump's base
+    /// index + folded anchor are durably written, so the watermark never advances past
+    /// non-durable state (restart-during-dump re-dumps rather than skipping).
+    pub fn mark_catalog_dumped(&self, shard_id: ShardId) {
+        let mut inner = self.inner.lock().expect("index log lock poisoned");
+        let current = index_log_path(&inner.root, shard_id)
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        inner.last_dumped_len_by_shard.insert(shard_id, current);
+    }
+
+    /// The most recent `MetaItem` anchor carrying a folded band/zone catalog, or `None` if no
+    /// anchor with a non-empty `zones` list has been written. Used on load (gate on) to seed the
+    /// block-store band catalog from the folded anchor when the band-manifest file is absent.
+    pub fn latest_zone_catalog(&self, shard_id: ShardId) -> Result<Option<MetaItem>, IndexLogError> {
+        let records = self.read_delta_records(shard_id, 0)?;
+        Ok(records
+            .into_iter()
+            .filter_map(|record| record.meta)
+            .filter(|meta| !meta.zones.is_empty())
+            .next_back())
+    }
+
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root = root.into();
         let _ = fs::create_dir_all(&root);
@@ -248,6 +388,7 @@ impl LocalIndexLogStore {
                 root,
                 stats: IndexLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
+                last_dumped_len_by_shard: HashMap::new(),
             })),
         }
     }
@@ -865,11 +1006,12 @@ mod tests {
             version: 1,
             start_wal_sequence: 42,
             timestamp_ms: 100,
+            ..MetaItem::default()
         };
         store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta), true).unwrap();
         let records = store.read_delta_records(3, 0).unwrap();
         assert_eq!(records.len(), 2);
-        assert_eq!(records[1].meta.unwrap().start_wal_sequence, 42);
+        assert_eq!(records[1].meta.as_ref().unwrap().start_wal_sequence, 42);
     }
 
     #[test]
@@ -979,6 +1121,138 @@ mod tests {
             Err(IndexLogError::Corruption(_)) => {}
             other => panic!("out-of-order delta sequences must be a Corruption error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn meta_item_without_zones_serializes_byte_identically_to_pre_fold() {
+        // Byte-identical-when-off invariant: an anchor whose `zones` is empty (the only state
+        // reachable with TS_INDEX_CATALOG_FOLD off) must serialize with NO `zones` key and NO
+        // `zone_version` beyond what a pre-fold MetaItem produced. `zone_version` defaults to 0
+        // and is not skipped, so it appears; assert the value carries only the legacy three
+        // fields plus a zero zone_version and no zones array.
+        let meta = MetaItem {
+            version: 7,
+            start_wal_sequence: 11,
+            timestamp_ms: 22,
+            ..MetaItem::default()
+        };
+        let value = serde_json::to_value(&meta).unwrap();
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("zones"), "empty zones must be skipped");
+        assert_eq!(object.get("version").unwrap(), 7);
+        assert_eq!(object.get("start_wal_sequence").unwrap(), 11);
+        assert_eq!(object.get("timestamp_ms").unwrap(), 22);
+        assert_eq!(object.get("zone_version").unwrap(), 0);
+        // And it round-trips.
+        let back: MetaItem = serde_json::from_value(value).unwrap();
+        assert_eq!(back, meta);
+    }
+
+    #[test]
+    fn meta_item_zone_catalog_round_trips_through_the_delta_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        let meta = MetaItem {
+            version: 1,
+            start_wal_sequence: 5,
+            timestamp_ms: 100,
+            zone_version: 3,
+            zones: vec![
+                ZoneInfo {
+                    page_slab_id: 0,
+                    state: ZoneState::Sealed,
+                    physical_bytes: 4096,
+                    logical_bytes: 4000,
+                    created_unix_ms: Some(10),
+                    updated_unix_ms: Some(20),
+                    first_page_id: Some(0),
+                    last_page_id: Some(9),
+                    version: 3,
+                },
+                ZoneInfo {
+                    page_slab_id: 1,
+                    state: ZoneState::Active,
+                    physical_bytes: 512,
+                    logical_bytes: 512,
+                    created_unix_ms: Some(30),
+                    updated_unix_ms: Some(30),
+                    first_page_id: Some(10),
+                    last_page_id: Some(10),
+                    version: 3,
+                },
+            ],
+        };
+        store
+            .append_delta(4, Vec::new(), Vec::new(), Some(5), Some(meta.clone()), true)
+            .unwrap();
+        // A reopen reads the folded catalog back exactly, and latest_zone_catalog finds it.
+        let reopened = LocalIndexLogStore::new(dir.path());
+        let recovered = reopened.latest_zone_catalog(4).unwrap().unwrap();
+        assert_eq!(recovered, meta);
+        assert_eq!(recovered.zones.len(), 2);
+        assert_eq!(recovered.zones[0].state, ZoneState::Sealed);
+        assert_eq!(recovered.zones[1].page_slab_id, 1);
+    }
+
+    #[test]
+    fn latest_zone_catalog_prefers_the_newest_anchor_and_ignores_empty_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        let older = MetaItem {
+            version: 1,
+            start_wal_sequence: 1,
+            timestamp_ms: 1,
+            zone_version: 1,
+            zones: vec![ZoneInfo {
+                page_slab_id: 0,
+                state: ZoneState::Active,
+                physical_bytes: 1,
+                logical_bytes: 1,
+                created_unix_ms: None,
+                updated_unix_ms: None,
+                first_page_id: None,
+                last_page_id: None,
+                version: 1,
+            }],
+        };
+        let newer = MetaItem {
+            version: 2,
+            start_wal_sequence: 9,
+            timestamp_ms: 9,
+            zone_version: 2,
+            zones: vec![ZoneInfo {
+                page_slab_id: 0,
+                state: ZoneState::Sealed,
+                physical_bytes: 2,
+                logical_bytes: 2,
+                created_unix_ms: None,
+                updated_unix_ms: None,
+                first_page_id: None,
+                last_page_id: None,
+                version: 2,
+            }],
+        };
+        store
+            .append_delta(6, Vec::new(), Vec::new(), Some(1), Some(older), true)
+            .unwrap();
+        // An anchor with no zones between them must not shadow the folded catalog.
+        store
+            .append_delta(6, Vec::new(), Vec::new(), Some(5), Some(MetaItem::default()), true)
+            .unwrap();
+        store
+            .append_delta(6, Vec::new(), Vec::new(), Some(9), Some(newer.clone()), true)
+            .unwrap();
+        assert_eq!(store.latest_zone_catalog(6).unwrap().unwrap(), newer);
+    }
+
+    #[test]
+    fn should_dump_index_catalog_fires_only_past_the_gap() {
+        assert!(!should_dump_index_catalog(0, 1024));
+        assert!(!should_dump_index_catalog(1023, 1024));
+        assert!(should_dump_index_catalog(1024, 1024));
+        assert!(should_dump_index_catalog(4096, 1024));
+        // A zero gap disables the threshold cadence entirely.
+        assert!(!should_dump_index_catalog(u64::MAX, 0));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -11,6 +11,7 @@ pub const TS_COMPACTION_WATERMARK_BYTES: &str = "TS_COMPACTION_WATERMARK_BYTES";
 pub const TS_COLD_SCAN_NO_CACHE_FILL: &str = "TS_COLD_SCAN_NO_CACHE_FILL";
 pub const TS_PAGE_INDEX_CACHE_BYTES: &str = "TS_PAGE_INDEX_CACHE_BYTES";
 pub const TS_BLOCK_INDEX_CACHE_BYTES: &str = "TS_BLOCK_INDEX_CACHE_BYTES";
+pub const TS_INDEX_DUMP_OPLOG_GAP_BYTES: &str = "TS_INDEX_DUMP_OPLOG_GAP_BYTES";
 
 pub const DEFAULT_CONTEXT_PAGE_TARGET_BYTES: usize = 64 * 1024;
 pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
@@ -23,6 +24,10 @@ pub const DEFAULT_COMPACTION_WATERMARK_BYTES: u64 = 256 * 1024 * 1024;
 pub const DEFAULT_COLD_SCAN_NO_CACHE_FILL: bool = true;
 pub const DEFAULT_PAGE_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 pub const DEFAULT_BLOCK_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
+// Undumped index-log-gap threshold that triggers a background catalog/index dump under the
+// MANIFEST-PARITY FOLD (TS_INDEX_CATALOG_FOLD). Mirrors the reference
+// `storage_dump_index_meta_oplog_gap` default of 1 MiB.
+pub const DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageTuningConfig {
@@ -35,6 +40,7 @@ pub struct StorageTuningConfig {
     pub cold_scan_no_cache_fill: bool,
     pub page_index_cache_bytes: u64,
     pub block_index_cache_bytes: u64,
+    pub index_dump_oplog_gap_bytes: u64,
 }
 
 impl Default for StorageTuningConfig {
@@ -48,6 +54,7 @@ impl Default for StorageTuningConfig {
             cold_scan_no_cache_fill: DEFAULT_COLD_SCAN_NO_CACHE_FILL,
             page_index_cache_bytes: DEFAULT_PAGE_INDEX_CACHE_BYTES,
             block_index_cache_bytes: DEFAULT_BLOCK_INDEX_CACHE_BYTES,
+            index_dump_oplog_gap_bytes: DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES,
         }
     }
 }
@@ -93,6 +100,10 @@ impl StorageTuningConfig {
                 get(TS_BLOCK_INDEX_CACHE_BYTES),
                 defaults.block_index_cache_bytes,
             ),
+            index_dump_oplog_gap_bytes: parse_u64(
+                get(TS_INDEX_DUMP_OPLOG_GAP_BYTES),
+                defaults.index_dump_oplog_gap_bytes,
+            ),
         }
     }
 
@@ -106,7 +117,7 @@ impl StorageTuningConfig {
             .max(self.stream_max_blob_size)
     }
 
-    pub fn env_names() -> [&'static str; 8] {
+    pub fn env_names() -> [&'static str; 9] {
         [
             TS_CONTEXT_PAGE_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES,
@@ -116,6 +127,7 @@ impl StorageTuningConfig {
             TS_COLD_SCAN_NO_CACHE_FILL,
             TS_PAGE_INDEX_CACHE_BYTES,
             TS_BLOCK_INDEX_CACHE_BYTES,
+            TS_INDEX_DUMP_OPLOG_GAP_BYTES,
         ]
     }
 }
@@ -130,6 +142,13 @@ pub fn effective_block_slab_target_bytes() -> u64 {
 
 pub fn storage_zone_size_bytes() -> u64 {
     StorageTuningConfig::from_env().storage_zone_size
+}
+
+/// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
+/// the MANIFEST-PARITY FOLD. Reads the `TS_INDEX_DUMP_OPLOG_GAP_BYTES` env override, falling back
+/// to the 1 MiB reference-parity default. Only consulted when `index_catalog_fold_enabled()`.
+pub fn index_dump_oplog_gap_bytes() -> u64 {
+    StorageTuningConfig::from_env().index_dump_oplog_gap_bytes
 }
 
 fn parse_u64(value: Option<String>, default: u64) -> u64 {
@@ -186,6 +205,12 @@ mod tests {
             config.block_index_cache_bytes,
             DEFAULT_BLOCK_INDEX_CACHE_BYTES
         );
+        // 1 MiB reference-parity default (storage_dump_index_meta_oplog_gap).
+        assert_eq!(
+            config.index_dump_oplog_gap_bytes,
+            DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES
+        );
+        assert_eq!(config.index_dump_oplog_gap_bytes, 1024 * 1024);
     }
 
     #[test]
@@ -202,6 +227,7 @@ mod tests {
                 "TS_COLD_SCAN_NO_CACHE_FILL",
                 "TS_PAGE_INDEX_CACHE_BYTES",
                 "TS_BLOCK_INDEX_CACHE_BYTES",
+                "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
             ]
         );
     }
@@ -218,6 +244,7 @@ mod tests {
             (TS_COLD_SCAN_NO_CACHE_FILL, "false"),
             (TS_PAGE_INDEX_CACHE_BYTES, "2097152"),
             (TS_BLOCK_INDEX_CACHE_BYTES, "4194304"),
+            (TS_INDEX_DUMP_OPLOG_GAP_BYTES, "2097152"),
         ]);
         let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
         assert_eq!(config.context_page_target_bytes, 32 * 1024);
@@ -230,5 +257,6 @@ mod tests {
         assert!(!config.cold_scan_no_cache_fill);
         assert_eq!(config.page_index_cache_bytes, 2 * 1024 * 1024);
         assert_eq!(config.block_index_cache_bytes, 4 * 1024 * 1024);
+        assert_eq!(config.index_dump_oplog_gap_bytes, 2 * 1024 * 1024);
     }
 }

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -90,6 +90,7 @@ ENV_MAP: Dict[str, str] = {
     "storage.page_store_compression_level": "TS_PAGE_STORE_COMPRESSION_LEVEL",
     "storage.page_store_compression_min_bytes": "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
+    "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
     "wal.wal_single_barrier": "TS_WAL_SINGLE_BARRIER",
     "wal.group_commit": "TS_GROUP_COMMIT",


### PR DESCRIPTION
Gated manifest-parity catalog fold into the index-log. Ships dark: with the gate off, serialization, recovery, and persistence take the existing paths unchanged, so merging is byte-identical until the flag is set.

## What changed
`TS_INDEX_CATALOG_FOLD` (default **OFF**): at a threshold dump, fold a manifest-parity catalog into the index-log so the served-index and the block/band catalog are materialized together, mirroring the reference storage layout's dump/gap behavior. Populated ONLY at a threshold dump and ONLY when the gate is on; with the gate off the index-log serializes with no catalog key and the background storage-manager cycle is a no-op.

## Safety / testing
- Gate default OFF -> byte-identical serialization + recovery + persistence vs. today. Intended to flip on only after the crash-recovery suite is green.
- New tests exercise the fold path (gate on): catalog materialization at dump, and reload/recovery fidelity.
- wal / recovery / shared_store / index_log / block_store suites green.

## Notes
The O(n) reload benefit is not yet confirmed on a live cluster, and a follow-up may extend or supersede this path. It is landed gated-OFF so it is safe and inert by default while that work continues.
