### PR TITLE
memory api: read through the record log, so forget removes and history reports

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -85,6 +85,21 @@ def warn_if_profile_scope_missing(scope) -> str:
 _BATCH_MESSAGES_WARNED: set = set()
 BATCH_MESSAGES_WARN_THRESHOLD = int(os.environ.get("MATRIXARK_BATCH_MESSAGES_WARN_THRESHOLD", "6"))
 
+# Ingest fields that come from the CALLER rather than from extraction -- the exact set
+# MatrixArkLocalAdapter._stamp_ingest_fields puts on a `context_event`. Extraction cannot rebuild
+# them, so a commit that rewrites an existing event row has to carry them over (see the use below).
+# An explicit allowlist on purpose: the rewrite is meant to replace the extraction's own view of the
+# event, and inheriting anything broader would let a stale earlier row overrule a fresh
+# classification.
+CALLER_SUPPLIED_EVENT_FIELDS = (
+    "identity_key",
+    "truth_class",
+    "truth_rank",
+    "expires_at",
+    "expires_at_ms",
+    "ephemeral",
+)
+
 
 def warn_if_batched_messages(messages) -> str:
     """Warn when one message-ingest call carries many messages.
@@ -2069,6 +2084,43 @@ class _LocalAdapterIngestMixin:
                     continue
                 segment_hashes_by_position.setdefault(message_index, []).append(segment_hash)
                 segment_hash_by_position.setdefault(message_index, segment_hash)
+        # Fields the CALLER supplied on the original ingest. When extraction commits it REWRITES the
+        # `context_event` row for an id that already exists, building it from the extraction result
+        # alone -- and latest-value compaction then serves that newer row. Anything the caller put on
+        # the original row and the extractor does not reproduce is therefore silently dropped at read
+        # time: an `identity_key` ingest became unfindable by keyed recall and stopped superseding,
+        # and a `ttl_seconds` ingest became a record nothing would ever expire. They survived only
+        # when extraction ran inside the ingest call, because `_stamp_ingest_fields` is scoped to it
+        # -- so an in-process sync ingest looked correct while the same request through the gateway,
+        # where finalize commits separately, lost them. Carry them across the rewrite.
+        inherited_event_fields: dict[int, Json] = {}
+        if derive_from_existing_events and source_event_ids:
+            wanted_event_ids: set[int] = set()
+            for source_event_id in source_event_ids:
+                try:
+                    wanted_event_ids.add(int(source_event_id))
+                except (TypeError, ValueError):
+                    continue
+            # `prior_records` is the live view already loaded for prior context; only pay for a read
+            # when the caller asked to skip that. Reading the LIVE view rather than the raw log is
+            # deliberate -- a deleted row must not hand its identity key to its replacement.
+            lookup_records = prior_records if prior_records else self.read_all()
+            for prior_record in lookup_records:
+                if str(prior_record.get("record_type") or "") != "context_event":
+                    continue
+                try:
+                    prior_event_id = int(prior_record.get("event_id_hash"))
+                except (TypeError, ValueError):
+                    continue
+                if prior_event_id not in wanted_event_ids:
+                    continue
+                carried = {
+                    field: prior_record[field]
+                    for field in CALLER_SUPPLIED_EVENT_FIELDS
+                    if prior_record.get(field) is not None
+                }
+                if carried:
+                    inherited_event_fields[prior_event_id] = carried
         if derive_from_existing_events:
             for index, message in enumerate(envelope["messages"]):
                 if index >= len(source_event_ids):
@@ -2199,6 +2251,8 @@ class _LocalAdapterIngestMixin:
                     "extraction_phase": extraction_phase,
                     "final_session_boundary": final_session_boundary,
                     "extraction_context_event_ids": extraction_context_event_ids,
+                    # Last, so the caller's own fields win over anything above that shares a name.
+                    **inherited_event_fields.get(event_id_hash, {}),
                 }
                 event_memory_layer = candidate_memory_layer_name(event_record)
                 if event_memory_layer:

--- a/tools/matrixark_mcp_latest_context_state.py
+++ b/tools/matrixark_mcp_latest_context_state.py
@@ -21,6 +21,29 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
+def expand_record_bundles(records: list[Json]) -> list[Json]:
+    """Flatten bundled appends into their constituent records.
+
+    A bundled append stores ``{"record_bundle": [rec, rec, ...]}`` as ONE hash field. The
+    wrapper carries no ``record_type``; the type every reader filters on lives on the
+    records inside it. Readers walking the raw entries therefore saw a typeless wrapper and
+    skipped it, so a bundled ``context_event`` was invisible to get / get_all / update /
+    history even though it was durably stored. The JSONL adapter appends records
+    individually and never bundles, which is why the same reader code worked there.
+
+    Idempotent: unbundled records pass through untouched.
+    """
+    expanded: list[Json] = []
+    for record in records:
+        if isinstance(record, dict):
+            bundle = record.get("record_bundle")
+            if isinstance(bundle, list):
+                expanded.extend(inner for inner in bundle if isinstance(inner, dict))
+                continue
+        expanded.append(record)
+    return expanded
+
+
 def latest_context_state_storage_key(storage_prefix: str) -> str:
     return f"{storage_prefix}:context_latest_state"
 
@@ -108,7 +131,9 @@ class LatestContextStateAdapterMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        return compact_latest_context_state_records(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -366,6 +366,84 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
     proxy boundary.
     """
 
