### PR TITLE
Stop the auto-approve workflow failing on every run

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -33,17 +33,35 @@ jobs:
       REPO: ${{ github.repository }}
     steps:
       - name: Approve as maintainer 1
-        if: ${{ secrets.MAINTAINER_PAT_1 != '' }}
         env:
           GH_TOKEN: ${{ secrets.MAINTAINER_PAT_1 }}
-        run: gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true
+        run: |
+          # The secrets context is not available to a step-level `if:`, so the token is
+          # checked here instead. Absent token -> this workflow is inert, as intended.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "MAINTAINER_PAT_1 is not configured; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true
       - name: Approve as maintainer 2
-        if: ${{ secrets.MAINTAINER_PAT_2 != '' }}
         env:
           GH_TOKEN: ${{ secrets.MAINTAINER_PAT_2 }}
-        run: gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true
+        run: |
+          # The secrets context is not available to a step-level `if:`, so the token is
+          # checked here instead. Absent token -> this workflow is inert, as intended.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "MAINTAINER_PAT_2 is not configured; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true
       - name: Approve as maintainer 3
-        if: ${{ secrets.MAINTAINER_PAT_3 != '' }}
         env:
           GH_TOKEN: ${{ secrets.MAINTAINER_PAT_3 }}
-        run: gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true
+        run: |
+          # The secrets context is not available to a step-level `if:`, so the token is
+          # checked here instead. Absent token -> this workflow is inert, as intended.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "MAINTAINER_PAT_3 is not configured; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" --repo "$REPO" --approve --body "Auto-approved by maintainer (bot)." || true


### PR DESCRIPTION
The auto-approve workflow has failed on **every pull request** in this repository. Not a step failing — the run reports **zero jobs**, because it fails during evaluation before anything starts.

## Cause

Each step is guarded by:

```yaml
if: ${{ secrets.MAINTAINER_PAT_1 != '' }}
```

`secrets` is not one of the contexts available to a step-level `if:`. The condition can never be evaluated, so the run fails outright.

That is why the failure has no logs worth reading and no failed job to point at — a detail that made it easy to keep scrolling past.

## Fix

The guard moves into the step body, where the secret **is** reachable through `env:`. When the token is absent the step now says so and exits clean, so the workflow does what its own notice says it does: nothing at all until the maintainer tokens are configured.

```
MAINTAINER_PAT_1 is not configured; nothing to do.
```

## What this does not change

It does not make auto-approval any more likely. Behaviour when the tokens **are** configured is untouched, and the security notice at the top of the file still stands on its own terms — that auto-approving every pull request, including from forks, defeats human review as a merge gate.

If those tokens are set today, this change means the workflow starts doing what it was written to do rather than erroring out. That is worth a maintainer's eye before merging; it is the one behavioural difference here.

## Why bother

A check that is red on every pull request stops being a signal. Several genuine CI failures went unexamined during this series precisely because a permanent red X had become the background.
