### PR TITLE
raft: cut per-write durability barriers 12.38 -> 4.50 (two gated fixes)

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1829,7 +1829,7 @@ pub(super) fn wal_single_barrier() -> bool {
 /// byte-identical to the legacy in-lock `append_with_sync` barrier. The ack is always returned
 /// strictly AFTER the covering barrier succeeds, so durability is never weakened.
 fn engine_concurrent_commit() -> bool {
-    env_flag_on("TS_ENGINE_CONCURRENT_COMMIT")
+    env_flag_default_on("TS_ENGINE_CONCURRENT_COMMIT")
 }
 
 /// TS_PHASE1_FLAT: make phase-1 (the work under the global `shards` write lock in
@@ -1843,7 +1843,7 @@ fn engine_concurrent_commit() -> bool {
 /// path skips the repeat scan. Default OFF -> byte-identical (the scan runs every command exactly
 /// as before). Sharing one gate with the WAL fast-append so a single switch flattens phase-1.
 fn phase1_flat_enabled() -> bool {
-    env_flag_on("TS_PHASE1_FLAT")
+    env_flag_default_on("TS_PHASE1_FLAT")
 }
 
 /// TS_RAFT_APPLY_COALESCE: on the raft state-machine apply path, coalesce the per-committed-entry
@@ -1853,7 +1853,7 @@ fn phase1_flat_enabled() -> bool {
 /// raft log stays the durability + reconstruction source; the coalesced barrier still completes
 /// before the raft runtime advances the durable applied_index.
 fn raft_apply_coalesce() -> bool {
-    env_flag_on("TS_RAFT_APPLY_COALESCE")
+    env_flag_default_on("TS_RAFT_APPLY_COALESCE")
 }
 
 fn env_flag_on(name: &str) -> bool {
@@ -1864,6 +1864,20 @@ fn env_flag_on(name: &str) -> bool {
             .to_ascii_lowercase()
             .as_str(),
         "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
+/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
+/// fixed behavior by default; the env var remains only as an escape hatch.
+fn env_flag_default_on(name: &str) -> bool {
+    !matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
     )
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/concurrent_commit.rs
+++ b/crates/temporalstore-rust/src/engine/tests/concurrent_commit.rs
@@ -115,7 +115,7 @@ fn concurrent_commit_coalesces_fsyncs_while_off_path_is_one_fsync_per_write() {
     let _serial = ENGINE_COMMIT_ENV_LOCK.lock().unwrap();
 
     // --- Baseline: gate OFF -> barrier under the shards lock -> group commit unreachable. ---
-    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "0");
     let off_dir = tempfile::tempdir().unwrap();
     let off = run_concurrent_same_shard_writes(&new_engine(off_dir.path()));
     assert_eq!(off.acked, off.writes, "gate OFF: all writes acked");

--- a/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
+++ b/crates/temporalstore-rust/src/engine/tests/phase1_flat.rs
@@ -142,7 +142,7 @@ fn phase1_flat_keeps_per_write_scans_flat_over_5k_writes() {
     );
 
     // --- Gate OFF baseline: each scan fires once per command -> counts track the write volume. ---
-    std::env::remove_var("TS_PHASE1_FLAT");
+    std::env::set_var("TS_PHASE1_FLAT", "0");
     let off_dir = tempfile::tempdir().unwrap();
     let off = new_engine(off_dir.path());
     // Smaller than N: with the gate off each of these writes pays the O(store) promote scan AND a

--- a/crates/temporalstore-rust/src/engine/tests/raft_apply_coalesce.rs
+++ b/crates/temporalstore-rust/src/engine/tests/raft_apply_coalesce.rs
@@ -69,7 +69,7 @@ fn raft_apply_batch_coalesces_to_one_fsync_while_off_is_one_per_entry() {
     let _serial = RAFT_APPLY_ENV_LOCK.lock().unwrap();
 
     // --- Baseline: gate OFF -> per-entry execute_raft_apply -> one fsync per committed entry. ---
-    std::env::remove_var("TS_RAFT_APPLY_COALESCE");
+    std::env::set_var("TS_RAFT_APPLY_COALESCE", "0");
     let off_dir = tempfile::tempdir().unwrap();
     let off = new_engine(off_dir.path());
     let before = off.write_ahead_log_store().stats(1).syncs;

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -271,6 +271,28 @@ fn raft_propose_serialize_on() -> bool {
     raft_env_flag_default_on("TS_RAFT_PROPOSE_SERIALIZE")
 }
 
+/// P3 (local-only durability): a DEPLOYED raft process runs exactly one node but keeps a full
+/// cluster view, so `wal_records()` emits a record per peer and `persist_configured_wal` fsyncs
+/// every one of them. A leader has no duty to make its peers' hard-state durable -- each node
+/// persists its own before answering an RPC, and peer state is re-learned from AppendEntries on
+/// restart. When this is on AND the runtime told us which node we are, persist only that record.
+/// Default OFF -> byte-identical. Has no effect on the in-process test cluster, which genuinely
+/// hosts every node and leaves `local_node_id` as None.
+fn raft_persist_local_only_on() -> bool {
+    raft_env_flag_on("TS_RAFT_PERSIST_LOCAL_ONLY")
+}
+
+/// P4 (one barrier per propose): a single propose calls `persist_configured_wal` several times
+/// as the log appends and then the commit index advances, so each write pays several barriers.
+/// Only the FINAL state has to be durable before the ack -- an intermediate state is subsumed by
+/// it, and a crash before the ack simply drops an unacked entry. When on, nested persists record
+/// that a barrier is owed and ONE persist flushes before the response is returned. Enabled only
+/// while the propose serialize lock is held, so exactly one writer can own the deferral.
+/// Default OFF -> byte-identical.
+fn raft_persist_defer_on() -> bool {
+    raft_env_flag_on("TS_RAFT_PERSIST_DEFER")
+}
+
 /// Fingerprint of the DURABILITY-relevant subset of a WAL record. `pipeline_state` and
 /// `read_safety_state` are cleared before hashing because they are volatile (reinitialised on
 /// election / re-driven on restart) and pure metrics respectively -- excluding them is what lets
@@ -3751,6 +3773,13 @@ struct RaftClusterInner {
     last_durable_fingerprint: BTreeMap<RaftNodeId, u64>,
     /// P2: serialize proposes into the log in order under `TS_RAFT_PROPOSE_SERIALIZE`.
     propose_serialize: Arc<Mutex<()>>,
+    /// P3: which node THIS process is, when the deployed runtime tells us. None for the
+    /// in-process test cluster (which hosts every node). Gates `TS_RAFT_PERSIST_LOCAL_ONLY`.
+    local_node_id: Option<RaftNodeId>,
+    /// P4: while set, `persist_configured_wal` records that a barrier is owed instead of taking
+    /// one; `flush_deferred_persist` takes the single real barrier before the propose acks.
+    persist_deferred: bool,
+    persist_dirty: bool,
 }
 
 impl RaftCluster {
@@ -3758,6 +3787,14 @@ impl RaftCluster {
     ///
     /// Production runtime/deployment paths must use the distributed production
     /// Raft runtime and are rejected by readiness if they select this local model.
+    /// P3: tell the cluster which node THIS process actually is. Set by the deployed
+    /// production runtime (one node per process); left unset by the in-process test cluster,
+    /// which hosts every node. Only consulted under `TS_RAFT_PERSIST_LOCAL_ONLY`.
+    pub fn set_local_node_id(&self, node_id: RaftNodeId) {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        inner.local_node_id = Some(node_id);
+    }
+
     pub fn new_single_shard(
         shard_id: ShardId,
         node_ids: impl IntoIterator<Item = RaftNodeId>,
@@ -3800,6 +3837,9 @@ impl RaftCluster {
                 membership_evidence: RaftMembershipRuntimeEvidence::default(),
                 last_durable_fingerprint: BTreeMap::new(),
                 propose_serialize: Arc::new(Mutex::new(())),
+                local_node_id: None,
+                persist_deferred: false,
+                persist_dirty: false,
             })),
         })
     }
@@ -3920,6 +3960,9 @@ impl RaftCluster {
                 membership_evidence,
                 last_durable_fingerprint: BTreeMap::new(),
                 propose_serialize: Arc::new(Mutex::new(())),
+                local_node_id: None,
+                persist_deferred: false,
+                persist_dirty: false,
             })),
         })
     }