+    def read_all(self) -> list[Json]:
+        """Read through the native record log, not MatrixArkLocalAdapter's JSONL log.
+
+        `MatrixArkLocalAdapter` precedes the direct mixins in this class's MRO and also
+        defines `read_all`, so its JSONL implementation won here -- and on a native backend
+        there is no JSONL log, so it returned ZERO records. Every reader built on read_all
+        (get / get_all / update / history / keyed recall) therefore read empty while the
+        records sat durably in the record log; the same inherited method is correct on the
+        JSONL backend, which is why only the native backends looked broken.
+
+        Only `read_all` collided: `read_all_without_disk_fallback_recovery` is defined solely
+        on `_TemporalDirectReadMixin` and already resolved correctly, so delegating to it
+        reproduces the direct read exactly without reordering bases (which would silently
+        move every other method both classes define).
+
+        The live-view filtering MUST be kept: `MatrixArkLocalAdapter.read_all` does not just
+        read, it filters the log down to live records. Delegating to the raw direct read alone
+        silently drops that -- forget/delete tombstones stop being honoured (the subject's
+        records stay visible after a forget) and a TTL record never expires, because expiry is
+        enforced on read and is never cached.
+
+        The body is deliberately identical to `MatrixArkLocalAdapter.read_all`; only the
+        `_read_all_compacted` beneath it differs per backend.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import filter_live_memory_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import filter_live_memory_records
+        return filter_live_memory_records(self._read_all_compacted())
+
+    def _read_all_compacted(self) -> list[Json]:
+        """The compacted, tombstone-swept view -- WITHOUT the expiry/retention filter.
+
+        The seam between "compacted" and "live" exists because some callers need to see records
+        the live view hides: `sweep_expired_memories` has to find the expired rows in order to
+        tombstone them, and would reclaim nothing if handed a view they had already been filtered
+        out of. Overriding it here rather than only `read_all` is what makes the three memory
+        paths built on it work on a native backend -- keyed upsert (`_apply_identity_upsert`),
+        the retention-cutoff scope resolver, and the expiry sweep. All three called the inherited
+        JSONL implementation, which returns `[]` as soon as `_local_jsonl_enabled` is False, so on
+        every native backend keyed upsert silently never ran: a second ingest under the same
+        `identity_key` found no existing record to supersede and both values stayed live.
+        """
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_all")
+        return self.read_all_without_disk_fallback_recovery()
+
+    def _read_raw_records(self) -> list[Json]:
+        """The native record log in append order -- NOT compacted, NOT tombstone-filtered.
+
+        Same MRO collision as `read_all`: `MatrixArkLocalAdapter._read_raw_records` reads the
+        JSONL shards and returns `[]` the moment `_local_jsonl_enabled` is False, which is
+        exactly what every native backend sets. `history` is built on this method -- it is
+        deliberately the RAW log, because the change history of a memory is the tombstones and
+        superseded rows that the live view exists to hide -- so on a native backend history
+        reported an empty log for a memory that plainly had one.
+
+        The delete-before-extract guard in `session_commit` also reads through here. It asks
+        whether a pending event survived the tombstone sweep and treats a tombstone-free log as
+        "keep everything", so an empty result made it silently inert on native backends rather
+        than wrong; with a real log behind it the guard now does its job there too.
+
+        Deliberately does NOT fold in `_load_latest_context_state_records()`: that store holds
+        the compacted latest state, which is the opposite of an append history, and none of it
+        is a `context_event` or a tombstone.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_raw_records")
+        with self._records_lock:
+            count = self._get_count()
+            if count > 0:
+                records = self._load_records_by_count(count)
+            else:
+                records = self._load_records(self._get_index())
+        return expand_record_bundles(records)
+
     def append(self, record: Json) -> None:
         self.append_many([record])
 
