### PR TITLE
Measure what a log record costs per byte written

### DIFF
--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -280,4 +280,170 @@ mod tests {
         };
         assert_eq!(with_block.encode_to_vec(), vec![0x6a, 0x02, b'a', b'b']);
     }
+
+    /// What a write costs on disk, in the shape the log uses today versus the binary one.
+    ///
+    /// The value of a write is stored as an array of decimal numbers when the record is JSON,
+    /// so every byte of user data becomes three or four characters before framing, metadata and
+    /// key names are counted at all. This measures both on identical content so the cost is a
+    /// number rather than an impression.
+    #[test]
+    fn record_encoding_cost_per_byte_written() {
+        use crate::types::Command;
+
+        for value_len in [64usize, 128, 1024, 4096] {
+            let value = vec![b'v'; value_len];
+            let key = "scale-key-000000000";
+
+            // As written today: a JSON document, then the integrity frame around it.
+            let json_record = serde_json::json!({
+                "shard_id": 1,
+                "sequence": 1,
+                "command": { "kind": "string_set", "key": key, "value": value },
+                "metadata": {
+                    "version": 1,
+                    "timestamp_ms": 1_787_270_070_192u64,
+                    "items": [{
+                        "item_kind": "kv",
+                        "model": "string",
+                        "object_key": key,
+                        "slot_id": 8539,
+                        "deleted": false,
+                        "meta_log": false,
+                        "block_log": false
+                    }]
+                }
+            });
+            let json_bytes = serde_json::to_vec(&json_record).unwrap();
+            let json_framed = crate::log_framing::encode_line(&json_bytes);
+
+            // The binary shape: one record carrying the same write, length-prefixed and
+            // checksummed by the shared framing.
+            let binary_record = WalRecord {
+                version: WAL_RECORD_VERSION,
+                sequence: 1,
+                items: vec![WalItem {
+                    routing_bucket: 8539,
+                    object_key: key.as_bytes().to_vec(),
+                    model_id: 1,
+                    key: key.as_bytes().to_vec(),
+                    value: value.clone(),
+                    timestamp_ms: 1_787_270_070_192,
+                    ..Default::default()
+                }],
+            };
+            let binary_framed = encode_framed(&binary_record);
+
+            let json_ratio = json_framed.len() as f64 / value_len as f64;
+            let binary_ratio = binary_framed.len() as f64 / value_len as f64;
+            println!(
+                "  value {value_len:>5}B -> json {:>7}B ({json_ratio:>5.2}x)   binary {:>6}B ({binary_ratio:>5.2}x)   {:>5.1}x smaller",
+                json_framed.len(),
+                binary_framed.len(),
+                json_framed.len() as f64 / binary_framed.len() as f64
+            );
+
+            // The binary record must never be the larger of the two.
+            assert!(
+                binary_framed.len() < json_framed.len(),
+                "binary encoding should be smaller at {value_len}B"
+            );
+        }
+
+        // Guard the headline: a small write costs several times its own size as JSON.
+        let value = vec![b'v'; 128];
+        let json = serde_json::to_vec(&serde_json::json!({
+            "shard_id": 1, "sequence": 1,
+            "command": { "kind": "string_set", "key": "scale-key-000000000", "value": value },
+        }))
+        .unwrap();
+        assert!(
+            json.len() > value.len() * 3,
+            "a 128B value should cost more than 3x as JSON, got {}B",
+            json.len()
+        );
+    }
+
+    /// What a write costs on disk, in the shape the log uses today versus the binary one.
+    ///
+    /// The value of a write is stored as an array of decimal numbers when the record is JSON,
+    /// so every byte of user data becomes three or four characters before framing, metadata and
+    /// key names are counted at all. This measures both on identical content so the cost is a
+    /// number rather than an impression.
+    #[test]
+    fn record_encoding_cost_per_byte_written() {
+        use crate::types::Command;
+
+        for value_len in [64usize, 128, 1024, 4096] {
+            let value = vec![b'v'; value_len];
+            let key = "scale-key-000000000";
+
+            // As written today: a JSON document, then the integrity frame around it.
+            let json_record = serde_json::json!({
+                "shard_id": 1,
+                "sequence": 1,
+                "command": { "kind": "string_set", "key": key, "value": value },
+                "metadata": {
+                    "version": 1,
+                    "timestamp_ms": 1_787_270_070_192u64,
+                    "items": [{
+                        "item_kind": "kv",
+                        "model": "string",
+                        "object_key": key,
+                        "slot_id": 8539,
+                        "deleted": false,
+                        "meta_log": false,
+                        "block_log": false
+                    }]
+                }
+            });
+            let json_bytes = serde_json::to_vec(&json_record).unwrap();
+            let json_framed = crate::log_framing::encode_line(&json_bytes);
+
+            // The binary shape: one record carrying the same write, length-prefixed and
+            // checksummed by the shared framing.
+            let binary_record = WalRecord {
+                version: WAL_RECORD_VERSION,
+                sequence: 1,
+                items: vec![WalItem {
+                    routing_bucket: 8539,
+                    object_key: key.as_bytes().to_vec(),
+                    model_id: 1,
+                    key: key.as_bytes().to_vec(),
+                    value: value.clone(),
+                    timestamp_ms: 1_787_270_070_192,
+                    ..Default::default()
+                }],
+            };
+            let binary_framed = encode_framed(&binary_record);
+
+            let json_ratio = json_framed.len() as f64 / value_len as f64;
+            let binary_ratio = binary_framed.len() as f64 / value_len as f64;
+            println!(
+                "  value {value_len:>5}B -> json {:>7}B ({json_ratio:>5.2}x)   binary {:>6}B ({binary_ratio:>5.2}x)   {:>5.1}x smaller",
+                json_framed.len(),
+                binary_framed.len(),
+                json_framed.len() as f64 / binary_framed.len() as f64
+            );
+
+            // The binary record must never be the larger of the two.
+            assert!(
+                binary_framed.len() < json_framed.len(),
+                "binary encoding should be smaller at {value_len}B"
+            );
+        }
+
+        // Guard the headline: a small write costs several times its own size as JSON.
+        let value = vec![b'v'; 128];
+        let json = serde_json::to_vec(&serde_json::json!({
+            "shard_id": 1, "sequence": 1,
+            "command": { "kind": "string_set", "key": "scale-key-000000000", "value": value },
+        }))
+        .unwrap();
+        assert!(
+            json.len() > value.len() * 3,
+            "a 128B value should cost more than 3x as JSON, got {}B",
+            json.len()
+        );
+    }
 }


### PR DESCRIPTION
The log stores one JSON document per record, so the value of a write becomes an array of decimal numbers: every byte of user data costs three or four characters, before framing, metadata and key names are counted at all.

That cost was visible in the code but had never been put to a number — and a number is what decides whether it is worth changing.

## Measured

| value | as JSON | binary | |
|---:|---:|---:|---|
| 64 B | 574 B (**8.97x**) | 131 B (2.05x) | 4.4x smaller |
| 128 B | 830 B (**6.48x**) | 198 B (1.55x) | 4.2x smaller |
| 1 KiB | 4,415 B (4.31x) | 1,094 B (1.07x) | 4.0x smaller |
| 4 KiB | 16,704 B (4.08x) | 4,166 B (1.02x) | 4.0x smaller |

Roughly **four times the bytes at every size**, and every one of them is written and fsynced on the synchronous path. Small writes are the worst case: 64 bytes of user data costs 574 bytes of log.

## What this is not

It only measures. No format changes here.

The binary record types it compares against already exist in the crate — same field numbers, same framing, checksummed the same way — and are still constructed by nothing. This is the evidence for deciding whether to wire them up, not a step that does it.

A real switch needs a migration story for logs already on disk, and that deserves its own change rather than riding along with a measurement.
