### PR TITLE
Fix mem0 search returning nothing, and the OSS extractor on transformers 5.x

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -623,18 +623,27 @@ def one_pass_memory_extraction(envelope: Json, *, prior_context: Json) -> Json:
     """
 
     provider = understanding_provider(envelope)
+    # A provider that fails falls back to the deterministic rules below -- which is the right
+    # behaviour, but the result used to still advertise `understanding_provider: <the provider>`.
+    # That is actively misleading: an LLM call that times out (the client timeout is 30s by
+    # default, and a 7B on CPU needs minutes) produced rule-based entities while the payload
+    # claimed the LLM had run, so anyone measuring extraction quality would silently measure the
+    # deterministic path instead. The failure is recorded and the label corrected below.
+    provider_failure = ""
     if provider in {"openai", "openai_compatible", "openai_compatible_llm"}:
         try:
             return openai_compatible_one_pass_memory_extraction(envelope, prior_context=prior_context)
-        except MatrixArkError:
+        except MatrixArkError as exc:
             if require_oss_understanding():
                 raise
+            provider_failure = str(exc)
     if provider in {"anthropic", "claude", "anthropic_messages"}:
         try:
             return anthropic_one_pass_memory_extraction(envelope, prior_context=prior_context)
-        except MatrixArkError:
+        except MatrixArkError as exc:
             if require_oss_understanding():
                 raise
+            provider_failure = str(exc)
     messages = envelope["messages"]
     batch_text = text_from_messages(messages)
     batch_terms = tokens(batch_text)
@@ -682,7 +691,9 @@ def one_pass_memory_extraction(envelope: Json, *, prior_context: Json) -> Json:
     )
     return {
         "mode": "matrixark_one_pass_schema_oss_encoder" if provider == "oss_encoder" else "matrixark_one_pass_schema",
-        "understanding_provider": provider,
+        "understanding_provider": "deterministic" if provider_failure else provider,
+        "understanding_provider_requested": provider if provider_failure else "",
+        "understanding_provider_error": provider_failure,
         "schema": ONE_PASS_MEMORY_SCHEMA,
         "classification": classification,
         "status": "observed",

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -814,9 +814,20 @@ def oss_model_memory_segments(messages: list[Json], *, model: str, model_path: s
             {"role": "system", "content": "Return only JSON. No markdown."},
             {"role": "user", "content": prompt},
         ]
-        input_ids = tokenizer.apply_chat_template(chat, add_generation_prompt=True, return_tensors="pt").to(device)
-        outputs = model_obj.generate(input_ids, max_new_tokens=max_new_tokens, do_sample=False)
-        generated = outputs[0][input_ids.shape[-1]:]
+        encoded = tokenizer.apply_chat_template(chat, add_generation_prompt=True, return_tensors="pt")
+        # transformers >= 5 returns a BatchEncoding (input_ids + attention_mask) here, where older
+        # versions returned a bare tensor. Passing the mapping positionally to generate() made it
+        # read `.shape` off a dict-like and raise a bare AttributeError, so the OSS extractor could
+        # not run at all on a current transformers. Accept both shapes.
+        if hasattr(encoded, "keys"):
+            inputs = {key: value.to(device) for key, value in dict(encoded).items()}
+            prompt_length = inputs["input_ids"].shape[-1]
+            outputs = model_obj.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+        else:
+            input_ids = encoded.to(device)
+            prompt_length = input_ids.shape[-1]
+            outputs = model_obj.generate(input_ids, max_new_tokens=max_new_tokens, do_sample=False)
+        generated = outputs[0][prompt_length:]
         response = tokenizer.decode(generated, skip_special_tokens=True)
     else:
         inputs = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=4096)

--- a/tools/matrixark_mem0_compat.py
+++ b/tools/matrixark_mem0_compat.py
@@ -65,14 +65,41 @@ def _reshape_search_results(res: Json) -> Json:
     """Map a MatrixArk ContextPack response to mem0's ``search`` shape.
 
     mem0 callers read ``res["results"][i]["memory"]`` (the text), plus ``id`` / ``score`` /
