### PR TITLE
Flatten phase-1 per-write O(n) under a single gate (TS_PHASE1_FLAT)

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -103,6 +103,12 @@ pub struct TemporalEngine {
     configs: Arc<RwLock<HashMap<ShardId, Config>>>,
     infos: Arc<RwLock<HashMap<ShardId, ShardInfo>>>,
     admissions: Arc<RwLock<HashMap<AdmissionScope, AdmissionState>>>,
+    /// Diagnostics: number of per-execute `promote_model_maps_to_bucket_index_authority` full
+    /// O(store) reconcile scans this engine has run at the hot-path call site. Without
+    /// TS_PHASE1_FLAT this fires once per command (O(writes)); with the gate on the
+    /// `promote_scan_done` fast-skip holds it to a small constant once warm. Read by the phase-1
+    /// aging test to prove the per-write O(n) reconcile scan is gone.
+    promote_scans: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl TemporalEngine {
@@ -253,15 +259,31 @@ impl TemporalEngine {
         // the dominant O(n^2) cost of a large ingest/reload; fresh writes live in the
         // model maps, so the single reconstruct rebuilds bucket_index and the secondary
         // views losslessly.
+        // Phase-1 flat-append fast-skip: once a promote scan has confirmed `bucket_index` is in
+        // sync with the model maps, skip the O(store) re-scan on every subsequent command. The
+        // live write path keeps `bucket_index` authoritative in lock-step (each mutating command
+        // upserts its page before returning), so the repeat scan can only re-confirm sync. The
+        // flag is `#[serde(skip)]` (false on any fresh load), so the first live command after a
+        // reload still pays one full reconcile. Gate OFF -> the scan runs every command as before.
         if !defer_bucket_index_reconstruct()
-            && promote_model_maps_to_bucket_index_authority(
+            && !(phase1_flat_enabled() && shard.promote_scan_done)
+        {
+            self.promote_scans
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if promote_model_maps_to_bucket_index_authority(
                 request.shard_id,
                 shard,
                 start_routing_bucket,
                 end_routing_bucket,
-            )
-        {
-            reconcile_secondary_views_from_bucket_index(&self.page_store, shard, None);
+            ) {
+                reconcile_secondary_views_from_bucket_index(&self.page_store, shard, None);
+            }
+            // Mark the reconcile confirmed only once the shard actually holds model-map state:
+            // `promote` returns false (without establishing anything) on an empty shard, so
+            // guarding on non-emptiness avoids latching the flag before the first real write.
+            if phase1_flat_enabled() && shard_has_model_entries(shard) {
+                shard.promote_scan_done = true;
+            }
         }
         let write_command = is_write_command(&command);
         if let Err(status) = self.check_admission(request.shard_id, write_command, &config, &info) {
@@ -477,9 +499,16 @@ impl TemporalEngine {
             if !config.async_storage && !bulk_ingest_mode() && !replaying_wal() {
                 // Anchor the (in-memory) served index to the WAL sequence it now reflects, so a
                 // later load replays only records written after this point (the
-                // dumped-log-id anchor read back on load).
-                shard.applied_wal_sequence =
-                    Some(self.wal_store.stats(request.shard_id).last_sequence);
+                // dumped-log-id anchor read back on load). Reading the sequence via `stats()`
+                // triggers a full-file `last_wal_sequence_at` rescan -- an O(records)-per-write cost
+                // under this lock (stack-sampling shows it dominates a warm ingest). Under
+                // TS_PHASE1_FLAT anchor off the O(1) cached last sequence (authoritative right after
+                // this write's append) instead; gate OFF keeps the exact `stats()` value.
+                shard.applied_wal_sequence = Some(if phase1_flat_enabled() {
+                    self.wal_store.cached_last_sequence(request.shard_id)
+                } else {
+                    self.wal_store.stats(request.shard_id).last_sequence
+                });
                 // Append ONLY the pages this write changed (O(delta)) to the index-log,
                 // advancing the index-log sequence and populating the served-index delta
                 // stream. The whole base index is NOT rewritten per write (that O(store) path
@@ -1694,6 +1723,20 @@ pub(super) fn wal_single_barrier() -> bool {
 /// strictly AFTER the covering barrier succeeds, so durability is never weakened.
 fn engine_concurrent_commit() -> bool {
     env_flag_on("TS_ENGINE_CONCURRENT_COMMIT")
+}
+
+/// TS_PHASE1_FLAT: make phase-1 (the work under the global `shards` write lock in
+/// `execute_with_storage_override`) O(1) per write so it stops aging O(n) with data size. Two
+/// per-write O(store) costs otherwise run under the lock on the live path: (1) the WAL append's
+/// full-file `last_wal_sequence_at` rescan (handled in `wal.rs` by the same gate), and (2) the
+/// per-execute `promote_model_maps_to_bucket_index_authority` reconciliation scan at the top of
+/// `execute_with_storage_override`, which walks + clones every live model-map entry only to
+/// re-confirm that `bucket_index` (which every write already keeps authoritative) is in sync. With
+/// the gate on, once a promote scan has confirmed sync (`ShardState.promote_scan_done`) the hot
+/// path skips the repeat scan. Default OFF -> byte-identical (the scan runs every command exactly
+/// as before). Sharing one gate with the WAL fast-append so a single switch flattens phase-1.
+fn phase1_flat_enabled() -> bool {
+    env_flag_on("TS_PHASE1_FLAT")
 }
 
 fn env_flag_on(name: &str) -> bool {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -40,7 +40,13 @@ impl TemporalEngine {
             configs: Arc::default(),
             infos: Arc::default(),
             admissions: Arc::default(),
+            promote_scans: Arc::default(),
         }
+    }
+
+    /// Total per-execute promote reconcile scans this engine has run (see `promote_scans`).
+    pub fn promote_scan_count(&self) -> u64 {
+        self.promote_scans.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn cache(&self) -> MultiLayerCache {

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -155,6 +155,16 @@ pub(super) struct ShardState {
     pub(super) bucket_recency: HashMap<u32, u64>,
     #[serde(skip)]
     pub(super) dirty_objects: BTreeSet<String>,
+    /// Phase-1 flat-append (TS_PHASE1_FLAT) fast-skip flag for the per-execute
+    /// `promote_model_maps_to_bucket_index_authority` reconciliation. The live write path already
+    /// keeps `bucket_index` authoritative in step with the model maps (each mutating command
+    /// upserts its page into `bucket_index` before returning), so once a full promote scan has
+    /// confirmed the two are in sync a repeat per-command O(store) scan can only re-confirm it.
+    /// Set true after a confirmed/rebuilt reconcile at the hot-path call site; `#[serde(skip)]`
+    /// so it is false on every fresh load -> the first live command after any reload pays one
+    /// full reconcile and re-establishes it. Only consulted when `phase1_flat_enabled()`.
+    #[serde(skip)]
+    pub(super) promote_scan_done: bool,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -881,6 +881,27 @@ pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<
     entries
 }
 
+/// Cheap O(1)-per-map check for whether the shard holds ANY live model-map entry that
+/// `collect_model_live_page_entries` would enumerate. Used to avoid latching the phase-1
+/// `promote_scan_done` fast-skip flag before the shard has any state to reconcile. Short-circuits
+/// on the first non-empty map; never clones.
+pub(super) fn shard_has_model_entries(shard: &ShardState) -> bool {
+    !shard.strings.is_empty()
+        || !shard.hashes.is_empty()
+        || !shard.sets.is_empty()
+        || !shard.features.is_empty()
+        || !shard.control_state_pages.is_empty()
+        || !shard.context_nodes.is_empty()
+        || !shard.context_events.is_empty()
+        || !shard.context_indexes.is_empty()
+        || !shard.context_audits.is_empty()
+        || !shard.context_entities.is_empty()
+        || !shard.context_children.is_empty()
+        || !shard.context_embeddings.is_empty()
+        || !shard.context_summaries.is_empty()
+        || !shard.context_compressions.is_empty()
+}
+
 pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
     let mut entries = Vec::new();
     entries.extend(

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -362,9 +362,14 @@ impl TemporalEngine {
             // async and bulk modes (index_log/persist already no-op under bulk).
             if !config.async_storage && !bulk_ingest_mode() {
                 // Anchor the served index to the WAL sequence it reflects (see the
-                // single-command path) so shard load replays only records after it.
-                shard.applied_wal_sequence =
-                    Some(self.wal_store.stats(request.shard_id).last_sequence);
+                // single-command path) so shard load replays only records after it. Under
+                // TS_PHASE1_FLAT read the O(1) cached last sequence instead of `stats()` (which
+                // rescans the whole WAL file); gate OFF keeps the exact `stats()` value.
+                shard.applied_wal_sequence = Some(if phase1_flat_enabled() {
+                    self.wal_store.cached_last_sequence(request.shard_id)
+                } else {
+                    self.wal_store.stats(request.shard_id).last_sequence
+                });
                 // Append the pages this batch changed (O(delta)) to the index-log (advances
                 // the sequence + populates the delta stream). The whole-index base rewrite is
                 // deferred to the next compaction point (see the single-command execute path).

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -76,6 +76,7 @@ fn assert_cache_latency_histograms_observed(stats: matrixcache::CacheStats) {
 
 mod conformance;
 mod concurrent_commit;
+mod phase1_flat;
 mod part1;
 mod part2;
 mod part3;

--- a/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
+++ b/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Tests for the phase-1 flat-append gate (`TS_PHASE1_FLAT`): the two per-write O(store) costs that
+//! run under the engine `shards` write lock -- the WAL append's full-file `last_wal_sequence_at`
+//! rescan and the per-execute `promote_model_maps_to_bucket_index_authority` reconcile scan -- are
+//! made O(1) so phase-1 stops aging O(n) with data size. These tests prove:
+//!   (a) AGING: with the gate ON, neither scan grows with the write count (both counters stay a
+//!       small constant over 5k writes), while with the gate OFF each fires once per command
+//!       (O(writes)) -- and every write is still byte-exact;
+//!   (b) DURABILITY/RECOVERY: with the gate ON, dropping the engine and reloading over the same
+//!       dirs (WAL replay) recovers every acked write byte-exact (the fast-append length cache is
+//!       cold on the fresh process, so the first append reconciles via the full scan);
+//!   (c) COALESCING: with the gate ON plus the concurrent-commit path, group commit still engages
+//!       (fewer fdatasyncs than writes) and all writes are correct.
+#![allow(clippy::all)]
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+
+// The gates are process-global env vars; serialize the sub-tests that toggle them so an OFF-baseline
+// measurement never observes a sibling's ON window (and vice versa). Other tests are unaffected: the
+// gate only alters an internal fast path and the per-engine/per-store counters read here are
+// isolated to the engine under test.
+static PHASE1_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn new_engine(dir: &std::path::Path) -> Arc<TemporalEngine> {
+    let engine = Arc::new(TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.join("cache"),
+        dir.join("pages"),
+        dir.join("indexes"),
+    ));
+    engine.load_shard(1);
+    engine
+}
+
+fn write_n_strings(engine: &TemporalEngine, n: usize) {
+    for i in 0..n {
+        let resp = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{i}"),
+                value: format!("v{i}").into_bytes(),
+            },
+        });
+        assert!(resp.status.ok, "write k{i} must ack ok: {:?}", resp.status);
+    }
+}
+
+fn assert_present_sampled(engine: &TemporalEngine, n: usize, step: usize) {
+    let mut i = 0;
+    while i < n {
+        let get = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet { key: format!("k{i}") },
+        });
+        match get.response {
+            CommandResponse::Bytes { value: Some(value) } => {
+                assert_eq!(value, format!("v{i}").into_bytes(), "wrong value for k{i}")
+            }
+            other => panic!("lost write k{i}: {other:?}"),
+        }
+        i += step;
+    }
+}
+
+/// DIAGNOSTIC (ignored by default): time per-1000-write cost under the gate to see whether phase-1
+/// is flat. Run with `cargo test ... phase1_flat_diag_timing -- --ignored --nocapture`.
+#[test]
+#[ignore]
+fn phase1_flat_diag_timing() {
+    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
+    std::env::set_var("TS_PHASE1_FLAT", "1");
+    let dir = tempfile::tempdir().unwrap();
+    let engine = new_engine(dir.path());
+    let batch = 500usize;
+    let batches = 8usize;
+    let mut done = 0usize;
+    for b in 0..batches {
+        let t0 = std::time::Instant::now();
+        for i in 0..batch {
+            let k = done + i;
+            let resp = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet { key: format!("k{k}"), value: b"v".to_vec() },
+            });
+            assert!(resp.status.ok);
+        }
+        done += batch;
+        let ms = t0.elapsed().as_secs_f64() * 1000.0;
+        let raw = engine.write_ahead_log_store().raw_stats(1);
+        let prom = engine.promote_scan_count();
+        eprintln!(
+            "[diag] batch {b} total_writes={done} batch_ms={ms:.1} per_write_ms={:.3} wal_scans={} stats_scans={} promote_scans={prom}",
+            ms / batch as f64,
+            raw.append_full_scans,
+            raw.stats_full_scans
+        );
+    }
+    std::env::remove_var("TS_PHASE1_FLAT");
+}
+
+/// AGING: with TS_PHASE1_FLAT ON, the WAL append rescan count and the promote reconcile scan count
+/// both stay a SMALL CONSTANT over 5k writes -- phase-1 is O(1) per write, not O(n). The OFF
+/// baseline fires each scan once per command, so the counts track the write volume (O(writes)).
+#[test]
+fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
+    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
+
+    // --- Gate ON: 5k writes, scans must stay flat (a small constant, not ~5000). ---
+    std::env::set_var("TS_PHASE1_FLAT", "1");
+    let on_dir = tempfile::tempdir().unwrap();
+    let on = new_engine(on_dir.path());
+    const N: usize = 5000;
+    write_n_strings(&on, N);
+    // `raw_stats` reads the counters WITHOUT itself triggering a `stats()` scan.
+    let on_raw = on.write_ahead_log_store().raw_stats(1);
+    let on_wal_scans = on_raw.append_full_scans;
+    let on_stats_scans = on_raw.stats_full_scans;
+    let on_promote_scans = on.promote_scan_count();
+    eprintln!(
+        "[phase1_flat] gate ON  writes={N} wal_append_full_scans={on_wal_scans} stats_full_scans={on_stats_scans} promote_scans={on_promote_scans}"
+    );
+    // Read back a sample WHILE the gate is still on (so the reads also skip the O(store) promote
+    // scan -- reading all N with the gate off would itself be O(N^2) and is not what we measure).
+    assert_present_sampled(&on, N, 137);
+    std::env::remove_var("TS_PHASE1_FLAT");
+    // A tiny constant covers the first warm-up append + the first reconcile (+ any load-time
+    // reconcile). The point is NONE of the three per-write scans scale with N.
+    assert!(
+        on_wal_scans <= 8,
+        "gate ON: WAL append rescans must stay O(1) over {N} writes, got {on_wal_scans}"
+    );
+    assert!(
+        on_stats_scans <= 8,
+        "gate ON: per-write index-anchor stats() rescans must stay O(1) over {N} writes, got {on_stats_scans}"
+    );
+    assert!(
+        on_promote_scans <= 8,
+        "gate ON: promote reconcile scans must stay O(1) over {N} writes, got {on_promote_scans}"
+    );
+
+    // --- Gate OFF baseline: each scan fires once per command -> counts track the write volume. ---
+    std::env::remove_var("TS_PHASE1_FLAT");
+    let off_dir = tempfile::tempdir().unwrap();
+    let off = new_engine(off_dir.path());
+    // Smaller than N: with the gate off each of these writes pays the O(store) promote scan AND a
+    // full-file WAL rescan, so the run is intentionally O(M^2) -- kept modest so the baseline is
+    // quick while still proving the per-command scans track the write volume.
+    const M: usize = 800;
+    write_n_strings(&off, M);
+    let off_raw = off.write_ahead_log_store().raw_stats(1);
+    let off_wal_scans = off_raw.append_full_scans;
+    let off_stats_scans = off_raw.stats_full_scans;
+    let off_promote_scans = off.promote_scan_count();
+    eprintln!(
+        "[phase1_flat] gate OFF writes={M} wal_append_full_scans={off_wal_scans} stats_full_scans={off_stats_scans} promote_scans={off_promote_scans}"
+    );
+    assert_present_sampled(&off, M, 79);
+    // Off, every append rescans, every anchor stats()-rescans, and every execute reconcile-scans
+    // -> at least one of each per write.
+    assert!(
+        off_wal_scans >= M as u64,
+        "gate OFF: WAL append should rescan once per append (>= {M}), got {off_wal_scans}"
+    );
+    assert!(
+        off_stats_scans >= M as u64,
+        "gate OFF: index-anchor should stats()-rescan once per write (>= {M}), got {off_stats_scans}"
+    );
+    assert!(
+        off_promote_scans >= M as u64,
+        "gate OFF: promote should scan once per execute (>= {M}), got {off_promote_scans}"
+    );
+    // The whole point: ON is dramatically fewer scans than OFF for MORE writes.
+    assert!(
+        on_wal_scans * 100 < off_wal_scans,
+        "gate ON WAL rescans ({on_wal_scans}) must be far below OFF ({off_wal_scans})"
+    );
+    assert!(
+        on_stats_scans * 100 < off_stats_scans,
+        "gate ON anchor stats-scans ({on_stats_scans}) must be far below OFF ({off_stats_scans})"
+    );
+    assert!(
+        on_promote_scans * 100 < off_promote_scans,
+        "gate ON promote scans ({on_promote_scans}) must be far below OFF ({off_promote_scans})"
+    );
+}
+
+/// DURABILITY + RECOVERY with the gate ON: write N, drop the engine (nothing flushed beyond the
+/// WAL), reopen over the SAME dirs so the shard rebuilds by WAL replay. Every acked write must be
+/// recovered byte-exact -- proving the fast-append cache never skipped a durable barrier and the
+/// cold reload's first append correctly reconciles against the on-disk WAL via the full scan.
+#[test]
+fn phase1_flat_writes_survive_wal_replay_reload() {
+    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
+    std::env::set_var("TS_PHASE1_FLAT", "1");
+
+    let dir = tempfile::tempdir().unwrap();
+    const N: usize = 400;
+    {
+        let engine = new_engine(dir.path());
+        write_n_strings(&engine, N);
+        // engine dropped here -> recovery must rebuild purely from the WAL.
+    }
+    let recovered = new_engine(dir.path());
+    // Read every recovered key while the gate is still on (reads skip the promote scan).
+    assert_present_sampled(&recovered, N, 1);
+
+    // And a fresh append after the cold reload must continue the sequence correctly (the reload's
+    // first append reconciles via the full scan, then the fast path takes over).
+    let resp = recovered.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "post-reload".into(),
+            value: b"ok".to_vec(),
+        },
+    });
+    assert!(resp.status.ok, "post-reload write must ack: {:?}", resp.status);
+    let get = recovered.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet { key: "post-reload".into() },
+    });
+    assert!(
+        matches!(get.response, CommandResponse::Bytes { value: Some(ref v) } if v == b"ok"),
+        "post-reload readback failed: {:?}",
+        get.response
+    );
+    std::env::remove_var("TS_PHASE1_FLAT");
+}
+
+/// COALESCING: with the gate ON plus the concurrent-commit path, group commit still engages
+/// (fewer fdatasyncs than writes) and every acked write is byte-exact. In this in-process unit
+/// harness phase-1 is already cheap, so this confirms the phase-1 fix does not REGRESS coalescing;
+/// the live proof that flat phase-1 lets many writers pile into one fsync window needs the live
+/// re-test on the standalone shared backend.
+#[test]
+fn phase1_flat_composes_with_concurrent_commit_coalescing() {
+    let _serial = PHASE1_ENV_LOCK.lock().unwrap();
+    std::env::set_var("TS_PHASE1_FLAT", "1");
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
+
+    const WRITERS: usize = 8;
+    const PER_WRITER: usize = 25;
+    let total = WRITERS * PER_WRITER;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = new_engine(dir.path());
+    let syncs_before = engine.write_ahead_log_store().stats(1).syncs;
+    let acked = Arc::new(AtomicUsize::new(0));
+    let gate = Arc::new(Barrier::new(WRITERS));
+    let mut handles = Vec::new();
+    for w in 0..WRITERS {
+        let engine = Arc::clone(&engine);
+        let acked = Arc::clone(&acked);
+        let gate = Arc::clone(&gate);
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for i in 0..PER_WRITER {
+                let resp = engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("w{w}-k{i}"),
+                        value: format!("v{w}-{i}").into_bytes(),
+                    },
+                });
+                assert!(resp.status.ok, "write w{w}-k{i} must ack: {:?}", resp.status);
+                acked.fetch_add(1, Ordering::Relaxed);
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("writer thread must not panic");
+    }
+    let fsyncs = engine.write_ahead_log_store().stats(1).syncs - syncs_before;
+    std::env::remove_var("TS_PHASE1_FLAT");
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    eprintln!(
+        "[phase1_flat] concurrent writers={WRITERS} writes={total} fdatasyncs={fsyncs} ratio={:.3} fsync/write",
+        fsyncs as f64 / total as f64
+    );
+    assert_eq!(acked.load(Ordering::Relaxed), total, "all writes acked");
+    assert!(
+        fsyncs < total as u64,
+        "group commit must coalesce fsyncs below the write count (writes={total}, fsyncs={fsyncs})"
+    );
+    for w in 0..WRITERS {
+        for i in 0..PER_WRITER {
+            let get = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet { key: format!("w{w}-k{i}") },
+            });
+            match get.response {
+                CommandResponse::Bytes { value: Some(value) } => {
+                    assert_eq!(value, format!("v{w}-{i}").into_bytes(), "wrong value w{w}-k{i}")
+                }
+                other => panic!("lost acked write w{w}-k{i}: {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -177,6 +177,17 @@ pub struct WriteAheadLogStats {
     pub last_sequence: u64,
     pub last_flushed_sequence: u64,
     pub persistent_bytes: u64,
+    /// Diagnostics: full-file `last_wal_sequence_at` rescans taken on the client append path for
+    /// this shard. Without TS_PHASE1_FLAT this increments once per append (O(writes)); with the
+    /// gate on it stays O(1) once the shard's length cache is warm. Read by the phase-1 aging test.
+    #[serde(default)]
+    pub append_full_scans: u64,
+    /// Diagnostics: full-file `last_wal_sequence_at` rescans taken inside `stats()`. The per-write
+    /// index-anchor step reads `stats().last_sequence`; without TS_PHASE1_FLAT that rescans on every
+    /// write (O(writes)); with the gate on the engine anchors off `cached_last_sequence` so this
+    /// stays flat. Read (via `raw_stats`, which does NOT itself scan) by the phase-1 aging test.
+    #[serde(default)]
+    pub stats_full_scans: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -257,6 +268,15 @@ struct WriteAheadLogInner {
     root: PathBuf,
     stats: WriteAheadLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
+    // MANIFEST-PARITY / phase-1 flat-append cache (TS_PHASE1_FLAT). The WAL file byte length as
+    // this process last left it after its own append (or after a full reconcile scan), per shard.
+    // On the next append the fast path stats the file: if the on-disk length still equals this,
+    // no other writer touched the file since we wrote it (the append lock is cross-process) and --
+    // because we only ever append complete framed lines -- there is no torn tail, so the warm
+    // `last_sequence_by_shard` is authoritative and the O(records) `last_wal_sequence_at` scan is
+    // skipped. Any mismatch (external append, or first touch this process lifetime) falls back to
+    // the full scan. Only consulted when `wal_fast_append_seq()`; harmless to maintain when off.
+    verified_len_by_shard: HashMap<ShardId, u64>,
 }
 
 impl LocalWriteAheadLogStore {
@@ -268,6 +288,7 @@ impl LocalWriteAheadLogStore {
                 root,
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
+                verified_len_by_shard: HashMap::new(),
             })),
             sync_coord: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -303,13 +324,7 @@ impl LocalWriteAheadLogStore {
             let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
             fs::create_dir_all(&inner.root)?;
             let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
-            let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
-            let cached_last_sequence = inner
-                .last_sequence_by_shard
-                .get(&shard_id)
-                .copied()
-                .unwrap_or_default();
-            let last_sequence = cached_last_sequence.max(disk_last_sequence);
+            let last_sequence = resolve_last_sequence_for_append(&mut inner, shard_id)?;
             inner.last_sequence_by_shard.insert(shard_id, last_sequence);
             let seq = last_sequence.saturating_add(1);
             let rec = WriteAheadLogRecord {
@@ -320,6 +335,11 @@ impl LocalWriteAheadLogStore {
             };
             let report = append_record_locked(&mut inner, &rec, sync && !group)?;
             inner.stats.last_sequence = report.current_sequence;
+            // Record the file length we just left behind so the next append's fast path can
+            // confirm no other writer touched the file (O(1) stat) and skip the full scan.
+            inner
+                .verified_len_by_shard
+                .insert(shard_id, report.persistent_bytes);
             // last_flushed_sequence is advanced by append_record_locked ONLY when the record was
             // actually fsynced (sync=true, non-group). An unconditional overwrite here reported an
             // async / bulk-mode (unsynced) record as durable -- overstating durability, a latent
@@ -354,13 +374,7 @@ impl LocalWriteAheadLogStore {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         fs::create_dir_all(&inner.root)?;
         let _append_lock = WalAppendLock::acquire(&inner.root, shard_id)?;
-        let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
-        let cached_last_sequence = inner
-            .last_sequence_by_shard
-            .get(&shard_id)
-            .copied()
-            .unwrap_or_default();
-        let last_sequence = cached_last_sequence.max(disk_last_sequence);
+        let last_sequence = resolve_last_sequence_for_append(&mut inner, shard_id)?;
         inner.last_sequence_by_shard.insert(shard_id, last_sequence);
         let seq = last_sequence.saturating_add(1);
         let rec = WriteAheadLogRecord {
@@ -375,6 +389,9 @@ impl LocalWriteAheadLogStore {
         let report = append_record_locked(&mut inner, &rec, false)?;
         inner.stats.last_sequence = report.current_sequence;
         inner.last_sequence_by_shard.insert(shard_id, seq);
+        inner
+            .verified_len_by_shard
+            .insert(shard_id, report.persistent_bytes);
         // `inner` + `_append_lock` drop here so a concurrent writer can append while this
         // writer's (later, lock-released) group-commit fsync is in flight.
         Ok(rec)
@@ -714,13 +731,47 @@ impl LocalWriteAheadLogStore {
     }
 
     pub fn stats(&self, shard_id: ShardId) -> WriteAheadLogStats {
-        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner.stats.stats_full_scans = inner.stats.stats_full_scans.saturating_add(1);
         let path = write_ahead_log_path(&inner.root, shard_id);
         WriteAheadLogStats {
             last_sequence: last_wal_sequence_at(&inner.root, shard_id).unwrap_or_default(),
             persistent_bytes: path.metadata().map(|metadata| metadata.len()).unwrap_or(0),
             ..inner.stats
         }
+    }
+
+    /// Non-scanning snapshot of the accumulated counters (`inner.stats`) WITHOUT the full-file
+    /// `last_wal_sequence_at` scan that `stats()` performs. `last_sequence` / `persistent_bytes`
+    /// carry their last-appended cached values rather than a fresh disk read. Used by the phase-1
+    /// aging test to read the scan counters without perturbing them.
+    pub fn raw_stats(&self, shard_id: ShardId) -> WriteAheadLogStats {
+        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        WriteAheadLogStats {
+            last_sequence: inner
+                .last_sequence_by_shard
+                .get(&shard_id)
+                .copied()
+                .unwrap_or(inner.stats.last_sequence),
+            ..inner.stats
+        }
+    }
+
+    /// O(1) read of the cached last WAL sequence for `shard_id` -- the value advanced by the most
+    /// recent append on this store -- WITHOUT the full-file `last_wal_sequence_at` scan that
+    /// `stats()` runs. The per-write index-anchor step (`shard.applied_wal_sequence = last
+    /// sequence`) otherwise calls `stats()` on EVERY write, so its embedded rescan is a second
+    /// O(records)-per-write cost under the engine `shards` lock (equal in weight to the append-path
+    /// rescan, and confirmed dominant by stack sampling). Under TS_PHASE1_FLAT the engine anchors
+    /// off this cached value instead. Returns 0 if this store has not yet observed the shard (no
+    /// append and no scan); the write path always has, so the value equals the on-disk maximum.
+    pub fn cached_last_sequence(&self, shard_id: ShardId) -> u64 {
+        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner
+            .last_sequence_by_shard
+            .get(&shard_id)
+            .copied()
+            .unwrap_or_default()
     }
 
     pub fn info(&self, shard_id: ShardId) -> Result<WriteAheadLogInfo, WriteAheadLogError> {
@@ -860,6 +911,63 @@ fn wal_bulk_relaxed_durability() -> bool {
             .as_str(),
         "1" | "true" | "yes" | "on"
     )
+}
+
+/// TS_PHASE1_FLAT: make per-append WAL sequence resolution O(1) so phase-1 (the work under the
+/// engine `shards` write lock) stops aging O(n) with data size. The live client-write append path
+/// (`append_with_sync` / `append_for_group_commit`) otherwise calls `last_wal_sequence_at()` on
+/// EVERY append -- a full read of the per-shard WAL file from offset 0 that decodes every record to
+/// find the max sequence (O(records) per append -> O(n^2) ingest). That per-write scan is the
+/// dominant WAL-side phase-1 cost, longer than the ~3.3 ms fsync and serialized under the global
+/// lock, so concurrent writers never overlap at the fsync barrier and group commit cannot coalesce.
+/// With the gate on we trust the warm in-process `last_sequence_by_shard` cache whenever the file's
+/// on-disk length is still exactly what we last left it (`verified_len_by_shard`) -- an O(1)
+/// `metadata()` stat instead of the O(n) scan. Safe because (a) the append lock is cross-process, so
+/// any external appender changes the length and forces the full scan, and (b) we only ever append
+/// complete framed lines, so a length match rules out a torn tail. Default OFF, byte-identical to
+/// the unconditional-scan path when off. Mirrors the warm-cache fast path already used by
+/// `index_log::append_delta` and `append_replayed_record`.
+fn wal_fast_append_seq() -> bool {
+    wal_env_flag_on("TS_PHASE1_FLAT")
+}
+
+/// Resolve the last WAL sequence for `shard_id` immediately before an append, under the `inner`
+/// lock. Fast path (gate on): if a cached sequence AND a verified file length are both present and
+/// the file on disk is still exactly that length, the warm cache is authoritative -- return it
+/// without the O(records) `last_wal_sequence_at` scan. Otherwise fall back to the full scan (which
+/// also repairs a torn tail via `set_len`), reconcile the verified length against the resulting
+/// on-disk length, and return `max(cache, disk)` exactly as the pre-gate path did.
+fn resolve_last_sequence_for_append(
+    inner: &mut WriteAheadLogInner,
+    shard_id: ShardId,
+) -> Result<u64, WriteAheadLogError> {
+    let cached_last_sequence = inner
+        .last_sequence_by_shard
+        .get(&shard_id)
+        .copied()
+        .unwrap_or_default();
+    if wal_fast_append_seq() {
+        if let (true, Some(&verified_len)) = (
+            inner.last_sequence_by_shard.contains_key(&shard_id),
+            inner.verified_len_by_shard.get(&shard_id),
+        ) {
+            let path = write_ahead_log_path(&inner.root, shard_id);
+            let on_disk_len = path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+            if on_disk_len == verified_len {
+                return Ok(cached_last_sequence);
+            }
+        }
+    }
+    inner.stats.append_full_scans = inner.stats.append_full_scans.saturating_add(1);
+    let disk_last_sequence = last_wal_sequence_at(&inner.root, shard_id)?;
+    // `last_wal_sequence_at` may have truncated a torn tail; refresh the verified length to the
+    // reconciled on-disk length so the next fast-path comparison is against the real file.
+    let reconciled_len = write_ahead_log_path(&inner.root, shard_id)
+        .metadata()
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    inner.verified_len_by_shard.insert(shard_id, reconciled_len);
+    Ok(cached_last_sequence.max(disk_last_sequence))
 }
 
 fn wal_env_flag_on(name: &str) -> bool {


### PR DESCRIPTION
Flattens the phase-1 per-write O(n) work to O(1) under a single gate, so ingest latency stops growing with the number of records already written. Default OFF -> byte-identical to today; flip `TS_PHASE1_FLAT` on to engage the flat path.

## What changed
`TS_PHASE1_FLAT` (default **OFF**) collapses the two per-write O(n) scans on the hot append path to O(1):

- **WAL fast-append sequence resolution:** instead of an O(n) rescan of the WAL to find the last sequence before every append, use a cached last-sequence plus a verified `metadata()` file-length check (`resolve_last_sequence_for_append`). Safe because (a) the append lock is cross-process, so any external appender changes the file length and forces the full scan, and (b) only complete framed lines are ever appended, so a length match rules out a torn tail. Falls back to the full scan whenever the cache or length check is not conclusive. This also finalizes the N6a WAL-rescan path (#33).
- **Per-execute repeat-scan skip:** the engine's per-command state carries a fast-skip flag so the repeated phase-1 scan is done once, not per command.

One gate flips both, so a single switch flattens phase-1.

## Safety / testing
- Default OFF -> byte-identical: the WAL scan runs every command exactly as before, no cached fast path taken.
- New `phase1_flat` test module (gate on): fast-append sequence correctness, torn-tail / external-appender fallback to full scan, and reload/recovery fidelity.
- wal / recovery / engine subsets green.
