### PR TITLE
raft: make the safety properties unconditional (R3, R5, R8, R9)

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -86,7 +86,6 @@ index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped
 # multi-barrier write path + delta-fold recovery without a rebuild.
 # -----------------------------------------------------------------------------
 [wal]
-wal_single_barrier = 1                 # TS_WAL_SINGLE_BARRIER  1 = single write-path barrier (WAL-only fsync; base-only recovery). DEFAULT.
 group_commit = 1                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers (sub-ms/write under load); also coalesces the shared-store object-store SYNC publish onto one durable barrier per group. DEFAULT.
 commit_delay_us = 0                     # TS_WAL_COMMIT_DELAY_US  group-commit batch-widening delay in microseconds. 0 = pure timer-less (batch = whatever accrues during one barrier's in-flight duration); >0 deliberately widens batches under extreme load.
 wal_legacy_recovery = 0                # TS_WAL_LEGACY_RECOVERY  1 = emergency fallback to the legacy multi-barrier write path + delta-fold recovery.

--- a/crates/temporalstore-rust/src/bin/server/raft_route.rs
+++ b/crates/temporalstore-rust/src/bin/server/raft_route.rs
@@ -511,26 +511,15 @@ fn read_via_server_raft(
     // APPLIED up to that index could answer with stale/half-applied state. Wait for the target
     // to apply through the returned read_index before serving. Gated so default behavior is
     // unchanged.
-    if raft_applied_read_safety_enabled() {
-        cluster.wait_for_applied_index(
-            target_node_id,
-            read_index_response.read_index,
-            state.read_policy.read_index_timeout_ms,
-        )?;
-    }
+    // R3: a replica can hold commit_index == leader_commit while its state machine has applied
+    // only a prefix of that. Wait for apply to reach the read index before serving, so the read
+    // never returns half-applied state as fresh.
+    cluster.wait_for_applied_index(
+        target_node_id,
+        read_index_response.read_index,
+        state.read_policy.read_index_timeout_ms,
+    )?;
     cluster.read_from_replica(target_node_id, command)
-}
-
-/// R3 gate mirror for the server read path (see `raft::raft_applied_read_safety_on`).
-fn raft_applied_read_safety_enabled() -> bool {
-    matches!(
-        std::env::var("TS_RAFT_APPLIED_READ_SAFETY")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
 }
 
 fn command_response(

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -187,9 +187,14 @@ pub const DATA_RAFT_CODEC_VERSION: u32 = 1;
 const DATA_RAFT_LOG_HEADER_LEN: usize = 56;
 const DATA_RAFT_COMMAND_HEADER_LEN: usize = 40;
 
-/// Read a boolean gate env var (`1`/`true`/`yes`/`on`). Every replication-safety hardening in
-/// this module is gated OFF by default so the shipped behavior stays byte-identical until the
-/// operator opts in; the gated tests set the flag explicitly.
+/// Read a boolean gate env var (`1`/`true`/`yes`/`on`), default OFF.
+///
+/// The replication-SAFETY properties (quorum election, durable pre-vote persistence, applied-read
+/// freshness, §7 snapshot-boundary truncation) are no longer gated -- they are what makes this
+/// Raft, not options, and shipping them dark meant the default build was the only configuration
+/// nobody tested. What remains behind this helper is genuinely optional: an optimization whose
+/// cost profile an operator may not want, or a hardening that is not yet complete enough to be
+/// the default. Each surviving gate documents which of the two it is.
 fn raft_env_flag_on(name: &str) -> bool {
     matches!(
         std::env::var(name)
@@ -215,34 +220,18 @@ fn raft_env_flag_default_on(name: &str) -> bool {
     )
 }
 
-/// R8: §7 snapshot-install boundary-term truncation. When on, a snapshot install whose
-/// boundary entry does not term-match the local log discards the ENTIRE log instead of
-/// retaining a possibly-divergent tail.
-fn raft_snapshot_boundary_truncate_on() -> bool {
-    raft_env_flag_on("TS_RAFT_SNAPSHOT_BOUNDARY_TRUNCATE")
-}
-
-/// R9: durably persist the incremented term + a self-vote before advertising a RequestVote.
-fn raft_persist_vote_before_request_on() -> bool {
-    raft_env_flag_on("TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST")
-}
-
-/// R3: gate reads on `applied_index` (reject/await unapplied-but-committed state) rather than
-/// bounding on commit-lag alone.
-fn raft_applied_read_safety_on() -> bool {
-    raft_env_flag_on("TS_RAFT_APPLIED_READ_SAFETY")
-}
-
 /// R4: after an election, withhold read-index/lease reads until the new leader has committed a
 /// no-op entry in its own term (leader-ready barrier).
+///
+/// STILL GATED, deliberately. Raft releases this barrier by having a new leader append a no-op
+/// entry at its own term the moment it is elected (§8). This implementation never appends one:
+/// `leader_has_committed_current_term` can only be satisfied by a CLIENT write landing at the new
+/// term. Enabling the gate unconditionally would therefore reject every leader-served
+/// read-index/lease read from the end of an election until the next write commits -- indefinitely
+/// on an idle cluster. Promoting this gate requires appending the election no-op first, which is a
+/// new `Command` variant and thus a wire-format change for `#[serde(tag = "kind")]` peers.
 fn raft_leader_ready_barrier_on() -> bool {
     raft_env_flag_on("TS_RAFT_LEADER_READY_BARRIER")
-}
-
-/// R5: require a durable per-term quorum RequestVote round (a candidate must collect a
-/// majority of granted votes) before promotion, instead of promoting from a local view.
-fn raft_quorum_election_on() -> bool {
-    raft_env_flag_on("TS_RAFT_QUORUM_ELECTION")
 }
 
 /// S2: snapshot the engine STATE IMAGE (exported index + page slabs) instead of every committed

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -461,79 +461,14 @@ impl RaftClusterInner {
             .count())
     }
 
-    pub(super) fn elect_leader(&mut self, node_id: RaftNodeId) -> Result<(), RaftError> {
-        if raft_quorum_election_on() {
-            return self.elect_leader_quorum_round(node_id);
-        }
-        if self.config.prohibits_election {
-            for node in self.nodes.values_mut() {
-                node.pipeline_state.election_rejections =
-                    node.pipeline_state.election_rejections.saturating_add(1);
-            }
-            return Err(RaftError::ElectionProhibited);
-        }
-        let required = self.required_majority();
-        let live = self.live_quorum_participants();
-        if live < required {
-            return Err(RaftError::NoMajority { live, required });
-        }
-        if let Some((live, required)) = self.joint_majority_failure() {
-            return Err(RaftError::NoMajority { live, required });
-        }
-        if !self
-            .nodes
-            .get(&node_id)
-            .map(|node| node.alive && node.replica_role.can_be_leader())
-            .unwrap_or(false)
-        {
-            return Err(RaftError::NodeNotFound(node_id));
-        }
-        if !self.candidate_log_would_win(node_id)? {
-            let candidate_commit_index = self
-                .nodes
-                .get(&node_id)
-                .map(|node| node.commit_index)
-                .unwrap_or_default();
-            return Err(RaftError::ReplicaLagging {
-                replica_id: node_id,
-                replica_commit_index: candidate_commit_index,
-                leader_commit_index: self.leader_commit_index(),
-            });
-        }
-        self.leader_id = node_id;
-        let next_term = self
-            .nodes
-            .values()
-            .map(|node| node.current_term)
-            .max()
-            .unwrap_or_default()
-            + 1;
-        for node in self.nodes.values_mut() {
-            node.role = if node.id == node_id {
-                RaftRole::Leader
-            } else {
-                RaftRole::Follower
-            };
-            node.current_term = next_term;
-            node.voted_for = if node.id == node_id {
-                Some(node_id)
-            } else {
-                None
-            };
-        }
-        self.election_elapsed_tick = 0;
-        self.renew_leader_lease();
-        Ok(())
-    }
-
     /// R5: promote `node_id` only after a DURABLE per-term quorum RequestVote round grants it a
-    /// majority — instead of promoting from a local snapshot. This mirrors the receiver rules
+    /// majority. This mirrors the receiver rules
     /// already implemented in `receive_vote_request` (single vote per term via `voted_for`,
     /// leader-completeness log-freshness), but drives them across every voter and gates
     /// promotion on the collected grant count. A partitioned candidate whose granting voters
     /// fall short of majority cannot elect, so two disjoint partitions can never each promote a
     /// leader for the same term.
-    fn elect_leader_quorum_round(&mut self, node_id: RaftNodeId) -> Result<(), RaftError> {
+    pub(super) fn elect_leader(&mut self, node_id: RaftNodeId) -> Result<(), RaftError> {
         if self.config.prohibits_election {
             for node in self.nodes.values_mut() {
                 node.pipeline_state.election_rejections =

--- a/crates/temporalstore-rust/src/raft/cluster_read_status.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_read_status.rs
@@ -59,7 +59,7 @@ impl RaftCluster {
         // commit_index == leader_commit while its state machine has only applied a prefix of
         // that (applied_index < commit_index), which would serve HALF-APPLIED state as fresh.
         // Gate the read on applied_index reaching the leader's committed frontier.
-        if raft_applied_read_safety_on() && node.applied_index < leader_commit_index {
+        if node.applied_index < leader_commit_index {
             return Err(RaftError::ReplicaApplyLagging {
                 replica_id: node_id,
                 replica_applied_index: node.applied_index,
@@ -651,5 +651,38 @@ impl RaftCluster {
             .ok_or(RaftError::NodeNotFound(node_id))?;
         node.applied_index = applied_index;
         Ok(())
+    }
+
+    /// Replace a node's in-memory log wholesale. Test-only: lets a case construct a divergent
+    /// log tail (entries from a superseded branch) that cannot be produced through the normal
+    /// append path, which is what the §7 snapshot-boundary truncation has to discard.
+    #[cfg(test)]
+    pub(crate) fn set_node_log_for_test(
+        &self,
+        node_id: RaftNodeId,
+        entries: Vec<RaftLogEntry>,
+    ) -> Result<(), RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let node = inner
+            .nodes
+            .get_mut(&node_id)
+            .ok_or(RaftError::NodeNotFound(node_id))?;
+        node.log = entries;
+        Ok(())
+    }
+
+    /// The `(index, term)` pairs currently in a node's log, in log order. Test-only observation
+    /// point for truncation behavior.
+    #[cfg(test)]
+    pub(crate) fn node_log_index_terms_for_test(
+        &self,
+        node_id: RaftNodeId,
+    ) -> Result<Vec<(u64, u64)>, RaftError> {
+        let inner = self.inner.read().expect("raft cluster lock poisoned");
+        let node = inner
+            .nodes
+            .get(&node_id)
+            .ok_or(RaftError::NodeNotFound(node_id))?;
+        Ok(node.log.iter().map(|e| (e.index, e.term)).collect())
     }
 }

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -538,52 +538,33 @@ impl RaftCluster {
         candidate_id: RaftNodeId,
         target_id: RaftNodeId,
     ) -> Result<VoteRequest, RaftError> {
-        // R9: a candidate must durably persist its incremented term and a self-vote BEFORE it
-        // advertises the RequestVote, else a crash-restart could re-issue the same term without
-        // remembering it already voted for itself (double-vote in one term). Under the gate we
-        // take a write lock, bump `current_term`, record `voted_for = self`, and fsync the WAL
-        // before returning the request.
-        if raft_persist_vote_before_request_on() {
-            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
-            let shard_id = inner.shard_id;
-            let (election_term, last_log_index, last_log_term) = {
-                let candidate = inner
-                    .nodes
-                    .get_mut(&candidate_id)
-                    .ok_or(RaftError::NodeNotFound(candidate_id))?;
-                candidate.current_term = candidate.current_term.saturating_add(1);
-                candidate.voted_for = Some(candidate_id);
-                let last_log_index = node_last_log_or_snapshot_index(candidate);
-                let last_log_term =
-                    node_term_at_log_or_snapshot_index(candidate, last_log_index).unwrap_or_default();
-                (candidate.current_term, last_log_index, last_log_term)
-            };
-            inner.persist_configured_wal()?;
-            return Ok(VoteRequest {
-                rpc: None,
-                shard_id,
-                term: election_term,
-                candidate_id,
-                target_id,
-                last_log_index,
-                last_log_term,
-            });
-        }
-        let inner = self.inner.read().expect("raft cluster lock poisoned");
-        let candidate = inner
-            .nodes
-            .get(&candidate_id)
-            .ok_or(RaftError::NodeNotFound(candidate_id))?;
-        // Advertise the snapshot-aware tail: a fully-snapshotted candidate has an empty
-        // `log`, so raw `log.last()` would advertise (0,0) and lose every election it
-        // should win. Use the same helper as the AppendEntries / meta-raft paths.
-        let last_log_index = node_last_log_or_snapshot_index(candidate);
-        let last_log_term =
-            node_term_at_log_or_snapshot_index(candidate, last_log_index).unwrap_or_default();
+        // R9: a candidate durably persists its incremented term and a self-vote BEFORE it
+        // advertises the RequestVote. Without that ordering a crash-restart could re-issue the
+        // same term without remembering it already voted for itself, and grant a second vote in
+        // that term -- two leaders for one term. Take the write lock, bump `current_term`, record
+        // `voted_for = self`, and fsync the WAL before returning the request.
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let shard_id = inner.shard_id;
+        let (election_term, last_log_index, last_log_term) = {
+            let candidate = inner
+                .nodes
+                .get_mut(&candidate_id)
+                .ok_or(RaftError::NodeNotFound(candidate_id))?;
+            candidate.current_term = candidate.current_term.saturating_add(1);
+            candidate.voted_for = Some(candidate_id);
+            // Advertise the snapshot-aware tail: a fully-snapshotted candidate has an empty
+            // `log`, so raw `log.last()` would advertise (0,0) and lose every election it
+            // should win. Use the same helper as the AppendEntries / meta-raft paths.
+            let last_log_index = node_last_log_or_snapshot_index(candidate);
+            let last_log_term =
+                node_term_at_log_or_snapshot_index(candidate, last_log_index).unwrap_or_default();
+            (candidate.current_term, last_log_index, last_log_term)
+        };
+        inner.persist_configured_wal()?;
         Ok(VoteRequest {
             rpc: None,
-            shard_id: inner.shard_id,
-            term: candidate.current_term + 1,
+            shard_id,
+            term: election_term,
             candidate_id,
             target_id,
             last_log_index,

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -883,7 +883,7 @@ impl RaftCluster {
                 .find(|entry| entry.index == snapshot.last_included_index)
                 .map(|entry| entry.term == snapshot.last_included_term)
                 .unwrap_or(false);
-            if raft_snapshot_boundary_truncate_on() && !boundary_matches {
+            if !boundary_matches {
                 node.log.clear();
             } else {
                 node.log

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2131,7 +2131,6 @@ impl Drop for EnvFlagGuard {
 /// not answer a follower read with that half-applied state as if it were fresh.
 #[test]
 fn r3_replica_with_applied_below_commit_does_not_serve_unapplied_as_fresh() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_APPLIED_READ_SAFETY");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
     cluster
         .propose(Command::StringSet {
@@ -2188,7 +2187,6 @@ fn r3_replica_with_applied_below_commit_does_not_serve_unapplied_as_fresh() {
 /// disjoint partitions can never both promote a leader.
 #[test]
 fn r5_quorum_election_requires_majority_and_minority_cannot_elect() {
-    let _guard = EnvFlagGuard::set("TS_RAFT_QUORUM_ELECTION");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
 
     // Healthy quorum: node 2 collects a majority of grants and is promoted.
@@ -2531,7 +2529,6 @@ fn raft_wal_coalesce_preserves_committed_entries_across_restart() {
 #[test]
 fn raft_wal_coalesce_keeps_hard_state_vote_durable_before_request() {
     let _coalesce = EnvFlagGuard::set("TS_RAFT_WAL_COALESCE");
-    let _vote = EnvFlagGuard::set("TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST");
     let dir = tempfile::tempdir().unwrap();
     let term_before;
     {
@@ -2640,3 +2637,137 @@ fn raft_propose_serialize_commits_concurrent_proposals_in_order() {
 }
 
 
+
+fn r8_branch_entry(index: u64, term: u64, value: &str) -> RaftLogEntry {
+    RaftLogEntry {
+        term,
+        index,
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "k".to_string(),
+            value: value.as_bytes().to_vec(),
+        },
+    }
+}
+
+/// R8 (Raft §7): a snapshot install whose boundary entry does NOT term-match the local log must
+/// discard the entire log. The entries following a divergent boundary belong to an uncommitted,
+/// superseded branch; retaining them folds that dead branch onto the snapshot's state.
+#[test]
+fn r8_snapshot_install_with_divergent_boundary_discards_whole_log() {
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v1".to_vec(),
+        })
+        .unwrap();
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v2".to_vec(),
+        })
+        .unwrap();
+    assert_eq!(cluster.commit_index(3).unwrap(), 2);
+
+    // Rewrite node 3's log as a SUPERSEDED branch: the boundary index (2) carries term 1, and
+    // indexes 3-4 sit past it on that same dead branch.
+    cluster
+        .set_node_log_for_test(
+            3,
+            vec![
+                r8_branch_entry(1, 1, "v1"),
+                r8_branch_entry(2, 1, "v2"),
+                r8_branch_entry(3, 1, "dead-branch-3"),
+                r8_branch_entry(4, 1, "dead-branch-4"),
+            ],
+        )
+        .unwrap();
+
+    // A snapshot from the WINNING branch: same boundary index (2), different term (5).
+    cluster
+        .install_snapshot(
+            3,
+            RaftSnapshot {
+                shard_id: 1,
+                last_included_term: 5,
+                last_included_index: 2,
+                external_snapshot_ref: None,
+                entries: vec![r8_branch_entry(2, 5, "winning")],
+                state_image: None,
+            },
+        )
+        .unwrap();
+
+    assert!(
+        cluster.node_log_index_terms_for_test(3).unwrap().is_empty(),
+        "divergent boundary term must discard the whole log, got {:?}",
+        cluster.node_log_index_terms_for_test(3).unwrap()
+    );
+    assert_eq!(
+        cluster
+            .read_from_replica(
+                3,
+                Command::StringGet {
+                    key: "k".to_string(),
+                },
+            )
+            .unwrap(),
+        CommandResponse::Bytes {
+            value: Some(b"winning".to_vec())
+        },
+        "state must come from the snapshot, not the superseded branch"
+    );
+}
+
+/// R8 is CONDITIONAL, not a blanket truncation: when the boundary entry term-matches the
+/// snapshot, the log tail past the boundary is a legitimate continuation and must be retained.
+#[test]
+fn r8_snapshot_install_with_matching_boundary_retains_tail() {
+    let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v1".to_vec(),
+        })
+        .unwrap();
+    cluster
+        .propose(Command::StringSet {
+            key: "k".to_string(),
+            value: b"v2".to_vec(),
+        })
+        .unwrap();
+
+    // Boundary (index 2) is at term 1, and so is the snapshot -- the tail is a real continuation.
+    cluster
+        .set_node_log_for_test(
+            3,
+            vec![
+                r8_branch_entry(1, 1, "v1"),
+                r8_branch_entry(2, 1, "v2"),
+                r8_branch_entry(3, 1, "tail-3"),
+                r8_branch_entry(4, 1, "tail-4"),
+            ],
+        )
+        .unwrap();
+
+    cluster
+        .install_snapshot(
+            3,
+            RaftSnapshot {
+                shard_id: 1,
+                last_included_term: 1,
+                last_included_index: 2,
+                external_snapshot_ref: None,
+                entries: vec![r8_branch_entry(2, 1, "v2")],
+                state_image: None,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        cluster.node_log_index_terms_for_test(3).unwrap(),
+        vec![(3, 1), (4, 1)],
+        "a term-matching boundary must retain the tail past the snapshot"
+    );
+}

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -65,12 +65,11 @@ fn recover_ok(root: &str, keys: &str) {
 }
 
 // Single-barrier helpers: the TRUE single barrier (per-write data-page fdatasync also deferred)
-// with base-only recovery -- now the DEFAULT. TS_WAL_SINGLE_BARRIER=1 is left set as an explicit
-// intent marker (it resolves to the same default behavior). Each phase runs in its own subprocess.
+// with base-only recovery -- the unconditional write/recovery path. Each phase runs in its own
+// subprocess.
 fn populate_sb(root: &str, keys: &str, flush_at: Option<&str>) {
     let mut cmd = Command::new(bin());
-    cmd.env("TS_WAL_SINGLE_BARRIER", "1")
-        .args(["--mode", "populate", "--root", root, "--keys", keys]);
+    cmd.args(["--mode", "populate", "--root", root, "--keys", keys]);
     if let Some(f) = flush_at {
         cmd.args(["--flush-at", f]);
     }
@@ -83,7 +82,6 @@ fn populate_sb(root: &str, keys: &str, flush_at: Option<&str>) {
 
 fn powerloss_sb(root: &str, scope: &str) {
     let out = Command::new(bin())
-        .env("TS_WAL_SINGLE_BARRIER", "1")
         .args(["--mode", "powerloss", "--root", root, "--scope", scope])
         .output()
         .expect("powerloss_sb should run");
@@ -96,7 +94,6 @@ fn powerloss_sb(root: &str, scope: &str) {
 
 fn recover_sb_ok(root: &str, keys: &str) {
     let out = Command::new(bin())
-        .env("TS_WAL_SINGLE_BARRIER", "1")
         .args(["--mode", "recover", "--root", root, "--keys", keys])
         .output()
         .expect("recover_sb should run");
@@ -129,8 +126,7 @@ fn single_barrier_data_page_loss_after_dump_rebuilds_from_wal() {
 
 fn populate_counter_sb(root: &str, incrs: &str, flush_at: Option<&str>) {
     let mut cmd = Command::new(bin());
-    cmd.env("TS_WAL_SINGLE_BARRIER", "1")
-        .args(["--mode", "populate-counter", "--root", root, "--keys", incrs]);
+    cmd.args(["--mode", "populate-counter", "--root", root, "--keys", incrs]);
     if let Some(f) = flush_at {
         cmd.args(["--flush-at", f]);
     }
@@ -140,7 +136,6 @@ fn populate_counter_sb(root: &str, incrs: &str, flush_at: Option<&str>) {
 
 fn recover_counter_sb_ok(root: &str, expected: &str) {
     let out = Command::new(bin())
-        .env("TS_WAL_SINGLE_BARRIER", "1")
         .args(["--mode", "recover-counter", "--root", root, "--keys", expected])
         .output()
         .expect("recover-counter should run");
@@ -178,7 +173,6 @@ fn single_barrier_full_page_loss_no_dump_rebuilds_from_wal() {
 
 fn populate_feature(root: &str) {
     let out = Command::new(bin())
-        .env("TS_WAL_SINGLE_BARRIER", "1")
         .env("TS_GROUP_COMMIT", "1")
         .args(["--mode", "populate-feature", "--root", root])
         .output()
@@ -191,7 +185,6 @@ fn populate_feature(root: &str) {
 
 fn recover_feature_ok(root: &str) {
     let out = Command::new(bin())
-        .env("TS_WAL_SINGLE_BARRIER", "1")
         .args(["--mode", "recover-feature", "--root", root])
         .output()
         .expect("recover-feature should run");

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -92,7 +92,6 @@ ENV_MAP: Dict[str, str] = {
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
     "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
-    "wal.wal_single_barrier": "TS_WAL_SINGLE_BARRIER",
     "wal.group_commit": "TS_GROUP_COMMIT",
     "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",


### PR DESCRIPTION
## What

Four Raft safety properties shipped behind env gates that defaulted OFF and
were set nowhere in `config/`, `deploy/` or `docker/`. Only tests that set
the flag explicitly ever exercised them, so the default build was the one
configuration nothing tested. This makes them unconditional and deletes the
gates.

`TS_RAFT_QUORUM_ELECTION` · `TS_RAFT_PERSIST_VOTE_BEFORE_REQUEST` ·
`TS_RAFT_SNAPSHOT_BOUNDARY_TRUNCATE` · `TS_RAFT_APPLIED_READ_SAFETY`

## Why each one is not optional

**R5, quorum election.** The gate-off path had **no per-term vote-uniqueness
check at all**. It counted live nodes, then stamped `leader_id`,
`current_term` and `voted_for` directly onto every node in its local map.
Two candidates can be promoted in the same term. It also only works when
`self.nodes` genuinely *is* every node — true for the in-process test
cluster, false for a real deployment where each node holds its own view of
peers, which is why a deployed group can fail to elect anyone at all. The
whole body is deleted; the per-voter RequestVote round with an
`already_voted_other` check and a majority grant tally is now the only
election path.

**R9, persist-vote-before-request.** Off, a candidate advertises a
RequestVote at term T without durably recording that it voted for itself at
T. A crash-restart re-issues T and can grant to a different candidate — two
leaders in one term.

**R8, §7 snapshot-boundary truncation.** Off, the log tail past the snapshot
boundary is retained even when the boundary entry is missing or from a
divergent term, folding an uncommitted, superseded branch onto snapshot
state.

**R3, applied-read safety.** Off, a replica serves reads once
`commit_index >= leader_commit` even when `applied_index < commit_index` —
half-applied state returned as fresh. Fixed in the library predicate and in
the server read path, which now always waits for apply instead of mirroring
the same env gate.

R3 is worth noting as the lowest-risk of the four: it is a *monotone
restriction* — a stricter predicate, not an alternate code path — so
enabling it cannot introduce corruption. The only cost is more rejections
under apply lag.

## Tests

**R8 had no test at all.** This adds two, so the truncation is pinned in
both directions:

- `r8_snapshot_install_with_divergent_boundary_discards_whole_log`
- `r8_snapshot_install_with_matching_boundary_retains_tail` — a
  term-matching boundary must still retain the tail, so the truncation
  cannot silently become unconditional.

The existing R3/R5/R9 tests are un-gated so they run on the default path.
That also removes four env `set_var`/`remove_var` pairs, which are a source
of raft test races under `-j`.

## What stays gated

**R4, `TS_RAFT_LEADER_READY_BARRIER`** — deliberately. Raft releases that
barrier by having a newly elected leader append a no-op entry at its own
term (§8). This implementation never appends one, so
`leader_has_committed_current_term` can only be satisfied by a client write.
Made unconditional, it would reject every leader-served read-index/lease
read from the end of an election until the next write commits —
indefinitely on an idle cluster. Promoting it requires the election no-op
first, which is a new `Command` variant and therefore a wire-format change
for `#[serde(tag = "kind")]` peers. The blocker is now recorded at the gate
rather than left implicit.

## Scope

Deliberately limited to the safety gates. A companion change on the private
tree also promotes the write-path gates and removes the
`TS_WAL_LEGACY_RECOVERY` multi-barrier path, but this repo's write path has
moved independently, so that half should arrive via a normal sync rather
than a hand-resolved port.

`cargo check --all-targets` is clean.
