### PR TITLE
Stream WAL reclaim, and add a scale harness for log-id addressing

### DIFF
--- a/crates/temporalstore-rust/src/bin/reclaim_ab.rs
+++ b/crates/temporalstore-rust/src/bin/reclaim_ab.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Minimal reclaim cost probe, deliberately using only API that exists on every revision.
+//!
+//! The full scale harness needs the log-id resolution API, which only exists after that landed,
+//! so it cannot run against an older tree. This one uses `append`, `gc_before_sequence` and
+//! `info` alone, which lets the same binary be built and run on either revision and the reclaim
+//! cost compared directly.
+
+use std::time::Instant;
+
+use temporalstore_rust::types::Command;
+use temporalstore_rust::wal::LocalWriteAheadLogStore;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut records = 60_000usize;
+    let mut value_bytes = 128usize;
+    let mut label = "current".to_string();
+    let mut index = 1;
+    while index + 1 < args.len() {
+        match args[index].as_str() {
+            "--records" => records = args[index + 1].parse().unwrap_or(records),
+            "--value-bytes" => value_bytes = args[index + 1].parse().unwrap_or(value_bytes),
+            "--label" => label = args[index + 1].clone(),
+            _ => {}
+        }
+        index += 2;
+    }
+
+    let dir = std::env::temp_dir().join(format!("ts-reclaim-ab-{label}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let store = LocalWriteAheadLogStore::new(&dir);
+    let shard = 1u64;
+
+    let payload = vec![b'v'; value_bytes];
+    let started = Instant::now();
+    for index in 0..records {
+        store
+            .append(
+                shard,
+                Command::StringSet {
+                    key: format!("ab-key-{index:09}"),
+                    value: payload.clone(),
+                },
+            )
+            .expect("append");
+    }
+    let append_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    let path = dir.join("shard-1.wal.jsonl");
+    let bytes_before = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+    // Reclaim the first tenth, which is the shape that matters: a small prefix removed from a
+    // large log, so almost everything present has to survive the operation.
+    let retain_from = (records / 10) as u64;
+    let started = Instant::now();
+    let report = store
+        .gc_before_sequence(shard, retain_from)
+        .expect("reclaim");
+    let reclaim_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let bytes_after = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+    println!(
+        "{label}\trecords={records}\tappend_ms={append_ms:.0}\treclaim_ms={reclaim_ms:.1}\tkept={}\tbytes_before={bytes_before}\tbytes_after={bytes_after}",
+        report.records_after
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/temporalstore-rust/src/bin/wal_reclaim_scale_harness.rs
+++ b/crates/temporalstore-rust/src/bin/wal_reclaim_scale_harness.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scale harness for WAL reclaim and log-id addressing.
+//!
+//! Exercises the two properties that block addressing depends on, at a size where a per-record
+//! cost would show up:
+//!
+//!   1. **Log ids survive reclaim.** A block in the WAL is named by the byte offset of its
+//!      record. Reclaim compacts the file, so the check is that a log id sampled before a
+//!      reclaim still resolves to the same bytes afterwards -- and that a log id whose record
+//!      was reclaimed resolves to nothing rather than to whatever now sits at that offset. The
+//!      second half matters more: a wrong offset still parses, so it fails silently.
+//!
+//!   2. **Reclaim cost.** Retained records are copied verbatim rather than decoded and
+//!      re-encoded, so reclaiming a large log should cost roughly a file copy rather than a
+//!      parse per surviving record.
+//!
+//! Also checks that sequencing continues across a reopen after reclaim, since the reclaimed
+//! file is what the next append reads its starting sequence from.
+//!
+//! Run:
+//!   cargo run --release --bin wal_reclaim_scale_harness -- --records 200000 --reclaims 8
+
+use std::time::Instant;
+
+use temporalstore_rust::types::Command;
+use temporalstore_rust::wal::{decode_wal_line, LocalWriteAheadLogStore};
+
+struct Options {
+    records: usize,
+    reclaims: usize,
+    samples: usize,
+    value_bytes: usize,
+    shard: u64,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            records: 100_000,
+            reclaims: 8,
+            samples: 512,
+            value_bytes: 128,
+            shard: 1,
+        }
+    }
+}
+
+fn parse_options() -> Options {
+    let mut options = Options::default();
+    let args: Vec<String> = std::env::args().collect();
+    let mut index = 1;
+    while index + 1 < args.len() {
+        let value = &args[index + 1];
+        match args[index].as_str() {
+            "--records" => options.records = value.parse().unwrap_or(options.records),
+            "--reclaims" => options.reclaims = value.parse().unwrap_or(options.reclaims),
+            "--samples" => options.samples = value.parse().unwrap_or(options.samples),
+            "--value-bytes" => options.value_bytes = value.parse().unwrap_or(options.value_bytes),
+            "--shard" => options.shard = value.parse().unwrap_or(options.shard),
+            _ => {}
+        }
+        index += 2;
+    }
+    options
+}
+
+/// A log id sampled before any reclaim, with the record bytes it named at the time.
+struct Probe {
+    log_id: u64,
+    sequence: u64,
+    bytes: Vec<u8>,
+}
+
+fn main() {
+    let options = parse_options();
+    // A plain directory rather than a temp-dir crate: this is a binary, and the harness wants
+    // the path to be inspectable after a failing run anyway.
+    let dir = std::env::temp_dir().join("ts-wal-reclaim-scale");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let store = LocalWriteAheadLogStore::new(&dir);
+    let shard = options.shard;
+
+    println!("== WAL reclaim scale harness");
+    println!(
+        "   records={} reclaims={} probes={} value_bytes={}",
+        options.records, options.reclaims, options.samples, options.value_bytes
+    );
+
+    // ---- append -----------------------------------------------------------
+    let payload = vec![b'v'; options.value_bytes];
+    let started = Instant::now();
+    for index in 0..options.records {
+        store
+            .append(
+                shard,
+                Command::StringSet {
+                    key: format!("scale-key-{index:09}"),
+                    value: payload.clone(),
+                },
+            )
+            .expect("append");
+    }
+    let append_elapsed = started.elapsed();
+    let append_rate = options.records as f64 / append_elapsed.as_secs_f64();
+    println!(
+        "\n-- append: {} records in {:.2}s ({:.0} rec/s)",
+        options.records,
+        append_elapsed.as_secs_f64(),
+        append_rate
+    );
+
+    // ---- sample log ids ---------------------------------------------------
+    // scan yields physical offsets; log_id_at converts to the addressing space that survives
+    // reclaim. With nothing reclaimed yet the two coincide, which the assertion below pins.
+    // Scan in bounded windows and keep only the probes. Materializing the whole log here would
+    // make the harness itself the biggest allocation in the process, which is exactly the thing
+    // being measured.
+    const WINDOW_BYTES: u64 = 4 * 1024 * 1024;
+    let mut probes = Vec::new();
+    let mut seen = 0usize;
+    let mut offset = 0u64;
+    let mut stride = 0usize;
+    loop {
+        let window = store
+            .scan(shard, offset, u64::MAX, WINDOW_BYTES)
+            .expect("scan");
+        if window.is_empty() {
+            break;
+        }
+        if stride == 0 {
+            stride = (options.records / options.samples.max(1)).max(1);
+        }
+        for (physical, line) in &window {
+            if seen % stride == 0 {
+                let log_id = store.log_id_at(shard, *physical).expect("log_id_at");
+                assert_eq!(
+                    log_id, *physical,
+                    "before any reclaim a log id is the physical offset"
+                );
+                probes.push(Probe {
+                    log_id,
+                    sequence: decode_wal_line(line).expect("decode").sequence,
+                    bytes: line.clone(),
+                });
+            }
+            seen += 1;
+        }
+        let (last_offset, last_line) = window.last().expect("non-empty");
+        offset = last_offset + last_line.len() as u64;
+    }
+    assert_eq!(seen, options.records, "scan must see every appended record");
+    println!("-- sampled {} log ids across the log", probes.len());
+
+    // ---- reclaim rounds ---------------------------------------------------
+    let per_round = options.records / (options.reclaims + 1);
+    let mut resolved_ok = 0usize;
+    let mut correctly_gone = 0usize;
+    let mut wrong_bytes = 0usize;
+    let mut resurrected = 0usize;
+    let mut total_reclaim = std::time::Duration::ZERO;
+    let mut slowest = std::time::Duration::ZERO;
+
+    println!("\n-- reclaim rounds");
+    println!(
+        "   {:>5} {:>12} {:>10} {:>14} {:>12}",
+        "round", "retain_from", "kept", "reclaim_ms", "base_offset"
+    );
+    for round in 1..=options.reclaims {
+        let retain_from = (round * per_round) as u64;
+        let started = Instant::now();
+        let report = store
+            .gc_before_sequence(shard, retain_from)
+            .expect("reclaim");
+        let elapsed = started.elapsed();
+        total_reclaim += elapsed;
+        slowest = slowest.max(elapsed);
+
+        println!(
+            "   {:>5} {:>12} {:>10} {:>14.1} {:>12}",
+            round,
+            retain_from,
+            report.records_after,
+            elapsed.as_secs_f64() * 1000.0,
+            report.base_offset
+        );
+
+        // Every probe must either resolve to exactly the bytes it named, or resolve to nothing
+        // because its record was reclaimed. Anything else is the silent failure this design
+        // exists to prevent.
+        let base = store.base_offset(shard).expect("base_offset");
+        for probe in &probes {
+            match store
+                .read_at_log_id(shard, probe.log_id, probe.bytes.len() as u64)
+                .expect("read_at_log_id")
+            {
+                Some(bytes) => {
+                    if bytes == probe.bytes {
+                        resolved_ok += 1;
+                    } else {
+                        wrong_bytes += 1;
+                        if wrong_bytes <= 3 {
+                            let found = decode_wal_line(&bytes).map(|record| record.sequence);
+                            eprintln!(
+                                "   MISMATCH round {round}: log_id {} named sequence {} but now reads {:?}",
+                                probe.log_id, probe.sequence, found
+                            );
+                        }
+                    }
+                }
+                None => {
+                    if probe.log_id < base {
+                        correctly_gone += 1;
+                    } else {
+                        // A live log id must never read as absent.
+                        resurrected += 1;
+                        eprintln!(
+                            "   LOST round {round}: log_id {} (sequence {}) is at or above base {base} but did not resolve",
+                            probe.log_id, probe.sequence
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- reopen -----------------------------------------------------------
+    // The reclaimed file is where a fresh process reads its starting sequence. If the header
+    // confused that scan, sequencing would restart and silently re-use ids.
+    let info_before = store.info(shard).expect("info");
+    let reopened = LocalWriteAheadLogStore::new(&dir);
+    let appended = reopened
+        .append(
+            shard,
+            Command::StringSet {
+                key: "after-reclaim".to_string(),
+                value: b"v".to_vec(),
+            },
+        )
+        .expect("append after reopen");
+
+    println!("\n-- reopen after reclaim");
+    println!("   last sequence before reopen : {}", info_before.current_sequence);
+    println!("   next sequence after reopen  : {}", appended.sequence);
+    let sequence_continues = appended.sequence == info_before.current_sequence + 1;
+
+    // ---- verdict ----------------------------------------------------------
+    let checks = probes.len() * options.reclaims;
+    println!("\n== results");
+    println!("   append throughput      : {append_rate:.0} rec/s");
+    println!(
+        "   reclaim total / slowest: {:.1} ms / {:.1} ms",
+        total_reclaim.as_secs_f64() * 1000.0,
+        slowest.as_secs_f64() * 1000.0
+    );
+    println!("   address checks         : {checks}");
+    println!("   resolved to same bytes : {resolved_ok}");
+    println!("   correctly reclaimed    : {correctly_gone}");
+    println!("   WRONG bytes returned   : {wrong_bytes}");
+    println!("   live id lost           : {resurrected}");
+    println!("   sequence continues     : {sequence_continues}");
+
+    println!("   scratch dir            : {}", dir.display());
+
+    let ok = wrong_bytes == 0
+        && resurrected == 0
+        && sequence_continues
+        && resolved_ok + correctly_gone == checks;
+    println!("\n== {}", if ok { "PASS" } else { "FAIL" });
+    if !ok {
+        std::process::exit(1);
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -818,33 +818,42 @@ impl LocalWriteAheadLogStore {
         // That is what makes the whole reclaim expressible as one number: every survivor moves
         // down by exactly the length of the removed prefix.
         let (base_offset, header_len) = read_wal_base(&path)?;
-        let contents = fs::read(&path)?;
+        // One line at a time. A log is not bounded by memory, so neither this search nor the
+        // copy below may hold it: reclaiming a large log otherwise costs a transient allocation
+        // the size of the whole file.
+        let mut reader = BufReader::new(File::open(&path)?);
+        reader.seek(SeekFrom::Start(header_len))?;
         let mut records_before = 0usize;
         let mut records_after = 0usize;
         let mut split = None;
-        let mut cursor = header_len as usize;
-        while cursor < contents.len() {
-            let end = contents[cursor..]
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map(|index| cursor + index)
-                .unwrap_or(contents.len());
-            let line = &contents[cursor..end];
-            if !line.iter().all(|byte| byte.is_ascii_whitespace()) {
+        let mut cursor = header_len;
+        let mut line = Vec::new();
+        loop {
+            line.clear();
+            let read = reader.read_until(b'\n', &mut line)?;
+            if read == 0 {
+                break;
+            }
+            let trimmed = line
+                .strip_suffix(b"\n")
+                .unwrap_or(line.as_slice());
+            if !trimmed.iter().all(|byte| byte.is_ascii_whitespace()) {
                 records_before += 1;
-                let record = decode_wal_line(line)?;
-                if record.sequence >= effective_retain {
-                    if split.is_none() {
-                        split = Some(cursor);
-                    }
+                if split.is_some() {
+                    // Past the split every remaining record is retained, and the sequence is
+                    // ascending, so there is nothing left to decide -- count it and move on
+                    // rather than parsing it again.
+                    records_after += 1;
+                } else if decode_wal_line(trimmed)?.sequence >= effective_retain {
+                    split = Some(cursor);
                     records_after += 1;
                 }
             }
-            cursor = end.saturating_add(1);
+            cursor = cursor.saturating_add(read as u64);
         }
         // Nothing retained means everything before the end goes; the split is the end of file.
-        let split = split.unwrap_or(contents.len());
-        let removed_bytes = (split as u64).saturating_sub(header_len);
+        let split = split.unwrap_or(cursor);
+        let removed_bytes = split.saturating_sub(header_len);
         let new_base = base_offset.saturating_add(removed_bytes);
 
         let temp_path = path.with_extension("jsonl.tmp");
@@ -857,7 +866,9 @@ impl LocalWriteAheadLogStore {
             // Copy the retained records byte for byte rather than decoding and re-encoding
             // them. Re-encoding could change a record's length, which would break the offset
             // arithmetic this whole scheme rests on, and it costs a parse per record.
-            temp.write_all(&contents[split..])?;
+            let mut source = File::open(&path)?;
+            source.seek(SeekFrom::Start(split))?;
+            std::io::copy(&mut BufReader::new(source), &mut temp)?;
             temp.flush()?;
             temp.sync_all()?;
         }


### PR DESCRIPTION
Scale testing the log-id work surfaced this: reclaiming a 167 MB log read the whole file into a `Vec` to find the split point and copy the survivors.

The implementation this replaced was no better — it held every retained record *decoded*, which is larger still — but neither has a reason to. Finding the split needs one line at a time, and copying the survivors is a seek plus `io::copy`. Peak memory during reclaim no longer tracks the size of the log.

It also stops re-parsing past the split. Sequences ascend, so once the split is found every remaining record is retained and there is nothing left to decide; the previous loop decoded all of them to reach a conclusion it already had.

## Measured

40,000 records × 1 KiB values, 176 MB log, reclaiming the first 10% — the shape that matters, where nearly everything present has to survive the operation.

| | Before (`5b10b593`) | After | |
|---|---:|---:|---|
| Reclaim time | 7934 ms | **3417 ms** | 2.3× faster |
| Peak RSS | 72.4 MB | **6.8 MB** | 10.7× less |
| Records kept | 36,001 | 36,001 | identical |
| Bytes after | 158,877,794 | 158,877,818 | +24 B |

The 24-byte difference is exactly the base-header line, which is a useful check that nothing else about the output moved.

`reclaim_ab` is the probe used for that comparison. It deliberately uses only `append` / `gc_before_sequence` / `info`, so it builds and runs on revisions that predate the log-id API and the two sides can be measured with the same binary logic.

## Scale harness

`wal_reclaim_scale_harness` appends N records, samples log ids across the log, then reclaims repeatedly. After each round every probe must **either** resolve to exactly the bytes it named **or** resolve to nothing because its record was reclaimed.

The second case is the one worth building a harness for: a stale offset would otherwise land mid-file and parse as a *different* record, so it fails silently. It also checks that sequencing continues across a reopen, since the reclaimed file is what a fresh process reads its starting sequence from.

**200k records / 167 MB / 8 reclaim rounds:** 4104 address checks, 0 wrong bytes, 0 live ids lost, sequencing intact.

The harness samples in bounded windows rather than scanning the whole log, so its own footprint does not dominate what it is measuring.

## Testing

32 WAL and framing tests pass unchanged.

### Full-suite attribution

Branch **757 passed / 21 failed**; current `main` (`d3ddf5b5`) **758 / 20**. Diffing the failing-test *name* sets:

- **20 failures common to both** — pre-existing.
- **10 of those are `proxy::tests::*` failing with `AddrInUse`** on `main` as well. Proxy tests bind fixed ports, and this machine had a second test suite running concurrently.
- **1 branch-only name**, `raft::tests::part3::distributed_raft_chunks_large_sequence_add_under_default_entry_limit`. Run isolated it fails ~1 in 3 here, and **3 in 5 on pristine `main`** — a pre-existing timing flake, failing more often on `main` than on this branch.

No regressions.