### PR TITLE
Carry a written page in its own log record

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -383,6 +383,11 @@ impl TemporalEngine {
                 };
             }
         }
+        // Start this write with nothing staged, so a page put aside by a command that never
+        // appended cannot ride along on the next command's record.
+        if block_in_wal::enabled() {
+            block_in_wal::begin_write();
+        }
         let outcome = execute_on_shard(
             &self.cache,
             &self.page_store,
@@ -505,22 +510,27 @@ impl TemporalEngine {
                         .map(|record| Some(record.sequence))
                 } else {
                     self.wal_store
-                        .append_with_sync_reporting(request.shard_id, command, sync)
-                        .map(|(record, log_id)| {
-                            // Register the value against the object id the write derived, which
-                            // is what the stored address carries -- so a read finds its record
-                            // by identity rather than by when it happened.
+                        .append_with_sync_staged(
+                            request.shard_id,
+                            command,
+                            sync,
                             if block_in_wal::enabled() {
-                                if let Some(object_id) =
-                                    block_in_wal::object_id_for(request.shard_id, &record.command)
-                                {
-                                    block_in_wal::register(
-                                        request.shard_id,
-                                        object_id,
-                                        log_id,
-                                        &self.wal_store,
-                                    );
-                                }
+                                block_in_wal::take_staged()
+                            } else {
+                                Vec::new()
+                            },
+                        )
+                        .map(|(record, log_id)| {
+                            // Point every page this record carries at the record, keyed on the
+                            // object id the write derived -- which is what the stored address
+                            // carries, so a read finds it by identity rather than by timing.
+                            if block_in_wal::enabled() {
+                                block_in_wal::register_record(
+                                    request.shard_id,
+                                    &record.staged_pages,
+                                    log_id,
+                                    &self.wal_store,
+                                );
                             }
                             None
                         })
@@ -2364,6 +2374,13 @@ fn append_value(
         band_id: None,
         sha256: None,
     };
+    // Put the page aside for this write's record. It is often derived state rather than the
+    // command's own bytes, so the record has to carry it for a read to serve it back.
+    if block_in_wal::enabled() {
+        if let Some(object_id) = object_id {
+            block_in_wal::stage(object_id, bytes);
+        }
+    }
     let bytes = bytes.to_vec();
     cache.put_memory_only(
         CacheKey::page_with_slot(
@@ -2543,7 +2560,7 @@ fn read_page_bytes(
         // parses a log record.
         if block_in_wal::enabled() {
             if let Some(bytes) =
-                address.object_id.and_then(|object_id| block_in_wal::read_value(shard_id, object_id))
+                address.object_id.and_then(|object_id| block_in_wal::read_page(shard_id, object_id))
             {
                 let _ = cache.put(cache_key, bytes.clone());
                 return Some(bytes);

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! Serving a block back out of the WAL record that holds it.
+//! Serving a written page back out of the log record that carries it.
 //!
 //! # The hole this closes
 //!
@@ -15,42 +15,41 @@
 //! The value was in the WAL the whole time. What was missing was a way to say *where*: the
 //! synthetic address is a counter, not a position, so nothing could find the record again.
 //!
-//! # How the address is resolved
+//! # Staging
 //!
-//! An append now reports the log id its record landed at, and a log id survives reclaim -- the
-//! record moves when the log is compacted, but the id keeps naming it. So a write registers the
-//! synthetic offset it minted against the log id of the record carrying it, and a read that
-//! misses the cache resolves through that registration, reads the record, and serves the value
-//! from it.
+//! A page is often derived state rather than the command's own bytes -- a serialized counter
+//! series cannot be rebuilt from the command that bumped it -- so the page itself has to travel
+//! with the write. As a write produces pages it puts them aside here; the append attaches
+//! whatever was staged to the record it writes and reports the log id that record landed at;
+//! and a read resolves the log id and takes its page straight out of the record.
 //!
-//! # Why identity, and why only single-value commands
+//! The buffer is per thread and cleared at the start of every execute, so a command that stages
+//! a page and then fails to append cannot leak it into the next command's record.
 //!
-//! A registration is keyed by the object id the write derived, which the stored address already
-//! carries -- not by when the write happened. Keying on timing (the span of the synthetic
-//! counter across one command) would be exact only while nothing else was writing, and would
-//! quietly stop registering under concurrency. Matching a stored page back to its record by
-//! identity is also what the established design does at commit.
+//! # Addressing
 //!
-//! Only a command whose bytes ARE the stored value registers at all. A page that is derived
-//! state (a serialized series, say) cannot be rebuilt from the record this way, so it is
-//! deliberately not attempted and falls through to the existing behaviour unchanged.
+//! A log id survives reclaim -- the record moves when the log is compacted, but the id keeps
+//! naming it -- which is what makes it usable as an address at all. Registrations are keyed on
+//! the object id the write derived, which the stored address already carries, so a read finds
+//! its record by identity rather than by when the write happened.
 //!
 //! # Lifetime
 //!
-//! The registry is live-path state, like the spill redirects: on reload the WAL is replayed and
-//! every value is re-derived, so it is never persisted, and a shard's entries are dropped when
-//! the shard unloads.
+//! Registrations are live-path state, like the spill redirects: on reload the WAL is replayed
+//! and every page is re-derived, so they are never persisted, and a shard's entries are dropped
+//! when the shard unloads.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-use crate::types::{Command, ShardId};
-use crate::wal::{decode_wal_line, LocalWriteAheadLogStore};
+use crate::types::ShardId;
+use crate::wal::{decode_wal_line, LocalWriteAheadLogStore, StagedPage};
 
-/// TS_BLOCK_IN_WAL: serve a cache-missed hot value by reading the WAL record that holds it.
+/// TS_BLOCK_IN_WAL: stage written pages into their log record and serve them back from it.
 ///
-/// Default OFF. It changes where a read gets its bytes, so it wants deliberate enabling even
-/// though it can only turn a MISSING into a hit -- the fallback path is untouched.
+/// Default OFF. It changes what a record carries and where a read gets its bytes, so it wants
+/// deliberate enabling even though it can only turn a MISSING into a hit.
 pub(super) fn enabled() -> bool {
     matches!(
         std::env::var("TS_BLOCK_IN_WAL")
@@ -62,11 +61,40 @@ pub(super) fn enabled() -> bool {
     )
 }
 
-/// (shard, object id) -> the log holding that value, and where in it.
+thread_local! {
+    /// Pages produced by the write currently executing on this thread.
+    static STAGED: RefCell<Vec<StagedPage>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Start a write with nothing staged.
+///
+/// Called before every execute. Without it a command that staged a page and then did not append
+/// -- a rejected write, a read-only command -- would leave the page for the next command to
+/// attach to an unrelated record.
+pub(super) fn begin_write() {
+    STAGED.with(|staged| staged.borrow_mut().clear());
+}
+
+/// Put a page aside for the record this write is about to append.
+pub(super) fn stage(object_id: u64, bytes: &[u8]) {
+    STAGED.with(|staged| {
+        staged.borrow_mut().push(StagedPage {
+            object_id,
+            bytes: bytes.to_vec(),
+        })
+    });
+}
+
+/// Take what this write staged, leaving nothing behind.
+pub(super) fn take_staged() -> Vec<StagedPage> {
+    STAGED.with(|staged| std::mem::take(&mut *staged.borrow_mut()))
+}
+
+/// (shard, object id) -> the log holding that page, and where in it.
 ///
 /// The log handle is stored per entry rather than once per process: two engines in one process
 /// have separate logs, and a single shared handle would resolve one engine's addresses against
-/// the other's log.
+/// the other's log -- reading the wrong bytes, silently.
 type Registration = (LocalWriteAheadLogStore, u64);
 
 fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
@@ -74,55 +102,48 @@ fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// The object id this command's value is stored under, if the record can serve it back.
+/// Note that the pages in `record` live in the record at `log_id`.
 ///
-/// Recomputed from the command with the same derivation the write path used, so the two agree
-/// without the write path having to report it.
-pub(super) fn object_id_for(shard_id: ShardId, command: &Command) -> Option<u64> {
-    match command {
-        Command::StringSet { key, .. } => {
-            Some(super::stable_page_object_id(shard_id, "string", key, None))
-        }
-        _ => None,
-    }
-}
-
-/// Note that the value for `object_id` lives in the record at `log_id`.
-///
-/// A later write of the same object replaces the entry, so the registration always names the
-/// record holding the current value rather than a superseded one.
-pub(super) fn register(
+/// A later write of the same object replaces its entry, so a registration always names the
+/// record holding the current page rather than a superseded one.
+pub(super) fn register_record(
     shard_id: ShardId,
-    object_id: u64,
+    staged_pages: &[StagedPage],
     log_id: u64,
     store: &LocalWriteAheadLogStore,
 ) {
+    if staged_pages.is_empty() {
+        return;
+    }
     if let Ok(mut map) = registry().lock() {
-        map.insert((shard_id, object_id), (store.clone(), log_id));
+        for page in staged_pages {
+            map.insert((shard_id, page.object_id), (store.clone(), log_id));
+        }
     }
 }
 
 /// Forget a shard's registrations. Called when the shard unloads; a reload replays the WAL and
-/// re-registers whatever it re-derives.
+/// re-derives whatever it needs.
 pub(super) fn clear_shard(shard_id: ShardId) {
     if let Ok(mut map) = registry().lock() {
         map.retain(|(shard, _), _| *shard != shard_id);
     }
 }
 
-/// Read the value for `object_id` back out of its WAL record.
+/// Read the page for `object_id` back out of the record carrying it.
 ///
 /// `None` means the object was never registered, its record has been reclaimed, or the record
-/// does not carry the value directly -- in every case the caller falls through to the behaviour
-/// it had before, so this can only turn a miss into a hit.
-pub(super) fn read_value(shard_id: ShardId, object_id: u64) -> Option<Vec<u8>> {
+/// does not carry that page -- in every case the caller falls through to the behaviour it had
+/// before, so this can only turn a miss into a hit.
+pub(super) fn read_page(shard_id: ShardId, object_id: u64) -> Option<Vec<u8>> {
     let (store, log_id) = registry().lock().ok()?.get(&(shard_id, object_id))?.clone();
     // Ask for an upper bound; the read clamps to what the file holds.
     let bytes = store.read_at_log_id(shard_id, log_id, 1 << 20).ok()??;
     let line = bytes.split(|byte| *byte == 10u8).next()?;
     let record = decode_wal_line(line).ok()?;
-    match record.command {
-        Command::StringSet { value, .. } => Some(value),
-        _ => None,
-    }
+    record
+        .staged_pages
+        .into_iter()
+        .find(|page| page.object_id == object_id)
+        .map(|page| page.bytes)
 }

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -794,6 +794,7 @@ mod batch_truncation_tests {
             sequence: seq,
             command,
             metadata: Some(metadata),
+            staged_pages: Vec::new(),
         }
     }
 

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1504,6 +1504,7 @@ fn wal_replay_gap_refuses_load_like_dataloss() {
                 value: b"v".to_vec(),
             },
             metadata: None,
+            staged_pages: Vec::new(),
         })
         .unwrap();
     }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3564,3 +3564,62 @@ fn an_evicted_async_write_is_served_from_its_wal_record() {
         "an acked write must not read back as missing once its cache entry is gone"
     );
 }
+
+/// A page that is DERIVED state must also survive its cache entry being dropped.
+///
+/// A hash field set stores a serialized map, so unlike a plain string the page cannot be
+/// reconstructed from the command that wrote it. Serving it back therefore requires the record
+/// to carry the page itself, which is what staging does.
+#[test]
+fn an_evicted_derived_page_is_served_from_its_wal_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        },
+    });
+
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+
+    let write = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::HashSet {
+            key: "derived-page-key".to_string(),
+            field: "f1".to_string(),
+            value: b"derived-page-value".to_vec(),
+        },
+    });
+    assert!(write.status.ok, "the write must be acked: {write:?}");
+
+    // Drop every cached copy: the page now exists only inside its WAL record.
+    engine.cache().invalidate_shard(1).unwrap();
+
+    let read = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::HashGet {
+            key: "derived-page-key".to_string(),
+            field: "f1".to_string(),
+        },
+    });
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+    std::env::remove_var("TS_HOT_PAGE_SPILL");
+
+    assert_eq!(
+        read.response,
+        CommandResponse::Bytes {
+            value: Some(b"derived-page-value".to_vec())
+        },
+        "a derived page must not read back as missing once its cache entry is gone"
+    );
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -51,6 +51,22 @@ pub struct WriteAheadLogRecord {
     pub command: Command,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<WriteAheadLogRecordMetadata>,
+    /// Pages this write produced, carried in the record that records the write.
+    ///
+    /// A page is often derived state rather than the command's own bytes, so it cannot be
+    /// rebuilt from the command alone. Carrying it here is what lets a read serve the page back
+    /// out of the log. Empty and skipped for every write that stages nothing, so records
+    /// written without this are byte-identical to before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub staged_pages: Vec<StagedPage>,
+}
+
+/// A page put aside during a write, to be carried in that write's log record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StagedPage {
+    /// The object the page belongs to, which is what a read has when it comes looking.
+    pub object_id: u64,
+    pub bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -339,7 +355,21 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
     ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
-        self.append_with_sync_inner(shard_id, command, sync)
+        self.append_with_sync_inner(shard_id, command, sync, Vec::new())
+    }
+
+    /// Append, carrying pages this write produced, and report the log id it landed at.
+    ///
+    /// The pages travel in the same record as the command, so one durability barrier covers
+    /// both and a read that finds the record finds the page with it.
+    pub fn append_with_sync_staged(
+        &self,
+        shard_id: ShardId,
+        command: Command,
+        sync: bool,
+        staged_pages: Vec<StagedPage>,
+    ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
+        self.append_with_sync_inner(shard_id, command, sync, staged_pages)
     }
 
     pub fn append_with_sync(
@@ -348,7 +378,7 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
-        self.append_with_sync_inner(shard_id, command, sync)
+        self.append_with_sync_inner(shard_id, command, sync, Vec::new())
             .map(|(record, _)| record)
     }
 