-    ``metadata``. MatrixArk returns ``selected_refs`` (compacted ContextPack refs). Each ref becomes
-    ``{"id", "memory": <text>, "score", "metadata"}``; ``memory`` is the ref's text/citation, ``id``
-    is a stable identifier derived from the ref (``source_ref`` / ``ref_hash`` / a hash of the text)
-    and ``metadata`` carries the remaining ref fields. Unknown shapes yield ``{"results": []}``."""
+    ``metadata``. Each ref becomes ``{"id", "memory": <text>, "score", "metadata"}``; ``memory`` is
+    the ref's text/citation, ``id`` is a stable identifier derived from the ref (``source_ref`` /
+    ``ref_hash`` / a hash of the text) and ``metadata`` carries the remaining ref fields. Unknown
+    shapes yield ``{"results": []}``.
+
+    TWO pack shapes are accepted, because this is where mem0 parity silently broke: the shim was
+    written against flat ``selected_refs``, but a ContextPack now serves its refs GROUPED --
+    ``groups: [{"type": "event"|"entity", "n": N, "items": [{"text", ...}]}]`` -- and no key named
+    ``selected_refs`` appears at all. Every ``Memory.search()`` call therefore returned
+    ``{"results": []}`` against a pack that plainly had content (``search_raw`` showed it), for what
+    is mem0's primary read API. Group items are flattened in group order, and the group's ``type``
+    is carried into each item's metadata as ``ref_type`` so callers keep the event/entity
+    distinction the flat shape gave them."""
     refs = res.get("selected_refs")
     if not isinstance(refs, list):
         result = res.get("result")
         refs = result.get("selected_refs") if isinstance(result, dict) else None
+    if not isinstance(refs, list):
+        groups = res.get("groups")
+        if not isinstance(groups, list):
+            result = res.get("result")
+            groups = result.get("groups") if isinstance(result, dict) else None
+        if isinstance(groups, list):
+            flattened: list[Json] = []
+            for group in groups:
+                if not isinstance(group, dict):
+                    continue
+                group_type = group.get("type")
+                for item in group.get("items") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    if group_type and "ref_type" not in item:
+                        item = {**item, "ref_type": group_type}
+                    flattened.append(item)
+            refs = flattened
     results: list[Json] = []
     for index, ref in enumerate(refs or []):
         if not isinstance(ref, dict):
@@ -282,7 +309,58 @@ class Memory:
         pack = self.search_raw(query, user_id=user_id, agent_id=agent_id, run_id=run_id, limit=limit)
         if raw:
             return pack
