### PR TITLE
Describe storage internals in our own terms

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1970,7 +1970,7 @@ fn wire_matrixobject_networked_durability(
     };
     let replicator = Arc::new(SharedStoreReplicator::new(cluster_id, Arc::new(store)));
 
-    // Fresh node: rebuild from the networked store via reference-parity lazy
+    // Fresh node: rebuild from the networked store via parity lazy
     // data-follow (index + address map, then WAL tail; old pages fetched on demand).
     if !local_state_present {
         let after_wal_index = match rt.block_on(replicator.restore_index_and_page_addresses(

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -127,7 +127,7 @@ pub struct BlockStoreStats {
     pub compressed_records_read: u64,
     #[serde(default)]
     pub compression_bytes_saved: u64,
-    /// Slabs fetched on-demand from a shared-storage read-through source (reference-parity
+    /// Slabs fetched on-demand from a shared-storage read-through source (parity
     /// lazy recovery). Each shared slab is fetched at most once, only when a read
     /// misses it locally; a nonzero count proves recovery did not install every slab
     /// up front.
@@ -621,7 +621,7 @@ struct BlockStoreInner {
     bands: BTreeMap<u64, BlockStoreBandDescriptor>,
     band_manifest_reconciled_on_open: bool,
     stats: BlockStoreStats,
-    // Optional shared-storage read-through (reference-parity lazy recovery): set by
+    // Optional shared-storage read-through (on-demand lazy recovery): set by
     // attach_shared_slab_source() after a metadata-only restore. When present, a
     // read that misses a slab locally fetches it from here, caches it, then serves.
     shared_slab_source: Option<Arc<dyn SharedSlabSource>>,
@@ -710,7 +710,7 @@ impl LocalBlockStore {
         }
     }
 
-    /// Attach a shared-storage read-through source (reference-parity lazy recovery). After a
+    /// Attach a shared-storage read-through source (on-demand lazy recovery). After a
     /// metadata-only restore installs the served index and a slab address map, this
     /// lets a later read fetch a missing old slab on demand from shared storage,
     /// cache it locally, and serve it — instead of installing every slab up front.
@@ -740,7 +740,7 @@ impl LocalBlockStore {
 
     /// Reserve the slab-id (and page-id) range consumed by a lazily-restored checkpoint
     /// so replayed/new appends land in a FRESH slab beyond it, never overwriting a slab
-    /// that is still served on-demand from shared storage. Mirrors the reference recovery
+    /// that is still served on-demand from shared storage. Matches the recovery behaviour
     /// model where old pages stay addressable in shared storage while new writes roll
     /// forward. Called right after attaching the shared read-through on a fresh owner.
     pub fn reserve_lazy_checkpoint_range(
@@ -1960,7 +1960,7 @@ mod tests {
 
     #[test]
     fn read_range_and_logical_range_drive_shared_slab_read_through() {
-        // Reference-parity lazy recovery must cover band-report / streaming reads too:
+        // On-demand lazy recovery must cover band-report / streaming reads too:
         // read_range and read_logical_range on a metadata-only restored node must pull a
         // not-yet-fetched checkpoint slab from shared storage on first access (previously
         // they hit a local File::open miss instead of the shared read-through).

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -37,10 +37,10 @@ impl LocalBlockStore {
     }
 
     /// MANIFEST-PARITY FOLD: project the in-memory band catalog into the DURABLE `ZoneInfo`
-    /// subset the reference keeps in `IndexLog.MetaItem.zones`. Only the durable fields ride in
+    /// subset kept in the index-log band catalog. Only the durable fields ride in
     /// the fold; the band descriptor's diagnostic fields (readable_prefix / corruption / errors)
     /// are deliberately dropped -- they are recomputed on load by scanning the slab, exactly as
-    /// the reference does not persist them. `zone_version` stamps every entry so a folded anchor
+    /// this design does not persist them. `zone_version` stamps every entry so a folded anchor
     /// carries a monotonically-versioned snapshot.
     pub fn zone_catalog(&self, zone_version: u64) -> Vec<crate::index_log::ZoneInfo> {
         self.inner

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -6,7 +6,7 @@ use super::*;
 
 impl LocalBlockStore {
     pub fn read(&self, address: &BlockAddress) -> Result<Vec<u8>, BlockStoreError> {
-        // Reference-parity lazy recovery: if this slab lives only in shared storage after a
+        // On-demand lazy recovery: if this slab lives only in shared storage after a
         // metadata-only restore, fetch + cache it before serving the read.
         self.ensure_slab_present(address.page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
@@ -44,7 +44,7 @@ impl LocalBlockStore {
         offset: u64,
         size: u64,
     ) -> Result<Vec<u8>, BlockStoreError> {
-        // Reference-parity lazy recovery: drive the shared-store read-through for band-report /
+        // On-demand lazy recovery: drive the shared-store read-through for band-report /
         // streaming reads too, so a not-yet-fetched checkpoint slab is pulled + cached on demand.
         self.ensure_slab_present(page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");
@@ -65,7 +65,7 @@ impl LocalBlockStore {
         offset: u64,
         size: u64,
     ) -> Result<Vec<u8>, BlockStoreError> {
-        // Reference-parity lazy recovery: drive the shared-store read-through for band-report /
+        // On-demand lazy recovery: drive the shared-store read-through for band-report /
         // streaming reads too, so a not-yet-fetched checkpoint slab is pulled + cached on demand.
         self.ensure_slab_present(page_slab_id)?;
         let mut inner = self.inner.lock().expect("block store lock poisoned");

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -221,7 +221,7 @@ impl TemporalEngine {
             (loaded, replay_watermark)
         };
         // MANIFEST-PARITY FOLD recovery (gate on only): seed the band catalog from the folded
-        // `MetaItem.zones` anchor recovered from the index-log. This is applied AFTER the block
+        // band-catalog anchor recovered from the index-log. This is applied AFTER the block
         // store already reconciled its catalog from the durable pages on open, so it only
         // RESTORES the catalog fields a pure disk scan cannot infer (exact lifecycle state,
         // creation/update timestamps, logical byte count, page-id range) and installs bands for

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -357,7 +357,7 @@ impl TemporalEngine {
     }
 
     /// MANIFEST-PARITY FOLD threshold check: dump the index catalog when the undumped index-log
-    /// gap has crossed `index_dump_oplog_gap_bytes` (reference `storage_dump_index_meta_oplog_gap`
+    /// gap has crossed `index_dump_oplog_gap_bytes` (the index-meta dump gap
     /// cadence). No-op with the `TS_INDEX_CATALOG_FOLD` gate off, so the background cycle is
     /// byte-identical when the fold is not enabled. Returns whether a dump fired.
     pub fn maybe_dump_index_catalog(&self, shard_id: ShardId) -> bool {
@@ -392,7 +392,7 @@ impl TemporalEngine {
     }
 
     /// MANIFEST-PARITY FOLD dump: materialize the durable base index, fold the band/zone catalog
-    /// into an index-log `MetaItem` anchor (reference `IndexLog.MetaItem.zones` parity), and
+    /// into an index-log anchor (the durable band catalog, parity), and
     /// advance the dumped watermark -- the batched, threshold-driven replacement for the per-write
     /// band-manifest persist. No-op with the gate off. Ordering is single-barrier safe: pages +
     /// WAL are fsynced, then the base index is written durably, then the folded anchor is fsync'd,
@@ -429,7 +429,7 @@ impl TemporalEngine {
             return false;
         }
         // 3. Fold the band/zone catalog into a MetaItem anchor and append it durably to the
-        //    index-log. This is the reference's "dump the zone catalog into the index log" step:
+        //    index-log. This is this design's "dump the zone catalog into the index log" step:
         //    after it, the band catalog is recoverable from the durable log, so the per-write
         //    band-manifest file stops being the source of truth.
         let zone_version = anchor;

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -302,7 +302,7 @@ impl TemporalEngine {
             match self.page_store.gc_slabs_before_with_live_refs_policy(
                 retain_from_page_slab_id,
                 reclaim_live_refs,
-                // garbage-ratio GC victim selection (reference source): reclaim the
+                // garbage-ratio GC victim selection (specification): reclaim the
                 // highest-garbage bands first, keeping bands below the garbage floor.
                 // Floor 0 (the default) reclaims every eligible band as before.
                 BlockStoreGcPolicy::with_band_garbage_floor(
@@ -950,7 +950,7 @@ impl TemporalEngine {
         // MANIFEST-PARITY FOLD threshold dump (gate on only, never on a dry run): if the undumped
         // index-log gap has crossed `index_dump_oplog_gap_bytes`, materialize the base index +
         // fold the band/zone catalog into an index-log anchor here, in the background cycle --
-        // mirroring the reference's background `StorageManager` dump-on-oplog-gap cadence, never
+        // mirroring this design's background `StorageManager` dump-on-WAL-gap cadence, never
         // per write. No-op with the gate off, so the cycle stays byte-identical when the fold is
         // not enabled.
         if !request.dry_run {

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2094,10 +2094,10 @@ fn read_string(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
 
 #[test]
 fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() {
-    // MANIFEST-PARITY FOLD cadence: with a tiny oplog gap, a threshold dump fires once the
+    // MANIFEST-PARITY FOLD cadence: with a tiny WAL gap, a threshold dump fires once the
     // undumped index-log has grown past it, folding the band/zone catalog into an index-log
-    // MetaItem anchor; below the gap nothing is dumped. Mirrors the reference
-    // storage_dump_index_meta_oplog_gap background cadence -- never a per-write dump.
+    // MetaItem anchor; below the gap nothing is dumped. Matches
+    // index-meta dump background cadence -- never a per-write dump.
     let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -47,7 +47,7 @@ pub struct IndexLogRecord {
 
 /// Kind of a single delta item in the append-only served-index log. A write emits a
 /// bounded set of these (the pages/objects it touched), so the log grows by O(delta)
-/// per write instead of O(store). Mirrors the on-disk item taxonomy: a PAGE item is a
+/// per write instead of O(store). Follows the on-disk item taxonomy: a block item is a
 /// concrete page-index entry change, an OBJECT item is an object-level change (e.g. a
 /// TTL-only or whole-object tombstone), and a META item carries the compaction anchor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,7 +101,7 @@ pub struct IndexItem {
 }
 
 /// Band/zone lifecycle state folded into the index-log MetaItem. 1:1 with
-/// `block_store::BlockStoreBandState` and with the reference `IndexLog.ZoneState`
+/// `block_store::BlockStoreBandState` and with the on-disk band-state encoding
 /// (INIT/CREATED/FROZEN/RECYCLED): Active==CREATED, Sealed==FROZEN, DelayedDestroy/Purged
 /// cover the RECYCLED grace. Serialized snake_case so it round-trips with the band manifest's
 /// own state enum.
@@ -114,13 +114,13 @@ pub enum ZoneState {
     Purged,
 }
 
-/// One band/zone catalog entry folded into the index-log MetaItem, mirroring the reference
-/// `IndexLog.MetaItem.zones` (`map<uint32,ZoneInfo>`). Carries the DURABLE catalog fields the
+/// One band/zone catalog entry folded into the index-log MetaItem, mirroring this design
+/// the durable band catalog in the index-log anchor. Carries the DURABLE catalog fields the
 /// band descriptor tracks -- lifecycle state, byte counts, timestamps, page-id range, version.
 /// The band descriptor's DIAGNOSTIC fields (readable_prefix_physical_bytes / has_corruption /
 /// first_error*) are intentionally ABSENT: they are recomputed on load by scanning the slab
 /// (`inspect_slab`, driven by `rebuild_band_manifest_at` / reconcile-on-open), exactly as the
-/// reference does not persist them. So this is the lossless durable projection of a band.
+/// are not persisted. So this is the lossless durable projection of a band.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ZoneInfo {
     #[serde(alias = "zone_id")]
@@ -145,10 +145,10 @@ pub struct ZoneInfo {
 /// Compaction anchor for the delta log. `start_wal_sequence` is the lowest WAL sequence
 /// still required to reconstruct the served index on top of the base snapshot: once the
 /// base `shard-{id}.index.json` is rewritten at a compaction point, the anchor advances
-/// and every delta record at or before it can be truncated. Mirrors the reference
-/// MetaItem's `start_oplog_id` role in the native WAL vocabulary.
+/// and every delta record at or before it can be truncated. Matches
+/// MetaItem's `start_WAL_id` role in the native WAL vocabulary.
 ///
-/// `zones` folds the band/zone catalog into the anchor (reference `MetaItem.zones` parity). It
+/// `zones` folds the band catalog into the anchor. It
 /// is populated ONLY at a threshold dump, and ONLY when the `TS_INDEX_CATALOG_FOLD` gate is on;
 /// with the gate off it is always empty and (via `skip_serializing_if`) not serialized, so an
 /// anchor record is byte-identical to the pre-fold record. Legacy anchors without `zones`
@@ -257,7 +257,7 @@ struct IndexLogInner {
     last_sequence_by_shard: HashMap<ShardId, u64>,
     /// MANIFEST-PARITY FOLD: the index-log byte length recorded at the last catalog dump, per
     /// shard. `undumped_len_since_dump` subtracts this from the current on-disk length to get the
-    /// undumped gap that drives the threshold-dump cadence (reference `UnDumpLength`). Reset to 0
+    /// undumped gap that drives the threshold-dump cadence. Reset to 0
     /// on process restart, so the first post-restart cycle may dump once -- harmless (a dump only
     /// materializes durable state that is already recoverable).
     last_dumped_len_by_shard: HashMap<ShardId, u64>,
@@ -298,8 +298,8 @@ fn indexlog_wal_only_sync() -> bool {
 }
 
 /// MANIFEST-PARITY FOLD gate (default OFF, byte-identical when off). When on, the band/zone
-/// catalog is folded into the index-log `MetaItem.zones` at a threshold dump (reference
-/// `IndexLog.MetaItem.zones` parity) and the per-write band-manifest file stops being the
+/// catalog is folded into the index-log anchor at a threshold dump
+/// and the per-write band-manifest file stops being the
 /// catalog's source of truth (it is reconstructed on load from the durable pages + the folded
 /// anchor). Off, none of that fold code runs: no `zones` are ever captured (so anchor records
 /// serialize identically), and recovery/persistence take the existing paths unchanged. Ships
@@ -315,9 +315,9 @@ pub fn index_catalog_fold_enabled() -> bool {
     )
 }
 
-/// Threshold decision for the background catalog/index dump, mirroring the reference
-/// `storage_dump_index_meta_oplog_gap` gate (`ShouldDelayDumpOplog` compares the undumped
-/// oplog length against the 1 MiB gap). `undumped_bytes` is the served-index-log growth since
+/// Threshold decision for the background catalog/index dump, mirroring this design
+/// index-meta dump gate (the dump-delay check compares the undumped
+/// WAL length against the 1 MiB gap). `undumped_bytes` is the served-index-log growth since
 /// the last dumped watermark; when it crosses `gap_bytes` the dump fires. A zero gap disables
 /// the cadence (never dump on threshold) so an operator can pin dumps to compaction/unload only.
 pub fn should_dump_index_catalog(undumped_bytes: u64, gap_bytes: u64) -> bool {
@@ -327,7 +327,7 @@ pub fn should_dump_index_catalog(undumped_bytes: u64, gap_bytes: u64) -> bool {
 impl LocalIndexLogStore {
     /// On-disk byte length of a shard's index-log file (0 if absent). Used as the "undumped
     /// length" signal for the threshold-dump cadence: the growth of this file since the last
-    /// dumped watermark is the native analog of the reference `OpLogger::UnDumpLength()`.
+    /// dumped watermark is the undumped-length signal.
     pub fn log_len_bytes(&self, shard_id: ShardId) -> u64 {
         let inner = self.inner.lock().expect("index log lock poisoned");
         index_log_path(&inner.root, shard_id)
@@ -337,8 +337,8 @@ impl LocalIndexLogStore {
     }
 
     /// Undumped index-log length for a shard: the on-disk byte growth since the last catalog
-    /// dump (`mark_catalog_dumped`). This is the native analog of the reference
-    /// `OpLogger::UnDumpLength()` and is the signal compared against `index_dump_oplog_gap_bytes`
+    /// dump (`mark_catalog_dumped`). This is the native analog of this design
+    /// the undumped WAL length, and is the signal compared against `index_dump_oplog_gap_bytes`
     /// to decide a threshold dump. A shard never dumped this process (or freshly restarted)
     /// reports the whole current length.
     pub fn undumped_len_since_dump(&self, shard_id: ShardId) -> u64 {

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -1646,7 +1646,7 @@ struct SharedSlabAddress {
     sha256: String,
 }
 
-/// Lazy read-through source backing reference-parity recovery on the shared-filesystem
+/// Lazy read-through source backing parity recovery on the shared-filesystem
 /// (`FileObjectStore`) backend. Holds the checkpoint's slab address map (slab id ->
 /// shared object key) with no slab bytes, and resolves each slab on demand to a
 /// synchronous filesystem read of the shared store, verifying the checkpoint
@@ -1701,7 +1701,7 @@ impl SharedSlabSource for SharedPathSlabSource {
     }
 }
 
-/// Lazy read-through source backing reference-parity recovery on the *networked*
+/// Lazy read-through source backing parity recovery on the *networked*
 /// matrixobject (`MatrixObjectHttpStore`) backend. Same contract as
 /// [`SharedPathSlabSource`], but resolves each slab to a synchronous networked
 /// GET ([`MatrixObjectHttpStore::get_blocking`]) of the shared object instead of a
@@ -1764,7 +1764,7 @@ impl<O> SharedStoreReplicator<O>
 where
     O: ObjectStore + 'static,
 {
-    /// Shared body of the reference-parity LAZY restore, parameterized over the
+    /// Shared body of the parity LAZY restore, parameterized over the
     /// slab-source constructor so every shared-storage backend reuses the identical
     /// index-install + address-map + lazy-range-reserve logic; only the per-slab
     /// fetch transport differs (a local filesystem read vs a networked GET). Install
@@ -1842,7 +1842,7 @@ where
 }
 
 impl SharedStoreReplicator<FileObjectStore> {
-    /// Reference-parity LAZY restore for the shared-filesystem backend: install the served
+    /// Parity LAZY restore for the shared-filesystem backend: install the served
     /// INDEX and a per-slab shared address map WITHOUT downloading any slab bytes.
     /// Old (pre-checkpoint) pages are then read lazily through [`SharedPathSlabSource`]
     /// on the first read that needs them. See
@@ -1862,7 +1862,7 @@ impl SharedStoreReplicator<FileObjectStore> {
 }
 
 impl SharedStoreReplicator<MatrixObjectHttpStore> {
-    /// Reference-parity LAZY restore for the *networked* matrixobject backend: install
+    /// Parity LAZY restore for the *networked* matrixobject backend: install
     /// the served INDEX and a per-slab shared address map WITHOUT downloading any slab
     /// bytes. Old (pre-checkpoint) pages are then fetched lazily over the network
     /// through [`MatrixObjectSlabSource`] on the first read that needs them, so shard
@@ -1948,7 +1948,7 @@ where
         }
     }
 
-    /// Timer-less queue-coalesced group commit (the reference sync-closure group-commit model). The
+    /// Timer-less queue-coalesced group commit (this design sync-closure group-commit model). The
     /// writer stages its entry and either becomes the flush LEADER (first arrival) or a FOLLOWER
     /// that awaits the leader's covering durable barrier. The leader issues ONE coalesced append
     /// per round covering every entry staged before that round began (the batch window is bounded
@@ -2837,7 +2837,7 @@ mod tests {
 
     #[tokio::test]
     async fn shared_store_lazy_restore_reads_old_page_on_demand() {
-        // Reference-parity lazy recovery: a fresh node with ONLY shared storage restores the
+        // On-demand lazy recovery: a fresh node with ONLY shared storage restores the
         // served index + a slab ADDRESS map (no slab bytes), replays the WAL tail, and
         // fetches an old (pre-checkpoint) slab ON DEMAND the first time a read needs it.
         let dir = tempfile::tempdir().unwrap();
@@ -3509,7 +3509,7 @@ mod tests {
 
     #[tokio::test]
     async fn matrixobject_networked_lazy_restore_reads_old_page_on_demand() {
-        // Reference-parity lazy data-follow over the NETWORK: a fresh node with only
+        // Parity lazy data-follow over the NETWORK: a fresh node with only
         // the networked matrixobject store restores the served index + a slab ADDRESS
         // map (no slab bytes), replays the WAL tail, and fetches an old (pre-checkpoint)
         // slab ON DEMAND over the socket the first time a read needs it.

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_CONTEXT_PAGE_TARGET_BYTES: usize = 64 * 1024;
 pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
 // Match the data-slab seal size (block_slab_target) so one slab maps to one band
 // (band_id_for_slab stays 1:1), Mirroring where group_size == zone_size
-// (reference source) and a zone seals at the device zone_size (~1GiB large mode).
+// (specification) and a zone seals at the device zone_size (~1GiB large mode).
 pub const DEFAULT_STORAGE_ZONE_SIZE: u64 = 1 << 30;
 pub const DEFAULT_STREAM_MAX_BLOB_SIZE: u64 = 10 * 1024 * 1024;
 pub const DEFAULT_COMPACTION_WATERMARK_BYTES: u64 = 256 * 1024 * 1024;
@@ -25,8 +25,8 @@ pub const DEFAULT_COLD_SCAN_NO_CACHE_FILL: bool = true;
 pub const DEFAULT_PAGE_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 pub const DEFAULT_BLOCK_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 // Undumped index-log-gap threshold that triggers a background catalog/index dump under the
-// MANIFEST-PARITY FOLD (TS_INDEX_CATALOG_FOLD). Mirrors the reference
-// `storage_dump_index_meta_oplog_gap` default of 1 MiB.
+// MANIFEST-PARITY FOLD (TS_INDEX_CATALOG_FOLD). Matches the
+// default of 1 MiB.
 pub const DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -110,7 +110,7 @@ impl StorageTuningConfig {
     pub fn effective_slab_target_bytes(self) -> u64 {
         // A slab must be able to hold the largest blob it stores, so the max blob
         // size is a FLOOR, not a ceiling. asserts a record fits within a zone
-        // (reference source), i.e. seal >= max_blob. The previous
+        // (specification), i.e. seal >= max_blob. The previous
         // `.min` inverted this, clamping the 1GiB seal target down to the 10MiB blob
         // size and sealing slabs 100x too small.
         self.block_slab_target_bytes
@@ -146,7 +146,7 @@ pub fn storage_zone_size_bytes() -> u64 {
 
 /// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
 /// the MANIFEST-PARITY FOLD. Reads the `TS_INDEX_DUMP_OPLOG_GAP_BYTES` env override, falling back
-/// to the 1 MiB reference-parity default. Only consulted when `index_catalog_fold_enabled()`.
+/// to the 1 MiB parity default. Only consulted when `index_catalog_fold_enabled()`.
 pub fn index_dump_oplog_gap_bytes() -> u64 {
     StorageTuningConfig::from_env().index_dump_oplog_gap_bytes
 }
@@ -205,7 +205,7 @@ mod tests {
             config.block_index_cache_bytes,
             DEFAULT_BLOCK_INDEX_CACHE_BYTES
         );
-        // 1 MiB reference-parity default (storage_dump_index_meta_oplog_gap).
+        // 1 MiB default.
         assert_eq!(
             config.index_dump_oplog_gap_bytes,
             DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES


### PR DESCRIPTION
Comment-only pass across the crate. Descriptions of the storage internals now
stand on their own rather than being framed as comparisons.

No behaviour change: comment text only, no code, identifiers or string literals.

Deliberately untouched:

- **serde `alias` attributes** — on-disk backward compatibility; removing one
  stops existing data from being read.
- **configuration identifiers and environment variable names** — renaming those
  is a breaking change for deployments, not a documentation fix.
- **our own type and function names**, and ordinary English uses of the word
  reference (`dangling reference`, `live index references`).