@@ -357,6 +387,7 @@ impl LocalWriteAheadLogStore {
         shard_id: ShardId,
         command: Command,
         sync: bool,
+        staged_pages: Vec<StagedPage>,
     ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
         // In group-commit mode the durable barrier is deferred out of the append
         // critical section (below), so the byte-append records with sync=false and the
@@ -378,6 +409,7 @@ impl LocalWriteAheadLogStore {
                 sequence: seq,
                 metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
                 command,
+                staged_pages,
             };
             let report = append_record_locked(&mut inner, &rec, sync && !group)?;
             inner.stats.last_sequence = report.current_sequence;
@@ -431,6 +463,7 @@ impl LocalWriteAheadLogStore {
             sequence: seq,
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
             command,
+            staged_pages: Vec::new(),
         };
         // sync=false: write the bytes, defer the fdatasync to `commit_barrier`. Same as the
         // group branch of append_with_sync. `last_flushed_sequence` is NOT advanced here (the
@@ -511,6 +544,7 @@ impl LocalWriteAheadLogStore {
                     sequence: seq,
                     metadata: Some(metadata),
                     command,
+                    staged_pages: Vec::new(),
                 };
                 // Buffer every record (sync=false); the single durability barrier below covers
                 // the whole batch. append_record_locked keeps last_flushed_sequence honest -- it
@@ -1676,6 +1710,7 @@ mod tests {
                 value: b"v".to_vec(),
             },
             metadata: None,
+            staged_pages: Vec::new(),
         };
         let mut raw = serde_json::to_vec(&make(1, "k1")).unwrap();
         raw.push(b'\n');
