### PR TITLE
meta: expose the background subsystems on /metrics

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -910,7 +910,8 @@ fn drive_reassignments(
                 }
             }
         }
-        let ack = meta.reassign_shard(plan.shard_id, &plan.to_server);
+        let ack =
+            meta.reassign_shard_with_reason(plan.shard_id, &plan.to_server, plan.reason.as_str());
         if ack.status.ok {
             info!(
                 shard_id = plan.shard_id,
@@ -1511,6 +1512,9 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     let scheduler_snapshot = scheduler.snapshot();
     let scheduler_executions = scheduler.executions();
     let mut out = String::new();
+    // What the background subsystems did, so conviction, divergence, retention
+    // and freeze aging are observable without scraping logs.
+    out.push_str(&meta.subsystem_prometheus());
 
     out.push_str("# HELP temporalstore_meta_requests_total Metaserver request counters by kind.\n");
     out.push_str("# TYPE temporalstore_meta_requests_total counter\n");
@@ -2047,6 +2051,12 @@ mod tests {
         assert_eq!(code, 200);
         let metrics = String::from_utf8(body).unwrap();
         assert!(metrics.contains("# TYPE temporalstore_meta_requests_total counter"));
+        // The background subsystems report onto the same surface, so an
+        // operator sees conviction, divergence and retention without logs.
+        assert!(metrics.contains("# TYPE temporalstore_meta_convicted_total counter"));
+        assert!(metrics.contains("# TYPE temporalstore_meta_damage_severity gauge"));
+        assert!(metrics.contains("temporalstore_meta_shard_divergence_total 0"));
+        assert!(metrics.contains("temporalstore_meta_retention_blocked 0"));
         assert!(metrics.contains("temporalstore_meta_inventory{kind=\"namespace\"} 1"));
         assert!(metrics.contains("temporalstore_meta_inventory{kind=\"table\"} 1"));
         assert!(metrics

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -27,6 +27,16 @@ impl MetaBackend {
         Ok(Self::Single(meta))
     }
 
+    /// Prometheus text for the background subsystems. Empty for the raft
+    /// backend, which does not drive them -- every one of those loops declines
+    /// to start against it.
+    fn subsystem_prometheus(&self) -> String {
+        match self {
+            Self::Single(meta) => meta.subsystem_metrics().prometheus(),
+            Self::Raft(_) => String::new(),
+        }
+    }
+
     fn raft_status(&self) -> Option<RaftClusterStatus> {
         match self {
             Self::Single(_) => None,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -28,6 +28,7 @@ mod placement_rebalance;
 mod raft_failover;
 mod shard_check;
 mod retention;
+mod subsystem_metrics;
 use self::partitioning::*;
 use self::topology_helpers::*;
 pub use self::auto_rebalance::{
@@ -46,6 +47,7 @@ pub use self::raft_failover::{compute_raft_failover_triggers, RaftFailoverTrigge
 pub use self::shard_check::{
     ShardCheckOptions, ShardCheckReport, ShardChecker, ShardDivergence,
 };
+pub use self::subsystem_metrics::{SubsystemMetrics, TIER_PROXY, TIER_SERVER};
 pub use self::retention::{
     plan_freeze_aging, plan_meta_retention, FreezeAgingOptions, FreezeAgingPlan,
     FreezeAgingReport, MetaRetentionOptions, MetaRetentionPlan, MetaRetentionReport,
@@ -934,6 +936,10 @@ pub struct SingleNodeMeta {
     /// because today's automatic recovery is load-bearing for deployments
     /// running with a zero freeze cooldown.
     forbid_self_clearing_conviction: bool,
+    /// Where the background subsystems record what each round did, so `/metrics`
+    /// can report it. Shared by clone, so every handle to this meta writes to
+    /// and reads from the same recorder.
+    metrics: SubsystemMetrics,
 }
 
 impl Default for SingleNodeMeta {
@@ -946,6 +952,7 @@ impl Default for SingleNodeMeta {
             boot_time_ms: now_ms(),
             mutation_log: None,
             forbid_self_clearing_conviction: false,
+            metrics: SubsystemMetrics::new(),
         }
     }
 }
@@ -961,6 +968,11 @@ impl SingleNodeMeta {
     /// True when a convicted resource cannot clear its own freeze.
     pub fn conviction_lock_enabled(&self) -> bool {
         self.forbid_self_clearing_conviction
+    }
+
+    /// The recorder the background subsystems write their round outcomes into.
+    pub fn subsystem_metrics(&self) -> &SubsystemMetrics {
+        &self.metrics
     }
 
     pub fn register(&self, request: RegisterShardRequest) -> RegisterShardResponse {

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -47,6 +47,19 @@ pub enum ShardReassignmentReason {
     LocationViolation,
 }
 
+impl ShardReassignmentReason {
+    /// Stable label for metrics and logs. Matches the serde representation, so
+    /// a dashboard and a JSON payload name the same cause the same way.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OwnerUnavailable => "owner_unavailable",
+            Self::Rebalance => "rebalance",
+            Self::LocationViolation => "location_violation",
+            Self::OwnerDiverged => "owner_diverged",
+        }
+    }
+}
+
 /// A single planned shard ownership change.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ShardReassignment {
@@ -239,6 +252,18 @@ impl SingleNodeMeta {
     /// the new owner. This is the metaserver-driven counterpart to a datanode
     /// self-registering a shard.
     pub fn reassign_shard(&self, shard_id: ShardId, to_server: &str) -> AckResponse {
+        self.reassign_shard_with_reason(shard_id, to_server, "unspecified")
+    }
+
+    /// Reassign a shard, recording why it moved so `/metrics` can distinguish a
+    /// rebalance from an evacuation or a divergence repair.
+    pub fn reassign_shard_with_reason(
+        &self,
+        shard_id: ShardId,
+        to_server: &str,
+        reason: &str,
+    ) -> AckResponse {
+        self.metrics.record_reassignment(reason);
         self.record_mutation(MetaMutation::RegisterShard(RegisterShardRequest {
             shard_id,
             server_addr: to_server.to_string(),

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -792,7 +792,7 @@ impl SingleNodeMeta {
             frozen_servers.push(endpoint.clone());
         }
 
-        AdaptiveConvictionReport {
+        let report = AdaptiveConvictionReport {
             status: Status::ok(),
             frozen_servers,
             frozen_proxies: Vec::new(),
@@ -802,7 +802,9 @@ impl SingleNodeMeta {
             held_by_orphan_guard: plan.held_by_orphan_guard,
             orphaned_shards: plan.orphaned_shards,
             detector_paused,
-        }
+        };
+        self.metrics.record_conviction(TIER_SERVER, &report);
+        report
     }
 
     /// Run one adaptive detection round over the proxies and freeze exactly the
@@ -857,7 +859,7 @@ impl SingleNodeMeta {
             frozen_proxies.push(endpoint.clone());
         }
 
-        AdaptiveConvictionReport {
+        let report = AdaptiveConvictionReport {
             status: Status::ok(),
             frozen_servers: Vec::new(),
             frozen_proxies,
@@ -867,7 +869,9 @@ impl SingleNodeMeta {
             held_by_orphan_guard: plan.held_by_orphan_guard,
             orphaned_shards: plan.orphaned_shards,
             detector_paused,
-        }
+        };
+        self.metrics.record_conviction(TIER_PROXY, &report);
+        report
     }
 
     /// Background loop that replaces [`Self::start_failure_detector_loop`] when

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -283,6 +283,7 @@ impl SingleNodeMeta {
     /// table.
     pub fn purge_expired_meta(&self, options: MetaRetentionOptions) -> MetaRetentionReport {
         let plan = self.plan_meta_retention_now(options);
+        self.metrics.record_retention(&plan);
         if plan.is_empty() {
             return MetaRetentionReport {
                 status: Status::ok(),
@@ -506,6 +507,7 @@ impl SingleNodeMeta {
     /// every exported snapshot - forever.
     pub fn age_frozen_meta(&self, options: FreezeAgingOptions) -> FreezeAgingReport {
         let plan = self.plan_freeze_aging_now(options);
+        self.metrics.record_freeze_aging(&plan);
         if plan.is_empty() {
             return FreezeAgingReport {
                 status: Status::ok(),

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -406,6 +406,7 @@ impl SingleNodeMeta {
         };
         let mut report = checker.check(&shard_owners, &servers, now);
         let moves = checker.plan_moves(&mut report, &shard_owners, &live_servers);
+        self.metrics.record_divergence(&report);
         if !report.diverged.is_empty() {
             let mut state = self.inner.write().expect("meta lock poisoned");
             for divergence in &report.diverged {

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -1,0 +1,696 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Prometheus metrics for the metaserver's background subsystems.
+//!
+//! Conviction, shard-divergence reconciliation, retention, freeze aging and
+//! rebalancing all run on background loops and, until now, reported what they
+//! did only through tracing. That leaves an operator scraping logs to answer
+//! the questions they will actually ask during an incident: is the fleet being
+//! convicted right now, is any location in safe mode, how many shards is the
+//! metaserver routing to nodes that do not serve them, is retention keeping up.
+//!
+//! [`SubsystemMetrics`] is the recorder those loops write their round outcomes
+//! into, and [`SubsystemMetrics::prometheus`] renders them onto the metaserver's
+//! existing `/metrics` surface. It holds two kinds of series:
+//!
+//! * **Counters** that only ever climb — how many resources have been convicted,
+//!   purged, aged out or reassigned since this metaserver started. These answer
+//!   "is this happening, and how often".
+//! * **Gauges** describing the most recent round — per-location damage severity,
+//!   how many shards are currently diverged, whether a detector is paused. These
+//!   answer "what is true right now", and are replaced wholesale each round so a
+//!   location that recovers stops reporting damage rather than sticking at its
+//!   worst value.
+//!
+//! The recorder is cheap to clone (one `Arc`) and every method takes `&self`, so
+//! the loops write to it without threading a handle through their signatures.
+//!
+//! One deliberate cardinality note: damage is labelled by location, which
+//! matches the reference's per-tag emission. That is bounded by the number of
+//! distinct locations in the cluster, but with hierarchical locations a
+//! deployment labelling every rack separately will get one series per rack.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use super::*;
+
+/// Which tier a conviction series describes.
+pub const TIER_SERVER: &str = "server";
+/// Which tier a conviction series describes.
+pub const TIER_PROXY: &str = "proxy";
+
+#[derive(Debug, Default)]
+struct SubsystemMetricsState {
+    // --- counters ---
+    convicted_total: BTreeMap<String, u64>,
+    held_total: BTreeMap<(String, String), u64>,
+    reboots_detected_total: u64,
+    divergences_total: u64,
+    reassigned_total: BTreeMap<String, u64>,
+    purged_total: BTreeMap<String, u64>,
+    aged_total: BTreeMap<String, u64>,
+    rounds_total: BTreeMap<String, u64>,
+
+    // --- last-round gauges ---
+    damage: BTreeMap<String, Vec<LocationDamage>>,
+    detector_paused: BTreeMap<String, bool>,
+    diverged_now: u64,
+    settling_now: u64,
+    divergence_rate_limited: u64,
+    retention_blocked_servers: u64,
+    retention_capped: u64,
+}
+
+/// Shared recorder for background-subsystem outcomes.
+#[derive(Debug, Clone, Default)]
+pub struct SubsystemMetrics {
+    inner: Arc<Mutex<SubsystemMetricsState>>,
+}
+
+impl SubsystemMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn with<R>(&self, f: impl FnOnce(&mut SubsystemMetricsState) -> R) -> R {
+        // A poisoned metrics lock must never take the metaserver down with it:
+        // observability is not worth an outage, so recover the guard and carry on.
+        let mut state = match self.inner.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        f(&mut state)
+    }
+
+    /// Record one adaptive conviction round for `tier`.
+    pub fn record_conviction(&self, tier: &str, report: &AdaptiveConvictionReport) {
+        self.with(|state| {
+            *state.rounds_total.entry(tier.to_string()).or_default() += 1;
+            let convicted = (report.frozen_servers.len() + report.frozen_proxies.len()) as u64;
+            *state.convicted_total.entry(tier.to_string()).or_default() += convicted;
+            *state
+                .held_total
+                .entry((tier.to_string(), "safe_mode".to_string()))
+                .or_default() += report.held_by_safe_mode.len() as u64;
+            state.reboots_detected_total += report.rebooted.len() as u64;
+            state
+                .damage
+                .insert(tier.to_string(), report.damage.clone());
+            state
+                .detector_paused
+                .insert(tier.to_string(), report.detector_paused);
+        });
+    }
+
+    /// Record one shard-divergence reconciliation round.
+    pub fn record_divergence(&self, report: &ShardCheckReport) {
+        self.with(|state| {
+            *state
+                .rounds_total
+                .entry("divergence".to_string())
+                .or_default() += 1;
+            state.divergences_total += report.diverged.len() as u64;
+            state.diverged_now = report.diverged.len() as u64;
+            state.settling_now = report.settling.len() as u64;
+            state.divergence_rate_limited = report.rate_limited as u64;
+        });
+    }
+
+    /// Record one retention round.
+    pub fn record_retention(&self, plan: &MetaRetentionPlan) {
+        self.with(|state| {
+            *state
+                .rounds_total
+                .entry("retention".to_string())
+                .or_default() += 1;
+            for (kind, count) in [
+                ("server", plan.servers.len()),
+                ("proxy", plan.proxies.len()),
+                ("table", plan.tables.len()),
+                ("shard", plan.shards.len()),
+            ] {
+                *state.purged_total.entry(kind.to_string()).or_default() += count as u64;
+            }
+            state.retention_blocked_servers = plan.blocked_servers.len() as u64;
+            state.retention_capped = plan.capped as u64;
+        });
+    }
+
+    /// Record one freeze-aging round.
+    pub fn record_freeze_aging(&self, plan: &FreezeAgingPlan) {
+        self.with(|state| {
+            *state
+                .rounds_total
+                .entry("freeze_aging".to_string())
+                .or_default() += 1;
+            for (kind, count) in [
+                ("server", plan.servers.len()),
+                ("proxy", plan.proxies.len()),
+                ("table", plan.tables.len()),
+            ] {
+                *state.aged_total.entry(kind.to_string()).or_default() += count as u64;
+            }
+        });
+    }
+
+    /// Record one shard changing owner, labelled by why it moved.
+    pub fn record_reassignment(&self, reason: &str) {
+        self.with(|state| {
+            *state.reassigned_total.entry(reason.to_string()).or_default() += 1;
+        });
+    }
+
+    /// Render every series in the Prometheus text format.
+    pub fn prometheus(&self) -> String {
+        self.with(|state| render(state))
+    }
+}
+
+fn push(out: &mut String, name: &str, labels: &[(&str, &str)], value: u64) {
+    out.push_str(name);
+    if !labels.is_empty() {
+        out.push('{');
+        for (index, (key, value)) in labels.iter().enumerate() {
+            if index > 0 {
+                out.push(',');
+            }
+            out.push_str(key);
+            out.push_str("=\"");
+            // Label values come from locations and reasons, which are operator
+            // supplied; escape so a stray quote cannot corrupt the exposition.
+            for ch in value.chars() {
+                match ch {
+                    '\\' => out.push_str("\\\\"),
+                    '"' => out.push_str("\\\""),
+                    '\n' => out.push_str("\\n"),
+                    _ => out.push(ch),
+                }
+            }
+            out.push('"');
+        }
+        out.push('}');
+    }
+    out.push(' ');
+    out.push_str(&value.to_string());
+    out.push('\n');
+}
+
+fn severity_value(severity: DamageSeverity) -> u64 {
+    match severity {
+        DamageSeverity::Normal => 0,
+        DamageSeverity::Warning => 1,
+        DamageSeverity::Critical => 2,
+    }
+}
+
+fn render(state: &SubsystemMetricsState) -> String {
+    let mut out = String::new();
+
+    out.push_str(
+        "# HELP temporalstore_meta_convicted_total Resources frozen by the failure detector.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_convicted_total counter\n");
+    for (tier, value) in &state.convicted_total {
+        push(
+            &mut out,
+            "temporalstore_meta_convicted_total",
+            &[("tier", tier)],
+            *value,
+        );
+    }
+
+    out.push_str("# HELP temporalstore_meta_conviction_held_total Convictions held back by a guard rather than acted on.\n");
+    out.push_str("# TYPE temporalstore_meta_conviction_held_total counter\n");
+    for ((tier, guard), value) in &state.held_total {
+        push(
+            &mut out,
+            "temporalstore_meta_conviction_held_total",
+            &[("tier", tier), ("guard", guard)],
+            *value,
+        );
+    }
+
+    out.push_str(
+        "# HELP temporalstore_meta_detector_rounds_total Background subsystem rounds completed.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_detector_rounds_total counter\n");
+    for (subsystem, value) in &state.rounds_total {
+        push(
+            &mut out,
+            "temporalstore_meta_detector_rounds_total",
+            &[("subsystem", subsystem)],
+            *value,
+        );
+    }
+
+    out.push_str("# HELP temporalstore_meta_reboots_detected_total Datanodes observed to have restarted in place.\n");
+    out.push_str("# TYPE temporalstore_meta_reboots_detected_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_reboots_detected_total",
+        &[],
+        state.reboots_detected_total,
+    );
+
+    out.push_str("# HELP temporalstore_meta_damage_severity Damage severity per location: 0 normal, 1 warning, 2 critical.\n");
+    out.push_str("# TYPE temporalstore_meta_damage_severity gauge\n");
+    for (tier, damage) in &state.damage {
+        for entry in damage {
+            push(
+                &mut out,
+                "temporalstore_meta_damage_severity",
+                &[("tier", tier), ("location", &entry.location)],
+                severity_value(entry.severity),
+            );
+        }
+    }
+
+    out.push_str(
+        "# HELP temporalstore_meta_abnormal_resources Resources not serving, per location.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_abnormal_resources gauge\n");
+    for (tier, damage) in &state.damage {
+        for entry in damage {
+            push(
+                &mut out,
+                "temporalstore_meta_abnormal_resources",
+                &[("tier", tier), ("location", &entry.location)],
+                entry.abnormal_servers as u64,
+            );
+        }
+    }
+
+    out.push_str(
+        "# HELP temporalstore_meta_location_safe_mode Whether a location is held in safe mode.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_location_safe_mode gauge\n");
+    for (tier, damage) in &state.damage {
+        for entry in damage {
+            push(
+                &mut out,
+                "temporalstore_meta_location_safe_mode",
+                &[("tier", tier), ("location", &entry.location)],
+                u64::from(entry.safe_mode),
+            );
+        }
+    }
+
+    out.push_str("# HELP temporalstore_meta_detector_paused Whether a detector suppressed conviction this round.\n");
+    out.push_str("# TYPE temporalstore_meta_detector_paused gauge\n");
+    for (tier, paused) in &state.detector_paused {
+        push(
+            &mut out,
+            "temporalstore_meta_detector_paused",
+            &[("tier", tier)],
+            u64::from(*paused),
+        );
+    }
+
+    out.push_str("# HELP temporalstore_meta_shard_divergence_total Shards found routed to a server not serving them.\n");
+    out.push_str("# TYPE temporalstore_meta_shard_divergence_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_shard_divergence_total",
+        &[],
+        state.divergences_total,
+    );
+
+    out.push_str(
+        "# HELP temporalstore_meta_shard_divergence Divergence state as of the last round.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_shard_divergence gauge\n");
+    for (state_label, value) in [
+        ("diverged", state.diverged_now),
+        ("settling", state.settling_now),
+        ("rate_limited", state.divergence_rate_limited),
+    ] {
+        push(
+            &mut out,
+            "temporalstore_meta_shard_divergence",
+            &[("state", state_label)],
+            value,
+        );
+    }
+
+    out.push_str(
+        "# HELP temporalstore_meta_shards_reassigned_total Shard ownership changes, by cause.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_shards_reassigned_total counter\n");
+    for (reason, value) in &state.reassigned_total {
+        push(
+            &mut out,
+            "temporalstore_meta_shards_reassigned_total",
+            &[("reason", reason)],
+            *value,
+        );
+    }
+
+    out.push_str(
+        "# HELP temporalstore_meta_retention_purged_total Tombstones forgotten by retention.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_retention_purged_total counter\n");
+    for (kind, value) in &state.purged_total {
+        push(
+            &mut out,
+            "temporalstore_meta_retention_purged_total",
+            &[("kind", kind)],
+            *value,
+        );
+    }
+
+    out.push_str("# HELP temporalstore_meta_retention_blocked Dropped servers retention cannot forget because they still own a shard.\n");
+    out.push_str("# TYPE temporalstore_meta_retention_blocked gauge\n");
+    push(
+        &mut out,
+        "temporalstore_meta_retention_blocked",
+        &[],
+        state.retention_blocked_servers,
+    );
+
+    out.push_str("# HELP temporalstore_meta_retention_capped Purges the per-round cap held back last round.\n");
+    out.push_str("# TYPE temporalstore_meta_retention_capped gauge\n");
+    push(
+        &mut out,
+        "temporalstore_meta_retention_capped",
+        &[],
+        state.retention_capped,
+    );
+
+    out.push_str(
+        "# HELP temporalstore_meta_freeze_aged_total Frozen resources aged into the dropped state.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_freeze_aged_total counter\n");
+    for (kind, value) in &state.aged_total {
+        push(
+            &mut out,
+            "temporalstore_meta_freeze_aged_total",
+            &[("kind", kind)],
+            *value,
+        );
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn damage(location: &str, severity: DamageSeverity, abnormal: usize, safe_mode: bool) -> LocationDamage {
+        LocationDamage {
+            location: location.to_string(),
+            severity,
+            total_servers: 4,
+            abnormal_servers: abnormal,
+            safe_mode,
+        }
+    }
+
+    fn conviction(frozen: &[&str], held: &[&str], damage: Vec<LocationDamage>) -> AdaptiveConvictionReport {
+        AdaptiveConvictionReport {
+            status: Status::ok(),
+            frozen_servers: frozen.iter().map(|addr| addr.to_string()).collect(),
+            frozen_proxies: Vec::new(),
+            held_by_safe_mode: held.iter().map(|addr| addr.to_string()).collect(),
+            damage,
+            rebooted: Vec::new(),
+            held_by_orphan_guard: Vec::new(),
+            orphaned_shards: Vec::new(),
+            detector_paused: false,
+        }
+    }
+
+    fn line(rendered: &str, needle: &str) -> String {
+        rendered
+            .lines()
+            .find(|line| line.starts_with(needle))
+            .unwrap_or_else(|| panic!("no series starting with {needle} in:\n{rendered}"))
+            .to_string()
+    }
+
+    #[test]
+    fn conviction_counters_accumulate_across_rounds() {
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(&["a"], &[], vec![damage("rack-1", DamageSeverity::Normal, 1, false)]),
+        );
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(&["b", "c"], &["d"], vec![damage("rack-1", DamageSeverity::Warning, 3, true)]),
+        );
+        let rendered = metrics.prometheus();
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_convicted_total{tier=\"server\"}"),
+            "temporalstore_meta_convicted_total{tier=\"server\"} 3"
+        );
+        assert_eq!(
+            line(
+                &rendered,
+                "temporalstore_meta_conviction_held_total{tier=\"server\",guard=\"safe_mode\"}"
+            ),
+            "temporalstore_meta_conviction_held_total{tier=\"server\",guard=\"safe_mode\"} 1"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_detector_rounds_total{subsystem=\"server\"}"),
+            "temporalstore_meta_detector_rounds_total{subsystem=\"server\"} 2"
+        );
+    }
+
+    #[test]
+    fn damage_gauges_describe_only_the_latest_round() {
+        // A gauge that stuck at its worst value would keep paging after the
+        // location recovered, so each round replaces the whole set.
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(&[], &[], vec![damage("rack-1", DamageSeverity::Critical, 3, true)]),
+        );
+        assert_eq!(
+            line(
+                &metrics.prometheus(),
+                "temporalstore_meta_damage_severity{tier=\"server\",location=\"rack-1\"}"
+            ),
+            "temporalstore_meta_damage_severity{tier=\"server\",location=\"rack-1\"} 2"
+        );
+
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(&[], &[], vec![damage("rack-1", DamageSeverity::Normal, 0, false)]),
+        );
+        let rendered = metrics.prometheus();
+        assert_eq!(
+            line(
+                &rendered,
+                "temporalstore_meta_damage_severity{tier=\"server\",location=\"rack-1\"}"
+            ),
+            "temporalstore_meta_damage_severity{tier=\"server\",location=\"rack-1\"} 0"
+        );
+        assert_eq!(
+            line(
+                &rendered,
+                "temporalstore_meta_location_safe_mode{tier=\"server\",location=\"rack-1\"}"
+            ),
+            "temporalstore_meta_location_safe_mode{tier=\"server\",location=\"rack-1\"} 0"
+        );
+    }
+
+    #[test]
+    fn a_location_that_disappears_stops_reporting() {
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(
+                &[],
+                &[],
+                vec![
+                    damage("rack-1", DamageSeverity::Warning, 2, true),
+                    damage("rack-2", DamageSeverity::Normal, 0, false),
+                ],
+            ),
+        );
+        assert!(metrics.prometheus().contains("location=\"rack-2\""));
+
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(&[], &[], vec![damage("rack-1", DamageSeverity::Normal, 0, false)]),
+        );
+        assert!(!metrics.prometheus().contains("location=\"rack-2\""));
+    }
+
+    #[test]
+    fn the_two_tiers_report_separately() {
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(TIER_SERVER, &conviction(&["a"], &[], Vec::new()));
+        let mut proxy_round = conviction(&[], &[], Vec::new());
+        proxy_round.frozen_proxies = vec!["p1".to_string(), "p2".to_string()];
+        metrics.record_conviction(TIER_PROXY, &proxy_round);
+
+        let rendered = metrics.prometheus();
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_convicted_total{tier=\"server\"}"),
+            "temporalstore_meta_convicted_total{tier=\"server\"} 1"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_convicted_total{tier=\"proxy\"}"),
+            "temporalstore_meta_convicted_total{tier=\"proxy\"} 2"
+        );
+    }
+
+    #[test]
+    fn divergence_reports_a_running_total_and_a_current_state() {
+        let metrics = SubsystemMetrics::new();
+        let mut report = ShardCheckReport {
+            diverged: vec![ShardDivergence {
+                shard_id: 1,
+                server_addr: "s1".to_string(),
+                reported_unloaded: false,
+                serving_state: String::new(),
+            }],
+            settling: vec![2, 3],
+            rate_limited: 4,
+            ..ShardCheckReport::default()
+        };
+        metrics.record_divergence(&report);
+        report.diverged.clear();
+        report.settling.clear();
+        report.rate_limited = 0;
+        metrics.record_divergence(&report);
+
+        let rendered = metrics.prometheus();
+        // The counter keeps the history...
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_shard_divergence_total"),
+            "temporalstore_meta_shard_divergence_total 1"
+        );
+        // ...while the gauge says the cluster is clean right now.
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_shard_divergence{state=\"diverged\"}"),
+            "temporalstore_meta_shard_divergence{state=\"diverged\"} 0"
+        );
+    }
+
+    #[test]
+    fn retention_and_aging_counters_climb_by_kind() {
+        let metrics = SubsystemMetrics::new();
+        metrics.record_retention(&MetaRetentionPlan {
+            servers: vec!["s1".to_string()],
+            proxies: vec!["p1".to_string(), "p2".to_string()],
+            tables: Vec::new(),
+            shards: vec![7],
+            blocked_servers: vec!["s2".to_string()],
+            capped: 3,
+        });
+        metrics.record_freeze_aging(&FreezeAgingPlan {
+            servers: vec!["s3".to_string()],
+            proxies: Vec::new(),
+            tables: Vec::new(),
+            capped: 0,
+        });
+
+        let rendered = metrics.prometheus();
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_retention_purged_total{kind=\"proxy\"}"),
+            "temporalstore_meta_retention_purged_total{kind=\"proxy\"} 2"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_retention_purged_total{kind=\"shard\"}"),
+            "temporalstore_meta_retention_purged_total{kind=\"shard\"} 1"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_retention_blocked"),
+            "temporalstore_meta_retention_blocked 1"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_retention_capped"),
+            "temporalstore_meta_retention_capped 3"
+        );
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_freeze_aged_total{kind=\"server\"}"),
+            "temporalstore_meta_freeze_aged_total{kind=\"server\"} 1"
+        );
+    }
+
+    #[test]
+    fn reassignments_are_labelled_by_cause() {
+        let metrics = SubsystemMetrics::new();
+        metrics.record_reassignment(ShardReassignmentReason::Rebalance.as_str());
+        metrics.record_reassignment(ShardReassignmentReason::Rebalance.as_str());
+        metrics.record_reassignment(ShardReassignmentReason::OwnerDiverged.as_str());
+
+        let rendered = metrics.prometheus();
+        assert_eq!(
+            line(&rendered, "temporalstore_meta_shards_reassigned_total{reason=\"rebalance\"}"),
+            "temporalstore_meta_shards_reassigned_total{reason=\"rebalance\"} 2"
+        );
+        assert_eq!(
+            line(
+                &rendered,
+                "temporalstore_meta_shards_reassigned_total{reason=\"owner_diverged\"}"
+            ),
+            "temporalstore_meta_shards_reassigned_total{reason=\"owner_diverged\"} 1"
+        );
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        // Locations are operator supplied, so a stray quote must not be able to
+        // break the exposition format.
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(
+            TIER_SERVER,
+            &conviction(
+                &[],
+                &[],
+                vec![damage("rack\"1\\odd", DamageSeverity::Normal, 0, false)],
+            ),
+        );
+        let rendered = metrics.prometheus();
+        assert!(
+            rendered.contains("location=\"rack\\\"1\\\\odd\""),
+            "unescaped label in:\\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn every_series_carries_help_and_type() {
+        // A metric without them is one Prometheus will scrape but nobody can
+        // read on a dashboard.
+        let metrics = SubsystemMetrics::new();
+        metrics.record_conviction(TIER_SERVER, &conviction(&["a"], &[], Vec::new()));
+        let rendered = metrics.prometheus();
+        let mut names = rendered
+            .lines()
+            .filter(|line| line.starts_with("# TYPE "))
+            .map(|line| line.split_whitespace().nth(2).unwrap().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        names.dedup();
+        assert!(!names.is_empty());
+        for name in names {
+            assert!(
+                rendered.contains(&format!("# HELP {name} ")),
+                "{name} has a TYPE but no HELP"
+            );
+        }
+    }
+
+    #[test]
+    fn recording_through_a_clone_shares_one_recorder() {
+        // The loops hold clones of the meta handle; they must all write to the
+        // same series rather than to private copies.
+        let metrics = SubsystemMetrics::new();
+        let clone = metrics.clone();
+        metrics.record_reassignment("rebalance");
+        clone.record_reassignment("rebalance");
+        assert_eq!(
+            line(
+                &metrics.prometheus(),
+                "temporalstore_meta_shards_reassigned_total{reason=\"rebalance\"}"
+            ),
+            "temporalstore_meta_shards_reassigned_total{reason=\"rebalance\"} 2"
+        );
+    }
+}


### PR DESCRIPTION
## The problem

Conviction, shard-divergence reconciliation, retention, freeze aging and rebalancing all run on background loops and reported what they did **only through tracing**.

That leaves an operator scraping logs to answer the questions they actually ask during an incident:

- Is the fleet being convicted right now?
- Is any location in safe mode?
- How many shards is the metaserver routing to nodes that do not serve them?
- Is retention keeping up, or is the per-round cap always saturated?

These are exactly the quantities a metaserver is expected to expose per location: convictions, damage severity, abnormal counts, missing shards, rebalances and freezes.

## What this adds

`meta/subsystem_metrics.rs` — the recorder those loops write their round outcomes into, rendered onto the metaserver's **existing** `/metrics` surface alongside the request and inventory series already there.

It holds two kinds of series, and the distinction is the point:

**Counters** only climb — resources convicted, convictions held back by a guard, reboots detected, divergences found, shards reassigned by cause, tombstones purged, frozen resources aged out, rounds completed per subsystem. These answer *"is this happening, and how often"*.

**Gauges** describe the most recent round — per-location damage severity and abnormal count, whether a location is in safe mode, whether a detector is paused, how many shards are diverged or settling, what the retention cap held back. These answer *"what is true now"*, and are **replaced wholesale each round**: a location that recovers reports zero rather than sticking at its worst value, and a location that disappears stops reporting at all. Both are covered by tests, because **a gauge that latches is a gauge that pages after the incident is over**.

## Design notes

- The recorder lives on `SingleNodeMeta` and is **shared by clone**, so every handle writes to the same series and the loops need no extra plumbing.
- Recording happens at each subsystem's **entry point**, not in the loop bodies — so a direct call, including from a test or an admin route, is counted too.
- The **raft backend renders nothing**, because it drives none of these loops.
- `reassign_shard` grows a reason-carrying variant so a move can be attributed. `ShardReassignmentReason` gains `as_str`, matching its serde representation so a dashboard and a JSON payload name the same cause the same way. The existing `reassign_shard` keeps working and records `unspecified`.
- **A poisoned metrics lock recovers** rather than propagating: observability is not worth taking the metaserver down for.
- **Label values are escaped** — locations and reasons are operator-supplied, and a stray quote would otherwise corrupt the exposition format.

## Series

| Metric | Type | Labels |
|---|---|---|
| `temporalstore_meta_convicted_total` | counter | `tier` |
| `temporalstore_meta_conviction_held_total` | counter | `tier`, `guard` |
| `temporalstore_meta_detector_rounds_total` | counter | `subsystem` |
| `temporalstore_meta_reboots_detected_total` | counter | — |
| `temporalstore_meta_damage_severity` | gauge | `tier`, `location` |
| `temporalstore_meta_abnormal_resources` | gauge | `tier`, `location` |
| `temporalstore_meta_location_safe_mode` | gauge | `tier`, `location` |
| `temporalstore_meta_detector_paused` | gauge | `tier` |
| `temporalstore_meta_shard_divergence_total` | counter | — |
| `temporalstore_meta_shard_divergence` | gauge | `state` |
| `temporalstore_meta_shards_reassigned_total` | counter | `reason` |
| `temporalstore_meta_retention_purged_total` | counter | `kind` |
| `temporalstore_meta_retention_blocked` | gauge | — |
| `temporalstore_meta_retention_capped` | gauge | — |
| `temporalstore_meta_freeze_aged_total` | counter | `kind` |

**Cardinality note** (also in the module docs): damage is labelled by location, which is the natural granularity and is bounded by the number of distinct locations — but with hierarchical locations (#73) a deployment labelling every rack separately gets one series per rack.

## Tests

11 new tests: counters accumulating across rounds, damage gauges describing only the latest round, a location that disappears no longer reporting, the two tiers reporting separately, divergence keeping a running total beside a current state, retention and aging counters climbing by kind, reassignments labelled by cause, label escaping, every series carrying `HELP` and `TYPE`, a clone sharing one recorder, and the `/metrics` route exposing the new series end to end.

Verification:

- `cargo test -p temporalstore-rust --lib meta::subsystem_metrics` — 10 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **198 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.

No gate: this only adds series to an endpoint that already exists, and changes no behaviour. Covers the subsystems merged so far; the guards in #75 and #76 can add their own series when those land.