-        return _reshape_search_results(pack)
+        reshaped = _reshape_search_results(pack)
+        return self._attach_real_ids(reshaped, user_id=user_id, agent_id=agent_id, run_id=run_id)
+
+    def _attach_real_ids(self, reshaped: Json, *, user_id: Optional[str],
+                         agent_id: Optional[str], run_id: Optional[str]) -> Json:
+        """Replace synthetic ``ref-N-...`` ids with the real memory id, matching on text.
+
+        mem0's contract is that a ``search`` result is addressable: callers feed ``results[i]["id"]``
+        straight back into ``get`` / ``update`` / ``delete``. A ContextPack cannot satisfy that on
+        its own -- ``source_ref`` is classified as debug-only lineage and stripped from serving
+        items, so every item arrives with text but no id, and ``_reshape_search_results`` has to
+        synthesize one. Handing those synthesized ids back to ``get``/``update``/``delete`` fails
+        (``found: false``, HTTP 500, ``deleted: false``), which is the end-to-end break this repairs.
+
+        So the ids are recovered from ``get_all``, which does return them, by exact text match. One
+        extra request, made only when a synthetic id is actually present. Items that match nothing
+        keep their synthetic id: derived entity refs ("preference: drink is matcha") are projections
+        of a memory rather than an addressable memory, and inventing an id for them would only move
+        the failure downstream."""
+        results = reshaped.get("results")
+        if not isinstance(results, list) or not results:
+            return reshaped
+        if not any(str(entry.get("id") or "").startswith("ref-") for entry in results
+                   if isinstance(entry, dict)):
+            return reshaped
+        try:
+            listing = self.get_all(user_id=user_id, agent_id=agent_id, run_id=run_id)
+        except Exception:  # A search must not fail because the id lookup did.
+            return reshaped
+        rows = listing.get("memories") if isinstance(listing, dict) else None
+        if not isinstance(rows, list):
+            rows = listing.get("results") if isinstance(listing, dict) else None
+        by_text: Json = {}
+        for row in rows or []:
+            if not isinstance(row, dict):
+                continue
+            row_id = row.get("id") or row.get("memory_id")
+            body = str(row.get("memory") or row.get("text") or "").strip()
+            if row_id in (None, "") or not body:
+                continue
+            by_text.setdefault(body, row_id)
+        if not by_text:
+            return reshaped
+        for entry in results:
+            if not isinstance(entry, dict):
+                continue
+            if not str(entry.get("id") or "").startswith("ref-"):
+                continue
+            real = by_text.get(str(entry.get("memory") or "").strip())
+            if real not in (None, ""):
+                entry["id"] = str(real)
+        return reshaped
 
     def search_raw(self, query: str, *, user_id: Optional[str] = None,
                    agent_id: Optional[str] = None, run_id: Optional[str] = None,

--- a/tools/test_mem0_complete.py
+++ b/tools/test_mem0_complete.py
@@ -483,5 +483,88 @@ class GatewayCompletionRoutesCase(unittest.TestCase):
         self.assertEqual("insufficient_scope", json.loads(body)["error"])
 
 
+class Mem0SearchPackShapeCase(unittest.TestCase):
+    """search() must return the pack's refs, and they must be addressable.
+
+    Both of these shipped broken: the shim was written against a flat ``selected_refs`` pack, but a
+    ContextPack now serves refs GROUPED and emits no ``selected_refs`` key at all, so every
+    ``search()`` returned ``{"results": []}`` while ``search_raw`` showed content."""
+
+    def test_grouped_pack_is_reshaped_into_mem0_results(self):
+        pack = {
+            "context_pack_id": "1",
+            "groups": [
+                {"type": "event", "n": 1, "items": [
+                    {"text": "user: I live in Kyoto.", "memory_layer": "session"}]},
+                {"type": "entity", "n": 1, "items": [
+                    {"text": "location: Kyoto", "entity_type": "location"}]},
+            ],
+        }
+        results = _reshape_search_results(pack)["results"]
+        self.assertEqual(2, len(results), "grouped pack must not reshape to an empty result set")
+        self.assertEqual("user: I live in Kyoto.", results[0]["memory"])
+        self.assertEqual("location: Kyoto", results[1]["memory"])
+        # The group's type survives as metadata so callers keep the event/entity distinction the
+        # flat selected_refs shape gave them.
+        self.assertEqual("event", results[0]["metadata"].get("ref_type"))
+        self.assertEqual("entity", results[1]["metadata"].get("ref_type"))
+
+    def test_flat_selected_refs_pack_still_works(self):
+        pack = {"selected_refs": [{"text": "flat ref", "source_ref": "e1", "score": 0.5}]}
+        results = _reshape_search_results(pack)["results"]
+        self.assertEqual(1, len(results))
+        self.assertEqual("flat ref", results[0]["memory"])
+        self.assertEqual("e1", results[0]["id"])
+
+    def test_search_results_carry_addressable_ids(self):
+        """A synthetic ``ref-N-...`` id is useless: get/update/delete all reject it."""
+
+        class _Client(mem0.Memory):
+            def __init__(self):
+                pass  # no transport: the two hops are stubbed below
+
+            def search_raw(self, query, **kw):
+                return {"groups": [{"type": "event", "n": 1, "items": [
+                    {"text": "user: I live in Kyoto."}]}]}
+
+            def get_all(self, **kw):
+                return {"memories": [{"id": 12345, "memory": "user: I live in Kyoto."}]}
+
+        results = _Client().search("where do I live", user_id="u1")["results"]
+        self.assertEqual(1, len(results))
+        self.assertEqual("12345", results[0]["id"], "id must be the real memory id, not ref-N-...")
+
+    def test_unmatched_items_keep_their_synthetic_id(self):
+        """A derived entity ref is a projection of a memory, not an addressable memory."""
+
+        class _Client(mem0.Memory):
+            def __init__(self):
+                pass
+
+            def search_raw(self, query, **kw):
+                return {"groups": [{"type": "entity", "n": 1, "items": [
+                    {"text": "location: Kyoto"}]}]}
+
+            def get_all(self, **kw):
+                return {"memories": [{"id": 12345, "memory": "user: I live in Kyoto."}]}
+
+        results = _Client().search("where", user_id="u1")["results"]
+        self.assertTrue(results[0]["id"].startswith("ref-"))
+
+    def test_search_survives_a_failing_id_lookup(self):
+        class _Client(mem0.Memory):
+            def __init__(self):
+                pass
+
+            def search_raw(self, query, **kw):
+                return {"groups": [{"type": "event", "n": 1, "items": [{"text": "hello"}]}]}
+
+            def get_all(self, **kw):
+                raise RuntimeError("gateway down")
+
+        results = _Client().search("q", user_id="u1")["results"]
+        self.assertEqual("hello", results[0]["memory"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_oss_model_extraction.py
+++ b/tools/test_oss_model_extraction.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The OSS causal-LM extractor must accept BOTH chat-template return shapes.
+
+``apply_chat_template(..., return_tensors="pt")`` returned a bare tensor on older transformers and
+returns a BatchEncoding (a mapping of input_ids + attention_mask) on transformers >= 5. The extractor
+passed whatever it got positionally to ``generate()``, so on a current transformers it read ``.shape``
+off a dict-like and raised a bare ``AttributeError`` -- segment_provider=oss could not run at all.
+Nothing covered this path, which is why it went unnoticed; these tests stub the tokenizer and model so
+both shapes are exercised without downloading a model.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+import matrixark_mcp_core as core
+
+
+class _FakeTensor:
+    """Minimal stand-in for a torch tensor of token ids."""
+
+    def __init__(self, ids):
+        self._ids = list(ids)
+
+    @property
+    def shape(self):
+        return (1, len(self._ids))
+
+    def to(self, _device):
+        return self
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return _FakeTensor(self._ids[index])
+        return self._ids[index]
+
+
+class _FakeBatchEncoding(dict):
+    """BatchEncoding is dict-like -- and crucially has no usable ``.shape``."""
+
+    def to(self, _device):
+        return self
+
+
+class _FakeTokenizer:
+    chat_template = "present"
+
+    def __init__(self, encoded):
+        self._encoded = encoded
+        self.decoded_with = None
+
+    def apply_chat_template(self, chat, add_generation_prompt=True, return_tensors="pt"):
+        return self._encoded
+
+    def decode(self, generated, skip_special_tokens=True):
+        self.decoded_with = generated
+        return json.dumps({"segments": [{"topic": "t", "message_indexes": [0],
+                                         "saliency_score": 0.5, "summary_text": "s"}]})
+
+
+class _FakeModel:
+    def __init__(self):
+        self.called_with_kwargs = None
+        self.called_positionally = False
+
+    def generate(self, *args, **kwargs):
+        if args:
+            self.called_positionally = True
+        self.called_with_kwargs = kwargs
+        # Prompt tokens followed by the generated continuation.
+        return [_FakeTensor([1, 2, 3, 4, 5, 6])]
+
+
+class OssModelChatTemplateShapeCase(unittest.TestCase):
+    def setUp(self):
+        core._OSS_SEGMENT_MODEL_CACHE.clear()
+        self.addCleanup(core._OSS_SEGMENT_MODEL_CACHE.clear)
+
+    def _run(self, encoded):
+        tokenizer = _FakeTokenizer(encoded)
+        model = _FakeModel()
+        core._OSS_SEGMENT_MODEL_CACHE["stub:64"] = {
+            "tokenizer": tokenizer, "model": model, "device": "cpu"}
+        result = core.oss_model_memory_segments(
+            [{"role": "user", "content": "hello"}], model="stub", max_new_tokens=64)
+        return result, tokenizer, model
+
+    def test_batch_encoding_is_expanded_into_generate_kwargs(self):
+        encoded = _FakeBatchEncoding(input_ids=_FakeTensor([1, 2, 3]),
+                                     attention_mask=_FakeTensor([1, 1, 1]))
+        result, _tokenizer, model = self._run(encoded)
+        self.assertIn("segments", result)
+        self.assertFalse(model.called_positionally,
+                         "a BatchEncoding must be expanded, not passed positionally")
+        self.assertIn("input_ids", model.called_with_kwargs)
+
+    def test_bare_tensor_is_still_passed_positionally(self):
+        result, _tokenizer, model = self._run(_FakeTensor([1, 2, 3]))
+        self.assertIn("segments", result)
+        self.assertTrue(model.called_positionally)
+
+    def test_prompt_tokens_are_trimmed_from_the_decoded_output(self):
+        """The prompt length comes from input_ids either way, so the reply excludes the prompt."""
+        encoded = _FakeBatchEncoding(input_ids=_FakeTensor([1, 2, 3]))
+        _result, tokenizer, _model = self._run(encoded)
+        self.assertEqual(3, len(tokenizer.decoded_with._ids),
+                         "decode must see only the 3 generated tokens, not all 6")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three defects found by calling **every** public API end to end — all 39 MCP tools and all 11 `mem0.Memory` methods — against a real store and the **real** `/v1` gateway ASGI app, rather than the stub gateway the existing tests use.

## 1. `mem0.search()` returned nothing, for every query

`_reshape_search_results` reads `selected_refs`. A ContextPack now serves its refs **grouped** — `groups: [{type, n, items: [{text, ...}]}]` — and emits no `selected_refs` key at all. So mem0's primary read API returned `{"results": []}` on a store that plainly had matching content (`search_raw` showed it).

Both shapes are accepted now. A group's `type` is carried into each item's metadata as `ref_type`, so callers keep the event/entity distinction the flat shape gave them.

## 2. `mem0.search()` results were not addressable

Fixing (1) exposed this. Group items carry no id — `source_ref` is deliberately classified as debug-only lineage and stripped from serving items — so results got synthetic `ref-N-…` ids. Feeding those back into `get` / `update` / `delete`, which is mem0's documented flow, failed with `found: false`, HTTP 500, and `deleted: false`.

Real ids are recovered from `get_all` by exact text match: one extra request, made **only** when a synthetic id is actually present. Items that match nothing keep the synthetic id on purpose — a derived entity ref (`"preference: drink is matcha"`) is a projection of a memory, not an addressable memory, and inventing an id for it would only move the failure downstream.

## 3. The OSS causal-LM extractor could not run on transformers ≥ 5

`apply_chat_template(..., return_tensors="pt")` returns a `BatchEncoding` on transformers 5.x where it used to return a bare tensor. The result was passed positionally into `generate()`, which read `.shape` off a dict-like and raised a bare `AttributeError` with no indication of the cause — `segment_provider=oss` was simply unusable.

Both shapes are accepted now. Verified against `Qwen2.5-7B-Instruct` on transformers 5.15.0.

## Why the tests missed all three

`test_mem0_complete.py` exercises the mem0 client against a stub `BaseHTTPRequestHandler` that returns hand-written `selected_refs` payloads, so it only ever tested request *shaping* and never saw a real pack. Nothing at all covered `oss_model_memory_segments`.

## Verification

- 8 tests added. **4** of the mem0 tests and **2** of the extractor tests fail on the unfixed code, with the original errors.
- Full mem0 + extractor suite on this branch: **29 passing**.
- API sweep: **53/53** (39 MCP tools + 11 mem0 methods + variants), against a real store and the real gateway.
- Correctness checks on `retrieve`/`search` beyond non-emptiness — grounding, per-user scoping in both directions, id resolution, `limit`, and agreement between `search` and `search_raw`: **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