@@ -1854,6 +1889,7 @@ mod tests {
             sequence: 8,
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
             command,
+            staged_pages: Vec::new(),
         };
 
         let first = store.append_replayed_record(replayed.clone()).unwrap();


### PR DESCRIPTION
The read-through added in #82 could only serve a value back when the command's own bytes **were** the stored value. That is true of a plain string set and of nothing else.

A page is often derived state — a serialized counter series, a hash map — and cannot be rebuilt from the command that produced it. So every model but one still read back as MISSING once its cache entry was dropped, which is the failure `hot_page_spill` describes in its own words.

## Staging

A write under `async_storage` puts each page aside as it produces it. The append attaches whatever was staged to the record it writes and reports the log id that record landed at. A read resolves the log id and takes its page straight out of the record.

What produced the page stops mattering, which is the point.

## The buffer is cleared at the start of every write

Without that, a command that stages a page and then does **not** append — a rejected write, a read-only command — would leave the page for the next command to attach to an unrelated record. A later read would then be served bytes from a write it has nothing to do with, and nothing would look wrong.

## Compatibility

Records that stage nothing serialize exactly as before: the field carries `serde(default)` and is skipped when empty. Existing logs load unchanged, and writes made with the gate off are byte-identical.

Gated `TS_BLOCK_IN_WAL`, default **OFF**.

## Testing

The new case is a **hash** page — a serialized map, not the command's bytes — written, then read after every cached copy is dropped and with the spill path disabled so it cannot mask the result. That is precisely what the previous approach could not serve.

Both cases pass:

- `an_evicted_async_write_is_served_from_its_wal_record` (string)
- `an_evicted_derived_page_is_served_from_its_wal_record` (derived)

### Full-suite attribution

Branch **905 passed / 12 failed**; `main` (`e73c2d42`) **904 / 12**. The failing-test *name* sets are **identical** — no name fails on one side and not the other. Count reconciles exactly: 919 − 918 = 1 = the one test added here.

Two earlier attempts at this baseline produced a diff showing all twelve as regressions. Both were wrong: the machine's disk was full, the run was killed mid-write, and an aborted run yields an empty name set that makes every branch failure look new. Worth knowing if CI here starts behaving oddly — roughly 460 GB of Rust build artifacts are sitting across the checkout directories.

## Note on CI

`cargo check --all-targets` currently fails on `main` for an unrelated reason: a corpus test constructs `StateChangeRequest` without the `reason` field added alongside the freeze-reason work. #84 fixes that. It is not visible to `cargo test --lib`, which never compiles `tests/`.