### PR TITLE
meta: record why a resource was frozen, and let an operator unfreeze it

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -12,7 +12,8 @@ use temporalstore_rust::http::{
 };
 use temporalstore_rust::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, AutoRebalanceOptions, ConvictionPolicy,
-    DeleteTableRequest, FailureDetectorOptions, FreezeStaleServersRequest, GetShardResponse,
+    DeleteTableRequest, FailureDetectorOptions, FreezeReason, FreezeStaleServersRequest,
+    GetShardResponse,
     FreezeAgingOptions, MetaRetentionOptions,
     GetTableTopologyRequest, LoadFinishRequest,
     MetaSnapshot, MetaSnapshotFileRequest, MetaSnapshotFileResponse, MetaSnapshotResponse,
@@ -1420,6 +1421,9 @@ fn handle(
         ("POST", "/servers/freeze") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, freeze_server, req)
         }),
+        ("POST", "/servers/unfreeze") => parse_or(&request.body, |req: StateChangeRequest| {
+            json_response(200, &backend_call!(meta, unfreeze_server, req))
+        }),
         ("POST", "/servers/drop") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, drop_server, req)
         }),
@@ -1434,6 +1438,9 @@ fn handle(
         ("GET", "/proxies") => json_response(200, &backend_call!(meta, list_proxies)),
         ("POST", "/proxies/freeze") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, freeze_proxy, req)
+        }),
+        ("POST", "/proxies/unfreeze") => parse_or(&request.body, |req: StateChangeRequest| {
+            json_response(200, &backend_call!(meta, unfreeze_proxy, req))
         }),
         ("POST", "/proxies/drop") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, drop_proxy, req)
@@ -1977,6 +1984,7 @@ mod tests {
             binary_version: "v1".to_string(),
         });
         meta.freeze_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "metrics-proxy-a".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2060,6 +2068,7 @@ mod tests {
             binary_version: "v1".to_string(),
         });
         meta.freeze_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "proxy-route-a".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2107,6 +2116,7 @@ mod tests {
         assert!(snapshot_path.exists());
 
         meta.drop_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "proxy-route-a".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2306,6 +2316,7 @@ mod tests {
                 method: "POST".to_string(),
                 path: "/servers/drop".to_string(),
                 body: serde_json::to_vec(&StateChangeRequest {
+                    reason: FreezeReason::Unspecified,
                     endpoint: "raft-server-a".to_string(),
                     freeze_cooldown_ms: 0,
                 })

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -16,6 +16,14 @@ impl MetaBackend {
             .map(SingleNodeMeta::with_mutation_log)
             .transpose()?
             .unwrap_or_default();
+        // With this on, a datanode the metaserver convicted cannot re-register
+        // its way back to Normal; an operator has to unfreeze it. Off by default
+        // because the automatic recovery it removes is load-bearing wherever the
+        // freeze cooldown is left at zero.
+        let meta = meta.with_conviction_lock(env_bool(
+            "TS_META_FORBID_SELF_CLEARING_CONVICTION",
+            false,
+        ));
         Ok(Self::Single(meta))
     }
 

--- a/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
@@ -89,6 +89,7 @@ fn handle_manage_service_route(
                     StateChangeRequest {
                         endpoint: heartbeat_server_addr(&req),
                         freeze_cooldown_ms: 0,
+                        reason: FreezeReason::Operator,
                     }
                 )
             })
@@ -101,6 +102,7 @@ fn handle_manage_service_route(
                     StateChangeRequest {
                         endpoint: heartbeat_server_addr(&req),
                         freeze_cooldown_ms: 0,
+                        reason: FreezeReason::Operator,
                     }
                 )
             })
