### PR TITLE
WAL writes pages instead of commands and related changes (Oss/flat write path and crc32c)

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -881,6 +881,67 @@ impl LocalBlockStore {
         roll_slab_inner(&mut inner)
     }
 
+    /// Roll the active slab ahead of the write that would otherwise have to, off the client
+    /// path. Returns the roll report if a roll happened, `None` if the active slab still has
+    /// room.
+    ///
+    /// Rolling is not cheap: `roll_slab_inner` fsyncs the outgoing slab, scans the slab
+    /// directory to pick the next id, creates and fsyncs the new file, fsyncs the parent
+    /// directory, and persists the band manifest. Run inline from `append` -- which is where
+    /// it runs today -- one unlucky client write pays all of that on top of its own
+    /// durability barrier, a latency outlier unrelated to the size of the write that
+    /// triggered it.
+    ///
+    /// The reference implementation keeps this off the write path: its background
+    /// storage-manager cycle runs a prepare step that no-ops while the active zone is under
+    /// target and otherwise rolls to a fresh one, so a client append finds space already
+    /// waiting. The inline roll in `append` stays as the fallback for a write that arrives
+    /// before the background cycle got here -- the same role the reference's forced-roll path
+    /// plays.
+    pub fn prepare_next_slab(&self) -> Result<Option<BlockStoreRollReport>, BlockStoreError> {
+        self.prepare_next_slab_with_target(effective_block_slab_target_bytes())
+    }
+
+    /// [`prepare_next_slab`] against an explicit target rather than the process-wide
+    /// configured one.
+    ///
+    /// The slab target is only reachable through a global env var, so a test that wanted a
+    /// small target would have to mutate process state — and if it then failed an assertion
+    /// before restoring it, every later test in the process would inherit the small target.
+    /// Taking the target as an argument keeps that class of cross-test failure impossible.
+    pub fn prepare_next_slab_with_target(
+        &self,
+        slab_target_bytes: u64,
+    ) -> Result<Option<BlockStoreRollReport>, BlockStoreError> {
+        let mut inner = self.inner.lock().expect("block store lock poisoned");
+        if !slab_is_at_target(inner.write_offset, slab_target_bytes) {
+            return Ok(None);
+        }
+        roll_slab_inner(&mut inner).map(Some)
+    }
+
+    /// Whether [`prepare_next_slab`] would roll right now, without doing it. Lets a caller
+    /// (a report, or a scheduler deciding whether the phase is worth running) ask about
+    /// pressure without paying for it.
+    pub fn needs_slab_preparation(&self) -> bool {
+        self.needs_slab_preparation_with_target(effective_block_slab_target_bytes())
+    }
+
+    /// [`needs_slab_preparation`] against an explicit target.
+    pub fn needs_slab_preparation_with_target(&self, slab_target_bytes: u64) -> bool {
+        let inner = self.inner.lock().expect("block store lock poisoned");
+        slab_is_at_target(inner.write_offset, slab_target_bytes)
+    }
+
+    /// Bytes written to the active slab. Exposed so a caller can reason about slab pressure
+    /// (and so tests can drive the prepare threshold without touching global config).
+    pub fn active_slab_write_offset(&self) -> u64 {
+        self.inner
+            .lock()
+            .expect("block store lock poisoned")
+            .write_offset
+    }
+
     pub fn slab_ids(&self) -> Result<Vec<u64>, BlockStoreError> {
         let root = self
             .inner
@@ -1015,6 +1076,19 @@ fn should_roll_before_append(
     slab_target_bytes: u64,
 ) -> bool {
     write_offset > 0 && write_offset.saturating_add(record_len) > slab_target_bytes
+}
+
+/// Whether the active slab has reached its target and should be rolled ahead of the next
+/// append.
+///
+/// Deliberately NOT the same predicate as `should_roll_before_append`: that one asks "will
+/// THIS record overflow the slab", which needs the record length and is only answerable on
+/// the write path. This one asks "is the slab full enough to roll now", which is answerable
+/// in the background with no pending record. The `write_offset > 0` guard stops a freshly
+/// rolled, still-empty slab from rolling again immediately — without it a background cycle
+/// would mint an empty slab every pass.
+fn slab_is_at_target(write_offset: u64, slab_target_bytes: u64) -> bool {
+    write_offset > 0 && write_offset >= slab_target_bytes
 }
 
 /// Bulk backfill (MATRIXARK_BULK_INGEST) defers per-append fsync + manifest
@@ -1355,6 +1429,97 @@ mod tests {
         assert!(report.retained_current_page_slab_ids.is_empty());
         assert!(report.retained_live_page_slab_ids.is_empty());
         assert_eq!(store.slab_ids().unwrap(), vec![2]);
+    }
+
+    /// The point of pre-allocation: once the background prepare has rolled a full slab, the
+    /// next client append lands on the fresh one without rolling inline.
+    ///
+    /// Drives the threshold through the explicit-target API so the test never touches the
+    /// process-wide slab-target env var.
+    #[test]
+    fn prepare_next_slab_takes_the_roll_off_the_append_path() {
+        const TARGET: u64 = 2048;
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+
+        let payload = vec![b'x'; 512];
+        let mut guard = 0;
+        let mut full_slab = 0;
+        while !store.needs_slab_preparation_with_target(TARGET) {
+            full_slab = store.append(&payload).unwrap().page_slab_id;
+            guard += 1;
+            assert!(guard < 200, "filled {guard} times without reaching the target");
+        }
+
+        let rolled = store
+            .prepare_next_slab_with_target(TARGET)
+            .unwrap()
+            .expect("a slab at target must roll");
+        assert_eq!(rolled.previous_page_slab_id, full_slab);
+        assert!(rolled.new_page_slab_id > full_slab);
+
+        // The next append lands on the fresh slab, and did not have to roll to get there.
+        let after = store.append(&payload).unwrap();
+        assert_eq!(after.page_slab_id, rolled.new_page_slab_id);
+    }
+
+    /// Prepare must be a no-op while the slab has room, or a background cycle would shred the
+    /// store into one slab per pass.
+    #[test]
+    fn prepare_next_slab_is_a_noop_below_target() {
+        const TARGET: u64 = 1 << 20;
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        store.append(b"small").unwrap();
+
+        assert!(!store.needs_slab_preparation_with_target(TARGET));
+        assert!(store.prepare_next_slab_with_target(TARGET).unwrap().is_none());
+        // Repeated passes must stay no-ops.
+        assert!(store.prepare_next_slab_with_target(TARGET).unwrap().is_none());
+        assert_eq!(store.slab_ids().unwrap().len(), 1);
+    }
+
+    /// A freshly rolled, still-empty slab must not roll again — otherwise prepare would mint
+    /// an empty slab on every cycle forever.
+    #[test]
+    fn prepare_next_slab_does_not_roll_an_empty_slab() {
+        const TARGET: u64 = 2048;
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        let payload = vec![b'y'; 512];
+        let mut guard = 0;
+        while !store.needs_slab_preparation_with_target(TARGET) {
+            store.append(&payload).unwrap();
+            guard += 1;
+            assert!(guard < 200, "filled {guard} times without reaching the target");
+        }
+        store
+            .prepare_next_slab_with_target(TARGET)
+            .unwrap()
+            .expect("first roll");
+
+        assert!(!store.needs_slab_preparation_with_target(TARGET));
+        assert!(store.prepare_next_slab_with_target(TARGET).unwrap().is_none());
+    }
+
+    /// Pre-allocation is an optimisation, not a correctness requirement: with prepare never
+    /// called, every payload written across an explicit roll must still read back.
+    #[test]
+    fn data_survives_when_prepare_never_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        let payload = vec![b'z'; 512];
+        let mut addresses = Vec::new();
+        for round in 0..8 {
+            addresses.push(store.append(&payload).unwrap());
+            if round % 3 == 2 {
+                store.roll_slab().unwrap();
+            }
+        }
+        assert!(store.slab_ids().unwrap().len() > 1, "rolls must have happened");
+        for address in &addresses {
+            assert_eq!(store.read(address).unwrap(), payload);
+        }
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -12,7 +12,29 @@ use super::{
 };
 
 pub(super) const PAGE_RECORD_MAGIC: &[u8; 8] = b"TSPAGE01";
-pub(super) const PAGE_RECORD_VERSION: u8 = 6;
+pub(super) const PAGE_RECORD_VERSION: u8 = 7;
+
+/// Version at which the 32-byte checksum field switched from holding a full SHA-256 to
+/// holding a CRC32C.
+///
+/// The digest is computed per page record on the synchronous write path, before the
+/// durability barrier, and a cryptographic hash is the wrong tool for it: nothing here is
+/// defending against a forged page, only against a page that corrupted into something still
+/// decodable. CRC32C is what the reference implementation uses for exactly this. Records at
+/// version 6 and below keep verifying as SHA-256, so existing slabs read back unchanged.
+///
+/// The field stays 32 bytes wide even though CRC32C needs 4, because every subsequent header
+/// offset (page id, object id, routing bucket, band id, compression) is keyed off it. Keeping
+/// the width means v7 differs from v6 only in how those bytes are interpreted, rather than
+/// re-laying-out the header. The 28 unused bytes are written as zero and are worth reclaiming
+/// in a later format change that renumbers offsets deliberately.
+pub(super) const PAGE_RECORD_CHECKSUM_CRC32C_VERSION: u8 = 7;
+
+/// Width of the checksum field, unchanged across the switch.
+pub(super) const PAGE_RECORD_CHECKSUM_LEN: usize = 32;
+
+/// Marker used in the checksum field's tail so a v7 record is self-describing on inspection.
+const PAGE_RECORD_CHECKSUM_CRC32C: &[u8; 4] = b"C32C";
 pub(super) const PAGE_RECORD_V1_HEADER_LEN: usize = 8 + 1 + 1 + 2 + 8 + 8 + 32;
 pub(super) const PAGE_RECORD_V2_HEADER_LEN: usize = PAGE_RECORD_V1_HEADER_LEN + 8;
 pub(super) const PAGE_RECORD_V3_HEADER_LEN: usize = PAGE_RECORD_V2_HEADER_LEN + 8;
@@ -44,6 +66,9 @@ pub(super) enum PageRecordCompression {
 
 #[derive(Debug, Clone, Copy)]
 struct PageRecordHeader {
+    /// Record format version, retained so the checksum is verified with the algorithm the
+    /// record was written with.
+    version: u8,
     header_len: usize,
     payload_len: usize,
     pub(super) stored_len: usize,
@@ -84,7 +109,7 @@ pub(super) fn encode_page_record(
     band_id: u64,
     options: BlockStoreOptions,
 ) -> Result<EncodedPageRecord, BlockStoreError> {
-    let digest = Sha256::digest(payload);
+    let checksum_field = page_record_checksum_field(payload);
     let (stored_payload, compression) = encode_page_record_payload(payload, options)?;
     let stored_len = stored_payload.len();
     let mut record = Vec::with_capacity(PAGE_RECORD_HEADER_LEN + stored_payload.len());
@@ -94,7 +119,7 @@ pub(super) fn encode_page_record(
     record.extend_from_slice(&(PAGE_RECORD_HEADER_LEN as u16).to_le_bytes());
     record.extend_from_slice(&(payload.len() as u64).to_le_bytes());
     record.extend_from_slice(&(payload.len() as u64).to_le_bytes());
-    record.extend_from_slice(&digest);
+    record.extend_from_slice(&checksum_field);
     record.extend_from_slice(&page_id.to_le_bytes());
     record.extend_from_slice(&object_id.unwrap_or_default().to_le_bytes());
     record.push(u8::from(routing_bucket.is_some()));
@@ -198,7 +223,7 @@ pub(super) fn decode_page_record(
         ));
     }
     let payload = decode_page_record_payload(&record[header.header_len..], &header, address)?;
-    verify_page_record_checksum(&payload, &header.expected_sha256, address)?;
+    verify_page_record_checksum(&payload, &header.expected_sha256, header.version, address)?;
     Ok(DecodedPageRecord {
         payload,
         logical_len: header.payload_len,
@@ -283,7 +308,7 @@ pub(super) fn logical_range_from_slab(
             &header,
             &address,
         )?;
-        verify_page_record_checksum(&payload, &header.expected_sha256, &address)?;
+        verify_page_record_checksum(&payload, &header.expected_sha256, header.version, &address)?;
         if header.compression == PageRecordCompression::Zstd {
             compressed_records_read += 1;
         }
@@ -432,6 +457,7 @@ fn parse_page_record_header(
         ));
     }
     Ok(PageRecordHeader {
+        version,
         header_len,
         payload_len,
         stored_len,
@@ -470,22 +496,54 @@ fn decode_page_record_payload(
     }
 }
 
+/// Build the 32-byte checksum field for a new (v7) record: CRC32C little-endian in the first
+/// four bytes, a marker so the field is self-describing, then zero padding.
+fn page_record_checksum_field(payload: &[u8]) -> [u8; PAGE_RECORD_CHECKSUM_LEN] {
+    let mut field = [0_u8; PAGE_RECORD_CHECKSUM_LEN];
+    field[..4].copy_from_slice(&crate::checksum::crc32c(payload).to_le_bytes());
+    field[4..8].copy_from_slice(PAGE_RECORD_CHECKSUM_CRC32C);
+    field
+}
+
+/// Verify a page record's payload against its stored checksum field.
+///
+/// `version` selects the algorithm: v7 and later carry a CRC32C, v6 and earlier a full
+/// SHA-256. Dispatching on the record's own version (rather than sniffing the field) means an
+/// old slab always verifies the way it was written.
 fn verify_page_record_checksum(
     payload: &[u8],
-    expected_sha256: &[u8; 32],
+    expected_checksum: &[u8; PAGE_RECORD_CHECKSUM_LEN],
+    version: u8,
     address: &BlockAddress,
 ) -> Result<(), BlockStoreError> {
-    let actual_sha256 = Sha256::digest(payload);
-    if &actual_sha256[..] != expected_sha256 {
-        return Err(BlockStoreError::ChecksumMismatch {
-            page_slab_id: address.page_slab_id,
-            offset: address.offset,
-            length: address.length,
-            expected: hex::encode(expected_sha256),
-            actual: hex::encode(actual_sha256),
-        });
-    }
-    Ok(())
+    let (expected, actual) = if version >= PAGE_RECORD_CHECKSUM_CRC32C_VERSION {
+        let stored = u32::from_le_bytes(
+            expected_checksum[..4]
+                .try_into()
+                .expect("page envelope crc32c slice"),
+        );
+        let actual = crate::checksum::crc32c(payload);
+        if stored == actual {
+            return Ok(());
+        }
+        (format!("{stored:08x}"), format!("{actual:08x}"))
+    } else {
+        let actual_sha256 = Sha256::digest(payload);
+        if &actual_sha256[..] == expected_checksum {
+            return Ok(());
+        }
+        (
+            hex::encode(expected_checksum),
+            hex::encode(actual_sha256),
+        )
+    };
+    Err(BlockStoreError::ChecksumMismatch {
+        page_slab_id: address.page_slab_id,
+        offset: address.offset,
+        length: address.length,
+        expected,
+        actual,
+    })
 }
 
 pub(super) fn corrupt_page_envelope(
@@ -713,4 +771,112 @@ fn record_slab_inspection_error(
     report.has_corruption = true;
     report.first_error_offset = Some(offset);
     report.first_error = Some(error);
+}
+
+#[cfg(test)]
+mod crc32c_switch_tests {
+    use super::*;
+
+    fn address() -> BlockAddress {
+        BlockAddress {
+            page_slab_id: 1,
+            offset: 0,
+            length: 0,
+            page_id: None,
+            object_id: None,
+            routing_bucket: None,
+            generation: None,
+            band_id: None,
+            sha256: None,
+        }
+    }
+
+    /// Rewrite a freshly encoded record as if it had been written by the previous format:
+    /// version 6, with a full SHA-256 in the checksum field. The rest of the layout is
+    /// identical, which is the whole reason the field kept its width.
+    fn downgrade_to_v6_sha256(record: &mut [u8], payload: &[u8]) {
+        record[8] = 6;
+        let digest = Sha256::digest(payload);
+        record[28..60].copy_from_slice(&digest);
+    }
+
+    #[test]
+    fn new_records_are_written_at_the_crc32c_version() {
+        let payload = b"page payload that is long enough to be interesting";
+        let encoded = encode_page_record(payload, 7, None, None, 3, BlockStoreOptions::default())
+            .expect("encode");
+        assert_eq!(encoded.bytes[8], PAGE_RECORD_CHECKSUM_CRC32C_VERSION);
+        // CRC32C in the first four bytes, self-describing marker after it.
+        let stored = u32::from_le_bytes(encoded.bytes[28..32].try_into().unwrap());
+        assert_eq!(stored, crate::checksum::crc32c(payload));
+        assert_eq!(&encoded.bytes[32..36], PAGE_RECORD_CHECKSUM_CRC32C);
+    }
+
+    #[test]
+    fn crc32c_records_round_trip() {
+        let payload = b"round trip payload";
+        let encoded = encode_page_record(payload, 1, None, None, 0, BlockStoreOptions::default())
+            .expect("encode");
+        let decoded = decode_page_record(&encoded.bytes, &address()).expect("decode");
+        assert_eq!(decoded.payload, payload);
+    }
+
+    /// The compatibility case that matters: slabs written before the switch must still read.
+    #[test]
+    fn v6_sha256_page_records_still_verify() {
+        let payload = b"a page written before the checksum switch";
+        let mut encoded =
+            encode_page_record(payload, 2, None, None, 0, BlockStoreOptions::default())
+                .expect("encode");
+        downgrade_to_v6_sha256(&mut encoded.bytes, payload);
+        let decoded = decode_page_record(&encoded.bytes, &address()).expect("v6 record must decode");
+        assert_eq!(decoded.payload, payload);
+    }
+
+    #[test]
+    fn a_corrupted_v6_record_is_still_rejected() {
+        let payload = b"payload that will be corrupted after the fact";
+        let mut encoded =
+            encode_page_record(payload, 3, None, None, 0, BlockStoreOptions::default())
+                .expect("encode");
+        downgrade_to_v6_sha256(&mut encoded.bytes, payload);
+        // Corrupt the stored payload without touching the SHA-256 field.
+        let last = encoded.bytes.len() - 1;
+        encoded.bytes[last] ^= 0xff;
+        assert!(matches!(
+            decode_page_record(&encoded.bytes, &address()),
+            Err(BlockStoreError::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn a_corrupted_v7_record_is_rejected() {
+        let payload = b"payload protected by crc32c";
+        let mut encoded =
+            encode_page_record(payload, 4, None, None, 0, BlockStoreOptions::default())
+                .expect("encode");
+        let last = encoded.bytes.len() - 1;
+        encoded.bytes[last] ^= 0xff;
+        assert!(matches!(
+            decode_page_record(&encoded.bytes, &address()),
+            Err(BlockStoreError::ChecksumMismatch { .. })
+        ));
+    }
+
+    /// A v7 record must NOT be accepted on the strength of a SHA-256 that happens to sit in
+    /// the field, and vice versa -- the version alone selects the algorithm.
+    #[test]
+    fn the_version_selects_the_algorithm_not_the_field_contents() {
+        let payload = b"version selects the algorithm";
+        let mut encoded =
+            encode_page_record(payload, 5, None, None, 0, BlockStoreOptions::default())
+                .expect("encode");
+        // Leave the CRC32C field in place but claim the record is v6: SHA-256 verification
+        // must then fail, because those bytes are not a SHA-256.
+        encoded.bytes[8] = 6;
+        assert!(matches!(
+            decode_page_record(&encoded.bytes, &address()),
+            Err(BlockStoreError::ChecksumMismatch { .. })
+        ));
+    }
 }

--- a/crates/temporalstore-rust/src/checksum.rs
+++ b/crates/temporalstore-rust/src/checksum.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! CRC32C (Castagnoli) for on-disk record integrity.
+//!
+//! The append-only logs originally carried a truncated SHA-256 per record, and the block
+//! store a full 32-byte SHA-256 per page record. Both sit on the synchronous write path, so
+//! their cost is paid per write, before the durability barrier -- and a cryptographic digest
+//! is the wrong tool for the job. Nothing here is defending against a forged record; the
+//! threat is accidental corruption of a committed record (a flipped bit that still parses),
+//! which is exactly what a CRC is for. CRC32C is the same choice the reference implementation
+//! makes: a per-record CRC32C in the record header plus a running per-block CRC32C in the
+//! block footer.
+//!
+//! Implemented table-driven and dependency-free, matching how `crc64_jones` is already
+//! hand-rolled for routing. The table is built at compile time, so there is no lazy-init
+//! check on the hot path.
+//!
+//! [`crc32c_update`] takes a seed so a checksum can be accumulated across several buffers
+//! without concatenating them first.
+
+/// Castagnoli polynomial, bit-reversed (the normal form for a reflected CRC).
+const CRC32C_POLYNOMIAL: u32 = 0x82f6_3b78;
+
+/// Byte-at-a-time lookup table, generated at compile time.
+const CRC32C_TABLE: [u32; 256] = build_crc32c_table();
+
+const fn build_crc32c_table() -> [u32; 256] {
+    let mut table = [0_u32; 256];
+    let mut index = 0_usize;
+    while index < 256 {
+        let mut entry = index as u32;
+        let mut bit = 0;
+        while bit < 8 {
+            entry = if entry & 1 == 1 {
+                (entry >> 1) ^ CRC32C_POLYNOMIAL
+            } else {
+                entry >> 1
+            };
+            bit += 1;
+        }
+        table[index] = entry;
+        index += 1;
+    }
+    table
+}
+
+/// CRC32C of `bytes`.
+pub fn crc32c(bytes: &[u8]) -> u32 {
+    crc32c_update(0, bytes)
+}
+
+/// Continue a CRC32C over `bytes`, starting from `seed` (0 for a fresh checksum).
+///
+/// Seeding lets a caller checksum a header and a payload separately, or accumulate across a
+/// block, without building a combined buffer first.
+pub fn crc32c_update(seed: u32, bytes: &[u8]) -> u32 {
+    // The reflected algorithm pre- and post-inverts; carrying the inverted form across calls
+    // is what makes seeding compose exactly like one pass over the concatenation.
+    let mut crc = !seed;
+    for byte in bytes {
+        let index = ((crc ^ u32::from(*byte)) & 0xff) as usize;
+        crc = (crc >> 8) ^ CRC32C_TABLE[index];
+    }
+    !crc
+}
+
+/// CRC32C rendered as 8 lowercase hex characters, for the text log framing.
+pub fn crc32c_hex(bytes: &[u8]) -> String {
+    format!("{:08x}", crc32c(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_published_castagnoli_check_vectors() {
+        // The standard CRC-32/ISCSI check value: CRC32C("123456789") == 0xE3069283.
+        assert_eq!(crc32c(b"123456789"), 0xe306_9283);
+        assert_eq!(crc32c(b""), 0x0000_0000);
+        assert_eq!(crc32c(b"a"), 0xc1d0_4330);
+        assert_eq!(crc32c(b"foo"), 0xcfc4_ae1d);
+    }
+
+    #[test]
+    fn seeding_composes_like_one_pass_over_the_concatenation() {
+        let whole = b"the quick brown fox jumps over the lazy dog";
+        let (head, tail) = whole.split_at(11);
+        assert_eq!(crc32c_update(crc32c(head), tail), crc32c(whole));
+    }
+
+    #[test]
+    fn detects_a_value_preserving_single_bit_flip() {
+        // The corruption that motivated framing in the first place: a flipped digit that
+        // still parses as valid JSON.
+        let original = br#"{"sequence":42}"#;
+        let flipped = br#"{"sequence":49}"#;
+        assert_ne!(crc32c(original), crc32c(flipped));
+    }
+
+    #[test]
+    fn hex_rendering_is_fixed_width() {
+        // A checksum with leading zero bytes must still occupy 8 characters, or the
+        // space-delimited framing would mis-parse.
+        assert_eq!(crc32c_hex(b"").len(), 8);
+        assert_eq!(crc32c_hex(b""), "00000000");
+        assert_eq!(crc32c_hex(b"123456789"), "e3069283");
+    }
+}

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -107,6 +107,35 @@ impl DataNodeRuntime {
 
         if options.enable_prepare {
             executed_stages.push("prepare".to_string());
+            // Pre-allocate the next data slab so a client append never has to roll inline.
+            //
+            // Rolling costs several fsyncs plus a slab-directory scan (see
+            // LocalBlockStore::prepare_next_slab). Left to the write path it lands on one
+            // unlucky write as a latency outlier unrelated to that write's size. Doing it
+            // here -- the stage that already exists and is already named "prepare" -- is what
+            // the reference implementation does with PrepareNewZone in the same position of
+            // its background cycle.
+            //
+            // A no-op while the active slab has room, so this costs a lock and a comparison
+            // on the overwhelming majority of cycles. A failure is recorded and does not stop
+            // the cycle: the inline roll in `append` remains the fallback, so the only
+            // consequence is that the next append pays for the roll, exactly as it does today.
+            match self.inner.engine.block_store().prepare_next_slab() {
+                Ok(Some(roll)) => {
+                    tracing::debug!(
+                        previous_page_slab_id = roll.previous_page_slab_id,
+                        new_page_slab_id = roll.new_page_slab_id,
+                        "storage manager pre-allocated the next data slab"
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "storage manager could not pre-allocate the next data slab;                          the next append will roll inline"
+                    );
+                }
+            }
             self.inner
                 .stats
                 .lock()

--- a/crates/temporalstore-rust/src/index_log_record.rs
+++ b/crates/temporalstore-rust/src/index_log_record.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! The served-index log record, ported from the reference implementation's index log.
+//!
+//! Direct port: same record shape, same field numbers, same framing (see [`crate::record_framing`]).
+//! Only the names follow this crate's vocabulary — routing bucket for slot, block for page, band
+//! for zone, WAL for the operation log.
+//!
+//! The index log is the durable statement of *where blocks live* and *how far the WAL has been
+//! dumped*. Three things make it load-bearing, and all three are why it is ported rather than
+//! approximated:
+//!
+//!   * [`IndexMetaItem::start_wal_id`] is the dump watermark. Replay resumes from it, and WAL
+//!     truncation must never pass it — a record below the watermark has had its blocks
+//!     materialised into a band, one above it has not, and dropping the latter destroys the only
+//!     durable copy.
+//!   * [`IndexItem::in_wal`] records whether a block still lives in the WAL rather than a band.
+//!     It is the flag that makes an address resolvable without a lookup table.
+//!   * [`BandInfo`] carries the band lifecycle. The reference pre-allocates a band in an INIT
+//!     state, makes it durable, then creates the stream and moves it to CREATED — so a crash
+//!     between the two leaves a band that is reused rather than an orphaned stream.
+
+use prost::Message;
+
+/// Record format version, mirroring the reference's on-disk index-log version.
+pub const INDEX_LOG_RECORD_VERSION: u32 = 1;
+
+/// One served-index log record.
+///
+/// Field numbers match the reference one-for-one, including the gap at 2 where a since-deprecated
+/// item-type discriminator sat. The gap is preserved deliberately: reusing the tag would make the
+/// two encodings disagree while still parsing, which is worse than a hole.
+#[derive(Clone, PartialEq, Message)]
+pub struct IndexLogRecord {
+    /// On-disk version.
+    #[prost(uint32, tag = "1")]
+    pub version: u32,
+    // Tag 2 is retired (a deprecated item-type discriminator in the reference). Do not reuse.
+    /// The reference calls this the slot id. Fixed-width, matching the reference.
+    #[prost(fixed64, tag = "3")]
+    pub routing_bucket: u64,
+    /// Block-location entries.
+    #[prost(message, repeated, tag = "4")]
+    pub items: Vec<IndexItem>,
+    /// Present on a meta record.
+    #[prost(message, optional, tag = "5")]
+    pub meta_item: Option<IndexMetaItem>,
+    /// Every object in this routing bucket, on a meta record.
+    #[prost(message, repeated, tag = "6")]
+    pub object_items: Vec<IndexObjectItem>,
+    #[prost(uint64, tag = "7")]
+    pub sequence: u64,
+    /// The reference calls this the oplog sequence: the WAL sequence this index state reflects.
+    #[prost(uint64, tag = "8")]
+    pub wal_sequence: u64,
+    #[prost(uint64, tag = "9")]
+    pub timestamp_ms: u64,
+}
+
+/// Where one block lives.
+#[derive(Clone, PartialEq, Message)]
+pub struct IndexItem {
+    #[prost(uint32, tag = "1")]
+    pub object_id: u32,
+    /// The reference calls this `page_id`.
+    #[prost(uint32, tag = "2")]
+    pub block_id: u32,
+    /// The block's address. When [`Self::in_wal`] is set this is the log id — the byte offset of
+    /// the WAL record carrying the block — otherwise it addresses a band.
+    #[prost(uint64, tag = "3")]
+    pub address: u64,
+    #[prost(uint32, tag = "4")]
+    pub size: u32,
+    /// The reference calls this `in_log`: the block still lives in the WAL and has not been
+    /// dumped into a band yet.
+    #[prost(bool, tag = "5")]
+    pub in_wal: bool,
+    #[prost(bool, tag = "6")]
+    pub deleted: bool,
+    #[prost(uint32, tag = "7")]
+    pub model_id: u32,
+}
+
+/// Band lifecycle state. The reference calls a band a zone.
+///
+/// Numbering matches the reference exactly, including that RECYCLED is 4 and 3 is unused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum BandState {
+    /// Reserved and durable, but its stream does not exist yet.
+    Init = 0,
+    /// Stream created and accepting writes.
+    Created = 1,
+    /// Sealed; no further writes.
+    Frozen = 2,
+    // 3 is unused in the reference.
+    /// Reclaimed and available for reuse.
+    Recycled = 4,
+}
+
+/// One band's lifecycle record.
+#[derive(Clone, PartialEq, Message)]
+pub struct BandInfo {
+    /// The reference calls this `zone_id`.
+    #[prost(uint32, tag = "1")]
+    pub band_id: u32,
+    #[prost(uint64, tag = "2")]
+    pub total_bytes: u64,
+    #[prost(enumeration = "BandState", tag = "3")]
+    pub state: i32,
+    #[prost(uint64, tag = "4")]
+    pub init_time_ms: u64,
+    #[prost(uint64, tag = "5")]
+    pub created_time_ms: u64,
+    #[prost(uint64, tag = "6")]
+    pub frozen_time_ms: u64,
+    #[prost(uint64, tag = "7")]
+    pub recycled_time_ms: u64,
+    /// Unique id for the band's lifetime, used to identify out-of-date blocks that point at a
+    /// band slot which has since been recycled.
+    #[prost(uint64, tag = "8")]
+    pub version: u64,
+}
+
+/// The index meta record: the dump watermark and the band catalogue.
+#[derive(Clone, PartialEq, Message)]
+pub struct IndexMetaItem {
+    #[prost(uint64, tag = "1")]
+    pub version: u64,
+    /// The lowest WAL log id that has NOT been truncated — the dump watermark.
+    ///
+    /// The reference calls this `start_oplog_id`. Replay starts here, and truncation must never
+    /// advance past it.
+    #[prost(uint64, tag = "2")]
+    pub start_wal_id: u64,
+    /// The reference calls these zones.
+    #[prost(map = "uint32, message", tag = "3")]
+    pub bands: std::collections::HashMap<u32, BandInfo>,
+    #[prost(uint64, tag = "4")]
+    pub timestamp_ms: u64,
+    /// Version of the band catalogue.
+    #[prost(uint64, tag = "5")]
+    pub band_version: u64,
+}
+
+/// Per-object metadata carried on a meta record. Only the TTL is meaningful, matching the
+/// reference's note on the same message.
+#[derive(Clone, PartialEq, Message)]
+pub struct IndexObjectItem {
+    #[prost(uint64, tag = "1")]
+    pub version: u64,
+    #[prost(uint32, tag = "2")]
+    pub object_id: u32,
+    #[prost(uint64, tag = "3")]
+    pub ttl: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record_framing::{decode_framed_at, encode_framed, FramedRecords};
+
+    #[test]
+    fn field_numbers_match_the_reference_index_log() {
+        // Wire compatibility is the point, so assert on bytes rather than trusting attributes.
+        // routing_bucket is field 3, FIXED64 (wire type 1): key = (3 << 3) | 1 = 0x19.
+        let record = IndexLogRecord {
+            routing_bucket: 1,
+            ..Default::default()
+        };
+        let encoded = record.encode_to_vec();
+        assert_eq!(encoded[0], 0x19, "routing_bucket must be fixed64 at tag 3");
+        assert_eq!(encoded.len(), 9, "fixed64 is 8 bytes plus the key");
+
+        // in_wal is field 5, varint: key = (5 << 3) | 0 = 0x28.
+        let item = IndexItem {
+            in_wal: true,
+            ..Default::default()
+        };
+        assert_eq!(item.encode_to_vec(), vec![0x28, 0x01]);
+    }
+
+    #[test]
+    fn band_states_keep_the_reference_numbering() {
+        // RECYCLED is 4, not 3 -- the gap is real and a renumber would silently reinterpret
+        // existing records.
+        assert_eq!(BandState::Init as i32, 0);
+        assert_eq!(BandState::Created as i32, 1);
+        assert_eq!(BandState::Frozen as i32, 2);
+        assert_eq!(BandState::Recycled as i32, 4);
+    }
+
+    #[test]
+    fn tag_two_stays_retired() {
+        // The reference retired tag 2. Encoding must never emit it, or the two disagree while
+        // still parsing.
+        let record = IndexLogRecord {
+            version: INDEX_LOG_RECORD_VERSION,
+            routing_bucket: 9,
+            sequence: 3,
+            ..Default::default()
+        };
+        let encoded = record.encode_to_vec();
+        // Field 2 as varint would be key 0x10; as any wire type the key's tag bits are 2.
+        assert!(
+            !encoded.iter().any(|&byte| byte >> 3 == 2),
+            "no field with tag 2 may be emitted"
+        );
+    }
+
+    #[test]
+    fn index_records_share_the_wal_framing() {
+        // One framing for both streams, as in the reference.
+        let record = IndexLogRecord {
+            version: INDEX_LOG_RECORD_VERSION,
+            routing_bucket: 4,
+            items: vec![IndexItem {
+                object_id: 1,
+                block_id: 2,
+                address: 4096,
+                size: 512,
+                in_wal: true,
+                ..Default::default()
+            }],
+            sequence: 8,
+            wal_sequence: 77,
+            ..Default::default()
+        };
+        let framed = encode_framed(&record);
+        let (decoded, next_offset): (IndexLogRecord, usize) = decode_framed_at(&framed, 0).unwrap();
+        assert_eq!(decoded, record);
+        assert_eq!(next_offset, framed.len());
+    }
+
+    #[test]
+    fn the_dump_watermark_round_trips_with_the_band_catalogue() {
+        // start_wal_id is what replay resumes from and what truncation must not pass, so it has
+        // to survive a round trip alongside the bands it describes.
+        let mut bands = std::collections::HashMap::new();
+        bands.insert(
+            1,
+            BandInfo {
+                band_id: 1,
+                total_bytes: 1 << 20,
+                state: BandState::Frozen as i32,
+                version: 7,
+                ..Default::default()
+            },
+        );
+        let record = IndexLogRecord {
+            version: INDEX_LOG_RECORD_VERSION,
+            meta_item: Some(IndexMetaItem {
+                version: 2,
+                start_wal_id: 987_654,
+                bands,
+                timestamp_ms: 5,
+                band_version: 7,
+            }),
+            ..Default::default()
+        };
+        let framed = encode_framed(&record);
+        let (decoded, _): (IndexLogRecord, usize) = decode_framed_at(&framed, 0).unwrap();
+        let meta = decoded.meta_item.expect("meta item");
+        assert_eq!(meta.start_wal_id, 987_654);
+        assert_eq!(meta.bands[&1].state, BandState::Frozen as i32);
+        assert_eq!(meta.bands[&1].version, 7);
+    }
+
+    #[test]
+    fn a_scan_yields_the_log_id_of_each_index_record() {
+        let mut stream = Vec::new();
+        let mut expected = Vec::new();
+        for sequence in 1..=3 {
+            expected.push(stream.len() as u64);
+            stream.extend_from_slice(&encode_framed(&IndexLogRecord {
+                version: INDEX_LOG_RECORD_VERSION,
+                sequence,
+                ..Default::default()
+            }));
+        }
+        let seen: Vec<u64> = FramedRecords::<IndexLogRecord>::new(&stream, 0)
+            .map(|item| item.unwrap().0)
+            .collect();
+        assert_eq!(seen, expected);
+    }
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -31,6 +31,7 @@ pub mod storage_config;
 pub mod telemetry;
 pub mod types;
 pub mod wal;
+pub mod wal_record;
 
 pub use block_store::{
     BlockAddress, BlockStoreBandDescriptor, BlockStoreBandState, BlockStoreBandSummary,

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod block_store;
+pub mod checksum;
 pub mod client;
 pub mod context_workflow;
 pub mod control;

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -31,6 +31,8 @@ pub mod storage_config;
 pub mod telemetry;
 pub mod types;
 pub mod wal;
+pub mod record_framing;
+pub mod index_log_record;
 pub mod wal_record;
 
 pub use block_store::{

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -17,8 +17,18 @@
 //! writes are framed; the two coexist in one file across an upgrade (and across a GC rewrite,
 //! which re-emits every retained record framed).
 //!
-//! Framed line layout (single line, `\n`-terminated on disk):
-//! `#tsf1 <payload_len> <digest_hex> <payload_json>\n`
+//! Two framed formats exist. New writes use `#tsf2`, which carries a CRC32C:
+//! `#tsf2 <payload_len> <crc32c_hex> <payload_json>\n`
+//! `#tsf1` records carry a truncated SHA-256 instead and are still read:
+//! `#tsf1 <payload_len> <sha256_prefix_hex> <payload_json>\n`
+//!
+//! The switch to CRC32C is a write-path cost change, not a weakening. This checksum defends
+//! against accidental corruption of a committed record -- a flipped bit that still parses --
+//! and never against a forged one; nothing in the recovery path treats it as a signature. A
+//! cryptographic digest was simply the wrong tool here: it is computed per record,
+//! synchronously, before the durability barrier. CRC32C is what the reference implementation
+//! uses for the same job (a per-record CRC in the record header plus a running per-block CRC
+//! in the block footer).
 //! The payload JSON is compact serde output, so it contains neither a literal `\n` (line
 //! boundary) nor is its boundary ambiguous: the first two space-delimited fields after the
 //! magic are the length and digest, and everything after the third space is the payload
@@ -26,13 +36,19 @@
 
 use sha2::{Digest, Sha256};
 
-/// ASCII framing prefix, including the trailing space that delimits the fields after it.
-/// Chosen so it can never collide with a legacy record: a serialized JSON object always
-/// starts with `{`, never `#`.
-pub(crate) const FRAME_MAGIC: &[u8] = b"#tsf1 ";
+/// ASCII framing prefix for the current (CRC32C) format, including the trailing space that
+/// delimits the fields after it. Chosen so it can never collide with a legacy record: a
+/// serialized JSON object always starts with `{`, never `#`.
+pub(crate) const FRAME_MAGIC_V2: &[u8] = b"#tsf2 ";
 
-/// Number of leading SHA-256 bytes retained in the framed digest. 8 bytes (a 64-bit digest,
-/// 16 hex chars) is ample to catch accidental corruption of a committed record.
+/// Framing prefix for the previous (truncated SHA-256) format. Still decoded so logs written
+/// before the switch load unchanged; never written.
+pub(crate) const FRAME_MAGIC_V1: &[u8] = b"#tsf1 ";
+
+/// The prefix new writes use.
+pub(crate) const FRAME_MAGIC: &[u8] = FRAME_MAGIC_V2;
+
+/// Number of leading SHA-256 bytes retained in a v1 framed digest.
 const DIGEST_BYTES: usize = 8;
 
 /// Integrity failure discovered while decoding a framed log line. Carried into the WAL /
@@ -49,16 +65,22 @@ impl std::fmt::Display for FramingError {
 
 impl std::error::Error for FramingError {}
 
-fn digest_hex(payload: &[u8]) -> String {
+/// v1 checksum: the leading bytes of a SHA-256, hex encoded. Read-only.
+fn sha256_digest_hex(payload: &[u8]) -> String {
     let full = Sha256::digest(payload);
     hex::encode(&full[..DIGEST_BYTES])
+}
+
+/// v2 checksum: CRC32C, hex encoded, fixed width.
+fn crc_digest_hex(payload: &[u8]) -> String {
+    crate::checksum::crc32c_hex(payload)
 }
 
 /// Encode `payload` (a single-line JSON document with NO trailing newline) as a framed,
 /// newline-terminated log line.
 pub(crate) fn encode_line(payload: &[u8]) -> Vec<u8> {
-    let digest = digest_hex(payload);
-    let header = format!("#tsf1 {} {} ", payload.len(), digest);
+    let digest = crc_digest_hex(payload);
+    let header = format!("#tsf2 {} {} ", payload.len(), digest);
     let mut out = Vec::with_capacity(header.len() + payload.len() + 1);
     out.extend_from_slice(header.as_bytes());
     out.extend_from_slice(payload);
@@ -73,11 +95,16 @@ pub(crate) fn encode_line(payload: &[u8]) -> Vec<u8> {
 /// and returns `Err`.
 pub(crate) fn decode_line(line: &[u8]) -> Result<&[u8], FramingError> {
     let line = strip_trailing_newline(line);
-    if !line.starts_with(FRAME_MAGIC) {
+    // Pick the checksum by prefix so both framed formats round-trip out of one file: an
+    // upgrade, or a GC rewrite spanning one, leaves v1 and v2 records interleaved.
+    let (checksum_of, rest): (fn(&[u8]) -> String, &[u8]) = if line.starts_with(FRAME_MAGIC_V2) {
+        (crc_digest_hex, &line[FRAME_MAGIC_V2.len()..])
+    } else if line.starts_with(FRAME_MAGIC_V1) {
+        (sha256_digest_hex, &line[FRAME_MAGIC_V1.len()..])
+    } else {
         // Legacy unframed record (or a blank line): the whole line is the payload.
         return Ok(line);
-    }
-    let rest = &line[FRAME_MAGIC.len()..];
+    };
     let (len_field, rest) = split_once_space(rest)
         .ok_or_else(|| FramingError("framed record missing length field".to_string()))?;
     let (digest_field, payload) = split_once_space(rest)
@@ -92,7 +119,7 @@ pub(crate) fn decode_line(line: &[u8]) -> Result<&[u8], FramingError> {
             payload.len()
         )));
     }
-    let actual = digest_hex(payload);
+    let actual = checksum_of(payload);
     if actual.as_bytes() != digest_field {
         return Err(FramingError(format!(
             "framed record checksum mismatch: declared {}, actual {actual}",
@@ -156,6 +183,47 @@ mod tests {
             decoded.is_err(),
             "a value-preserving bit-flip must fail the framed checksum"
         );
+    }
+
+    #[test]
+    fn new_writes_use_the_crc_format() {
+        let framed = encode_line(br#"{"a":1}"#);
+        assert!(framed.starts_with(FRAME_MAGIC_V2));
+    }
+
+    #[test]
+    fn v1_sha256_records_still_decode() {
+        // A record written before the switch: same layout, SHA-256 prefix as the checksum.
+        let payload = br#"{"shard_id":5,"sequence":42}"#;
+        let digest = sha256_digest_hex(payload);
+        let mut legacy = format!("#tsf1 {} {} ", payload.len(), digest).into_bytes();
+        legacy.extend_from_slice(payload);
+        legacy.push(b'\n');
+        assert_eq!(decode_line(&legacy).unwrap(), payload);
+    }
+
+    #[test]
+    fn a_corrupted_v1_record_is_still_rejected_after_the_switch() {
+        let payload = br#"{"sequence":42}"#;
+        let digest = sha256_digest_hex(payload);
+        let mut legacy = format!("#tsf1 {} {} ", payload.len(), digest).into_bytes();
+        legacy.extend_from_slice(br#"{"sequence":49}"#); // same length, different value
+        legacy.push(b'\n');
+        assert!(decode_line(&legacy).is_err());
+    }
+
+    #[test]
+    fn both_formats_interleave_in_one_file() {
+        // A GC rewrite spanning the upgrade produces exactly this.
+        let payload = br#"{"k":"v"}"#;
+        let v2 = encode_line(payload);
+        let digest = sha256_digest_hex(payload);
+        let mut v1 = format!("#tsf1 {} {} ", payload.len(), digest).into_bytes();
+        v1.extend_from_slice(payload);
+        v1.push(b'\n');
+        for line in [v1, v2] {
+            assert_eq!(decode_line(&line).unwrap(), payload);
+        }
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/record_framing.rs
+++ b/crates/temporalstore-rust/src/record_framing.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Record framing shared by the write-ahead log and the served-index log.
+//!
+//! Both are append-only streams in the reference implementation, and both are framed by the
+//! same stream layer:
+//!
+//! ```text
+//! varint32(payload_len) | little_endian_u32(crc32c) | payload
+//! ```
+//!
+//! This module is that layer. It is shared rather than duplicated for the same reason the
+//! reference shares it: the two streams differ in what they carry, not in how a record is
+//! delimited or verified, and a second framing would be a second set of corruption and
+//! truncation semantics to keep correct.
+//!
+//! Length-prefixing is what makes a record addressable by its byte offset — the log id that a
+//! block address carries — and it is what allows a payload to contain any byte, including the
+//! newline that a line-oriented format cannot survive.
+
+use prost::Message;
+
+use crate::checksum::crc32c;
+
+/// A framing or integrity failure.
+///
+/// A record that fails to decode is corruption of committed data, not an absent record. In the
+/// WAL a block-carrying record IS the durable copy of that block; in the index log a record is
+/// the durable statement of where blocks live. Callers must surface this as data loss rather
+/// than skipping past it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordFramingError(pub String);
+
+impl std::fmt::Display for RecordFramingError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "record framing error: {}", self.0)
+    }
+}
+
+impl std::error::Error for RecordFramingError {}
+
+/// Frame one record: `varint32(payload_len) | little_endian_u32(crc32c) | payload`.
+pub fn encode_framed<M: Message>(record: &M) -> Vec<u8> {
+    let payload = record.encode_to_vec();
+    let checksum = crc32c(&payload);
+    let mut out = Vec::with_capacity(payload.len() + 9);
+    encode_varint32(payload.len() as u32, &mut out);
+    out.extend_from_slice(&checksum.to_le_bytes());
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Decode the record starting at `offset`, returning it together with the **absolute offset of
+/// the next record**.
+///
+/// `offset` is the log id — the value a block address carries.
+///
+/// The second element is deliberately an absolute offset rather than a relative length. Every
+/// caller either scans forward (`offset = next_offset`) or stops; returning a length invites
+/// `offset = consumed`, which silently walks backwards after the first record and loops
+/// forever, and the growing results then take the process out through the OOM killer rather
+/// than failing an assertion. That is not hypothetical — it is what the first consumer of this
+/// function did — so the signature is shaped to make it unrepresentable.
+pub fn decode_framed_at<M: Message + Default>(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<(M, usize), RecordFramingError> {
+    let rest = bytes.get(offset..).ok_or_else(|| {
+        RecordFramingError(format!("offset {offset} is past the end of the stream"))
+    })?;
+    let (payload_len, varint_len) = decode_varint32(rest)?;
+    let header_len = varint_len + 4;
+    let payload_len = payload_len as usize;
+    let end = header_len
+        .checked_add(payload_len)
+        .ok_or_else(|| RecordFramingError("record length overflows".to_string()))?;
+    if rest.len() < end {
+        return Err(RecordFramingError(format!(
+            "record at {offset} claims {payload_len} payload bytes but only {} remain",
+            rest.len().saturating_sub(header_len)
+        )));
+    }
+    let declared = u32::from_le_bytes(
+        rest[varint_len..header_len]
+            .try_into()
+            .expect("checksum slice is 4 bytes"),
+    );
+    let payload = &rest[header_len..end];
+    let actual = crc32c(payload);
+    if declared != actual {
+        return Err(RecordFramingError(format!(
+            "record at {offset} checksum mismatch: declared {declared:08x}, actual {actual:08x}"
+        )));
+    }
+    let record = M::decode(payload).map_err(|error| {
+        RecordFramingError(format!("record at {offset} failed to decode: {error}"))
+    })?;
+    Ok((record, offset + end))
+}
+
+/// Iterate every record in a framed stream, owning the cursor.
+///
+/// Callers get records rather than offsets, so they cannot do the offset arithmetic that the
+/// signature above exists to prevent. This mirrors the reference, whose log iterators advance
+/// internally for the same reason. Stops at the first malformed record, yielding the error.
+pub struct FramedRecords<'a, M> {
+    bytes: &'a [u8],
+    offset: usize,
+    finished: bool,
+    _record: std::marker::PhantomData<M>,
+}
+
+impl<'a, M> FramedRecords<'a, M> {
+    /// Iterate from `start_offset`, which is a log id.
+    pub fn new(bytes: &'a [u8], start_offset: usize) -> Self {
+        Self {
+            bytes,
+            offset: start_offset,
+            finished: false,
+            _record: std::marker::PhantomData,
+        }
+    }
+
+    /// The log id of the record the next call will decode.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+impl<M: Message + Default> Iterator for FramedRecords<'_, M> {
+    /// `(log_id, framed_size, record)` — the log id and size are what a block address is built
+    /// from, so a replay can address a block it just read without recomputing anything.
+    type Item = Result<(u64, u64, M), RecordFramingError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished || self.offset >= self.bytes.len() {
+            return None;
+        }
+        let log_id = self.offset as u64;
+        match decode_framed_at::<M>(self.bytes, self.offset) {
+            Ok((record, next_offset)) => {
+                debug_assert!(next_offset > self.offset, "framed scan must advance");
+                let framed_size = (next_offset - self.offset) as u64;
+                self.offset = next_offset;
+                Some(Ok((log_id, framed_size, record)))
+            }
+            Err(error) => {
+                self.finished = true;
+                Some(Err(error))
+            }
+        }
+    }
+}
+
+fn encode_varint32(mut value: u32, out: &mut Vec<u8>) {
+    loop {
+        if value < 0x80 {
+            out.push(value as u8);
+            return;
+        }
+        out.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+}
+
+fn decode_varint32(bytes: &[u8]) -> Result<(u32, usize), RecordFramingError> {
+    let mut value = 0_u32;
+    for (index, &byte) in bytes.iter().take(5).enumerate() {
+        let part = u32::from(byte & 0x7f);
+        value |= part
+            .checked_shl(7 * index as u32)
+            .ok_or_else(|| RecordFramingError("varint overflows 32 bits".to_string()))?;
+        if byte & 0x80 == 0 {
+            return Ok((value, index + 1));
+        }
+    }
+    Err(RecordFramingError(
+        "varint is truncated or overlong".to_string(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wal_record::{WalItem, WalRecord, WAL_RECORD_VERSION};
+
+    fn record(sequence: u64, block: &[u8]) -> WalRecord {
+        WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence,
+            items: vec![WalItem {
+                block_log: true,
+                block: block.to_vec(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn iterator_yields_log_id_and_size_for_every_record() {
+        let records: Vec<WalRecord> = (1..=4)
+            .map(|sequence| record(sequence, format!("block-{sequence}").as_bytes()))
+            .collect();
+        let mut stream = Vec::new();
+        let mut expected_log_ids = Vec::new();
+        for value in &records {
+            expected_log_ids.push(stream.len() as u64);
+            stream.extend_from_slice(&encode_framed(value));
+        }
+
+        let seen: Vec<(u64, u64, WalRecord)> = FramedRecords::new(&stream, 0)
+            .map(|item| item.unwrap())
+            .collect();
+        assert_eq!(seen.len(), records.len());
+        for (index, (log_id, framed_size, value)) in seen.iter().enumerate() {
+            assert_eq!(*log_id, expected_log_ids[index], "log id is the byte offset");
+            assert_eq!(value, &records[index]);
+            assert!(*framed_size > 0);
+        }
+    }
+
+    #[test]
+    fn iterator_can_start_from_a_watermark() {
+        // Replay resumes from the dumped-log-id watermark rather than from zero.
+        let first = encode_framed(&record(1, b"first"));
+        let second_log_id = first.len();
+        let mut stream = first;
+        stream.extend_from_slice(&encode_framed(&record(2, b"second")));
+
+        let seen: Vec<WalRecord> = FramedRecords::new(&stream, second_log_id)
+            .map(|item| item.unwrap().2)
+            .collect();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].sequence, 2);
+    }
+
+    #[test]
+    fn iterator_stops_at_corruption_rather_than_skipping_it() {
+        let mut stream = encode_framed(&record(1, b"good"));
+        let corrupt_at = stream.len();
+        stream.extend_from_slice(&encode_framed(&record(2, b"bad")));
+        let last = stream.len() - 1;
+        stream[last] ^= 0xff;
+
+        let results: Vec<_> = FramedRecords::<WalRecord>::new(&stream, 0).collect();
+        assert_eq!(results.len(), 2, "one good record, then the error");
+        assert!(results[0].is_ok());
+        let error = results[1].as_ref().unwrap_err();
+        assert!(
+            error.0.contains(&corrupt_at.to_string()),
+            "error names the offending offset: {error}"
+        );
+    }
+
+    #[test]
+    fn a_truncated_tail_surfaces_as_an_error_not_a_silent_stop() {
+        // A crash mid-append leaves a partial record. Replay must see an error, not treat the
+        // stream as having ended cleanly.
+        let mut stream = encode_framed(&record(1, b"complete"));
+        stream.extend_from_slice(&encode_framed(&record(2, b"incomplete")));
+        stream.truncate(stream.len() - 4);
+
+        let results: Vec<_> = FramedRecords::<WalRecord>::new(&stream, 0).collect();
+        assert!(results[0].is_ok());
+        assert!(results.last().unwrap().is_err());
+    }
+}

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! The write-ahead log record, ported from the reference implementation's operation log.
+//!
+//! This is a direct port: same record shape, same field numbers, same framing, and the same
+//! addressing scheme. Only the names differ, following this crate's vocabulary — a routing
+//! bucket rather than a slot, a block rather than a page, a shard rather than a partition.
+//!
+//! # Why this replaces a command log
+//!
+//! The existing WAL record carries a `Command`, so recovery re-executes the operation. That
+//! only reproduces state if everything that influenced the original execution is reproduced
+//! too, which is why config-driven eviction had to be made WAL-sequence-ordered and why expiry
+//! needs a replay clock. The reference stores the *result* instead: an item describes a
+//! mutation at the storage layer, and a block-carrying item holds the block image itself.
+//! Replay installs bytes rather than re-deriving them.
+//!
+//! # Addressing: the log id
+//!
+//! A block-carrying item does not name a slab. Its address is the **log id** — the byte offset
+//! of the record that contains it — exactly as the reference sets `address = log_id` when it
+//! turns a log item into a block descriptor. Nothing needs to be looked up: a read seeks to the
+//! offset and parses the record there. That is why the framing below must be length-prefixed
+//! and offset-addressable rather than line-oriented.
+//!
+//! The address cannot be known while a command executes, because the record has not been
+//! appended yet and therefore has no offset. The reference resolves this by staging: items
+//! accumulate during execution, and at commit the append returns the offset which is then
+//! written back into every staged block descriptor. This module provides the pieces for that;
+//! see [`block_address_from_item`].
+//!
+//! # Framing
+//!
+//! `varint32(payload_len) | little_endian_u32(crc32c) | payload`
+//!
+//! matching the reference's record header exactly. The payload is protobuf, with the same field
+//! numbers as the reference's log item, so the encodings are wire-compatible.
+
+use prost::Message;
+
+use crate::block_store::BlockAddress;
+use crate::checksum::crc32c;
+
+/// Record format version, mirroring the reference's log version.
+pub const WAL_RECORD_VERSION: u32 = 1;
+
+/// One write-ahead log record: the unit that is appended, and whose byte offset becomes the log
+/// id for every block it carries. Mirrors the reference's operation-log message.
+#[derive(Clone, PartialEq, Message)]
+pub struct WalRecord {
+    #[prost(uint32, tag = "1")]
+    pub version: u32,
+    #[prost(message, repeated, tag = "2")]
+    pub items: Vec<WalItem>,
+    #[prost(uint64, tag = "3")]
+    pub sequence: u64,
+}
+
+/// One mutation inside a record. Field numbers match the reference's log item one-for-one, so
+/// the two encodings are wire-compatible; only the names are this crate's.
+#[derive(Clone, PartialEq, Message)]
+pub struct WalItem {
+    /// The reference calls this the slot id.
+    #[prost(uint64, tag = "1")]
+    pub routing_bucket: u64,
+    #[prost(bytes = "vec", tag = "2")]
+    pub object_key: Vec<u8>,
+    #[prost(uint32, tag = "3")]
+    pub model_id: u32,
+    #[prost(bytes = "vec", tag = "4")]
+    pub key: Vec<u8>,
+    #[prost(bytes = "vec", tag = "5")]
+    pub value: Vec<u8>,
+    #[prost(uint64, tag = "6")]
+    pub timestamp_ms: u64,
+    #[prost(uint64, tag = "7")]
+    pub cluster_id: u64,
+    #[prost(bool, tag = "8")]
+    pub deleted: bool,
+    #[prost(bool, tag = "9")]
+    pub object_deleted: bool,
+    /// The reference calls this `page_log`: the item carries a block image.
+    #[prost(bool, tag = "10")]
+    pub block_log: bool,
+    #[prost(uint32, tag = "11")]
+    pub object_id: u32,
+    /// The reference calls this `page_id`.
+    #[prost(uint32, tag = "12")]
+    pub block_id: u32,
+    /// The block image. The reference calls this `page`.
+    #[prost(bytes = "vec", tag = "13")]
+    pub block: Vec<u8>,
+    #[prost(uint64, tag = "14")]
+    pub ttl: u64,
+    #[prost(bool, tag = "15")]
+    pub meta_log: bool,
+}
+
+/// A framing or integrity failure. A record that fails to decode is corruption of committed
+/// data, not an absent record: a block-carrying item IS the durable copy, so callers must
+/// surface this as data loss rather than skipping past it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalFramingError(pub String);
+
+impl std::fmt::Display for WalFramingError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "wal record framing error: {}", self.0)
+    }
+}
+
+impl std::error::Error for WalFramingError {}
+
+/// Encode a record with the reference's framing:
+/// `varint32(payload_len) | little_endian_u32(crc32c) | payload`.
+pub fn encode_framed(record: &WalRecord) -> Vec<u8> {
+    let payload = record.encode_to_vec();
+    let checksum = crc32c(&payload);
+    let mut out = Vec::with_capacity(payload.len() + 9);
+    encode_varint32(payload.len() as u32, &mut out);
+    out.extend_from_slice(&checksum.to_le_bytes());
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Decode the record starting at `offset`, returning it together with the **absolute offset of
+/// the next record**.
+///
+/// `offset` is the log id: the value carried in a block address.
+///
+/// The second element is deliberately an absolute offset rather than a relative length. Every
+/// caller either scans forward (`offset = next_offset`) or stops; returning a length invites
+/// `offset = consumed`, which silently walks backwards after the first record and loops
+/// forever. That is not hypothetical -- it is the bug this signature exists to prevent.
+pub fn decode_framed_at(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<(WalRecord, usize), WalFramingError> {
+    let rest = bytes
+        .get(offset..)
+        .ok_or_else(|| WalFramingError(format!("offset {offset} is past the end of the log")))?;
+    let (payload_len, varint_len) = decode_varint32(rest)?;
+    let header_len = varint_len + 4;
+    let payload_len = payload_len as usize;
+    let end = header_len
+        .checked_add(payload_len)
+        .ok_or_else(|| WalFramingError("record length overflows".to_string()))?;
+    if rest.len() < end {
+        return Err(WalFramingError(format!(
+            "record at {offset} claims {payload_len} payload bytes but only {} remain",
+            rest.len().saturating_sub(header_len)
+        )));
+    }
+    let declared = u32::from_le_bytes(
+        rest[varint_len..header_len]
+            .try_into()
+            .expect("checksum slice is 4 bytes"),
+    );
+    let payload = &rest[header_len..end];
+    let actual = crc32c(payload);
+    if declared != actual {
+        return Err(WalFramingError(format!(
+            "record at {offset} checksum mismatch: declared {declared:08x}, actual {actual:08x}"
+        )));
+    }
+    let record = WalRecord::decode(payload)
+        .map_err(|error| WalFramingError(format!("record at {offset} failed to decode: {error}")))?;
+    Ok((record, offset + end))
+}
+
+/// Build the block address for a block-carrying item, from the log id of the record that
+/// contains it.
+///
+/// This is the port of the reference's log-item-to-block-descriptor conversion: the address is
+/// the log id, and the length is the record's framed size. Nothing is looked up — the address
+/// alone locates the bytes.
+pub fn block_address_from_item(log_id: u64, log_size: u64, item: &WalItem) -> BlockAddress {
+    BlockAddress {
+        page_slab_id: WAL_LOG_SLAB_ID,
+        offset: log_id,
+        length: log_size,
+        page_id: Some(u64::from(item.block_id)),
+        object_id: Some(u64::from(item.object_id)),
+        routing_bucket: u32::try_from(item.routing_bucket).ok(),
+        generation: None,
+        band_id: None,
+        sha256: None,
+    }
+}
+
+/// Sentinel slab id marking an address that resolves inside the WAL rather than a slab. The
+/// reference distinguishes these with a `page_in_log` flag on the descriptor; a reserved slab
+/// id carries the same information through this crate's existing address type without widening
+/// it.
+pub const WAL_LOG_SLAB_ID: u64 = u64::MAX - 1;
+
+/// Whether an address resolves inside the WAL.
+pub fn is_wal_resident(page_slab_id: u64) -> bool {
+    page_slab_id == WAL_LOG_SLAB_ID
+}
+
+fn encode_varint32(mut value: u32, out: &mut Vec<u8>) {
+    loop {
+        if value < 0x80 {
+            out.push(value as u8);
+            return;
+        }
+        out.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+}
+
+fn decode_varint32(bytes: &[u8]) -> Result<(u32, usize), WalFramingError> {
+    let mut value = 0_u32;
+    for (index, &byte) in bytes.iter().take(5).enumerate() {
+        let part = u32::from(byte & 0x7f);
+        value |= part
+            .checked_shl(7 * index as u32)
+            .ok_or_else(|| WalFramingError("varint overflows 32 bits".to_string()))?;
+        if byte & 0x80 == 0 {
+            return Ok((value, index + 1));
+        }
+    }
+    Err(WalFramingError("varint is truncated or overlong".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_item(routing_bucket: u64, block: &[u8]) -> WalItem {
+        WalItem {
+            routing_bucket,
+            block_log: true,
+            block: block.to_vec(),
+            block_id: 7,
+            object_id: 3,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn framed_record_round_trips() {
+        let record = WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence: 42,
+            items: vec![block_item(5, b"block bytes with a \n newline inside")],
+        };
+        let framed = encode_framed(&record);
+        let (decoded, next_offset) = decode_framed_at(&framed, 0).unwrap();
+        assert_eq!(decoded, record);
+        assert_eq!(next_offset, framed.len());
+        // The newline is the whole reason this framing is length-prefixed rather than
+        // line-oriented: a line reader would have split this record in two.
+        assert!(decoded.items[0].block.contains(&b'\n'));
+    }
+
+    #[test]
+    fn the_log_id_is_the_byte_offset_of_the_record() {
+        // Two records in one log; the second is addressed by where it starts.
+        let first = WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence: 1,
+            items: vec![block_item(1, b"first")],
+        };
+        let second = WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence: 2,
+            items: vec![block_item(2, b"second")],
+        };
+        let mut log = encode_framed(&first);
+        let second_log_id = log.len();
+        log.extend_from_slice(&encode_framed(&second));
+
+        let (decoded, _) = decode_framed_at(&log, second_log_id).unwrap();
+        assert_eq!(decoded.sequence, 2);
+        assert_eq!(decoded.items[0].block, b"second");
+    }
+
+    #[test]
+    fn sequential_scan_walks_every_record() {
+        let records: Vec<WalRecord> = (1..=5)
+            .map(|sequence| WalRecord {
+                version: WAL_RECORD_VERSION,
+                sequence,
+                items: vec![block_item(sequence, format!("block-{sequence}").as_bytes())],
+            })
+            .collect();
+        let mut log = Vec::new();
+        for record in &records {
+            log.extend_from_slice(&encode_framed(record));
+        }
+
+        let mut offset = 0;
+        let mut seen = Vec::new();
+        while offset < log.len() {
+            let (record, next_offset) = decode_framed_at(&log, offset).unwrap();
+            // A scan MUST make progress; without this the loop is unbounded and the growing
+            // `seen` takes the process out via the OOM killer rather than failing an assert.
+            assert!(next_offset > offset, "scan did not advance past {offset}");
+            seen.push(record);
+            offset = next_offset;
+        }
+        assert_eq!(seen, records);
+    }
+
+    #[test]
+    fn a_corrupted_payload_is_rejected_not_skipped() {
+        // A block-carrying record IS the durable copy, so corruption must surface as an error
+        // rather than as an absent block.
+        let record = WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence: 9,
+            items: vec![block_item(1, b"payload")],
+        };
+        let mut framed = encode_framed(&record);
+        let last = framed.len() - 1;
+        framed[last] ^= 0xff;
+        assert!(decode_framed_at(&framed, 0).is_err());
+    }
+
+    #[test]
+    fn a_truncated_tail_is_rejected() {
+        let record = WalRecord {
+            version: WAL_RECORD_VERSION,
+            sequence: 9,
+            items: vec![block_item(1, b"payload that will be cut short")],
+        };
+        let framed = encode_framed(&record);
+        let truncated = &framed[..framed.len() - 5];
+        assert!(decode_framed_at(truncated, 0).is_err());
+    }
+
+    #[test]
+    fn varint_lengths_round_trip_across_byte_boundaries() {
+        // The header is varint-length-prefixed, so a record straddling 127/128 bytes (and each
+        // later boundary) must still frame and re-parse exactly.
+        for payload_len in [0_usize, 1, 126, 127, 128, 129, 16_383, 16_384] {
+            let record = WalRecord {
+                version: WAL_RECORD_VERSION,
+                sequence: 1,
+                items: vec![block_item(1, &vec![b'x'; payload_len])],
+            };
+            let framed = encode_framed(&record);
+            let (decoded, next_offset) = decode_framed_at(&framed, 0).unwrap();
+            assert_eq!(decoded.items[0].block.len(), payload_len);
+            assert_eq!(next_offset, framed.len(), "payload_len {payload_len}");
+        }
+    }
+
+    #[test]
+    fn block_address_carries_the_log_id() {
+        let item = block_item(11, b"bytes");
+        let address = block_address_from_item(4096, 512, &item);
+        assert!(is_wal_resident(address.page_slab_id));
+        assert_eq!(address.offset, 4096, "the address IS the log id");
+        assert_eq!(address.length, 512);
+        assert_eq!(address.routing_bucket, Some(11));
+        assert_eq!(address.page_id, Some(7));
+        assert_eq!(address.object_id, Some(3));
+    }
+
+    #[test]
+    fn field_numbers_match_the_reference_log_item() {
+        // Wire compatibility is the point of porting the field numbers, so assert on the
+        // encoding rather than trusting the attributes. routing_bucket is field 1, varint:
+        // key byte = (1 << 3) | 0 = 0x08.
+        let item = WalItem {
+            routing_bucket: 5,
+            ..Default::default()
+        };
+        assert_eq!(item.encode_to_vec(), vec![0x08, 0x05]);
+
+        // block is field 13, length-delimited: key byte = (13 << 3) | 2 = 0x6a.
+        let with_block = WalItem {
+            block: b"ab".to_vec(),
+            ..Default::default()
+        };
+        assert_eq!(with_block.encode_to_vec(), vec![0x6a, 0x02, b'a', b'b']);
+    }
+}

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -40,7 +40,7 @@
 use prost::Message;
 
 use crate::block_store::BlockAddress;
-use crate::checksum::crc32c;
+pub use crate::record_framing::{decode_framed_at, encode_framed, RecordFramingError as WalFramingError};
 
 /// Record format version, mirroring the reference's log version.
 pub const WAL_RECORD_VERSION: u32 = 1;
@@ -97,77 +97,6 @@ pub struct WalItem {
     pub meta_log: bool,
 }
 
-/// A framing or integrity failure. A record that fails to decode is corruption of committed
-/// data, not an absent record: a block-carrying item IS the durable copy, so callers must
-/// surface this as data loss rather than skipping past it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WalFramingError(pub String);
-
-impl std::fmt::Display for WalFramingError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "wal record framing error: {}", self.0)
-    }
-}
-
-impl std::error::Error for WalFramingError {}
-
-/// Encode a record with the reference's framing:
-/// `varint32(payload_len) | little_endian_u32(crc32c) | payload`.
-pub fn encode_framed(record: &WalRecord) -> Vec<u8> {
-    let payload = record.encode_to_vec();
-    let checksum = crc32c(&payload);
-    let mut out = Vec::with_capacity(payload.len() + 9);
-    encode_varint32(payload.len() as u32, &mut out);
-    out.extend_from_slice(&checksum.to_le_bytes());
-    out.extend_from_slice(&payload);
-    out
-}
-
-/// Decode the record starting at `offset`, returning it together with the **absolute offset of
-/// the next record**.
-///
-/// `offset` is the log id: the value carried in a block address.
-///
-/// The second element is deliberately an absolute offset rather than a relative length. Every
-/// caller either scans forward (`offset = next_offset`) or stops; returning a length invites
-/// `offset = consumed`, which silently walks backwards after the first record and loops
-/// forever. That is not hypothetical -- it is the bug this signature exists to prevent.
-pub fn decode_framed_at(
-    bytes: &[u8],
-    offset: usize,
-) -> Result<(WalRecord, usize), WalFramingError> {
-    let rest = bytes
-        .get(offset..)
-        .ok_or_else(|| WalFramingError(format!("offset {offset} is past the end of the log")))?;
-    let (payload_len, varint_len) = decode_varint32(rest)?;
-    let header_len = varint_len + 4;
-    let payload_len = payload_len as usize;
-    let end = header_len
-        .checked_add(payload_len)
-        .ok_or_else(|| WalFramingError("record length overflows".to_string()))?;
-    if rest.len() < end {
-        return Err(WalFramingError(format!(
-            "record at {offset} claims {payload_len} payload bytes but only {} remain",
-            rest.len().saturating_sub(header_len)
-        )));
-    }
-    let declared = u32::from_le_bytes(
-        rest[varint_len..header_len]
-            .try_into()
-            .expect("checksum slice is 4 bytes"),
-    );
-    let payload = &rest[header_len..end];
-    let actual = crc32c(payload);
-    if declared != actual {
-        return Err(WalFramingError(format!(
-            "record at {offset} checksum mismatch: declared {declared:08x}, actual {actual:08x}"
-        )));
-    }
-    let record = WalRecord::decode(payload)
-        .map_err(|error| WalFramingError(format!("record at {offset} failed to decode: {error}")))?;
-    Ok((record, offset + end))
-}
-
 /// Build the block address for a block-carrying item, from the log id of the record that
 /// contains it.
 ///
@@ -199,31 +128,6 @@ pub fn is_wal_resident(page_slab_id: u64) -> bool {
     page_slab_id == WAL_LOG_SLAB_ID
 }
 
-fn encode_varint32(mut value: u32, out: &mut Vec<u8>) {
-    loop {
-        if value < 0x80 {
-            out.push(value as u8);
-            return;
-        }
-        out.push((value as u8 & 0x7f) | 0x80);
-        value >>= 7;
-    }
-}
-
-fn decode_varint32(bytes: &[u8]) -> Result<(u32, usize), WalFramingError> {
-    let mut value = 0_u32;
-    for (index, &byte) in bytes.iter().take(5).enumerate() {
-        let part = u32::from(byte & 0x7f);
-        value |= part
-            .checked_shl(7 * index as u32)
-            .ok_or_else(|| WalFramingError("varint overflows 32 bits".to_string()))?;
-        if byte & 0x80 == 0 {
-            return Ok((value, index + 1));
-        }
-    }
-    Err(WalFramingError("varint is truncated or overlong".to_string()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,7 +151,7 @@ mod tests {
             items: vec![block_item(5, b"block bytes with a \n newline inside")],
         };
         let framed = encode_framed(&record);
-        let (decoded, next_offset) = decode_framed_at(&framed, 0).unwrap();
+        let (decoded, next_offset): (WalRecord, usize) = decode_framed_at(&framed, 0).unwrap();
         assert_eq!(decoded, record);
         assert_eq!(next_offset, framed.len());
         // The newline is the whole reason this framing is length-prefixed rather than
@@ -272,7 +176,7 @@ mod tests {
         let second_log_id = log.len();
         log.extend_from_slice(&encode_framed(&second));
 
-        let (decoded, _) = decode_framed_at(&log, second_log_id).unwrap();
+        let (decoded, _): (WalRecord, usize) = decode_framed_at(&log, second_log_id).unwrap();
         assert_eq!(decoded.sequence, 2);
         assert_eq!(decoded.items[0].block, b"second");
     }
@@ -292,9 +196,10 @@ mod tests {
         }
 
         let mut offset = 0;
-        let mut seen = Vec::new();
+        let mut seen: Vec<WalRecord> = Vec::new();
         while offset < log.len() {
-            let (record, next_offset) = decode_framed_at(&log, offset).unwrap();
+            let (record, next_offset): (WalRecord, usize) =
+                decode_framed_at(&log, offset).unwrap();
             // A scan MUST make progress; without this the loop is unbounded and the growing
             // `seen` takes the process out via the OOM killer rather than failing an assert.
             assert!(next_offset > offset, "scan did not advance past {offset}");
@@ -316,7 +221,7 @@ mod tests {
         let mut framed = encode_framed(&record);
         let last = framed.len() - 1;
         framed[last] ^= 0xff;
-        assert!(decode_framed_at(&framed, 0).is_err());
+        assert!(decode_framed_at::<WalRecord>(&framed, 0).is_err());
     }
 
     #[test]
@@ -328,7 +233,7 @@ mod tests {
         };
         let framed = encode_framed(&record);
         let truncated = &framed[..framed.len() - 5];
-        assert!(decode_framed_at(truncated, 0).is_err());
+        assert!(decode_framed_at::<WalRecord>(truncated, 0).is_err());
     }
 
     #[test]
@@ -342,7 +247,7 @@ mod tests {
                 items: vec![block_item(1, &vec![b'x'; payload_len])],
             };
             let framed = encode_framed(&record);
-            let (decoded, next_offset) = decode_framed_at(&framed, 0).unwrap();
+            let (decoded, next_offset): (WalRecord, usize) = decode_framed_at(&framed, 0).unwrap();
             assert_eq!(decoded.items[0].block.len(), payload_len);
             assert_eq!(next_offset, framed.len(), "payload_len {payload_len}");
         }


### PR DESCRIPTION
CRC32C instead of SHA-256 for on-disk record integrity — WAL framing and block records. A cryptographic digest was being computed per record on the synchronous write path; nothing treats it as a signature. Old records still verify as SHA-256, selected by version.
Flat write path on by default — TS_PHASE1_FLAT, TS_ENGINE_CONCURRENT_COMMIT, TS_RAFT_APPLY_COALESCE.
Band pre-allocation — slab rolls (~4 fsyncs + a directory scan) move off the client append path into the existing background prepare stage.
Record ports — WAL and index-log records, shared length-prefixed framing, address = log id. Inert: nothing writes them yet; no on-disk format changed.
Measured (in-process, unit-test scale — not cluster figures): 5000 writes → 1 WAL scan (was one per write); 0.330 fsync/write composed (was 1.000); raft apply batch of 64 → 1 fsync.

Compatibility: the CRC32C change is one-way — new records read on this version and later, not earlier.