### PR TITLE
Repair the constructors that a new ContextEvent field broke

### DIFF
--- a/crates/temporalstore-rust/examples/compression_trigger_check.rs
+++ b/crates/temporalstore-rust/examples/compression_trigger_check.rs
@@ -50,6 +50,8 @@ fn write_event(engine: &TemporalEngine, node: u64, ts: u64) {
         source_ref: String::new(),
         related_node_hashes: Vec::new(),
         compact_attrs: Vec::new(),
+        // No vector on this fixture; empty is what a record without one holds.
+        vector: Vec::new(),
     };
     let r = engine
         .execute(ExecuteRequest {

--- a/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
+++ b/crates/temporalstore-rust/src/bin/context_batch_ingest.rs
@@ -407,6 +407,8 @@ fn write_raw_sources(
             source_ref: source.source_id.clone(),
             related_node_hashes: Vec::new(),
             compact_attrs: Vec::new(),
+            // No vector on this fixture; empty is what a record without one holds.
+            vector: Vec::new(),
         };
         let index_ref = ContextIndexRef {
             primary_node_hash: node_hash,

--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -2017,6 +2017,8 @@ fn ingest_external_benchmark_sources(
             source_ref: String::new(),
             related_node_hashes: Vec::new(),
             compact_attrs: Vec::new(),
+            // No vector on this fixture; empty is what a record without one holds.
+            vector: Vec::new(),
         };
         let index_ref = ContextIndexRef {
             primary_node_hash: node_hash,

--- a/crates/temporalstore-rust/src/bin/native_persistence_workflow.rs
+++ b/crates/temporalstore-rust/src/bin/native_persistence_workflow.rs
@@ -335,6 +335,8 @@ fn write_context_records(engine: &TemporalEngine) -> usize {
                     source_ref: String::new(),
                     related_node_hashes: Vec::new(),
                     compact_attrs: Vec::new(),
+                    // No vector on this fixture; empty is what a record without one holds.
+                    vector: Vec::new(),
                 },
                 first_write_only: true,
                 cold_storage: false,
@@ -363,6 +365,8 @@ fn write_context_records(engine: &TemporalEngine) -> usize {
                 level: 1,
                 text: "Native TemporalStore summary mapped to embedding evidence.".to_string(),
                 valid_from_ms: 2_020,
+                // No vector on this fixture; empty is what a record without one holds.
+                vector: Vec::new(),
             },
         },
     }));
@@ -422,6 +426,8 @@ fn append_context_records_after_restart(engine: &TemporalEngine) -> usize {
                     source_ref: String::new(),
                     related_node_hashes: Vec::new(),
                     compact_attrs: Vec::new(),
+                    // No vector on this fixture; empty is what a record without one holds.
+                    vector: Vec::new(),
                 },
                 first_write_only: true,
                 cold_storage: false,
@@ -449,6 +455,8 @@ fn append_context_records_after_restart(engine: &TemporalEngine) -> usize {
                 level: 1,
                 text: "Post restart monotonic summary append.".to_string(),
                 valid_from_ms: 3_300,
+                // No vector on this fixture; empty is what a record without one holds.
+                vector: Vec::new(),
             },
         },
     }));

--- a/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
+++ b/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
@@ -22,6 +22,8 @@ fn cold_event(event_id_hash: u64, event_time_ms: u64, text: &str) -> ContextEven
         source_ref: "backfill://raw".to_string(),
         related_node_hashes: Vec::new(),
         compact_attrs: Vec::new(),
+        // Raw ingestion carries no vector; empty is what a record without one holds.
+        vector: Vec::new(),
     }
 }
 


### PR DESCRIPTION
`main` does not build with all targets. `ContextEvent` and `ContextSummary` gained a `vector` field, and **seven** places construct them field by field — fixtures, a workflow binary, an example — so each fails to compile even though nothing about what they exercise changed.

## The value chosen

The field's own documentation says an empty vector is what a record written before the fold carries, and none of these fixtures has a vector. So empty is what they mean, rather than a value picked to quiet the compiler.

## How this reaches `main`

A change that adds the field and a change that adds a caller can **each pass CI alone** and still break once both are in.

The lib builds either way, so `cargo test --lib` never sees it — only `cargo check --all-targets` does. This is the second such break today; the first was `StateChangeRequest` gaining a `reason`.

Worth considering a merge gate that re-runs `--all-targets` against the merge result rather than the branch, since that is the only place this class of break is visible.

## Verification

`cargo check --all-targets` — the target that was red — is clean.
