### PR TITLE
Time a snapshot send by how long it is stuck, and release either flag

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -1139,6 +1139,9 @@ pub struct RaftPeerPipelineRuntimeState {
     pub snapshot_install_rejected: u64,
     pub snapshot_install_rolled_back: u64,
     pub snapshot_install_received_chunks: u64,
+    /// Chunk count as of the last stall check. The send counts as progressing while this
+    /// keeps changing, however long the transfer takes overall.
+    pub snapshot_send_progress_mark: u64,
     pub snapshot_install_total_chunks: u64,
     #[serde(default)]
     pub snapshot_install_progress_per_mille: u64,
@@ -3234,7 +3237,11 @@ impl Default for RaftConfig {
             enable_pre_vote: false,
             prohibits_election: false,
             ignore_witness: false,
-            send_snapshot_timeout_ms: 60_000,
+            // A stall budget, not a transfer budget: the clock resets on every chunk, so
+            // this is how long a send may make NO progress before the peer is released. A
+            // minute of complete silence is a dead transfer, and holding the peer that long
+            // rejects every proposal to it for the same minute.
+            send_snapshot_timeout_ms: 10_000,
             raft_transport_timeout_ms: 1_000,
             wal_sync: false,
             max_segment_bytes: 64 * 1024 * 1024,

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -36,8 +36,26 @@ impl RaftClusterInner {
             return;
         }
         for node in self.nodes.values_mut() {
-            if !node.pipeline_state.snapshot_sending {
+            // Either flag makes the guard reject a proposal to this peer, so either has to be
+            // able to time out. Watching only the sending flag left a peer stuck installing to
+            // reject proposals forever: the refresh skipped it and reset its clock every pass.
+            let in_transfer = node.pipeline_state.snapshot_sending
+                || node.pipeline_state.snapshot_installing;
+            if !in_transfer {
                 node.pipeline_state.snapshot_send_started_ms = None;
+                node.pipeline_state.snapshot_send_elapsed_ms = 0;
+                node.pipeline_state.snapshot_send_progress_mark = 0;
+                continue;
+            }
+            // Progress resets the clock. Measuring from the start of the send instead would
+            // abort a large transfer that is moving along perfectly well, which is the reason
+            // the timeout had to be set long enough to be useless against a real stall.
+            let progressed = node.pipeline_state.snapshot_install_received_chunks
+                != node.pipeline_state.snapshot_send_progress_mark;
+            if progressed {
+                node.pipeline_state.snapshot_send_progress_mark =
+                    node.pipeline_state.snapshot_install_received_chunks;
+                node.pipeline_state.snapshot_send_started_ms = Some(self.logical_time_ms);
                 node.pipeline_state.snapshot_send_elapsed_ms = 0;
                 continue;
             }
@@ -52,6 +70,7 @@ impl RaftClusterInner {
                 node.pipeline_state.snapshot_sending = false;
                 node.pipeline_state.snapshot_installing = false;
                 node.pipeline_state.snapshot_send_started_ms = None;
+                node.pipeline_state.snapshot_send_progress_mark = 0;
                 node.pipeline_state.snapshot_send_timeouts =
                     node.pipeline_state.snapshot_send_timeouts.saturating_add(1);
                 node.pipeline_state.snapshot_retry_count =


### PR DESCRIPTION
Two bugs in how a snapshot send is released. Both were found while chasing a harness that these **do not fix** — that is stated up front because it is the most important thing in this description.

## The timeout measured the wrong thing

It measured elapsed since the send **started**, so it could not tell a transfer that is moving from one that is dead.

That is why the budget had to be a full minute: anything shorter would abort a large but perfectly healthy transfer. The cost is that a peer whose transfer really had stalled kept its flag — and rejected every proposal to it — for that entire minute.

The clock now resets whenever another chunk lands. A transfer that is progressing is never cut off however long it takes; one making no progress at all is released quickly.

That is also what makes the shorter default defensible. A minute of *complete silence* is not a slow transfer, it is a dead one.

## The release watched one flag; the guard rejects on two

Sharper, and independent of any timeout value.

`cluster_snapshot` rejects a proposal when **either** `snapshot_sending` or `snapshot_installing` is set. But `refresh_snapshot_send_timeouts` only ever inspected `snapshot_sending`.

A peer left with `installing` set and `sending` clear was skipped by the refresh entirely — its clock reset on every pass — so it rejected proposals with **no way out at all**, at any configured timeout.

## What this does not fix

`raft_secondary_replication_harness` still fails.

It also fails **0/3 on the commit before the clock fix landed**, with the same symptoms, so it predates this work and neither change here addresses it. Across seven runs on an idle machine — load 2.4 on 16 cores, 362 GB free, nothing else running — it failed three different ways:

- propose blocked on snapshot backpressure
- a replica that never caught up after the partition healed
- `not enough live replicas for majority: live=1`

Three distinct symptoms on quiet hardware points at something real in multi-node behaviour that deserves its own investigation. I stopped rather than keep patching toward it: a change that turns a red harness green by coincidence is worse than one that states its scope.

## Testing

Raft suite: **174 passed, 2 failed** — identical with these changes stashed, same two names, neither caused here.
