### PR TITLE
meta: let a datanode or proxy announce its own shutdown

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -20,7 +20,7 @@ use temporalstore_rust::meta::{
     ProxyHeartbeatRequest, PublishShardSnapshotRequest, RegisterProxyRequest,
     RegisterServerRequest, RegisterShardRequest, SafeModePolicy, ServerHeartbeatRequest,
     ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason,
-    SingleNodeMeta, StateChangeRequest, TopologyVersionRequest, UpdateServerRequest,
+    NotifyStopRequest, SingleNodeMeta, StateChangeRequest, TopologyVersionRequest, UpdateServerRequest,
     UpdateTableRequest,
 };
 use temporalstore_rust::raft::{
@@ -1426,6 +1426,16 @@ fn handle(
         ("POST", "/servers/update") => parse_or(&request.body, |req: UpdateServerRequest| {
             json_response(200, &backend_call!(meta, update_server, req))
         }),
+        ("POST", "/servers/notify_stop") => {
+            parse_or(&request.body, |req: NotifyStopRequest| {
+                json_response(200, &backend_call!(meta, notify_server_stop, req))
+            })
+        }
+        ("POST", "/proxies/notify_stop") => {
+            parse_or(&request.body, |req: NotifyStopRequest| {
+                json_response(200, &backend_call!(meta, notify_proxy_stop, req))
+            })
+        }
         ("POST", "/servers/freeze") => parse_or(&request.body, |req: StateChangeRequest| {
             backend_call!(meta, freeze_server, req)
         }),

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -73,6 +73,9 @@ pub enum FreezeReason {
     /// The metaserver observed it restart in place, so it no longer holds what
     /// the metaserver believes it holds.
     Restarted,
+    /// It announced its own shutdown, so it was taken out of service before the
+    /// failure detector could notice the silence.
+    Stopping,
 }
 
 impl FreezeReason {
@@ -82,12 +85,16 @@ impl FreezeReason {
             Self::Operator => "operator",
             Self::Unresponsive => "unresponsive",
             Self::Restarted => "restarted",
+            Self::Stopping => "stopping",
         }
     }
 
     /// True when the metaserver, not an operator, decided this resource was
     /// unhealthy. These are the freezes a resource must not clear for itself.
     pub fn is_conviction(self) -> bool {
+        // `Stopping` is deliberately absent. A node that announced its own
+        // shutdown is expected back, and locking it out of re-registration
+        // would turn every clean restart into an operator ticket.
         matches!(self, Self::Unresponsive | Self::Restarted)
     }
 }
@@ -662,6 +669,12 @@ pub struct UpdateServerRequest {
     /// The new location. May be empty, which means "unlabelled, place anywhere".
     #[serde(default)]
     pub location: String,
+}
+
+/// A resource announcing that it is shutting down.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotifyStopRequest {
+    pub endpoint: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1988,6 +2001,179 @@ mod tests {
         }
         let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
         assert_eq!(located(&recovered, "node-a").location, "rack-9");
+    }
+
+    fn stop_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "ns".to_string(),
+            location: "rack-1".to_string(),
+            config_version: 1,
+            binary_version: "v1".to_string(),
+        });
+        meta
+    }
+
+    fn stop(endpoint: &str) -> NotifyStopRequest {
+        NotifyStopRequest {
+            endpoint: endpoint.to_string(),
+        }
+    }
+
+    fn stopped_server(meta: &SingleNodeMeta) -> ServerMetaInfo {
+        meta.list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == "node-a")
+            .expect("registered")
+    }
+
+    #[test]
+    fn announcing_a_stop_beats_the_failure_detector() {
+        // The point of the whole thing. A clean shutdown is otherwise
+        // indistinguishable from a crash: the node stops heartbeating and the
+        // metaserver waits out the detection window, routing reads to a process
+        // that has already exited.
+        let meta = stop_meta();
+
+        // The detector is not going to help: the heartbeat is fresh, so a sweep
+        // with a realistic window leaves the node serving.
+        assert!(meta.freeze_stale_resources(30_000).status.ok);
+        assert_eq!(stopped_server(&meta).state, MetaEntityState::Normal);
+
+        // Announcing the stop takes it out immediately.
+        assert!(meta.notify_server_stop(stop("node-a")).status.ok);
+        let server = stopped_server(&meta);
+        assert_eq!(server.state, MetaEntityState::Frozen);
+        assert_eq!(server.freeze_reason, FreezeReason::Stopping);
+    }
+
+    #[test]
+    fn a_stopping_server_is_not_a_conviction_and_can_come_back() {
+        // A node that announced its own shutdown is expected back. Treating the
+        // freeze as a conviction would turn every clean restart into an operator
+        // ticket under the self-clearing lock.
+        assert!(!FreezeReason::Stopping.is_conviction());
+
+        let meta = SingleNodeMeta::default().with_conviction_lock(true);
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        assert!(meta.notify_server_stop(stop("node-a")).status.ok);
+
+        // It restarts and registers again; the lock does not stand in its way.
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v2".to_string(),
+            })
+            .status
+            .ok);
+        assert_eq!(stopped_server(&meta).state, MetaEntityState::Normal);
+    }
+
+    #[test]
+    fn announcing_a_stop_drops_a_proxy_rather_than_freezing_it() {
+        // A proxy holds no data, so there is nothing to preserve by keeping a
+        // frozen tombstone -- and a frozen proxy stays in the damage accounting
+        // the conviction gate reads.
+        let meta = stop_meta();
+        assert!(meta.notify_proxy_stop(stop("proxy-a")).status.ok);
+        let proxy = meta
+            .list_proxies()
+            .proxies
+            .into_iter()
+            .find(|proxy| proxy.proxy_addr == "proxy-a")
+            .expect("registered");
+        assert_eq!(proxy.state, MetaEntityState::Dropped);
+    }
+
+    #[test]
+    fn announcing_a_stop_twice_is_not_an_error() {
+        // A shutdown hook may retry, or race the failure detector. Neither
+        // should produce a spurious failure in a node's last log line.
+        let meta = stop_meta();
+        assert!(meta.notify_server_stop(stop("node-a")).status.ok);
+        assert_eq!(
+            meta.notify_server_stop(stop("node-a")).status.code,
+            "not_modified"
+        );
+        assert!(meta.notify_proxy_stop(stop("proxy-a")).status.ok);
+        assert_eq!(
+            meta.notify_proxy_stop(stop("proxy-a")).status.code,
+            "not_modified"
+        );
+    }
+
+    #[test]
+    fn announcing_a_stop_for_an_unknown_endpoint_is_rejected() {
+        let meta = stop_meta();
+        assert_eq!(
+            meta.notify_server_stop(stop("ghost")).status.code,
+            "server_not_found"
+        );
+        assert_eq!(
+            meta.notify_proxy_stop(stop("ghost")).status.code,
+            "proxy_not_found"
+        );
+    }
+
+    #[test]
+    fn a_stop_leaves_no_freeze_cooldown_behind() {
+        // The node is coming back; a cooldown would delay its return for no
+        // reason, since nothing about it was judged unhealthy.
+        let meta = stop_meta();
+        assert!(meta.notify_server_stop(stop("node-a")).status.ok);
+        // A zero cooldown is stored as "expires now" rather than as zero, so
+        // assert the behaviour that matters: the window is not in the future,
+        // and the node can register again the moment it comes back.
+        assert!(stopped_server(&meta).freeze_cooldown_until_ms <= now_ms());
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v2".to_string(),
+            })
+            .status
+            .ok);
+    }
+
+    #[test]
+    fn a_stop_survives_mutation_log_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("stop-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            meta.register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            });
+            assert!(meta.notify_server_stop(stop("node-a")).status.ok);
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        let server = recovered
+            .list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == "node-a")
+            .expect("registered");
+        assert_eq!(server.state, MetaEntityState::Frozen);
+        assert_eq!(server.freeze_reason, FreezeReason::Stopping);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -274,6 +274,65 @@ impl SingleNodeMeta {
         self.set_server_state(request, MetaEntityState::Normal)
     }
 
