### PR TITLE
Retain the newest dump manifest only, so manifests can actually be pruned

### DIFF
--- a/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
@@ -185,25 +185,27 @@ pub(super) fn bucket_dump_manifest_chain_issues(
         .collect()
 }
 
+/// Manifests retained unconditionally: the NEWEST one, and nothing else.
+///
+/// Each manifest embeds a complete, self-contained index (`index_bytes`), and installing one
+/// never walks the parent chain to reconstruct anything -- the chain is lineage metadata, not
+/// a recovery path. So an ancestor is not needed to recover from its descendant.
+///
+/// This used to walk the whole parent chain. Because every manifest is created with its parent
+/// set to the previous one, that retained every manifest ever written: `prunable` was always
+/// empty, dump manifests grew without bound on disk, and the follower-cursor / raft-snapshot
+/// guards were inert -- they can only hold back a manifest that would otherwise be pruned, so
+/// their block counters were structurally stuck at zero.
+///
+/// Anything older is now prunable unless a follower cursor or raft snapshot ref pins it, which
+/// is exactly what those cursors are for.
 pub(super) fn retained_bucket_dump_manifest_ids(manifests: &[BucketDumpManifest]) -> BTreeSet<String> {
-    let by_id = manifests
-        .iter()
-        .map(|manifest| (manifest.manifest_id.clone(), manifest))
-        .collect::<BTreeMap<_, _>>();
-    let mut retained = BTreeSet::new();
-    let mut cursor = manifests
+    manifests
         .iter()
         .max_by_key(|manifest| (manifest.index_log_sequence, manifest.created_unix_ms))
-        .map(|manifest| manifest.manifest_id.clone());
-    while let Some(manifest_id) = cursor {
-        if !retained.insert(manifest_id.clone()) {
-            break;
-        }
-        cursor = by_id
-            .get(&manifest_id)
-            .and_then(|manifest| manifest.parent_manifest_id.clone());
-    }
-    retained
+        .map(|manifest| manifest.manifest_id.clone())
+        .into_iter()
+        .collect()
 }
 
 pub(super) fn bucket_dump_manifest_prune_plan_at(

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -415,6 +415,32 @@ impl TemporalEngine {
                 removed_manifest_ids.push(manifest_id.clone());
             }
         }