@@ -395,7 +473,20 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # this class); the fast direct-ingest path calls _append_many_materialized
         # itself (never append), so there is no double write. Disable with
         # MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND=0 as an escape hatch.
-        materialized = materialize_serving_record_batch(records)
+        #
+        # Per-ingestion stamping runs HERE, as it does in MatrixArkLocalAdapter.append_many,
+        # because it was being skipped entirely on every native backend. `_stamp_ingest_fields`
+        # is what puts `expires_at_ms`/`ephemeral` and `identity_key`/`truth_class`/`truth_rank`
+        # onto the records; without it an `ttl_seconds` ingest stored a record that nothing
+        # would ever expire, and an `identity_key` ingest stored a record keyed recall could not
+        # find (404) and keyed-upsert never superseded.
+        #
+        # `_apply_serving_dedup` is deliberately NOT applied here: its summary-dirty
+        # coalescing calls read_all(), which on a native backend is a full record-log read on
+        # every append batch. It only removes redundant pending markers -- a size
+        # optimization, not correctness -- and paying an O(store) read per ingest to get it
+        # is the wrong trade on this path.
+        materialized = self._stamp_ingest_fields(materialize_serving_record_batch(records))
         if not materialized:
             return
         if self._queue_batched_records(materialized):

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1184,7 +1184,39 @@ class _TemporalDirectBackendMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        """Run the serving pipeline over the native record log.
+
+        This is the native read choke point, the counterpart of the JSONL adapter's
+        `_read_all_compacted`. It used to run only the LAST of the pipeline's three stages,
+        `compact_latest_context_state_records`, which left two behaviours missing on every
+        native backend:
+
+          * `compact_latest_value_records` collapses records that share a latest-value key.
+            For a `context_event` that key is the `event_id_hash`, and the ingest pipeline
+            persists an event row twice -- once on the hot path (`extraction_phase:
+            hot_path`, parent `context_node`) and again when extraction commits
+            (`extraction_phase: final`, parent `context_segment`). Without this stage BOTH
+            rows serve, so `get_all` reported one memory as two.
+          * `apply_memory_tombstones` is what makes a forget/delete actually remove
+            anything. Without it a forget returned an accurate `removed_count` and then
+            served every one of those records right back.
+
+        `compact_and_apply_tombstones` composes all three in the one order that is correct
+        for both orphan sweeping and supersede (see its docstring); running the stages here
+        rather than at `read_all` keeps the deleted content out of the retrieval candidate
+        set too, exactly as on the JSONL backend. Both added stages fast-path a log with no
+        duplicate keys / no tombstone, and all three are idempotent, which matters because
+        this method is re-applied to already-processed cached records.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+            from tools.matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+            from matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        return compact_and_apply_tombstones(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/test_mem0_native_read_path.py
+++ b/tools/test_mem0_native_read_path.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The memory API on a native (record-log) backend: forget removes, history has a log, get_all
+lists one entry per memory, and the fields the caller supplied on an ingest survive the rewrite
+extraction performs when it commits.
+
+Each test here fails on the unfixed tree. The adapter is driven through a stub record log rather
+than a live datanode, because every defect these cover is in the Python read/write path, not in
+the engine: the native branch skipped two of the three serving-pipeline stages, and three memory
+methods called a JSONL-only reader that returns `[]` the moment the JSONL log is disabled -- which
+is exactly what a native backend does.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_mcp_local_adapter as local_mod
+
+
+TENANT = 4848243343181226175
+USER = 4473490034483841169
+SCOPE_KEY = f"t={TENANT}|u={USER}|s=1|"
+
+
+def _event(event_id, text, *, phase="hot_path", updated_at_ms=1000, **extra):
+    """A `context_event` row shaped like the ones the ingest pipeline writes."""
+    record = {
+        "record_type": "context_event",
+        "event_id_hash": event_id,
+        "text": text,
+        "scope_key": SCOPE_KEY,
+        "access_scope": {"tenant_hash": TENANT, "user_hash": USER, "scope_key": SCOPE_KEY},
+        "extraction_phase": phase,
+        "status": "observed" if phase == "hot_path" else "extraction_committed",
+        "updated_at_ms": updated_at_ms,
+        "timestamp_key_ms": updated_at_ms,
+    }
+    record.update(extra)
+    return record
+
+
+def _forget_tombstone(created_at_ms=9000):
+    return {
+        "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+        "tombstone_kind": "forget",
+        "target_tenant_hash": TENANT,
+        "target_user_hash": USER,
+        "target_scope_key": SCOPE_KEY,
+        "removed_count": 2,
+        "created_at_ms": created_at_ms,
+    }
+
+
+class _StubNativeAdapter:
+    """Build a direct adapter whose native record log is a plain list.
+
+    `object.__new__` skips __init__ (which would dial a metaserver / spawn a CLI); everything the
+    read path touches is stubbed. This is the same construction the membership-index tests use.
+    """
+
+    @staticmethod
+    def build(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._storage_prefix = "matrixark:mcp"
+        adapter._local_jsonl_enabled = False
+        adapter._native_log = list(records)
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._load_latest_context_state_records = lambda: []
+        # The native read, before any serving pipeline runs on it.
+        adapter.read_all_without_disk_fallback_recovery = (
+            lambda: adapter._with_latest_context_state_records(list(adapter._native_log))
+        )
+        return adapter
+
+
+class NativeReadPathTests(unittest.TestCase):
+    def test_forget_tombstone_is_applied_on_the_native_read(self):
+        """A forget wrote a durable tombstone and reported an accurate removed_count, then served
+        every one of those records straight back: the native read ran only the last of the three
+        serving-pipeline stages, so `apply_memory_tombstones` never ran."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _event(22, "user: My favourite language is Rust.", updated_at_ms=2000),
+            _forget_tombstone(),
+        ])
+        live = adapter.read_all()
+        self.assertEqual([], [r for r in live if r.get("record_type") == "context_event"])
+        # The tombstone marker itself is internal and must not surface either.
+        self.assertEqual([], [r for r in live
+                              if r.get("record_type") == local_mod.MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def test_forget_does_not_remove_a_later_re_ingest(self):
+        """The sweep is order-aware: re-ingesting after a forget produces live memories again."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _forget_tombstone(),
+            _event(33, "user: I am vegetarian.", updated_at_ms=11000),
+        ])
+        live_ids = [r["event_id_hash"] for r in adapter.read_all()
+                    if r.get("record_type") == "context_event"]
+        self.assertEqual([33], live_ids)
+
+    def test_one_memory_serves_as_one_record_not_two(self):
+        """The ingest pipeline persists an event row twice -- once on the hot path and again when
+        extraction commits -- and both rows served, so get_all reported 2 ingests as 4 memories.
+        Latest-value compaction collapses them to the committed row."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", phase="hot_path", updated_at_ms=1000),
+            _event(11, "user: I am vegetarian.", phase="final", updated_at_ms=1500),
+            _event(22, "user: My favourite language is Rust.", phase="hot_path", updated_at_ms=2000),
+            _event(22, "user: My favourite language is Rust.", phase="final", updated_at_ms=2500),
+        ])
+        events = [r for r in adapter.read_all() if r.get("record_type") == "context_event"]
+        self.assertEqual(2, len(events))
+        self.assertEqual([11, 22], sorted(r["event_id_hash"] for r in events))
+        self.assertEqual({"final"}, {r["extraction_phase"] for r in events})
+
+    def test_compacted_view_keeps_expired_records_for_the_sweep(self):
+        """`_read_all_compacted` is the seam below the live view: the expiry sweep has to SEE an
+        expired record to tombstone it, so only `read_all` may filter by expiry."""
+        expired = _event(11, "user: Use gate B12 today.", expires_at_ms=1, ephemeral=True)
+        adapter = _StubNativeAdapter.build([expired])
+        self.assertEqual(
+            [11], [r["event_id_hash"] for r in adapter._read_all_compacted()
+                   if r.get("record_type") == "context_event"])
+        self.assertEqual(
+            [], [r for r in adapter.read_all() if r.get("record_type") == "context_event"])
+
+
+class NativeRawLogReadTests(unittest.TestCase):
+    """`history` reads the RAW log on purpose -- a memory's change history IS the tombstones and
+    superseded rows the live view exists to hide. The inherited reader is JSONL-only, so on a
+    native backend history reported an empty log for a memory that plainly had one."""
+
+    @staticmethod
+    def _adapter(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._records_lock = __import__("threading").RLock()
+        adapter._get_count = lambda: len(records)
+        adapter._load_records_by_count = lambda count: list(records[:count])
+        adapter._load_records = lambda index: list(records)
+        adapter._get_index = lambda: []
+        return adapter
+
+    def test_raw_records_read_the_native_log(self):
+        records = [_event(11, "user: I am vegetarian."), _forget_tombstone()]
+        self.assertEqual(2, len(self._adapter(records)._read_raw_records()))
+
+    def test_raw_records_expand_a_bundled_append(self):
+        """A bundled append stores several records as ONE hash field; the wrapper carries no
+        record_type, which is what every reader filters on."""
+        bundled = [{"record_bundle": [_event(11, "user: a"), _event(22, "user: b")]}]
+        raw = self._adapter(bundled)._read_raw_records()
+        self.assertEqual([11, 22], [r["event_id_hash"] for r in raw])
+
+    def test_history_reports_ingest_and_supersede_from_the_raw_log(self):
+        adapter = self._adapter([
+            _event(11, "user: I am vegetarian."),
+            {
+                "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+                "tombstone_kind": "delete",
+                "target_memory_id": "11",
+                "tombstone_reason": "supersede",
+                "superseded_by": 22,
+                "created_at_ms": 5000,
+            },
+        ])
+        history = adapter.history({"memory_id": "11"})
+        self.assertEqual(2, history["count"])
+        self.assertEqual(["ingested", "superseded"], [entry["event"] for entry in history["history"]])
+        self.assertEqual(22, history["history"][1]["superseded_by"])
+
+
+class CallerSuppliedFieldsSurviveExtractionTests(unittest.TestCase):
+    """`identity_key` / TTL come from the CALLER; extraction cannot rebuild them. When extraction
+    commits it rewrites the event row for an id that already exists and latest-value compaction
+    serves that newer row, so anything the extractor does not reproduce was silently dropped at
+    read time -- keyed recall 404'd and a TTL record never expired. They survived only when
+    extraction happened to run inside the ingest call, which is why an in-process sync ingest
+    looked correct while the same request through the gateway did not."""
+
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.adapter = local_mod.MatrixArkLocalAdapter(
+            __import__("pathlib").Path(self._dir.name) / "events.jsonl")
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def _scope(self):
+        return {"tenant_id": "t1", "user_id": "u1", "session_id": "s1"}
+
+    def _live_event(self, event_id):
+        for record in self.adapter.read_all():
+            if (str(record.get("record_type") or "") == "context_event"
+                    and str(record.get("event_id_hash")) == str(event_id)):
+                return record
+        return None
+
+    def test_identity_key_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "identity_key": "pref.seat",
+            "truth_class": "asserted",
+        })
+        event_id = result["event_id_hash"]
+        self.assertEqual("pref.seat", self._live_event(event_id).get("identity_key"))
+        # Commit extraction OUTSIDE the ingest call -- what a finalize through the gateway does.
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served, "the event must still serve after extraction commits")
+        self.assertEqual("pref.seat", served.get("identity_key"))
+        self.assertEqual("asserted", served.get("truth_class"))
+
+    def test_ttl_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "ttl_seconds": 3600,
+        })
+        event_id = result["event_id_hash"]
+        expires_at_ms = self._live_event(event_id).get("expires_at_ms")
+        self.assertTrue(expires_at_ms, "the ingest must stamp an expiry")
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served)
+        self.assertEqual(expires_at_ms, served.get("expires_at_ms"))
+        self.assertTrue(served.get("ephemeral"))
+
+
+class NativeWritePathStampTests(unittest.TestCase):
+    """The native writer built its own record batch and skipped the per-ingestion stamp the
+    JSONL writer applies, so those fields never reached the store at all."""
+
+    def test_append_many_stamps_like_the_jsonl_writer(self):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        written = []
+        adapter._append_many_materialized = lambda records, allow_queue=True: written.extend(records)
+        adapter._queue_batched_records = lambda records: False
+        adapter._update_latest_entity_cache = lambda records: None
+        adapter._maintain_event_membership_after_append = lambda records: None
+        adapter._push_ingest_stamp({"identity_key": "pref.seat", "truth_class": "asserted"})
+        try:
+            adapter.append_many([_event(11, "user: Preferred seat: aisle")])
+        finally:
+            adapter._pop_ingest_stamp()
+        events = [r for r in written if r.get("record_type") == "context_event"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("pref.seat", events[0].get("identity_key"))
+        self.assertEqual("asserted", events[0].get("truth_class"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Every memory method except ingest and retrieve misbehaved on the record-log backends — the ones that actually ship — while looking correct on the JSONL one. Five problems, all the same shape: a method either resolved to the JSONL adapter's implementation on a backend that has no JSONL log, or the native read skipped a stage of the serving pipeline the JSONL read runs.

## What was wrong

**`read_all` resolved to the JSONL implementation.** `MatrixArkLocalAdapter` precedes the direct mixins in the adapter's MRO and also defines `read_all`, so on a native backend it returned zero records — and every reader built on it (`get`, `get_all`, `update`, `history`, keyed recall) read empty while the records sat durably in the record log.

**A bundled append was invisible.** It stores several records as one hash field; the wrapper carries no `record_type`, which is what every reader filters on, so bundled records were skipped even once they were being read.

**The native read ran only the LAST of the serving pipeline's three stages.** Restoring the other two fixes two symptoms at once:

- `apply_memory_tombstones` is what makes a forget, a delete or a reset remove anything. Without it, `forget` wrote its durable tombstone, reported an accurate `removed_count`, and then served every one of those records straight back.
- `compact_latest_value_records` collapses rows that share a latest-value key, which for a `context_event` is the event id. Ingest persists an event row twice — once on the hot path, again when extraction commits — so without this stage both rows served and one memory listed as two.

**`history` read a log that was always empty.** It reads the RAW log on purpose: a memory's change history *is* the tombstones and superseded rows the live view exists to hide. But it called the inherited reader, which returns an empty list the moment the JSONL log is disabled. The delete-before-extract guard in `session_commit` reads through the same method and had been silently inert on native backends for the same reason.

**Keyed upsert never ran.** Overriding the compacted-view seam rather than only `read_all` is what carries the fix to the three memory paths built on it. A second ingest under the same `identity_key` found no existing record to supersede, so both values stayed live and keyed recall returned 404.

**The native writer skipped the per-ingestion stamp** that the JSONL writer applies, so `identity_key`/`truth_class` and `expires_at`/`ephemeral` never reached the store at all.

**Extraction dropped caller-supplied fields when it rewrote an event row.** It builds the row from the extraction result alone, so anything the extractor cannot reproduce was lost as soon as compaction served the newer row. Those fields survived only when extraction happened to run inside the ingest call, which is why an in-process ingest looked correct while the same request through the gateway did not.

## Measured

Single-worker gateway on the record-log backend, a 20-operation sweep, 5 memories ingested:

| | before | after |
|---|---|---|
| `get` | 404 | the memory |
| `get_all` | 0, then 10 rows for 5 memories | 5 |
| `update` | 500 | updated, new id issued |
| `get_all` after `forget` | every record served back | 0 |
| `reset` | tenant not wiped | wiped |
| `history` | empty log | ingested / superseded / deleted |
| keyed recall | 404 | current value; a second keyed ingest supersedes, so `get_all` stays 1 |
| TTL | never expired | present before expiry, gone after |

The one operation still failing in the sweep needs a live embedding provider: it queries with no lexical overlap, and this host runs the deterministic provider, so retrieval's prefilter has nothing to match. Not a defect in these APIs, and unchanged by this PR.

## Tests

10 new tests in `tools/test_mem0_native_read_path.py`, every one of which fails without these changes. Existing memory suites 104/104 (`test_mem0_complete`, `test_mem0_compat`, `test_memory_delete_forget`, `test_memory_ttl`, `test_memory_upsert`, `test_delete_before_extract`).

## Notes for review

- The serving pipeline runs at the native read choke point rather than at `read_all`, so deleted content stays out of the retrieval candidate set too, exactly as on the JSONL backend. Both added stages fast-path a log with no duplicate keys and no tombstone, and all three stages are idempotent — which matters, because the method is re-applied to already-processed cached records.
- `_apply_serving_dedup` is deliberately *not* added to the native write path: its summary-dirty coalescing calls `read_all()`, an O(store) read on every append batch, and it only removes redundant pending markers. That is a size optimization, not correctness.
- The keyed and TTL ingest paths get slower, because `_apply_identity_upsert` now actually runs instead of returning early on an empty read. Plain ingest is unchanged.
