### PR TITLE
Proxy: give the control plane its own timeout, and make a proxy restart visible

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1871,6 +1871,10 @@ struct HeartbeatProxyRequest {
     config_version: u64,
     #[serde(default)]
     binary_version: String,
+    /// Boot time in MICROseconds, as the legacy wire shape reports it. Normalised to
+    /// milliseconds before it reaches the meta layer.
+    #[serde(default)]
+    boot_time_us: u64,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
@@ -265,6 +265,7 @@ fn handle_heartbeat_service_route(
                     proxy_heartbeat,
                     ProxyHeartbeatRequest {
                         proxy_addr,
+                        boot_time_ms: req.boot_time_us / 1_000,
                         namespace,
                         config_version: req.config_version,
                         binary_version: req.binary_version,

--- a/crates/temporalstore-rust/src/bin/proxy.rs
+++ b/crates/temporalstore-rust/src/bin/proxy.rs
@@ -36,6 +36,7 @@ fn main() {
         max_inflight_requests: env_u64("TS_PROXY_MAX_INFLIGHT_REQUESTS", 0),
         max_inflight_write_requests: env_u64("TS_PROXY_MAX_INFLIGHT_WRITE_REQUESTS", 0),
         pin_primary_reads: env_bool("TS_PROXY_PIN_PRIMARY_READS", true),
+        heartbeat_timeout_ms: env_u64("TS_PROXY_HEARTBEAT_TIMEOUT_MS", 5_000),
         context_first_shard_id: env_u64("TS_PROXY_CONTEXT_FIRST_SHARD", 1),
         context_shard_count: env_u64("TS_PROXY_CONTEXT_SHARD_COUNT", 1),
         context_io_timeout_ms: env_u64("TS_PROXY_CONTEXT_IO_TIMEOUT_MS", 30_000),

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -367,6 +367,14 @@ pub struct RegisterProxyRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProxyHeartbeatRequest {
     pub proxy_addr: String,
+    /// Milliseconds-since-epoch when this proxy process started. Lets the
+    /// metaserver see a RESTART: the address is unchanged and the heartbeats
+    /// never stop, so without this an in-place reboot is invisible and a proxy
+    /// that came back with an empty route cache and a reset config looks
+    /// identical to one that has been up for days. Datanodes already report it
+    /// (`ServerHeartbeatRequest::boot_time_ms`); proxies were the gap.
+    #[serde(default)]
+    pub boot_time_ms: u64,
     #[serde(default)]
     pub namespace: String,
     #[serde(default)]
@@ -403,6 +411,14 @@ pub struct ProxyMetaInfo {
     #[serde(default)]
     pub freeze_reason: FreezeReason,
     pub binary_version: String,
+    /// Boot time last reported by this proxy; `0` when it has never reported one.
+    /// Mirrors `ServerMetaInfo::boot_time_ms`.
+    #[serde(default)]
+    pub boot_time_ms: u64,
+    /// How many times this proxy has come back with a different boot time while
+    /// still registered -- i.e. observed in-place restarts.
+    #[serde(default)]
+    pub restart_count: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1833,6 +1849,7 @@ mod tests {
         assert_eq!(
             meta.proxy_heartbeat(ProxyHeartbeatRequest {
                 proxy_addr: "cooldown-proxy".to_string(),
+                boot_time_ms: 0,
                 namespace: "ns".to_string(),
                 config_version: 1,
                 binary_version: "v".to_string(),
@@ -2572,6 +2589,52 @@ mod tests {
     }
 
     #[test]
+    fn metaserver_counts_proxy_restarts_from_boot_time() {
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_proxy(RegisterProxyRequest {
+                proxy_addr: "127.0.0.1:17000".to_string(),
+                namespace: "ns".to_string(),
+                location: String::new(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+
+        let beat = |boot_time_ms: u64| {
+            meta.proxy_heartbeat(ProxyHeartbeatRequest {
+                proxy_addr: "127.0.0.1:17000".to_string(),
+                boot_time_ms,
+                namespace: "ns".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+        };
+        let recorded = || {
+            meta.list_proxies()
+                .proxies
+                .into_iter()
+                .find(|proxy| proxy.proxy_addr == "127.0.0.1:17000")
+                .expect("proxy is registered")
+        };
+
+        assert!(beat(1_000).status.ok);
+        assert_eq!(recorded().boot_time_ms, 1_000);
+        assert_eq!(recorded().restart_count, 0);
+
+        assert!(beat(1_000).status.ok);
+        assert_eq!(recorded().restart_count, 0);
+
+        assert!(beat(2_000).status.ok);
+        assert_eq!(recorded().boot_time_ms, 2_000);
+        assert_eq!(recorded().restart_count, 1);
+
+        assert!(beat(0).status.ok);
+        assert_eq!(recorded().boot_time_ms, 2_000);
+        assert_eq!(recorded().restart_count, 1);
+    }
+    #[test]
     fn metaserver_tracks_proxy_heartbeat_config_changes() {
         let meta = SingleNodeMeta::default();
         meta.register_proxy(RegisterProxyRequest {
@@ -2582,6 +2645,7 @@ mod tests {
             binary_version: "v".to_string(),
         });
         let response = meta.proxy_heartbeat(ProxyHeartbeatRequest {
+            boot_time_ms: 0,
             proxy_addr: "p1".to_string(),
             namespace: "ns".to_string(),
             config_version: 2,
@@ -2601,6 +2665,7 @@ mod tests {
         });
         assert!(frozen.status.ok, "{frozen:?}");
         let response = meta.proxy_heartbeat(ProxyHeartbeatRequest {
+            boot_time_ms: 0,
             proxy_addr: "p1".to_string(),
             namespace: "ns".to_string(),
             config_version: 3,

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -1169,6 +1169,8 @@ mod tests {
             frozen_since_ms: 0,
             freeze_cooldown_until_ms: 0,
             binary_version: "test".to_string(),
+            boot_time_ms: 0,
+            restart_count: 0,
         }
     }
 

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -200,6 +200,8 @@ impl SingleNodeMeta {
                 frozen_since_ms: 0,
                 freeze_cooldown_until_ms: 0,
                 binary_version: request.binary_version,
+                boot_time_ms: 0,
+                restart_count: 0,
             },
         );
         AckResponse {
@@ -231,6 +233,15 @@ impl SingleNodeMeta {
             };
         }
         proxy.last_heartbeat_ms = now_ms();
+        // A changed boot time on an address we already know means the proxy restarted
+        // in place. Heartbeats never stopped, so this is the only signal that its route
+        // cache and config were reset underneath us.
+        if request.boot_time_ms != 0 {
+            if proxy.boot_time_ms != 0 && proxy.boot_time_ms != request.boot_time_ms {
+                proxy.restart_count = proxy.restart_count.saturating_add(1);
+            }
+            proxy.boot_time_ms = request.boot_time_ms;
+        }
         if !request.binary_version.is_empty() {
             proxy.binary_version = request.binary_version;
         }

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -20,6 +20,7 @@ mod response;
 
 use config::{
     default_context_first_shard_id, default_context_io_timeout_ms, default_context_shard_count,
+    default_heartbeat_timeout_ms,
     default_pin_primary_reads, default_proxy_addr, default_service_registry_ttl_ms, now_ms,
     proxy_client_from_options, proxy_config_version,
 };
@@ -105,6 +106,14 @@ pub struct ProxyOptions {
     /// tenant on `context_first_shard_id` (single-shard deploys).
     #[serde(default = "default_context_shard_count")]
     pub context_shard_count: u64,
+    /// I/O timeout (ms) for control-plane calls to the metaserver: heartbeat,
+    /// auto-register and notify-stop. Deliberately NOT the command `io_timeout_ms`,
+    /// which is sized for a data-path hop and defaults to 200ms. A metaserver
+    /// pausing briefly -- GC, an election, a snapshot install -- would blow that
+    /// budget and make a perfectly healthy proxy miss heartbeats until it is
+    /// declared dead. Liveness must not be decided by a data-path deadline.
+    #[serde(default = "default_heartbeat_timeout_ms")]
+    pub heartbeat_timeout_ms: u64,
     /// I/O timeout (ms) for forwarding a `/context/*` request to the owning
     /// datanode. Larger than the command io_timeout because extraction /
     /// embedding generation runs inline on the datanode.
@@ -138,6 +147,16 @@ impl ProxyOptions {
             max_retries: self.max_retries,
         }
     }
+
+    /// Timeouts for metaserver control-plane calls. Same connect budget, but the
+    /// read budget is the heartbeat one -- see `heartbeat_timeout_ms`.
+    pub(super) fn control_http_options(&self) -> HttpRequestOptions {
+        HttpRequestOptions {
+            connect_timeout_ms: self.connect_timeout_ms,
+            io_timeout_ms: self.heartbeat_timeout_ms.max(self.io_timeout_ms),
+            max_retries: self.max_retries,
+        }
+    }
 }
 
 impl Default for ProxyOptions {
@@ -166,6 +185,7 @@ impl Default for ProxyOptions {
             context_first_shard_id: default_context_first_shard_id(),
             context_shard_count: default_context_shard_count(),
             context_io_timeout_ms: default_context_io_timeout_ms(),
+            heartbeat_timeout_ms: default_heartbeat_timeout_ms(),
         }
     }
 }
@@ -2363,6 +2383,59 @@ mod tests {
         );
         assert_eq!(code, 200);
         assert!(!proxy.policy_report().enforce_ingestion_account);
+    }
+
+    #[test]
+    fn proxy_control_plane_timeout_is_not_the_command_timeout() {
+        // A metaserver that pauses briefly must not cost a healthy proxy its liveness.
+        // The command path is sized for a data hop (200ms); heartbeats get their own budget.
+        let options = ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            ..ProxyOptions::default()
+        };
+        assert_eq!(options.io_timeout_ms, 200);
+        assert_eq!(options.heartbeat_timeout_ms, 5_000);
+        assert_eq!(options.http_options().io_timeout_ms, 200);
+        assert_eq!(options.control_http_options().io_timeout_ms, 5_000);
+
+        // A deployment that widens the command timeout past the heartbeat budget keeps the
+        // wider one -- the control plane is never given LESS room than the data path.
+        let slow_backend = ProxyOptions {
+            io_timeout_ms: 9_000,
+            ..options.clone()
+        };
+        assert_eq!(slow_backend.control_http_options().io_timeout_ms, 9_000);
+
+        // It is part of the config hash, so a rollout can confirm the change landed.
+        assert_ne!(
+            proxy_config_version(&options),
+            proxy_config_version(&ProxyOptions {
+                heartbeat_timeout_ms: 30_000,
+                ..options
+            })
+        );
+    }
+
+    #[test]
+    fn proxy_heartbeat_reports_boot_time_so_a_restart_is_visible() {
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            proxy_addr: "127.0.0.1:17000".to_string(),
+            ..ProxyOptions::default()
+        });
+        let info = proxy.info();
+        assert!(info.boot_time_ms > 0, "proxy knows when it started");
+
+        // A restarted process reports a different boot time on the same address, which is the
+        // only signal the metaserver gets: the address never changes and the heartbeats never
+        // stop, so without this an in-place reboot is invisible.
+        let restarted = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            proxy_addr: "127.0.0.1:17000".to_string(),
+            ..ProxyOptions::default()
+        });
+        assert_eq!(restarted.info().meta_addr, info.meta_addr);
+        assert!(restarted.info().boot_time_ms >= info.boot_time_ms);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/proxy/config.rs
+++ b/crates/temporalstore-rust/src/proxy/config.rs
@@ -29,6 +29,10 @@ pub(super) fn default_context_shard_count() -> u64 {
     1
 }
 
+pub(super) fn default_heartbeat_timeout_ms() -> u64 {
+    5_000
+}
+
 pub(super) fn default_context_io_timeout_ms() -> u64 {
     30_000
 }
@@ -76,6 +80,7 @@ pub(super) fn proxy_config_version(options: &ProxyOptions) -> u64 {
         max_inflight_requests: options.max_inflight_requests,
         max_inflight_write_requests: options.max_inflight_write_requests,
         pin_primary_reads: options.pin_primary_reads,
+        heartbeat_timeout_ms: options.heartbeat_timeout_ms,
     };
     for byte in serde_json::to_vec(&view).unwrap_or_default() {
         version ^= byte as u64;
@@ -102,4 +107,5 @@ struct ProxyConfigHashView<'a> {
     max_inflight_requests: u64,
     max_inflight_write_requests: u64,
     pin_primary_reads: bool,
+    heartbeat_timeout_ms: u64,
 }

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -36,7 +36,7 @@ impl ProxyService {
             &TopologyVersionRequest {
                 old_topology_version,
             },
-            options.http_options(),
+            options.control_http_options(),
         )
         .map_err(|err| Status::error("topology_check_failed", err.to_string()))
     }
@@ -50,6 +50,7 @@ impl ProxyService {
             .heartbeat_total += 1;
         let request = ProxyHeartbeatRequest {
             proxy_addr: options.proxy_addr.clone(),
+            boot_time_ms: self.inner.boot_time_ms,
             namespace: options.namespace.clone(),
             config_version: proxy_config_version(&options),
             binary_version: options.binary_version.clone(),
@@ -58,7 +59,7 @@ impl ProxyService {
             &options.meta_addr,
             "/proxies/heartbeat",
             &request,
-            options.http_options(),
+            options.control_http_options(),
         ) {
             Ok(response) if response.status.ok || response.status.code == "resource_frozen" => {
                 self.record_service_discovery_heartbeat(&response.status);
@@ -71,7 +72,7 @@ impl ProxyService {
                         &options.meta_addr,
                         "/proxies/heartbeat",
                         &request,
-                        options.http_options(),
+                        options.control_http_options(),
                     )
                     .unwrap_or_else(|err| ProxyHeartbeatResponse {
                         status: Status::error("metaserver_error", err.to_string()),
@@ -137,7 +138,7 @@ impl ProxyService {
                 config_version: proxy_config_version(options),
                 binary_version: options.binary_version.clone(),
             },
-            options.http_options(),
+            options.control_http_options(),
         )
         .unwrap_or_else(|err| AckResponse {
             status: Status::error("metaserver_error", err.to_string()),


### PR DESCRIPTION
Proxy: give the control plane its own timeout, and make a proxy restart visible

Two problems in how a proxy talks to the metaserver.

CONTROL-PLANE TIMEOUT. Every metaserver call the proxy makes -- heartbeat,
auto-register, notify-stop, topology-version -- went through http_options(),
which is the COMMAND path budget and defaults to 200ms. A proxy control plane has
always given heartbeats their own proxy_heartbeat_timeout_ms (5s) precisely
because these are not the same thing: 200ms is sized for a data hop to a
datanode, while a metaserver briefly pausing for GC, a leader election or a
snapshot install routinely takes longer. Under that budget a perfectly healthy
proxy starts missing heartbeats and is eventually declared dead -- liveness
decided by a data-path deadline.

heartbeat_timeout_ms (default 5000, TS_PROXY_HEARTBEAT_TIMEOUT_MS) now backs a
control_http_options() used by all four call sites. It resolves to
max(heartbeat_timeout_ms, io_timeout_ms), so a deployment that widens the
command timeout past 5s never ends up granting the control plane LESS room than
the data path. It is part of the config hash, so a rollout can confirm it landed.

RESTART VISIBILITY. ServerHeartbeatRequest carries boot_time_ms and the
metaserver records it, so a datanode restarting in place is observable.
ProxyHeartbeatRequest carried no such field, even though the proxy already
tracks its own boot time and reports it on /proxy/info. The address never
changes and the heartbeats never stop, so a proxy that came back with an empty
route cache and a reset config was indistinguishable from one that had been up
for days.

Proxies now report it. ProxyMetaInfo gains boot_time_ms and restart_count,
incremented when a known address reports a boot time different from the last one
-- the same shape the datanode path already had. The legacy compat route accepts
the wire's microsecond field and normalises it.

Both are additive and default-compatible: boot_time_ms is serde-default, so an
older proxy that reports nothing is not mistaken for a restart and does not
erase what the metaserver already knows. That case is asserted, not assumed.

Full serial suite: 723 passed. Three failures, none from this change -- the
client-shape test passes 2/2 in isolation (the suite's own fixed-port
interference), and the storage-manager jitter test and
distributed_raft_chunks_large_sequence_add are both known-failing on main.
