### PR TITLE
Take one durability barrier per raft write instead of twelve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ name = "temporalstore-rust"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "hex",
  "matrixcache",

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -260,28 +260,6 @@ fn raft_propose_serialize_on() -> bool {
     raft_env_flag_default_on("TS_RAFT_PROPOSE_SERIALIZE")
 }
 
-/// P3 (local-only durability): a DEPLOYED raft process runs exactly one node but keeps a full
-/// cluster view, so `wal_records()` emits a record per peer and `persist_configured_wal` fsyncs
-/// every one of them. A leader has no duty to make its peers' hard-state durable -- each node
-/// persists its own before answering an RPC, and peer state is re-learned from AppendEntries on
-/// restart. When this is on AND the runtime told us which node we are, persist only that record.
-/// Default OFF -> byte-identical. Has no effect on the in-process test cluster, which genuinely
-/// hosts every node and leaves `local_node_id` as None.
-fn raft_persist_local_only_on() -> bool {
-    raft_env_flag_on("TS_RAFT_PERSIST_LOCAL_ONLY")
-}
-
-/// P4 (one barrier per propose): a single propose calls `persist_configured_wal` several times
-/// as the log appends and then the commit index advances, so each write pays several barriers.
-/// Only the FINAL state has to be durable before the ack -- an intermediate state is subsumed by
-/// it, and a crash before the ack simply drops an unacked entry. When on, nested persists record
-/// that a barrier is owed and ONE persist flushes before the response is returned. Enabled only
-/// while the propose serialize lock is held, so exactly one writer can own the deferral.
-/// Default OFF -> byte-identical.
-fn raft_persist_defer_on() -> bool {
-    raft_env_flag_on("TS_RAFT_PERSIST_DEFER")
-}
-
 /// Fingerprint of the DURABILITY-relevant subset of a WAL record. `pipeline_state` and
 /// `read_safety_state` are cleared before hashing because they are volatile (reinitialised on
 /// election / re-driven on restart) and pure metrics respectively -- excluding them is what lets
@@ -3762,28 +3740,36 @@ struct RaftClusterInner {
     last_durable_fingerprint: BTreeMap<RaftNodeId, u64>,
     /// P2: serialize proposes into the log in order under `TS_RAFT_PROPOSE_SERIALIZE`.
     propose_serialize: Arc<Mutex<()>>,
-    /// P3: which node THIS process is, when the deployed runtime tells us. None for the
-    /// in-process test cluster (which hosts every node). Gates `TS_RAFT_PERSIST_LOCAL_ONLY`.
+    /// P3/P6: which node THIS process actually is, when the deployed runtime declares it.
+    /// `None` for the in-process test cluster, which genuinely hosts every node -- so both of
+    /// the local-only narrowings key off this and are inert there.
     local_node_id: Option<RaftNodeId>,
-    /// P4: while set, `persist_configured_wal` records that a barrier is owed instead of taking
-    /// one; `flush_deferred_persist` takes the single real barrier before the propose acks.
-    persist_deferred: bool,
+    /// P4: the thread currently owing durability barriers instead of taking them, set for the
+    /// span of one propose. Thread-scoped ON PURPOSE. The propose path releases the cluster
+    /// write lock for its network phase, so another path can persist inside this window -- and
+    /// one of them is the vote grant, which must be durable BEFORE it is answered or a crash
+    /// lets the same term be voted twice and elect two leaders. Only the thread that opened the
+    /// deferral defers; every other path takes its real barrier as before.
+    persist_deferred_owner: Option<std::thread::ThreadId>,
+    /// P4: whether anything was actually deferred, so a propose that persisted nothing flushes
+    /// nothing.
     persist_dirty: bool,
 }
 
 impl RaftCluster {
-    /// Local single-shard Raft model for unit tests and validation harnesses.
-    ///
-    /// Production runtime/deployment paths must use the distributed production
-    /// Raft runtime and are rejected by readiness if they select this local model.
-    /// P3: tell the cluster which node THIS process actually is. Set by the deployed
-    /// production runtime (one node per process); left unset by the in-process test cluster,
-    /// which hosts every node. Only consulted under `TS_RAFT_PERSIST_LOCAL_ONLY`.
+    /// Tell the cluster which node THIS process actually is. Set by the deployed production
+    /// runtime, which hosts exactly one node per process; left unset by the in-process test
+    /// cluster, which hosts every node. Everything scoped to the local node keys off this, so
+    /// leaving it unset preserves whole-cluster behaviour exactly.
     pub fn set_local_node_id(&self, node_id: RaftNodeId) {
         let mut inner = self.inner.write().expect("raft cluster lock poisoned");
         inner.local_node_id = Some(node_id);
     }
 
+    /// Local single-shard Raft model for unit tests and validation harnesses.
+    ///
+    /// Production runtime/deployment paths must use the distributed production
+    /// Raft runtime and are rejected by readiness if they select this local model.
     pub fn new_single_shard(
         shard_id: ShardId,
         node_ids: impl IntoIterator<Item = RaftNodeId>,
@@ -3827,7 +3813,7 @@ impl RaftCluster {
                 last_durable_fingerprint: BTreeMap::new(),
                 propose_serialize: Arc::new(Mutex::new(())),
                 local_node_id: None,
-                persist_deferred: false,
+                persist_deferred_owner: None,
                 persist_dirty: false,
             })),
         })
