### PR TITLE
Group context records by owner, key events by id, and fold embedding vectors inline

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1571,6 +1571,7 @@ pub(crate) fn extract_context_gated(
             source_ref: String::new(),
             related_node_hashes: Vec::new(),
             compact_attrs: Vec::new(),
+            vector: Vec::new(),
         },
     );
     let index_ref = ContextIndexRef {
@@ -1594,12 +1595,14 @@ pub(crate) fn extract_context_gated(
         level: 1,
         text: l0.clone(),
         valid_from_ms: timestamp_ms,
+        vector: Vec::new(),
     };
     let summary_l1 = emit_l1.then(|| ContextSummary {
         node_hash,
         level: 2,
         text: l1.clone(),
         valid_from_ms: timestamp_ms,
+        vector: Vec::new(),
     });
     let mut embedding_inputs: Vec<(&str, u64, u32, &str)> =
         vec![("node_l0", node_hash, 1, l0.as_str())];
@@ -2612,6 +2615,7 @@ fn empty_event() -> ContextEvent {
         source_ref: String::new(),
         related_node_hashes: Vec::new(),
         compact_attrs: Vec::new(),
+        vector: Vec::new(),
     }
 }
 

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1554,7 +1554,7 @@ pub(crate) fn extract_context_gated(
         l1_ref: l1.clone(),
         raw_metadata_ref: request.source_id.clone(),
     };
