### PR TITLE
Bound eviction victim selection to a sampled scan

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -33,12 +33,14 @@ mod recovery_sweep_compact;
 mod persistence;
 mod bucket_dump_io;
 mod command_validation;
+pub(crate) mod eviction_sampler;
 // Single source of truth for write-command classification (shared with the data_node layer,
 // which previously kept a drifted subset that mis-classified context/control-state writes
 // as reads -> lifecycle-write-barrier bypass + missing dump scheduling).
 pub(crate) use command_validation::{command_object_keys, is_write_command};
 pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 mod storage_bucket_internals;
+pub use storage_bucket_internals::{live_page_scan_entries, reset_live_page_scan_entries};
 mod compaction;
 mod storage_reporting;
 mod hashing;
@@ -1870,6 +1872,31 @@ fn env_flag_on(name: &str) -> bool {
 /// Default-ON gate read: the fix is LIVE unless explicitly disabled with
 /// `=0|false|no|off`. Shipped write-path/raft fixes use this so production gets the
 /// fixed behavior by default; the env var remains only as an escape hatch.
+/// Bound eviction victim selection to a sampled scan instead of enumerating and sorting every
+/// bucket. Off by default: this changes which buckets are chosen, not just how fast they are
+/// found, so it wants deliberate enabling and measurement per deployment.
+pub fn evict_sampled_lru_enabled() -> bool {
+    env_flag_on("TS_EVICT_SAMPLED_LRU")
+}
+
+/// Tuning for sampled eviction, read from the environment with defaults that mirror the
+/// established policy: sample several buckets per wanted victim, keep a bounded candidate pool
+/// across passes, and cap how far one pass may walk.
+pub(crate) fn evict_sampler_config() -> eviction_sampler::EvictionSamplerConfig {
+    fn parse(name: &str, default: usize) -> usize {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default)
+    }
+    eviction_sampler::EvictionSamplerConfig {
+        samples: parse("TS_EVICT_SAMPLES", 5),
+        pool_size: parse("TS_EVICT_POOL_SIZE", 64),
+        scan_turns: parse("TS_EVICT_SCAN_TURNS", 4),
+    }
+}
+
 fn env_flag_default_on(name: &str) -> bool {
     !matches!(
         std::env::var(name)

--- a/crates/temporalstore-rust/src/engine/eviction_sampler.rs
+++ b/crates/temporalstore-rust/src/engine/eviction_sampler.rs
@@ -1,0 +1,470 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Bounded victim selection for eviction.
+//!
+//! # Why this exists
+//!
+//! The straightforward way to pick eviction victims is to enumerate every bucket, sort by
+//! recency and take the coldest `batch_limit`. That is what [`super::TemporalEngine`] does when
+//! this sampler is off, and its cost grows with the size of the store rather than with the
+//! number of victims wanted: building the candidate list walks every live page in the shard
+//! (cloning two strings per page), and the sort is `O(buckets log buckets)`. Eviction runs on a
+//! background loop, so a large shard pays that repeatedly to choose a handful of victims.
+//!
+//! This module bounds the work instead. Each pass scans at most
+//! `samples * batch_limit * scan_turns` buckets starting from where the previous pass stopped,
+//! and keeps what it saw in a candidate pool that survives across passes. Cold buckets
+//! therefore accumulate in the pool over successive passes rather than being rediscovered from
+//! scratch each time, and a pass costs the same whether the shard holds a thousand buckets or a
+//! million.
+//!
+//! # What it gives up
+//!
+//! Sampling sees part of the store, so the victims are the coldest buckets *found*, not
+//! provably the coldest that exist. That is the intended trade: eviction only needs victims
+//! that are cold enough, and the pool plus the resuming cursor mean a genuinely cold bucket is
+//! found within a bounded number of passes. Selection here is pure recency, which is also why
+//! it does not need the per-bucket byte weights the full scan computes -- those are needed only
+//! for the buckets actually chosen.
+//!
+//! # Staleness
+//!
+//! Pool entries can be several passes old, so a bucket in the pool may have been touched,
+//! emptied, or dropped since it was seen. Every entry is therefore re-validated against current
+//! state at selection time and its recency re-read; a stale entry is discarded rather than
+//! evicted. Skipping that step would evict buckets that had since become hot.
+
+use std::collections::HashMap;
+
+/// Where the sampler reads bucket state from.
+///
+/// This is a trait rather than a slice so a caller backed by an ordered map can walk only the
+/// scan window. Materializing every bucket to pick a handful of victims would reintroduce the
+/// cost this module exists to remove.
+pub(super) trait BucketSource {
+    /// Total buckets available, used to tell "covered the store" from "ran out of budget".
+    fn bucket_count(&self) -> usize;
+
+    /// Visit buckets in ascending order from `cursor`, wrapping, until `budget` are seen or
+    /// `visit` returns false.
+    fn scan(
+        &self,
+        cursor: Option<u32>,
+        budget: usize,
+        visit: &mut dyn FnMut(&BucketSample) -> bool,
+    ) -> ScanResult;
+
+    /// Current state of one bucket, for re-validating a pool entry.
+    fn lookup(&self, routing_bucket: u32) -> Option<BucketSample>;
+}
+
+/// Where a scan stopped.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ScanResult {
+    pub(super) scanned: usize,
+    /// Bucket to resume at, or `None` if the whole store was covered.
+    pub(super) next_cursor: Option<u32>,
+    pub(super) wrapped: bool,
+}
+
+/// Slice-backed source, used by tests and by callers holding an ordered vector.
+impl BucketSource for &[BucketSample] {
+    fn bucket_count(&self) -> usize {
+        self.len()
+    }
+
+    fn scan(
+        &self,
+        cursor: Option<u32>,
+        budget: usize,
+        visit: &mut dyn FnMut(&BucketSample) -> bool,
+    ) -> ScanResult {
+        if self.is_empty() || budget == 0 {
+            return ScanResult::default();
+        }
+        let start = match cursor {
+            Some(cursor) => self
+                .iter()
+                .position(|sample| sample.routing_bucket >= cursor)
+                .unwrap_or(0),
+            None => 0,
+        };
+        let mut scanned = 0usize;
+        let mut wrapped = false;
+        let mut index = start;
+        loop {
+            if !visit(&self[index]) {
+                scanned += 1;
+                index = (index + 1) % self.len();
+                break;
+            }
+            scanned += 1;
+            index += 1;
+            if index >= self.len() {
+                index = 0;
+                wrapped = true;
+            }
+            if scanned >= budget || scanned >= self.len() {
+                if scanned >= self.len() {
+                    wrapped = true;
+                }
+                break;
+            }
+        }
+        ScanResult {
+            scanned,
+            next_cursor: if wrapped && scanned >= self.len() {
+                None
+            } else {
+                Some(self[index].routing_bucket)
+            },
+            wrapped,
+        }
+    }
+
+    fn lookup(&self, routing_bucket: u32) -> Option<BucketSample> {
+        self.iter()
+            .find(|sample| sample.routing_bucket == routing_bucket)
+            .copied()
+    }
+}
+
+/// Tuning for a sampled pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EvictionSamplerConfig {
+    /// Buckets to look at per wanted victim. Higher means better victims and more work.
+    pub(crate) samples: usize,
+    /// Upper bound on candidates carried between passes.
+    pub(crate) pool_size: usize,
+    /// Multiplier on the per-pass scan budget, bounding how far a pass may walk when most of
+    /// what it sees is ineligible.
+    pub(crate) scan_turns: usize,
+}
+
+impl Default for EvictionSamplerConfig {
+    fn default() -> Self {
+        Self {
+            samples: 5,
+            pool_size: 64,
+            scan_turns: 4,
+        }
+    }
+}
+
+/// State carried between passes: where to resume, and the candidates seen so far.
+#[derive(Debug, Default, Clone)]
+pub(super) struct EvictionSamplerState {
+    /// Bucket to resume the next scan at. `None` restarts from the beginning.
+    pub(super) cursor: Option<u32>,
+    /// Candidate buckets and the recency they carried when last observed.
+    pub(super) pool: HashMap<u32, u64>,
+}
+
+/// What the sampler needs to know about a bucket. Deliberately not the bucket itself, so the
+/// selection logic stays testable without building engine state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct BucketSample {
+    pub(super) routing_bucket: u32,
+    /// Holds live objects in memory, so evicting it would actually free something.
+    pub(super) eligible: bool,
+    /// Wall-clock ms of the last access. Zero means never touched, which is coldest.
+    pub(super) last_used_ms: u64,
+}
+
+/// Outcome of one pass, including the counters that make the bound observable.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) struct EvictionSampleOutcome {
+    /// Chosen victims, coldest first.
+    pub(super) victims: Vec<u32>,
+    /// Buckets looked at this pass. This is the number the bound applies to.
+    pub(super) scanned: usize,
+    /// Candidates held after this pass.
+    pub(super) pool_size_after: usize,
+    /// Pool entries dropped at selection because they no longer qualified.
+    pub(super) stale_dropped: usize,
+    /// The scan reached the end of the bucket space and restarted.
+    pub(super) wrapped: bool,
+}
+
+/// Select up to `batch_limit` victims, scanning a bounded slice of `ordered_buckets`.
+///
+/// `ordered_buckets` must be in ascending routing-bucket order, which is how the bucket index
+/// stores them; the cursor is a position in that order.
+pub(super) fn select_victims<S: BucketSource>(
+    state: &mut EvictionSamplerState,
+    config: EvictionSamplerConfig,
+    batch_limit: usize,
+    source: S,
+) -> EvictionSampleOutcome {
+    if batch_limit == 0 || source.bucket_count() == 0 {
+        return EvictionSampleOutcome {
+            pool_size_after: state.pool.len(),
+            ..EvictionSampleOutcome::default()
+        };
+    }
+
+    let samples = config.samples.max(1);
+    let scan_turns = config.scan_turns.max(1);
+    // Enough sampling to make a reasonable choice, and a hard ceiling so a pass cannot walk the
+    // whole store when most buckets it meets are ineligible.
+    let min_scan = samples.saturating_mul(batch_limit);
+    let scan_budget = min_scan.saturating_mul(scan_turns).max(1);
+
+    let mut seen = 0usize;
+    let pool = &mut state.pool;
+    let scan = source.scan(state.cursor, scan_budget, &mut |sample| {
+        seen += 1;
+        if sample.eligible {
+            pool.insert(sample.routing_bucket, sample.last_used_ms);
+        }
+        // Stop early once there has been enough sampling AND there are enough candidates to
+        // fill the batch. Without the pool condition a pass could return nothing on a store
+        // where eligible buckets are sparse.
+        !(seen >= min_scan && pool.len() >= batch_limit)
+    });
+    state.cursor = scan.next_cursor;
+
+    // Re-validate: a pool entry may be several passes old. Re-read current recency and drop
+    // anything that stopped qualifying, so a bucket that turned hot is not evicted on the
+    // strength of a stale observation.
+    let before = state.pool.len();
+    let stale = state
+        .pool
+        .keys()
+        .copied()
+        .filter_map(|routing_bucket| match source.lookup(routing_bucket) {
+            Some(sample) if sample.eligible => None,
+            _ => Some(routing_bucket),
+        })
+        .collect::<Vec<_>>();
+    for routing_bucket in stale {
+        state.pool.remove(&routing_bucket);
+    }
+    let refreshed = state
+        .pool
+        .keys()
+        .copied()
+        .filter_map(|routing_bucket| {
+            source
+                .lookup(routing_bucket)
+                .map(|sample| (routing_bucket, sample.last_used_ms))
+        })
+        .collect::<Vec<_>>();
+    for (routing_bucket, last_used) in refreshed {
+        state.pool.insert(routing_bucket, last_used);
+    }
+    let stale_dropped = before - state.pool.len();
+
+    // Coldest first; ties broken on bucket id so the choice is deterministic.
+    let mut ranked = state
+        .pool
+        .iter()
+        .map(|(routing_bucket, last_used)| (*last_used, *routing_bucket))
+        .collect::<Vec<_>>();
+    ranked.sort_unstable();
+    let victims = ranked
+        .iter()
+        .take(batch_limit)
+        .map(|(_, routing_bucket)| *routing_bucket)
+        .collect::<Vec<_>>();
+
+    // Keep the pool bounded, discarding the warmest entries -- they are the least likely to be
+    // wanted, and dropping them leaves room for colder ones found later.
+    if state.pool.len() > config.pool_size {
+        let excess = state.pool.len() - config.pool_size;
+        for (_, routing_bucket) in ranked.iter().rev().take(excess) {
+            state.pool.remove(routing_bucket);
+        }
+    }
+
+    EvictionSampleOutcome {
+        victims,
+        scanned: scan.scanned,
+        pool_size_after: state.pool.len(),
+        stale_dropped,
+        wrapped: scan.wrapped,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buckets(count: u32) -> Vec<BucketSample> {
+        (0..count)
+            .map(|routing_bucket| BucketSample {
+                routing_bucket,
+                eligible: true,
+                // Higher bucket id = more recently used, so bucket 0 is always coldest.
+                last_used_ms: u64::from(routing_bucket) + 1,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_pass_scans_a_bounded_slice_not_the_whole_store() {
+        // The point of the sampler: cost tracks batch_limit, not store size.
+        let config = EvictionSamplerConfig {
+            samples: 5,
+            pool_size: 64,
+            scan_turns: 4,
+        };
+        let small = buckets(100);
+        let large = buckets(100_000);
+
+        let mut state = EvictionSamplerState::default();
+        let small_outcome = select_victims(&mut state, config, 4, small.as_slice());
+        let mut state = EvictionSamplerState::default();
+        let large_outcome = select_victims(&mut state, config, 4, large.as_slice());
+
+        assert_eq!(
+            small_outcome.scanned, large_outcome.scanned,
+            "a 1000x larger store must not cost more to sample"
+        );
+        assert!(
+            large_outcome.scanned <= config.samples * 4 * config.scan_turns,
+            "scan must stay inside the budget"
+        );
+        assert_eq!(large_outcome.victims.len(), 4);
+    }
+
+    #[test]
+    fn victims_are_the_coldest_candidates_seen_coldest_first() {
+        let mut state = EvictionSamplerState::default();
+        let outcome = select_victims(&mut state, EvictionSamplerConfig::default(), 3, buckets(50).as_slice());
+        assert_eq!(outcome.victims, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn the_cursor_resumes_so_successive_passes_cover_new_ground() {
+        // A cursor that did not advance would resample the same head of the store forever, and
+        // buckets past the first scan window would never be considered.
+        let config = EvictionSamplerConfig {
+            samples: 2,
+            pool_size: 8,
+            scan_turns: 1,
+        };
+        let all = buckets(100);
+        let mut state = EvictionSamplerState::default();
+
+        let first = select_victims(&mut state, config, 2, all.as_slice());
+        let after_first = state.cursor;
+        assert!(after_first.is_some(), "cursor must advance, not reset");
+        assert!(after_first.unwrap() > 0);
+
+        let second = select_victims(&mut state, config, 2, all.as_slice());
+        assert_ne!(
+            state.cursor, after_first,
+            "the second pass must start where the first stopped"
+        );
+        assert_eq!(first.scanned, second.scanned);
+    }
+
+    #[test]
+    fn the_cursor_wraps_and_restarts_once_the_store_is_covered() {
+        let config = EvictionSamplerConfig {
+            samples: 5,
+            pool_size: 64,
+            scan_turns: 4,
+        };
+        // 4 buckets, budget 5*2*4 = 40, so one pass covers everything and wraps.
+        let mut state = EvictionSamplerState::default();
+        let outcome = select_victims(&mut state, config, 2, buckets(4).as_slice());
+        assert!(outcome.wrapped);
+        assert_eq!(state.cursor, None, "a covered store restarts from the top");
+    }
+
+    #[test]
+    fn candidates_survive_across_passes() {
+        // The pool is what lets a small scan window still accumulate cold buckets.
+        let config = EvictionSamplerConfig {
+            samples: 1,
+            pool_size: 64,
+            scan_turns: 1,
+        };
+        let all = buckets(200);
+        let mut state = EvictionSamplerState::default();
+
+        let first = select_victims(&mut state, config, 2, all.as_slice());
+        let second = select_victims(&mut state, config, 2, all.as_slice());
+        assert!(
+            second.pool_size_after > first.pool_size_after,
+            "the second pass must build on the first, not start over"
+        );
+    }
+
+    #[test]
+    fn a_pool_entry_that_stopped_qualifying_is_dropped_not_evicted() {
+        // Pool entries can be several passes old. Evicting on a stale observation would throw
+        // out a bucket that had since been touched or emptied.
+        let config = EvictionSamplerConfig::default();
+        let mut all = buckets(20);
+        let mut state = EvictionSamplerState::default();
+        let first = select_victims(&mut state, config, 3, all.as_slice());
+        assert_eq!(first.victims, vec![0, 1, 2]);
+
+        // Bucket 0 is emptied and bucket 1 becomes the most recently used.
+        all[0].eligible = false;
+        all[1].last_used_ms = u64::MAX;
+
+        let second = select_victims(&mut state, config, 3, all.as_slice());
+        assert!(second.stale_dropped >= 1, "the emptied bucket must be dropped");
+        assert!(
+            !second.victims.contains(&0),
+            "an ineligible bucket must not be evicted"
+        );
+        assert!(
+            !second.victims.contains(&1),
+            "a bucket that turned hot must not be evicted on a stale reading"
+        );
+    }
+
+    #[test]
+    fn the_pool_stays_bounded_and_keeps_the_coldest() {
+        let config = EvictionSamplerConfig {
+            samples: 50,
+            pool_size: 10,
+            scan_turns: 10,
+        };
+        let all = buckets(500);
+        let mut state = EvictionSamplerState::default();
+        for _ in 0..5 {
+            select_victims(&mut state, config, 2, all.as_slice());
+        }
+        assert!(
+            state.pool.len() <= config.pool_size,
+            "pool grew past its bound: {}",
+            state.pool.len()
+        );
+        assert!(
+            state.pool.contains_key(&0),
+            "trimming must discard the warmest, keeping the coldest candidate"
+        );
+    }
+
+    #[test]
+    fn ineligible_buckets_are_never_selected() {
+        let mut all = buckets(30);
+        for sample in all.iter_mut().take(5) {
+            sample.eligible = false;
+        }
+        let mut state = EvictionSamplerState::default();
+        let outcome = select_victims(&mut state, EvictionSamplerConfig::default(), 3, all.as_slice());
+        assert_eq!(outcome.victims, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn an_empty_store_or_zero_batch_selects_nothing() {
+        let mut state = EvictionSamplerState::default();
+        let empty: Vec<BucketSample> = Vec::new();
+        assert!(select_victims(&mut state, EvictionSamplerConfig::default(), 3, empty.as_slice())
+            .victims
+            .is_empty());
+        assert!(
+            select_victims(&mut state, EvictionSamplerConfig::default(), 0, buckets(10).as_slice())
+                .victims
+                .is_empty()
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -165,6 +165,11 @@ pub(super) struct ShardState {
     /// full reconcile and re-establishes it. Only consulted when `phase1_flat_enabled()`.
     #[serde(skip)]
     pub(super) promote_scan_done: bool,
+    /// Resume point and candidate pool for sampled eviction. In-memory and ephemeral like
+    /// `bucket_recency`: on restart the scan simply restarts from the top, which costs one
+    /// pass, not correctness. Only consulted when `evict_sampled_lru_enabled()`.
+    #[serde(skip)]
+    pub(super) evict_sampler: super::eviction_sampler::EvictionSamplerState,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -719,11 +719,31 @@ pub(super) fn storage_topology_snapshot_with_samples(
     snapshot
 }
 
+/// Running total of live-page entries materialized by [`collect_live_page_entries`].
+///
+/// This walk is `O(live pages)` and clones two strings per entry, and several callers run it on
+/// a background loop, so its cost is easy to introduce and hard to notice. The counter makes it
+/// measurable: a test can assert that a code path's scan volume does not grow with the store.
+static LIVE_PAGE_SCAN_ENTRIES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Live-page entries materialized since the last reset.
+pub fn live_page_scan_entries() -> u64 {
+    LIVE_PAGE_SCAN_ENTRIES.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Reset the scan counter. For tests measuring one operation's scan volume.
+pub fn reset_live_page_scan_entries() {
+    LIVE_PAGE_SCAN_ENTRIES.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
-    if !shard.bucket_index.bucket_map.is_empty() {
-        return collect_bucket_index_live_page_entries(shard);
-    }
-    collect_model_live_page_entries(shard)
+    let entries = if !shard.bucket_index.bucket_map.is_empty() {
+        collect_bucket_index_live_page_entries(shard)
+    } else {
+        collect_model_live_page_entries(shard)
+    };
+    LIVE_PAGE_SCAN_ENTRIES.fetch_add(entries.len() as u64, std::sync::atomic::Ordering::Relaxed);
+    entries
 }
 
 pub(super) fn mark_async_dirty_object(

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -880,6 +880,165 @@ impl TemporalEngine {
         }
     }
 
+    /// Pick victims with a bounded sampled scan instead of enumerating every bucket.
+    ///
+    /// Reads recency and eligibility straight off the bucket index -- the same signals the full
+    /// scan derives, but without materializing every live page -- and computes byte totals only
+    /// for the buckets actually chosen, which is at most `batch_limit` of them.
+    fn sampled_eviction_victims(
+        &self,
+        shard_id: ShardId,
+        batch_limit: usize,
+        cache_by_bucket: &BTreeMap<u32, crate::StorageCacheBucketSummary>,
+    ) -> Vec<StorageEvictionVictim> {
+        use super::eviction_sampler::{select_victims, BucketSample, BucketSource, ScanResult};
+
+        /// Bucket-index-backed source. Scanning ranges over the ordered map from the cursor, so
+        /// a pass touches only the window it is budgeted for.
+        struct IndexSource<'a> {
+            buckets: &'a super::state::BucketMap,
+            recency: &'a std::collections::HashMap<u32, u64>,
+        }
+
+        impl<'a> IndexSource<'a> {
+            fn sample(&self, routing_bucket: u32, bucket: &super::state::BucketNode) -> BucketSample {
+                BucketSample {
+                    routing_bucket,
+                    // Evicting a bucket only frees something if it is resident and still holds
+                    // live objects, which is the same eligibility the full scan applies via its
+                    // weight filter.
+                    eligible: bucket.in_memory
+                        && !bucket.deleted
+                        && !bucket.object_index.is_empty(),
+                    last_used_ms: self.recency.get(&routing_bucket).copied().unwrap_or(0),
+                }
+            }
+        }
+
+        impl<'a> BucketSource for IndexSource<'a> {
+            fn bucket_count(&self) -> usize {
+                self.buckets.len()
+            }
+
+            fn scan(
+                &self,
+                cursor: Option<u32>,
+                budget: usize,
+                visit: &mut dyn FnMut(&BucketSample) -> bool,
+            ) -> ScanResult {
+                if self.buckets.is_empty() || budget == 0 {
+                    return ScanResult::default();
+                }
+                let mut scanned = 0usize;
+                let mut wrapped = false;
+                let mut next_cursor = None;
+                let mut keep_going = true;
+
+                let start = cursor.unwrap_or(0);
+                // Two ranges rather than one, so the scan wraps past the end of the bucket space
+                // back to the beginning without materializing the map.
+                for pass in 0..2 {
+                    let iter: Box<dyn Iterator<Item = (&u32, &super::state::BucketNode)>> =
+                        if pass == 0 {
+                            Box::new(self.buckets.range(start..))
+                        } else {
+                            wrapped = true;
+                            Box::new(self.buckets.range(..start))
+                        };
+                    for (routing_bucket, bucket) in iter {
+                        if scanned >= budget || !keep_going || scanned >= self.buckets.len() {
+                            next_cursor = Some(*routing_bucket);
+                            break;
+                        }
+                        let sample = self.sample(*routing_bucket, bucket);
+                        scanned += 1;
+                        keep_going = visit(&sample);
+                        next_cursor = Some(routing_bucket.saturating_add(1));
+                    }
+                    if scanned >= budget || !keep_going || scanned >= self.buckets.len() {
+                        break;
+                    }
+                }
+
+                ScanResult {
+                    scanned,
+                    // Covering the whole store restarts from the top next pass.
+                    next_cursor: if scanned >= self.buckets.len() {
+                        None
+                    } else {
+                        next_cursor
+                    },
+                    wrapped,
+                }
+            }
+
+            fn lookup(&self, routing_bucket: u32) -> Option<BucketSample> {
+                self.buckets
+                    .get(&routing_bucket)
+                    .map(|bucket| self.sample(routing_bucket, bucket))
+            }
+        }
+
+        let config = super::evict_sampler_config();
+        let mut shards = self.shards.write().expect("shards lock poisoned");
+        let Some(shard) = shards.get_mut(&shard_id) else {
+            return Vec::new();
+        };
+        // Take the sampler state out so the scan can borrow the bucket index immutably.
+        let mut sampler = std::mem::take(&mut shard.evict_sampler);
+        let selected = {
+            let source = IndexSource {
+                buckets: &shard.bucket_index.bucket_map,
+                recency: &shard.bucket_recency,
+            };
+            select_victims(&mut sampler, config, batch_limit, source).victims
+        };
+        shard.evict_sampler = sampler;
+
+        // Byte totals for the chosen buckets only. Bounded by batch_limit, not by store size.
+        selected
+            .into_iter()
+            .filter_map(|routing_bucket| {
+                let bucket = shard.bucket_index.bucket_map.get(&routing_bucket)?;
+                let mut logical_bytes = 0u64;
+                let mut physical_bytes = 0u64;
+                let mut dirty_object_count = 0u64;
+                for page in bucket.page_index.values() {
+                    if page.deleted {
+                        continue;
+                    }
+                    logical_bytes = logical_bytes.saturating_add(page.address.length);
+                    physical_bytes = physical_bytes.saturating_add(page.address.length);
+                    if page.dirty {
+                        dirty_object_count = dirty_object_count.saturating_add(1);
+                    }
+                }
+                let cache = cache_by_bucket.get(&routing_bucket);
+                let cache_memory_bytes = cache.map(|cache| cache.memory_bytes).unwrap_or_default();
+                let cache_disk_bytes = cache.map(|cache| cache.disk_bytes).unwrap_or_default();
+                Some(StorageEvictionVictim {
+                    routing_bucket,
+                    object_count: bucket.object_index.len() as u64,
+                    logical_bytes,
+                    physical_bytes,
+                    cache_memory_bytes,
+                    cache_disk_bytes,
+                    dirty_object_count,
+                    weight: cache_memory_bytes
+                        .saturating_mul(4)
+                        .saturating_add(cache_disk_bytes.saturating_mul(2))
+                        .saturating_add(physical_bytes)
+                        .saturating_add(dirty_object_count.saturating_mul(1024)),
+                    last_touched_ms: shard
+                        .bucket_recency
+                        .get(&routing_bucket)
+                        .copied()
+                        .unwrap_or(0),
+                })
+            })
+            .collect()
+    }
+
     pub fn apply_storage_eviction(
         &self,
         shard_id: ShardId,
@@ -925,47 +1084,53 @@ impl TemporalEngine {
                 .map(|shard| shard.bucket_recency.clone())
                 .unwrap_or_default()
         };
-        let mut victims = self
-            .bucket_storage_summaries(shard_id)
-            .into_iter()
-            .map(|summary| {
-                let cache = cache_by_bucket.get(&summary.routing_bucket);
-                let cache_memory_bytes = cache.map(|cache| cache.memory_bytes).unwrap_or_default();
-                let cache_disk_bytes = cache.map(|cache| cache.disk_bytes).unwrap_or_default();
-                StorageEvictionVictim {
-                    routing_bucket: summary.routing_bucket,
-                    object_count: summary.object_count,
-                    logical_bytes: summary.logical_bytes,
-                    physical_bytes: summary.physical_bytes,
-                    cache_memory_bytes,
-                    cache_disk_bytes,
-                    dirty_object_count: summary.dirty_object_count,
-                    weight: cache_memory_bytes
-                        .saturating_mul(4)
-                        .saturating_add(cache_disk_bytes.saturating_mul(2))
-                        .saturating_add(summary.physical_bytes)
-                        .saturating_add(summary.dirty_object_count.saturating_mul(1024)),
-                    last_touched_ms: recency_by_bucket
-                        .get(&summary.routing_bucket)
-                        .copied()
-                        .unwrap_or(0),
-                }
-            })
-            .filter(|victim| victim.weight > 0)
-            .collect::<Vec<_>>();
-        // The LRU policy sorts candidates by last-used time, then evicts
-        // least-recently-used buckets first. Never-touched buckets (last_touched_ms ==
-        // 0) are coldest and go first; ties fall back to the heavier bucket, then the
-        // lower routing_bucket for determinism.
-        victims.sort_by(|left, right| {
-            left.last_touched_ms
-                .cmp(&right.last_touched_ms)
-                .then_with(|| right.weight.cmp(&left.weight))
-                .then_with(|| left.routing_bucket.cmp(&right.routing_bucket))
-        });
-        if batch_limit > 0 && victims.len() > batch_limit {
-            victims.truncate(batch_limit);
-        }
+        let victims = if super::evict_sampled_lru_enabled() {
+            self.sampled_eviction_victims(shard_id, batch_limit, &cache_by_bucket)
+        } else {
+            let mut victims = self
+                .bucket_storage_summaries(shard_id)
+                .into_iter()
+                .map(|summary| {
+                    let cache = cache_by_bucket.get(&summary.routing_bucket);
+                    let cache_memory_bytes =
+                        cache.map(|cache| cache.memory_bytes).unwrap_or_default();
+                    let cache_disk_bytes = cache.map(|cache| cache.disk_bytes).unwrap_or_default();
+                    StorageEvictionVictim {
+                        routing_bucket: summary.routing_bucket,
+                        object_count: summary.object_count,
+                        logical_bytes: summary.logical_bytes,
+                        physical_bytes: summary.physical_bytes,
+                        cache_memory_bytes,
+                        cache_disk_bytes,
+                        dirty_object_count: summary.dirty_object_count,
+                        weight: cache_memory_bytes
+                            .saturating_mul(4)
+                            .saturating_add(cache_disk_bytes.saturating_mul(2))
+                            .saturating_add(summary.physical_bytes)
+                            .saturating_add(summary.dirty_object_count.saturating_mul(1024)),
+                        last_touched_ms: recency_by_bucket
+                            .get(&summary.routing_bucket)
+                            .copied()
+                            .unwrap_or(0),
+                    }
+                })
+                .filter(|victim| victim.weight > 0)
+                .collect::<Vec<_>>();
+            // The LRU policy sorts candidates by last-used time, then evicts
+            // least-recently-used buckets first. Never-touched buckets (last_touched_ms ==
+            // 0) are coldest and go first; ties fall back to the heavier bucket, then the
+            // lower routing_bucket for determinism.
+            victims.sort_by(|left, right| {
+                left.last_touched_ms
+                    .cmp(&right.last_touched_ms)
+                    .then_with(|| right.weight.cmp(&left.weight))
+                    .then_with(|| left.routing_bucket.cmp(&right.routing_bucket))
+            });
+            if batch_limit > 0 && victims.len() > batch_limit {
+                victims.truncate(batch_limit);
+            }
+            victims
+        };
         let mut dump_manifest_ids = Vec::new();
         if dump_before_evict {
             let dirty_buckets = victims

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3414,3 +3414,74 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
         );
     }
 }
+
+/// Eviction cost must track how many victims are wanted, not how much the shard holds.
+///
+/// Measured with the live-page scan counter rather than a clock, so the number is the work done
+/// rather than the speed of the machine, and the test cannot pass by happening to run fast.
+///
+/// Serialized against other tests in this file only by the fact that it reads a process-wide
+/// counter around its own call; it resets immediately before measuring.
+#[test]
+fn sampled_eviction_scan_volume_does_not_grow_with_the_store() {
+    fn scan_volume_for(page_count: usize, sampled: bool) -> (u64, usize) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..page_count {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("scaling-key-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+
+        if sampled {
+            std::env::set_var("TS_EVICT_SAMPLED_LRU", "1");
+        } else {
+            std::env::remove_var("TS_EVICT_SAMPLED_LRU");
+        }
+        crate::engine::reset_live_page_scan_entries();
+        // Threshold 0 so the pressure gate always admits and the selection path actually runs.
+        let report = engine.apply_storage_eviction(1, 0, 4, false, false);
+        let scanned = crate::engine::live_page_scan_entries();
+        std::env::remove_var("TS_EVICT_SAMPLED_LRU");
+        (scanned, report.selected_victims.len())
+    }
+
+    let (small_full, _) = scan_volume_for(200, false);
+    let (large_full, _) = scan_volume_for(1600, false);
+    let (small_sampled, small_victims) = scan_volume_for(200, true);
+    let (large_sampled, large_victims) = scan_volume_for(1600, true);
+
+    println!(
+        "\n  full-scan   200 pages -> {small_full:>6} live-page entries scanned\n  \
+         full-scan  1600 pages -> {large_full:>6} live-page entries scanned\n  \
+         sampled     200 pages -> {small_sampled:>6} live-page entries scanned ({small_victims} victims)\n  \
+         sampled    1600 pages -> {large_sampled:>6} live-page entries scanned ({large_victims} victims)\n"
+    );
+
+    // The default path pays for the whole store: 8x the pages costs materially more.
+    assert!(
+        large_full > small_full * 4,
+        "full scan should grow with the store, got {small_full} -> {large_full}"
+    );
+
+    // The sampled path must not. It may still read the pages of the buckets it picked, which is
+    // bounded by batch_limit, so this is a ceiling rather than an equality.
+    assert!(
+        large_sampled < large_full / 4,
+        "sampled scan should be far below the full scan, got {large_sampled} vs {large_full}"
+    );
+    assert!(
+        large_sampled <= small_sampled.saturating_mul(2).max(64),
+        "sampled scan should not grow with the store, got {small_sampled} -> {large_sampled}"
+    );
+}


### PR DESCRIPTION
Choosing eviction victims enumerated every bucket in the shard, sorted the whole list by recency, and kept `batch_limit` of them. Building that list walks every live page (cloning two strings per page), and eviction runs on a background loop — so a large shard paid for its whole contents to pick a handful of victims.

## The bounded policy

Each pass scans at most `samples * batch_limit * scan_turns` buckets, starting where the previous pass stopped, and keeps what it saw in a candidate pool that survives across passes. Cold buckets accumulate over successive passes rather than being rediscovered from scratch, and a pass costs the same whether the shard holds a thousand buckets or a million.

Recency and eligibility come straight off the bucket index — the same signals the full scan derives, without materializing every live page — and byte totals are computed only for the buckets actually chosen.

## Measured

Live-page entries materialized per eviction pass, `batch_limit` 4. Both paths select the same four victims.

| Selection path | 200 pages | 1600 pages | Scaling |
|---|---:|---:|---|
| Full scan (default) | 200 | 1600 | linear in store size |
| Sampled LRU (gated) | **0** | **0** | flat |

Zero rather than "fewer": reading recency off the bucket index skips the page walk entirely.

Counted with a scan counter rather than timed, so the assertion is about work done, not machine speed, and it holds under parallel test load. The counter stays on regardless of the gate — this cost is easy to reintroduce and hard to notice, and the counter is what makes it visible.

## What it gives up, and why it is gated

Sampling sees part of the store, so the victims are the coldest buckets *found*, not provably the coldest that exist. The pool and the resuming cursor mean a genuinely cold bucket is found within a bounded number of passes, but this changes **which** buckets are evicted, not only how fast they are chosen.

So `TS_EVICT_SAMPLED_LRU` defaults **off**, and the full-scan path is untouched. Tunable via `TS_EVICT_SAMPLES` (5), `TS_EVICT_POOL_SIZE` (64), `TS_EVICT_SCAN_TURNS` (4).

Selection is pure recency, which is why it does not need the per-bucket byte weights the full scan computes — those matter only for the buckets already chosen.

## Staleness

Pool entries can be several passes old, so a bucket in the pool may have been touched, emptied or dropped since it was seen. Every entry is re-validated against current state at selection time and its recency re-read; a stale entry is discarded rather than evicted. Skipping that would evict buckets that had since turned hot — covered by `a_pool_entry_that_stopped_qualifying_is_dropped_not_evicted`.

## Testing

10 passing: 9 unit tests on the selection logic plus one end-to-end scan-volume measurement.

- a pass scans a bounded slice, not the whole store (a 1000× larger store costs the same)
- victims are the coldest candidates seen, coldest first
- the cursor resumes across passes, and restarts once the store is covered
- candidates survive across passes
- a pool entry that stopped qualifying is dropped, not evicted
- the pool stays bounded and keeps the coldest
- ineligible buckets are never selected; empty store and zero batch select nothing

### Full-suite attribution

Branch: **760 passed / 10 failed**. Pristine `main` at the same base: **736 passed / 11 failed**. Diffing the failing-test *name* sets: **zero branch-only failures** — every name failing here also fails on `main`, and three that fail on `main` pass here.

Test-count delta reconciles exactly: 772 − 749 = 23 = the 13 tests added by #56 plus the 10 added here.