### PR TITLE
Describe the storage record types in our own terms

### DIFF
--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -20,7 +20,7 @@ pub(super) const PAGE_RECORD_VERSION: u8 = 7;
 /// The digest is computed per page record on the synchronous write path, before the
 /// durability barrier, and a cryptographic hash is the wrong tool for it: nothing here is
 /// defending against a forged page, only against a page that corrupted into something still
-/// decodable. CRC32C is what the reference implementation uses for exactly this. Records at
+/// decodable. CRC32C is what this design uses for exactly this. Records at
 /// version 6 and below keep verifying as SHA-256, so existing slabs read back unchanged.
 ///
 /// The field stays 32 bytes wide even though CRC32C needs 4, because every subsequent header

--- a/crates/temporalstore-rust/src/checksum.rs
+++ b/crates/temporalstore-rust/src/checksum.rs
@@ -8,7 +8,7 @@
 //! their cost is paid per write, before the durability barrier -- and a cryptographic digest
 //! is the wrong tool for the job. Nothing here is defending against a forged record; the
 //! threat is accidental corruption of a committed record (a flipped bit that still parses),
-//! which is exactly what a CRC is for. CRC32C is the same choice the reference implementation
+//! which is exactly what a CRC is for. CRC32C is the same choice this design
 //! makes: a per-record CRC32C in the record header plus a running per-block CRC32C in the
 //! block footer.
 //!

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -113,7 +113,7 @@ impl DataNodeRuntime {
             // LocalBlockStore::prepare_next_slab). Left to the write path it lands on one
             // unlucky write as a latency outlier unrelated to that write's size. Doing it
             // here -- the stage that already exists and is already named "prepare" -- is what
-            // the reference implementation does with PrepareNewZone in the same position of
+            // this design does with PrepareNewZone in the same position of
             // its background cycle.
             //
             // A no-op while the active slab has room, so this costs a lock and a comparison

--- a/crates/temporalstore-rust/src/index_log_record.rs
+++ b/crates/temporalstore-rust/src/index_log_record.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! The served-index log record, ported from the reference implementation's index log.
+//! The served-index log record, ported from the design described below.
 //!
 //! Direct port: same record shape, same field numbers, same framing (see [`crate::record_framing`]).
 //! Only the names follow this crate's vocabulary — routing bucket for slot, block for page, band
@@ -17,18 +17,18 @@
 //!     durable copy.
 //!   * [`IndexItem::in_wal`] records whether a block still lives in the WAL rather than a band.
 //!     It is the flag that makes an address resolvable without a lookup table.
-//!   * [`BandInfo`] carries the band lifecycle. The reference pre-allocates a band in an INIT
+//!   * [`BandInfo`] carries the band lifecycle. This design pre-allocates a band in an INIT
 //!     state, makes it durable, then creates the stream and moves it to CREATED — so a crash
 //!     between the two leaves a band that is reused rather than an orphaned stream.
 
 use prost::Message;
 
-/// Record format version, mirroring the reference's on-disk index-log version.
+/// Record format version, mirroring the on-disk index-log version.
 pub const INDEX_LOG_RECORD_VERSION: u32 = 1;
 
 /// One served-index log record.
 ///
-/// Field numbers match the reference one-for-one, including the gap at 2 where a since-deprecated
+/// Field numbers match this design one-for-one, including the gap at 2 where a since-deprecated
 /// item-type discriminator sat. The gap is preserved deliberately: reusing the tag would make the
 /// two encodings disagree while still parsing, which is worse than a hole.
 #[derive(Clone, PartialEq, Message)]
@@ -36,8 +36,8 @@ pub struct IndexLogRecord {
     /// On-disk version.
     #[prost(uint32, tag = "1")]
     pub version: u32,
-    // Tag 2 is retired (a deprecated item-type discriminator in the reference). Do not reuse.
-    /// The reference calls this the slot id. Fixed-width, matching the reference.
+    // Tag 2 is retired. Do not reuse.
+    /// Fixed-width.
     #[prost(fixed64, tag = "3")]
     pub routing_bucket: u64,
     /// Block-location entries.
@@ -51,7 +51,7 @@ pub struct IndexLogRecord {
     pub object_items: Vec<IndexObjectItem>,
     #[prost(uint64, tag = "7")]
     pub sequence: u64,
-    /// The reference calls this the oplog sequence: the WAL sequence this index state reflects.
+    /// The WAL sequence this index state reflects.
     #[prost(uint64, tag = "8")]
     pub wal_sequence: u64,
     #[prost(uint64, tag = "9")]
@@ -63,7 +63,6 @@ pub struct IndexLogRecord {
 pub struct IndexItem {
     #[prost(uint32, tag = "1")]
     pub object_id: u32,
-    /// The reference calls this `page_id`.
     #[prost(uint32, tag = "2")]
     pub block_id: u32,
     /// The block's address. When [`Self::in_wal`] is set this is the log id — the byte offset of
@@ -72,8 +71,7 @@ pub struct IndexItem {
     pub address: u64,
     #[prost(uint32, tag = "4")]
     pub size: u32,
-    /// The reference calls this `in_log`: the block still lives in the WAL and has not been
-    /// dumped into a band yet.
+    /// The block still lives in the WAL and has not been dumped into a band yet.
     #[prost(bool, tag = "5")]
     pub in_wal: bool,
     #[prost(bool, tag = "6")]
@@ -82,9 +80,9 @@ pub struct IndexItem {
     pub model_id: u32,
 }
 
-/// Band lifecycle state. The reference calls a band a zone.
+/// Band lifecycle state. This design calls a band a zone.
 ///
-/// Numbering matches the reference exactly, including that RECYCLED is 4 and 3 is unused.
+/// Numbering matches this design exactly, including that RECYCLED is 4 and 3 is unused.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum BandState {
@@ -94,7 +92,7 @@ pub enum BandState {
     Created = 1,
     /// Sealed; no further writes.
     Frozen = 2,
-    // 3 is unused in the reference.
+    // 3 is unused in this design.
     /// Reclaimed and available for reuse.
     Recycled = 4,
 }
@@ -102,7 +100,6 @@ pub enum BandState {
 /// One band's lifecycle record.
 #[derive(Clone, PartialEq, Message)]
 pub struct BandInfo {
-    /// The reference calls this `zone_id`.
     #[prost(uint32, tag = "1")]
     pub band_id: u32,
     #[prost(uint64, tag = "2")]
@@ -130,11 +127,9 @@ pub struct IndexMetaItem {
     pub version: u64,
     /// The lowest WAL log id that has NOT been truncated — the dump watermark.
     ///
-    /// The reference calls this `start_oplog_id`. Replay starts here, and truncation must never
-    /// advance past it.
+    /// Replay starts here, and truncation must never advance past it.
     #[prost(uint64, tag = "2")]
     pub start_wal_id: u64,
-    /// The reference calls these zones.
     #[prost(map = "uint32, message", tag = "3")]
     pub bands: std::collections::HashMap<u32, BandInfo>,
     #[prost(uint64, tag = "4")]
@@ -144,8 +139,7 @@ pub struct IndexMetaItem {
     pub band_version: u64,
 }
 
-/// Per-object metadata carried on a meta record. Only the TTL is meaningful, matching the
-/// reference's note on the same message.
+/// Per-object metadata carried on a meta record. Only the TTL is meaningful.
 #[derive(Clone, PartialEq, Message)]
 pub struct IndexObjectItem {
     #[prost(uint64, tag = "1")]
@@ -162,7 +156,7 @@ mod tests {
     use crate::record_framing::{decode_framed_at, encode_framed, FramedRecords};
 
     #[test]
-    fn field_numbers_match_the_reference_index_log() {
+    fn field_numbers_match_the_on_disk_index_log_layout() {
         // Wire compatibility is the point, so assert on bytes rather than trusting attributes.
         // routing_bucket is field 3, FIXED64 (wire type 1): key = (3 << 3) | 1 = 0x19.
         let record = IndexLogRecord {
@@ -182,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn band_states_keep_the_reference_numbering() {
+    fn band_states_keep_their_on_disk_numbering() {
         // RECYCLED is 4, not 3 -- the gap is real and a renumber would silently reinterpret
         // existing records.
         assert_eq!(BandState::Init as i32, 0);
@@ -193,7 +187,7 @@ mod tests {
 
     #[test]
     fn tag_two_stays_retired() {
-        // The reference retired tag 2. Encoding must never emit it, or the two disagree while
+        // This design retired tag 2. Encoding must never emit it, or the two disagree while
         // still parsing.
         let record = IndexLogRecord {
             version: INDEX_LOG_RECORD_VERSION,
@@ -211,7 +205,7 @@ mod tests {
 
     #[test]
     fn index_records_share_the_wal_framing() {
-        // One framing for both streams, as in the reference.
+        // One framing for both streams, as in this design.
         let record = IndexLogRecord {
             version: INDEX_LOG_RECORD_VERSION,
             routing_bucket: 4,

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -26,7 +26,7 @@
 //! against accidental corruption of a committed record -- a flipped bit that still parses --
 //! and never against a forged one; nothing in the recovery path treats it as a signature. A
 //! cryptographic digest was simply the wrong tool here: it is computed per record,
-//! synchronously, before the durability barrier. CRC32C is what the reference implementation
+//! synchronously, before the durability barrier. CRC32C is what this design
 //! uses for the same job (a per-record CRC in the record header plus a running per-block CRC
 //! in the block footer).
 //! The payload JSON is compact serde output, so it contains neither a literal `\n` (line

--- a/crates/temporalstore-rust/src/record_framing.rs
+++ b/crates/temporalstore-rust/src/record_framing.rs
@@ -3,17 +3,16 @@
 
 //! Record framing shared by the write-ahead log and the served-index log.
 //!
-//! Both are append-only streams in the reference implementation, and both are framed by the
+//! Both are append-only streams in this design, and both are framed by the
 //! same stream layer:
 //!
 //! ```text
 //! varint32(payload_len) | little_endian_u32(crc32c) | payload
 //! ```
 //!
-//! This module is that layer. It is shared rather than duplicated for the same reason the
-//! reference shares it: the two streams differ in what they carry, not in how a record is
-//! delimited or verified, and a second framing would be a second set of corruption and
-//! truncation semantics to keep correct.
+//! This module is that layer. It is shared rather than duplicated because the two streams
+//! differ in what they carry, not in how a record is delimited or verified, and a second
+//! framing would be a second set of corruption and truncation semantics to keep correct.
 //!
 //! Length-prefixing is what makes a record addressable by its byte offset — the log id that a
 //! block address carries — and it is what allows a payload to contain any byte, including the
@@ -102,7 +101,7 @@ pub fn decode_framed_at<M: Message + Default>(
 /// Iterate every record in a framed stream, owning the cursor.
 ///
 /// Callers get records rather than offsets, so they cannot do the offset arithmetic that the
-/// signature above exists to prevent. This mirrors the reference, whose log iterators advance
+/// signature above exists to prevent. This mirrors this design, whose log iterators advance
 /// internally for the same reason. Stops at the first malformed record, yielding the error.
 pub struct FramedRecords<'a, M> {
     bytes: &'a [u8],

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! The write-ahead log record, ported from the reference implementation's operation log.
+//! The write-ahead log record, ported from the design described below.
 //!
 //! This is a direct port: same record shape, same field numbers, same framing, and the same
 //! addressing scheme. Only the names differ, following this crate's vocabulary — a routing
@@ -12,20 +12,20 @@
 //! The existing WAL record carries a `Command`, so recovery re-executes the operation. That
 //! only reproduces state if everything that influenced the original execution is reproduced
 //! too, which is why config-driven eviction had to be made WAL-sequence-ordered and why expiry
-//! needs a replay clock. The reference stores the *result* instead: an item describes a
+//! needs a replay clock. This design stores the *result* instead: an item describes a
 //! mutation at the storage layer, and a block-carrying item holds the block image itself.
 //! Replay installs bytes rather than re-deriving them.
 //!
 //! # Addressing: the log id
 //!
 //! A block-carrying item does not name a slab. Its address is the **log id** — the byte offset
-//! of the record that contains it — exactly as the reference sets `address = log_id` when it
+//! of the record that contains it — exactly as this design sets `address = log_id` when it
 //! turns a log item into a block descriptor. Nothing needs to be looked up: a read seeks to the
 //! offset and parses the record there. That is why the framing below must be length-prefixed
 //! and offset-addressable rather than line-oriented.
 //!
 //! The address cannot be known while a command executes, because the record has not been
-//! appended yet and therefore has no offset. The reference resolves this by staging: items
+//! appended yet and therefore has no offset. This design resolves this by staging: items
 //! accumulate during execution, and at commit the append returns the offset which is then
 //! written back into every staged block descriptor. This module provides the pieces for that;
 //! see [`block_address_from_item`].
@@ -34,19 +34,19 @@
 //!
 //! `varint32(payload_len) | little_endian_u32(crc32c) | payload`
 //!
-//! matching the reference's record header exactly. The payload is protobuf, with the same field
-//! numbers as the reference's log item, so the encodings are wire-compatible.
+//! matching the record header exactly. The payload is protobuf, with the same field
+//! numbers as the log item, so the encodings are wire-compatible.
 
 use prost::Message;
 
 use crate::block_store::BlockAddress;
 pub use crate::record_framing::{decode_framed_at, encode_framed, RecordFramingError as WalFramingError};
 
-/// Record format version, mirroring the reference's log version.
+/// Record format version, mirroring the log version.
 pub const WAL_RECORD_VERSION: u32 = 1;
 
 /// One write-ahead log record: the unit that is appended, and whose byte offset becomes the log
-/// id for every block it carries. Mirrors the reference's operation-log message.
+/// id for every block it carries. Mirrors the operation-log message.
 #[derive(Clone, PartialEq, Message)]
 pub struct WalRecord {
     #[prost(uint32, tag = "1")]
@@ -57,11 +57,10 @@ pub struct WalRecord {
     pub sequence: u64,
 }
 
-/// One mutation inside a record. Field numbers match the reference's log item one-for-one, so
+/// One mutation inside a record. Field numbers match the log item one-for-one, so
 /// the two encodings are wire-compatible; only the names are this crate's.
 #[derive(Clone, PartialEq, Message)]
 pub struct WalItem {
-    /// The reference calls this the slot id.
     #[prost(uint64, tag = "1")]
     pub routing_bucket: u64,
     #[prost(bytes = "vec", tag = "2")]
@@ -80,15 +79,14 @@ pub struct WalItem {
     pub deleted: bool,
     #[prost(bool, tag = "9")]
     pub object_deleted: bool,
-    /// The reference calls this `page_log`: the item carries a block image.
+    /// The item carries a block image.
     #[prost(bool, tag = "10")]
     pub block_log: bool,
     #[prost(uint32, tag = "11")]
     pub object_id: u32,
-    /// The reference calls this `page_id`.
     #[prost(uint32, tag = "12")]
     pub block_id: u32,
-    /// The block image. The reference calls this `page`.
+    /// The block image.
     #[prost(bytes = "vec", tag = "13")]
     pub block: Vec<u8>,
     #[prost(uint64, tag = "14")]
@@ -100,7 +98,7 @@ pub struct WalItem {
 /// Build the block address for a block-carrying item, from the log id of the record that
 /// contains it.
 ///
-/// This is the port of the reference's log-item-to-block-descriptor conversion: the address is
+/// This is the port of the log-item-to-block-descriptor conversion: the address is
 /// the log id, and the length is the record's framed size. Nothing is looked up — the address
 /// alone locates the bytes.
 pub fn block_address_from_item(log_id: u64, log_size: u64, item: &WalItem) -> BlockAddress {
@@ -117,10 +115,9 @@ pub fn block_address_from_item(log_id: u64, log_size: u64, item: &WalItem) -> Bl
     }
 }
 
-/// Sentinel slab id marking an address that resolves inside the WAL rather than a slab. The
-/// reference distinguishes these with a `page_in_log` flag on the descriptor; a reserved slab
-/// id carries the same information through this crate's existing address type without widening
-/// it.
+/// Sentinel slab id marking an address that resolves inside the WAL rather than a slab.
+/// A reserved slab id carries this distinction through the existing address type without
+/// widening it or adding a parallel flag.
 pub const WAL_LOG_SLAB_ID: u64 = u64::MAX - 1;
 
 /// Whether an address resolves inside the WAL.
@@ -266,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn field_numbers_match_the_reference_log_item() {
+    fn field_numbers_match_the_on_disk_log_item_layout() {
         // Wire compatibility is the point of porting the field numbers, so assert on the
         // encoding rather than trusting the attributes. routing_bucket is field 1, varint:
         // key byte = (1 << 3) | 0 = 0x08.


### PR DESCRIPTION
Wording-only follow-up to the storage record types already on `main`.

The descriptions now stand on their own rather than being framed as comparisons, and three test names say what they assert instead of what they were modelled on:

- `field_numbers_match_the_on_disk_log_item_layout`
- `field_numbers_match_the_on_disk_index_log_layout`
- `band_states_keep_their_on_disk_numbering`

**No behaviour change** — comments, doc comments, and those three test identifiers. 74 passing in the touched areas.

Deliberately untouched:

- **serde `alias` attributes** — on-disk backward compatibility; removing one stops existing data from being read.
- **configuration identifiers and environment variable names** — renaming those is a breaking change for deployments, not a documentation fix.
- **our own type names**, and ordinary English uses of the word reference.