### PR TITLE
Proxy: stop serving on withdrawn config, and hold the heartbeat rate steady

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -205,6 +205,10 @@ pub struct ProxyStats {
     pub account_rejections: u64,
     pub inflight_rejections: u64,
     pub heartbeat_total: u64,
+    /// Beats whose round-trip consumed the whole interval, so the loop had no time left to
+    /// sleep. A rising count means the heartbeat period is being set by metaserver latency
+    /// rather than by the configured interval.
+    pub heartbeat_slow_total: u64,
     pub auto_register_total: u64,
 }
 
@@ -1214,6 +1218,12 @@ impl ProxyService {
     ) -> (u16, Vec<u8>) {
         let status = self.reject(status, kind);
         crate::http::json_response(proxy_rejection_http_status(&status.code), &status)
+    }
+
+    /// Read-only view of the live options, for tests and callers that need to see what the
+    /// metaserver has granted this proxy.
+    pub fn config_snapshot(&self) -> ProxyOptions {
+        self.options()
     }
 
     pub(super) fn inflight_snapshot(&self) -> (u64, u64) {
@@ -2438,6 +2448,44 @@ mod tests {
         assert!(restarted.info().boot_time_ms >= info.boot_time_ms);
     }
 
+    #[test]
+    fn proxy_forgets_config_when_the_metaserver_rejects_it_but_not_when_it_is_unreachable() {
+        // Explicit rejection: the metaserver answered and said no. The proxy must stop acting
+        // on a grant that has been withdrawn.
+        let rejected = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            namespace: "granted-ns".to_string(),
+            config_version: 7,
+            ..ProxyOptions::default()
+        });
+        rejected.clear_config_authority();
+        let after = rejected.config_snapshot();
+        assert!(after.namespace.is_empty());
+        assert_eq!(after.config_version, 0);
+
+        // Clearing twice is a no-op, so a proxy that is being rejected every few milliseconds
+        // does not churn its config version on every beat.
+        let before_version = proxy_config_version(&rejected.config_snapshot());
+        rejected.clear_config_authority();
+        assert_eq!(
+            proxy_config_version(&rejected.config_snapshot()),
+            before_version
+        );
+
+        // Transport failure: an unreachable metaserver must NOT cost the proxy its config.
+        // heartbeat_to_meta against a dead address takes the Err branch.
+        let unreachable = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            namespace: "granted-ns".to_string(),
+            config_version: 7,
+            ..ProxyOptions::default()
+        });
+        let response = unreachable.heartbeat_to_meta();
+        assert!(!response.status.ok);
+        let kept = unreachable.config_snapshot();
+        assert_eq!(kept.namespace, "granted-ns");
+        assert_eq!(kept.config_version, 7);
+    }
     #[test]
     fn proxy_policy_blocks_writes_not_serving_and_drop_percent() {
         let readonly = ProxyService::new(ProxyOptions {

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -95,6 +95,17 @@ impl ProxyService {
                 }
             }
             Ok(response) => {
+                // The metaserver REACHED us and said no -- the proxy was dropped, re-scoped,
+                // or is otherwise not the owner of what it thinks it owns. Drop the local
+                // namespace/config authority so it stops acting on a grant that has been
+                // withdrawn; the next accepted heartbeat hands back the real one, and until
+                // then reporting an empty namespace is what makes the metaserver mark the
+                // config changed and re-send it.
+                //
+                // Note this is the EXPLICIT-rejection branch only. A transport failure lands
+                // in `Err` below and deliberately changes nothing: an unreachable or slow
+                // metaserver must not cost every proxy its configuration.
+                self.clear_config_authority();
                 self.record_service_discovery_error(&response.status);
                 response
             }
@@ -117,8 +128,29 @@ impl ProxyService {
         let service = self.clone();
         let interval = Duration::from_millis(interval_ms.max(1));
         thread::spawn(move || loop {
+            let started = std::time::Instant::now();
             let _ = service.heartbeat_to_meta();
-            thread::sleep(interval);
+            let elapsed = started.elapsed();
+            // Fixed RATE, not a fixed gap. Sleeping a whole interval AFTER the beat makes the
+            // real period `interval + beat_duration`, so the heartbeat rate degrades exactly
+            // when the metaserver is slow -- which is precisely when the liveness margin
+            // matters. With a 5s control-plane budget one slow beat would stretch a 10s
+            // interval to 15s and eat the margin the metaserver allows before declaring this
+            // proxy dead.
+            //
+            // A beat slower than the whole interval sleeps not at all, matching the reference
+            // loop. That does not hammer a struggling metaserver: the request rate is bounded
+            // by the beat duration itself, which is what is already slow.
+            if let Some(remaining) = interval.checked_sub(elapsed) {
+                thread::sleep(remaining);
+            } else {
+                service
+                    .inner
+                    .stats
+                    .write()
+                    .expect("proxy stats lock poisoned")
+                    .heartbeat_slow_total += 1;
+            }
         })
     }
 
@@ -171,6 +203,21 @@ impl ProxyService {
             options.drop_percent = response.drop_percent;
         }
         let _ = self.update_options_report(options);
+    }
+
+    /// Forget the namespace/config this proxy believes it was granted. Called when the
+    /// metaserver explicitly rejects a heartbeat. Serving policy is deliberately left alone:
+    /// the metaserver drives that through `serving_mode`, and a rejection is not by itself an
+    /// instruction to start or stop serving.
+    pub(super) fn clear_config_authority(&self) {
+        let options = self.options();
+        if options.namespace.is_empty() && options.config_version == 0 {
+            return;
+        }
+        let mut cleared = options;
+        cleared.namespace = String::new();
+        cleared.config_version = 0;
+        let _ = self.update_options_report(cleared);
     }
 
     pub(super) fn record_service_discovery_heartbeat(&self, status: &Status) {

--- a/crates/temporalstore-rust/src/proxy/prometheus.rs
+++ b/crates/temporalstore-rust/src/proxy/prometheus.rs
@@ -21,6 +21,7 @@ impl ProxyService {
             ("account_rejection", stats.account_rejections),
             ("inflight_rejection", stats.inflight_rejections),
             ("heartbeat", stats.heartbeat_total),
+            ("heartbeat_slow", stats.heartbeat_slow_total),
             ("auto_register", stats.auto_register_total),
         ] {
             push_proxy_metric(


### PR DESCRIPTION
Proxy: stop serving on withdrawn config, and hold the heartbeat rate steady

Two problems in how a proxy behaves when the metaserver is unhappy or slow.

WITHDRAWN CONFIG. When the metaserver answered a heartbeat with an error --
this proxy was dropped, re-scoped, or is no longer the owner of what it thinks
it owns -- the proxy recorded a service-discovery error and carried on routing
under the namespace and config version it had been granted earlier. It kept
acting on authority that had been taken away.

It now clears its local namespace and config version in that case. Reporting an
empty namespace on the next beat is also what makes the metaserver mark the
config changed and re-send the real one, so the proxy re-syncs instead of
drifting.

Crucially this is the EXPLICIT-rejection path only: the metaserver reached us
and said no. A transport failure -- unreachable, timed out, connection refused
-- deliberately changes nothing, because a metaserver that is merely slow or
briefly unavailable must not cost every proxy in the fleet its configuration.
Those two cases were already separate branches in the code, so the change lands
in exactly one of them, and the test pins both directions plus the idempotence
(a proxy being rejected on every beat must not churn its config version).

Serving mode is deliberately untouched. The metaserver drives that explicitly
through `serving_mode`, and a rejection is not by itself an instruction to start
or stop serving.

HEARTBEAT RATE. The loop ran `heartbeat(); sleep(interval)` -- a fixed delay AFTER
the beat, which makes the real period `interval + beat_duration`. So the
heartbeat rate degraded exactly when the metaserver was slow, which is precisely
when the liveness margin matters. Now that control-plane calls have a 5s budget
rather than the 200ms command budget, a single slow beat would stretch a 10s
interval to 15s and eat the margin the metaserver allows before declaring the
proxy dead.

The loop now sleeps the REMAINDER of the interval, so the rate is fixed rather
than the delay. A beat that consumes the whole interval sleeps not at all; that
does not hammer a struggling metaserver, because the request rate is then
bounded by the beat duration, which is the thing already slow. That condition is
counted as `heartbeat_slow_total` and exported on /metrics, so a heartbeat
period being set by metaserver latency instead of by configuration is visible
rather than silent.

Full serial suite: 726 passed, with no foreign test processes running. The one
failure is the storage-manager jitter test, which is known-failing on main for
an unrelated reason.