@@ -4120,6 +4163,40 @@ impl RaftCluster {
         let _propose_guard = propose_gate
             .as_ref()
             .map(|gate| gate.lock().unwrap_or_else(|poisoned| poisoned.into_inner()));
+        // P4: the propose lock makes us the only writer, so nested persists can record that a
+        // barrier is owed and let one flush below cover the final state -- before the ack.
+        let deferring = raft_persist_defer_on() && _propose_guard.is_some();
+        if deferring {
+            self.inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .begin_deferred_persist();
+        }
+        let outcome = self.propose_distributed_one_locked(command, transport);
+        if !deferring {
+            return outcome;
+        }
+        let flushed = self
+            .inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .flush_deferred_persist();
+        // Never ack a write whose barrier failed: a flush error wins over a successful propose.
+        match (outcome, flushed) {
+            (Ok(response), Ok(())) => Ok(response),
+            (Ok(_), Err(err)) => Err(err),
+            (Err(err), _) => Err(err),
+        }
+    }
+
+    fn propose_distributed_one_locked<T>(
+        &self,
+        command: Command,
+        transport: &T,
+    ) -> Result<CommandResponse, RaftError>
+    where
+        T: RaftTransport + Clone + Send + 'static,
+    {
         let (entry, leader_id, target_ids, required) = {
             let mut inner = self.inner.write().expect("raft cluster lock poisoned");
             inner.ensure_live_leader()?;

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -201,6 +201,20 @@ fn raft_env_flag_on(name: &str) -> bool {
     )
 }
 
+/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
+/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
+/// fixed behavior by default; the env var remains only as an escape hatch.
+fn raft_env_flag_default_on(name: &str) -> bool {
+    !matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
 /// R8: §7 snapshot-install boundary-term truncation. When on, a snapshot install whose
 /// boundary entry does not term-match the local log discards the ENTIRE log instead of
 /// retaining a possibly-divergent tail.
@@ -247,14 +261,14 @@ fn raft_snapshot_state_image_on() -> bool {
 /// read-index accounting counters) are excluded from the change check. Default OFF -> every call
 /// fsyncs exactly as before (byte-identical).
 fn raft_wal_coalesce_on() -> bool {
-    raft_env_flag_on("TS_RAFT_WAL_COALESCE")
+    raft_env_flag_default_on("TS_RAFT_WAL_COALESCE")
 }
 
 /// P2 (in-order propose): hold a per-cluster serialize lock across the append+replicate+commit
 /// critical section of `propose_distributed_one` so concurrent proposals reach followers in log
 /// order and never trigger a `prev_log` mismatch + full-deadline stall. Default OFF.
 fn raft_propose_serialize_on() -> bool {
-    raft_env_flag_on("TS_RAFT_PROPOSE_SERIALIZE")
+    raft_env_flag_default_on("TS_RAFT_PROPOSE_SERIALIZE")
 }
 
 /// Fingerprint of the DURABILITY-relevant subset of a WAL record. `pipeline_state` and

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -646,6 +646,11 @@ impl RaftClusterInner {
     }
 
     pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
+        // P4: a barrier is owed, not skipped -- flush_deferred_persist takes it before the ack.
+        if self.persist_deferred {
+            self.persist_dirty = true;
+            return Ok(());
+        }
         // Clone the WAL handle (cheap -- it shares the cursor cache via an Arc) so `self` is free
         // to be borrowed mutably below for the coalescing fingerprint map.
         let wal = match &self.wal {
@@ -656,7 +661,15 @@ impl RaftClusterInner {
         let max_segment_bytes = self.config.max_segment_bytes;
         let min_keep_segment_num = self.config.min_keep_segment_num as usize;
         let coalesce = raft_wal_coalesce_on();
+        // P3: a deployed process owns exactly one node; persisting a peer's hard-state buys no
+        // Raft safety (the peer fsyncs its own before answering) and costs a barrier per peer.
+        let local_only = if raft_persist_local_only_on() { self.local_node_id } else { None };
         for (node_id, record) in self.wal_records() {
+            if let Some(local) = local_only {
+                if node_id != local {
+                    continue;
+                }
+            }
             // P1: when coalescing is enabled, skip the fdatasync for a node whose durability-
             // relevant state is byte-identical to what we last persisted. A false "changed" only
             // costs a redundant (safe) fsync; the skip fires ONLY when nothing Raft must persist
@@ -687,6 +700,22 @@ impl RaftClusterInner {
             }
         }
         Ok(())
+    }
+
+    /// P4: start owing barriers instead of taking them. Caller must hold the propose lock.
+    pub(super) fn begin_deferred_persist(&mut self) {
+        self.persist_deferred = true;
+        self.persist_dirty = false;
+    }
+
+    /// P4: take the single real barrier covering everything deferred since `begin_deferred_persist`.
+    pub(super) fn flush_deferred_persist(&mut self) -> Result<(), RaftError> {
+        self.persist_deferred = false;
+        if !self.persist_dirty {
+            return Ok(());
+        }
+        self.persist_dirty = false;
+        self.persist_configured_wal()
     }
 
     pub(super) fn wal_records(&self) -> Vec<(RaftNodeId, RaftWalRecord)> {

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -105,6 +105,9 @@ impl ProductionRaftRuntime {
             options.voter_ids(),
             options.config.clone(),
         )?;
+        // P3: one node per process here, so the WAL persist can be scoped to our own record
+        // under `TS_RAFT_PERSIST_LOCAL_ONLY` instead of fsyncing every peer's hard-state.
+        cluster.set_local_node_id(options.local_node_id);
         Ok(Self { options, cluster })
     }
 

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2367,11 +2367,59 @@ fn s2_snapshot_gate_off_still_carries_entries_and_no_image() {
 
 /// Sum the durable WAL records on disk for one node (each record == one real fdatasync in the
 /// segmented append path), read via a fresh WAL handle so it reflects the on-disk truth.
+/// Serialises the tests in this file that mutate process-global env gates.
+static PART4_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn node_wal_record_count(root: &std::path::Path, shard: ShardId, node: RaftNodeId) -> u64 {
     LocalRaftWal::new(root)
         .segment_report(shard, node)
         .map(|report| report.segments.iter().map(|s| s.record_count).sum())
         .unwrap_or(0)
+}
+
+/// P3 core: a DEPLOYED process owns one node but keeps a full cluster view, so the default
+/// persist fsyncs a record for every peer. With `TS_RAFT_PERSIST_LOCAL_ONLY` on and the runtime
+/// having declared which node we are, only OUR record may grow -- peers persist their own
+/// hard-state before answering an RPC, so the leader writing it buys no Raft safety. Durability
+/// of the local node is unchanged, which is what the first assertion pins.
+#[test]
+fn persist_local_only_writes_just_this_nodes_record() {
+    let _serial = PART4_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _gate = EnvFlagGuard::set("TS_RAFT_PERSIST_LOCAL_ONLY");
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(1);
+
+    let base: Vec<u64> = (1..=3).map(|n| node_wal_record_count(dir.path(), 1, n)).collect();
+    for i in 0..10 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("p3-{i}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+    let after: Vec<u64> = (1..=3).map(|n| node_wal_record_count(dir.path(), 1, n)).collect();
+
+    assert!(
+        after[0] > base[0],
+        "local node 1 must still take its durability barrier: {} -> {}",
+        base[0],
+        after[0]
+    );
+    for peer in 1..3 {
+        assert_eq!(
+            after[peer], base[peer],
+            "peer node {} must not be persisted by us under local-only: {} -> {}",
+            peer + 1,
+            base[peer],
+            after[peer]
+        );
+    }
 }
 
 /// P1 core: with `TS_RAFT_WAL_COALESCE` on, a burst of read-index calls (which only touch the

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2112,6 +2112,13 @@ impl EnvFlagGuard {
         std::env::set_var(name, "1");
         Self { name }
     }
+
+    /// Explicitly DISABLES a gate for the test's lifetime. Needed because the shipped fixes are
+    /// default-ON: leaving the variable unset now selects the fixed path, not the legacy one.
+    fn off(name: &'static str) -> Self {
+        std::env::set_var(name, "0");
+        Self { name }
+    }
 }
 
 impl Drop for EnvFlagGuard {
@@ -2406,6 +2413,7 @@ fn raft_wal_coalesce_skips_volatile_only_read_index_persists() {
 /// persists, so the same burst grows the WAL by one record per call. This pins the win as real.
 #[test]
 fn raft_wal_coalesce_off_persists_every_read_index() {
+    let _gate = EnvFlagGuard::off("TS_RAFT_WAL_COALESCE");
     let dir = tempfile::tempdir().unwrap();
     let cluster =
         RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -928,7 +928,7 @@ fn wal_bulk_relaxed_durability() -> bool {
 /// the unconditional-scan path when off. Mirrors the warm-cache fast path already used by
 /// `index_log::append_delta` and `append_replayed_record`.
 fn wal_fast_append_seq() -> bool {
-    wal_env_flag_on("TS_PHASE1_FLAT")
+    wal_env_flag_default_on("TS_PHASE1_FLAT")
 }
 
 /// Resolve the last WAL sequence for `shard_id` immediately before an append, under the `inner`
@@ -978,6 +978,20 @@ fn wal_env_flag_on(name: &str) -> bool {
             .to_ascii_lowercase()
             .as_str(),
         "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Default-ON gate read: the fix is LIVE unless explicitly disabled with
+/// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
+/// fixed behavior by default; the env var remains only as an escape hatch.
+fn wal_env_flag_default_on(name: &str) -> bool {
+    !matches!(
+        std::env::var(name)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
     )
 }
 


### PR DESCRIPTION
> **Stacked on** `mirror/default-on-write-path-gates`. Review that one first;
> this branch contains it as its parent commit.

Cuts raft's per-write durability barriers from **12.38 to 4.50**, measured on a
3-node cluster.

**Where the barriers came from.** A deployed raft process owns exactly one node
but keeps a full cluster view, so `wal_records()` emitted a record per peer and
`persist_configured_wal()` took a barrier for every one of them. A single
propose also calls that function several times — once as the log appends, again
as the commit index advances. Three nodes x ~4 calls = ~12.

**P3 — `TS_RAFT_PERSIST_LOCAL_ONLY`** (default OFF)

Adds `local_node_id` to the cluster inner state, set by the deployed runtime
(one node per process) and left unset by the in-process test cluster, which
genuinely hosts every node and must still persist them all. When set, the
persist covers only this node's own record.

Safe because a peer makes its own hard-state durable before answering an RPC and
re-learns the rest from AppendEntries on restart — the leader persisting it
buys no Raft safety.

**P4 — `TS_RAFT_PERSIST_DEFER`** (default OFF)

Nested persists record that a barrier is *owed*; one flush covers the final
state before the propose acks. Intermediate states are subsumed by the final
one, and a crash before the ack drops an entry that was never acked.

Two details that matter for correctness:

- deferral is enabled **only while the propose serialize lock is held**, so
  exactly one writer owns it — otherwise concurrent proposes would interleave
  the flag
- the flush error is propagated on the success path
  (`(Ok(_), Err(err)) => Err(err)`), so a write whose barrier failed is never
  acked. A `Drop`-based flush would have swallowed that error, which is why the
  propose function is split rather than wrapped in a guard

**Measured** — 3x c7i.xlarge, one binary, gates enabled separately so each is
attributed on its own:

| config | fsync/write | write p50 | write QPS | C=32 p50 | C=32 QPS |
|---|---|---|---|---|---|
| baseline | 12.38 | 67.0 ms | 14.9 | 3575 ms | 6.7 |
| +P3 | 7.88 | 48.9 ms | 20.5 | 2340 ms | 11.2 |
| +P3+P4 | **4.50** | **37.6 ms** | **26.6** | **1620 ms** | **17.1** |

2.75x fewer barriers, 1.8x write latency, 2.55x throughput at C=32. Latency is
barrier-bound here, so cutting barriers moves latency and scale together.
Reads take **zero** barriers in every config (measured with a separate read-only
window).

**Testing.** P4 lives on the distributed propose path, which the in-process test
cluster does not exercise (`propose()` goes via `propose_one`), so it is
verified on a real cluster rather than by a unit test — worth knowing before
relying on CI alone for it. P3 *is* unit-tested: only the local node's record
grows while peers stay flat, and the local node still takes its own barrier.
174 raft tests pass with both gates on and with both off.

Also adds the env lock `raft/tests/part4.rs` has always needed — about ten of
its tests mutate process-global gates with no serialisation, which made them
fail unpredictably under the parallel runner.

**Still on the table:** 4.50 is above the ~2 design target. P4 only defers
inside `propose_distributed_one`; the apply path and tick handlers still take
their own barriers. Two dead ends worth recording so they are not retried —
`TS_RAFT_PROPOSE_SERIALIZE` is *not* the bottleneck (on vs off is identical:
75.78 vs 75.83 ms, 12.38 fsync both), and heartbeat tuning does nothing
(100/20/5 ms all land at ~83 ms).
