### PR TITLE
meta: detect a datanode that restarted in place

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -813,6 +813,7 @@ fn conviction_policy_from_env() -> ConvictionPolicy {
         ) as usize,
         safe_mode_enabled: env_bool("TS_META_CONVICT_SAFE_MODE", defaults.safe_mode_enabled),
         convict_enabled: env_bool("TS_META_CONVICT_ENABLED", defaults.convict_enabled),
+        convict_on_reboot: env_bool("TS_META_CONVICT_ON_REBOOT", defaults.convict_on_reboot),
     }
 }
 

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -225,6 +225,18 @@ pub struct ServerMetaInfo {
     #[serde(default)]
     pub freeze_cooldown_until_ms: u64,
     pub boot_time_ms: u64,
+    /// The boot time the metaserver anchored on for this server: the first
+    /// non-zero boot time it heartbeated after registering. `boot_time_ms`
+    /// tracks whatever the latest heartbeat claimed; this one does not move, so
+    /// the two disagreeing is the signal that the process restarted.
+    #[serde(default)]
+    pub reported_boot_time_ms: u64,
+    /// Set once the server heartbeats a boot time different from the anchored
+    /// one, meaning the process restarted without re-registering. Sticky until
+    /// the server registers again, because a restarted datanode has lost the
+    /// shards the metaserver still believes it is serving.
+    #[serde(default)]
+    pub reboot_detected: bool,
     pub binary_version: String,
     pub shard_loads: Vec<ShardLoad>,
     #[serde(default)]
@@ -1272,6 +1284,103 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
         panic!("failure detector loop did not freeze stale resources");
+    }
+
+    #[test]
+    fn metaserver_detects_a_datanode_that_restarted_in_place() {
+        // The heartbeats never stop, so nothing in the stale-timeout path notices
+        // this. But the restarted node has dropped every shard the metaserver
+        // still believes it serves, and reads routed there will all miss.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+
+        let heartbeat = |boot_time_ms: u64| ServerHeartbeatRequest {
+            server_addr: "node-a".to_string(),
+            boot_time_ms,
+            binary_version: "v1".to_string(),
+            shard_loads: Vec::new(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: ServerRuntimeLoad::default(),
+            shard_states: Vec::new(),
+        };
+        let server_state = || {
+            meta.list_servers()
+                .servers
+                .into_iter()
+                .find(|server| server.server_addr == "node-a")
+                .expect("registered")
+        };
+
+        // The first heartbeat anchors the boot time; repeats of it are normal.
+        assert!(meta.server_heartbeat(heartbeat(1_000)).status.ok);
+        assert_eq!(server_state().reported_boot_time_ms, 1_000);
+        assert!(!server_state().reboot_detected);
+        assert!(meta.server_heartbeat(heartbeat(1_000)).status.ok);
+        assert!(!server_state().reboot_detected);
+
+        // A different boot time means the process restarted underneath us.
+        assert!(meta.server_heartbeat(heartbeat(2_000)).status.ok);
+        assert!(server_state().reboot_detected);
+        // The anchor does not follow the new value, so the verdict is sticky
+        // rather than resetting itself on the next beat.
+        assert_eq!(server_state().reported_boot_time_ms, 1_000);
+        assert!(meta.server_heartbeat(heartbeat(2_000)).status.ok);
+        assert!(server_state().reboot_detected);
+
+        // Re-registering is how a datanode says it is ready to be trusted again.
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        assert!(!server_state().reboot_detected);
+        assert_eq!(server_state().reported_boot_time_ms, 0);
+        assert!(meta.server_heartbeat(heartbeat(2_000)).status.ok);
+        assert_eq!(server_state().reported_boot_time_ms, 2_000);
+        assert!(!server_state().reboot_detected);
+    }
+
+    #[test]
+    fn a_datanode_that_never_reports_a_boot_time_is_not_flagged() {
+        // Older datanodes send 0. Treating that as a changed boot time would
+        // convict the entire fleet on upgrade.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        for boot_time_ms in [0, 0, 0] {
+            assert!(meta
+                .server_heartbeat(ServerHeartbeatRequest {
+                    server_addr: "node-a".to_string(),
+                    boot_time_ms,
+                    binary_version: "v1".to_string(),
+                    shard_loads: Vec::new(),
+                    shard_stat_loads: Vec::new(),
+                    runtime_load: ServerRuntimeLoad::default(),
+                    shard_states: Vec::new(),
+                })
+                .status
+                .ok);
+        }
+        let server = meta
+            .list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == "node-a")
+            .expect("registered");
+        assert!(!server.reboot_detected);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -138,6 +138,11 @@ pub struct ConvictionPolicy {
     /// Master switch for conviction itself. With it off the plan is still
     /// computed and reportable but no server is named for freezing (dry run).
     pub convict_enabled: bool,
+    /// Treat a detected reboot as a failure. A restarted datanode has dropped
+    /// every shard the metaserver still believes it is serving, so leaving it in
+    /// the topology means routing reads to a node that will miss on all of them.
+    /// With this off a reboot is reported but not acted on.
+    pub convict_on_reboot: bool,
 }
 
 impl Default for ConvictionPolicy {
@@ -148,6 +153,7 @@ impl Default for ConvictionPolicy {
             min_abnormal_for_safe_mode: 2,
             safe_mode_enabled: true,
             convict_enabled: true,
+            convict_on_reboot: true,
         }
     }
 }
