### PR TITLE
gitleaks: allowlist the v1 gateway test fixtures (secret scan is red on main)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,6 +16,7 @@ useDefault = true
 description = "Test fixtures, local onebox test config, and public AWS resource identifiers (no production secrets)."
 paths = [
   "tools/test_matrixark_access_governance\\.py",
+  "tools/test_matrixark_v1_gateway\\.py",
   "test/onebox/.*\\.ya?ml",
   "docs/.*[Aa][Ww][Ss].*\\.md",
   "docs/aws_data_raft_replication.*\\.md",


### PR DESCRIPTION
The **secret scan has been red on `main`** since the v1 gateway tests landed —
it is not a regression from any recent PR. `generic-api-key` fires on
`sk_live_quota_3` in `tools/test_matrixark_v1_gateway.py:1197`.

That file holds ~10 synthetic fixtures whose `sk_live_` prefix mimics a real
key prefix — `sk_live_demo`, `sk_live_no_quota`, `sk_live_tenantA_secret`,
`sk_live_retrieve_only` … Only `sk_live_quota_3` has enough entropy after the
prefix to trip the rule:

```python
QUOTA_KEY = "sk_live_quota_3"        # request_quota=3 (lifetime window)
```

It is a unit-test constant, never a credential. It is also in published
history across two commits (`04f3c035`, `fbf41d4f`), so editing the file
cannot make the scan green — a full-history scan still finds it. The
allowlist is the fix.

This adds the path immediately next to the existing entry for
`tools/test_matrixark_access_governance.py`, which was allowlisted for exactly
the same reason.

**Scoped to the path deliberately.** An `sk_live_` allowlist *regex* would be
global and would suppress a genuine leak anywhere else in the tree; a path
entry only blinds the scanner to this one known-synthetic test file.

## Verified

With the version CI pins (gitleaks 8.18.4), running the exact CI command:

```
gitleaks detect --source . --config .gitleaks.toml --redact --no-banner --exit-code 1
INF 90 commits scanned.
INF no leaks found
exit 0
```

Before the change the same command reports `leaks found: 2`. This restores the
claim already made in the config's own header — that a full-history scan
reports no leaks.