### PR TITLE
meta: reconcile the owner map against what datanodes actually serve

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -17,7 +17,8 @@ use temporalstore_rust::meta::{
     MetaSnapshot, MetaSnapshotFileRequest, MetaSnapshotFileResponse, MetaSnapshotResponse,
     ProxyHeartbeatRequest, PublishShardSnapshotRequest, RegisterProxyRequest,
     RegisterServerRequest, RegisterShardRequest, SafeModePolicy, ServerHeartbeatRequest,
-    ShardReassignmentReason, SingleNodeMeta, StateChangeRequest, TopologyVersionRequest,
+    ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason,
+    SingleNodeMeta, StateChangeRequest, TopologyVersionRequest,
     UpdateTableRequest,
 };
 use temporalstore_rust::raft::{
@@ -117,6 +118,46 @@ fn main() {
             }
             MetaBackend::Raft(_) => {
                 warn!("TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    // Shard-divergence reconciliation: compare the owner map against what each
+    // datanode reports serving, and re-place the shards its recorded owner is
+    // not actually serving. OFF by default (TS_META_SHARD_DIVERGENCE_CHECK)
+    // because it moves data. Only the single-node backend is auto-driven here.
+    let _shard_divergence = if env_bool("TS_META_SHARD_DIVERGENCE_CHECK", false) {
+        match &backend {
+            MetaBackend::Single(meta) => {
+                let interval_ms =
+                    env_u64("TS_META_SHARD_DIVERGENCE_INTERVAL_MS", detector_interval_ms);
+                let defaults = ShardCheckOptions::default();
+                let options = ShardCheckOptions {
+                    reboot_grace_ms: env_u64(
+                        "TS_META_SHARD_DIVERGENCE_REBOOT_GRACE_MS",
+                        defaults.reboot_grace_ms,
+                    ),
+                    max_moves_per_window: env_u64(
+                        "TS_META_SHARD_DIVERGENCE_MAX_MOVES",
+                        defaults.max_moves_per_window as u64,
+                    ) as usize,
+                    window_ms: env_u64(
+                        "TS_META_SHARD_DIVERGENCE_WINDOW_MS",
+                        defaults.window_ms,
+                    ),
+                };
+                info!(
+                    interval_ms,
+                    reboot_grace_ms = options.reboot_grace_ms,
+                    max_moves_per_window = options.max_moves_per_window,
+                    "shard-divergence reconciliation enabled"
+                );
+                Some(start_shard_divergence_loop(meta.clone(), options, interval_ms))
+            }
+            MetaBackend::Raft(_) => {
+                warn!("TS_META_SHARD_DIVERGENCE_CHECK ignored: raft backend manages placement itself");
                 None
             }
         }
@@ -696,6 +737,16 @@ fn run_auto_rebalance_round(
         ..AutoRebalanceOptions::default()
     };
     let plans = meta.plan_auto_rebalance_with_options(options);
+    drive_reassignments(meta, plans, http_options);
+}
+
+/// Drive a set of reassignments: ask the target to load the shard, unload the
+/// source when it still holds it, then rewrite the owner map.
+fn drive_reassignments(
+    meta: &SingleNodeMeta,
+    plans: Vec<ShardReassignment>,
+    http_options: HttpRequestOptions,
+) {
     for plan in plans {
         let load_version = now_epoch_ms();
         let load_request = LoadShardRequest {
@@ -727,7 +778,9 @@ fn run_auto_rebalance_round(
             );
             continue;
         }
-        // A balance move vacates a still-live source: unload there (best-effort).
+        // A balance move vacates a still-live source: unload there
+        // (best-effort). An evacuation has no live source, and a divergence's
+        // source is precisely the node that no longer holds the shard.
         if plan.reason == ShardReassignmentReason::Rebalance {
             if let Some(from_server) = &plan.from_server {
                 let unload_status = post_unload_or_error(
@@ -759,6 +812,44 @@ fn run_auto_rebalance_round(
             );
         }
     }
+}
+
+/// Background loop that reconciles the metaserver's shard->owner map against
+/// what datanodes report serving.
+///
+/// A shard can vanish from a healthy node -- unloaded by hand, failed to reload
+/// after a restart, a rolled-back load -- and nothing else notices: the node
+/// keeps heartbeating, so neither the stale-heartbeat detector nor reboot
+/// detection has anything to say, and auto-rebalance only evacuates shards whose
+/// *owner* is unavailable. This owner is available; it is the shard that is
+/// gone. Until something compares the two views, every read for that shard is
+/// routed to a server that will miss on all of them.
+fn start_shard_divergence_loop(
+    meta: SingleNodeMeta,
+    options: ShardCheckOptions,
+    interval_ms: u64,
+) -> std::thread::JoinHandle<()> {
+    let interval = std::time::Duration::from_millis(interval_ms.max(1));
+    let http_options = HttpRequestOptions {
+        connect_timeout_ms: env_u64("TS_META_SHARD_DIVERGENCE_CONNECT_TIMEOUT_MS", 500),
+        io_timeout_ms: env_u64("TS_META_SHARD_DIVERGENCE_IO_TIMEOUT_MS", 2_000),
+        ..HttpRequestOptions::default()
+    };
+    let mut checker = ShardChecker::new(options);
+    std::thread::spawn(move || loop {
+        let (report, moves) = meta.check_shard_divergence(&mut checker);
+        if !report.diverged.is_empty() {
+            warn!(
+                diverged = report.diverged.len(),
+                planned = moves.len(),
+                rate_limited = report.rate_limited,
+                skipped_booting = report.skipped_in_reboot_grace.len(),
+                "shard-divergence: owner map disagrees with what datanodes serve"
+            );
+        }
+        drive_reassignments(&meta, moves, http_options);
+        std::thread::sleep(interval);
+    })
 }
 
 /// Wire body for `POST /raft/admin/liveness` on a datanode (mirrors the private

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -24,6 +24,7 @@ mod topology_helpers;
 mod auto_rebalance;
 mod failure_detector;
 mod raft_failover;
+mod shard_check;
 use self::partitioning::*;
 use self::topology_helpers::*;
 pub use self::auto_rebalance::{
@@ -35,6 +36,9 @@ pub use self::failure_detector::{
     MetaFailureDetector,
 };
 pub use self::raft_failover::{compute_raft_failover_triggers, RaftFailoverTrigger};
+pub use self::shard_check::{
+    ShardCheckOptions, ShardCheckReport, ShardChecker, ShardDivergence,
+};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -237,6 +241,11 @@ pub struct ServerMetaInfo {
     /// shards the metaserver still believes it is serving.
     #[serde(default)]
     pub reboot_detected: bool,
+    /// Set once this server has been seen reporting `shard_states` at all.
+    /// Until then an empty report is indistinguishable from an old build that
+    /// does not send them, so the shard-divergence check declines to judge it.
+    #[serde(default)]
+    pub reports_shard_states: bool,
     pub binary_version: String,
     pub shard_loads: Vec<ShardLoad>,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -35,6 +35,11 @@ pub enum ShardReassignmentReason {
     /// The shard's owner is live, but load is uneven; the shard moves to spread
     /// shards more evenly across live servers (e.g. onto a newly-joined node).
     Rebalance,
+    /// The shard's owner is live and healthy but is not serving this shard, so
+    /// every read routed to it misses. Produced by [`ShardChecker`]; evacuation
+    /// cannot catch it because the owner itself is perfectly available -- it is
+    /// the shard that is gone, not the server.
+    OwnerDiverged,
 }
 
 /// A single planned shard ownership change.

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -655,6 +655,7 @@ mod tests {
             boot_time_ms: 1,
             reported_boot_time_ms: 0,
             reboot_detected: false,
+            reports_shard_states: false,
             binary_version: "test".to_string(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -106,6 +106,7 @@ mod tests {
             boot_time_ms: 1,
             reported_boot_time_ms: 0,
             reboot_detected: false,
+            reports_shard_states: false,
             binary_version: "test".to_string(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -41,6 +41,7 @@ impl SingleNodeMeta {
                 // from its next heartbeat.
                 reported_boot_time_ms: 0,
                 reboot_detected: false,
+                reports_shard_states: false,
                 binary_version: request.binary_version,
                 shard_loads: Vec::new(),
                 shard_stat_loads: Vec::new(),
@@ -108,6 +109,11 @@ impl SingleNodeMeta {
         server.shard_loads = request.shard_loads;
         server.shard_stat_loads = request.shard_stat_loads;
         server.runtime_load = request.runtime_load;
+        // Sticky: once a server has been seen reporting shard states, a later
+        // empty report is real information (it dropped everything) rather than
+        // an old build that never sends them.
+        server.reports_shard_states =
+            server.reports_shard_states || !request.shard_states.is_empty();
         server.shard_states = request.shard_states;
         let server_state = server.state.as_str().to_string();
         let anchored = server.reported_boot_time_ms;

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Reconciliation between what the metaserver routes and what datanodes serve.
+//!
+//! Every datanode heartbeat carries `shard_states`: the shards that node is
+//! actually serving right now. The metaserver keeps its own `shard -> owner`
+//! map. Nothing has ever compared the two.
+//!
+//! So when the two drift apart the metaserver never finds out. A shard can
+//! disappear from a node -- it was unloaded by an operator, it failed to reload
+//! after a restart, a load was rolled back, a disk went read-only -- and the
+//! owner map keeps pointing at that node indefinitely. The node is healthy, its
+//! heartbeats never stop, so neither the stale-heartbeat detector nor reboot
+//! detection has anything to say about it. Every read for that shard is routed
+//! to a server that will miss on all of them, and the only signal is client-side
+//! errors.
+//!
+//! [`compute_auto_rebalance`] cannot see it either: it evacuates shards whose
+//! *owner* is unavailable, and this owner is perfectly available. It is the
+//! shard that is gone, not the server.
+//!
+//! This module closes that loop. [`ShardChecker::check`] compares the owner map
+//! against what each server reports and produces one
+//! [`ShardReassignmentReason::OwnerDiverged`] reassignment per shard that its
+//! recorded owner is not serving, so the existing rebalance loop re-places it
+//! onto a node that will.
+//!
+//! Three guards keep the check from doing more harm than the drift:
+//!
+//! * **Reboot grace.** A node that restarted seconds ago has not finished
+//!   reloading, so its shards are legitimately missing for a while. Servers
+//!   inside [`ShardCheckOptions::reboot_grace_ms`] of their boot time are
+//!   skipped -- otherwise every restart would trigger a full re-placement of
+//!   everything that node owned.
+//! * **Report capability.** A server is only judged once it has been *seen* to
+//!   report shard states at least once
+//!   ([`ServerMetaInfo::reports_shard_states`]). A node that never reports them
+//!   is indistinguishable from one serving nothing, and treating silence as
+//!   "serving nothing" would re-place the entire cluster.
+//! * **Rate limit.** At most [`ShardCheckOptions::max_moves_per_window`]
+//!   divergences are acted on per window. A correlated fault can make many
+//!   shards look missing at once, and reacting to all of them would move more
+//!   data than the fault did.
+//!
+//! The comparison itself is pure; only the rate-limit window is stateful.
+
+use std::collections::BTreeSet;
+
+use super::*;
+
+/// Tuning for [`ShardChecker`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardCheckOptions {
+    /// Skip a server this recently booted; it is still reloading its shards.
+    pub reboot_grace_ms: u64,
+    /// Most divergences acted on per window.
+    pub max_moves_per_window: usize,
+    /// Length of the rate-limit window.
+    pub window_ms: u64,
+}
+
+impl Default for ShardCheckOptions {
+    fn default() -> Self {
+        Self {
+            reboot_grace_ms: 30_000,
+            max_moves_per_window: 10,
+            window_ms: 60_000,
+        }
+    }
+}
+
+/// One shard the metaserver routes to a server that is not serving it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardDivergence {
+    pub shard_id: ShardId,
+    /// The recorded owner, which is live but does not report this shard.
+    pub server_addr: String,
+    /// True when the owner reports the shard but has it marked not loaded --
+    /// a weaker signal than the shard being absent entirely.
+    #[serde(default)]
+    pub reported_unloaded: bool,
+}
+
+/// What one reconciliation round found.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardCheckReport {
+    /// Divergences observed, ordered by shard id. Includes ones the rate limit
+    /// declined to act on, so the full picture is always reportable.
+    pub diverged: Vec<ShardDivergence>,
+    /// Servers skipped because they booted too recently, ordered by address.
+    pub skipped_in_reboot_grace: Vec<String>,
+    /// Servers skipped because they have never reported shard states, ordered
+    /// by address.
+    pub skipped_without_shard_reports: Vec<String>,
+    /// How many divergences the rate limit held back this round.
+    pub rate_limited: usize,
+}
+
+/// Stateful reconciler: pure comparison plus a rate-limit window.
+#[derive(Debug, Clone)]
+pub struct ShardChecker {
+    options: ShardCheckOptions,
+    window_start_ms: u64,
+    moves_this_window: usize,
+}
+
+impl Default for ShardChecker {
+    fn default() -> Self {
+        Self::new(ShardCheckOptions::default())
+    }
+}
+
+impl ShardChecker {
+    pub fn new(options: ShardCheckOptions) -> Self {
+        Self {
+            options,
+            window_start_ms: 0,
+            moves_this_window: 0,
+        }
+    }
+
+    pub fn options(&self) -> ShardCheckOptions {
+        self.options
+    }
+
+    /// Divergences acted on in the current window.
+    pub fn moves_this_window(&self) -> usize {
+        self.moves_this_window
+    }
+
+    /// Compare the owner map against what each server reports serving.
+    ///
+    /// Pure apart from the rate-limit window: the same inputs produce the same
+    /// report, and every output vector is sorted.
+    pub fn check(
+        &mut self,
+        shard_owners: &BTreeMap<ShardId, String>,
+        servers: &[ServerMetaInfo],
+        now_ms: u64,
+    ) -> ShardCheckReport {
+        self.roll_window(now_ms);
+
+        let mut report = ShardCheckReport::default();
+        // Which servers may be judged this round, and what each one serves.
+        let mut served: BTreeMap<&str, BTreeMap<ShardId, bool>> = BTreeMap::new();
+        let mut judgeable: BTreeSet<&str> = BTreeSet::new();
+        for server in servers {
+            if server.state != MetaEntityState::Normal {
+                // A frozen or dropped server is already being handled elsewhere;
+                // its shards are not "diverged", they are unavailable.
+                continue;
+            }
+            if !server.reports_shard_states {
+                report
+                    .skipped_without_shard_reports
+                    .push(server.server_addr.clone());
+                continue;
+            }
+            if self.in_reboot_grace(server, now_ms) {
+                report.skipped_in_reboot_grace.push(server.server_addr.clone());
+                continue;
+            }
+            judgeable.insert(server.server_addr.as_str());
+            let entry = served.entry(server.server_addr.as_str()).or_default();
+            for state in &server.shard_states {
+                // A shard reported twice (two workers mid-handoff) counts as
+                // loaded if any report says so.
+                let loaded = entry.get(&state.shard_id).copied().unwrap_or(false) || state.loaded;
+                entry.insert(state.shard_id, loaded);
+            }
+        }
+        report.skipped_in_reboot_grace.sort();
+        report.skipped_without_shard_reports.sort();
+
+        for (shard_id, owner_addr) in shard_owners {
+            if !judgeable.contains(owner_addr.as_str()) {
+                continue;
+            }
+            let owner_view = served.get(owner_addr.as_str());
+            match owner_view.and_then(|shards| shards.get(shard_id)) {
+                Some(true) => {}
+                Some(false) => report.diverged.push(ShardDivergence {
+                    shard_id: *shard_id,
+                    server_addr: owner_addr.clone(),
+                    reported_unloaded: true,
+                }),
+                None => report.diverged.push(ShardDivergence {
+                    shard_id: *shard_id,
+                    server_addr: owner_addr.clone(),
+                    reported_unloaded: false,
+                }),
+            }
+        }
+        report
+    }
+
+    /// Turn a report into reassignments, spending the window's budget. Each
+    /// diverged shard moves to the least loaded live server that is not its
+    /// current owner; a shard with nowhere else to go is left alone rather than
+    /// pointed at the same node again.
+    pub fn plan_moves(
+        &mut self,
+        report: &mut ShardCheckReport,
+        shard_owners: &BTreeMap<ShardId, String>,
+        live_servers: &BTreeSet<String>,
+    ) -> Vec<ShardReassignment> {
+        let mut moves = Vec::new();
+        if live_servers.is_empty() {
+            return moves;
+        }
+        let mut load: BTreeMap<String, usize> =
+            live_servers.iter().map(|addr| (addr.clone(), 0)).collect();
+        for owner_addr in shard_owners.values() {
+            if let Some(count) = load.get_mut(owner_addr) {
+                *count += 1;
+            }
+        }
+
+        let mut rate_limited = 0_usize;
+        let diverged = report.diverged.clone();
+        for divergence in &diverged {
+            if self.moves_this_window >= self.options.max_moves_per_window {
+                rate_limited += 1;
+                continue;
+            }
+            let Some(target) = load
+                .iter()
+                .filter(|(addr, _)| *addr != &divergence.server_addr)
+                .min_by(|(addr_a, load_a), (addr_b, load_b)| {
+                    load_a.cmp(load_b).then_with(|| addr_a.cmp(addr_b))
+                })
+                .map(|(addr, _)| addr.clone())
+            else {
+                // The diverging owner is the only live server. Re-placing onto
+                // itself would achieve nothing; leave the route and let the
+                // node reload.
+                continue;
+            };
+            if let Some(count) = load.get_mut(&divergence.server_addr) {
+                *count = count.saturating_sub(1);
+            }
+            *load.entry(target.clone()).or_default() += 1;
+            self.moves_this_window += 1;
+            moves.push(ShardReassignment {
+                shard_id: divergence.shard_id,
+                from_server: Some(divergence.server_addr.clone()),
+                to_server: target,
+                reason: ShardReassignmentReason::OwnerDiverged,
+            });
+        }
+        report.rate_limited = rate_limited;
+        moves
+    }
+
+    fn roll_window(&mut self, now_ms: u64) {
+        let window = self.options.window_ms.max(1);
+        if self.window_start_ms == 0 || now_ms.saturating_sub(self.window_start_ms) >= window {
+            self.window_start_ms = now_ms;
+            self.moves_this_window = 0;
+        }
+    }
+
+    /// True while the server is still inside its post-boot reload window. A zero
+    /// or future-dated boot time yields false: an unknown boot time must not
+    /// grant an unbounded grace.
+    fn in_reboot_grace(&self, server: &ServerMetaInfo, now_ms: u64) -> bool {
+        if self.options.reboot_grace_ms == 0 || server.boot_time_ms == 0 {
+            return false;
+        }
+        now_ms
+            .checked_sub(server.boot_time_ms)
+            .is_some_and(|age| age < self.options.reboot_grace_ms)
+    }
+}
+
+impl SingleNodeMeta {
+    /// Run one reconciliation round against the current state and return both
+    /// the findings and the reassignments to drive.
+    pub fn check_shard_divergence(
+        &self,
+        checker: &mut ShardChecker,
+    ) -> (ShardCheckReport, Vec<ShardReassignment>) {
+        let now = now_ms();
+        let (shard_owners, servers, live_servers) = {
+            let state = self.inner.read().expect("meta lock poisoned");
+            let shard_owners = state
+                .shards
+                .values()
+                .map(|location| (location.shard_id, location.server_addr.clone()))
+                .collect::<BTreeMap<_, _>>();
+            let servers = state.servers.values().cloned().collect::<Vec<_>>();
+            let live_servers = state
+                .servers
+                .values()
+                .filter(|server| server.state == MetaEntityState::Normal)
+                .map(|server| server.server_addr.clone())
+                .collect::<BTreeSet<_>>();
+            (shard_owners, servers, live_servers)
+        };
+        let mut report = checker.check(&shard_owners, &servers, now);
+        let moves = checker.plan_moves(&mut report, &shard_owners, &live_servers);
+        if !report.diverged.is_empty() {
+            let mut state = self.inner.write().expect("meta lock poisoned");
+            for divergence in &report.diverged {
+                record_topology_event(
+                    &mut state,
+                    "shard_divergence_detected",
+                    format!("shard:{}", divergence.shard_id),
+                    format!(
+                        "owner={},reported_unloaded={}",
+                        divergence.server_addr, divergence.reported_unloaded
+                    ),
+                );
+            }
+        }
+        (report, moves)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owners(pairs: &[(ShardId, &str)]) -> BTreeMap<ShardId, String> {
+        pairs
+            .iter()
+            .map(|(shard_id, addr)| (*shard_id, (*addr).to_string()))
+            .collect()
+    }
+
+    fn live(addrs: &[&str]) -> BTreeSet<String> {
+        addrs.iter().map(|addr| (*addr).to_string()).collect()
+    }
+
+    fn serving_state(shard_id: ShardId, loaded: bool) -> ServerShardServingState {
+        ServerShardServingState {
+            shard_id,
+            serving_state: "serving".to_string(),
+            worker_index: 0,
+            worker_threads: 1,
+            loaded,
+            readonly: false,
+            load_version: 1,
+            table_name: "ns.orders".to_string(),
+            shard_uri: String::new(),
+            start_routing_bucket: 0,
+            end_routing_bucket: u32::MAX,
+            total_records: 0,
+            storage_bytes: 0,
+            cache_memory_bytes: 0,
+            storage: ShardCanonicalStorageStats::default(),
+            block_store_bytes_written: 0,
+            wal_sequence: 0,
+            dirty_object_count: 0,
+            dirty_bucket_count: 0,
+        }
+    }
+
+    /// A healthy, reporting server that boots long before any test clock.
+    fn server(addr: &str, serving: &[(ShardId, bool)]) -> ServerMetaInfo {
+        ServerMetaInfo {
+            server_addr: addr.to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            state: MetaEntityState::Normal,
+            last_heartbeat_ms: 1_000_000,
+            frozen_since_ms: 0,
+            freeze_cooldown_until_ms: 0,
+            boot_time_ms: 1,
+            reported_boot_time_ms: 1,
+            reboot_detected: false,
+            reports_shard_states: true,
+            binary_version: "test".to_string(),
+            shard_loads: Vec::new(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: ServerRuntimeLoad::default(),
+            shard_states: serving
+                .iter()
+                .map(|(shard_id, loaded)| serving_state(*shard_id, *loaded))
+                .collect(),
+        }
+    }
+
+    const NOW: u64 = 1_000_000;
+
+    #[test]
+    fn a_shard_the_owner_no_longer_serves_is_detected_and_re_placed() {
+        // The owner is healthy and heartbeating; it simply stopped serving
+        // shard 2. Nothing else in the metaserver can see this.
+        let mut checker = ShardChecker::default();
+        let shard_owners = owners(&[(1, "s1"), (2, "s1"), (3, "s2")]);
+        let servers = vec![
+            server("s1", &[(1, true)]),
+            server("s2", &[(3, true)]),
+        ];
+        let mut report = checker.check(&shard_owners, &servers, NOW);
+        assert_eq!(report.diverged.len(), 1);
+        assert_eq!(report.diverged[0].shard_id, 2);
+        assert_eq!(report.diverged[0].server_addr, "s1");
+        assert!(!report.diverged[0].reported_unloaded);
+
+        let moves = checker.plan_moves(&mut report, &shard_owners, &live(&["s1", "s2"]));
+        assert_eq!(moves.len(), 1);
+        assert_eq!(moves[0].shard_id, 2);
+        assert_eq!(moves[0].to_server, "s2");
+        assert_eq!(moves[0].reason, ShardReassignmentReason::OwnerDiverged);
+    }
+
+    #[test]
+    fn a_shard_reported_but_not_loaded_is_flagged_more_weakly() {
+        let mut checker = ShardChecker::default();
+        let report = checker.check(
+            &owners(&[(1, "s1")]),
+            &[server("s1", &[(1, false)])],
+            NOW,
+        );
+        assert_eq!(report.diverged.len(), 1);
+        assert!(report.diverged[0].reported_unloaded);
+    }
+
+    #[test]
+    fn a_fully_consistent_cluster_reports_nothing() {
+        let mut checker = ShardChecker::default();
+        let report = checker.check(
+            &owners(&[(1, "s1"), (2, "s2")]),
+            &[server("s1", &[(1, true)]), server("s2", &[(2, true)])],
+            NOW,
+        );
+        assert!(report.diverged.is_empty());
+        assert!(report.skipped_in_reboot_grace.is_empty());
+        assert!(report.skipped_without_shard_reports.is_empty());
+    }
+
+    #[test]
+    fn a_server_that_just_booted_is_left_alone_to_reload() {
+        // Every shard is missing because the node has not finished loading yet.
+        // Acting on that would re-place the node's entire holding on every
+        // restart -- far more damage than the restart itself.
+        let mut checker = ShardChecker::default();
+        let mut booting = server("s1", &[]);
+        booting.boot_time_ms = NOW - 5_000; // 5s old, grace is 30s
+        let report = checker.check(&owners(&[(1, "s1"), (2, "s1")]), &[booting], NOW);
+        assert!(report.diverged.is_empty());
+        assert_eq!(report.skipped_in_reboot_grace, vec!["s1"]);
+    }
+
+    #[test]
+    fn the_reboot_grace_expires() {
+        let mut checker = ShardChecker::default();
+        let mut booted = server("s1", &[]);
+        booted.boot_time_ms = NOW - 31_000; // past the 30s grace
+        let report = checker.check(&owners(&[(1, "s1")]), &[booted], NOW);
+        assert!(report.skipped_in_reboot_grace.is_empty());
+        assert_eq!(report.diverged.len(), 1);
+    }
+
+    #[test]
+    fn a_server_that_never_reports_shard_states_is_never_judged() {
+        // An old build reporting nothing is indistinguishable from one serving
+        // nothing. Guessing would re-place the whole cluster on upgrade.
+        let mut checker = ShardChecker::default();
+        let mut silent = server("s1", &[]);
+        silent.reports_shard_states = false;
+        let report = checker.check(&owners(&[(1, "s1"), (2, "s1")]), &[silent], NOW);
+        assert!(report.diverged.is_empty());
+        assert_eq!(report.skipped_without_shard_reports, vec!["s1"]);
+    }
+
+    #[test]
+    fn a_reporting_server_that_now_serves_nothing_is_judged() {
+        // Once a server has been seen reporting shard states, an empty report is
+        // real information: it dropped everything.
+        let mut checker = ShardChecker::default();
+        let report = checker.check(&owners(&[(1, "s1"), (2, "s1")]), &[server("s1", &[])], NOW);
+        assert_eq!(report.diverged.len(), 2);
+    }
+
+    #[test]
+    fn a_frozen_owner_is_not_a_divergence() {
+        // The freeze path already owns this server; its shards are unavailable,
+        // not diverged, and evacuation will move them.
+        let mut checker = ShardChecker::default();
+        let mut frozen = server("s1", &[]);
+        frozen.state = MetaEntityState::Frozen;
+        let report = checker.check(&owners(&[(1, "s1")]), &[frozen], NOW);
+        assert!(report.diverged.is_empty());
+        assert!(report.skipped_without_shard_reports.is_empty());
+    }
+
+    #[test]
+    fn an_unregistered_owner_is_not_a_divergence() {
+        // Nothing is known about this address, so nothing can be concluded.
+        let mut checker = ShardChecker::default();
+        let report = checker.check(&owners(&[(1, "ghost")]), &[server("s1", &[])], NOW);
+        assert!(report.diverged.is_empty());
+    }
+
+    #[test]
+    fn the_rate_limit_bounds_how_much_moves_per_window() {
+        // A correlated fault can make many shards look missing at once. Reacting
+        // to all of them would move more data than the fault did.
+        let mut checker = ShardChecker::new(ShardCheckOptions {
+            max_moves_per_window: 2,
+            ..ShardCheckOptions::default()
+        });
+        let shard_owners = owners(&[(1, "s1"), (2, "s1"), (3, "s1"), (4, "s1"), (5, "s1")]);
+        let servers = vec![server("s1", &[]), server("s2", &[])];
+        let mut report = checker.check(&shard_owners, &servers, NOW);
+        // The report is complete even though the action is capped.
+        assert_eq!(report.diverged.len(), 5);
+        let moves = checker.plan_moves(&mut report, &shard_owners, &live(&["s1", "s2"]));
+        assert_eq!(moves.len(), 2);
+        assert_eq!(report.rate_limited, 3);
+
+        // Still inside the same window: the budget stays spent.
+        let mut again = checker.check(&shard_owners, &servers, NOW + 1_000);
+        assert!(checker
+            .plan_moves(&mut again, &shard_owners, &live(&["s1", "s2"]))
+            .is_empty());
+
+        // A new window refills it.
+        let mut next = checker.check(&shard_owners, &servers, NOW + 61_000);
+        assert_eq!(
+            checker
+                .plan_moves(&mut next, &shard_owners, &live(&["s1", "s2"]))
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn a_divergence_with_nowhere_else_to_go_is_reported_but_not_moved() {
+        // Re-placing a shard onto the same node that just lost it achieves
+        // nothing; better to leave the route and let the node reload.
+        let mut checker = ShardChecker::default();
+        let shard_owners = owners(&[(1, "s1")]);
+        let mut report = checker.check(&shard_owners, &[server("s1", &[])], NOW);
+        assert_eq!(report.diverged.len(), 1);
+        assert!(checker
+            .plan_moves(&mut report, &shard_owners, &live(&["s1"]))
+            .is_empty());
+    }
+
+    #[test]
+    fn moves_spread_across_targets_rather_than_stacking_on_one() {
+        let mut checker = ShardChecker::default();
+        let shard_owners = owners(&[(1, "s1"), (2, "s1"), (3, "s1"), (4, "s1")]);
+        let servers = vec![server("s1", &[]), server("s2", &[]), server("s3", &[])];
+        let mut report = checker.check(&shard_owners, &servers, NOW);
+        let moves = checker.plan_moves(&mut report, &shard_owners, &live(&["s1", "s2", "s3"]));
+        assert_eq!(moves.len(), 4);
+        let targets = moves
+            .iter()
+            .map(|plan| plan.to_server.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(targets.len(), 2, "both spare servers should take load");
+    }
+}

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -102,6 +102,7 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
             boot_time_ms: 0,
             reported_boot_time_ms: 0,
             reboot_detected: false,
+            reports_shard_states: false,
             binary_version: String::new(),
             shard_loads: Vec::new(),
             shard_stat_loads: Vec::new(),

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -320,6 +320,7 @@ pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> S
         boot_time_ms: 1,
         reported_boot_time_ms: 0,
         reboot_detected: false,
+        reports_shard_states: false,
         binary_version: "test".to_string(),
         shard_loads: Vec::new(),
         shard_stat_loads: Vec::new(),


### PR DESCRIPTION
> **Stacked on #64** — it uses the boot-time anchor added there for the reboot-grace window. Its own diff is the last commit; this will retarget to `main` when #64 merges.

## The problem

Every datanode heartbeat carries `shard_states` — the shards that node is serving right now. The metaserver keeps its own `shard → owner` map. **Nothing has ever compared the two.**

So when they drift apart the metaserver never finds out. A shard can disappear from a node — unloaded by an operator, failed to reload after a restart, a load rolled back, a disk gone read-only — and the owner map keeps pointing at that node indefinitely.

Nothing else can catch this:

- The node is healthy and **its heartbeats never stop**, so the stale-heartbeat detector has nothing to say.
- Its boot time is unchanged, so reboot detection (#64) has nothing to say.
- `compute_auto_rebalance` evacuates shards whose **owner** is unavailable, and this owner is perfectly available. **It is the shard that is gone, not the server.**

Every read for that shard is routed to a node that will miss on all of them, and the only signal is client-side errors.

## What this adds

`meta/shard_check.rs`. `ShardChecker::check` compares the owner map against what each server reports and produces one `ShardReassignmentReason::OwnerDiverged` reassignment per shard the recorded owner is not serving, which the existing rebalance drive path re-places onto a node that will serve it. A shard the owner reports but has marked *not loaded* is flagged separately as the weaker signal it is.

## Three guards

A reconciler that acts on every disagreement is more dangerous than the drift it repairs.

**Reboot grace.** A node that restarted seconds ago has not finished reloading, so its shards are legitimately missing for a while. Servers within `reboot_grace_ms` of their boot time are skipped — without this, *every restart* would trigger a full re-placement of everything that node owned.

**Report capability.** A server is judged only once it has been *seen* reporting shard states at least once, tracked by a new sticky `ServerMetaInfo::reports_shard_states`. A build that never reports them is indistinguishable from one serving nothing, and treating silence as "serving nothing" would re-place the entire cluster on upgrade. Once a server has reported, a later *empty* report is real information and is acted on.

**Rate limit.** At most `max_moves_per_window` divergences are acted on per window. A correlated fault can make many shards look missing at once, and reacting to all of them would move more data than the fault did. The report always lists **every** divergence found, so the limit bounds the action without hiding the picture.

## Deliberate non-cases

- **A frozen or dropped owner** is not a divergence — the freeze path already owns it, and its shards are *unavailable* rather than diverged, which evacuation handles.
- **An unregistered owner** is not a divergence — nothing is known about it, so nothing can be concluded.
- **A divergence whose owner is the only live server** is reported but not moved. Re-placing a shard onto the node that just lost it achieves nothing; better to leave the route and let the node reload.

The drive body is extracted into `drive_reassignments` so the divergence loop reuses the rebalance path verbatim. The source unload stays scoped to balance moves, since a divergence's source is precisely the node that no longer holds the shard.

## Off by default

It moves data, so it stays behind `TS_META_SHARD_DIVERGENCE_CHECK`.

| Variable | Default | Meaning |
|---|---|---|
| `TS_META_SHARD_DIVERGENCE_CHECK` | `0` | Master switch |
| `TS_META_SHARD_DIVERGENCE_INTERVAL_MS` | detector interval | Round period |
| `TS_META_SHARD_DIVERGENCE_REBOOT_GRACE_MS` | `30000` | Skip a server this recently booted |
| `TS_META_SHARD_DIVERGENCE_MAX_MOVES` | `10` | Divergences acted on per window |
| `TS_META_SHARD_DIVERGENCE_WINDOW_MS` | `60000` | Rate-limit window |

## Tests

12 new unit tests: detection of a dropped shard and its re-placement, the not-loaded case, a consistent cluster reporting nothing, the reboot grace holding and then expiring, a never-reporting server never being judged, a reporting server that now serves nothing being judged, frozen and unregistered owners being ignored, the rate limit bounding moves and refilling on the next window, the nowhere-to-go case, and moves spreading across targets rather than stacking.

Verification:

- `cargo test -p temporalstore-rust --lib meta::shard_check` — 12 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **122 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.
