### PR TITLE
Stage written pages by default

### DIFF
--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -48,16 +48,20 @@ use crate::wal::{decode_wal_line, LocalWriteAheadLogStore, StagedPage};
 
 /// TS_BLOCK_IN_WAL: stage written pages into their log record and serve them back from it.
 ///
-/// Default OFF. It changes what a record carries and where a read gets its bytes, so it wants
-/// deliberate enabling even though it can only turn a MISSING into a hit.
+/// Default ON. Without it an acked write reads back as MISSING when its cache entry is dropped
+/// before a dump -- a correctness result, not a tuning one -- and the cost that kept it off is
+/// gone: a staged page now costs about a third over its contents rather than five times.
+///
+/// Set to a falsey value to restore the previous behaviour: records carry no pages, and an
+/// evicted write is served only if the spill path happened to catch it.
 pub(super) fn enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_BLOCK_IN_WAL")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 


### PR DESCRIPTION
An acked write under `async_storage` reads back as **MISSING** when its cache entry is dropped before a dump. Its only durable copy is its log record, and until recently nothing could find that record again.

Staging fixes it. That is a correctness result rather than a tuning one, so it should not need opting into.

The cost that kept it off is gone: after #86 a staged page costs about a third over its contents rather than five times, so carrying pages is no longer a reason to leave the default off.

`TS_BLOCK_IN_WAL=0` restores the previous behaviour — records carry no pages, and an evicted write is served only if the spill path happened to catch it.

## The concern this raises, and what was checked

Records now carry more, and recovery reads those records. So the question is whether restoration still behaves.

**Restoration surface** — every test matching recovery / replay / restart / reload / crash / snapshot, run both ways:

| | |
|---|---|
| on (new default) | **134 passed** |
| off | **134 passed** |

Identical.

**Full suite with it on: 914 passed.** Two names fail that do not on `main`:

- `raft::tests::part2::http_raft_transport_sends_append_vote_and_snapshot_over_tcp` — binds a fixed port; passes 4/4 isolated, and has been a verified flake throughout this series.
- `raft::tests::part4::wal_backed_installed_snapshot_survives_restart_without_old_log_entries` — this one is WAL-backed and about restart, so it got a direct experiment rather than a flake assumption:

| | isolated runs |
|---|---|
| feature **on** | 5 pass / 0 fail |
| feature **off** | 5 pass / 0 fail |

The same either way. It fails only under parallel load, and the setting makes no difference to it.

That test also passed on `main` in one run and failed in another earlier in this series, which is the same picture.

## Compatibility

Unchanged from #85 and #86: a record that stages nothing still serializes without the field at all, and decoding accepts both the current and previous shapes, so logs written by earlier builds still load.
