### PR TITLE
raft: coalesce write-path fdatasync + configurable replication deadline + in-order propose (all gated, default-safe)

### DIFF
--- a/RAFT_FSYNC_NOTES.md
+++ b/RAFT_FSYNC_NOTES.md
@@ -1,0 +1,106 @@
+# Raft write-path fsync amplification — investigation notes
+
+Base: origin/main `17398c2e` (task quoted `ae97d938`; same write path, re-based off current main).
+Files: `crates/temporalstore-rust/src/raft.rs`, `raft/cluster_replication.rs`,
+`raft/cluster_read_status.rs`, `raft/cluster_inner.rs`, `raft/local_wal.rs`.
+
+## Where every raft-write fdatasync comes from
+
+All raft durability funnels through ONE call: `RaftClusterInner::persist_configured_wal()`
+(`raft/cluster_inner.rs:648`). It does:
+
+```
+for (node_id, record) in self.wal_records() {      // <-- iterates ALL nodes in the map
+    wal.persist_node_segmented(...)                // <-- exactly ONE sync_data() per node
+}
+```
+
+`persist_node_segmented_with_fsync_threshold` (`local_wal.rs:76`) does exactly one
+`file.sync_data()` (line 137) per node record. So:
+
+    fdatasync per persist_configured_wal() call  =  number of nodes in inner.nodes
+
+In the live 3-node cluster each process holds the full 3-node map (built by
+`restore_single_shard_from_wal(..., voter_ids(), ...)`, `production_runtime.rs:102` →
+`voter_ids()` returns all nodes). So **every `persist_configured_wal()` = 3 fdatasync on the
+leader box**, and it is called many times per client write.
+
+### Amplification dimension 1 — `persist_configured_wal` is called on VOLATILE-only mutations
+
+Per client write via `propose_distributed_one` (`raft.rs:4034`), on the leader:
+
+| call site | file:line | what it actually mutates | durable? |
+|---|---|---|---|
+| `build_append_entries_request` (×live followers) | cluster_replication.rs:233 | `pipeline_state` inflight/queue counters | NO |
+| `record_append_entries_response` (main wait loop, ×responses) | cluster_replication.rs:270 | `pipeline_state.match_index/next_index` | NO |
+| `record_append_entries_response` (try_recv drain, ×late) | cluster_replication.rs:270 | same | NO |
+| commit block | raft.rs:4266 | leader `log` grew + `commit_index` advanced | **YES** |
+| post-commit heartbeat loop `record_append_entries_response` (×followers) | cluster_replication.rs:270 | `pipeline_state` | NO |
+
+Gross ≈ (2 + 2 + 2 + 1 + 2) calls × 3 nodes ≈ **27–30 fdatasync/write** (more with catch_up /
+snapshot retries → the ~45 gross the benchmark saw). Only ONE of those calls (the commit block)
+persists anything Raft requires to be durable.
+
+`match_index` / `next_index` are **volatile leader state** — canonical Raft reinitialises them on
+every leader election (§5.3, Fig 2 "Volatile state on leaders"). Persisting them, and fsyncing
+3 node records to do it, on every AppendEntries response is pure amplification.
+
+### Amplification dimension 2 — idle read-index / tick fsync storm (~67×/sec even idle)
+
+- `read_index_accounted` (`cluster_read_status.rs:239`) calls `persist_configured_wal()` on the
+  **accepted** path just to bump observability counters in `read_safety_state`
+  (`read_index_requests/accepted`). The health/heartbeat loop issues read-index ~67×/sec →
+  ~200 fdatasync/sec on an otherwise idle leader. `read_safety_state` is metrics only — not
+  hard-state, log, membership, or snapshot.
+- `advance_time_ms` (the timer tick, `cluster_read_status.rs:91`) persists on every time advance;
+  it only refreshes offline/lease/transfer **timeout** state (volatile `pipeline_state`).
+
+### Amplification dimension 3 — persisting ALL N node records
+
+Even the one legitimate commit-block persist fsyncs 3 records (leader + 2 follower *mirror*
+records). On a real per-process deployment only the LOCAL node's record is authoritative for that
+process's crash recovery; the peer mirror records are re-learned from replication on restart.
+(In the distributed write path only the leader's own record actually changes per write, so
+dimension-2 coalescing already collapses this to 1 — see below.)
+
+## What is safe to coalesce vs what must stay
+
+Durability/safety invariants that MUST be preserved (a persist MUST happen before the ack when
+any of these change):
+- **hard_state**: `current_term`, `voted_for`, `commit_index` — durable before responding to
+  RequestVote / AppendEntries and before acking a committed write.
+- **log entries** — a committed (client-acked) entry must be on disk on a quorum.
+- **installed_snapshot / joint_membership / membership / replica_role / apply & storage fences /
+  latest_external_snapshot_ref** — membership + snapshot safety.
+
+Safe to NOT fsync (reconstructable / volatile, never gates correctness):
+- `pipeline_state` (match_index, next_index, inflight/queue depths, all perf + snapshot-progress
+  counters) — reinitialised on election / re-driven on restart.
+- `read_safety_state` (read-index & lease accounting counters) — pure metrics.
+
+## The fix (all behind default-OFF gates; byte-identical when OFF)
+
+**Fix A — `TS_RAFT_WAL_COALESCE` (durable-fingerprint skip).** `persist_configured_wal` computes,
+per node, a fingerprint over the record with `pipeline_state` + `read_safety_state` cleared. If a
+node's fingerprint is unchanged since its last persisted value, skip its fsync. This is *driven by
+whether durable state changed*, so it can never skip a persist durability requires (a false
+"changed" only costs an extra safe fsync; the skip only fires when hard_state/log/membership/
+snapshot/fences are all identical). Effect: idle read-index/tick storm → 0; per-response
+match_index fsyncs → 0; a committed write → exactly the commit-block persist of the ONE node whose
+log+commit_index advanced = **~1 fdatasync/write**.
+
+**Fix B — configurable replication deadline.** New `RaftConfig.replication_deadline_ms`
+(default 5000 = byte-identical) replaces the hardcoded `Duration::from_secs(5)` in
+`propose_distributed_one`. The cluster can drop it (e.g. 500 ms) so a lagging/rejecting follower
+no longer freezes the proposer for a full 5 s. Safe: on timeout the propose returns
+`NoMajority` (retryable) — it never commits anything it shouldn't.
+
+**Fix C — `TS_RAFT_PROPOSE_SERIALIZE` (in-order propose).** Concurrent proposes append under the
+write lock (sequential indices) but release it before the network phase, so their AppendEntries
+race and arrive out of order at followers → `prev_log` mismatch → reject → each stalls the full
+deadline. A per-cluster serialize mutex held across the append+replicate+commit critical section
+forces proposes to commit in log order, eliminating the mismatch/stall. Safe: pure serialisation,
+no change to what commits.
+
+Fold-in: wt-raftevt widened `max_inflights_replicate` 128→1024 as a plain default; kept at 128
+here to stay byte-identical — the cluster sets 1024 via config alongside the gates.

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -2114,6 +2114,24 @@ fn env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
+/// Build the datanode's `RaftConfig`, overlaying the write-path tuning knobs from env. Unset ->
+/// `RaftConfig::default()` verbatim (replication_deadline_ms 5000, max_inflights_replicate 128),
+/// so behavior is byte-identical unless an operator opts in.
+fn raft_config_from_env() -> RaftConfig {
+    let defaults = RaftConfig::default();
+    RaftConfig {
+        replication_deadline_ms: env_u64(
+            "TS_RAFT_REPLICATION_DEADLINE_MS",
+            defaults.replication_deadline_ms,
+        ),
+        max_inflights_replicate: env_u64(
+            "TS_RAFT_MAX_INFLIGHTS_REPLICATE",
+            defaults.max_inflights_replicate,
+        ),
+        ..defaults
+    }
+}
+
 fn block_store_options_from_env() -> BlockStoreOptions {
     let defaults = BlockStoreOptions::default();
     BlockStoreOptions {
@@ -2291,13 +2309,18 @@ fn start_server_raft_from_env(
         "local-raft-token",
         env_bool("TS_RAFT_ALLOW_PLAINTEXT", true),
     );
+    // Make the write-path tuning knobs reachable from the datanode entrypoint. Byte-identical
+    // when unset: replication_deadline_ms stays 5000 (the legacy hardcoded deadline) and
+    // max_inflights_replicate stays 128. (This entrypoint is env-only; there is no config-file
+    // loader in scope here, so the `[raft]` file equivalents are not read at this layer.)
+    let raft_config = raft_config_from_env();
     let runtime = ProductionRaftRuntime::start(ProductionRaftRuntimeOptions {
         engine: ProductionRaftEngineKind::TemporalRaft,
         shard_id: raft_shard_id,
         local_node_id,
         nodes,
         wal_dir,
-        config: RaftConfig::default(),
+        config: raft_config,
         rpc: RaftRpcRuntimeOptions {
             max_retries: env_usize("TS_RAFT_RPC_RETRIES", 2),
             deadline_ms: env_u64("TS_RAFT_RPC_DEADLINE_MS", 1_000),
@@ -3559,5 +3582,31 @@ mod tests {
             local_admin_enabled,
             blocked_peers: Arc::new(Mutex::new(BTreeSet::new())),
         }
+    }
+
+    /// The datanode entrypoint must make the write-path tuning knobs reachable: unset -> the
+    /// byte-identical defaults (5000 ms deadline / 128 inflight); set -> honored on the
+    /// `RaftConfig` that starts the runtime.
+    #[test]
+    fn raft_config_from_env_honors_deadline_and_inflight_overrides() {
+        // Unset: byte-identical defaults.
+        std::env::remove_var("TS_RAFT_REPLICATION_DEADLINE_MS");
+        std::env::remove_var("TS_RAFT_MAX_INFLIGHTS_REPLICATE");
+        let defaults = raft_config_from_env();
+        assert_eq!(defaults.replication_deadline_ms, 5000);
+        assert_eq!(defaults.max_inflights_replicate, 128);
+
+        // Set: both overrides flow through to the config the runtime is started with.
+        std::env::set_var("TS_RAFT_REPLICATION_DEADLINE_MS", "300");
+        std::env::set_var("TS_RAFT_MAX_INFLIGHTS_REPLICATE", "1024");
+        let tuned = raft_config_from_env();
+        assert_eq!(tuned.replication_deadline_ms, 300);
+        assert_eq!(tuned.max_inflights_replicate, 1024);
+        // Overriding these two knobs must not disturb the rest of the config.
+        assert_eq!(tuned.max_segment_bytes, defaults.max_segment_bytes);
+        assert_eq!(tuned.min_keep_segment_num, defaults.min_keep_segment_num);
+
+        std::env::remove_var("TS_RAFT_REPLICATION_DEADLINE_MS");
+        std::env::remove_var("TS_RAFT_MAX_INFLIGHTS_REPLICATE");
     }
 }

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -240,6 +240,39 @@ fn raft_snapshot_state_image_on() -> bool {
     raft_env_flag_on("TS_RAFT_SNAPSHOT_STATE_IMAGE")
 }
 
+/// P1 (fsync coalescing): skip a node's WAL fdatasync when none of its DURABILITY-relevant state
+/// changed since the last persist. Driven purely by whether hard_state / log / membership /
+/// snapshot / fences changed, so it can never skip a persist that Raft safety requires -- only the
+/// volatile `pipeline_state` + `read_safety_state` (match/next index, inflight/queue depths,
+/// read-index accounting counters) are excluded from the change check. Default OFF -> every call
+/// fsyncs exactly as before (byte-identical).
+fn raft_wal_coalesce_on() -> bool {
+    raft_env_flag_on("TS_RAFT_WAL_COALESCE")
+}
+
+/// P2 (in-order propose): hold a per-cluster serialize lock across the append+replicate+commit
+/// critical section of `propose_distributed_one` so concurrent proposals reach followers in log
+/// order and never trigger a `prev_log` mismatch + full-deadline stall. Default OFF.
+fn raft_propose_serialize_on() -> bool {
+    raft_env_flag_on("TS_RAFT_PROPOSE_SERIALIZE")
+}
+
+/// Fingerprint of the DURABILITY-relevant subset of a WAL record. `pipeline_state` and
+/// `read_safety_state` are cleared before hashing because they are volatile (reinitialised on
+/// election / re-driven on restart) and pure metrics respectively -- excluding them is what lets
+/// the read-index/tick/match-index storm coalesce to zero fsyncs while any change to term,
+/// voted_for, commit_index, the log, membership, snapshots, or the apply/storage fences still
+/// flips the fingerprint and forces a durable persist.
+fn raft_durable_fingerprint(record: &RaftWalRecord) -> u64 {
+    let mut reduced = record.clone();
+    reduced.pipeline_state = RaftPeerPipelineRuntimeState::default();
+    reduced.read_safety_state = RaftReadSafetyRuntimeState::default();
+    let bytes = serde_json::to_vec(&reduced).unwrap_or_default();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hasher::write(&mut hasher, &bytes);
+    std::hash::Hasher::finish(&hasher)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DataRaftLogCodecEntry {
     pub shard_id: ShardId,
@@ -3143,6 +3176,16 @@ pub struct RaftConfig {
     pub min_keep_segment_num: u64,
     pub can_trigger_snapshot: bool,
     pub max_applied_log_bytes: u64,
+    /// P2: how long `propose_distributed_one` waits for the replication quorum before returning
+    /// `NoMajority`. Defaults to 5000 ms (the legacy hardcoded deadline); a config that omits the
+    /// field also resolves to 5000 so behavior stays byte-identical. Lower it (e.g. 500) so a
+    /// lagging/rejecting follower no longer freezes the proposer for a full 5 s.
+    #[serde(default = "default_replication_deadline_ms")]
+    pub replication_deadline_ms: u64,
+}
+
+fn default_replication_deadline_ms() -> u64 {
+    5000
 }
 
 impl Default for RaftConfig {
@@ -3173,6 +3216,7 @@ impl Default for RaftConfig {
             min_keep_segment_num: 2,
             can_trigger_snapshot: true,
             max_applied_log_bytes: 1024 * 1024 * 1024,
+            replication_deadline_ms: default_replication_deadline_ms(),
         }
     }
 }
@@ -3688,6 +3732,11 @@ struct RaftClusterInner {
     pending_snapshots: BTreeMap<(RaftNodeId, String), PendingSnapshotChunks>,
     read_safety_state: RaftReadSafetyRuntimeState,
     membership_evidence: RaftMembershipRuntimeEvidence,
+    /// P1: last durable fingerprint persisted per node (see `raft_durable_fingerprint`). Only
+    /// consulted when `TS_RAFT_WAL_COALESCE` is on; otherwise left untouched.
+    last_durable_fingerprint: BTreeMap<RaftNodeId, u64>,
+    /// P2: serialize proposes into the log in order under `TS_RAFT_PROPOSE_SERIALIZE`.
+    propose_serialize: Arc<Mutex<()>>,
 }
 
 impl RaftCluster {
@@ -3735,6 +3784,8 @@ impl RaftCluster {
                 pending_snapshots: BTreeMap::new(),
                 read_safety_state: RaftReadSafetyRuntimeState::default(),
                 membership_evidence: RaftMembershipRuntimeEvidence::default(),
+                last_durable_fingerprint: BTreeMap::new(),
+                propose_serialize: Arc::new(Mutex::new(())),
             })),
         })
     }