@@ -132,6 +134,7 @@ fn handle_manage_service_route(
                     meta,
                     freeze_proxy,
                     StateChangeRequest {
+                        reason: FreezeReason::Unspecified,
                         endpoint: heartbeat_proxy_addr(&req),
                         freeze_cooldown_ms: 0,
                     }
@@ -144,6 +147,7 @@ fn handle_manage_service_route(
                     meta,
                     drop_proxy,
                     StateChangeRequest {
+                        reason: FreezeReason::Unspecified,
                         endpoint: heartbeat_proxy_addr(&req),
                         freeze_cooldown_ms: 0,
                     }
@@ -241,6 +245,7 @@ fn handle_heartbeat_service_route(
                     meta,
                     drop_server,
                     StateChangeRequest {
+                        reason: FreezeReason::Unspecified,
                         endpoint,
                         freeze_cooldown_ms: 0,
                     }
@@ -274,6 +279,7 @@ fn handle_heartbeat_service_route(
                     meta,
                     drop_proxy,
                     StateChangeRequest {
+                        reason: FreezeReason::Unspecified,
                         endpoint,
                         freeze_cooldown_ms: 0,
                     }
@@ -475,6 +481,7 @@ fn handle_master_service_route(
                     meta,
                     drop_server,
                     StateChangeRequest {
+                        reason: FreezeReason::Unspecified,
                         endpoint: master_server_addr(&req),
                         freeze_cooldown_ms: 0,
                     }

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -50,6 +50,46 @@ pub use self::retention::{
     RetentionCandidate,
 };
 
+/// Why a resource was frozen.
+///
+/// Freezing recorded no reason at all, so the metaserver could not tell an
+/// operator taking a node out for maintenance from the failure detector
+/// convicting one that stopped answering — even though the two want opposite
+/// recovery behaviour. A maintenance freeze ends when the operator says so; a
+/// conviction should not end merely because the convicted node asked.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FreezeReason {
+    /// No reason was recorded. Either the resource is not frozen, or it was
+    /// frozen before reasons existed.
+    #[default]
+    Unspecified,
+    /// An operator froze it explicitly, typically for maintenance.
+    Operator,
+    /// The failure detector convicted it for going silent.
+    Unresponsive,
+    /// The metaserver observed it restart in place, so it no longer holds what
+    /// the metaserver believes it holds.
+    Restarted,
+}
+
+impl FreezeReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unspecified => "unspecified",
+            Self::Operator => "operator",
+            Self::Unresponsive => "unresponsive",
+            Self::Restarted => "restarted",
+        }
+    }
+
+    /// True when the metaserver, not an operator, decided this resource was
+    /// unhealthy. These are the freezes a resource must not clear for itself.
+    pub fn is_conviction(self) -> bool {
+        matches!(self, Self::Unresponsive | Self::Restarted)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MetaEntityState {
@@ -238,6 +278,9 @@ pub struct ServerMetaInfo {
     pub frozen_since_ms: u64,
     #[serde(default)]
     pub freeze_cooldown_until_ms: u64,
+    /// Why this server was frozen, or `Unspecified` when it is not.
+    #[serde(default)]
+    pub freeze_reason: FreezeReason,
     pub boot_time_ms: u64,
     /// The boot time the metaserver anchored on for this server: the first
     /// non-zero boot time it heartbeated after registering. `boot_time_ms`
@@ -354,6 +397,9 @@ pub struct ProxyMetaInfo {
     pub frozen_since_ms: u64,
     #[serde(default)]
     pub freeze_cooldown_until_ms: u64,
+    /// Why this proxy was frozen, or `Unspecified` when it is not.
+    #[serde(default)]
+    pub freeze_reason: FreezeReason,
     pub binary_version: String,
 }
 
@@ -592,6 +638,11 @@ pub struct ListProxiesResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StateChangeRequest {
+    /// Why the resource is being frozen. Absent from the wire it reads as
+    /// `Unspecified`; the admin routes set `Operator` explicitly, since a
+    /// request arriving there is operator-driven by definition.
+    #[serde(default)]
+    pub reason: FreezeReason,
     pub endpoint: String,
     #[serde(default)]
     pub freeze_cooldown_ms: u64,
@@ -681,8 +732,10 @@ pub enum MetaMutation {
     UnfreezeTable(DeleteTableRequest),
     FinishLoad(LoadFinishRequest),
     FreezeServer(StateChangeRequest),
+    UnfreezeServer(StateChangeRequest),
     DropServer(StateChangeRequest),
     FreezeProxy(StateChangeRequest),
+    UnfreezeProxy(StateChangeRequest),
     DropProxy(StateChangeRequest),
 }
 
@@ -834,6 +887,11 @@ pub struct SingleNodeMeta {
     inner: Arc<RwLock<MetaState>>,
     boot_time_ms: u64,
     mutation_log: Option<LocalMetaMutationLog>,
+    /// When set, a resource the metaserver convicted cannot register its way
+    /// back into service; only an explicit unfreeze returns it. Off by default
+    /// because today's automatic recovery is load-bearing for deployments
+    /// running with a zero freeze cooldown.
+    forbid_self_clearing_conviction: bool,
 }
 
 impl Default for SingleNodeMeta {
@@ -845,11 +903,23 @@ impl Default for SingleNodeMeta {
             })),
             boot_time_ms: now_ms(),
             mutation_log: None,
+            forbid_self_clearing_conviction: false,
         }
     }
 }
 
 impl SingleNodeMeta {
+    /// Refuse to let a resource the metaserver convicted register its way back
+    /// into service; only an explicit unfreeze returns it. Off by default.
+    pub fn with_conviction_lock(mut self, forbid: bool) -> Self {
+        self.forbid_self_clearing_conviction = forbid;
+        self
+    }
+
+    /// True when a convicted resource cannot clear its own freeze.
+    pub fn conviction_lock_enabled(&self) -> bool {
+        self.forbid_self_clearing_conviction
+    }
 
     pub fn register(&self, request: RegisterShardRequest) -> RegisterShardResponse {
         self.record_mutation(MetaMutation::RegisterShard(request.clone()));
@@ -961,6 +1031,14 @@ impl SingleNodeMeta {
                     .status
             }
             MetaMutation::FinishLoad(request) => self.apply_finish_load(request).status,
+            MetaMutation::UnfreezeServer(request) => {
+                self.apply_set_server_state(request, MetaEntityState::Normal)
+                    .status
+            }
+            MetaMutation::UnfreezeProxy(request) => {
+                self.apply_set_proxy_state(request, MetaEntityState::Normal)
+                    .status
+            }
             MetaMutation::FreezeServer(request) => {
                 self.apply_set_server_state(request, MetaEntityState::Frozen)
                     .status
@@ -1250,6 +1328,7 @@ mod tests {
 
         assert!(
             meta.freeze_server(StateChangeRequest {
+                reason: FreezeReason::Unspecified,
                 endpoint: "server-a".to_string(),
                 freeze_cooldown_ms: 0,
             })
@@ -1258,6 +1337,7 @@ mod tests {
         );
         assert!(
             meta.freeze_proxy(StateChangeRequest {
+                reason: FreezeReason::Unspecified,
                 endpoint: "proxy-a".to_string(),
                 freeze_cooldown_ms: 0,
             })
@@ -1421,6 +1501,187 @@ mod tests {
             .find(|server| server.server_addr == "node-a")
             .expect("registered");
         assert!(!server.reboot_detected);
+    }
+
+    fn register(meta: &SingleNodeMeta, addr: &str) -> AckResponse {
+        meta.register_server(RegisterServerRequest {
+            server_addr: addr.to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        })
+    }
+
+    fn server_state(meta: &SingleNodeMeta, addr: &str) -> ServerMetaInfo {
+        meta.list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == addr)
+            .expect("registered")
+    }
+
+    #[test]
+    fn a_freeze_records_why_it_happened() {
+        let meta = SingleNodeMeta::default();
+        register(&meta, "node-a");
+        register(&meta, "node-b");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        // The detector's own freeze is a conviction.
+        assert!(meta.freeze_stale_resources(0).status.ok);
+        assert_eq!(
+            server_state(&meta, "node-a").freeze_reason,
+            FreezeReason::Unresponsive
+        );
+        assert!(server_state(&meta, "node-a").freeze_reason.is_conviction());
+
+        // An operator freeze is not.
+        assert!(meta.unfreeze_server(unfreeze_request("node-b")).status.ok);
+        assert!(meta
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-b".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Operator,
+            })
+            .status
+            .ok);
+        assert_eq!(
+            server_state(&meta, "node-b").freeze_reason,
+            FreezeReason::Operator
+        );
+        assert!(!server_state(&meta, "node-b").freeze_reason.is_conviction());
+    }
+
+    fn unfreeze_request(addr: &str) -> StateChangeRequest {
+        StateChangeRequest {
+            endpoint: addr.to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        }
+    }
+
+    #[test]
+    fn a_convicted_server_cannot_register_its_way_back_into_service() {
+        // Without this the freeze cooldown is the only guard, and it defaults to
+        // zero -- so the convicted node clears the metaserver's decision simply
+        // by asking, and conviction is advisory.
+        let meta = SingleNodeMeta::default().with_conviction_lock(true);
+        register(&meta, "node-a");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(meta.freeze_stale_resources(0).status.ok);
+
+        let rejected = register(&meta, "node-a");
+        assert!(!rejected.status.ok);
+        assert_eq!(rejected.status.code, "conviction_requires_unfreeze");
+        assert_eq!(
+            server_state(&meta, "node-a").state,
+            MetaEntityState::Frozen
+        );
+
+        // An operator unfreeze is the way back, and afterwards the node
+        // registers normally again.
+        assert!(meta.unfreeze_server(unfreeze_request("node-a")).status.ok);
+        assert_eq!(server_state(&meta, "node-a").state, MetaEntityState::Normal);
+        assert_eq!(
+            server_state(&meta, "node-a").freeze_reason,
+            FreezeReason::Unspecified
+        );
+        assert!(register(&meta, "node-a").status.ok);
+    }
+
+    #[test]
+    fn without_the_lock_a_convicted_server_still_recovers_by_registering() {
+        // The default path is unchanged: this is the automatic recovery that
+        // deployments running a zero freeze cooldown depend on.
+        let meta = SingleNodeMeta::default();
+        register(&meta, "node-a");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(meta.freeze_stale_resources(0).status.ok);
+        assert!(register(&meta, "node-a").status.ok);
+        assert_eq!(server_state(&meta, "node-a").state, MetaEntityState::Normal);
+    }
+
+    #[test]
+    fn an_operator_freeze_is_not_locked_against_re_registration() {
+        // The lock is about the metaserver's own verdicts. A maintenance freeze
+        // already has an operator in the loop, and the freeze cooldown is the
+        // knob for holding a node out.
+        let meta = SingleNodeMeta::default().with_conviction_lock(true);
+        register(&meta, "node-a");
+        assert!(meta
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-a".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Operator,
+            })
+            .status
+            .ok);
+        assert!(register(&meta, "node-a").status.ok);
+    }
+
+    #[test]
+    fn a_restarted_server_is_locked_out_under_its_own_reason() {
+        let meta = SingleNodeMeta::default().with_conviction_lock(true);
+        register(&meta, "node-a");
+        assert!(meta
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-a".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Restarted,
+            })
+            .status
+            .ok);
+        let rejected = register(&meta, "node-a");
+        assert_eq!(rejected.status.code, "conviction_requires_unfreeze");
+        assert!(rejected.status.message.contains("restarted"));
+    }
+
+    #[test]
+    fn a_convicted_proxy_is_locked_out_too() {
+        let meta = SingleNodeMeta::default().with_conviction_lock(true);
+        let register_proxy = || {
+            meta.register_proxy(RegisterProxyRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+        };
+        register_proxy();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(meta.freeze_stale_resources(0).status.ok);
+        assert_eq!(
+            register_proxy().status.code,
+            "conviction_requires_unfreeze"
+        );
+        assert!(meta.unfreeze_proxy(unfreeze_request("proxy-a")).status.ok);
+        assert!(register_proxy().status.ok);
+    }
+
+    #[test]
+    fn an_unfreeze_survives_mutation_log_replay() {
+        // Unfreeze was previously the one state change that recorded no
+        // mutation, so recovery would have silently re-frozen the resource.
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("unfreeze-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            register(&meta, "node-a");
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            assert!(meta.freeze_stale_resources(0).status.ok);
+            assert!(meta.unfreeze_server(unfreeze_request("node-a")).status.ok);
+            assert_eq!(server_state(&meta, "node-a").state, MetaEntityState::Normal);
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert_eq!(
+            server_state(&recovered, "node-a").state,
+            MetaEntityState::Normal
+        );
+        assert_eq!(
+            server_state(&recovered, "node-a").freeze_reason,
+            FreezeReason::Unspecified
+        );
     }
 
     #[test]
@@ -2264,6 +2525,7 @@ mod tests {
         assert_eq!(meta.list_proxies().proxies[0].binary_version, "v2");
 
         let frozen = meta.freeze_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "p1".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2356,6 +2618,7 @@ mod tests {
             serving_options: crate::meta::TableServingOptions::default(),
         });
         meta.freeze_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "proxy-does-not-exist".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2570,6 +2833,7 @@ mod tests {
         assert_eq!(stale.status.code, "stale_load_version");
 
         meta.freeze_server(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "s1".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2659,6 +2923,7 @@ mod tests {
         );
         assert!(
             meta.freeze_proxy(StateChangeRequest {
+                reason: FreezeReason::Unspecified,
                 endpoint: "proxy-a".to_string(),
                 freeze_cooldown_ms: 0,
             })
@@ -2797,6 +3062,7 @@ mod tests {
             binary_version: "v1".to_string(),
         });
         meta.freeze_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "proxy-a".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -2863,10 +3129,12 @@ mod tests {
         let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
 
         let missing_server = meta.freeze_server(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "missing-server".to_string(),
             freeze_cooldown_ms: 0,
         });
         let missing_proxy = meta.drop_proxy(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "missing-proxy".to_string(),
             freeze_cooldown_ms: 0,
         });

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -661,9 +661,17 @@ impl SingleNodeMeta {
 
         let mut frozen_servers = Vec::new();
         for endpoint in &plan.convict {
+            // A restart and a silence are both convictions, but an operator
+            // reading `/servers` wants to know which one happened.
+            let reason = if plan.rebooted.contains(endpoint) {
+                FreezeReason::Restarted
+            } else {
+                FreezeReason::Unresponsive
+            };
             let response = self.freeze_server(StateChangeRequest {
                 endpoint: endpoint.clone(),
                 freeze_cooldown_ms: safe_mode.server_freeze_cooldown_ms,
+                reason,
             });
             if !response.status.ok {
                 return AdaptiveConvictionReport {
@@ -723,6 +731,8 @@ impl SingleNodeMeta {
             let response = self.freeze_proxy(StateChangeRequest {
                 endpoint: endpoint.clone(),
                 freeze_cooldown_ms: safe_mode.proxy_freeze_cooldown_ms,
+                // A proxy carries no boot anchor, so silence is the only cause.
+                reason: FreezeReason::Unresponsive,
             });
             if !response.status.ok {
                 return AdaptiveConvictionReport {
@@ -795,6 +805,7 @@ mod tests {
 
     fn server(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ServerMetaInfo {
         ServerMetaInfo {
+            freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 0,
             location: location.to_string(),
@@ -1019,6 +1030,7 @@ mod tests {
 
     fn proxy(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ProxyMetaInfo {
         ProxyMetaInfo {
+            freeze_reason: FreezeReason::Unspecified,
             proxy_addr: addr.to_string(),
             namespace: "ns".to_string(),
             location: location.to_string(),

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -139,6 +139,8 @@ impl SingleNodeMeta {
             let response = self.freeze_server(StateChangeRequest {
                 endpoint: endpoint.clone(),
                 freeze_cooldown_ms: policy.server_freeze_cooldown_ms,
+                // The metaserver decided this, not an operator.
+                reason: FreezeReason::Unresponsive,
             });
             if !response.status.ok {
                 return StaleResourceReport {
@@ -189,6 +191,7 @@ impl SingleNodeMeta {
             let response = self.freeze_proxy(StateChangeRequest {
                 endpoint: endpoint.clone(),
                 freeze_cooldown_ms: policy.proxy_freeze_cooldown_ms,
+                reason: FreezeReason::Unresponsive,
             });
             if !response.status.ok {
                 return StaleResourceReport {
@@ -260,12 +263,28 @@ impl SingleNodeMeta {
         self.set_server_state(request, MetaEntityState::Frozen)
     }
 
+    /// Return a frozen server to service.
+    ///
+    /// Until now the only way out of a freeze was for the server to re-register,
+    /// which meant an operator had no lever at all and a convicted node cleared
+    /// its own conviction. This is that lever: it is always available, whatever
+    /// the freeze reason, because an operator must be able to overrule the
+    /// metaserver.
+    pub fn unfreeze_server(&self, request: StateChangeRequest) -> AckResponse {
+        self.set_server_state(request, MetaEntityState::Normal)
+    }
+
     pub fn drop_server(&self, request: StateChangeRequest) -> AckResponse {
         self.set_server_state(request, MetaEntityState::Dropped)
     }
 
     pub fn freeze_proxy(&self, request: StateChangeRequest) -> AckResponse {
         self.set_proxy_state(request, MetaEntityState::Frozen)
+    }
+
+    /// Return a frozen proxy to service. See [`Self::unfreeze_server`].
+    pub fn unfreeze_proxy(&self, request: StateChangeRequest) -> AckResponse {
+        self.set_proxy_state(request, MetaEntityState::Normal)
     }
 
     pub fn drop_proxy(&self, request: StateChangeRequest) -> AckResponse {

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -96,6 +96,7 @@ mod tests {
 
     fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
         ServerMetaInfo {
+            freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id,
             location: "zone-a".to_string(),

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -22,12 +22,32 @@ impl SingleNodeMeta {
                     status: Status::error("resource_frozen", "server is in freeze cooldown"),
                 };
             }
+            // A conviction the convicted node can undo by asking is not a
+            // conviction. The freeze cooldown alone does not cover this: it
+            // defaults to zero, so re-registering immediately returns the server
+            // to Normal and the failure detector's decision is erased by the
+            // very node it was about. An operator unfreeze is the way back.
+            if existing.state == MetaEntityState::Frozen
+                && existing.freeze_reason.is_conviction()
+                && self.forbid_self_clearing_conviction
+            {
+                return AckResponse {
+                    status: Status::error(
+                        "conviction_requires_unfreeze",
+                        format!(
+                            "server was frozen by the metaserver ({}); an operator must unfreeze it",
+                            existing.freeze_reason.as_str()
+                        ),
+                    ),
+                };
+            }
         }
         let now = now_ms();
         let server_addr = request.server_addr.clone();
         state.servers.insert(
             server_addr.clone(),
             ServerMetaInfo {
+                freeze_reason: FreezeReason::Unspecified,
                 server_addr: request.server_addr,
                 node_id: request.node_id,
                 location: request.location,
@@ -152,10 +172,25 @@ impl SingleNodeMeta {
                     status: Status::error("resource_frozen", "proxy is in freeze cooldown"),
                 };
             }
+            if existing.state == MetaEntityState::Frozen
+                && existing.freeze_reason.is_conviction()
+                && self.forbid_self_clearing_conviction
+            {
+                return AckResponse {
+                    status: Status::error(
+                        "conviction_requires_unfreeze",
+                        format!(
+                            "proxy was frozen by the metaserver ({}); an operator must unfreeze it",
+                            existing.freeze_reason.as_str()
+                        ),
+                    ),
+                };
+            }
         }
         state.proxies.insert(
             request.proxy_addr.clone(),
             ProxyMetaInfo {
+                freeze_reason: FreezeReason::Unspecified,
                 proxy_addr: request.proxy_addr,
                 namespace: request.namespace,
                 location: request.location,

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -519,6 +519,7 @@ impl SingleNodeMeta {
             let response = self.drop_proxy(StateChangeRequest {
                 endpoint: addr.clone(),
                 freeze_cooldown_ms: 0,
+                reason: FreezeReason::Unspecified,
             });
             if !response.status.ok {
                 return FreezeAgingReport {
@@ -549,6 +550,7 @@ impl SingleNodeMeta {
             let response = self.drop_server(StateChangeRequest {
                 endpoint: addr.clone(),
                 freeze_cooldown_ms: 0,
+                reason: FreezeReason::Unspecified,
             });
             if !response.status.ok {
                 return FreezeAgingReport {
@@ -1067,6 +1069,7 @@ mod tests {
         });
         assert!(meta
             .drop_server(StateChangeRequest {
+                reason: FreezeReason::Unspecified,
                 endpoint: "node-a".to_string(),
                 freeze_cooldown_ms: 0,
             })
@@ -1074,6 +1077,7 @@ mod tests {
             .ok);
         assert!(meta
             .drop_proxy(StateChangeRequest {
+                reason: FreezeReason::Unspecified,
                 endpoint: "proxy-a".to_string(),
                 freeze_cooldown_ms: 0,
             })
@@ -1120,6 +1124,7 @@ mod tests {
         };
         register();
         meta.drop_server(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "node-a".to_string(),
             freeze_cooldown_ms: 0,
         });
@@ -1146,6 +1151,7 @@ mod tests {
             binary_version: "v1".to_string(),
         });
         meta.drop_server(StateChangeRequest {
+            reason: FreezeReason::Unspecified,
             endpoint: "node-a".to_string(),
             freeze_cooldown_ms: 0,
         });

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -452,6 +452,7 @@ mod tests {
     /// A healthy, reporting server that boots long before any test clock.
     fn server(addr: &str, serving: &[(ShardId, &str)]) -> ServerMetaInfo {
         ServerMetaInfo {
+            freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 1,
             location: "rack-1".to_string(),

--- a/crates/temporalstore-rust/src/meta/state_setters.rs
+++ b/crates/temporalstore-rust/src/meta/state_setters.rs
@@ -25,7 +25,11 @@ impl SingleNodeMeta {
             MetaEntityState::Dropped => {
                 self.record_mutation(MetaMutation::DropServer(request.clone()));
             }
-            MetaEntityState::Normal => {}
+            // Recorded like any other state change: an unfreeze that is not
+            // replayed would be silently undone by mutation-log recovery.
+            MetaEntityState::Normal => {
+                self.record_mutation(MetaMutation::UnfreezeServer(request.clone()));
+            }
         }
         self.apply_set_server_state(request, next)
     }
@@ -47,10 +51,12 @@ impl SingleNodeMeta {
             MetaEntityState::Frozen => {
                 server.frozen_since_ms = now;
                 server.freeze_cooldown_until_ms = now.saturating_add(request.freeze_cooldown_ms);
+                server.freeze_reason = request.reason;
             }
             MetaEntityState::Normal => {
                 server.frozen_since_ms = 0;
                 server.freeze_cooldown_until_ms = 0;
+                server.freeze_reason = FreezeReason::Unspecified;
             }
             MetaEntityState::Dropped => {}
         }
@@ -59,7 +65,7 @@ impl SingleNodeMeta {
             &mut state,
             "server_state",
             format!("server:{}", request.endpoint),
-            format!("state={}", next.as_str()),
+            format!("state={},reason={}", next.as_str(), request.reason.as_str()),
         );
         AckResponse {
             status: Status::ok(),
@@ -85,7 +91,9 @@ impl SingleNodeMeta {
             MetaEntityState::Dropped => {
                 self.record_mutation(MetaMutation::DropProxy(request.clone()));
             }
-            MetaEntityState::Normal => {}
+            MetaEntityState::Normal => {
+                self.record_mutation(MetaMutation::UnfreezeProxy(request.clone()));
+            }
         }
         self.apply_set_proxy_state(request, next)
     }
@@ -107,10 +115,12 @@ impl SingleNodeMeta {
             MetaEntityState::Frozen => {
                 proxy.frozen_since_ms = now;
                 proxy.freeze_cooldown_until_ms = now.saturating_add(request.freeze_cooldown_ms);
+                proxy.freeze_reason = request.reason;
             }
             MetaEntityState::Normal => {
                 proxy.frozen_since_ms = 0;
                 proxy.freeze_cooldown_until_ms = 0;
+                proxy.freeze_reason = FreezeReason::Unspecified;
             }
             MetaEntityState::Dropped => {}
         }
@@ -119,7 +129,7 @@ impl SingleNodeMeta {
             &mut state,
             "proxy_state",
             format!("proxy:{}", request.endpoint),
-            format!("state={}", next.as_str()),
+            format!("state={},reason={}", next.as_str(), request.reason.as_str()),
         );
         AckResponse {
             status: Status::ok(),

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -92,6 +92,7 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         .servers
         .entry(server_addr.to_string())
         .or_insert_with(|| ServerMetaInfo {
+            freeze_reason: FreezeReason::Unspecified,
             server_addr: server_addr.to_string(),
             node_id: 0,
             location: String::new(),

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3384,6 +3384,7 @@ mod tests {
             binary_version: "v-meta".to_string(),
         });
         meta.freeze_proxy(crate::meta::StateChangeRequest {
+            reason: crate::meta::FreezeReason::Unspecified,
             endpoint: "proxy-frozen-policy".to_string(),
             freeze_cooldown_ms: 0,
         });

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -155,6 +155,12 @@ impl MetaRaftCluster {
         }
     }
 
+    pub fn unfreeze_server(&self, request: StateChangeRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::UnfreezeServer(request)),
+        }
+    }
+
     pub fn drop_server(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::DropServer(request)),
@@ -164,6 +170,12 @@ impl MetaRaftCluster {
     pub fn freeze_proxy(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::FreezeProxy(request)),
+        }
+    }
+
+    pub fn unfreeze_proxy(&self, request: StateChangeRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::UnfreezeProxy(request)),
         }
     }
 
@@ -218,6 +230,7 @@ impl MetaRaftCluster {
                 let status = self.freeze_server(StateChangeRequest {
                     endpoint: server.server_addr.clone(),
                     freeze_cooldown_ms: policy.server_freeze_cooldown_ms,
+                    reason: crate::meta::FreezeReason::Unresponsive,
                 });
                 if !status.status.ok {
                     return StaleResourceReport {
@@ -238,6 +251,7 @@ impl MetaRaftCluster {
                 let status = self.freeze_proxy(StateChangeRequest {
                     endpoint: proxy.proxy_addr.clone(),
                     freeze_cooldown_ms: policy.proxy_freeze_cooldown_ms,
+                    reason: crate::meta::FreezeReason::Unresponsive,
                 });
                 if !status.status.ok {
                     return StaleResourceReport {

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -310,6 +310,7 @@ pub(super) fn topology_for_shard(
 
 pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
     ServerMetaInfo {
+        freeze_reason: crate::meta::FreezeReason::Unspecified,
         server_addr: addr.to_string(),
         node_id,
         location: "zone-a".to_string(),


### PR DESCRIPTION
## The problem

**Freezing recorded no reason at all.** The metaserver could not tell an operator taking a node out for maintenance from the failure detector convicting one that stopped answering — even though the two want opposite recovery behaviour.

**There was also no way out of a freeze.** Tables have `unfreeze_table`; servers and proxies had nothing. The only path back to `Normal` was for the frozen resource to **re-register itself**, and `apply_register_server` permits that as soon as the freeze cooldown has elapsed.

The cooldown defaults to **zero**. So a convicted node re-registers immediately and returns itself to service: the failure detector's decision is erased by the very node it was about, and **conviction is advisory rather than binding**.

## What this adds

**`FreezeReason` on servers and proxies** — `Operator` for an explicit admin request, `Unresponsive` when the detector convicts for silence, `Restarted` when reboot detection (#64) fires. Reported through `list_servers` and the topology event stream, so an operator can see why a node is out. Set at every freeze site: the stale-heartbeat sweep and the adaptive detector mark their own verdicts as convictions, and the adaptive path distinguishes a restart from a silence using the plan it already computes.

**`unfreeze_server` / `unfreeze_proxy`**, exposed as `POST /servers/unfreeze` and `POST /proxies/unfreeze`. Always available whatever the freeze reason, because an operator has to be able to overrule the metaserver.

Unfreeze is recorded as its **own mutation**. It was previously the one state change that recorded nothing, so mutation-log recovery would have silently re-frozen the resource — a test covers that replay.

**`TS_META_FORBID_SELF_CLEARING_CONVICTION`** makes the metaserver refuse a re-registration from a resource it convicted, returning `conviction_requires_unfreeze` until an operator intervenes.

An **operator freeze is deliberately not covered** by the lock: that already has a human in the loop, and the freeze cooldown is the knob for holding a node out.

## Off by default

| Variable | Default | Meaning |
|---|---|---|
| `TS_META_FORBID_SELF_CLEARING_CONVICTION` | `0` | A convicted resource cannot re-register its way back |

The automatic recovery this removes is load-bearing wherever the freeze cooldown is left at zero, so turning it on is a deployment decision. **Recording the reason and offering unfreeze are unconditional** — neither changes existing behaviour.

## Tests

7 new tests: the reason recorded for a detector freeze and for an operator freeze, a convicted server refused re-registration and readmitted after unfreeze, the default path still recovering automatically, an operator freeze not being locked, a restart locked out under its own reason, a convicted proxy covered the same way, and an unfreeze surviving mutation-log replay.

Verification:

- `cargo test -p temporalstore-rust --lib meta::tests` — 34 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **176 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.

Independent of #73.