+    /// Take a server out of service because it announced its own shutdown.
+    ///
+    /// Without this a clean shutdown is indistinguishable from a crash: the node
+    /// simply stops heartbeating, and the metaserver waits out the whole
+    /// detection window before reacting. Every read routed to that node during
+    /// the window fails, and a rolling deploy pays that cost once per node.
+    ///
+    /// Idempotent: a server that is already out of service reports
+    /// `not_modified` rather than failing, so a shutdown hook that retries or
+    /// races the failure detector does not produce spurious errors.
+    pub fn notify_server_stop(&self, request: NotifyStopRequest) -> AckResponse {
+        {
+            let state = self.inner.read().expect("meta lock poisoned");
+            let Some(server) = state.servers.get(&request.endpoint) else {
+                return AckResponse {
+                    status: Status::error("server_not_found", "server not found"),
+                };
+            };
+            if server.state != MetaEntityState::Normal {
+                return AckResponse {
+                    status: Status::error("not_modified", "server is already out of service"),
+                };
+            }
+        }
+        self.freeze_server(StateChangeRequest {
+            endpoint: request.endpoint,
+            freeze_cooldown_ms: 0,
+            // No cooldown and not a conviction: this node is expected back.
+            reason: FreezeReason::Stopping,
+        })
+    }
+
+    /// Take a proxy out of service because it announced its own shutdown.
+    ///
+    /// A proxy is dropped rather than frozen, matching the reference. It holds
+    /// no data, so there is nothing to preserve by keeping a tombstone in the
+    /// routing set -- and leaving it frozen would keep it in the damage
+    /// accounting the conviction gate reads.
+    pub fn notify_proxy_stop(&self, request: NotifyStopRequest) -> AckResponse {
+        {
+            let state = self.inner.read().expect("meta lock poisoned");
+            let Some(proxy) = state.proxies.get(&request.endpoint) else {
+                return AckResponse {
+                    status: Status::error("proxy_not_found", "proxy not found"),
+                };
+            };
+            if proxy.state != MetaEntityState::Normal {
+                return AckResponse {
+                    status: Status::error("not_modified", "proxy is already out of service"),
+                };
+            }
+        }
+        self.drop_proxy(StateChangeRequest {
+            endpoint: request.endpoint,
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Stopping,
+        })
+    }
+
     pub fn drop_server(&self, request: StateChangeRequest) -> AckResponse {
         self.set_server_state(request, MetaEntityState::Dropped)
     }

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -155,6 +155,48 @@ impl MetaRaftCluster {
         }
     }
 