@@ -164,6 +170,11 @@ pub struct ConvictionCandidate {
     pub abnormal: bool,
     /// The detector diagnosed this serving server as [`Diagnosis::Failed`].
     pub failed: bool,
+    /// The server restarted in place: it heartbeated a boot time different from
+    /// the one the metaserver anchored on. Unlike `failed` this is not inferred
+    /// from silence, so it is trustworthy even while the detector is paused.
+    #[serde(default)]
+    pub rebooted: bool,
 }
 
 /// The damage assessment for one location.
@@ -187,6 +198,11 @@ pub struct ConvictionPlan {
     pub held_by_safe_mode: Vec<String>,
     /// Per-location damage, ordered by location.
     pub damage: Vec<LocationDamage>,
+    /// Serving servers observed to have restarted in place, ordered by address.
+    /// Reported whether or not the policy converts a reboot into a conviction,
+    /// so the restart is visible even when it is not acted on.
+    #[serde(default)]
+    pub rebooted: Vec<String>,
 }
 
 impl ConvictionPlan {
@@ -218,17 +234,29 @@ pub fn plan_conviction(
     let mut plan = ConvictionPlan::default();
     for (location, members) in by_location {
         let total = members.len();
-        // A failed server counts as damage too: it is about to stop serving.
+        // A server is a conviction target when the detector called it failed, or
+        // when it restarted in place and the policy treats that as a failure.
+        let is_target = |member: &ConvictionCandidate| {
+            member.failed || (member.rebooted && policy.convict_on_reboot)
+        };
+        // A targeted server counts as damage too: it is about to stop serving.
         let abnormal = members
             .iter()
-            .filter(|member| member.abnormal || member.failed)
+            .filter(|member| member.abnormal || is_target(member))
             .count();
         let severity = assess_severity(total, abnormal, policy);
         let safe_mode = policy.safe_mode_enabled && severity != DamageSeverity::Normal;
 
+        plan.rebooted.extend(
+            members
+                .iter()
+                .filter(|member| member.rebooted && !member.abnormal)
+                .map(|member| member.server_addr.clone()),
+        );
+
         let mut failed = members
             .iter()
-            .filter(|member| member.failed && !member.abnormal)
+            .filter(|member| is_target(member) && !member.abnormal)
             .map(|member| member.server_addr.clone())
             .collect::<Vec<_>>();
         failed.sort();
@@ -248,6 +276,7 @@ pub fn plan_conviction(
     }
     plan.convict.sort();
     plan.held_by_safe_mode.sort();
+    plan.rebooted.sort();
     plan
 }
 
@@ -486,6 +515,11 @@ impl MetaFailureDetector {
                     failed: active
                         && serving
                         && self.diagnose(&server.server_addr, now_ms) == Diagnosis::Failed,
+                    // Not gated on `active`: a changed boot time is direct
+                    // evidence the process restarted, not an inference drawn
+                    // from silence, so the detector's stall guard does not
+                    // apply to it.
+                    rebooted: serving && server.reboot_detected,
                 }
             })
             .collect::<Vec<_>>();
