### PR TITLE
Repair the corpus build after StateChangeRequest gained a reason

### DIFF
--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -2798,6 +2798,9 @@ fn verify_metaserver_scheduler_control_plane() {
     let frozen = meta.freeze_server(temporalstore_rust::StateChangeRequest {
         endpoint: "127.0.0.1:27113".to_string(),
         freeze_cooldown_ms: 30_000,
+        // The wire default, which is what this case carried before the field existed --
+        // naming it keeps the behaviour rather than reclassifying it as an operator freeze.
+        reason: Default::default(),
     });
     assert!(frozen.status.ok, "{frozen:?}");
     let safe_mode = meta.safe_mode_report();


### PR DESCRIPTION
`main` does not build with all targets. The corpus case that freezes a server constructs `StateChangeRequest` without the `reason` field added alongside the freeze-reason work, so `cargo check --all-targets` fails on it.

The lib builds fine, which is why it slipped through: `cargo test --lib` never compiles `tests/`.

## The value chosen

The field carries `#[serde(default)]`, so a request that omits it reads as `Unspecified`. This call site drives `freeze_server` directly rather than through an admin route — where a request is operator-driven by definition — so the wire default is what it meant before the field existed.

Naming it explicitly keeps the case's behaviour rather than quietly reclassifying it as an operator freeze, which would have changed what the safe-mode assertions below it are exercising.

## Verification

`cargo check --all-targets`, which is what CI runs, is clean.