### PR TITLE
Storage: block and stream descriptors, and a reclaim guard for blocks in the WAL

### DIFF
--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -357,14 +357,14 @@ impl TemporalEngine {
     }
 
     /// MANIFEST-PARITY FOLD threshold check: dump the index catalog when the undumped index-log
-    /// gap has crossed `index_dump_oplog_gap_bytes` (the index-meta dump gap
+    /// gap has crossed `index_dump_wal_gap_bytes` (the index-meta dump gap
     /// cadence). No-op with the `TS_INDEX_CATALOG_FOLD` gate off, so the background cycle is
     /// byte-identical when the fold is not enabled. Returns whether a dump fired.
     pub fn maybe_dump_index_catalog(&self, shard_id: ShardId) -> bool {
         if !crate::index_log::index_catalog_fold_enabled() {
             return false;
         }
-        let gap = crate::storage_config::index_dump_oplog_gap_bytes();
+        let gap = crate::storage_config::index_dump_wal_gap_bytes();
         let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
         if !crate::index_log::should_dump_index_catalog(undumped, gap) {
             return false;

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -948,7 +948,7 @@ impl TemporalEngine {
         );
 
         // MANIFEST-PARITY FOLD threshold dump (gate on only, never on a dry run): if the undumped
-        // index-log gap has crossed `index_dump_oplog_gap_bytes`, materialize the base index +
+        // index-log gap has crossed `index_dump_wal_gap_bytes`, materialize the base index +
         // fold the band/zone catalog into an index-log anchor here, in the background cycle --
         // mirroring this design's background `StorageManager` dump-on-WAL-gap cadence, never
         // per write. No-op with the gate off, so the cycle stays byte-identical when the fold is

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -338,7 +338,7 @@ impl LocalIndexLogStore {
 
     /// Undumped index-log length for a shard: the on-disk byte growth since the last catalog
     /// dump (`mark_catalog_dumped`). This is the native analog of this design
-    /// the undumped WAL length, and is the signal compared against `index_dump_oplog_gap_bytes`
+    /// the undumped WAL length, and is the signal compared against `index_dump_wal_gap_bytes`
     /// to decide a threshold dump. A shard never dumped this process (or freshly restarted)
     /// reports the whole current length.
     pub fn undumped_len_since_dump(&self, shard_id: ShardId) -> u64 {

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -28,6 +28,7 @@ pub mod sdk;
 pub mod shared_store;
 pub mod storage_backend;
 pub mod storage_config;
+pub mod storage_descriptor;
 pub mod telemetry;
 pub mod types;
 pub mod wal;

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -11,7 +11,10 @@ pub const TS_COMPACTION_WATERMARK_BYTES: &str = "TS_COMPACTION_WATERMARK_BYTES";
 pub const TS_COLD_SCAN_NO_CACHE_FILL: &str = "TS_COLD_SCAN_NO_CACHE_FILL";
 pub const TS_PAGE_INDEX_CACHE_BYTES: &str = "TS_PAGE_INDEX_CACHE_BYTES";
 pub const TS_BLOCK_INDEX_CACHE_BYTES: &str = "TS_BLOCK_INDEX_CACHE_BYTES";
-pub const TS_INDEX_DUMP_OPLOG_GAP_BYTES: &str = "TS_INDEX_DUMP_OPLOG_GAP_BYTES";
+pub const TS_INDEX_DUMP_WAL_GAP_BYTES: &str = "TS_INDEX_DUMP_WAL_GAP_BYTES";
+/// Previous name for [`TS_INDEX_DUMP_WAL_GAP_BYTES`], still honoured so a deployment that
+/// sets it keeps working. Read only when the current name is unset.
+pub const TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME: &str = "TS_INDEX_DUMP_OPLOG_GAP_BYTES";
 
 pub const DEFAULT_CONTEXT_PAGE_TARGET_BYTES: usize = 64 * 1024;
 pub const DEFAULT_BLOCK_SLAB_TARGET_BYTES: u64 = 1 << 30;
@@ -27,7 +30,7 @@ pub const DEFAULT_BLOCK_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 // Undumped index-log-gap threshold that triggers a background catalog/index dump under the
 // MANIFEST-PARITY FOLD (TS_INDEX_CATALOG_FOLD). Matches the
 // default of 1 MiB.
-pub const DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES: u64 = 1024 * 1024;
+pub const DEFAULT_INDEX_DUMP_WAL_GAP_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageTuningConfig {
@@ -40,7 +43,7 @@ pub struct StorageTuningConfig {
     pub cold_scan_no_cache_fill: bool,
     pub page_index_cache_bytes: u64,
     pub block_index_cache_bytes: u64,
-    pub index_dump_oplog_gap_bytes: u64,
+    pub index_dump_wal_gap_bytes: u64,
 }
 
 impl Default for StorageTuningConfig {
@@ -54,7 +57,7 @@ impl Default for StorageTuningConfig {
             cold_scan_no_cache_fill: DEFAULT_COLD_SCAN_NO_CACHE_FILL,
             page_index_cache_bytes: DEFAULT_PAGE_INDEX_CACHE_BYTES,
             block_index_cache_bytes: DEFAULT_BLOCK_INDEX_CACHE_BYTES,
-            index_dump_oplog_gap_bytes: DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES,
+            index_dump_wal_gap_bytes: DEFAULT_INDEX_DUMP_WAL_GAP_BYTES,
         }
     }
 }
@@ -100,9 +103,10 @@ impl StorageTuningConfig {
                 get(TS_BLOCK_INDEX_CACHE_BYTES),
                 defaults.block_index_cache_bytes,
             ),
-            index_dump_oplog_gap_bytes: parse_u64(
-                get(TS_INDEX_DUMP_OPLOG_GAP_BYTES),
-                defaults.index_dump_oplog_gap_bytes,
+            index_dump_wal_gap_bytes: parse_u64(
+                get(TS_INDEX_DUMP_WAL_GAP_BYTES)
+                    .or_else(|| get(TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME)),
+                defaults.index_dump_wal_gap_bytes,
             ),
         }
     }
@@ -117,7 +121,7 @@ impl StorageTuningConfig {
             .max(self.stream_max_blob_size)
     }
 
-    pub fn env_names() -> [&'static str; 9] {
+    pub fn env_names() -> [&'static str; 10] {
         [
             TS_CONTEXT_PAGE_TARGET_BYTES,
             TS_BLOCK_SLAB_TARGET_BYTES,
@@ -127,7 +131,8 @@ impl StorageTuningConfig {
             TS_COLD_SCAN_NO_CACHE_FILL,
             TS_PAGE_INDEX_CACHE_BYTES,
             TS_BLOCK_INDEX_CACHE_BYTES,
-            TS_INDEX_DUMP_OPLOG_GAP_BYTES,
+            TS_INDEX_DUMP_WAL_GAP_BYTES,
+            TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME,
         ]
     }
 }
@@ -145,10 +150,11 @@ pub fn storage_zone_size_bytes() -> u64 {
 }
 
 /// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
-/// the MANIFEST-PARITY FOLD. Reads the `TS_INDEX_DUMP_OPLOG_GAP_BYTES` env override, falling back
-/// to the 1 MiB parity default. Only consulted when `index_catalog_fold_enabled()`.
-pub fn index_dump_oplog_gap_bytes() -> u64 {
-    StorageTuningConfig::from_env().index_dump_oplog_gap_bytes
+/// the MANIFEST-PARITY FOLD. Reads the `TS_INDEX_DUMP_WAL_GAP_BYTES` env override -- or the
+/// previous name for it, so existing deployments keep working -- falling back to the 1 MiB
+/// default. Only consulted when `index_catalog_fold_enabled()`.
+pub fn index_dump_wal_gap_bytes() -> u64 {
+    StorageTuningConfig::from_env().index_dump_wal_gap_bytes
 }
 
 fn parse_u64(value: Option<String>, default: u64) -> u64 {
@@ -207,10 +213,10 @@ mod tests {
         );
         // 1 MiB default.
         assert_eq!(
-            config.index_dump_oplog_gap_bytes,
-            DEFAULT_INDEX_DUMP_OPLOG_GAP_BYTES
+            config.index_dump_wal_gap_bytes,
+            DEFAULT_INDEX_DUMP_WAL_GAP_BYTES
         );
-        assert_eq!(config.index_dump_oplog_gap_bytes, 1024 * 1024);
+        assert_eq!(config.index_dump_wal_gap_bytes, 1024 * 1024);
     }
 
     #[test]
@@ -227,8 +233,39 @@ mod tests {
                 "TS_COLD_SCAN_NO_CACHE_FILL",
                 "TS_PAGE_INDEX_CACHE_BYTES",
                 "TS_BLOCK_INDEX_CACHE_BYTES",
+                "TS_INDEX_DUMP_WAL_GAP_BYTES",
                 "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
             ]
+        );
+    }
+
+    #[test]
+    fn the_previous_gap_env_name_still_configures_the_knob() {
+        // A deployment that sets the old name must be unaffected by the rename.
+        let env = HashMap::from([(TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME, "4194304")]);
+        let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
+        assert_eq!(config.index_dump_wal_gap_bytes, 4 * 1024 * 1024);
+    }
+
+    #[test]
+    fn the_current_gap_env_name_wins_when_both_are_set() {
+        // Precedence has to be defined, or a deployment mid-migration gets whichever the
+        // lookup happened to try first.
+        let env = HashMap::from([
+            (TS_INDEX_DUMP_WAL_GAP_BYTES, "8388608"),
+            (TS_INDEX_DUMP_GAP_BYTES_PREVIOUS_NAME, "4194304"),
+        ]);
+        let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
+        assert_eq!(config.index_dump_wal_gap_bytes, 8 * 1024 * 1024);
+    }
+
+    #[test]
+    fn neither_gap_env_name_set_falls_back_to_the_default() {
+        let env: HashMap<&str, &str> = HashMap::new();
+        let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
+        assert_eq!(
+            config.index_dump_wal_gap_bytes,
+            DEFAULT_INDEX_DUMP_WAL_GAP_BYTES
         );
     }
 
@@ -244,7 +281,7 @@ mod tests {
             (TS_COLD_SCAN_NO_CACHE_FILL, "false"),
             (TS_PAGE_INDEX_CACHE_BYTES, "2097152"),
             (TS_BLOCK_INDEX_CACHE_BYTES, "4194304"),
-            (TS_INDEX_DUMP_OPLOG_GAP_BYTES, "2097152"),
+            (TS_INDEX_DUMP_WAL_GAP_BYTES, "2097152"),
         ]);
         let config = StorageTuningConfig::from_getter(|name| env.get(name).map(|v| v.to_string()));
         assert_eq!(config.context_page_target_bytes, 32 * 1024);
@@ -257,6 +294,6 @@ mod tests {
         assert!(!config.cold_scan_no_cache_fill);
         assert_eq!(config.page_index_cache_bytes, 2 * 1024 * 1024);
         assert_eq!(config.block_index_cache_bytes, 4 * 1024 * 1024);
-        assert_eq!(config.index_dump_oplog_gap_bytes, 2 * 1024 * 1024);
+        assert_eq!(config.index_dump_wal_gap_bytes, 2 * 1024 * 1024);
     }
 }

--- a/crates/temporalstore-rust/src/storage_descriptor.rs
+++ b/crates/temporalstore-rust/src/storage_descriptor.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Storage-layer descriptors: the per-block header and the segmented-stream layer.
+//!
+//! Completes the on-disk type set alongside [`crate::wal_record`] (the write-ahead log) and
+//! [`crate::index_log_record`] (the served-index log). Three groups live here:
+//!
+//!   * [`BlockHeader`] — the per-block descriptor. This is what the log-item-to-block
+//!     conversion fills in, and it is where [`BlockHeader::block_in_wal`] records that a
+//!     block's bytes are still in the WAL rather than in a band.
+//!   * [`SlabInfo`] / [`SlabHeader`] / [`BlockFooter`] — the segmented-stream layer. A stream
+//!     is a chain of slabs; each slab carries a header naming the whole chain, and the
+//!     fixed-size blocks inside it end with a footer that makes a torn tail detectable on
+//!     reopen.
+//!   * [`StreamInfo`] / [`WalInfo`] — the runtime views a follower uses to adopt a leader's
+//!     stream state without re-reading the stream itself.
+//!
+//! Field numbers are fixed by the on-disk layout and must not be renumbered: a stored stream
+//! outlives the process that wrote it.
+
+use prost::Message;
+
+/// Block size a stream is written in: 128 KiB.
+pub const STREAM_BLOCK_SIZE: u64 = 1 << 17;
+
+/// Footer reserved at the end of every stream block: 128 B.
+pub const STREAM_BLOCK_FOOTER_SIZE: u64 = 1 << 7;
+
+/// Magic stamped into slab headers and block footers.
+pub const STREAM_MAGIC: u64 = 0xBCBC_BCBC_6666_6666;
+
+/// Stream format version.
+pub const STREAM_VERSION: u32 = 1;
+
+/// How a block's payload was compressed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum BlockCompression {
+    None = 0,
+    Lz4 = 1,
+}
+
+/// Per-block descriptor.
+///
+/// `raw_data_size` is the size before compression and `data_size` after, so a reader can size
+/// its buffer without decompressing first.
+#[derive(Clone, PartialEq, Message)]
+pub struct BlockHeader {
+    /// Fixed-width, so the encoded size does not vary with the bucket value.
+    #[prost(fixed64, tag = "1")]
+    pub routing_bucket: u64,
+    #[prost(uint32, tag = "2")]
+    pub object_id: u32,
+    #[prost(uint32, tag = "3")]
+    pub block_id: u32,
+    /// Size before compression.
+    #[prost(uint64, tag = "4")]
+    pub raw_data_size: u64,
+    /// Size after compression.
+    #[prost(uint64, tag = "5")]
+    pub data_size: u64,
+    #[prost(uint64, tag = "6")]
+    pub timestamp_ms: u64,
+    #[prost(bytes = "vec", tag = "7")]
+    pub key: Vec<u8>,
+    #[prost(uint32, tag = "8")]
+    pub model_id: u32,
+    #[prost(enumeration = "BlockCompression", tag = "9")]
+    pub compress: i32,
+    /// The block's bytes live in the WAL record at [`Self::wal_sequence`], not in a band. Set
+    /// for every block that has not been dumped yet.
+    #[prost(bool, tag = "10")]
+    pub block_in_wal: bool,
+    /// Blocks for one object are ordered by this. It is derived from the log sequence, so a
+    /// later write always wins.
+    #[prost(uint64, tag = "11")]
+    pub version: u64,
+    /// Position in the WAL when the block was written.
+    #[prost(uint64, tag = "12")]
+    pub wal_sequence: u64,
+}
+
+/// One slab in a stream's chain.
+///
+/// `truncated_offset` is how a stream records that its head has been logically discarded
+/// without rewriting the slab.
+#[derive(Clone, PartialEq, Message)]
+pub struct SlabInfo {
+    #[prost(uint64, tag = "1")]
+    pub slab_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub start_offset: u64,
+    #[prost(uint64, tag = "3")]
+    pub slab_start_offset: u64,
+    #[prost(uint64, tag = "4")]
+    pub slab_end_offset: u64,
+    #[prost(uint64, tag = "5")]
+    pub end_record_sequence: u64,
+    #[prost(uint64, tag = "6")]
+    pub freeze_ms: u64,
+    #[prost(uint64, tag = "7")]
+    pub end_offset: u64,
+    #[prost(uint64, tag = "8")]
+    pub truncated_offset: u64,
+}
+
+/// The header written at the front of every slab.
+///
+/// It names the whole chain (`data_slabs`), which is what lets a reopen rebuild the stream
+/// from the last slab alone rather than scanning all of them.
+#[derive(Clone, PartialEq, Message)]
+pub struct SlabHeader {
+    #[prost(fixed64, tag = "1")]
+    pub magic: u64,
+    #[prost(uint64, tag = "2")]
+    pub slab_id: u64,
+    #[prost(bytes = "vec", tag = "3")]
+    pub slab_name: Vec<u8>,
+    #[prost(uint64, tag = "4")]
+    pub timestamp_ms: u64,
+    #[prost(uint32, tag = "5")]
+    pub version: u32,
+    #[prost(uint64, tag = "6")]
+    pub start_record_sequence: u64,
+    #[prost(bytes = "vec", tag = "7")]
+    pub client_token: Vec<u8>,
+    #[prost(message, repeated, tag = "8")]
+    pub data_slabs: Vec<SlabInfo>,
+    #[prost(uint64, tag = "9")]
+    pub start_offset: u64,
+    #[prost(uint32, tag = "10")]
+    pub prev_block_crc32c: u32,
+    #[prost(uint64, tag = "11")]
+    pub truncated_offset: u64,
+    #[prost(fixed32, tag = "12")]
+    pub header_size: u32,
+    #[prost(message, repeated, tag = "13")]
+    pub obsolete_slabs: Vec<SlabInfo>,
+}
+
+/// The footer closing every fixed-size block within a slab.
+///
+/// A tail scan on reopen reads these to recover where the stream really ended: the last
+/// complete record, its sequence, and the running CRC. Tag 11 is unused in the on-disk layout
+/// and stays unused here.
+#[derive(Clone, PartialEq, Message)]
+pub struct BlockFooter {
+    #[prost(fixed64, tag = "1")]
+    pub magic: u64,
+    #[prost(uint32, tag = "2")]
+    pub version: u32,
+    #[prost(uint64, tag = "3")]
+    pub timestamp_ms: u64,
+    #[prost(fixed32, tag = "4")]
+    pub block_crc: u32,
+    #[prost(uint64, tag = "5")]
+    pub block_number: u64,
+    #[prost(uint32, tag = "6")]
+    pub block_end: u32,
+    #[prost(uint64, tag = "7")]
+    pub last_record_offset: u64,
+    #[prost(uint32, tag = "8")]
+    pub last_record_left_size: u32,
+    #[prost(uint64, tag = "9")]
+    pub last_record_sequence: u64,
+    #[prost(bytes = "vec", tag = "10")]
+    pub client_token: Vec<u8>,
+    // Tag 11 is unused on disk. Do not reuse.
+    #[prost(uint64, tag = "12")]
+    pub truncated_offset: u64,
+}
+
+/// Runtime view of a stream, used to restore a follower's stream state from a leader's.
+#[derive(Clone, PartialEq, Message)]
+pub struct StreamInfo {
+    #[prost(message, repeated, tag = "1")]
+    pub slab_infos: Vec<SlabInfo>,
+    #[prost(uint64, tag = "2")]
+    pub start_record_id: u64,
+    #[prost(uint64, tag = "3")]
+    pub length: u64,
+    #[prost(uint64, tag = "4")]
+    pub persistent_length: u64,
+}
+
+/// Runtime view of the WAL, carrying the sequence a follower may trust.
+///
+/// The reported sequence is clamped to the last durable slab's end sequence, so a follower
+/// never adopts a sequence that exists only in the leader's memory.
+#[derive(Clone, PartialEq, Message)]
+pub struct WalInfo {
+    #[prost(message, optional, tag = "1")]
+    pub stream_info: Option<StreamInfo>,
+    #[prost(uint64, tag = "2")]
+    pub current_sequence: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record_framing::{decode_framed_at, encode_framed};
+
+    #[test]
+    fn field_numbers_match_the_on_disk_block_header_layout() {
+        // routing_bucket is field 1, FIXED64 (wire type 1): key = (1 << 3) | 1 = 0x09.
+        let header = BlockHeader {
+            routing_bucket: 1,
+            ..Default::default()
+        };
+        let encoded = header.encode_to_vec();
+        assert_eq!(encoded[0], 0x09, "routing_bucket must be fixed64 at tag 1");
+        assert_eq!(encoded.len(), 9);
+
+        // block_in_wal is field 10, varint: key = (10 << 3) | 0 = 0x50.
+        let in_wal = BlockHeader {
+            block_in_wal: true,
+            ..Default::default()
+        };
+        assert_eq!(in_wal.encode_to_vec(), vec![0x50, 0x01]);
+    }
+
+    #[test]
+    fn stream_constants_keep_their_on_disk_values() {
+        assert_eq!(STREAM_BLOCK_SIZE, 131_072, "128 KiB blocks");
+        assert_eq!(STREAM_BLOCK_FOOTER_SIZE, 128);
+        assert_eq!(STREAM_MAGIC, 0xBCBC_BCBC_6666_6666);
+        assert_eq!(STREAM_VERSION, 1);
+        // A footer must fit inside a block with room left for payload, or the framing
+        // degenerates into all-footer.
+        assert!(STREAM_BLOCK_FOOTER_SIZE < STREAM_BLOCK_SIZE);
+    }
+
+    #[test]
+    fn block_footer_leaves_tag_eleven_unused() {
+        // Emitting tag 11 would make our encoding disagree with a stored one while still
+        // parsing, which is the failure mode that does not announce itself.
+        let footer = BlockFooter {
+            magic: STREAM_MAGIC,
+            version: STREAM_VERSION,
+            block_number: 3,
+            truncated_offset: 9,
+            ..Default::default()
+        };
+        assert!(
+            !footer.encode_to_vec().iter().any(|&byte| byte >> 3 == 11),
+            "tag 11 must stay unused"
+        );
+    }
+
+    #[test]
+    fn a_block_in_wal_header_round_trips_through_the_shared_framing() {
+        let header = BlockHeader {
+            routing_bucket: 7,
+            object_id: 2,
+            block_id: 5,
+            raw_data_size: 4096,
+            data_size: 1024,
+            compress: BlockCompression::Lz4 as i32,
+            block_in_wal: true,
+            version: 42,
+            wal_sequence: 42,
+            key: b"object-key".to_vec(),
+            ..Default::default()
+        };
+        let framed = encode_framed(&header);
+        let (decoded, next): (BlockHeader, usize) = decode_framed_at(&framed, 0).unwrap();
+        assert_eq!(decoded, header);
+        assert_eq!(next, framed.len());
+        assert!(decoded.block_in_wal);
+        assert_eq!(decoded.compress, BlockCompression::Lz4 as i32);
+    }
+
+    #[test]
+    fn slab_header_carries_the_chain_so_a_reopen_can_rebuild_from_the_last_slab() {
+        let header = SlabHeader {
+            magic: STREAM_MAGIC,
+            slab_id: 3,
+            version: STREAM_VERSION,
+            data_slabs: vec![
+                SlabInfo {
+                    slab_id: 1,
+                    end_record_sequence: 10,
+                    ..Default::default()
+                },
+                SlabInfo {
+                    slab_id: 2,
+                    end_record_sequence: 20,
+                    ..Default::default()
+                },
+            ],
+            obsolete_slabs: vec![SlabInfo {
+                slab_id: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let framed = encode_framed(&header);
+        let (decoded, _): (SlabHeader, usize) = decode_framed_at(&framed, 0).unwrap();
+        assert_eq!(decoded.data_slabs.len(), 2);
+        assert_eq!(decoded.data_slabs[1].end_record_sequence, 20);
+        assert_eq!(decoded.obsolete_slabs.len(), 1);
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -199,6 +199,13 @@ pub struct WriteAheadLogGcReport {
     pub records_removed: usize,
     pub bytes_before: u64,
     pub bytes_after: u64,
+    /// The retain floor actually used, after clamping. Differs from
+    /// `retain_from_sequence` when the caller asked to reclaim further than the tail or the
+    /// block-retention floor allowed.
+    pub effective_retain_from_sequence: u64,
+    /// The block-retention floor held this reclaim back: records at or above it may still be
+    /// the only copy of a block's bytes.
+    pub clamped_by_block_retention: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -277,6 +284,12 @@ struct WriteAheadLogInner {
     // skipped. Any mismatch (external append, or first touch this process lifetime) falls back to
     // the full scan. Only consulted when `wal_fast_append_seq()`; harmless to maintain when off.
     verified_len_by_shard: HashMap<ShardId, u64>,
+    // Lowest sequence whose record may still hold the only copy of a block's bytes -- the dump
+    // watermark. A block written into the WAL is addressed by the byte offset of its record and
+    // has no copy in a band until it is dumped, so reclaiming that record destroys the block.
+    // GC clamps its retain floor to this. Absent = no shard has WAL-resident blocks, and GC is
+    // unconstrained, which is the behaviour when nothing registers a floor.
+    block_retention_floor_by_shard: HashMap<ShardId, u64>,
 }
 
 impl LocalWriteAheadLogStore {
@@ -289,6 +302,7 @@ impl LocalWriteAheadLogStore {
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
                 verified_len_by_shard: HashMap::new(),
+                block_retention_floor_by_shard: HashMap::new(),
             })),
             sync_coord: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -664,6 +678,30 @@ impl LocalWriteAheadLogStore {
         })
     }
 
+    /// Hold WAL reclaim at `sequence`: records at or above it may still be the only copy of a
+    /// block's bytes, so GC must not reclaim past it.
+    ///
+    /// Set this to the dump watermark and advance it as blocks are dumped into bands. Until a
+    /// shard registers a floor its GC is unconstrained, so this is inert for callers that do not
+    /// put blocks in the WAL.
+    pub fn set_block_retention_floor(&self, shard_id: ShardId, sequence: u64) {
+        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner.block_retention_floor_by_shard.insert(shard_id, sequence);
+    }
+
+    /// The shard's block-retention floor, if one is registered.
+    pub fn block_retention_floor(&self, shard_id: ShardId) -> Option<u64> {
+        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner.block_retention_floor_by_shard.get(&shard_id).copied()
+    }
+
+    /// Drop the shard's floor, letting GC reclaim freely again. Call this only once no block
+    /// resolves inside this shard's WAL.
+    pub fn clear_block_retention_floor(&self, shard_id: ShardId) {
+        let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        inner.block_retention_floor_by_shard.remove(&shard_id);
+    }
+
     pub fn gc_before_sequence(
         &self,
         shard_id: ShardId,
@@ -676,6 +714,7 @@ impl LocalWriteAheadLogStore {
             return Ok(WriteAheadLogGcReport {
                 shard_id,
                 retain_from_sequence,
+                effective_retain_from_sequence: retain_from_sequence,
                 ..WriteAheadLogGcReport::default()
             });
         }
@@ -690,6 +729,17 @@ impl LocalWriteAheadLogStore {
         // it. the zone-aligned wal Truncate always retains the tail zone holding the highest
         // sequence for exactly this continuity reason. Clamp the retain floor to keep the tail.
         let effective_retain = retain_from_sequence.min(last_sequence);
+        // Never reclaim past the block-retention floor. A record at or above it may carry the
+        // only copy of a block's bytes -- a block in the WAL has no copy in a band until it is
+        // dumped -- so removing it loses data that the served index still points at, and the
+        // read fails at some later, unrelated moment.
+        let floor = inner
+            .block_retention_floor_by_shard
+            .get(&shard_id)
+            .copied()
+            .unwrap_or(u64::MAX);
+        let clamped_by_block_retention = effective_retain > floor;
+        let effective_retain = effective_retain.min(floor);
         let file = File::open(&path)?;
         let reader = BufReader::new(file);
         let mut records_before = 0usize;
@@ -727,6 +777,8 @@ impl LocalWriteAheadLogStore {
             records_removed: records_before.saturating_sub(retained.len()),
             bytes_before,
             bytes_after,
+            effective_retain_from_sequence: effective_retain,
+            clamped_by_block_retention,
         })
     }
 
@@ -1656,5 +1708,155 @@ mod tests {
         assert_eq!(info.records, 2);
         assert_eq!(info.persistent_length_bytes, flush.persistent_bytes);
         assert_eq!(info.format_version, WRITE_AHEAD_LOG_FORMAT_VERSION);
+    }
+
+    // ---- block-retention floor -------------------------------------------------------------
+
+    /// Decode the shard's WAL the way GC does, so a test can assert on what survived.
+    fn sequences_on_disk(root: &std::path::Path, shard: ShardId) -> Vec<u64> {
+        let bytes = std::fs::read(write_ahead_log_path(root, shard)).unwrap();
+        bytes
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| decode_wal_line(line).unwrap().sequence)
+            .collect()
+    }
+
+    /// Byte offset at which each record starts, in order.
+    fn record_offsets_on_disk(root: &std::path::Path, shard: ShardId) -> Vec<usize> {
+        let bytes = std::fs::read(write_ahead_log_path(root, shard)).unwrap();
+        let mut offsets = vec![0usize];
+        for (index, byte) in bytes.iter().enumerate() {
+            if *byte == b'\n' && index + 1 < bytes.len() {
+                offsets.push(index + 1);
+            }
+        }
+        offsets
+    }
+
+    fn append_n(store: &LocalWriteAheadLogStore, shard: ShardId, count: usize) {
+        for index in 0..count {
+            store
+                .append(
+                    shard,
+                    Command::StringSet {
+                        key: format!("k{index}"),
+                        value: b"v".to_vec(),
+                    },
+                )
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn gc_is_unconstrained_when_no_block_retention_floor_is_registered() {
+        // The floor is opt-in: a caller that puts no blocks in the WAL must see the reclaim
+        // behaviour it had before the floor existed.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        append_n(&store, 1, 6);
+
+        assert_eq!(store.block_retention_floor(1), None);
+        let report = store.gc_before_sequence(1, 4).unwrap();
+
+        assert_eq!(report.records_before, 6);
+        assert_eq!(report.records_after, 3, "sequences 4, 5, 6 survive");
+        assert!(!report.clamped_by_block_retention);
+        assert_eq!(report.effective_retain_from_sequence, 4);
+    }
+
+    #[test]
+    fn gc_will_not_reclaim_past_the_block_retention_floor() {
+        // Records at or above the floor may hold the only copy of a block's bytes. Reclaiming
+        // them destroys data the served index still points at.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        append_n(&store, 1, 6);
+
+        store.set_block_retention_floor(1, 3);
+        let report = store.gc_before_sequence(1, 6).unwrap();
+
+        assert!(
+            report.clamped_by_block_retention,
+            "the reclaim asked to go past the floor and must report being held back"
+        );
+        assert_eq!(report.effective_retain_from_sequence, 3);
+        assert_eq!(report.records_after, 4, "sequences 3..=6 are retained");
+
+        // The retained records are the ones at and above the floor, in order.
+        assert_eq!(sequences_on_disk(dir.path(), 1), vec![3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn advancing_the_floor_lets_the_held_back_records_go() {
+        // The floor is the dump watermark: as blocks are dumped into bands the WAL stops being
+        // their only copy, and the records become reclaimable.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        append_n(&store, 1, 6);
+
+        store.set_block_retention_floor(1, 2);
+        assert_eq!(store.gc_before_sequence(1, 6).unwrap().records_after, 5);
+
+        store.set_block_retention_floor(1, 5);
+        let report = store.gc_before_sequence(1, 6).unwrap();
+        assert_eq!(report.effective_retain_from_sequence, 5);
+        assert_eq!(report.records_after, 2, "sequences 5 and 6");
+
+        store.clear_block_retention_floor(1);
+        assert_eq!(store.block_retention_floor(1), None);
+        let report = store.gc_before_sequence(1, 6).unwrap();
+        assert!(!report.clamped_by_block_retention);
+        assert_eq!(report.records_after, 1, "the tail record is always kept");
+    }
+
+    #[test]
+    fn the_floor_never_overrides_the_tail_retention_rule() {
+        // Clamping must compose with the existing rule that the highest-sequence record is
+        // never removed -- the WAL is the sequence generator on restart, so emptying it would
+        // restart sequencing at 1 and silently drop the re-used sequences on replay.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        append_n(&store, 1, 3);
+
+        store.set_block_retention_floor(1, u64::MAX);
+        let report = store.gc_before_sequence(1, u64::MAX).unwrap();
+
+        assert_eq!(report.records_after, 1, "the tail survives both clamps");
+        assert_eq!(report.effective_retain_from_sequence, 3);
+    }
+
+    #[test]
+    fn reclaim_moves_the_surviving_records_so_byte_offsets_are_not_stable() {
+        // This GC rewrites the file rather than dropping whole segments from the head, so
+        // removing a prefix shifts every surviving record down. Any address that names a record
+        // by its byte offset is therefore invalidated by a reclaim -- and the shifted offset
+        // still parses, as some other record, so nothing announces the error.
+        //
+        // This is why nothing addresses a block by its WAL offset yet: offset-stable reclaim
+        // needs the slab chain, where whole slabs leave the head and the survivors keep their
+        // absolute positions.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        append_n(&store, 1, 4);
+
+        let offsets_before = record_offsets_on_disk(dir.path(), 1);
+        let sequences_before = sequences_on_disk(dir.path(), 1);
+        assert_eq!(sequences_before, vec![1, 2, 3, 4]);
+        let tail_offset_before = *offsets_before.last().unwrap();
+
+        store.gc_before_sequence(1, 3).unwrap();
+
+        let offsets_after = record_offsets_on_disk(dir.path(), 1);
+        let sequences_after = sequences_on_disk(dir.path(), 1);
+        assert_eq!(sequences_after, vec![3, 4], "the prefix was reclaimed");
+
+        // Sequence 4 is the same record either way, but it no longer lives where it did.
+        let tail_offset_after = *offsets_after.last().unwrap();
+        assert_ne!(
+            tail_offset_before, tail_offset_after,
+            "reclaim shifted the surviving tail, so its byte offset is not a stable address"
+        );
+        assert!(tail_offset_after < tail_offset_before);
     }
 }


### PR DESCRIPTION
Two pieces of the block-in-WAL work — the descriptors it needs, and the reclaim guard that has to exist before any block is addressed into the WAL — plus a vocabulary fix on one config knob.

## Storage descriptors

`storage_descriptor.rs` completes the on-disk type set alongside `wal_record` and `index_log_record`:

- **`BlockHeader`** — the per-block descriptor, including `block_in_wal`, which records that a block's bytes are still in the WAL rather than in a band.
- **`SlabInfo` / `SlabHeader` / `BlockFooter`** — the segmented-stream layer. A stream is a chain of slabs; each slab header names the whole chain, so a reopen can rebuild from the last slab alone rather than scanning all of them, and the fixed-size blocks inside carry footers that make a torn tail detectable.
- **`StreamInfo` / `WalInfo`** — the runtime views a follower uses to adopt a leader's stream state without re-reading the stream.

These are inert: nothing constructs them yet, so no on-disk format changes here.

## Reclaim guard

A block written into the WAL has **no second copy** until it is dumped into a band. Reclaiming the record that carries it destroys the block, and the failure does not surface at reclaim time — it surfaces later, as an unrelated read error.

`set_block_retention_floor(shard, sequence)` holds reclaim at the dump watermark. `gc_before_sequence` clamps its retain floor to it, and the report now carries `effective_retain_from_sequence` and `clamped_by_block_retention` so the clamp is observable rather than silent.

The floor is opt-in. Until a shard registers one, reclaim behaves exactly as before, so this is inert for callers that put no blocks in the WAL. It also composes with the existing rule that the highest-sequence record is never removed, rather than overriding it.

## Why nothing addresses a block by its WAL offset yet

Worth flagging, because it changes the shape of the remaining work.

This GC **rewrites** the WAL file. Removing a prefix shifts every surviving record down, so a byte offset is not a stable address across a reclaim — and a shifted offset still parses, as some *other* record. That failure is silent, which is the bad kind.

The retention floor does not fix this. It stops live records being deleted; it does not stop the survivors from moving.

Offset-stable reclaim needs the slab chain, where whole slabs leave the head and the remaining slabs keep their absolute positions. That is what `SlabInfo::truncated_offset` is for, and it is the next step. `reclaim_moves_the_surviving_records_so_byte_offsets_are_not_stable` pins the current behaviour so this cannot be forgotten.

## Config knob rename

The index-dump gap knob measures undumped WAL length, so it is now named for it: `index_dump_wal_gap_bytes`, read from `TS_INDEX_DUMP_WAL_GAP_BYTES`.

**This is not a configuration change.** The previous environment variable name is still honoured as a fallback, so a deployment that sets it is unaffected, and precedence when both are set is defined rather than incidental.

## Testing

27 passing in the touched areas, including every pre-existing WAL test. New coverage:

- reclaim is unconstrained when no floor is registered — the no-regression case
- reclaim will not pass the floor, and reports being held back
- advancing the floor releases the held-back records
- the floor composes with the tail-retention rule rather than overriding it
- reclaim shifts surviving offsets — the blocker above, pinned
- the previous env name still configures the knob; the current name wins when both are set; neither falls back to the default

### Full-suite attribution

Full suite on this branch: **747 passed / 10 failed**. Pristine `main` at the same base: **736 passed / 11 failed**. Diffing the failing-test *name* sets rather than the counts:

- **8 fail on both** — pre-existing.
- **3 fail only on `main`** and pass here.
- **2 fail only here** — `raft::tests::part2::http_raft_transport_sends_append_vote_and_snapshot_over_tcp` and `raft::tests::part3::distributed_raft_chunks_large_sequence_add_under_default_entry_limit`. Both pass 3/3 run isolated single-threaded, so they are parallel/port-contention flakes.

The raft set being unstable in *both* directions is the signature of a flaky cluster rather than a regression. Test-count delta 759 − 749 = exactly the 10 tests added here.