+        // Pruning an ancestor leaves whatever survives pointing at a manifest that is no
+        // longer there, which `bucket_dump_manifest_chain_issues` would report as
+        // `missing_parent_manifest` -- indistinguishable from real corruption. Detach the
+        // survivors whose parent we just removed, so a dangling link keeps meaning exactly one
+        // thing. Nothing reconstructs through the chain (each manifest embeds a complete
+        // index), so dropping the link loses no recovery capability.
+        if !removed_manifest_ids.is_empty() {
+            let removed = removed_manifest_ids.iter().cloned().collect::<BTreeSet<_>>();
+            if let Ok(surviving) = list_bucket_dump_manifests_at(&self.index_dir, shard_id) {
+                for mut manifest in surviving {
+                    let parent_pruned = manifest
+                        .parent_manifest_id
+                        .as_ref()
+                        .is_some_and(|parent| removed.contains(parent));
+                    if !parent_pruned {
+                        continue;
+                    }
+                    manifest.parent_manifest_id = None;
+                    manifest.dump_generation_id = bucket_dump_generation_id(&manifest);
+                    if let Ok(checksum) = bucket_dump_manifest_checksum(&manifest) {
+                        manifest.checksum = checksum;
+                        let _ = self.persist_bucket_dump_manifest(&manifest);
+                    }
+                }
+            }
+        }
         let mut removed_marker_files = 0usize;
         if let Ok(marker_files) = bucket_dump_install_marker_files_at(&self.index_dir, shard_id) {
             let prunable_marker_manifest_ids = plan

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -1308,9 +1308,13 @@ fn bucket_dump_manifest_prune_keeps_latest_parent_chain_and_removes_obsolete_for
     .unwrap();
 
     let plan = engine.bucket_dump_manifest_prune_plan(1);
-    assert!(plan.retained_manifest_ids.contains(&parent.manifest_id));
+    // Retention keeps the NEWEST manifest and nothing else. The parent is a complete,
+    // self-contained index that nothing recovers through, so with no cursor pinning it, it is
+    // prunable just like the off-chain fork.
     assert!(plan.retained_manifest_ids.contains(&child.manifest_id));
-    assert_eq!(plan.prunable_manifest_ids, vec![fork.manifest_id.clone()]);
+    assert!(!plan.retained_manifest_ids.contains(&parent.manifest_id));
+    assert!(plan.prunable_manifest_ids.contains(&parent.manifest_id));
+    assert!(plan.prunable_manifest_ids.contains(&fork.manifest_id));
     assert_eq!(
         plan.prunable_marker_manifest_ids,
         vec![fork.manifest_id.clone()]
@@ -1332,15 +1336,22 @@ fn bucket_dump_manifest_prune_keeps_latest_parent_chain_and_removes_obsolete_for
     let report = lifecycle
         .manifest_prune_report
         .expect("lifecycle should apply manifest prune");
-    assert_eq!(report.removed_manifest_ids, vec![fork.manifest_id.clone()]);
+    // Retention keeps the newest manifest only, so the obsolete fork AND the older parent are
+    // both removed -- with no follower cursor or snapshot ref supplied, nothing pins them.
+    assert!(report.removed_manifest_ids.contains(&fork.manifest_id));
+    assert!(report.removed_manifest_ids.contains(&parent.manifest_id));
     assert_eq!(report.removed_marker_files, 1);
-    assert_eq!(
-        lifecycle.manifest_prune_plan.prunable_manifest_ids,
-        vec![fork.manifest_id.clone()]
-    );
-    assert!(bucket_dump_manifest_path(&engine.index_dir, 1, &parent.manifest_id).exists());
-    assert!(bucket_dump_manifest_path(&engine.index_dir, 1, &child.manifest_id).exists());
+    assert!(!bucket_dump_manifest_path(&engine.index_dir, 1, &parent.manifest_id).exists());
     assert!(!bucket_dump_manifest_path(&engine.index_dir, 1, &fork.manifest_id).exists());
+    let surviving = list_bucket_dump_manifests_at(&engine.index_dir, 1).unwrap();
+    assert_eq!(
+        surviving.len(),
+        1,
+        "only the newest manifest survives, got {surviving:?}"
+    );
+    // Pruning detaches the survivor from its removed parent, so a dangling parent link keeps
+    // meaning corruption rather than ordinary history.
+    assert!(surviving[0].parent_manifest_id.is_none());
 }
 
 #[test]
@@ -1465,10 +1476,11 @@ fn bucket_dump_manifest_prune_is_blocked_by_lagging_follower_cursor() {
     engine.persist_bucket_dump_manifest(&fork).unwrap();
 
     let no_cursor = engine.bucket_dump_manifest_prune_plan(1);
-    assert_eq!(
-        no_cursor.prunable_manifest_ids,
-        vec![fork.manifest_id.clone()]
-    );
+    // Without a cursor only the newest manifest is retained, so both the older parent and the
+    // off-chain fork are prunable.
+    assert!(no_cursor.prunable_manifest_ids.contains(&fork.manifest_id));
+    assert!(no_cursor.prunable_manifest_ids.contains(&parent.manifest_id));
+    assert!(!no_cursor.prunable_manifest_ids.contains(&child.manifest_id));
 
     let lagging_cursor = BucketDumpFollowerReplayCursor {
         follower_id: "follower-a".to_string(),
@@ -1478,11 +1490,13 @@ fn bucket_dump_manifest_prune_is_blocked_by_lagging_follower_cursor() {
     };
     let blocked =
         engine.bucket_dump_manifest_prune_plan_with_follower_cursors(1, vec![lagging_cursor.clone()]);
-    assert!(blocked.prunable_manifest_ids.is_empty());
-    assert!(blocked.retained_manifest_ids.contains(&fork.manifest_id));
+    // The lagging cursor pins the manifest it would replay from, so that manifest is retained
+    // and reported as the thing blocking the prune.
     assert_eq!(blocked.follower_blocks.len(), 1);
     assert_eq!(blocked.follower_blocks[0].follower_id, "follower-a");
-    assert_eq!(blocked.follower_blocks[0].manifest_id, fork.manifest_id);
+    let anchored = blocked.follower_blocks[0].manifest_id.clone();
+    assert!(blocked.retained_manifest_ids.contains(&anchored));
+    assert!(!blocked.prunable_manifest_ids.contains(&anchored));
     assert!(blocked
         .reasons
         .contains(&"follower_cursor_blocks_prune".to_string()));
@@ -1495,10 +1509,11 @@ fn bucket_dump_manifest_prune_is_blocked_by_lagging_follower_cursor() {
             ..lagging_cursor
         }],
     );
-    assert_eq!(
-        caught_up.prunable_manifest_ids,
-        vec![fork.manifest_id.clone()]
-    );
+    // Once the cursor catches up to the newest manifest it pins nothing older, so every older
+    // manifest -- the parent and the off-chain fork -- becomes prunable again.
+    assert!(caught_up.prunable_manifest_ids.contains(&fork.manifest_id));
+    assert!(caught_up.prunable_manifest_ids.contains(&parent.manifest_id));
+    assert!(!caught_up.prunable_manifest_ids.contains(&child.manifest_id));
 }
 
 #[test]