+    pub fn notify_server_stop(&self, request: crate::meta::NotifyStopRequest) -> AckResponse {
+        let serving = self
+            .list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == request.endpoint);
+        match serving {
+            None => AckResponse {
+                status: Status::error("server_not_found", "server not found"),
+            },
+            Some(server) if server.state != MetaEntityState::Normal => AckResponse {
+                status: Status::error("not_modified", "server is already out of service"),
+            },
+            Some(_) => self.freeze_server(StateChangeRequest {
+                endpoint: request.endpoint,
+                freeze_cooldown_ms: 0,
+                reason: crate::meta::FreezeReason::Stopping,
+            }),
+        }
+    }
+
+    pub fn notify_proxy_stop(&self, request: crate::meta::NotifyStopRequest) -> AckResponse {
+        let serving = self
+            .list_proxies()
+            .proxies
+            .into_iter()
+            .find(|proxy| proxy.proxy_addr == request.endpoint);
+        match serving {
+            None => AckResponse {
+                status: Status::error("proxy_not_found", "proxy not found"),
+            },
+            Some(proxy) if proxy.state != MetaEntityState::Normal => AckResponse {
+                status: Status::error("not_modified", "proxy is already out of service"),
+            },
+            Some(_) => self.drop_proxy(StateChangeRequest {
+                endpoint: request.endpoint,
+                freeze_cooldown_ms: 0,
+                reason: crate::meta::FreezeReason::Stopping,
+            }),
+        }
+    }
+
     pub fn freeze_server(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::FreezeServer(request)),


### PR DESCRIPTION
## The problem

**A clean shutdown is indistinguishable from a crash.** A node being terminated simply stops heartbeating, and the metaserver waits out the whole detection window before reacting — **thirty seconds** on the default stale threshold.

Every read routed to that node during the window goes to a process that has already exited, and a rolling deploy pays that cost **once per node**.

The metaserver had no way to be told. There is no endpoint for it, so even an orchestrator that knew a pod was about to go could not say so.

## What this adds

`notify_server_stop` and `notify_proxy_stop`, exposed as `POST /servers/notify_stop` and `POST /proxies/notify_stop`. They take the resource out of service immediately rather than leaving it to be inferred from silence.

**A server is frozen** under a new `FreezeReason::Stopping`.

**A proxy is dropped rather than frozen.** It holds no data, so there is nothing to preserve by keeping a tombstone in the routing set — and a frozen proxy would linger in the damage accounting the conviction gate (#71) reads.

## Two deliberate choices

**`Stopping` is not a conviction.** A node that announced its own shutdown is *expected back*, so `is_conviction()` returns false for it and the self-clearing lock (#75) does not stand in the way of the restart. Otherwise every clean restart would become an operator ticket. The freeze also carries **no cooldown**, since nothing about the node was judged unhealthy.

**Both calls are idempotent.** A resource already out of service reports `not_modified` rather than failing — a shutdown hook may retry, or race the failure detector, and neither should produce a spurious error in a node's last log line.

## Scope

**The caller side is not wired here.** The metaserver-side operation is the missing piece and is independently useful — a `preStop` hook or a deploy script can call it before terminating the process. Having the datanode call it on `SIGTERM` belongs with that binary's own lifecycle and is a separate change.

## Tests

7 new tests: a stop taking effect where a stale sweep with a realistic window would not, `Stopping` not being a conviction and the node re-registering under the conviction lock, a proxy being dropped rather than frozen, idempotence on both paths, unknown endpoints rejected, no cooldown left behind, and replay through the mutation log.

One of them caught a representation detail worth knowing: a zero cooldown is stored as *"expires now"* rather than as literal zero, so the test asserts the behaviour (the window is not in the future and the node can re-register immediately) rather than the field value.

Verification:

- `cargo test -p temporalstore-rust --lib meta::tests` — 49 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta` — **219 passed, 0 failed.**
- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — 18 passed, 0 failed. (This suite binds fixed ports, so a parallel run can collide; one earlier parallel run showed 2 spurious failures that pass serially and on re-run.)
- `cargo build -p temporalstore-rust --bin metaserver` — clean, no new warnings.

No gate: it adds operations that did not exist, and changes nothing that did. Independent of #78, #81 and #87.

