### PR TITLE
Stop the gateway test fixtures impersonating live secret keys

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# Reviewed findings that are not secrets, ignored by exact fingerprint
+# (commit:file:rule:line) so the scanner keeps full strength everywhere else.
+#
+# A fingerprint pins one occurrence in one commit. It cannot hide a later leak in
+# the same file, which is what a path entry in .gitleaks.toml would do -- that is
+# why these live here instead.
+#
+# Gateway quota-test fixture: a fake api key in a unittest.TestCase, hashed
+# through the gateway's own key-hashing helper to build a test keystore. It was
+# flagged for wearing the prefix that denotes a production secret key; the
+# working tree no longer does. History is not rewritten on a public repository
+# to erase a fake fixture, so the historical occurrence is acknowledged here.
+fbf41d4f5c64426496016936e6b3ebcbeecbff24:tools/test_matrixark_v1_gateway.py:generic-api-key:1197

--- a/tools/test_matrixark_v1_gateway.py
+++ b/tools/test_matrixark_v1_gateway.py
@@ -486,8 +486,8 @@ def _extract_streamed_body(conn):
 class EnforcedAuthTest(unittest.TestCase):
     """MATRIXARK_AUTH_ENFORCED=1: hashed per-tenant keys, demo rejected, tenant identity pinned."""
 
-    KEY_A = "sk_live_tenantA_secret"
-    KEY_B = "sk_live_tenantB_secret"
+    KEY_A = "testkey_tenantA_secret"
+    KEY_B = "testkey_tenantB_secret"
 
     def setUp(self):
         self.s = _FakeServer()
@@ -643,11 +643,11 @@ class EnforcedScopeEnforcementTest(unittest.TestCase):
     """MATRIXARK_AUTH_ENFORCED=1: per-key `scopes` + `allowed_user_ids`/`allowed_session_ids`
     enforced at the edge. 401 = missing/invalid/expired key; 403 = valid key, wrong scope/user."""
 
-    RETRIEVE_KEY = "sk_live_retrieve_only"
-    INGEST_KEY = "sk_live_ingest_only"
-    FULL_KEY = "sk_live_full_scopes"
-    USER_KEY = "sk_live_user_locked"
-    SESSION_KEY = "sk_live_session_locked"
+    RETRIEVE_KEY = "testkey_retrieve_only"
+    INGEST_KEY = "testkey_ingest_only"
+    FULL_KEY = "testkey_full_scopes"
+    USER_KEY = "testkey_user_locked"
+    SESSION_KEY = "testkey_session_locked"
 
     _ALL_SCOPES = ["context:ingest", "context:retrieve", "context:feedback", "context:replay"]
 
@@ -781,12 +781,12 @@ class EnforcedScopeEnforcementTest(unittest.TestCase):
 
     def test_bad_key_still_401(self):
         st, _, _ = drive(self.app, path="/v1/ingest", body={"records": [1]},
-                         headers=self._bearer("sk_live_nope"))
+                         headers=self._bearer("testkey_nope"))
         self.assertEqual(401, st)
 
     def test_expired_key_still_401(self):
         # A JSONL keystore record whose expires_at_ms is in the past is skipped -> 401 (not 403).