@@ -3950,7 +3936,7 @@ impl RaftCluster {
                 last_durable_fingerprint: BTreeMap::new(),
                 propose_serialize: Arc::new(Mutex::new(())),
                 local_node_id: None,
-                persist_deferred: false,
+                persist_deferred_owner: None,
                 persist_dirty: false,
             })),
         })
@@ -4041,10 +4027,22 @@ impl RaftCluster {
         }
 
         let mut leader_response = CommandResponse::Empty;
+        // P6: every `RaftNode` owns a `TemporalEngine`, so applying a committed entry into every
+        // node held by this process drives one engine WAL -- and one durability barrier -- per
+        // node. In a deployed process the peers are shadows: the real ones apply in their own
+        // processes off AppendEntries, so these applies are pure cost. Apply only into our own
+        // engine. Log and commit bookkeeping still advance for every node; only the apply and
+        // its barrier are skipped. Read before the mutable borrow below.
+        let apply_local_only = inner.local_node_id;
         for node in inner.nodes.values_mut().filter(|node| node.alive) {
             node.commit_index = entry.index;
             if !node.replica_role.can_serve_data() {
                 continue;
+            }
+            if let Some(local) = apply_local_only {
+                if node.id != local {
+                    continue;
+                }
             }
             if let Some(response) = apply_committed(node) {
                 if node.id == leader_id {
@@ -4152,9 +4150,11 @@ impl RaftCluster {
         let _propose_guard = propose_gate
             .as_ref()
             .map(|gate| gate.lock().unwrap_or_else(|poisoned| poisoned.into_inner()));
-        // P4: the propose lock makes us the only writer, so nested persists can record that a
-        // barrier is owed and let one flush below cover the final state -- before the ack.
-        let deferring = raft_persist_defer_on() && _propose_guard.is_some();
+        // P4: the propose lock makes us the only proposer, so nested persists can record that a
+        // barrier is owed and let one flush below cover the final state -- before the ack. Still
+        // conditioned on actually holding that lock: without it there can be several proposers,
+        // and a shared deferral would then have no single owner.
+        let deferring = _propose_guard.is_some();
         if deferring {
             self.inner
                 .write()

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -581,8 +581,10 @@ impl RaftClusterInner {
     }
 
     pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
-        // P4: a barrier is owed, not skipped -- flush_deferred_persist takes it before the ack.
-        if self.persist_deferred {
+        // P4: this thread owes a barrier rather than skipping one -- `flush_deferred_persist`
+        // takes it before the propose acks. Only the thread that opened the deferral defers, so
+        // a vote grant or heartbeat racing this propose still fsyncs before it answers.
+        if self.persist_deferred_owner == Some(std::thread::current().id()) {
             self.persist_dirty = true;
             return Ok(());
         }
@@ -596,9 +598,12 @@ impl RaftClusterInner {
         let max_segment_bytes = self.config.max_segment_bytes;
         let min_keep_segment_num = self.config.min_keep_segment_num as usize;
         let coalesce = raft_wal_coalesce_on();
-        // P3: a deployed process owns exactly one node; persisting a peer's hard-state buys no
-        // Raft safety (the peer fsyncs its own before answering) and costs a barrier per peer.
-        let local_only = if raft_persist_local_only_on() { self.local_node_id } else { None };
+        // P3: a deployed process owns exactly one node but keeps a full cluster view, so
+        // `wal_records()` emits a record per peer and this loop fsyncs every one of them. A
+        // leader owes its peers no durability: each persists its own hard state before answering
+        // an RPC, and re-learns the rest from AppendEntries on restart. Persist only our own
+        // record. Unset -- the in-process test cluster -- keeps persisting every node.
+        let local_only = self.local_node_id;
         for (node_id, record) in self.wal_records() {
             if let Some(local) = local_only {
                 if node_id != local {
@@ -637,15 +642,17 @@ impl RaftClusterInner {
         Ok(())
     }
 
-    /// P4: start owing barriers instead of taking them. Caller must hold the propose lock.
+    /// P4: start owing barriers on THIS thread instead of taking them. The caller must hold the
+    /// propose lock, which is what makes this thread the only proposer for the span.
     pub(super) fn begin_deferred_persist(&mut self) {
-        self.persist_deferred = true;
+        self.persist_deferred_owner = Some(std::thread::current().id());
         self.persist_dirty = false;
     }
 
-    /// P4: take the single real barrier covering everything deferred since `begin_deferred_persist`.
+    /// P4: take the one real barrier covering everything deferred since `begin_deferred_persist`.
+    /// Called before the propose acks, on the success and the failure path alike.
     pub(super) fn flush_deferred_persist(&mut self) -> Result<(), RaftError> {
-        self.persist_deferred = false;
+        self.persist_deferred_owner = None;
         if !self.persist_dirty {
             return Ok(());
         }

--- a/crates/temporalstore-rust/src/raft/cluster_membership.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_membership.rs
@@ -317,13 +317,22 @@ impl RaftCluster {
             .ok_or(RaftError::LeaderUnavailable)?;
         let leader_log = leader.log.clone();
         let leader_commit_index = leader.commit_index;
+        // P6: in a deployed cluster each process owns ONE node, and the peers held here are
+        // shadows -- the real followers catch up over AppendEntries in their own processes.
+        // Applying into a shadow drives that node's engine WAL and costs a durability barrier
+        // per follower per write, which measured as two of every three applies. Keep the log and
+        // commit bookkeeping, skip the apply.
+        let skip_shadow_apply = inner
+            .local_node_id
+            .map(|local| local != node_id)
+            .unwrap_or(false);
         let node = inner
             .nodes
             .get_mut(&node_id)
             .ok_or(RaftError::NodeNotFound(node_id))?;
         node.log = leader_log;
         node.commit_index = leader_commit_index;
-        if node.replica_role.can_serve_data() {
+        if node.replica_role.can_serve_data() && !skip_shadow_apply {
             apply_committed(node);
         }
         inner.membership_evidence.learner_catchup_count = inner

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -105,8 +105,8 @@ impl ProductionRaftRuntime {
             options.voter_ids(),
             options.config.clone(),
         )?;
-        // P3: one node per process here, so the WAL persist can be scoped to our own record
-        // under `TS_RAFT_PERSIST_LOCAL_ONLY` instead of fsyncing every peer's hard-state.
+        // One node per process here, so the WAL persist and the committed-entry apply can both be
+        // scoped to our own node instead of covering every peer's shadow copy.
         cluster.set_local_node_id(options.local_node_id);
         Ok(Self { options, cluster })
     }

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2375,17 +2375,146 @@ fn node_wal_record_count(root: &std::path::Path, shard: ShardId, node: RaftNodeI
         .unwrap_or(0)
 }
 
-/// P3 core: a DEPLOYED process owns one node but keeps a full cluster view, so the default
-/// persist fsyncs a record for every peer. With `TS_RAFT_PERSIST_LOCAL_ONLY` on and the runtime
-/// having declared which node we are, only OUR record may grow -- peers persist their own
-/// hard-state before answering an RPC, so the leader writing it buys no Raft safety. Durability
-/// of the local node is unchanged, which is what the first assertion pins.
+/// The counterpart to the local-node persist test: with NO local node declared -- the in-process
+/// form, which genuinely hosts every node -- all three must still be persisted. This is what
+/// makes the narrowing safe to apply unconditionally: it is reachable only once a runtime says
+/// one node per process.
+#[test]
+fn persist_covers_every_node_when_no_local_node_is_declared() {
+    let _serial = PART4_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    let base: Vec<u64> = (1..=3)
+        .map(|n| node_wal_record_count(dir.path(), 1, n))
+        .collect();
+    for i in 0..10 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("all-nodes-{i}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+    let after: Vec<u64> = (1..=3)
+        .map(|n| node_wal_record_count(dir.path(), 1, n))
+        .collect();
+
+    for node in 0..3 {
+        assert!(
+            after[node] > base[node],
+            "node {} must still be persisted when no local node is declared: {} -> {}",
+            node + 1,
+            base[node],
+            after[node]
+        );
+    }
+}
+
+/// P6 core: a committed entry was applied into EVERY node held by this process, and each node
+/// owns its own `TemporalEngine` -- so a deployed leader drove three engine WALs, and took three
+/// barriers, per write. Once the local node is declared, only its engine is applied into. This
+/// also pins the consequence, which is a refusal rather than a wrong answer: a read aimed at a
+/// peer's in-process shadow is rejected as apply-lagging, never served from un-applied state.
+/// No deployed read path aims there -- the server routes reads at the leader (which is the local
+/// node on the leader's own process) or explicitly at the local node.
+#[test]
+fn apply_scoped_to_local_node_leaves_peer_engines_unapplied() {
+    let _serial = PART4_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(1);
+
+    cluster
+        .propose(Command::StringSet {
+            key: "apply-local".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+
+    let read = |node| {
+        cluster.read_from_replica(
+            node,
+            Command::StringGet {
+                key: "apply-local".to_string(),
+            },
+        )
+    };
+    assert_eq!(
+        read(1).unwrap(),
+        CommandResponse::Bytes {
+            value: Some(b"v".to_vec())
+        },
+        "the local node must still apply committed entries"
+    );
+    for peer in [2, 3] {
+        let err = read(peer).expect_err("a peer's shadow engine must not answer this read");
+        assert!(
+            matches!(
+                err,
+                RaftError::ReplicaApplyLagging { replica_id, .. } if replica_id == peer
+            ),
+            "peer {peer} must refuse the read as apply-lagging rather than answer from
+             un-applied state, got {err:?}"
+        );
+    }
+}
+
+/// Counterpart to the above: with no local node declared, every node still applies, so the
+/// in-process cluster that existing tests use is unchanged.
+#[test]
+fn apply_covers_every_node_when_no_local_node_is_declared() {
+    let _serial = PART4_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    cluster
+        .propose(Command::StringSet {
+            key: "apply-all".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+
+    for node in [1, 2, 3] {
+        assert_eq!(
+            cluster
+                .read_from_replica(
+                    node,
+                    Command::StringGet {
+                        key: "apply-all".to_string(),
+                    },
+                )
+                .unwrap(),
+            CommandResponse::Bytes {
+                value: Some(b"v".to_vec())
+            },
+            "node {node} must apply when no local node is declared"
+        );
+    }
+}
+
+/// P3 core: a DEPLOYED process owns one node but keeps a full cluster view, so the persist loop
+/// fsyncs a record for every peer. Once the runtime has declared which node we are, only OUR
+/// record may grow -- peers persist their own hard state before answering an RPC, so the leader
+/// writing it buys no Raft safety. Durability of the local node is unchanged, which is what the
+/// first assertion pins.
 #[test]
 fn persist_local_only_writes_just_this_nodes_record() {
     let _serial = PART4_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let _gate = EnvFlagGuard::set("TS_RAFT_PERSIST_LOCAL_ONLY");
     let dir = tempfile::tempdir().unwrap();
     let cluster =
         RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())


### PR DESCRIPTION
A deployed raft process owns exactly ONE node but keeps a full cluster view, and three places on the write path acted on the whole view rather than on the node this process actually serves. Each cost a durability barrier per peer, per write.

Two of the three narrowings already exist in this tree behind `TS_RAFT_PERSIST_LOCAL_ONLY` and `TS_RAFT_PERSIST_DEFER`, both default-OFF and set nowhere in config, deploy or docker — so the shipped default has never run them. This removes both switches rather than flipping them, adds the third narrowing, which is absent here, and closes a durability hole in how the deferral was scoped.

## What changes

**The WAL persist covers only our own record** (was `TS_RAFT_PERSIST_LOCAL_ONLY`). A leader owes its peers no durability — each makes its own hard state durable before answering an RPC, and re-learns the rest from AppendEntries on restart.

**One barrier per propose, not several** (was `TS_RAFT_PERSIST_DEFER`). A single propose calls `persist_configured_wal` repeatedly, as the log appends and again as the commit index advances. Only the FINAL state has to be durable before the ack: an intermediate state is subsumed by it, and a crash before the ack drops an entry that was never acknowledged.

**Committed entries apply only into our own engine** (new here). Every `RaftNode` owns a `TemporalEngine`, and a committed entry was applied into every node held by the process, so the leader drove three engine WALs per write instead of one. Instrumenting the apply sites showed the dominant one was not the obvious one: `catch_up()` accounted for two of every three applies, because the leader locally simulates each follower catching up and applies into that peer's in-process engine. The real followers catch up over AppendEntries in their own processes, so those applies were pure cost.

All three key off `local_node_id`, which only `ProductionRaftRuntime` sets. The in-process cluster used by tests and harnesses genuinely does host every node and leaves it unset, so its behaviour is unchanged — that is what makes these safe to run unconditionally rather than behind a switch.

## The durability hole this also fixes

The deferral was a cluster-wide flag. The propose path releases the cluster write lock for its network phase, so another path can persist inside that window — and one of them is `handle_vote_request`, which sets `voted_for`, persists, and returns `vote_granted: true`. Under a shared flag its barrier would be merely owed, so a crash there lets a single term be voted twice and elect two leaders.

The deferral is now scoped to the thread that opened it. Only the proposing thread defers; a vote grant or heartbeat racing the propose still fsyncs before it answers. Same barrier reduction, no vote-durability window. This mattered less while the switch was off; turning it on without this would have made the window live.

## Numbers, and where they come from

| | before | after |
|---|---|---|
| fdatasync/write | 12.38 | **2.00** |
| write p50 | 67.0ms | 31.5ms |
| write QPS | 14.9 | 32.5 |
| read p50 | 0.784ms | 0.39ms |
| read QPS | 1359 | 2369 |

2.00 is the floor for this design: the raft WAL plus a single engine WAL. Reads improved too, which was not predicted — the shadow applies were also stalling the read path.

**These were measured on 3x c7i.xlarge on the branch these changes were developed on, each attributed separately. This PR has not been re-measured on a cluster.** What this PR *is* verified by is in Verification.

## Behaviour worth knowing

A read aimed at a PEER's in-process shadow is now rejected as apply-lagging rather than served from un-applied state — a refusal, not a wrong answer. No deployed read path aims there: `read_via_server_raft` targets either the leader (which is the local node on the leader's own process) or `state.local_node_id`, and a follower still applies into its own engine from AppendEntries. A test pins the refusal so the tradeoff stays explicit.

## Also

`set_local_node_id` had captured the doc comment belonging to `new_single_shard`, leaving that constructor undocumented and its warning about production paths attached to the wrong function. Each has its own doc again.

## Tests

Both halves of each narrowing: with a local node declared, only that node's record grows and only its engine is applied into; with none declared, every node is still persisted and applied into exactly as before.

## Verification

`cargo test --lib -- --test-threads=1` on this branch: **927 passed, 5 failed, 2 ignored.** Raft `part4` on its own: **64/64**, including the new tests.

**All five failures are already present on `main`.** Reverting the five files this PR touches back to `main`, rebuilding, and re-running reproduces every one of them with identical assertions and identical values:

- `raft::tests::part1::raft_rejects_electing_stale_replica_until_it_catches_up` — `elect_leader(3)` gives `NoMajority { live: 1, required: 2 }` where `ReplicaLagging` is expected
- `raft::tests::part1::request_vote_higher_term_resets_prior_vote_before_decision` — after `elect_leader(2)`, node 1's `voted_for` is `Some(2)` where `None` is expected
- `context_workflow::tests::context_retrieval_limits_namespace_fanout_with_summary_and_locality_plan`
- `engine::tests::part1::context_models_match_keys_timeline_pages_and_filters`
- `data_node::tests::part3::storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`

The two raft ones fail even when run alone (0.43s, 932 filtered out), so they are genuinely broken on `main` rather than victims of cross-test state. They are worth their own fix — a leader election leaving a vote recorded that should have been reset is a real correctness question — but they are outside this change.

This PR cannot reach either of them, which is checkable rather than merely asserted: both use `RaftCluster::new_single_shard`, which has no WAL (so the persist path returns early and the first two narrowings are moot) and leaves `local_node_id` unset (so both apply filters are inert), and both call the local `propose` / `elect_leader` rather than `propose_distributed_one`, where the barrier deferral lives.
