### PR TITLE
meta: treat server locations as a hierarchy, not an opaque string

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -23,6 +23,7 @@ mod table_ops;
 mod topology_helpers;
 mod auto_rebalance;
 mod failure_detector;
+mod location;
 mod placement_rebalance;
 mod raft_failover;
 mod shard_check;
@@ -40,6 +41,7 @@ pub use self::failure_detector::{
 pub use self::placement_rebalance::{
     compute_placement_aware_rebalance, PlacementTarget, ShardPlacement,
 };
+pub use self::location::{separated_from, separation_ladder, Location};
 pub use self::raft_failover::{compute_raft_failover_triggers, RaftFailoverTrigger};
 pub use self::shard_check::{
     ShardCheckOptions, ShardCheckReport, ShardChecker, ShardDivergence,
@@ -1421,6 +1423,74 @@ mod tests {
             .find(|server| server.server_addr == "node-a")
             .expect("registered");
         assert!(!server.reboot_detected);
+    }
+
+    #[test]
+    fn replicas_spread_across_availability_units_not_just_racks() {
+        // Four servers, two availability units, two racks each. Comparing whole
+        // location strings makes rack1 and rack2 of az1 look like "different
+        // locations", so both replicas of a shard land inside az1 and losing
+        // that unit loses both. Placement must reach for az2 instead.
+        let meta = SingleNodeMeta::default();
+        for (addr, location) in [
+            ("a1", "us-east/dc1/az1/rack1"),
+            ("a2", "us-east/dc1/az1/rack2"),
+            ("b1", "us-east/dc1/az2/rack1"),
+            ("b2", "us-east/dc1/az2/rack2"),
+        ] {
+            assert!(meta
+                .register_server(RegisterServerRequest {
+                    server_addr: addr.to_string(),
+                    node_id: 1,
+                    location: location.to_string(),
+                    binary_version: "v1".to_string(),
+                })
+                .status
+                .ok);
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+                first_shard_id: 1,
+                shard_count: 1,
+                replica_count: 2,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+
+        let topology = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+        });
+        assert!(topology.status.ok);
+        assert_eq!(topology.shards.len(), 1);
+        let replicas = &topology.shards[0].replicas;
+        assert_eq!(replicas.len(), 2, "expected two replicas, got {replicas:?}");
+
+        let units = replicas
+            .iter()
+            .map(|addr| {
+                let server = meta
+                    .list_servers()
+                    .servers
+                    .into_iter()
+                    .find(|server| &server.server_addr == addr)
+                    .expect("replica is a registered server");
+                Location::parse(&server.location).ancestor(3).to_path()
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            units.len(),
+            2,
+            "both replicas landed in the same availability unit: {units:?}"
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/location.rs
+++ b/crates/temporalstore-rust/src/meta/location.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Hierarchical server locations.
+//!
+//! A server's `location` is a plain `String` that the metaserver only ever
+//! compares for exact equality. Real deployments write a path into it —
+//! `us-east/dc1/az1/rack7` — and the metaserver reads that as one opaque token,
+//! which costs correctness in two places.
+//!
+//! **Replica spread happens at the wrong granularity.** [`build_shards`] refuses
+//! to place two replicas of a shard in the same `location`, comparing whole
+//! strings. `us-east/dc1/az1/rack1` and `us-east/dc1/az1/rack2` are different
+//! strings, so both are accepted — and the shard ends up with two replicas in
+//! one availability unit. Losing that unit loses both. The check looks like it
+//! is spreading across failure domains while it is only spreading across the
+//! deepest one.
+//!
+//! **A table can only be pinned to exactly one location.** A `preferred_location`
+//! is matched by string equality, so "keep this table in dc1" is not
+//! expressible: you can name one rack, or nothing.
+//!
+//! [`Location`] parses the string into its `/`-separated levels, coarsest first,
+//! and supplies the two comparisons those cases need:
+//!
+//! * [`Location::belongs_to`] — prefix containment. A preference naming fewer
+//!   levels matches every location beneath it, so `dc1` covers every rack in it.
+//! * [`Location::shared_prefix_len`] — how much of a failure domain two
+//!   locations have in common, which is what lets replica placement prefer the
+//!   *widest* separation available instead of merely a different leaf.
+//!
+//! A location with no separator has a single level, so a deployment using flat
+//! tags (`zone-a`, `zone-b`) behaves exactly as it does today: different strings
+//! differ at level 0, and neither is a prefix of the other.
+//!
+//! This generalises the reference's fixed four-field location
+//! (region / datacenter / availability unit / tag) to a path of any depth. The
+//! reference compares its last field exactly and the earlier ones only when the
+//! pattern sets them; a variable-depth path expresses the same intent as plain
+//! prefix matching, and does not force every deployment onto exactly four
+//! levels.
+
+use super::*;
+
+/// A parsed server location: `/`-separated levels, coarsest first.
+///
+/// Empty segments are dropped, so leading, trailing and doubled separators are
+/// tolerated — an operator writing `/dc1/az1/` means the same thing as
+/// `dc1/az1`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Location {
+    levels: Vec<String>,
+}
+
+impl Location {
+    /// Parse a location string into its levels.
+    pub fn parse(raw: &str) -> Self {
+        Self {
+            levels: raw
+                .split('/')
+                .map(str::trim)
+                .filter(|level| !level.is_empty())
+                .map(str::to_string)
+                .collect(),
+        }
+    }
+
+    /// True when no level was declared at all.
+    pub fn is_empty(&self) -> bool {
+        self.levels.is_empty()
+    }
+
+    /// How many levels this location names.
+    pub fn depth(&self) -> usize {
+        self.levels.len()
+    }
+
+    pub fn levels(&self) -> &[String] {
+        &self.levels
+    }
+
+    /// The `depth`-level prefix of this location, or the whole thing when it is
+    /// shallower. Used to name the failure domain a server sits in at a given
+    /// granularity.
+    pub fn ancestor(&self, depth: usize) -> Location {
+        Location {
+            levels: self.levels.iter().take(depth).cloned().collect(),
+        }
+    }
+
+    /// True when `self` sits at or beneath `pattern`.
+    ///
+    /// An empty pattern matches everything ("anywhere"), and a pattern naming
+    /// fewer levels than `self` matches every location beneath it — so a table
+    /// pinned to `dc1` accepts a server in `dc1/az2/rack9`. A pattern deeper
+    /// than `self` never matches: `dc1` does not belong to `dc1/az1`.
+    pub fn belongs_to(&self, pattern: &Location) -> bool {
+        if pattern.levels.len() > self.levels.len() {
+            return false;
+        }
+        pattern
+            .levels
+            .iter()
+            .zip(self.levels.iter())
+            .all(|(want, have)| want == have)
+    }
+
+    /// How many leading levels two locations share. Zero means they diverge at
+    /// the coarsest level, which is the widest separation available.
+    pub fn shared_prefix_len(&self, other: &Location) -> usize {
+        self.levels
+            .iter()
+            .zip(other.levels.iter())
+            .take_while(|(left, right)| left == right)
+            .count()
+    }
+
+    /// Render back to the canonical `a/b/c` form.
+    pub fn to_path(&self) -> String {
+        self.levels.join("/")
+    }
+}
+
+impl std::fmt::Display for Location {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.to_path())
+    }
+}
+
+/// Does `candidate` diverge from everything in `placed` within the first
+/// `separation` levels?
+///
+/// `separation` is how far down the hierarchy the divergence must occur, so
+/// *smaller is stricter*: 1 demands a different top-level domain, while 4
+/// accepts any difference in the first four levels. Placement walks it upward,
+/// taking the widest separation the topology can actually provide.
+pub fn separated_from(placed: &[Location], candidate: &Location, separation: usize) -> bool {
+    if candidate.is_empty() {
+        // A server that declares no location cannot be reasoned about; leave the
+        // decision to the host and identity checks the caller also applies.
+        return true;
+    }
+    placed.iter().all(|existing| {
+        if existing.is_empty() {
+            return true;
+        }
+        let shared = existing.shared_prefix_len(candidate);
+        // Two identical locations are the same failure domain at every
+        // granularity, so they conflict however weak the requirement is.
+        if shared == existing.depth() && shared == candidate.depth() {
+            return false;
+        }
+        shared < separation
+    })
+}
+
+/// The separation levels to try when placing replicas, widest first.
+///
+/// Placement walks these in order and takes the first level at which a candidate
+/// is acceptable, so replicas are spread as far apart as the topology allows
+/// rather than merely onto a different leaf. Always yields at least one rung, so
+/// a caller with no locations at all still has a pass to run.
+pub fn separation_ladder(locations: &[Location]) -> Vec<usize> {
+    let deepest = locations
+        .iter()
+        .map(Location::depth)
+        .max()
+        .unwrap_or_default();
+    (1..=deepest.max(1)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loc(raw: &str) -> Location {
+        Location::parse(raw)
+    }
+
+    #[test]
+    fn a_path_parses_into_levels_coarsest_first() {
+        let parsed = loc("us-east/dc1/az1/rack7");
+        assert_eq!(parsed.depth(), 4);
+        assert_eq!(parsed.levels(), ["us-east", "dc1", "az1", "rack7"]);
+        assert_eq!(parsed.to_path(), "us-east/dc1/az1/rack7");
+    }
+
+    #[test]
+    fn separators_are_forgiving() {
+        assert_eq!(loc("/dc1//az1/ ").levels(), ["dc1", "az1"]);
+        assert!(loc("").is_empty());
+        assert!(loc("///").is_empty());
+    }
+
+    #[test]
+    fn a_flat_tag_is_a_single_level() {
+        // The behaviour existing deployments already rely on: two flat tags are
+        // simply different, and neither contains the other.
+        let a = loc("zone-a");
+        let b = loc("zone-b");
+        assert_eq!(a.depth(), 1);
+        assert!(!a.belongs_to(&b));
+        assert!(!b.belongs_to(&a));
+        assert_eq!(a.shared_prefix_len(&b), 0);
+    }
+
+    #[test]
+    fn a_shallower_pattern_matches_everything_beneath_it() {
+        // The point of the hierarchy: "keep this table in dc1" becomes
+        // expressible, instead of having to name one exact rack.
+        let server = loc("us-east/dc1/az1/rack7");
+        assert!(server.belongs_to(&loc("us-east")));
+        assert!(server.belongs_to(&loc("us-east/dc1")));
+        assert!(server.belongs_to(&loc("us-east/dc1/az1")));
+        assert!(server.belongs_to(&loc("us-east/dc1/az1/rack7")));
+        assert!(!server.belongs_to(&loc("us-east/dc2")));
+        assert!(!server.belongs_to(&loc("us-west")));
+    }
+
+    #[test]
+    fn an_empty_pattern_means_anywhere() {
+        assert!(loc("us-east/dc1").belongs_to(&loc("")));
+        assert!(loc("").belongs_to(&loc("")));
+    }
+
+    #[test]
+    fn a_deeper_pattern_never_matches_a_shallower_location() {
+        // A server that only declares `dc1` is not known to be in az1.
+        assert!(!loc("us-east/dc1").belongs_to(&loc("us-east/dc1/az1")));
+    }
+
+    #[test]
+    fn shared_prefix_measures_the_common_failure_domain() {
+        assert_eq!(
+            loc("us-east/dc1/az1/rack1").shared_prefix_len(&loc("us-east/dc1/az1/rack2")),
+            3
+        );
+        assert_eq!(
+            loc("us-east/dc1/az1/rack1").shared_prefix_len(&loc("us-east/dc1/az2/rack1")),
+            2
+        );
+        assert_eq!(
+            loc("us-east/dc1/az1").shared_prefix_len(&loc("us-west/dc9/az9")),
+            0
+        );
+    }
+
+    #[test]
+    fn separation_prefers_the_widest_split_available() {
+        let placed = vec![loc("us-east/dc1/az1/rack1")];
+        // A different region is separated at every level.
+        assert!(separated_from(&placed, &loc("us-west/dc9/az9/rack9"), 1));
+        // A different availability unit is not separated at the region level...
+        assert!(!separated_from(&placed, &loc("us-east/dc1/az2/rack1"), 1));
+        // ...but is at the availability-unit level.
+        assert!(separated_from(&placed, &loc("us-east/dc1/az2/rack1"), 3));
+    }
+
+    #[test]
+    fn two_racks_in_one_availability_unit_are_not_separated_at_that_level() {
+        // The bug this exists to prevent: these are different strings, so the
+        // old whole-string check accepted both and put two replicas in one unit.
+        let placed = vec![loc("us-east/dc1/az1/rack1")];
+        assert!(!separated_from(&placed, &loc("us-east/dc1/az1/rack2"), 3));
+        // At the deepest level they are distinguishable, which is the fallback.
+        assert!(separated_from(&placed, &loc("us-east/dc1/az1/rack2"), 4));
+    }
+
+    #[test]
+    fn an_identical_location_is_never_separated() {
+        let placed = vec![loc("us-east/dc1/az1/rack1")];
+        for separation in 1..=6 {
+            assert!(
+                !separated_from(&placed, &loc("us-east/dc1/az1/rack1"), separation),
+                "identical locations must conflict at separation {separation}"
+            );
+        }
+    }
+
+    #[test]
+    fn flat_tags_still_separate_at_every_level() {
+        // Existing deployments must be unaffected.
+        let placed = vec![loc("zone-a")];
+        assert!(separated_from(&placed, &loc("zone-b"), 1));
+        assert!(!separated_from(&placed, &loc("zone-a"), 1));
+    }
+
+    #[test]
+    fn a_server_without_a_location_never_blocks_placement() {
+        let placed = vec![loc(""), loc("us-east/dc1")];
+        assert!(separated_from(&placed, &loc(""), 1));
+        assert!(separated_from(&placed, &loc("us-west/dc2"), 1));
+    }
+
+    #[test]
+    fn the_ladder_walks_from_widest_to_narrowest() {
+        // Smaller separation is stricter, so widest-first means ascending.
+        let locations = vec![loc("us-east/dc1/az1/rack1"), loc("us-east/dc1")];
+        assert_eq!(separation_ladder(&locations), vec![1, 2, 3, 4]);
+        // Flat tags give a single rung.
+        assert_eq!(separation_ladder(&[loc("zone-a")]), vec![1]);
+        // No locations at all still yields one rung rather than none.
+        assert_eq!(separation_ladder(&[]), vec![1]);
+    }
+
+    #[test]
+    fn ancestor_names_the_domain_at_a_given_depth() {
+        let server = loc("us-east/dc1/az1/rack7");
+        assert_eq!(server.ancestor(0).to_path(), "");
+        assert_eq!(server.ancestor(2).to_path(), "us-east/dc1");
+        assert_eq!(server.ancestor(99).to_path(), "us-east/dc1/az1/rack7");
+    }
+}

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -84,6 +84,11 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
                 &right.server_addr,
             ))
     });