@@ -505,6 +539,9 @@ pub struct AdaptiveConvictionReport {
     pub held_by_safe_mode: Vec<String>,
     /// Per-location damage assessment for this round.
     pub damage: Vec<LocationDamage>,
+    /// Serving servers observed to have restarted in place this round.
+    #[serde(default)]
+    pub rebooted: Vec<String>,
     /// True when the detector was paused this round (it had only just started,
     /// or it stalled), so no server could be convicted whatever its silence.
     pub detector_paused: bool,
@@ -550,6 +587,7 @@ impl SingleNodeMeta {
                     frozen_servers,
                     held_by_safe_mode: plan.held_by_safe_mode,
                     damage: plan.damage,
+                    rebooted: plan.rebooted,
                     detector_paused,
                 };
             }
@@ -561,6 +599,7 @@ impl SingleNodeMeta {
             frozen_servers,
             held_by_safe_mode: plan.held_by_safe_mode,
             damage: plan.damage,
+            rebooted: plan.rebooted,
             detector_paused,
         }
     }
@@ -614,6 +653,8 @@ mod tests {
             frozen_since_ms: 0,
             freeze_cooldown_until_ms: 0,
             boot_time_ms: 1,
+            reported_boot_time_ms: 0,
+            reboot_detected: false,
             binary_version: "test".to_string(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),
@@ -628,6 +669,14 @@ mod tests {
             location: location.to_string(),
             abnormal,
             failed,
+            rebooted: false,
+        }
+    }
+
+    fn rebooted_candidate(addr: &str, location: &str) -> ConvictionCandidate {
+        ConvictionCandidate {
+            rebooted: true,
+            ..candidate(addr, location, false, false)
         }
     }
 