@@ -3853,6 +3904,8 @@ impl RaftCluster {
                 pending_snapshots: BTreeMap::new(),
                 read_safety_state,
                 membership_evidence,
+                last_durable_fingerprint: BTreeMap::new(),
+                propose_serialize: Arc::new(Mutex::new(())),
             })),
         })
     }
@@ -4039,6 +4092,20 @@ impl RaftCluster {
     where
         T: RaftTransport + Clone + Send + 'static,
     {
+        // P2: serialize proposes into the log in order. Concurrent proposers otherwise append
+        // under the write lock (sequential indices) but release it before the async network phase,
+        // so their AppendEntries race and can reach a follower out of order -> `prev_log` mismatch
+        // -> reject -> a full-deadline stall. Holding this per-cluster lock across the whole
+        // append+replicate+commit critical section forces index N to commit before N+1 begins.
+        let propose_gate = if raft_propose_serialize_on() {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            Some(inner.propose_serialize.clone())
+        } else {
+            None
+        };
+        let _propose_guard = propose_gate
+            .as_ref()
+            .map(|gate| gate.lock().unwrap_or_else(|poisoned| poisoned.into_inner()));
         let (entry, leader_id, target_ids, required) = {
             let mut inner = self.inner.write().expect("raft cluster lock poisoned");
             inner.ensure_live_leader()?;
@@ -4132,7 +4199,19 @@ impl RaftCluster {
             });
         }
         drop(tx);
-        let replication_deadline = Instant::now() + Duration::from_secs(5);
+        // P2: configurable replication deadline (legacy hardcoded 5 s). A config that leaves the
+        // field at 0 resolves to the 5000 ms default so behavior stays byte-identical.
+        let replication_deadline_ms = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let configured = inner.config.replication_deadline_ms;
+            if configured == 0 {
+                default_replication_deadline_ms()
+            } else {
+                configured
+            }
+        };
+        let replication_deadline =
+            Instant::now() + Duration::from_millis(replication_deadline_ms);
         while replicated < required {
             let remaining = replication_deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -645,19 +645,46 @@ impl RaftClusterInner {
         Ok(())
     }
 
-    pub(super) fn persist_configured_wal(&self) -> Result<(), RaftError> {
-        let Some(wal) = &self.wal else {
-            return Ok(());
+    pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
+        // Clone the WAL handle (cheap -- it shares the cursor cache via an Arc) so `self` is free
+        // to be borrowed mutably below for the coalescing fingerprint map.
+        let wal = match &self.wal {
+            Some(wal) => wal.clone(),
+            None => return Ok(()),
         };
+        let shard_id = self.shard_id;
+        let max_segment_bytes = self.config.max_segment_bytes;
+        let min_keep_segment_num = self.config.min_keep_segment_num as usize;
+        let coalesce = raft_wal_coalesce_on();
         for (node_id, record) in self.wal_records() {
-            wal.persist_node_segmented(
-                self.shard_id,
-                node_id,
-                &record,
-                self.config.max_segment_bytes,
-                self.config.min_keep_segment_num as usize,
-            )
-            .map_err(|err| RaftError::Wal(err.to_string()))?;
+            // P1: when coalescing is enabled, skip the fdatasync for a node whose durability-
+            // relevant state is byte-identical to what we last persisted. A false "changed" only
+            // costs a redundant (safe) fsync; the skip fires ONLY when nothing Raft must persist
+            // has changed, so it can never drop a committed entry or an un-fsynced hard-state.
+            if coalesce {
+                let fingerprint = raft_durable_fingerprint(&record);
+                if self.last_durable_fingerprint.get(&node_id) == Some(&fingerprint) {
+                    continue;
+                }
+                wal.persist_node_segmented(
+                    shard_id,
+                    node_id,
+                    &record,
+                    max_segment_bytes,
+                    min_keep_segment_num,
+                )
+                .map_err(|err| RaftError::Wal(err.to_string()))?;
+                self.last_durable_fingerprint.insert(node_id, fingerprint);
+            } else {
+                wal.persist_node_segmented(
+                    shard_id,
+                    node_id,
+                    &record,
+                    max_segment_bytes,
+                    min_keep_segment_num,
+                )
+                .map_err(|err| RaftError::Wal(err.to_string()))?;
+            }
         }
         Ok(())
     }

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2358,4 +2358,229 @@ fn s2_snapshot_gate_off_still_carries_entries_and_no_image() {
     );
 }
 
+/// Sum the durable WAL records on disk for one node (each record == one real fdatasync in the
+/// segmented append path), read via a fresh WAL handle so it reflects the on-disk truth.
+fn node_wal_record_count(root: &std::path::Path, shard: ShardId, node: RaftNodeId) -> u64 {
+    LocalRaftWal::new(root)
+        .segment_report(shard, node)
+        .map(|report| report.segments.iter().map(|s| s.record_count).sum())
+        .unwrap_or(0)
+}
+
+/// P1 core: with `TS_RAFT_WAL_COALESCE` on, a burst of read-index calls (which only touch the
+/// volatile `read_safety_state` accounting counters) must NOT append/fsync a single new WAL
+/// record, while a real committed write still does. This is the idle read-index/tick fsync-storm
+/// fix, and the durability barrier of a write is preserved.
+#[test]
+fn raft_wal_coalesce_skips_volatile_only_read_index_persists() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    let baseline = node_wal_record_count(dir.path(), 1, 1);
+    for _ in 0..25 {
+        cluster.read_index(1).unwrap();
+    }
+    let after_reads = node_wal_record_count(dir.path(), 1, 1);
+    assert_eq!(
+        after_reads, baseline,
+        "read-index (volatile-only) must not fsync a new WAL record when coalescing is on"
+    );
+
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+    let after_write = node_wal_record_count(dir.path(), 1, 1);
+    assert!(
+        after_write > after_reads,
+        "a committed write must still persist a durable WAL record (coalescing never drops it)"
+    );
+}
+
+/// P1 contrast: with the gate OFF the shipped behavior is byte-identical -- every read-index
+/// persists, so the same burst grows the WAL by one record per call. This pins the win as real.
+#[test]
+fn raft_wal_coalesce_off_persists_every_read_index() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    let baseline = node_wal_record_count(dir.path(), 1, 1);
+    for _ in 0..25 {
+        cluster.read_index(1).unwrap();
+    }
+    let after_reads = node_wal_record_count(dir.path(), 1, 1);
+    assert!(
+        after_reads >= baseline + 25,
+        "gate-off must persist every read-index (byte-identical legacy behavior): {baseline} -> {after_reads}"
+    );
+}
+
+/// P1 safety: coalescing must never lose a committed entry. Commit three writes with the gate on,
+/// drop the cluster, and recover from the WAL: commit_index and the full log must survive.
+#[test]
+fn raft_wal_coalesce_preserves_committed_entries_across_restart() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(dir.path(), 9, [1, 2, 3], RaftConfig::default())
+                .unwrap();
+        for index in 0..3 {
+            cluster
+                .propose(Command::StringSet {
+                    key: format!("k{index}"),
+                    value: format!("v{index}").into_bytes(),
+                })
+                .unwrap();
+        }
+        assert_eq!(cluster.commit_index(1).unwrap(), 3);
+    }
+
+    let restored =
+        RaftCluster::restore_single_shard_from_wal(dir.path(), 9, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    assert_eq!(
+        restored.commit_index(1).unwrap(),
+        3,
+        "committed index must survive restart under coalescing"
+    );
+    for index in 0..3 {
+        assert_eq!(
+            restored
+                .read_from_replica(
+                    1,
+                    Command::StringGet {
+                        key: format!("k{index}"),
+                    },
+                )
+                .unwrap(),
+            CommandResponse::Bytes {
+                value: Some(format!("v{index}").into_bytes())
+            },
+            "committed write k{index} must be durable across restart"
+        );
+    }
+}
+
+/// P1 safety: hard-state (term + self-vote) must be fsynced before a RequestVote is advertised,
+/// even with coalescing on -- the fingerprint includes hard_state, so the vote persist is never
+/// coalesced away. Recover from the WAL and confirm the bumped term + vote survived.
+#[test]
+fn raft_wal_coalesce_keeps_hard_state_vote_durable_before_request() {
+    let _coalesce = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
+    let _vote = EnvFlagGuard::set("TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST");
+    let dir = tempfile::tempdir().unwrap();
+    let term_before;
+    {
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(dir.path(), 11, [1, 2, 3], RaftConfig::default())
+                .unwrap();
+        term_before = cluster.hard_state(2).unwrap().current_term;
+        // Advertising a vote bumps node 2's term + records a self-vote and must fsync BEFORE
+        // returning the request.
+        cluster.build_vote_request(2, 3).unwrap();
+    }
+
+    let restored = RaftCluster::restore_single_shard_from_wal(
+        dir.path(),
+        11,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    let hs = restored.hard_state(2).unwrap();
+    assert_eq!(
+        hs.current_term,
+        term_before + 1,
+        "the incremented vote term must be durable before the request was advertised"
+    );
+    assert_eq!(
+        hs.voted_for,
+        Some(2),
+        "the self-vote must be durable before the request was advertised"
+    );
+}
+
+/// P2: the replication deadline is configurable (was a hardcoded 5 s). With a low deadline and a
+/// transport where no follower can ack, a propose returns `NoMajority` in ~deadline, NOT 5 s -- so
+/// a lagging/rejecting follower no longer freezes the proposer.
+#[test]
+fn raft_replication_deadline_is_configurable_and_bounds_propose() {
+    let config = RaftConfig {
+        replication_deadline_ms: 300,
+        ..RaftConfig::default()
+    };
+    let cluster = RaftCluster::new_single_shard_with_config(1, [1, 2, 3], config).unwrap();
+    let transport = FlakyTransport {
+        cluster: cluster.clone(),
+        failures_left: Arc::new(Mutex::new(usize::MAX)),
+    };
+
+    let started = Instant::now();
+    let result = cluster.propose_distributed(
+        Command::StringSet {
+            key: "k".to_string(),
+            value: b"v".to_vec(),
+        },
+        &transport,
+    );
+    let elapsed = started.elapsed();
+
+    assert!(
+        matches!(result, Err(RaftError::NoMajority { .. })),
+        "an unreachable follower quorum must fail as NoMajority, got {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "propose must return in ~deadline (300ms), not the legacy 5s: {elapsed:?}"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(150),
+        "propose must actually honor the configured deadline before giving up: {elapsed:?}"
+    );
+}
+
+/// P2: the in-order propose serialize gate must not deadlock and must preserve correctness --
+/// concurrent proposers all commit, in sequential log order, and the run completes promptly (not a
+/// pile of full-deadline stalls).
+#[test]
+fn raft_propose_serialize_commits_concurrent_proposals_in_order() {
+    let _guard = EnvFlagGuard::set("TS_RAFT_PROPOSE_SERIALIZE");
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    let started = Instant::now();
+    let mut handles = Vec::new();
+    for index in 0..6 {
+        let c = cluster.clone();
+        handles.push(std::thread::spawn(move || {
+            c.propose_distributed(
+                Command::StringSet {
+                    key: format!("k{index}"),
+                    value: format!("v{index}").into_bytes(),
+                },
+                &c,
+            )
+        }));
+    }
+    for handle in handles {
+        handle.join().unwrap().unwrap();
+    }
+    let elapsed = started.elapsed();
+    assert_eq!(
+        cluster.commit_index(1).unwrap(),
+        6,
+        "all six serialized proposals must commit with sequential indices"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "serialized concurrent proposals must not pile up into deadline stalls: {elapsed:?}"
+    );
+}
+
 


### PR DESCRIPTION
Raft write-path fdatasync coalescing plus configurable replication tuning and in-order propose. All new behavior is gated or defaults to the existing values, so merging is byte-identical until the flags are set.

## What changed

**`TS_RAFT_WAL_COALESCE` (default OFF):** skip a node's WAL fdatasync when none of its durability-relevant state (hard_state / log / membership / snapshot / fences) changed since the last persist. Only the volatile pipeline/read-safety state (match/next index, inflight/queue depths, read-index accounting) is excluded from the change check, so a persist that Raft safety requires can never be skipped — only the read-index/tick/match-index storm coalesces to zero fsyncs. Cuts the write-path from ~30 fdatasync/write toward ~1.

**`TS_RAFT_PROPOSE_SERIALIZE` (default OFF):** hold a per-cluster serialize lock across the append+replicate+commit critical section so concurrent proposals reach followers in log order and never trigger a prev_log mismatch + full-deadline stall.

**Configurable replication tuning (unset ⇒ existing defaults):** `TS_RAFT_REPLICATION_DEADLINE_MS` (default 5000) and `TS_RAFT_MAX_INFLIGHTS_REPLICATE` (default 128), now reachable from the datanode entrypoint.

## Safety / testing
- All gates default OFF and both config knobs default to today's values (a unit test asserts the 5000 / 128 defaults) -> byte-identical when unset.
- New tests cover the coalescing (read-index bursts fsync zero times) and the in-order propose path.
- raft / recovery suites green.