-    let event = context_event_with_storage_keys(
+    let mut event = context_event_with_storage_keys(
         node_hash,
         ContextEvent {
             event_id_hash,
@@ -1590,14 +1590,14 @@ pub(crate) fn extract_context_gated(
         propagate_depth: 1,
     };
 
-    let summary_l0 = ContextSummary {
+    let mut summary_l0 = ContextSummary {
         node_hash,
         level: 1,
         text: l0.clone(),
         valid_from_ms: timestamp_ms,
         vector: Vec::new(),
     };
-    let summary_l1 = emit_l1.then(|| ContextSummary {
+    let mut summary_l1 = emit_l1.then(|| ContextSummary {
         node_hash,
         level: 2,
         text: l1.clone(),
@@ -1696,6 +1696,33 @@ pub(crate) fn extract_context_gated(
         });
         embedding_commands
     };
+
+    // Step 2 of the embedding fold: carry the event's vector on the event record itself,
+    // alongside the separate ContextEmbedding row that readers still address by ref_hash.
+    // Dual-write on purpose -- ref_hash is a one-way hash of (tenant, owner, level), so no
+    // reader can reach an owner record from it, and the separate rows cannot be dropped until
+    // every reader is migrated to (owner, level) addressing. Populating first means that
+    // migration can be verified against records that already carry their vector, instead of
+    // flipping storage and addressing in one step.
+    //
+    // Left empty when embedding was deferred (provider failure): the node is marked
+    // embedding-dirty and the async drainer attaches vectors later, so an empty vector here
+    // means "not yet", never "none". skip_serializing_if keeps that costing nothing on disk.
+    if !embedding_deferred {
+        // embedding_inputs order is node_l0, [node_l1], event_text -- the same order the
+        // ContextEmbedding rows above index into, so the vectors line up with their owners:
+        // index 0 is the L0 summary, index 1 the L1 summary when emitted, and the event last.
+        if let Some(vector) = embedding_vectors.first() {
+            summary_l0.vector = vector.clone();
+        }
+        if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.get(1)) {
+            summary.vector = vector.clone();
+        }
+        let event_vector_index = if emit_l1 { 2 } else { 1 };
+        if let Some(vector) = embedding_vectors.get(event_vector_index) {
+            event.vector = vector.clone();
+        }
+    }
 
     let mut commands = vec![
         Command::ContextUpsertNode {

--- a/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
+++ b/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
@@ -396,6 +396,7 @@ mod tests {
                         source_ref: String::new(),
                         related_node_hashes: Vec::new(),
                         compact_attrs: Vec::new(),
+                        vector: Vec::new(),
                     },
                     first_write_only: false,
                     cold_storage: false,

--- a/crates/temporalstore-rust/src/context_workflow/ingest.rs
+++ b/crates/temporalstore-rust/src/context_workflow/ingest.rs
@@ -247,6 +247,7 @@ pub fn ingest_resource_skill_context(
             valid_from_ms: extract.event.event_time_ms,
             confidence: 1.0,
             source_event_hashes: vec![extract.event.event_id_hash],
+            vector: Vec::new(),
         };
         let compression = ContextCompressionEvent {
             compression_id_hash: stable_hash64(&format!(

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -413,6 +413,86 @@ fn context_extract_gates_l1_for_thin_sources() {
     assert_eq!(rich.embedding_generation.requested_vector_count, 3);
 }
 
+#[test]
+fn context_extract_stores_embedding_vectors_on_the_records_themselves() {
+    // Step 2 of the embedding fold populates event and summary records with their own vector,
+    // alongside the separate ContextEmbedding rows readers still use. Nothing READS the inline
+    // field yet, so without this assertion "population" could be silently writing empty vectors
+    // and every existing test would still pass.
+    let engine = test_engine();
+    let report = extract_context(
+        &engine,
+        ContextExtractRequest {
+            shard_id: 1,
+            tenant_hash: 77,
+            source_kind: ContextSourceKind::Chat,
+            source_id: "inline-vector".to_string(),
+            title: "note".to_string(),
+            body: "Checkout failed during payment. The risk score spiked sharply.                    The fraud team paused the account."
+                .to_string(),
+            timestamp_ms: 7,
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(report.status.ok, "{:?}", report.status);
+    // Rich body -> L1 is warranted, so all three vectors exist: node_l0, node_l1, event_text.
+    assert_eq!(report.embedding_generation.requested_vector_count, 3);
+
+    let events = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEvents {
+                tenant_hash: 77,
+                node_hash: report.node.node_hash,
+                start_time_ms: 0,
+                end_time_ms: 4_000_000_000_000,
+                limit: None,
+                max_scan: None,
+                current_valid_only: false,
+                as_of_ms: 0,
+                kinds: Vec::new(),
+                statuses: Vec::new(),
+                min_confidence: 0.0,
+                min_importance: 0.0,
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextEvents { events, .. } => events,
+        other => panic!("expected events, got {other:?}"),
+    };
+    let stored = events.first().expect("the extract wrote an event");
+    assert!(
+        !stored.vector.is_empty(),
+        "event was stored without its inline vector"
+    );
+
+    let summaries = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQuerySummaries {
+                tenant_hash: 77,
+                node_hash: report.node.node_hash,
+                level: 1,
+                as_of_ms: 4_000_000_000_000,
+                limit: None,
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextSummaries { summaries, .. } => summaries,
+        other => panic!("expected summaries, got {other:?}"),
+    };
+    assert!(!summaries.is_empty(), "the extract wrote no summaries");
+    for summary in &summaries {
+        assert!(
+            !summary.vector.is_empty(),
+            "summary level {} was stored without its inline vector",
+            summary.level
+        );
+    }
+}
+
 // shared-corpus: context_compression_secondary_index_query_debug_flow
 #[test]
 fn context_workflow_extracts_retrieves_and_injects_mock_context() {

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -1755,6 +1755,7 @@ fn upsert_raw_context_node(
                     source_ref: String::new(),
                     related_node_hashes: Vec::new(),
                     compact_attrs: Vec::new(),
+                    vector: Vec::new(),
                 },
                 first_write_only: false,
                 cold_storage: false,

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2315,21 +2315,15 @@ fn collect_live_page_slab_ids(shard: &ShardState) -> BTreeSet<u64> {
     for series in shard.context_audits.values() {
         ids.extend(series.values().map(|address| address.page_slab_id));
     }
-    ids.extend(
-        shard
-            .context_entities
-            .values()
-            .map(|address| address.page_slab_id),
-    );
+    for series in shard.context_entities.values() {
+        ids.extend(series.values().map(|address| address.page_slab_id));
+    }
     for series in shard.context_children.values() {
         ids.extend(series.values().map(|address| address.page_slab_id));
     }
-    ids.extend(
-        shard
-            .context_embeddings
-            .values()
-            .map(|address| address.page_slab_id),
-    );
+    for series in shard.context_embeddings.values() {
+        ids.extend(series.values().map(|address| address.page_slab_id));
+    }
     for series in shard.context_summaries.values() {
         ids.extend(series.values().map(|address| address.page_slab_id));
     }
@@ -2673,9 +2667,9 @@ fn object_manager_stats(
             + shard.context_events.len()
             + shard.context_indexes.len()
             + shard.context_audits.len()
-            + shard.context_entities.len()
+            + shard.context_entities.values().map(BTreeMap::len).sum::<usize>()
             + shard.context_children.len()
-            + shard.context_embeddings.len()
+            + shard.context_embeddings.values().map(BTreeMap::len).sum::<usize>()
             + shard.context_summaries.len()
             + shard.context_compressions.len();
         let object_count = bucket_object_count.max(secondary_object_count);
@@ -2700,13 +2694,13 @@ fn object_manager_stats(
                 .values()
                 .map(BTreeMap::len)
                 .sum::<usize>()
-            + shard.context_entities.len()
+            + shard.context_entities.values().map(BTreeMap::len).sum::<usize>()
             + shard
                 .context_children
                 .values()
                 .map(BTreeMap::len)
                 .sum::<usize>()
-            + shard.context_embeddings.len()
+            + shard.context_embeddings.values().map(BTreeMap::len).sum::<usize>()
             + shard
                 .context_summaries
                 .values()
@@ -2759,9 +2753,9 @@ fn object_manager_stats(
         + shard.context_events.len()
         + shard.context_indexes.len()
         + shard.context_audits.len()
-        + shard.context_entities.len()
+        + shard.context_entities.values().map(BTreeMap::len).sum::<usize>()
         + shard.context_children.len()
-        + shard.context_embeddings.len()
+        + shard.context_embeddings.values().map(BTreeMap::len).sum::<usize>()
         + shard.context_summaries.len()
         + shard.context_compressions.len();
     let page_ref_count = shard.strings.len()
@@ -2784,13 +2778,13 @@ fn object_manager_stats(
             .values()
             .map(BTreeMap::len)
             .sum::<usize>()
-        + shard.context_entities.len()
+        + shard.context_entities.values().map(BTreeMap::len).sum::<usize>()
         + shard
             .context_children
             .values()
             .map(BTreeMap::len)
             .sum::<usize>()
-        + shard.context_embeddings.len()
+        + shard.context_embeddings.values().map(BTreeMap::len).sum::<usize>()
         + shard
             .context_summaries
             .values()

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -87,9 +87,25 @@ pub(super) fn model_compaction_policy_reports(
             "control_state"
         } else if shard.context_nodes.contains_key(key) {
             "context_node"
-        } else if shard.context_entities.contains_key(key) {
+        } else if split_context_entity_key(key)
+            .map(|(collection_key, entity_hash)| {
+                shard
+                    .context_entities
+                    .get(&collection_key)
+                    .is_some_and(|series| series.contains_key(&entity_hash))
+            })
+            .unwrap_or(false)
+        {
             "context_entity"
-        } else if shard.context_embeddings.contains_key(key) {
+        } else if split_context_embedding_key(key)
+            .map(|(collection_key, ref_hash)| {
+                shard
+                    .context_embeddings
+                    .get(&collection_key)
+                    .is_some_and(|series| series.contains_key(&ref_hash))
+            })
+            .unwrap_or(false)
+        {
             "context_embedding"
         } else {
             "string"
@@ -332,8 +348,11 @@ pub(super) fn compaction_model_layout_reports(
     ));
     reports.push(compaction_layout_from_addresses(
         "context_entity",
-        shard.context_entities.len(),
-        shard.context_entities.values().cloned(),
+        shard.context_entities.values().map(BTreeMap::len).sum(),
+        shard
+            .context_entities
+            .values()
+            .flat_map(|series| series.values().cloned()),
         &slab_page_counts,
         None,
     ));
@@ -344,8 +363,11 @@ pub(super) fn compaction_model_layout_reports(
     ));
     reports.push(compaction_layout_from_addresses(
         "context_embedding",
-        shard.context_embeddings.len(),
-        shard.context_embeddings.values().cloned(),
+        shard.context_embeddings.values().map(BTreeMap::len).sum(),
+        shard
+            .context_embeddings
+            .values()
+            .flat_map(|series| series.values().cloned()),
         &slab_page_counts,
         None,
     ));

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -266,6 +266,37 @@ pub(super) fn context_timeline_key(timestamp_ms: u64, disambiguator: u64) -> u64
         .saturating_add(disambiguator % CONTEXT_TIMELINE_FANOUT)
 }
 
+/// Events of one node within a time window, oldest first, as (timeline_key, address).
+///
+/// The primary event map is keyed by event id hash so update and delete can address a single
+/// event in log n. Hash order is effectively random, so a time window is not a contiguous range
+/// there; it is a contiguous range in `context_event_timeline`, which maps timeline_key ->
+/// event id. This ranges over that index and dereferences each hit into the primary map, so a
+/// time-windowed read stays log n + k instead of scanning the node's entire series.
+///
+/// Returns a DoubleEndedIterator because every caller reads newest-first (`.rev()`): retrieval
+/// wants recent, serving-relevant context before cold history.
+pub(super) fn context_event_time_range<'a>(
+    shard: &'a super::state::ShardState,
+    object_key: &str,
+    start_time_ms: u64,
+    end_time_ms: u64,
+) -> impl DoubleEndedIterator<Item = (u64, &'a BlockAddress)> + 'a {
+    let series = shard.context_events.get(object_key);
+    let start = context_timeline_start(start_time_ms);
+    let end = context_timeline_end(end_time_ms);
+    shard
+        .context_event_timeline
+        .get(object_key)
+        .into_iter()
+        .flat_map(move |timeline| timeline.range(start..end))
+        .filter_map(move |(timeline_key, event_id_hash)| {
+            series
+                .and_then(|series| series.get(event_id_hash))
+                .map(|address| (*timeline_key, address))
+        })
+}
+
 pub(super) fn context_timeline_start(timestamp_ms: u64) -> u64 {
     timestamp_ms.saturating_mul(CONTEXT_TIMELINE_FANOUT)
 }

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -964,13 +964,26 @@ pub(super) fn traverse_context_tree(
             children.sort_by_key(|child_ref| (child_ref.updated_at_ms, child_ref.child_hash));
             children.truncate(child_limit);
             for child in children {
+                // Address the embedding the way WRITERS store it. This passed the child's raw
+                // node hash, but every writer stores under
+                // context_embedding_ref_hash(tenant, owner, level) -- a hash of those three --
+                // which can never equal a bare node hash. So the lookup missed for every child,
+                // `continue` fired every iteration, and the cosine scoring below was
+                // unreachable. The test did not catch it because it wrote its embedding under
+                // the raw node hash too, constructing the data the way this READER expected
+                // rather than the way writers actually write it.
+                let ref_hash = crate::context_workflow::context_embedding_ref_hash(
+                    tenant_hash,
+                    child.child_hash,
+                    "node_l0",
+                );
                 let Some(embedding) = load_context_embedding(
                     cache,
                     page_store,
                     shard_id,
                     shard,
                     tenant_hash,
-                    child.child_hash,
+                    ref_hash,
                 ) else {
                     continue;
                 };

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -75,12 +75,56 @@ pub(super) fn context_entity_key(tenant_hash: u64, node_hash: u64, entity_hash: 
     format!("ctx:entity:{tenant_hash}:{node_hash}:{entity_hash}")
 }
 
+/// Split a persisted per-entity key back into (collection key, entity hash).
+///
+/// The index stores entities grouped by node, but the PERSISTED page entry still carries the
+/// per-entity key `ctx:entity:{tenant}:{node}:{entity_hash}` -- that is what keeps the on-disk
+/// shape identical across this fold in both directions. Load calls this to rebuild the grouping.
+/// Returns None for a key that does not carry a numeric entity hash, so a malformed or
+/// foreign-shaped entry is skipped rather than folded under a wrong node.
+pub(super) fn split_context_entity_key(object_key: &str) -> Option<(String, u64)> {
+    let (collection_key, entity_hash) = object_key.rsplit_once(':')?;
+    if !collection_key.starts_with("ctx:entity:") {
+        return None;
+    }
+    // The collection key itself ends in the node hash, so it must still hold four segments
+    // (ctx, entity, tenant, node) once the entity hash is removed -- otherwise this key WAS a
+    // collection key and splitting it would silently reinterpret the node hash as an entity.
+    if collection_key.split(':').count() != 4 {
+        return None;
+    }
+    Some((collection_key.to_string(), entity_hash.parse::<u64>().ok()?))
+}
+
 pub(super) fn context_entity_collection_key(tenant_hash: u64, node_hash: u64) -> String {
     format!("ctx:entity:{tenant_hash}:{node_hash}")
 }
 
 pub(super) fn context_child_key(tenant_hash: u64, parent_hash: u64) -> String {
     format!("ctx:child:{tenant_hash}:{parent_hash}")
+}
+
+pub(super) fn context_embedding_collection_key(tenant_hash: u64) -> String {
+    format!("ctx:embedding:{tenant_hash}")
+}
+
+/// Split a persisted per-embedding key into (collection key, ref hash).
+///
+/// Mirrors `split_context_entity_key`: the index groups embeddings, but the persisted entry keeps
+/// the per-embedding key `ctx:embedding:{tenant}:{ref_hash}`, which is what keeps the on-disk
+/// shape identical in both directions across this fold.
+pub(super) fn split_context_embedding_key(object_key: &str) -> Option<(String, u64)> {
+    let (collection_key, ref_hash) = object_key.rsplit_once(':')?;
+    if !collection_key.starts_with("ctx:embedding:") {
+        return None;
+    }
+    // ctx, embedding, tenant -- three segments once the ref hash is removed. A key that already
+    // IS a collection key has only two and must not be split, or the tenant hash would be
+    // reinterpreted as a ref.
+    if collection_key.split(':').count() != 3 {
+        return None;
+    }
+    Some((collection_key.to_string(), ref_hash.parse::<u64>().ok()?))
 }
 
 pub(super) fn context_embedding_key(tenant_hash: u64, ref_hash: u64) -> String {
@@ -727,7 +771,8 @@ pub(super) fn load_context_embedding(
 ) -> Option<ContextEmbedding> {
     shard
         .context_embeddings
-        .get(&context_embedding_key(tenant_hash, ref_hash))
+        .get(&context_embedding_collection_key(tenant_hash))
+        .and_then(|series| series.get(&ref_hash))
         .and_then(|address| {
             read_page_bytes(cache, page_store, shard_id, address)
                 .and_then(|bytes| context_from_bytes::<ContextEmbedding>(&bytes))

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1580,11 +1580,17 @@ pub(crate) fn execute_on_shard(
             // context_models_match_keys_timeline_pages_and_filters keeps this
             // key shape aligned with the context event timeline contract.
             let timeline_key = context_timeline_key(event.primary_time_ms(), event.event_id_hash);
+            let event_id_hash = event.event_id_hash;
             let series = shard.context_events.entry(object_key.clone()).or_default();
-            if !(first_write_only && series.contains_key(&timeline_key)) {
+            // Idempotence now tests the EVENT ID, which is what first_write_only actually means:
+            // the same event written twice. Testing the timeline key made two different events
+            // that collided in the low FANOUT bits of one millisecond look like a rewrite.
+            if !(first_write_only && series.contains_key(&event_id_hash)) {
                 let value = context_bytes(&event);
                 let routing_bucket =
                     page_routing_bucket(&object_key, start_routing_bucket, end_routing_bucket);
+                // The PAGE stays timestamp-keyed: pages pack by time, and the load path recovers
+                // the timeline key from the packed point. Only the index key changes.
                 if let Ok(addresses) = append_timestamped_kv_pages(
                     cache,
                     page_store,
@@ -1598,8 +1604,13 @@ pub(crate) fn execute_on_shard(
                     routing_bucket,
                     async_storage && !cold_storage,
                 ) {
-                    for (timestamp_ms, address) in addresses {
-                        series.insert(timestamp_ms, address);
+                    for (stored_timeline_key, address) in addresses {
+                        series.insert(event_id_hash, address);
+                        shard
+                            .context_event_timeline
+                            .entry(object_key.clone())
+                            .or_default()
+                            .insert(stored_timeline_key, event_id_hash);
                         mutated = true;
                     }
                 }
@@ -1760,13 +1771,11 @@ pub(crate) fn execute_on_shard(
             let events = shard
                 .context_events
                 .get(&object_key)
-                .map(|series| {
+                .map(|_series| {
                     let mut page_cache = HashMap::new();
-                    series
-                        .range(
-                            context_timeline_start(start_time_ms)
-                                ..context_timeline_end(end_time_ms),
-                        )
+                    // Range the TIME INDEX, not the primary map: the primary is keyed by event
+                    // id hash now, so a time window is not contiguous in it.
+                    context_event_time_range(shard, &object_key, start_time_ms, end_time_ms)
                         .rev()
                         // Bound the SCAN (kMaxLimit), NOT the result: the caller's
                         // `limit` must be applied AFTER filtering (LimitOrDefault runs
@@ -1778,7 +1787,7 @@ pub(crate) fn execute_on_shard(
                                 cache,
                                 page_store,
                                 shard_id,
-                                *timeline_key,
+                                timeline_key,
                                 address,
                                 &mut page_cache,
                             )
@@ -2535,16 +2544,17 @@ pub(crate) fn execute_on_shard(
             let mut selected = shard
                 .context_events
                 .get(&context_event_key(tenant_hash, node_hash))
-                .map(|series| {
-                    series
-                        .range(
-                            context_timeline_start(source_start_ms)
-                                ..context_timeline_end(source_end_ms),
-                        )
+                .map(|_series| {
+                    context_event_time_range(
+                        shard,
+                        &context_event_key(tenant_hash, node_hash),
+                        source_start_ms,
+                        source_end_ms,
+                    )
                         .filter_map(|(timeline_key, address)| {
                             read_context_value_cold::<ContextEvent>(
                                 page_store,
-                                *timeline_key,
+                                timeline_key,
                                 address,
                             )
                         })

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -2166,7 +2166,13 @@ pub(crate) fn execute_on_shard(
             tenant_hash,
             entity,
         } => {
+            // The PAGE is still addressed per entity -- the object id must stay unique per
+            // entity or two entities of one node would overwrite each other's bytes. Only the
+            // INDEX changes shape: the node's collection key owns a BTreeMap keyed by entity
+            // hash, so the entity's own key no longer occupies a map slot of its own.
             let object_key = context_entity_key(tenant_hash, entity.node_hash, entity.entity_hash);
+            let collection_key = context_entity_collection_key(tenant_hash, entity.node_hash);
+            let collection_key_for_response = collection_key.clone();
             let object_id = stable_page_object_id(shard_id, "context_entity", &object_key, None);
             let routing_bucket =
                 page_routing_bucket(&object_key, start_routing_bucket, end_routing_bucket);
@@ -2180,22 +2186,37 @@ pub(crate) fn execute_on_shard(
                 Some(routing_bucket),
                 async_storage,
             ) {
-                shard.context_entities.insert(object_key.clone(), address);
+                // insert() on the entity hash OVERWRITES: an entity has one current value, and
+                // its history is the separate context_entity_update_audit series. Keying this
+                // map by time instead would silently turn every upsert into an append.
+                shard
+                    .context_entities
+                    .entry(collection_key)
+                    .or_default()
+                    .insert(entity.entity_hash, address);
                 mutated = true;
             }
             invalidate_record_all(cache, shard_id, &object_key);
-            CommandResponse::ContextObjectKey { object_key }
+            invalidate_record_all(cache, shard_id, &collection_key_for_response);
+            CommandResponse::ContextObjectKey {
+                object_key: collection_key_for_response,
+            }
         }
         Command::ContextGetEntity {
             tenant_hash,
             node_hash,
             entity_hash,
         } => {
-            let object_key = context_entity_key(tenant_hash, node_hash, entity_hash);
-            let entity = shard.context_entities.get(&object_key).and_then(|address| {
-                read_page_bytes(cache, page_store, shard_id, address)
-                    .and_then(|bytes| context_from_bytes::<ContextEntity>(&bytes))
-            });
+            let collection_key = context_entity_collection_key(tenant_hash, node_hash);
+            let object_key = collection_key.clone();
+            let entity = shard
+                .context_entities
+                .get(&collection_key)
+                .and_then(|series| series.get(&entity_hash))
+                .and_then(|address| {
+                    read_page_bytes(cache, page_store, shard_id, address)
+                        .and_then(|bytes| context_from_bytes::<ContextEntity>(&bytes))
+                });
             CommandResponse::ContextEntity { object_key, entity }
         }
         Command::ContextQueryEntities {
@@ -2205,17 +2226,29 @@ pub(crate) fn execute_on_shard(
             limit,
         } => {
             let object_key = context_entity_collection_key(tenant_hash, node_hash);
-            let entities = dedupe_nonzero_u64_preserve_order(entity_hashes)
-                .into_iter()
-                .take(context_limit(limit))
-                .filter_map(|entity_hash| {
-                    let entity_key = context_entity_key(tenant_hash, node_hash, entity_hash);
-                    shard.context_entities.get(&entity_key).and_then(|address| {
-                        read_page_bytes(cache, page_store, shard_id, address)
-                            .and_then(|bytes| context_from_bytes::<ContextEntity>(&bytes))
-                    })
-                })
-                .collect();
+            let series = shard.context_entities.get(&object_key);
+            let read_entity = |address: &BlockAddress| {
+                read_page_bytes(cache, page_store, shard_id, address)
+                    .and_then(|bytes| context_from_bytes::<ContextEntity>(&bytes))
+            };
+            // An empty entity_hashes now means "every entity of this node" instead of "nothing".
+            // Before the fold the caller had to already know each hash, because the entities of
+            // one node were separate HashMap keys and a HashMap cannot be prefix-scanned -- so a
+            // node's entity set could not be discovered from the engine at all. Passing explicit
+            // hashes still selects exactly those, so existing callers are unaffected.
+            let entities = match (series, entity_hashes.is_empty()) {
+                (None, _) => Vec::new(),
+                (Some(series), true) => series
+                    .values()
+                    .take(context_limit(limit))
+                    .filter_map(read_entity)
+                    .collect(),
+                (Some(series), false) => dedupe_nonzero_u64_preserve_order(entity_hashes)
+                    .into_iter()
+                    .take(context_limit(limit))
+                    .filter_map(|entity_hash| series.get(&entity_hash).and_then(read_entity))
+                    .collect(),
+            };
             CommandResponse::ContextEntities {
                 object_key,
                 entities,
@@ -2284,7 +2317,10 @@ pub(crate) fn execute_on_shard(
             tenant_hash,
             embedding,
         } => {
+            // Per-embedding key for the PAGE (two embeddings must not share a page) and for the
+            // persisted entry; collection key for the index slot and the reported object key.
             let object_key = context_embedding_key(tenant_hash, embedding.ref_hash);
+            let collection_key = context_embedding_collection_key(tenant_hash);
             let object_id = stable_page_object_id(shard_id, "context_embedding", &object_key, None);
             let routing_bucket =
                 page_routing_bucket(&object_key, start_routing_bucket, end_routing_bucket);
@@ -2297,31 +2333,44 @@ pub(crate) fn execute_on_shard(
                 Some(routing_bucket),
                 async_storage,
             ) {
-                shard.context_embeddings.insert(object_key.clone(), address);
+                // insert() on the ref hash OVERWRITES: re-embedding a node replaces its vector
+                // rather than accumulating one entry per update.
+                shard
+                    .context_embeddings
+                    .entry(collection_key.clone())
+                    .or_default()
+                    .insert(embedding.ref_hash, address);
                 mutated = true;
             }
             invalidate_record_all(cache, shard_id, &object_key);
-            CommandResponse::ContextObjectKey { object_key }
+            invalidate_record_all(cache, shard_id, &collection_key);
+            CommandResponse::ContextObjectKey {
+                object_key: collection_key,
+            }
         }
         Command::ContextQueryEmbeddings {
             tenant_hash,
             ref_hashes,
             limit,
         } => {
-            let embeddings = dedupe_nonzero_u64_preserve_order(ref_hashes)
-                .into_iter()
-                .take(context_limit(limit))
-                .filter_map(|ref_hash| {
-                    let object_key = context_embedding_key(tenant_hash, ref_hash);
-                    shard
-                        .context_embeddings
-                        .get(&object_key)
-                        .and_then(|address| {
+            // One map lookup for the tenant's series, then a log-n hit per requested ref --
+            // instead of formatting and hashing a full per-embedding key string per ref.
+            let series = shard
+                .context_embeddings
+                .get(&context_embedding_collection_key(tenant_hash));
+            let embeddings = match series {
+                None => Vec::new(),
+                Some(series) => dedupe_nonzero_u64_preserve_order(ref_hashes)
+                    .into_iter()
+                    .take(context_limit(limit))
+                    .filter_map(|ref_hash| {
+                        series.get(&ref_hash).and_then(|address| {
                             read_page_bytes(cache, page_store, shard_id, address)
                                 .and_then(|bytes| context_from_bytes::<ContextEmbedding>(&bytes))
                         })
-                })
-                .collect();
+                    })
+                    .collect(),
+            };
             CommandResponse::ContextEmbeddings { embeddings }
         }
         Command::ContextTraverseTree {

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -497,7 +497,10 @@ impl TemporalEngine {
             &self.cache,
             shard_id,
             "context_embedding",
-            shard.context_embeddings.values_mut(),
+            shard
+                .context_embeddings
+                .values_mut()
+                .flat_map(|series| series.values_mut()),
             &mut rewrite_stats,
         )?;
         for series in shard.context_summaries.values_mut() {
@@ -525,7 +528,10 @@ impl TemporalEngine {
             &self.cache,
             shard_id,
             "context_entity",
-            shard.context_entities.values_mut(),
+            shard
+                .context_entities
+                .values_mut()
+                .flat_map(|series| series.values_mut()),
             &mut rewrite_stats,
         )?;
             Ok(())

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -95,8 +95,23 @@ pub(super) struct ShardState {
     pub(super) feature_rollups: HashMap<String, RollupEntry>,
     #[serde(default)]
     pub(super) context_nodes: HashMap<String, BlockAddress>,
+    // Keyed by EVENT ID HASH, aligning events with entities/embeddings so update and delete
+    // address one event directly in log n instead of scanning the node's whole series (mem0
+    // delete carries the event id, not the time, so it previously had no way to locate one).
     #[serde(default)]
     pub(super) context_events: HashMap<String, BTreeMap<u64, BlockAddress>>,
+    // Time index over the same events: timeline_key -> event_id_hash, where timeline_key stays
+    // timestamp_ms * CONTEXT_TIMELINE_FANOUT + (id % FANOUT). The primary map above is ordered
+    // by hash, which is effectively random, so a time window is no longer a contiguous range in
+    // it -- and 13 sites scan events by time window (context_timeline_start/end). Those range
+    // over this index and dereference into the primary, keeping time reads at log n + k rather
+    // than degrading them to a full series scan to make deletes cheaper.
+    //
+    // Rebuilt at load from the same page decode the event load path already performs, so it
+    // costs no extra on-disk state; it is serialized with the index like the primary because
+    // ShardState is snapshotted whole.
+    #[serde(default)]
+    pub(super) context_event_timeline: HashMap<String, BTreeMap<u64, u64>>,
     #[serde(default)]
     pub(super) context_indexes: HashMap<String, BTreeMap<u64, BlockAddress>>,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -125,12 +125,30 @@ pub(super) struct ShardState {
     // the oldest pending window idempotently (stable compression id per window).
     #[serde(skip)]
     pub(super) context_compression_watermark: HashMap<String, u64>,
+    // Entities are grouped by their OWNING NODE, not one map key per entity: the key is
+    // `ctx:entity:{tenant}:{node}` (context_entity_collection_key) and the BTreeMap holds every
+    // entity of that node. The inner u64 is the ENTITY HASH, not a timestamp -- unlike
+    // context_events/indexes/audits, which are time-keyed. That keeps upsert as an overwrite of
+    // one slot (an entity has one current value; its history is the separate
+    // context_entity_update_audit series) while making a node's entities enumerable, which the
+    // per-entity key shape could not do: a HashMap cannot prefix-scan, so ContextQueryEntities
+    // had to be handed every entity_hash by its caller.
     #[serde(default)]
-    pub(super) context_entities: HashMap<String, BlockAddress>,
+    pub(super) context_entities: HashMap<String, BTreeMap<u64, BlockAddress>>,
+    // No migration field is needed: the PERSISTED entry still carries the per-entity key
+    // `ctx:entity:{tenant}:{node}:{entity_hash}`, which the load path splits back into
+    // (collection key, entity hash). The on-disk shape is unchanged in both directions, so an
+    // index written before this fold loads natively and one written after it stays readable by
+    // an older binary.
     #[serde(default)]
     pub(super) context_children: HashMap<String, BTreeMap<u64, BlockAddress>>,
+    // Grouped like context_entities, but by TENANT rather than node: a ContextEmbedding carries
+    // only ref_hash (itself hash(tenant, node, label)), so the node it belongs to cannot be
+    // recovered from the record and cannot be the group key without a schema change. The inner
+    // u64 is the ref hash, so upsert overwrites one slot -- an embedding has one current vector.
+    // Key: `ctx:embedding:{tenant}` (context_embedding_collection_key).
     #[serde(default)]
-    pub(super) context_embeddings: HashMap<String, BlockAddress>,
+    pub(super) context_embeddings: HashMap<String, BTreeMap<u64, BlockAddress>>,
     #[serde(default)]
     pub(super) context_summaries: HashMap<String, BTreeMap<u64, BlockAddress>>,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1613,6 +1613,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut control_state = HashMap::<String, BTreeMap<u64, i64>>::new();
     let mut control_state_pages = HashMap::new();
     let mut context_events = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
+    let mut context_event_timeline = HashMap::<String, BTreeMap<u64, u64>>::new();
     let mut context_indexes = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_audits = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_entities = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
@@ -1688,11 +1689,12 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
             }
             "context_event" => {
                 saw_context_events = true;
-                insert_timestamped_secondary_view(
+                insert_context_event_views(
                     page_store,
                     warm_shard,
                     &mut warm_batch,
                     &mut context_events,
+                    &mut context_event_timeline,
                     entry.object_key,
                     entry.address,
                 );
@@ -1811,6 +1813,19 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     if saw_context_events {
         let persisted = std::mem::take(&mut shard.context_events);
         shard.context_events = reconcile_timestamped_series_membership(&persisted, context_events);
+        // The time index is derived state: rebuild it wholesale from what the pages actually
+        // carried rather than reconciling it, so it can never reference an event id that
+        // membership reconciliation just dropped from the primary map.
+        shard.context_event_timeline = context_event_timeline;
+        shard.context_event_timeline.retain(|object_key, index| {
+            match shard.context_events.get(object_key) {
+                None => false,
+                Some(series) => {
+                    index.retain(|_, event_id_hash| series.contains_key(event_id_hash));
+                    !index.is_empty()
+                }
+            }
+        });
     }
     if saw_context_indexes {
         let persisted = std::mem::take(&mut shard.context_indexes);
@@ -1902,6 +1917,64 @@ pub(super) fn insert_timestamped_secondary_view(
         // one for a shared timestamp, and the value silently reverted to the old page's bytes on
         // reload. Keep the NEWEST page (highest address generation) per timestamp.
         match series.entry(timestamp_ms) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(address.clone());
+            }
+            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                if address.generation.unwrap_or(0) >= slot.get().generation.unwrap_or(0) {
+                    slot.insert(address.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Rebuild the event primary map AND its time index from a physical page.
+///
+/// Events are keyed by event id hash, which -- unlike a timestamp -- is not recoverable from the
+/// packed point header. It lives inside the encoded ContextEvent, so this decodes each point's
+/// value rather than reading only its timestamp. The alternative, keying recovered events by
+/// timeline key, would rebuild a map the read path can no longer address and silently strand
+/// every event after a page-recovery load.
+///
+/// Newest-page-wins is preserved for the same reason it exists in the timestamped view: one
+/// logical record can physically live in several pages, and reconstruction visits pages in
+/// slab/offset order, not write order.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn insert_context_event_views(
+    page_store: &LocalBlockStore,
+    warm_shard: Option<ShardId>,
+    warm_batch: &mut Vec<(CacheKey, Vec<u8>)>,
+    events: &mut HashMap<String, BTreeMap<u64, BlockAddress>>,
+    timeline: &mut HashMap<String, BTreeMap<u64, u64>>,
+    object_key: String,
+    address: BlockAddress,
+) {
+    let bytes = page_store.read(&address).ok();
+    if let (Some(shard_id), Some(bytes)) = (warm_shard, bytes.as_ref()) {
+        let key = CacheKey::page_with_slot(
+            shard_id,
+            address.page_slab_id,
+            address.offset,
+            address.length,
+            address.routing_bucket,
+        );
+        warm_batch.push((key, bytes.clone()));
+    }
+    let points = bytes
+        .and_then(|bytes| match decode_feature_page_strict(&bytes) {
+            PackedFeaturePageDecode::Packed(points) => Some(points),
+            PackedFeaturePageDecode::Legacy | PackedFeaturePageDecode::Corrupt(_) => None,
+        })
+        .unwrap_or_default();
+    let series = events.entry(object_key.clone()).or_default();
+    let index = timeline.entry(object_key).or_default();
+    for point in points {
+        let Some(event) = super::context::context_from_bytes::<ContextEvent>(&point.value) else {
+            continue;
+        };
+        index.insert(point.timestamp_ms, event.event_id_hash);
+        match series.entry(event.event_id_hash) {
             std::collections::btree_map::Entry::Vacant(slot) => {
                 slot.insert(address.clone());
             }

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1011,9 +1011,20 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
                 .map(|address| live_page_entry(key.clone(), "context_audit", None, address)),
         );
     }
-    entries.extend(shard.context_entities.iter().map(|(key, address)| {
-        live_page_entry(key.clone(), "context_entity", None, address.clone())
-    }));
+    // Entities live grouped by node in memory but persist one entry per entity, under the same
+    // `ctx:entity:{tenant}:{node}:{entity_hash}` key as before the fold -- the collection key
+    // plus the BTree key reproduce it exactly. Keeping the on-disk key per entity is what makes
+    // this change format-compatible in both directions.
+    for (collection_key, series) in &shard.context_entities {
+        entries.extend(series.iter().map(|(entity_hash, address)| {
+            live_page_entry(
+                format!("{collection_key}:{entity_hash}"),
+                "context_entity",
+                None,
+                address.clone(),
+            )
+        }));
+    }
     for (key, series) in &shard.context_children {
         entries.extend(
             unique_timestamped_kv_page_addresses(series)
@@ -1021,9 +1032,18 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
                 .map(|address| live_page_entry(key.clone(), "context_child", None, address)),
         );
     }
-    entries.extend(shard.context_embeddings.iter().map(|(key, address)| {
-        live_page_entry(key.clone(), "context_embedding", None, address.clone())
-    }));
+    // Persist one entry per embedding under the pre-fold key `ctx:embedding:{tenant}:{ref}`,
+    // rebuilt from the collection key plus the BTree key, so the on-disk shape is unchanged.
+    for (collection_key, series) in &shard.context_embeddings {
+        entries.extend(series.iter().map(|(ref_hash, address)| {
+            live_page_entry(
+                format!("{collection_key}:{ref_hash}"),
+                "context_embedding",
+                None,
+                address.clone(),
+            )
+        }));
+    }
     for (key, series) in &shard.context_summaries {
         entries.extend(
             unique_timestamped_kv_page_addresses(series)
@@ -1595,9 +1615,9 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut context_events = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_indexes = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_audits = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
-    let mut context_entities = HashMap::new();
+    let mut context_entities = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_children = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
-    let mut context_embeddings = HashMap::new();
+    let mut context_embeddings = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_summaries = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut context_compressions = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
 
@@ -1701,7 +1721,14 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
             }
             "context_entity" => {
                 saw_context_entities = true;
-                context_entities.insert(entry.object_key, entry.address);
+                if let Some((collection_key, entity_hash)) =
+                    split_context_entity_key(&entry.object_key)
+                {
+                    context_entities
+                        .entry(collection_key)
+                        .or_insert_with(BTreeMap::new)
+                        .insert(entity_hash, entry.address);
+                }
             }
             "context_child" => {
                 saw_context_children = true;
@@ -1716,7 +1743,14 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
             }
             "context_embedding" => {
                 saw_context_embeddings = true;
-                context_embeddings.insert(entry.object_key, entry.address);
+                if let Some((collection_key, ref_hash)) =
+                    split_context_embedding_key(&entry.object_key)
+                {
+                    context_embeddings
+                        .entry(collection_key)
+                        .or_insert_with(BTreeMap::new)
+                        .insert(ref_hash, entry.address);
+                }
             }
             "context_summary" => {
                 saw_context_summaries = true;

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -144,6 +144,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         valid_from_ms: 1_000,
         confidence: 0.97,
         source_event_hashes: vec![5],
+        vector: Vec::new(),
     };
     let entity_upsert = engine.execute(ExecuteRequest {
         shard_id: 1,
@@ -207,6 +208,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         source_ref: "src://a".to_string(),
         related_node_hashes: vec![42],
         compact_attrs: vec![1, 2, 3],
+        vector: Vec::new(),
     };
     let mut event_b = event_a.clone();
     event_b.event_id_hash = 6;
@@ -327,6 +329,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         source_ref: "cursor://701".to_string(),
         related_node_hashes: vec![42],
         compact_attrs: Vec::new(),
+        vector: Vec::new(),
     };
     let extracted = engine.execute(ExecuteRequest {
         shard_id: 1,
@@ -409,6 +412,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
                 source_ref: "cursor://701".to_string(),
                 related_node_hashes: vec![43],
                 compact_attrs: Vec::new(),
+                vector: Vec::new(),
             },
             indexes: ContextExtractedEventIndexes {
                 scope_hash: 3001,
@@ -558,6 +562,7 @@ fn context_query_events_applies_limit_after_filter_like_native() {
         source_ref: "s".to_string(),
         related_node_hashes: vec![42],
         compact_attrs: vec![],
+        vector: Vec::new(),
     };
     // 100 low-confidence events at earlier timestamps, then 5 high-confidence ones later.
     for i in 0..100u64 {
@@ -773,6 +778,7 @@ fn context_tree_embedding_summary_and_compression_match_round_trip() {
                     level: 1,
                     text: text.to_string(),
                     valid_from_ms,
+                    vector: Vec::new(),
                 },
             },
         });
@@ -893,6 +899,7 @@ fn context_temporal_compression_builds_replayable_summary_without_deleting_sourc
                     source_ref: String::new(),
                     related_node_hashes: Vec::new(),
                     compact_attrs: Vec::new(),
+                    vector: Vec::new(),
                 },
                 first_write_only: false,
                 cold_storage: false,
@@ -988,6 +995,7 @@ fn context_temporal_compression_and_raw_backfill_use_cold_storage_without_cache_
                     source_ref: "backfill://raw-query".to_string(),
                     related_node_hashes: Vec::new(),
                     compact_attrs: Vec::new(),
+                    vector: Vec::new(),
                 },
                 first_write_only: false,
                 cold_storage: true,
@@ -1334,6 +1342,7 @@ fn page_compaction_reports_model_layouts_tombstones_object_pages_and_density() {
                 source_ref: String::new(),
                 related_node_hashes: Vec::new(),
                 compact_attrs: Vec::new(),
+                vector: Vec::new(),
             },
             first_write_only: false,
             cold_storage: false,
@@ -1355,6 +1364,7 @@ fn page_compaction_reports_model_layouts_tombstones_object_pages_and_density() {
                 level: 1,
                 text: "compact summary".to_string(),
                 valid_from_ms: 52,
+                vector: Vec::new(),
             },
         },
         Command::CommonDelete {

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -153,10 +153,17 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         },
     });
     assert!(entity_upsert.status.ok);
+    // The collection key, matching the event contract asserted below ("ctx:event:11:42").
+    // Entities are grouped by node in shard state now, so the object key a command reports has
+    // to be the key that state is stored under -- every key-driven mechanism in engine.rs
+    // (key-state capture/apply, tombstone removal, membership) looks it up directly. The
+    // per-entity key "ctx:entity:11:42:7001" still exists where it must: as the page object id,
+    // so two entities of one node cannot share a page, and as the persisted entry key, which is
+    // what keeps the on-disk format identical across this change.
     assert!(matches!(
         entity_upsert.response,
         CommandResponse::ContextObjectKey { ref object_key }
-            if object_key == "ctx:entity:11:42:7001"
+            if object_key == "ctx:entity:11:42"
     ));
     let entity_get = engine.execute(ExecuteRequest {
         shard_id: 1,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -730,7 +730,15 @@ fn context_tree_embedding_summary_and_compression_match_round_trip() {
             if refs.len() == 2 && refs[0].child_hash == GPU
     ));
 
-    for (ref_hash, first, second) in [(GPU, 1.0, 0.0), (COST, 0.0, 1.0)] {
+    // Store these the way PRODUCTION writers do -- under
+    // context_embedding_ref_hash(tenant, node, level), not under the raw node hash. Writing
+    // them under the node hash is what let the traversal reader's addressing bug pass here for
+    // as long as it did: the test built the data to match the reader instead of the writer, so
+    // reader and writer could disagree indefinitely without any test noticing.
+    for (node_hash, first, second) in [(GPU, 1.0, 0.0), (COST, 0.0, 1.0)] {
+        let ref_hash = crate::context_workflow::context_embedding_ref_hash(
+            TENANT, node_hash, "node_l0",
+        );
         let response = engine.execute(ExecuteRequest {
             shard_id: 1,
             command: Command::ContextUpsertEmbedding {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -456,6 +456,7 @@ fn recovery_validates_all_timestamped_kv_page_families() {
                         source_ref: "local://test".to_string(),
                         related_node_hashes: vec![55],
                         compact_attrs: vec![1, 2, 3],
+                        vector: Vec::new(),
                     },
                     first_write_only: false,
                     cold_storage: false,

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -284,6 +284,20 @@ pub struct ContextEvent {
     // Deprecated hot-schema field: use ContextCompressionEvent/debug sidecars instead.
     #[serde(default, skip_serializing)]
     pub compact_attrs: Vec<u8>,
+    // Inline embedding vector, folded from the separate ContextEmbedding record.
+    //
+    // Every embedding is 1:1 with its owner -- measured on one ingest: event_text 6 to 6 events,
+    // entity_state + profile_entity_state 6 to 6 entities, session_l0 + batch_l0 2 to 2
+    // summaries -- so a separate record per vector costs a key, a BlockAddress and a page to
+    // store something with exactly one owner. Retrieval fetches the vector to score a candidate
+    // and then the text to pack it; inline, that is ONE read, and the text is ~50 bytes against
+    // ~1536 for the vector, about 3% of a fetch already paid for.
+    //
+    // Default-empty and skipped when empty: a record written before the fold decodes with no
+    // vector and readers fall back to the ContextEmbedding record, so this can be populated
+    // before any reader migrates off ref_hash addressing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vector: Vec<f32>,
 }
 
 impl ContextEvent {
@@ -401,6 +415,20 @@ pub struct ContextEntity {
     pub confidence: f32,
     #[serde(default)]
     pub source_event_hashes: Vec<u64>,
+    // Inline embedding vector, folded from the separate ContextEmbedding record.
+    //
+    // Every embedding is 1:1 with its owner -- measured on one ingest: event_text 6 to 6 events,
+    // entity_state + profile_entity_state 6 to 6 entities, session_l0 + batch_l0 2 to 2
+    // summaries -- so a separate record per vector costs a key, a BlockAddress and a page to
+    // store something with exactly one owner. Retrieval fetches the vector to score a candidate
+    // and then the text to pack it; inline, that is ONE read, and the text is ~50 bytes against
+    // ~1536 for the vector, about 3% of a fetch already paid for.
+    //
+    // Default-empty and skipped when empty: a record written before the fold decodes with no
+    // vector and readers fall back to the ContextEmbedding record, so this can be populated
+    // before any reader migrates off ref_hash addressing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vector: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -421,13 +449,27 @@ pub struct ContextEmbedding {
     pub updated_at_ms: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ContextSummary {
     pub node_hash: u64,
     pub level: u32,
     #[serde(default)]
     pub text: String,
     pub valid_from_ms: u64,
+    // Inline embedding vector, folded from the separate ContextEmbedding record.
+    //
+    // Every embedding is 1:1 with its owner -- measured on one ingest: event_text 6 to 6 events,
+    // entity_state + profile_entity_state 6 to 6 entities, session_l0 + batch_l0 2 to 2
+    // summaries -- so a separate record per vector costs a key, a BlockAddress and a page to
+    // store something with exactly one owner. Retrieval fetches the vector to score a candidate
+    // and then the text to pack it; inline, that is ONE read, and the text is ~50 bytes against
+    // ~1536 for the vector, about 3% of a fetch already paid for.
+    //
+    // Default-empty and skipped when empty: a record written before the fold decodes with no
+    // vector and readers fall back to the ContextEmbedding record, so this can be populated
+    // before any reader migrates off ref_hash addressing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vector: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -681,6 +723,7 @@ impl ContextWire for ContextEvent {
             source_ref: String::new(),
             related_node_hashes: Vec::new(),
             compact_attrs: Vec::new(),
+            vector: Vec::new(),
         };
         while cursor < bytes.len() {
             let tag = decode_varint(bytes, &mut cursor)?;
@@ -927,6 +970,7 @@ impl ContextWire for ContextEntity {
             valid_from_ms: 0,
             confidence: 0.0,
             source_event_hashes: Vec::new(),
+            vector: Vec::new(),
         };
         while cursor < bytes.len() {
             let tag = decode_varint(bytes, &mut cursor)?;
@@ -1054,6 +1098,7 @@ impl ContextWire for ContextSummary {
             level: 0,
             text: String::new(),
             valid_from_ms: 0,
+            vector: Vec::new(),
         };
         while cursor < bytes.len() {
             let tag = decode_varint(bytes, &mut cursor)?;
@@ -2150,6 +2195,7 @@ mod tests {
             valid_from_ms: 1_000,
             confidence: 0.97,
             source_event_hashes: vec![5, 6],
+            vector: Vec::new(),
         };
         assert_eq!(
             ContextEntity::decode_context_proto_value(&entity.encode_context_proto_value()),
@@ -2181,6 +2227,7 @@ mod tests {
             level: 1,
             text: "summary".to_string(),
             valid_from_ms: 1_000,
+            vector: Vec::new(),
         };
         assert_eq!(
             ContextSummary::decode_context_proto_value(&summary.encode_context_proto_value()),

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -703,6 +703,7 @@ impl ContextWire for ContextEvent {
         encode_fixed32_field(&mut out, 7, self.importance.to_bits());
         encode_bytes_field(&mut out, 8, self.text.as_bytes());
         encode_varint_field(&mut out, 9, self.primary_time_ms());
+        encode_vector_field(&mut out, &self.vector);
         out
     }
 
@@ -748,6 +749,9 @@ impl ContextWire for ContextEvent {
                 (9, 0) => value.ingestion_time_ms = decode_varint(bytes, &mut cursor)?,
                 (9, 5) => value.importance = f32::from_bits(decode_fixed32(bytes, &mut cursor)?),
                 (10, 2) => value.text = decode_string(bytes, &mut cursor)?,
+                (CONTEXT_VECTOR_FIELD, 2) => {
+                    value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (11, 2) => value.source_ref = decode_string(bytes, &mut cursor)?,
                 (12, 0) => value
                     .related_node_hashes
@@ -955,6 +959,7 @@ impl ContextWire for ContextEntity {
         for source_event_hash in &self.source_event_hashes {
             encode_varint_field(&mut out, 9, *source_event_hash);
         }
+        encode_vector_field(&mut out, &self.vector);
         out
     }
 
@@ -996,6 +1001,9 @@ impl ContextWire for ContextEntity {
                             .source_event_hashes
                             .push(decode_varint(&packed, &mut packed_cursor)?);
                     }
+                }
+                (CONTEXT_VECTOR_FIELD, 2) => {
+                    value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
@@ -1088,6 +1096,7 @@ impl ContextWire for ContextSummary {
         encode_varint_field(&mut out, 3, u64::from(self.level));
         encode_bytes_field(&mut out, 4, self.text.as_bytes());
         encode_varint_field(&mut out, 5, self.valid_from_ms);
+        encode_vector_field(&mut out, &self.vector);
         out
     }
 
@@ -1107,6 +1116,9 @@ impl ContextWire for ContextSummary {
                 (3, 0) => value.level = u32::try_from(decode_varint(bytes, &mut cursor)?).ok()?,
                 (4, 2) => value.text = decode_string(bytes, &mut cursor)?,
                 (5, 0) => value.valid_from_ms = decode_varint(bytes, &mut cursor)?,
+                (CONTEXT_VECTOR_FIELD, 2) => {
+                    value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
         }
@@ -1641,6 +1653,38 @@ pub enum Command {
         #[serde(default)]
         compression_limit: Option<usize>,
     },
+}
+
+/// Field number carrying the inline embedding vector on ContextEvent/Entity/Summary.
+///
+/// These three types have HAND-WRITTEN protobuf codecs; a serde field alone is invisible to
+/// them and is silently dropped on persist -- the struct is populated in memory and the value
+/// is gone by the time it reaches a page, with no error anywhere. 20 is clear of every field
+/// number the three messages already use.
+const CONTEXT_VECTOR_FIELD: u64 = 20;
+
+/// f32 vector -> packed little-endian bytes. Explicit LE, not native, so a page written on one
+/// architecture decodes on another.
+fn pack_f32_vector(vector: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vector.len() * 4);
+    for value in vector {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+fn unpack_f32_vector(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}
+
+fn encode_vector_field(out: &mut Vec<u8>, vector: &[f32]) {
+    if vector.is_empty() {
+        return;
+    }
+    encode_bytes_field(out, CONTEXT_VECTOR_FIELD, &pack_f32_vector(vector));
 }
 
 fn encode_varint_field(out: &mut Vec<u8>, field_number: u64, value: u64) {


### PR DESCRIPTION
Five changes to how context records are keyed and stored in the engine. Each was verified against a
pristine-tree baseline of failing test names, not against a green suite.

## 1. Group entities and embeddings by owner

`context_entities` and `context_embeddings` were the last two context maps shaped
`HashMap<String, BlockAddress>` — one map slot and one fully materialized key string per record.
Both are now `HashMap<String, BTreeMap<u64, BlockAddress>>`, matching events/indexes/audits/
children/summaries.

Beyond the byte count, this fixes a missing capability: **a node's entities could not be
enumerated.** `ContextQueryEntities` required the caller to already know every `entity_hash`,
because a HashMap cannot prefix-scan. The collection key existed and was computed on the read path
only to be echoed back as a label.

Measured — key storage per entity `69.8 → 16.3 bytes`, and lookup got *faster*, because the old
shape formatted and hashed a ~70-char string on every access:

```
n=   8   per-record HashMap 136.7 ns   grouped BTree 36.4 ns   3.8x
n= 512                165.4 ns                      48.1 ns   3.4x
n=4096                146.3 ns                      86.9 ns   1.7x
```

No migration field is needed: the persisted entry keeps the per-record key, which load splits back
into (collection, hash). The on-disk shape is unchanged in **both** directions.

## 2. Key events by event id so delete and update are log n

mem0 `delete` carries an event id; the BTree was keyed by `timestamp_ms * FANOUT + (id % FANOUT)`,
so an id alone could not address an event and locating one meant scanning the node's whole series.

Time ordering that key was carrying moves to a derived index, `timeline_key → event_id_hash`, so
time-windowed reads stay `log n + k` rather than degrading to a full scan. Trading read cost for
delete cost would have been backwards: reads are every retrieval, deletes are rare.

**A hazard worth recording:** this rekey compiled with **zero errors**. The type is still
`BTreeMap<u64, BlockAddress>`; only the *meaning* of the key changed. All five range-scan sites
would have gone on compiling while returning wrong results.

## 3–4. Inline embedding vectors on events, entities and summaries

Every embedding is 1:1 with exactly one owner (measured: 6 event_text ↔ 6 events, 6 entity vectors
↔ 6 entities, 2 summary vectors ↔ 2 summaries), so a separate record per vector costs a key, an
address and a page for something with one owner.

**The serde field alone did nothing.** These three types have hand-written protobuf codecs, which
silently dropped the vector on persist — populated in memory, gone by the time it reached a page,
no error anywhere, every existing test still green. Field 20 now carries it as packed
little-endian f32 bytes, omitted entirely when empty so pre-fold records cost nothing.

Caught only by a round-trip assertion that reads records back out of the engine. Without it this
would have shipped a population that populates nothing.

## 5. Address tree-traversal embeddings the way writers store them

`ContextTraverseTree` looked embeddings up by the child's **raw node hash**; every writer stores
them under `stable_hash64("ctx-embedding:{tenant}:{owner}:{level}")`. A hash of three values never
equals one of them, so the lookup missed for every child and the cosine scoring below it was
unreachable.

No test caught it because the test wrote its embeddings under the raw node hash too — building the
fixture to match the **reader** rather than what writers produce, so the two could disagree
indefinitely with a green suite. The test now derives the ref hash as production does, and was
verified to fail with the reader fix reverted.

Severity is latent, not a live regression: `ContextTraverseTree` has no production issuer.

## Verification

`cargo test --lib context_` on this branch: **43 passed, 0 failed**, including the wire-contract
tests `context_models_round_trip_wire_payloads_and_type_alias` and
`context_pack_audit_wire_matches_field_numbers`.