+    // Every live server's parsed location, used to size the separation ladder.
+    let candidate_locations = normal_servers
+        .iter()
+        .map(|candidate| Location::parse(&candidate.location))
+        .collect::<Vec<_>>();
     let bucket_count = 1_u64 << 30;
     let mut shards = Vec::new();
     for offset in 0..table.shard_count {
@@ -94,7 +99,11 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
         let mut seen_replicas = BTreeSet::new();
         let mut used_locations = BTreeSet::new();
         let mut used_hosts = BTreeSet::new();
+        let mut placed_locations: Vec<Location> = Vec::new();
         if let Some(location) = state.shards.get(&shard_id) {
+            if let Some(server) = state.servers.get(&location.server_addr) {
+                placed_locations.push(Location::parse(&server.location));
+            }
             push_replica(
                 state,
                 &mut replicas,
@@ -104,28 +113,42 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
                 &location.server_addr,
             );
         }
-        for candidate in &normal_servers {
+        // Spread replicas as far apart as the topology allows: try the widest
+        // separation first (a different top-level domain) and only narrow when
+        // nothing qualifies. Comparing whole location strings, as this used to,
+        // treats two racks in one availability unit as "different locations" and
+        // happily puts both replicas of a shard inside it.
+        for separation in separation_ladder(&candidate_locations) {
             if replicas.len() >= table.replica_count as usize {
                 break;
             }
-            if seen_replicas.contains(&candidate.server_addr) {
-                continue;
+            for candidate in &normal_servers {
+                if replicas.len() >= table.replica_count as usize {
+                    break;
+                }
+                if seen_replicas.contains(&candidate.server_addr) {
+                    continue;
+                }
+                let candidate_location = Location::parse(&candidate.location);
+                if !separated_from(&placed_locations, &candidate_location, separation) {
+                    continue;
+                }
+                let host = server_host(&candidate.server_addr);
+                if !host.is_empty() && used_hosts.contains(&host) {
+                    continue;
+                }
+                if !candidate_location.is_empty() {
+                    placed_locations.push(candidate_location);
+                }
+                push_replica(
+                    state,
+                    &mut replicas,
+                    &mut seen_replicas,
+                    &mut used_locations,
+                    &mut used_hosts,
+                    &candidate.server_addr,
+                );
             }
-            if !candidate.location.is_empty() && used_locations.contains(&candidate.location) {
-                continue;
-            }
-            let host = server_host(&candidate.server_addr);
-            if !host.is_empty() && used_hosts.contains(&host) {
-                continue;
-            }
-            push_replica(
-                state,
-                &mut replicas,
-                &mut seen_replicas,
-                &mut used_locations,
-                &mut used_hosts,
-                &candidate.server_addr,
-            );
         }
         for candidate in &normal_servers {
             if replicas.len() >= table.replica_count as usize {

--- a/crates/temporalstore-rust/src/meta/placement_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/placement_rebalance.rs
@@ -295,13 +295,27 @@ fn build_index(
     for target in live_servers {
         all.insert(target.server_addr.clone());
     }
-    for target in live_servers {
-        if !target.location.is_empty() {
-            eligible_sets
-                .entry(target.location.clone())
-                .or_default()
-                .insert(target.server_addr.clone());
+    // A preference is matched by hierarchical containment rather than string
+    // equality, so a table pinned to `dc1` accepts any server beneath it -- with
+    // exact matching, only a single rack could ever be named.
+    let parsed_targets = live_servers
+        .iter()
+        .map(|target| (target, Location::parse(&target.location)))
+        .collect::<Vec<_>>();
+    let mut wanted_locations = BTreeSet::new();
+    for placement in shard_placement.values() {
+        if !placement.preferred_location.is_empty() {
+            wanted_locations.insert(placement.preferred_location.clone());
         }
+    }
+    for wanted in wanted_locations {
+        let pattern = Location::parse(&wanted);
+        let matching = parsed_targets
+            .iter()
+            .filter(|(_, location)| location.belongs_to(&pattern))
+            .map(|(target, _)| target.server_addr.clone())
+            .collect::<BTreeSet<_>>();
+        eligible_sets.insert(wanted, matching);
     }
 
     let mut shard_eligible = BTreeMap::new();
@@ -583,6 +597,89 @@ mod tests {
         assert_eq!(
             moves(&plans),
             vec![(1, "a2", ShardReassignmentReason::OwnerUnavailable)]
+        );
+    }
+
+    #[test]
+    fn a_preference_can_name_a_whole_datacenter() {
+        // With exact string matching this is impossible to express: a table
+        // could only ever be pinned to one rack. Any server beneath dc1 now
+        // qualifies, and one outside it does not.
+        let plans = compute_placement_aware_rebalance(
+            &owners(&[(1, "dead")]),
+            &placement(&[(1, "ns.orders", "us-east/dc1")]),
+            &targets(&[
+                ("a1", "us-east/dc1/az1/rack1"),
+                ("a2", "us-east/dc1/az2/rack9"),
+                ("b1", "us-east/dc2/az1/rack1"),
+            ]),
+            AutoRebalanceOptions {
+                balance_load: false,
+                ..AutoRebalanceOptions::default()
+            },
+        );
+        assert_eq!(plans.len(), 1);
+        assert!(
+            plans[0].to_server == "a1" || plans[0].to_server == "a2",
+            "must land inside dc1, got {}",
+            plans[0].to_server
+        );
+    }
+
+    #[test]
+    fn a_shard_outside_its_preferred_datacenter_is_pulled_back_into_it() {
+        let plans = compute_placement_aware_rebalance(
+            &owners(&[(1, "b1")]),
+            &placement(&[(1, "ns.orders", "us-east/dc1")]),
+            &targets(&[
+                ("a1", "us-east/dc1/az1/rack1"),
+                ("b1", "us-east/dc2/az1/rack1"),
+            ]),
+            AutoRebalanceOptions {
+                balance_load: false,
+                ..AutoRebalanceOptions::default()
+            },
+        );
+        assert_eq!(
+            moves(&plans),
+            vec![(1, "a1", ShardReassignmentReason::LocationViolation)]
+        );
+    }
+
+    #[test]
+    fn a_deeper_preference_still_pins_to_one_rack() {
+        // The narrow case keeps working: naming every level pins exactly.
+        let plans = compute_placement_aware_rebalance(
+            &owners(&[(1, "dead")]),
+            &placement(&[(1, "ns.orders", "us-east/dc1/az2/rack9")]),
+            &targets(&[
+                ("a1", "us-east/dc1/az1/rack1"),
+                ("a2", "us-east/dc1/az2/rack9"),
+            ]),
+            AutoRebalanceOptions {
+                balance_load: false,
+                ..AutoRebalanceOptions::default()
+            },
+        );
+        assert_eq!(
+            moves(&plans),
+            vec![(1, "a2", ShardReassignmentReason::OwnerUnavailable)]
+        );
+    }
+
+    #[test]
+    fn a_preference_no_live_server_matches_falls_back_to_anywhere() {
+        // Same guard as before, now evaluated hierarchically: dc9 is empty, so
+        // the shard is placed rather than stranded.
+        let plans = compute_placement_aware_rebalance(
+            &owners(&[(1, "dead")]),
+            &placement(&[(1, "ns.orders", "us-east/dc9")]),
+            &targets(&[("a1", "us-east/dc1/az1/rack1")]),
+            AutoRebalanceOptions::default(),
+        );
+        assert_eq!(
+            moves(&plans),
+            vec![(1, "a1", ShardReassignmentReason::OwnerUnavailable)]
         );
     }
 


### PR DESCRIPTION
## The problem

A server's `location` is a plain `String` the metaserver only ever compares for **exact equality**. Real deployments write a path into it — `us-east/dc1/az1/rack7` — and the metaserver reads that as one opaque token. That costs correctness twice.

**Replica spread happens at the wrong granularity.** `build_shards` refuses to put two replicas of a shard in the same `location`, comparing whole strings. `us-east/dc1/az1/rack1` and `us-east/dc1/az1/rack2` are *different strings*, so both are accepted — and the shard ends up with **two replicas inside one availability unit**. Losing that unit loses both. The check looks like it is spreading across failure domains while it is only spreading across the deepest one.

This is measured, not argued: the new end-to-end test fails on current `main` with

```
both replicas landed in the same availability unit: {"us-east/dc1/az1"}
```

**A table can only be pinned to exactly one location.** `preferred_location` is matched by string equality, so "keep this table in dc1" is not expressible — an operator can name one rack, or nothing.

## What this adds

`meta/location.rs` parses the string into its `/`-separated levels, coarsest first, and supplies the two comparisons those cases need:

- **`belongs_to`** — prefix containment. A preference naming fewer levels matches every location beneath it.
- **`shared_prefix_len`** — how much of a failure domain two locations have in common, which is what lets placement prefer the *widest* separation available rather than merely a different leaf.

**`build_shards` now walks a separation ladder**: place each replica in a different top-level domain if it can, and only narrow when nothing qualifies — down to a different leaf, and finally the existing unconstrained pass. Two identical locations are the same failure domain at every granularity and conflict however weak the requirement, which is what preserves today's behaviour for flat tags.

**Placement eligibility in the rebalancer is hierarchical too**, so a table pinned to `us-east/dc1` accepts any server beneath it, a deeper preference still pins to one rack, and a preference no live server matches still falls back to anywhere rather than stranding the shard.

## Compatibility

A location with **no separator has a single level**, so a deployment using flat tags (`zone-a`, `zone-b`) behaves exactly as it does today: different strings differ at level 0, and neither is a prefix of the other. Servers that declare no location at all never block placement. No wire type changes — the field is still a `String`, just interpreted.

## On the shape of a location

A fixed four-field location (region / datacenter / availability unit / tag) would express the same intent, matching the last field exactly and earlier ones only when a pattern sets them. A variable-depth path says the same thing as plain prefix matching, without forcing every deployment onto exactly four levels.

## Tests

18 new tests: parsing and separator tolerance, flat tags staying flat, prefix containment in both directions, an empty pattern meaning anywhere, shared-prefix measurement, the separation ladder and its ordering, identical locations never separating, two racks in one availability unit not separating at that level, a preference naming a whole datacenter, a shard outside its datacenter being pulled back, a deeper preference still pinning to one rack, the empty-preference fallback, and the end-to-end topology test above.

Verification:

- `cargo test -p temporalstore-rust --lib meta::location` — 14 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta::placement_rebalance` — 16 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **181 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- The spread test was run against unmodified `partitioning.rs` and **fails**, confirming it is a genuine regression test rather than a tautology.

