### PR TITLE
meta: add a runtime mute for metadata change

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -818,6 +818,10 @@ fn start_auto_rebalance_loop(
         max_retries: 1,
     };
     std::thread::spawn(move || loop {
+        if meta.is_meta_change_muted() {
+            std::thread::sleep(interval);
+            continue;
+        }
         run_auto_rebalance_round(&meta, balance_load, placement_aware, http_options);
         std::thread::sleep(interval);
     })
@@ -946,6 +950,10 @@ fn start_shard_divergence_loop(
     };
     let mut checker = ShardChecker::new(options);
     std::thread::spawn(move || loop {
+        if meta.is_meta_change_muted() {
+            std::thread::sleep(interval);
+            continue;
+        }
         let (report, moves) = meta.check_shard_divergence(&mut checker);
         if !report.diverged.is_empty() {
             warn!(
@@ -1436,6 +1444,12 @@ fn handle(
             parse_or(&request.body, |req: NotifyStopRequest| {
                 json_response(200, &backend_call!(meta, notify_proxy_stop, req))
             })
+        }
+        ("POST", "/meta/mute") => {
+            json_response(200, &backend_call!(meta, set_meta_change_muted, true))
+        }
+        ("POST", "/meta/resume") => {
+            json_response(200, &backend_call!(meta, set_meta_change_muted, false))
         }
         ("POST", "/servers/freeze") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, freeze_server, req)

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -745,6 +745,9 @@ pub struct MetaInfo {
     pub stats: MetaStats,
     pub boot_time_ms: u64,
     pub durable_mutation_log: bool,
+    /// Whether recorded metadata mutations are currently refused.
+    #[serde(default)]
+    pub meta_change_muted: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -781,6 +784,12 @@ pub enum MetaMutation {
     FreezeProxy(StateChangeRequest),
     UnfreezeProxy(StateChangeRequest),
     DropProxy(StateChangeRequest),
+    /// Mute or resume metadata change. Recorded like any other mutation so it
+    /// replays in order and reaches raft peers; the guard is deliberately not
+    /// applied during replay, because the log only ever contains mutations that
+    /// were accepted live, and a mute entry flips the flag at exactly the point
+    /// the original sequence did.
+    SetMetaChangeMuted(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -875,6 +884,13 @@ pub(crate) struct MetaState {
     /// expressible; retention ages against this. Kept beside the resources
     /// rather than inside them so the wire types are unchanged.
     dropped_since_ms: BTreeMap<String, u64>,
+    /// While set, the metaserver refuses every recorded metadata mutation.
+    ///
+    /// This is an incident lever: every automatic subsystem is otherwise gated
+    /// by an environment variable, so the only way to stop the metaserver making
+    /// changes was to restart it with different configuration -- during exactly
+    /// the incident where a restart is least welcome.
+    meta_change_muted: bool,
     /// When each frozen table was frozen, keyed `table:<namespace.table>`.
     /// Servers and proxies carry `frozen_since_ms` on the resource itself;
     /// tables do not, and adding a field there would touch every
@@ -902,6 +918,11 @@ pub struct MetaSnapshot {
     /// every tombstone's clock.
     #[serde(default)]
     pub dropped_since_ms: BTreeMap<String, u64>,
+    /// Whether metadata change was muted when this snapshot was taken. Carried
+    /// so a peer installing it does not silently resume a mute an operator put
+    /// in place.
+    #[serde(default)]
+    pub meta_change_muted: bool,
     /// Freeze timestamps for the frozen tables in this snapshot, so a peer that
     /// installs it keeps ageing them instead of restarting their clocks.
     #[serde(default)]
@@ -976,6 +997,9 @@ impl SingleNodeMeta {
     }
 
     pub fn register(&self, request: RegisterShardRequest) -> RegisterShardResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return RegisterShardResponse { status };
+        }
         self.record_mutation(MetaMutation::RegisterShard(request.clone()));
         self.apply_register(request)
     }
@@ -1022,6 +1046,9 @@ impl SingleNodeMeta {
     }
 
     pub fn publish_shard_snapshot(&self, request: PublishShardSnapshotRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::PublishShardSnapshot(request.clone()));
         self.apply_publish_shard_snapshot(request)
     }
@@ -1056,6 +1083,48 @@ impl SingleNodeMeta {
     }
 
 
+
+    /// True while recorded metadata mutations are being refused.
+    pub fn is_meta_change_muted(&self) -> bool {
+        self.inner
+            .read()
+            .expect("meta lock poisoned")
+            .meta_change_muted
+    }
+
+    /// The refusal every guarded entry point returns while muted, or `None` when
+    /// metadata change is flowing normally.
+    fn meta_change_refusal(&self) -> Option<Status> {
+        self.is_meta_change_muted().then(|| {
+            Status::error(
+                "meta_change_muted",
+                "metadata change is muted; resume it before making changes",
+            )
+        })
+    }
+
+    /// Mute or resume metadata change.
+    ///
+    /// Never guarded by the mute itself -- an operator must always be able to
+    /// resume -- and recorded so it survives restart and reaches raft peers.
+    pub fn set_meta_change_muted(&self, muted: bool) -> AckResponse {
+        self.record_mutation(MetaMutation::SetMetaChangeMuted(muted));
+        self.apply_set_meta_change_muted(muted)
+    }
+
+    pub(crate) fn apply_set_meta_change_muted(&self, muted: bool) -> AckResponse {
+        let mut state = self.inner.write().expect("meta lock poisoned");
+        state.meta_change_muted = muted;
+        record_topology_event(
+            &mut state,
+            "meta_change_mute",
+            "cluster".to_string(),
+            format!("muted={muted}"),
+        );
+        AckResponse {
+            status: Status::ok(),
+        }
+    }
 
     fn record_mutation(&self, mutation: MetaMutation) {
         if let Some(log) = &self.mutation_log {
@@ -1094,6 +1163,9 @@ impl SingleNodeMeta {
                     .status
             }
             MetaMutation::UpdateServer(request) => self.apply_update_server(request).status,
+            MetaMutation::SetMetaChangeMuted(muted) => {
+                self.apply_set_meta_change_muted(muted).status
+            }
             MetaMutation::FreezeServer(request) => {
                 self.apply_set_server_state(request, MetaEntityState::Frozen)
                     .status
@@ -2186,6 +2258,174 @@ mod tests {
             .expect("registered");
         assert_eq!(server.state, MetaEntityState::Frozen);
         assert_eq!(server.freeze_reason, FreezeReason::Stopping);
+    }
+
+    fn muted_meta_with_a_server() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        assert!(meta.set_meta_change_muted(true).status.ok);
+        meta
+    }
+
+    #[test]
+    fn muting_refuses_every_recorded_mutation() {
+        let meta = muted_meta_with_a_server();
+        assert!(meta.is_meta_change_muted());
+
+        for (what, status) in [
+            (
+                "freeze_server",
+                meta.freeze_server(StateChangeRequest {
+                    endpoint: "node-a".to_string(),
+                    freeze_cooldown_ms: 0,
+                    reason: FreezeReason::Operator,
+                })
+                .status,
+            ),
+            (
+                "add_table",
+                meta.add_table(AddTableRequest {
+                    namespace: "ns".to_string(),
+                    table_name: "orders".to_string(),
+                    first_shard_id: 1,
+                    shard_count: 1,
+                    replica_count: 1,
+                    partition_version: 0,
+                    serving_options: TableServingOptions::default(),
+                })
+                .status,
+            ),
+            (
+                "register_server",
+                meta.register_server(RegisterServerRequest {
+                    server_addr: "node-b".to_string(),
+                    node_id: 2,
+                    location: "rack-1".to_string(),
+                    binary_version: "v1".to_string(),
+                })
+                .status,
+            ),
+            (
+                "reassign_shard",
+                meta.reassign_shard(1, "node-a").status,
+            ),
+        ] {
+            assert!(!status.ok, "{what} should have been refused");
+            assert_eq!(status.code, "meta_change_muted", "{what}");
+        }
+
+        // Nothing landed: the fleet is exactly as it was.
+        assert_eq!(meta.list_servers().servers.len(), 1);
+        assert_eq!(
+            meta.list_servers().servers[0].state,
+            MetaEntityState::Normal
+        );
+        assert!(meta.list_tables().tables.is_empty());
+    }
+
+    #[test]
+    fn muting_does_not_touch_reads_or_heartbeats() {
+        // The mute gates recorded mutations. A heartbeat records none -- it is
+        // liveness, not a metadata change -- and muting it would blind the
+        // failure detector to the very fleet the operator is inspecting.
+        let meta = muted_meta_with_a_server();
+        assert!(meta
+            .server_heartbeat(ServerHeartbeatRequest {
+                server_addr: "node-a".to_string(),
+                boot_time_ms: 1,
+                binary_version: "v1".to_string(),
+                shard_loads: Vec::new(),
+                shard_stat_loads: Vec::new(),
+                runtime_load: ServerRuntimeLoad::default(),
+                shard_states: Vec::new(),
+            })
+            .status
+            .ok);
+        assert!(meta.list_servers().status.ok);
+        assert!(meta.list_namespaces().status.ok);
+        assert!(meta.stats().shard_count == 0);
+    }
+
+    #[test]
+    fn a_muted_metaserver_will_not_admit_a_restarting_datanode() {
+        // The sharp edge, asserted so it is a decision rather than a surprise:
+        // registration is a recorded mutation, so while muted a node that
+        // restarts cannot rejoin until an operator resumes.
+        let meta = muted_meta_with_a_server();
+        let rejoin = meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v2".to_string(),
+        });
+        assert_eq!(rejoin.status.code, "meta_change_muted");
+    }
+
+    #[test]
+    fn resume_is_never_itself_muted() {
+        // An operator must always be able to undo this, or the lever is a trap.
+        let meta = muted_meta_with_a_server();
+        assert!(meta.set_meta_change_muted(false).status.ok);
+        assert!(!meta.is_meta_change_muted());
+        assert!(meta
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-a".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Operator,
+            })
+            .status
+            .ok);
+    }
+
+    #[test]
+    fn meta_info_reports_whether_change_is_muted() {
+        let meta = SingleNodeMeta::default();
+        assert!(!meta.info().meta_change_muted);
+        meta.set_meta_change_muted(true);
+        assert!(meta.info().meta_change_muted);
+    }
+
+    #[test]
+    fn a_mute_survives_mutation_log_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("mute-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            meta.register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            });
+            assert!(meta.set_meta_change_muted(true).status.ok);
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert!(recovered.is_meta_change_muted());
+        // The registration recorded before the mute still replayed: the guard
+        // applies to live calls, not to replaying a log of accepted changes.
+        assert_eq!(recovered.list_servers().servers.len(), 1);
+    }
+
+    #[test]
+    fn a_mute_survives_a_snapshot_round_trip() {
+        // Otherwise a peer installing the snapshot quietly resumes the change an
+        // operator stopped.
+        let meta = SingleNodeMeta::default();
+        meta.set_meta_change_muted(true);
+        let snapshot = meta.export_snapshot();
+        assert!(snapshot.meta_change_muted);
+
+        let restored = SingleNodeMeta::default();
+        assert!(restored.install_snapshot(snapshot).status.ok);
+        assert!(restored.is_meta_change_muted());
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -263,6 +263,11 @@ impl SingleNodeMeta {
         to_server: &str,
         reason: &str,
     ) -> AckResponse {
+        // Checked before the metric: a refused reassignment did not happen, so
+        // counting it would overstate what the rebalancer actually did.
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.metrics.record_reassignment(reason);
         self.record_mutation(MetaMutation::RegisterShard(RegisterShardRequest {
             shard_id,

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -896,6 +896,10 @@ impl SingleNodeMeta {
         let mut server_detector = MetaFailureDetector::new(options);
         let mut proxy_detector = MetaFailureDetector::new(options);
         thread::spawn(move || loop {
+            if meta.is_meta_change_muted() {
+                thread::sleep(interval);
+                continue;
+            }
             let report =
                 meta.convict_stale_servers_adaptive(&mut server_detector, policy, safe_mode.clone());
             if !report.orphaned_shards.is_empty() {

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -351,6 +351,9 @@ impl SingleNodeMeta {
     }
 
     pub fn finish_load(&self, request: LoadFinishRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::FinishLoad(request.clone()));
         self.apply_finish_load(request)
     }

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -86,7 +86,9 @@ impl SingleNodeMeta {
     }
 
     pub fn info(&self) -> MetaInfo {
+        let meta_change_muted = self.is_meta_change_muted();
         MetaInfo {
+            meta_change_muted,
             status: Status::ok(),
             stats: self.stats(),
             boot_time_ms: self.boot_time_ms,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -7,6 +7,9 @@ use super::*;
 
 impl SingleNodeMeta {
     pub fn register_server(&self, request: RegisterServerRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::RegisterServer(request.clone()));
         self.apply_register_server(request)
     }
@@ -94,6 +97,9 @@ impl SingleNodeMeta {
     /// placement. This changes the label and nothing else, and bumps the
     /// topology version so clients pick up the placement that follows from it.
     pub fn update_server(&self, request: UpdateServerRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::UpdateServer(request.clone()));
         self.apply_update_server(request)
     }
@@ -218,6 +224,9 @@ impl SingleNodeMeta {
     }
 
     pub fn register_proxy(&self, request: RegisterProxyRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::RegisterProxy(request.clone()));
         self.apply_register_proxy(request)
     }
@@ -321,6 +330,9 @@ impl SingleNodeMeta {
     }
 
     pub fn add_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::AddNamespace(request.clone()));
         self.apply_add_namespace(request)
     }

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -339,6 +339,10 @@ impl SingleNodeMeta {
         let meta = self.clone();
         let interval = Duration::from_millis(interval_ms.max(1));
         thread::spawn(move || loop {
+            if meta.is_meta_change_muted() {
+                thread::sleep(interval);
+                continue;
+            }
             let _ = meta.purge_expired_meta(options);
             thread::sleep(interval);
         })
@@ -576,6 +580,10 @@ impl SingleNodeMeta {
         let meta = self.clone();
         let interval = Duration::from_millis(interval_ms.max(1));
         thread::spawn(move || loop {
+            if meta.is_meta_change_muted() {
+                thread::sleep(interval);
+                continue;
+            }
             let _ = meta.age_frozen_meta(options);
             thread::sleep(interval);
         })

--- a/crates/temporalstore-rust/src/meta/snapshot_ops.rs
+++ b/crates/temporalstore-rust/src/meta/snapshot_ops.rs
@@ -62,6 +62,9 @@ impl SingleNodeMeta {
             // Carried across the install so a peer keeps ageing the tombstones
             // it inherits instead of restarting every one of their clocks.
             dropped_since_ms: snapshot.dropped_since_ms,
+            // An operator's mute must survive a snapshot install, or a peer
+            // taking over quietly resumes the change they stopped.
+            meta_change_muted: snapshot.meta_change_muted,
             frozen_since_ms: snapshot.frozen_since_ms,
         })
     }
@@ -97,6 +100,7 @@ impl MetaSnapshot {
             topology_version: state.topology_version,
             scheduler_finish_generations: state.scheduler_finish_generations.clone(),
             dropped_since_ms: state.dropped_since_ms.clone(),
+            meta_change_muted: state.meta_change_muted,
             frozen_since_ms: state.frozen_since_ms.clone(),
         }
     }

--- a/crates/temporalstore-rust/src/meta/state_setters.rs
+++ b/crates/temporalstore-rust/src/meta/state_setters.rs
@@ -7,6 +7,10 @@ use super::*;
 
 impl SingleNodeMeta {
     pub(super) fn set_server_state(&self, request: StateChangeRequest, next: MetaEntityState) -> AckResponse {
+        // Covers freeze, unfreeze and drop for servers in one place.
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         if !self
             .inner
             .read()
@@ -73,6 +77,9 @@ impl SingleNodeMeta {
     }
 
     pub(super) fn set_proxy_state(&self, request: StateChangeRequest, next: MetaEntityState) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         if !self
             .inner
             .read()

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -7,6 +7,9 @@ use super::*;
 
 impl SingleNodeMeta {
     pub fn add_table(&self, request: AddTableRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::AddTable(request.clone()));
         self.apply_add_table(request)
     }
@@ -73,6 +76,9 @@ impl SingleNodeMeta {
     }
 
     pub fn delete_table(&self, request: DeleteTableRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::DeleteTable(request.clone()));
         self.apply_delete_table(request)
     }
@@ -113,16 +119,25 @@ impl SingleNodeMeta {
     }
 
     pub fn freeze_table(&self, request: DeleteTableRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::FreezeTable(request.clone()));
         self.apply_set_table_state(request, MetaEntityState::Frozen)
     }
 
     pub fn unfreeze_table(&self, request: DeleteTableRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::UnfreezeTable(request.clone()));
         self.apply_set_table_state(request, MetaEntityState::Normal)
     }
 
     pub fn update_table(&self, request: UpdateTableRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
         self.record_mutation(MetaMutation::UpdateTable(request.clone()));
         self.apply_update_table(request)
     }

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -197,6 +197,13 @@ impl MetaRaftCluster {
         }
     }
 
+    /// Mute or resume metadata change across the raft group.
+    pub fn set_meta_change_muted(&self, muted: bool) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetMetaChangeMuted(muted)),
+        }
+    }
+
     pub fn freeze_server(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::FreezeServer(request)),
@@ -387,6 +394,7 @@ impl MetaRaftCluster {
     pub fn info(&self) -> MetaInfo {
         self.read_meta().map_or_else(
             |status| MetaInfo {
+                meta_change_muted: false,
                 status,
                 stats: MetaStats::default(),
                 boot_time_ms: 0,


### PR DESCRIPTION
## The problem

Every automatic metaserver subsystem — conviction, rebalance, divergence repair, retention, freeze aging — is gated by an **environment variable**. So the only way to stop the metaserver making changes is to **restart it with different configuration**, during exactly the incident where a restart is least welcome.

An operator watching automation do the wrong thing has no lever at all.

A metadata plane needs one: a flag that makes the state machine refuse every meta mutation until an operator resumes. This adds it.

## What this adds

`set_meta_change_muted`, exposed as `POST /meta/mute` and `POST /meta/resume`, and reported in `/meta/info`.

Three properties make it a lever rather than a trap:

**It is a recorded mutation like any other.** It replays from the mutation log, reaches raft peers through the same path every other change takes, and is carried in `MetaSnapshot` — so a peer installing a snapshot does not quietly resume the change an operator stopped.

**The guard applies to live calls, not to replay.** The mutation log only ever contains changes that were *accepted*, and a mute entry flips the flag at exactly the point in the sequence the original did, so replaying the whole log reproduces the same state. A test covers a registration recorded *before* a mute still replaying afterwards.

**Resume is never itself muted.** An operator must always be able to undo this.

## Scope of the mute

It gates **recorded mutations** — the set that actually changes durable metadata.

**Reads and heartbeats are untouched.** A heartbeat records no mutation because it is liveness rather than a metadata change, and muting it would blind the failure detector to the very fleet the operator is inspecting.

The background loops check the flag and **idle** instead of generating refused writes every tick.

## One sharp edge

**While muted, a datanode that restarts cannot rejoin** — registration is a recorded mutation. That is what freezing the metadata plane means, but it is worth knowing before reaching for the lever, so there is a test asserting it rather than leaving it to be discovered.

## Implementation note

Six of the fourteen guarded entry points collapse into two: freeze, unfreeze and drop for both servers and proxies all funnel through `set_server_state` / `set_proxy_state`.

## Tests

7 new tests: every recorded mutation refused and nothing landing, reads and heartbeats unaffected, a restarting datanode locked out, resume never being muted, `/meta/info` reporting the state, and the mute surviving both mutation-log replay and a snapshot round trip.

Verification:

- `cargo test -p temporalstore-rust --lib meta::tests` — 35 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **195 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.

No gate: the flag defaults to unmuted, so behaviour is unchanged until an operator uses it. Independent of #75, #76 and #78.

