### PR TITLE
Serve a cache-missed async write from its own WAL record

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -48,6 +48,7 @@ mod bucket_store;
 mod control_rollup;
 mod hll;
 mod hot_page_spill;
+mod block_in_wal;
 mod state;
 
 // shared-corpus: storage_bucket_first_physical_index storage_object_manager_bucketstore_runtime_authority storage_model_layout_compaction_policies storage_merged_dump_load_lifecycle storage_object_manager_cold_hot_reload storage_page_address_disk_cache_shared_store_fallback
@@ -504,8 +505,25 @@ impl TemporalEngine {
                         .map(|record| Some(record.sequence))
                 } else {
                     self.wal_store
-                        .append_with_sync(request.shard_id, command, sync)
-                        .map(|_| None)
+                        .append_with_sync_reporting(request.shard_id, command, sync)
+                        .map(|(record, log_id)| {
+                            // Register the value against the object id the write derived, which
+                            // is what the stored address carries -- so a read finds its record
+                            // by identity rather than by when it happened.
+                            if block_in_wal::enabled() {
+                                if let Some(object_id) =
+                                    block_in_wal::object_id_for(request.shard_id, &record.command)
+                                {
+                                    block_in_wal::register(
+                                        request.shard_id,
+                                        object_id,
+                                        log_id,
+                                        &self.wal_store,
+                                    );
+                                }
+                            }
+                            None
+                        })
                 };
                 match append_result {
                     Ok(deferred_seq) => {
@@ -2515,6 +2533,18 @@ fn read_page_bytes(
     if address.page_slab_id == HOT_PAGE_SLAB_ID {
         if let Some(real_address) = hot_page_spill::lookup_spilled(shard_id, address.offset) {
             if let Ok(bytes) = page_store.read(&real_address) {
+                let _ = cache.put(cache_key, bytes.clone());
+                return Some(bytes);
+            }
+        }
+        // Nothing spilled, so the value exists only in its WAL record -- which is where it has
+        // been all along. Read it back by the log id the write registered. Tried after the
+        // spill redirect because a spilled copy is a direct block-store read, while this one
+        // parses a log record.
+        if block_in_wal::enabled() {
+            if let Some(bytes) =
+                address.object_id.and_then(|object_id| block_in_wal::read_value(shard_id, object_id))
+            {
                 let _ = cache.put(cache_key, bytes.clone());
                 return Some(bytes);
             }

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Serving a block back out of the WAL record that holds it.
+//!
+//! # The hole this closes
+//!
+//! Under `async_storage` a written value is never handed to the block store. Its only durable
+//! copy is its WAL record, and it is served from the memory cache at a synthetic address that
+//! names no file. So when the cache drops that entry before a dump materializes it, the read
+//! finds nothing: an acked write reads back as MISSING until a full reload replays the WAL.
+//! [`super::hot_page_spill`] works around that by copying evicted values to a real slab, which
+//! helps only if the spill happened and succeeded.
+//!
+//! The value was in the WAL the whole time. What was missing was a way to say *where*: the
+//! synthetic address is a counter, not a position, so nothing could find the record again.
+//!
+//! # How the address is resolved
+//!
+//! An append now reports the log id its record landed at, and a log id survives reclaim -- the
+//! record moves when the log is compacted, but the id keeps naming it. So a write registers the
+//! synthetic offset it minted against the log id of the record carrying it, and a read that
+//! misses the cache resolves through that registration, reads the record, and serves the value
+//! from it.
+//!
+//! # Why identity, and why only single-value commands
+//!
+//! A registration is keyed by the object id the write derived, which the stored address already
+//! carries -- not by when the write happened. Keying on timing (the span of the synthetic
+//! counter across one command) would be exact only while nothing else was writing, and would
+//! quietly stop registering under concurrency. Matching a stored page back to its record by
+//! identity is also what the established design does at commit.
+//!
+//! Only a command whose bytes ARE the stored value registers at all. A page that is derived
+//! state (a serialized series, say) cannot be rebuilt from the record this way, so it is
+//! deliberately not attempted and falls through to the existing behaviour unchanged.
+//!
+//! # Lifetime
+//!
+//! The registry is live-path state, like the spill redirects: on reload the WAL is replayed and
+//! every value is re-derived, so it is never persisted, and a shard's entries are dropped when
+//! the shard unloads.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::types::{Command, ShardId};
+use crate::wal::{decode_wal_line, LocalWriteAheadLogStore};
+
+/// TS_BLOCK_IN_WAL: serve a cache-missed hot value by reading the WAL record that holds it.
+///
+/// Default OFF. It changes where a read gets its bytes, so it wants deliberate enabling even
+/// though it can only turn a MISSING into a hit -- the fallback path is untouched.
+pub(super) fn enabled() -> bool {
+    matches!(
+        std::env::var("TS_BLOCK_IN_WAL")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// (shard, object id) -> the log holding that value, and where in it.
+///
+/// The log handle is stored per entry rather than once per process: two engines in one process
+/// have separate logs, and a single shared handle would resolve one engine's addresses against
+/// the other's log.
+type Registration = (LocalWriteAheadLogStore, u64);
+
+fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<(ShardId, u64), Registration>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The object id this command's value is stored under, if the record can serve it back.
+///
+/// Recomputed from the command with the same derivation the write path used, so the two agree
+/// without the write path having to report it.
+pub(super) fn object_id_for(shard_id: ShardId, command: &Command) -> Option<u64> {
+    match command {
+        Command::StringSet { key, .. } => {
+            Some(super::stable_page_object_id(shard_id, "string", key, None))
+        }
+        _ => None,
+    }
+}
+
+/// Note that the value for `object_id` lives in the record at `log_id`.
+///
+/// A later write of the same object replaces the entry, so the registration always names the
+/// record holding the current value rather than a superseded one.
+pub(super) fn register(
+    shard_id: ShardId,
+    object_id: u64,
+    log_id: u64,
+    store: &LocalWriteAheadLogStore,
+) {
+    if let Ok(mut map) = registry().lock() {
+        map.insert((shard_id, object_id), (store.clone(), log_id));
+    }
+}
+
+/// Forget a shard's registrations. Called when the shard unloads; a reload replays the WAL and
+/// re-registers whatever it re-derives.
+pub(super) fn clear_shard(shard_id: ShardId) {
+    if let Ok(mut map) = registry().lock() {
+        map.retain(|(shard, _), _| *shard != shard_id);
+    }
+}
+
+/// Read the value for `object_id` back out of its WAL record.
+///
+/// `None` means the object was never registered, its record has been reclaimed, or the record
+/// does not carry the value directly -- in every case the caller falls through to the behaviour
+/// it had before, so this can only turn a miss into a hit.
+pub(super) fn read_value(shard_id: ShardId, object_id: u64) -> Option<Vec<u8>> {
+    let (store, log_id) = registry().lock().ok()?.get(&(shard_id, object_id))?.clone();
+    // Ask for an upper bound; the read clamps to what the file holds.
+    let bytes = store.read_at_log_id(shard_id, log_id, 1 << 20).ok()??;
+    let line = bytes.split(|byte| *byte == 10u8).next()?;
+    let record = decode_wal_line(line).ok()?;
+    match record.command {
+        Command::StringSet { value, .. } => Some(value),
+        _ => None,
+    }
+}

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -593,6 +593,9 @@ impl TemporalEngine {
         // the hot pages (and re-spills them as needed), so the live-path redirect map stays
         // bounded across load/unload cycles.
         hot_page_spill::clear_shard(request.shard_id);
+        // Drop this shard's WAL-resident registrations too: they name records in a log this
+        // engine no longer serves, and a reload re-derives them from the WAL anyway.
+        block_in_wal::clear_shard(request.shard_id);
         UnloadShardResponse {
             status: Status::ok(),
         }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3503,3 +3503,64 @@ fn sampled_eviction_scan_volume_does_not_grow_with_the_store() {
         "sampled scan should not grow with the store, got {small_sampled} -> {large_sampled}"
     );
 }
+
+/// An async write whose cache entry is dropped before any dump must still read back.
+///
+/// Without this its only durable copy is the WAL record, at an address naming no file, so the
+/// read returns MISSING for a write that was acked -- the hole the spill workaround was added
+/// to paper over. Here the record itself serves the value.
+#[test]
+fn an_evicted_async_write_is_served_from_its_wal_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        },
+    });
+
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    // The spill path would otherwise mask what is being tested by copying the value to a real
+    // slab on eviction.
+    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+
+    let key = "block-in-wal-key";
+    let value = b"block-in-wal-value".to_vec();
+    let write = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.clone(),
+        },
+    });
+    assert!(write.status.ok, "the write must be acked");
+
+    // Drop every cached copy: the value now exists only in its WAL record.
+    engine.cache().invalidate_shard(1).unwrap();
+
+    let read = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: key.to_string(),
+        },
+    });
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+    std::env::remove_var("TS_HOT_PAGE_SPILL");
+
+    assert_eq!(
+        read.response,
+        CommandResponse::Bytes {
+            value: Some(value)
+        },
+        "an acked write must not read back as missing once its cache entry is gone"
+    );
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -802,7 +802,20 @@ impl LocalWriteAheadLogStore {
         let Some(physical) = self.resolve_log_id(shard_id, log_id)? else {
             return Ok(None);
         };
-        self.read_range(shard_id, physical, size).map(Some)
+        // A caller asking by log id does not know how long the record is, so it asks for an
+        // upper bound. Reading past the end of the file would fail and report the value as
+        // absent -- a read that should have succeeded -- so clamp to what is actually there.
+        let length = {
+            let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+            let path = write_ahead_log_path(&inner.root, shard_id);
+            path.metadata().map(|metadata| metadata.len()).unwrap_or(0)
+        };
+        let available = length.saturating_sub(physical);
+        if available == 0 {
+            return Ok(None);
+        }
+        self.read_range(shard_id, physical, size.min(available))
+            .map(Some)
     }
 
     pub fn gc_before_sequence(


### PR DESCRIPTION
Under `async_storage` a written value is never handed to the block store. Its only durable copy is its WAL record, and it is served from the memory cache at a synthetic address that names no file.

So when the cache drops that entry before a dump materializes it, the read finds nothing: **an acked write reads back as MISSING** until a full reload replays the WAL. `hot_page_spill` works around that by copying evicted values to a real slab on eviction, which helps only if the spill happened and succeeded.

The value was in the WAL the whole time. What was missing was a way to say *where*.

## What changed

The synthetic address is a counter, not a position, so nothing could find the record again. Now an append reports the **log id** its record landed at, and a log id survives reclaim — the record moves when the log is compacted, but the id keeps naming it. A write registers its value against that id; a read that misses the cache resolves through it and serves the value from the record.

`an_evicted_async_write_is_served_from_its_wal_record` reproduces the documented failure — acked write, cache fully invalidated, spill disabled — and asserts the value comes back.

## Three decisions worth reviewing

**Keyed on object identity, not on timing.** The first cut identified a value by the span of the synthetic counter across one command. That is exact only while nothing else is writing: under concurrent writes it refuses to register rather than register wrongly, so it degrades to doing nothing. The object id the write derived is already carried on the stored address, so registering against it is exact and independent of timing.

**The log handle is stored per registration, not once per process.** A single shared handle binds to whichever engine was constructed first, so a second engine in the same process would resolve its addresses against the *first engine's log* — and read the wrong bytes, silently. Holding the handle per entry means a registration always points at the log that actually holds its record. The handle is cheap to clone; it is a handle, not the log.

**Registrations are dropped on shard unload.** They name records in a log this engine no longer serves, and a reload re-derives them from the WAL. Without that the map grows for the process lifetime.

## Scope, stated plainly

This covers commands whose bytes **are** the stored value. A page that is derived state — a serialized series, say — cannot be rebuilt from its record this way, so it is not attempted and falls through to the behaviour it had before.

That is narrower than the established design, which carries the page inside the log item and back-patches the address at commit, and so covers every page write. Doing that here means threading staging through the twelve places that mint addresses during apply, before the record exists. This change takes the bounded route and leaves that open.

Gated `TS_BLOCK_IN_WAL`, default **OFF**.

## A read fix that is not gated

`read_at_log_id` took the caller's size literally, so asking for an upper bound — which is what a caller asking by log id must do, not knowing the record's length — read past the end of the file, failed, and reported the value as **absent**. The clamp is not gated because it can only turn a failed read into a successful one.

## Testing

36 passing across the touched areas (block-in-WAL end to end, WAL, framing).

### Full-suite attribution

Branch **885 passed / 12 failed**; current `main` (`24b0e5ff`) **884 / 12**. Diffing the failing-test *name* sets: one name each way — `http_raft_transport_sends_append_vote_and_snapshot_over_tcp` fails only here, and one raft test fails only on `main`. The former passes **4/4** run isolated; it binds a fixed port and has been a verified flake through this series.

Count reconciles exactly: 899 − 898 = 1 = the one test added here. No regressions.