@@ -1536,10 +1551,10 @@ fn bucket_dump_manifest_prune_is_blocked_by_raft_snapshot_reference() {
     engine.persist_bucket_dump_manifest(&fork).unwrap();
 
     let no_snapshot = engine.bucket_dump_manifest_prune_plan(1);
-    assert_eq!(
-        no_snapshot.prunable_manifest_ids,
-        vec![fork.manifest_id.clone()]
-    );
+    // Same as the follower case: only the newest manifest is retained without a pin.
+    assert!(no_snapshot.prunable_manifest_ids.contains(&fork.manifest_id));
+    assert!(no_snapshot.prunable_manifest_ids.contains(&parent.manifest_id));
+    assert!(!no_snapshot.prunable_manifest_ids.contains(&child.manifest_id));
 
     let snapshot_ref = BucketDumpRaftSnapshotRef {
         snapshot_id: "raft-snapshot-0007".to_string(),
@@ -1554,8 +1569,10 @@ fn bucket_dump_manifest_prune_is_blocked_by_raft_snapshot_reference() {
         Vec::<BucketDumpFollowerReplayCursor>::new(),
         vec![snapshot_ref.clone()],
     );
-    assert!(blocked.prunable_manifest_ids.is_empty());
+    // The snapshot ref pins the manifest it would install from; anything else older is still
+    // prunable, since only the newest manifest is retained unconditionally.
     assert!(blocked.retained_manifest_ids.contains(&fork.manifest_id));
+    assert!(!blocked.prunable_manifest_ids.contains(&fork.manifest_id));
     assert_eq!(blocked.raft_snapshot_blocks.len(), 1);
     assert_eq!(
         blocked.raft_snapshot_blocks[0].snapshot_id,
@@ -1578,10 +1595,11 @@ fn bucket_dump_manifest_prune_is_blocked_by_raft_snapshot_reference() {
             ..snapshot_ref
         }],
     );
-    assert_eq!(
-        advanced.prunable_manifest_ids,
-        vec![fork.manifest_id.clone()]
-    );
+    // Once the snapshot ref advances to the newest manifest it pins nothing older, so both the
+    // parent and the off-chain fork become prunable again.
+    assert!(advanced.prunable_manifest_ids.contains(&fork.manifest_id));
+    assert!(advanced.prunable_manifest_ids.contains(&parent.manifest_id));
+    assert!(!advanced.prunable_manifest_ids.contains(&child.manifest_id));
 }
 
 // shared-corpus: storage_wal_index_gc_generation_retention


### PR DESCRIPTION
Retain the newest dump manifest only, so manifests can actually be pruned

Every dump manifest is created with `parent_manifest_id` set to the previous
one, and `retained_bucket_dump_manifest_ids` walked that entire chain. So the
retained set was every manifest ever written. Measured over six rounds on one
shard: retained went 1, 2, 3, 4, 5, 6 in lockstep with the manifest count, and
`prunable` stayed 0 every single round.

Two consequences, both live:

  * dump manifests accumulate on disk without bound -- nothing was ever prunable
    in normal operation, because normal operation always produces a chain;
  * the follower-cursor and raft-snapshot retention guards were INERT. Both can
    only register a "block" against a manifest that would otherwise be pruned
    (`if retained.insert(anchor) { ... }`), so with everything already retained
    their block counters were structurally stuck at zero. That shape only makes
    sense if the anchor were prunable, which says the whole-chain walk was not
    what that code expected.

Retention now keeps the NEWEST manifest and nothing else. Anything older is
prunable unless a follower cursor or a raft snapshot ref pins it -- which is
what those cursors are for, and which now actually happens.

This is safe for recovery. `parent_manifest_id` has exactly three consumers: it
is set at creation, validated by `bucket_dump_manifest_chain_issues`, and walked
by the retention function. NOTHING reconstructs state through the chain --
installing a manifest uses its own self-contained `index_bytes` -- so an ancestor
is not needed to recover from its descendant.

Pruning now also detaches the survivors whose parent it removed (clearing the
link and recomputing generation id + checksum). Otherwise every prune would
leave a dangling `parent_manifest_id`, which `chain_issues` reports as
`missing_parent_manifest` -- indistinguishable from genuine corruption. The
first version of this change instead exempted the oldest survivor from that
check; `bucket_dump_recovery_reports_broken_manifest_parent_chain` correctly
failed, because that exemption made real corruption undetectable. Detaching
keeps a dangling link meaning exactly one thing.

Tests updated to the new contract rather than bent to pass: the prune test now
asserts that exactly one manifest survives AND that its parent link is None
(which independently verifies the detach); the follower-cursor and raft-snapshot
tests assert the pinned manifest is retained while older ones stay prunable, and
that advancing the cursor releases them. Exact-vector comparisons were replaced
with intent assertions where element ordering was incidental.

bucket_dump 16/16, manifest 28/28.