### PR TITLE
Advance the cluster clock from the timer loop

### DIFF
--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -360,7 +360,19 @@ impl ProductionRaftRuntime {
         let stop_thread = Arc::clone(&stop);
         let handle = thread::spawn(move || {
             let mut last_heartbeat = InstantCompat::now();
+            let mut last_tick = InstantCompat::now();
             while !stop_thread.load(Ordering::SeqCst) {
+                // Move the cluster's clock forward by the time that actually passed. The
+                // recovery timeouts -- stalled snapshot send, offline peer, abandoned leader
+                // transfer -- are refreshed from here and from nowhere else, so a clock that
+                // never advances leaves them unable to fire: a snapshot send that stalls keeps
+                // its peer flagged as sending, and every proposal to that peer is rejected with
+                // backpressure until the process restarts.
+                let elapsed_ms = last_tick.elapsed().as_millis() as u64;
+                if elapsed_ms > 0 {
+                    cluster.advance_time_ms(elapsed_ms);
+                    last_tick = InstantCompat::now();
+                }
                 let _ = cluster.tick_election();
                 if last_heartbeat.elapsed() >= heartbeat_interval {
                     if cluster.leader_id() == local_node_id {


### PR DESCRIPTION
Several recovery timeouts — a stalled snapshot send, an offline peer, an abandoned leader transfer — are refreshed only by `advance_time_ms`.

**Nothing in a running node ever called it.** Its only callers are tests driving the clock by hand. So in a real node the clock never moved, and none of those timeouts could fire at any configured duration.

## What that costs

A snapshot send that stalls leaves the peer's `snapshot_sending` flag set. `cluster_snapshot` then rejects **every** proposal to that peer with backpressure:

```
raft snapshot sender backpressure for node 2: snapshot transfer already in progress
```

Nothing clears the flag, so writes to that peer do not recover until the process restarts. The mechanism that was supposed to release it — `refresh_snapshot_send_timeouts` — is reachable only through `advance_time_ms`, which is to say: only from tests.

## Fix

The timer loop already measures real elapsed time for its heartbeat. It now feeds the same measurement to the cluster once per iteration, so the timeouts can fire.

## What this does not fix

**The secondary-replication harness still fails the same way.** Its proposer retries for 60 s, and `send_snapshot_timeout_ms` defaults to `60_000`, so the release cannot land before the client gives up. Whether a minute is the right default for a client that waits a minute is a separate question, and not one to settle inside this change.

That harness deserves its own investigation. It fails identically with the staged-pages default disabled, and it failed at two different points across runs — a stalled propose in some, a replica that never caught up in others — so it is not deterministic either.

I am flagging that rather than folding it in, because a fix that makes a red harness green by coincidence is worse than one that states its scope.

## Testing

Raft suite: **174 passed, 2 failed**. Both failures are already on `main` without this change — verified by running the same suite with the change stashed — and neither is caused by it.

`cargo check --all-targets` is clean.