@@ -721,6 +770,100 @@ mod tests {
         detector.observe("node-a", after_grace);
         assert!(detector.begin_round(after_grace));
         assert_eq!(detector.diagnose("node-a", after_grace), Diagnosis::Healthy);
+    }
+
+    #[test]
+    fn a_restarted_server_is_convicted_without_waiting_for_silence() {
+        // The heartbeats never stopped, so no amount of phi would ever flag this
+        // node. What changed is that it dropped every shard it was serving.
+        let plan = plan_conviction(
+            &[
+                rebooted_candidate("node-a", "rack-1"),
+                candidate("node-b", "rack-1", false, false),
+                candidate("node-c", "rack-1", false, false),
+                candidate("node-d", "rack-1", false, false),
+            ],
+            ConvictionPolicy::default(),
+        );
+        assert_eq!(plan.convict, vec!["node-a"]);
+        assert_eq!(plan.rebooted, vec!["node-a"]);
+    }
+
+    #[test]
+    fn a_reboot_is_still_subject_to_safe_mode() {
+        // A rolling restart that takes out half a rack is as damaging as a rack
+        // fault, and the same guard has to hold.
+        let plan = plan_conviction(
+            &[
+                rebooted_candidate("node-a", "rack-1"),
+                rebooted_candidate("node-b", "rack-1"),
+                candidate("node-c", "rack-1", false, false),
+                candidate("node-d", "rack-1", false, false),
+            ],
+            ConvictionPolicy::default(),
+        );
+        assert!(plan.convict.is_empty());
+        assert_eq!(plan.held_by_safe_mode, vec!["node-a", "node-b"]);
+        assert_eq!(plan.rebooted, vec!["node-a", "node-b"]);
+        assert_eq!(plan.worst_severity(), DamageSeverity::Critical);
+    }
+
+    #[test]
+    fn reboot_conviction_can_be_turned_off_while_still_being_reported() {
+        let policy = ConvictionPolicy {
+            convict_on_reboot: false,
+            ..ConvictionPolicy::default()
+        };
+        let plan = plan_conviction(
+            &[
+                rebooted_candidate("node-a", "rack-1"),
+                candidate("node-b", "rack-1", false, false),
+            ],
+            policy,
+        );
+        assert!(plan.convict.is_empty());
+        assert!(plan.held_by_safe_mode.is_empty());
+        // Still surfaced: an operator needs to see the restart either way.
+        assert_eq!(plan.rebooted, vec!["node-a"]);
+        assert_eq!(plan.worst_severity(), DamageSeverity::Normal);
+    }
+
+    #[test]
+    fn a_reboot_is_trusted_even_while_the_detector_is_paused() {
+        // The stall guard exists because silence is ambiguous after a detector
+        // pause. A changed boot time is not an inference from silence, so it
+        // stays actionable.
+        let mut detector = MetaFailureDetector::new(options());
+        let policy = ConvictionPolicy::default();
+        let mut rebooted_server = server("a", "rack-1", MetaEntityState::Normal, 10_000);
+        rebooted_server.reboot_detected = true;
+        let servers = vec![
+            rebooted_server,
+            server("b", "rack-1", MetaEntityState::Normal, 10_000),
+            server("c", "rack-1", MetaEntityState::Normal, 10_000),
+            server("d", "rack-1", MetaEntityState::Normal, 10_000),
+        ];
+        // First round ever: the detector is paused, so phi convicts nobody.
+        let plan = detector.plan_round(&servers, 10_000, policy);
+        assert!(plan.damage.iter().all(|entry| entry.total_servers == 4));
+        assert_eq!(plan.convict, vec!["a"]);
+    }
+
+    #[test]
+    fn a_frozen_server_that_rebooted_is_not_reconvicted() {
+        let plan = plan_conviction(
+            &[
+                ConvictionCandidate {
+                    abnormal: true,
+                    rebooted: true,
+                    ..candidate("node-a", "rack-1", true, false)
+                },
+                candidate("node-b", "rack-1", false, false),
+            ],
+            ConvictionPolicy::default(),
+        );
+        assert!(plan.convict.is_empty());
+        assert!(plan.rebooted.is_empty());
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -104,6 +104,8 @@ mod tests {
             frozen_since_ms: 0,
             freeze_cooldown_until_ms: 0,
             boot_time_ms: 1,
+            reported_boot_time_ms: 0,
+            reboot_detected: false,
             binary_version: "test".to_string(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -36,6 +36,11 @@ impl SingleNodeMeta {
                 frozen_since_ms: 0,
                 freeze_cooldown_until_ms: 0,
                 boot_time_ms: 0,
+                // Registration is the server declaring a fresh identity, so any
+                // previous reboot verdict is cleared and the anchor is re-taken
+                // from its next heartbeat.
+                reported_boot_time_ms: 0,
+                reboot_detected: false,
                 binary_version: request.binary_version,
                 shard_loads: Vec::new(),
                 shard_stat_loads: Vec::new(),
@@ -75,6 +80,27 @@ impl SingleNodeMeta {
             };
         }
         server.last_heartbeat_ms = now_ms();
+        // Reboot detection. The metaserver anchors on the first non-zero boot
+        // time a registered server reports; a later heartbeat claiming a
+        // different one means the process restarted in place. That matters even
+        // though the heartbeats never stopped: a restarted datanode has dropped
+        // every shard the metaserver still believes it is serving, so routing to
+        // it returns misses until it reloads. Without this the restart is
+        // invisible - the old code simply overwrote boot_time_ms.
+        //
+        // The verdict is sticky. It clears when the server registers again,
+        // which is how a datanode announces it is ready to be trusted.
+        let rebooted = if server.reported_boot_time_ms == 0 {
+            server.reported_boot_time_ms = request.boot_time_ms;
+            false
+        } else {
+            request.boot_time_ms != 0
+                && request.boot_time_ms != server.reported_boot_time_ms
+                && !server.reboot_detected
+        };
+        if rebooted {
+            server.reboot_detected = true;
+        }
         server.boot_time_ms = request.boot_time_ms;
         if !request.binary_version.is_empty() {
             server.binary_version = request.binary_version;
@@ -83,11 +109,24 @@ impl SingleNodeMeta {
         server.shard_stat_loads = request.shard_stat_loads;
         server.runtime_load = request.runtime_load;
         server.shard_states = request.shard_states;
+        let server_state = server.state.as_str().to_string();
+        let anchored = server.reported_boot_time_ms;
+        if rebooted {
+            record_topology_event(
+                &mut state,
+                "server_reboot_detected",
+                format!("server:{}", request.server_addr),
+                format!(
+                    "anchored_boot_time_ms={anchored},reported_boot_time_ms={}",
+                    request.boot_time_ms
+                ),
+            );
+        }
         ServerHeartbeatResponse {
             status: Status::ok(),
             forbid_auto_register: false,
             topology_version,
-            server_state: server.state.as_str().to_string(),
+            server_state,
         }
     }
 

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -100,6 +100,8 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
             frozen_since_ms: 0,
             freeze_cooldown_until_ms: 0,
             boot_time_ms: 0,
+            reported_boot_time_ms: 0,
+            reboot_detected: false,
             binary_version: String::new(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -318,6 +318,8 @@ pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> S
         frozen_since_ms: 0,
         freeze_cooldown_until_ms: 0,
         boot_time_ms: 1,
+        reported_boot_time_ms: 0,
+        reboot_detected: false,
         binary_version: "test".to_string(),
         shard_loads: Vec::new(),
         shard_stat_loads: Vec::new(),


### PR DESCRIPTION
> Builds on #61 (merged): it wires into the conviction planner introduced there.

## The problem

`server_heartbeat` overwrote `server.boot_time_ms` with whatever the latest heartbeat claimed and never compared it to anything, so **a datanode that crashed and came back between two heartbeats was completely invisible to the metaserver.**

That is a routing correctness hole, not a missing metric. The restarted process has dropped every shard the metaserver still believes it is serving, so reads routed there miss until it finishes reloading — and nothing in the stale-timeout path will ever notice, **because the heartbeats never stopped.** Only silence is detectable today, and a restart is precisely the failure that produces no silence.

## What this adds

The metaserver anchors on the first non-zero boot time a registered server reports, and flags a later heartbeat claiming a different one as a reboot.

`ServerMetaInfo` carries the anchor (`reported_boot_time_ms`) alongside the latest claim (`boot_time_ms`); the two disagreeing is the signal. The anchor deliberately **does not follow** the new value — that is what makes the verdict sticky rather than resetting itself on the next beat. It clears on re-registration, which is how a datanode announces it is ready to be trusted again. Both fields carry `#[serde(default)]`, so existing snapshots load unchanged.

**A boot time of zero never flags anything.** Older datanodes report zero, and treating that as a changed boot time would convict the whole fleet during an upgrade.

## How it feeds conviction

The planner treats a reboot as a failure (`ConvictionPolicy::convict_on_reboot`, on by default). Two properties matter:

- **Not gated on the detector being active.** The stall guard from #61 exists because silence is ambiguous after the detector itself pauses. A changed boot time is *direct evidence* that the process restarted, not an inference drawn from silence, so the guard does not apply and a restart is actionable on the very first round.
- **Still gated by safe mode.** A rolling restart that takes out half a rack is as damaging as a rack fault and has to hit the same brake.

`ConvictionPlan` reports rebooted servers separately from convicted ones, so a restart stays visible whether or not the policy acts on it — including when `convict_on_reboot` is off.

Detection itself is always on: it adds two fields and a topology event, and nothing acts on the flag unless the adaptive failure detector is enabled, which is still off by default.

| Variable | Default | Meaning |
|---|---|---|
| `TS_META_CONVICT_ON_REBOOT` | `1` | Treat a detected reboot as a failure |

## Tests

7 new tests: heartbeat anchoring, stickiness across repeats, the clear on re-registration, zero boot times never flagging, a restart being convicted **with no silence at all**, a restart still being held by safe mode, reboot conviction being switchable off while still reported, a restart surviving the detector pause, and an already-frozen server not being reconvicted for a reboot.

Verification:

- `cargo test -p temporalstore-rust --lib meta` — **110 passed, 0 failed.** (The base branch scores 101 passed + 2 flaky `proxy::tests` failures that also fail on pristine `main`; both passed this run.)
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.
