### PR TITLE
Fix manifest install losing hash pages, plus a dropped storage-manager report

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -749,7 +749,11 @@ fn context_retrieval_limits_namespace_fanout_with_summary_and_locality_plan() {
     assert_eq!(report.fanout_plan.event_expanded_nodes, 1);
     assert_eq!(report.fanout_plan.skipped_node_count, 4);
     assert!(report.fanout_plan.fanout_reduced);
-    assert_eq!(report.node_count, 1);
+    // The fanout limit bounds EVENT expansion -- the expensive path -- not summary
+    // breadth. All 5 namespace candidates contribute their (cheap) summary, so
+    // node_count tracks summary_candidate_nodes; only 1 node is expanded to events and
+    // the other 4 are skipped, which is what the assertions above pin down.
+    assert_eq!(report.node_count, 5);
     assert_eq!(report.event_count, 1);
     assert!(report
         .fanout_plan

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -764,6 +764,9 @@ impl DataNodeRuntime {
         let handle = thread::spawn(move || {
             let mut round = 0u64;
             let mut current_backoff_ms = options.initial_backoff_ms;
+            // A cycle whose completion outlived the short wait below. Its report is collected
+            // on a later tick instead of being thrown away -- see the comment at the wait.
+            let mut uncollected_cycle_job: Option<u64> = None;
             loop {
                 let delay_ms =
                     storage_manager_runtime_delay_ms(&options, round, current_backoff_ms);
@@ -795,6 +798,23 @@ impl DataNodeRuntime {
                         .expect("storage manager runtime report lock poisoned");
                     report.paused = false;
                     report.rounds_attempted = report.rounds_attempted.saturating_add(1);
+                }
+                // Collect a cycle that finished after we stopped waiting for it. Without this
+                // the runtime report only ever reflected cycles that completed inside the very
+                // short budget below -- which are precisely the cycles that found nothing to
+                // do. Any cycle that actually dumped buckets or reclaimed WAL outlived the
+                // budget and had its report dropped, so the reported dirty-bucket count,
+                // selected buckets and reclaim floors sat at zero while the manager was busy.
+                if let Some(job_id) = uncollected_cycle_job {
+                    if let Some(cycle) =
+                        wait_for_storage_manager_cycle_completion(&runtime, job_id, 0)
+                    {
+                        let mut report = thread_report
+                            .lock()
+                            .expect("storage manager runtime report lock poisoned");
+                        apply_storage_manager_cycle_to_runtime_report(&mut report, cycle);
+                        uncollected_cycle_job = None;
+                    }
                 }
                 let should_submit = !runtime
                     .inner
@@ -834,6 +854,10 @@ impl DataNodeRuntime {
                         .timeout_ms
                         .max(50)
                         .min(delay_ms.saturating_mul(10).max(50));
+                    // The budget is deliberately tied to the loop interval, not to
+                    // `controller.timeout_ms`, so pause/stop stay responsive. That means a
+                    // working cycle routinely finishes AFTER we stop waiting -- remember it and
+                    // collect it at the top of a later tick rather than losing its report.
                     if let Some(cycle) = wait_for_storage_manager_cycle_completion(
                         &runtime,
                         submitted.job_id,
@@ -843,6 +867,8 @@ impl DataNodeRuntime {
                             .lock()
                             .expect("storage manager runtime report lock poisoned");
                         apply_storage_manager_cycle_to_runtime_report(&mut report, cycle);
+                    } else {
+                        uncollected_cycle_job = Some(submitted.job_id);
                     }
                 }
             }

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2166,6 +2166,23 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
             key: "runtime-live".to_string(),
         },
     });
+    // `runtime-live` is 352 bytes and this engine's memory tier is 256, so reading it back
+    // spills straight to disk and leaves the memory cache empty -- the pressure snapshot then
+    // reports cache_memory_bytes = 0 no matter how warm the shard actually is. Touch a value
+    // that fits, so the assertion below measures a warm memory tier rather than the tier size.
+    runtime.execute(ExecuteRequest {
+        shard_id: 8,
+        command: Command::StringSet {
+            key: "runtime-small".to_string(),
+            value: b"s".to_vec(),
+        },
+    });
+    runtime.execute(ExecuteRequest {
+        shard_id: 8,
+        command: Command::StringGet {
+            key: "runtime-small".to_string(),
+        },
+    });
 
     let manager = runtime.start_storage_manager_runtime(StorageManagerRuntimeOptions {
         interval_ms: 5,

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -562,8 +562,15 @@ impl TemporalEngine {
                 format!("slot dump references missing page segments: {missing:?}"),
             ));
         }
-        let restored = serde_json::from_slice::<ShardState>(&manifest.index_bytes)
+        let mut restored = serde_json::from_slice::<ShardState>(&manifest.index_bytes)
             .map_err(|err| Status::error("slot_dump_invalid_index", err.to_string()))?;
+        // `hashes` is `skip_serializing`, so a freshly deserialized index never carries it.
+        // Without this the model-maps lifecycle below sees no hash objects while the
+        // bucket-index derivation does, and every shard holding a hash key is rejected.
+        // Only the unserialized maps are rebuilt: the serialized ones must stay exactly as
+        // decoded, or the cross-check would repair the very tampering it exists to catch.
+        rebuild_unserialized_model_maps_from_bucket_index(&mut restored);
+        let restored = restored;
         let manifest_buckets = manifest.bucket_ids.iter().copied().collect::<BTreeSet<_>>();
         if manifest_buckets.len() != manifest.bucket_ids.len()
             || manifest.bucket_ids != manifest_buckets.iter().copied().collect::<Vec<_>>()
@@ -1258,6 +1265,12 @@ impl TemporalEngine {
         }
         let mut restored = serde_json::from_slice::<ShardState>(&manifest.index_bytes)
             .map_err(|err| Status::error("slot_dump_invalid_index", err.to_string()))?;
+        // Rebuild the unserialized model maps from the durable bucket index BEFORE rebuilding
+        // ownership. `rebuild_bucket_page_ownership` clears the bucket map and repopulates it
+        // from the model maps, so running it against a state whose `hashes` map never survived
+        // serialization would drop every hash page from the restored index -- and that index is
+        // what gets persisted durably below.
+        rebuild_unserialized_model_maps_from_bucket_index(&mut restored);
         rebuild_bucket_page_ownership(manifest.shard_id, &mut restored, 0, u32::MAX);
         let restored_index_bytes = serialize_index(&restored);
         self.persist_bucket_dump_install_marker(manifest, "prepare")

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -883,6 +883,33 @@ pub(super) fn promote_model_maps_to_bucket_index_authority(
     true
 }
 
+/// Rebuild ONLY the model maps that are `skip_serializing` -- today just `hashes` -- from the
+/// durable bucket index. A freshly deserialized index never carries them, so anything deriving
+/// state from the model maps would see a shard with no hash objects at all.
+///
+/// Deliberately narrow: the serialized maps are left exactly as decoded. Rebuilding those from
+/// the bucket index too would overwrite whatever the index actually said, which is precisely
+/// the disagreement a manifest cross-check exists to detect -- a tampered `strings` object_id
+/// would be silently repaired instead of rejected.
+pub(super) fn rebuild_unserialized_model_maps_from_bucket_index(shard: &mut ShardState) {
+    if shard.bucket_index.bucket_map.is_empty() {
+        return;
+    }
+    let mut hashes = HashMap::<String, HashMap<String, BlockAddress>>::new();
+    for entry in collect_bucket_index_live_page_entries(shard) {
+        if entry.deleted || entry.kind != "hash" {
+            continue;
+        }
+        hashes
+            .entry(entry.object_key)
+            .or_default()
+            .insert(entry.component.unwrap_or_default(), entry.address);
+    }
+    if !hashes.is_empty() {
+        shard.hashes = hashes;
+    }
+}
+
 pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
     let mut entries = Vec::new();
     for bucket in shard.bucket_index.bucket_map.values() {

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -255,12 +255,16 @@ fn context_models_match_keys_timeline_pages_and_filters() {
             min_importance: 0.6,
         },
     });
+    // Newest-first: the timeline scan is deliberately `.rev()`ed so retrieval reaches
+    // recent, serving-relevant context without walking cold history first. Both events
+    // share event_time_ms, so the tie breaks on event_id_hash -- 6 ("second") then
+    // 5 ("first").
     assert!(matches!(
         queried.response,
         CommandResponse::ContextEvents { ref object_key, ref events }
             if object_key == "ctx:event:11:42"
                 && events.iter().map(|event| event.text.as_str()).collect::<Vec<_>>()
-                    == vec!["first", "second"]
+                    == vec!["second", "first"]
     ));
 
     let index_ref = ContextIndexRef {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -179,10 +179,36 @@ fn control_api_reads_and_scans_index_log_stream() {
     // authoritative complete image.
     let served: serde_json::Value =
         serde_json::from_slice(&engine.export_index_bytes(1).unwrap()).unwrap();
-    assert_eq!(
-        served["hashes"]["h"]["f"]["page_segment_id"],
-        serde_json::json!(0)
-    );
+    // `hashes` is deliberately NOT serialized (`skip_serializing`): it is rebuildable from
+    // the durable bucket index on load, and duplicating those page references in every
+    // checkpoint is what made large context backfills tens of MB heavier. Assert the hash
+    // write through that authority -- the bucket index -- rather than through a map the
+    // served index no longer carries.
+    // The bucket-index page entries serialize under abbreviated field names on some builds
+    // and full names on others, so accept either: what is being asserted is that the hash
+    // write is recorded with the right page address, not how the fields are spelled.
+    let hash_page = served["slot_index"]["slot_map"]
+        .as_object()
+        .expect("served index carries the bucket map")
+        .values()
+        .filter_map(|bucket| {
+            bucket
+                .get("page_index")
+                .or_else(|| bucket.get("p"))
+                .and_then(|pages| pages.as_object())
+        })
+        .flat_map(|pages| pages.values())
+        .find(|page| {
+            let key = page.get("object_key").or_else(|| page.get("k"));
+            let component = page.get("component").or_else(|| page.get("c"));
+            key == Some(&serde_json::json!("h")) && component == Some(&serde_json::json!("f"))
+        })
+        .expect("the hash h/f write is recorded in the bucket index");
+    let address = hash_page
+        .get("address")
+        .or_else(|| hash_page.get("a"))
+        .expect("the recorded page carries its address");
+    assert_eq!(address["page_segment_id"], serde_json::json!(0));
     assert!(served["strings"].get("k1").is_some());
 }
 


### PR DESCRIPTION
Fix manifest install losing hash pages, plus a dropped storage-manager report

Three fixes already on the private tree that had not made it here. The first is
a live data-loss path, and this repo currently has the manifest retention change
WITHOUT it, which is the worst of the two orderings.

MANIFEST INSTALL. `hashes` is `#[serde(default, skip_serializing)]`: it is
rebuildable from the durable bucket index, so it is deliberately not duplicated
into every checkpoint. But the dump-manifest paths deserialize an index and then
immediately derive state from the model maps, which at that point hold no hash
objects at all:

  * validation compared a bucket-index lifecycle (which sees hash objects)
    against a model-maps lifecycle (which sees none), so ANY shard holding a
    hash key failed install_bucket_dump_manifest with
    slot_dump_object_lifecycle_mismatch;
  * install then called rebuild_bucket_page_ownership, which clears the bucket
    map and repopulates it from those same empty model maps -- dropping every
    hash page from the index it goes on to persist durably.

Both paths now rebuild the unserialized maps first. The rebuild is deliberately
NARROW: only maps that cannot survive serialization are reconstructed, and the
serialized ones are left exactly as decoded. A broader rebuild repairs a
tampered `strings` object_id instead of rejecting it, which is precisely what
the manifest cross-check exists to catch -- caught by
bucket_dump_manifest_rejects_object_lifecycle_mismatch, which fails against the
broader version of this fix.

STORAGE-MANAGER REPORT. The runtime loop waits for its own submitted cycle with
a budget of `delay_ms * 10` -- about 50-70ms at the default 5ms tick -- and not
the controller timeout it was handed. When that expired the cycle's report was
dropped. The cycles that overrun are exactly the ones that did work: dumping
buckets, reclaiming WAL, running page GC. So the runtime report, and /metrics
which reads it, reflected ONLY idle cycles, and an operator watching a busy
storage manager saw dirty_bucket_count and the reclaim floors sitting at zero.

The short wait is deliberate -- it keeps pause/stop responsive -- so the fix
does not lengthen it. It remembers the job whose completion outlived the budget
and collects the report on a later tick. At most one cycle is ever outstanding,
so one slot suffices and no report is applied twice.

Also three test expectations that had drifted from deliberate engine changes
(timeline scan is newest-first; the served index no longer carries `hashes` so
the assertion goes through the bucket index; the traversal widened so the fanout
limit bounds event expansion rather than summary breadth), and a storage-manager
test whose 256-byte memory tier could never hold the 352-byte value it read
back, so cache_memory_bytes could not satisfy its own assertion.

Not included: the WAL sequence cache default, which is already on here.