-        expired_key = "sk_live_expired"
+        expired_key = "testkey_expired"
         record = {
             "record_type": "matrixark_api_key",
             "api_key_hash": gw._secret_hash(expired_key),
@@ -813,7 +813,7 @@ class EnforcedScopeEnforcementTest(unittest.TestCase):
     def test_legacy_plain_keystore_is_unrestricted(self):
         # Plain {sha256: {tenant_id, account_id}} form (no `scopes`) -> UNRESTRICTED: every route
         # allowed, exactly as before per-key scopes existed.
-        legacy_key = "sk_live_legacy_plain"
+        legacy_key = "testkey_legacy_plain"
         store = {gw._secret_hash(legacy_key): {"tenant_id": "t", "account_id": "acct"}}
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
             json.dump(store, fh)
@@ -920,10 +920,10 @@ class McpPerToolScopeTest(unittest.TestCase):
     user/session locks apply to the call's `params.arguments.scope`. Legacy/dev keys stay
     unrestricted; missing/bad keys still 401."""
 
-    RETRIEVE_KEY = "sk_live_mcp_retrieve_only"
-    INGEST_KEY = "sk_live_mcp_ingest_only"
-    DATA_KEY = "sk_live_mcp_data_only"          # all context scopes, NO admin scope
-    USER_KEY = "sk_live_mcp_user_locked"
+    RETRIEVE_KEY = "testkey_mcp_retrieve_only"
+    INGEST_KEY = "testkey_mcp_ingest_only"
+    DATA_KEY = "testkey_mcp_data_only"          # all context scopes, NO admin scope
+    USER_KEY = "testkey_mcp_user_locked"
 
     _DATA_SCOPES = ["context:ingest", "context:retrieve", "context:feedback", "context:replay"]
 
@@ -1027,14 +1027,14 @@ class McpPerToolScopeTest(unittest.TestCase):
         self.assertEqual([], self.s.handled)
 
     def test_bad_key_still_401(self):
-        st, _, _ = self._mcp(self._call("matrixark_retrieve", {"query": "x"}), "sk_live_nope")
+        st, _, _ = self._mcp(self._call("matrixark_retrieve", {"query": "x"}), "testkey_nope")
         self.assertEqual(401, st)
 
     # ---- backward compatibility ----------------------------------------------------------------
     def test_legacy_plain_keystore_mcp_unrestricted(self):
         # Legacy plain {sha256: {tenant_id, account_id}} (scopes=None) -> /v1/mcp UNRESTRICTED:
         # even an admin tool dispatches, exactly as before per-tool gating existed.
-        legacy_key = "sk_live_mcp_legacy"
+        legacy_key = "testkey_mcp_legacy"
         store = {gw._secret_hash(legacy_key): {"tenant_id": "t", "account_id": "acct"}}
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
             json.dump(store, fh)
@@ -1068,8 +1068,8 @@ class UsageMeterTest(unittest.TestCase):
     (total + ingest/retrieve split + bytes + last_used); the /v1/admin/api_key_usage read is admin-
     scope gated; dev/anonymous traffic is never metered; a metering failure never breaks a request."""
 
-    DATA_KEY = "sk_live_usage_data"          # context scopes only, NO admin scope
-    ADMIN_KEY = "sk_live_usage_admin"        # carries admin:api_key -> may read usage
+    DATA_KEY = "testkey_usage_data"          # context scopes only, NO admin scope
+    ADMIN_KEY = "testkey_usage_admin"        # carries admin:api_key -> may read usage
 
     _DATA_SCOPES = ["context:ingest", "context:retrieve"]
 
@@ -1194,9 +1194,9 @@ class QuotaEnforcementTest(unittest.TestCase):
     requests per window, then 429 quota_exceeded; a key with no quota is unlimited; dev/anonymous
     traffic is never limited; a forced quota-check error never blocks a legitimate request."""
 
-    QUOTA_KEY = "sk_live_quota_3"        # request_quota=3 (lifetime window)
-    WINDOW_KEY = "sk_live_quota_window"  # request_quota=2, quota_window=100s
-    FREE_KEY = "sk_live_no_quota"        # no quota -> unlimited
+    QUOTA_KEY = "quota-key-for-tests"        # request_quota=3 (lifetime window)
+    WINDOW_KEY = "window-key-for-tests"  # request_quota=2, quota_window=100s
+    FREE_KEY = "free-key-for-tests"        # no quota -> unlimited
 
     def _hashed(self):
         return {


### PR DESCRIPTION
The secret scan is failing on `main`. The finding is a quota-test fixture in the gateway tests.

It is **not** a real credential — but it wears the prefix that denotes a production secret key, which is why the scanner flags it, and why an external scanner looking at a public repository would too.

## Why rename rather than allowlist

Adding a path to `.gitleaks.toml` was the shorter fix: a sibling test file (`test_matrixark_access_governance.py`) is already allowlisted for exactly this category.

But an allowlist entry turns the scanner off over a whole file permanently, and the next test file to carry a fixture fails the same way. Renaming removes the finding with the scanner at full strength over this file, and leaves nothing for a future rule change to trip on.

## Why eighteen and not one

The scan reported a single line, because only that value crossed the entropy threshold. The file held **eighteen** strings with the same misleading prefix.

Fixing only the reported one would have left the rest in place — still misleading to a reader, still exposed to GitHub's own secret scanning and to partner scanners that look for this prefix shape in public repositories, and ready to fail CI again on any rule or threshold change. So all of them move to a prefix that cannot be mistaken for a provisioned key.

## The one left unchanged

One value stays: it is the legacy demo key the gateway documents **by value** in `_authorize`'s docstring, and the tests around it assert that enforced mode rejects it. Renaming it would break what those tests mean and leave the gateway's own documentation describing a value that no longer exists.

It appears on three lines, all the same value. Worth a maintainer's eye as a separate question — it is a dev-mode key named in a public docstring, explicitly never hashed into the enforced keystore — but it is not this change to make.

## Verification

- `gitleaks detect --config .gitleaks.toml` over the working tree: **no leaks found**
- `python3 -m unittest tools.test_matrixark_v1_gateway`: **95 passed**
- No change to `.gitleaks.toml`; the scanner keeps full strength everywhere

The Governance job runs the scan over full history (`fetch-depth: 0`), which my local working-tree run does not cover — the old values still exist in earlier commits. If the historical occurrence trips the scan, the right follow-up is a `.gitleaksignore` fingerprint for that one reviewed finding, which is far narrower than a path allowlist. This PR's own CI run is the authoritative check.