### PR TITLE
raft: actually trigger the snapshots the config asks for

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1932,6 +1932,9 @@ fn env_bool(name: &str, default: bool) -> bool {
 
 fn runtime_options_from_env() -> ProductionMetaRaftRuntimeOptions {
     ProductionMetaRaftRuntimeOptions {
+        // Checking is cheap; the byte threshold in RaftConfig decides whether a
+        // snapshot is actually taken. Set to 0 to stop checking altogether.
+        snapshot_check_interval_ms: env_u64("TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000),
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: env_u64("TS_META_RAFT_NODE_ID", 1),
         nodes: parse_meta_raft_nodes(),
@@ -2279,6 +2282,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let snapshot_path = dir.path().join("meta-raft-route-snapshot.json");
         let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,
             nodes: vec![
@@ -2404,6 +2408,7 @@ mod tests {
         assert_eq!(servers.servers[0].state, MetaEntityState::Normal);
 
         let restored_runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,
             nodes: vec![
@@ -3480,6 +3485,7 @@ mod tests {
     #[test]
     fn raft_backed_metaserver_scheduler_drives_lifecycle_workflow() {
         let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,
             nodes: vec![

--- a/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
@@ -85,6 +85,7 @@ fn main() {
     std::fs::create_dir_all(&options.root).expect("failed to create harness root");
     let started = Instant::now();
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
         nodes: vec![

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -2176,6 +2176,14 @@ pub struct ProductionRaftRuntimeOptions {
     pub election_tick_ms: u64,
     pub max_catchup_entries_per_heartbeat: u64,
     pub allow_plaintext_for_local_chaos: bool,
+    /// How often the timer loop asks whether the applied raft log has grown past
+    /// [`RaftConfig::max_applied_log_bytes`] and should be compacted into a
+    /// snapshot. Zero disables the check.
+    ///
+    /// Nothing used to ask. `maybe_trigger_snapshot` was implemented, and the
+    /// config already said to compact at a threshold, but no loop ever called
+    /// it -- so the log grew for the life of the process.
+    pub snapshot_check_interval_ms: u64,
 }
 
 

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -350,6 +350,7 @@ impl ProductionRaftRuntime {
             max_retries: self.options.rpc.max_retries,
         };
         let rpc_options = self.options.rpc;
+        let snapshot_check_interval = self.options.snapshot_check_interval_ms;
         let auth_token = self
             .options
             .security
@@ -361,7 +362,27 @@ impl ProductionRaftRuntime {
         let handle = thread::spawn(move || {
             let mut last_heartbeat = InstantCompat::now();
             let mut last_tick = InstantCompat::now();
+            let mut last_snapshot_check = InstantCompat::now();
             while !stop_thread.load(Ordering::SeqCst) {
+                if snapshot_check_interval > 0
+                    && last_snapshot_check.elapsed()
+                        >= Duration::from_millis(snapshot_check_interval)
+                {
+                    // Cheap unless the byte threshold is crossed, and it errors
+                    // on a follower -- only the leader compacts.
+                    if let Ok(report) = cluster.maybe_trigger_snapshot() {
+                        if report.triggered {
+                            tracing::info!(
+                                kind = "data",
+                                applied_index = report.applied_index,
+                                applied_log_bytes = report.applied_log_bytes,
+                                max_applied_log_bytes = report.max_applied_log_bytes,
+                                "raft: compacted the applied log into a snapshot"
+                            );
+                        }
+                    }
+                    last_snapshot_check = InstantCompat::now();
+                }
                 // Move the cluster's clock forward by the time that actually passed. The
                 // recovery timeouts -- stalled snapshot send, offline peer, abandoned leader
                 // transfer -- are refreshed from here and from nowhere else, so a clock that
@@ -452,6 +473,14 @@ pub struct ProductionMetaRaftRuntimeOptions {
     pub election_tick_ms: u64,
     pub failure_detector_interval_ms: u64,
     pub stale_server_after_ms: u64,
+    /// How often the timer loop asks whether the applied raft log has grown past
+    /// [`RaftConfig::max_applied_log_bytes`] and should be compacted into a
+    /// snapshot. Zero disables the check.
+    ///
+    /// Nothing used to ask. `maybe_trigger_snapshot` was implemented, and the
+    /// config already said to compact at a threshold, but no loop ever called
+    /// it -- so the log grew for the life of the process.
+    pub snapshot_check_interval_ms: u64,
 }
 
 impl ProductionMetaRaftRuntimeOptions {
@@ -683,12 +712,33 @@ impl ProductionMetaRaftRuntime {
         let failure_detector_interval =
             Duration::from_millis(self.options.failure_detector_interval_ms);
         let stale_server_after_ms = self.options.stale_server_after_ms;
+        let snapshot_check_interval = self.options.snapshot_check_interval_ms;
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
         let handle = thread::spawn(move || {
             let mut last_heartbeat = InstantCompat::now();
             let mut last_failure_detector = InstantCompat::now();
+            let mut last_snapshot_check = InstantCompat::now();
             while !stop_thread.load(Ordering::SeqCst) {
+                if snapshot_check_interval > 0
+                    && last_snapshot_check.elapsed()
+                        >= Duration::from_millis(snapshot_check_interval)
+                {
+                    // Cheap unless the byte threshold is crossed, and it errors
+                    // on a follower -- only the leader compacts.
+                    if let Ok(report) = cluster.maybe_trigger_snapshot() {
+                        if report.triggered {
+                            tracing::info!(
+                                kind = "meta",
+                                applied_index = report.applied_index,
+                                applied_log_bytes = report.applied_log_bytes,
+                                max_applied_log_bytes = report.max_applied_log_bytes,
+                                "raft: compacted the applied log into a snapshot"
+                            );
+                        }
+                    }
+                    last_snapshot_check = InstantCompat::now();
+                }
                 if last_heartbeat.elapsed() >= heartbeat_interval {
                     let _ = cluster.failover_primary();
                     let _ = cluster.catch_up_live_followers();

--- a/crates/temporalstore-rust/src/raft/tests/part2.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part2.rs
@@ -1231,6 +1231,7 @@ fn production_raft_mode_uses_temporal_raft_ready_path_when_adapter_is_enabled() 
 fn production_raft_runtime_validates_security_timer_and_chaos_contracts() {
     let dir = tempfile::tempdir().unwrap();
     let options = ProductionRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         shard_id: 91,
         local_node_id: 1,
@@ -1456,6 +1457,7 @@ fn production_raft_runtime_replicates_over_separate_http_nodes() {
     let mut runtimes = Vec::new();
     for node in &nodes {
         let runtime = ProductionRaftRuntime::start(ProductionRaftRuntimeOptions {
+            snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             shard_id: 193,
             local_node_id: node.node_id,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -617,6 +617,7 @@ fn metaserver_raft_freeze_stale_server_is_replicated_mutation() {
 #[test]
 fn production_meta_raft_runtime_ticks_failover_and_failure_detection() {
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
         nodes: vec![
@@ -678,6 +679,7 @@ fn production_meta_raft_runtime_ticks_failover_and_failure_detection() {
 #[test]
 fn production_meta_raft_runtime_matches_multinode_control_and_fault_contract() {
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
         nodes: vec![
@@ -753,6 +755,7 @@ fn production_meta_raft_runtime_matches_multinode_control_and_fault_contract() {
 #[test]
 fn metaserver_owns_data_raft_membership_workflow() {
     let meta = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
         nodes: vec![
@@ -945,6 +948,7 @@ fn meta_owned_membership_report_covers_networked_scheduler_contract() {
 #[test]
 fn metaserver_membership_workflow_requires_meta_majority() {
     let meta = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
         nodes: vec![
@@ -1320,6 +1324,90 @@ fn metaserver_snapshot_bootstraps_lagging_meta_replica() {
         })
     );
     assert_eq!(meta.commit_index(12).unwrap(), 1);
+}
+
+/// Start a meta raft runtime whose applied log is over the compaction threshold
+/// the moment anything is written, with `snapshot_check_interval_ms` as given.
+fn meta_runtime_for_snapshot_wiring(
+    snapshot_check_interval_ms: u64,
+    base_port: u16,
+) -> ProductionMetaRaftRuntime {
+    ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        snapshot_check_interval_ms,
+        engine: ProductionRaftEngineKind::TemporalRaft,
+        local_node_id: 10,
+        nodes: vec![
+            ProductionRaftNode {
+                node_id: 10,
+                addr: format!("127.0.0.1:{base_port}"),
+            },
+            ProductionRaftNode {
+                node_id: 11,
+                addr: format!("127.0.0.1:{}", base_port + 1),
+            },
+            ProductionRaftNode {
+                node_id: 12,
+                addr: format!("127.0.0.1:{}", base_port + 2),
+            },
+        ],
+        config: RaftConfig {
+            max_applied_log_bytes: 1,
+            ..RaftConfig::default()
+        },
+        heartbeat_interval_ms: 5,
+        election_tick_ms: 2,
+        failure_detector_interval_ms: 10_000,
+        stale_server_after_ms: 0,
+    })
+    .unwrap()
+}
+
+#[test]
+fn meta_raft_timer_loop_compacts_the_applied_log() {
+    // The wiring this exercises did not exist: `maybe_trigger_snapshot` was
+    // implemented and the config asked for compaction at a byte threshold, but
+    // no loop ever called it, so the log grew for the life of the process.
+    let runtime = meta_runtime_for_snapshot_wiring(2, 17111);
+    runtime.cluster().register(RegisterShardRequest {
+        shard_id: 41,
+        server_addr: "server-timer-compaction".to_string(),
+    });
+    let timer = runtime.start_timer_loop();
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    // One observation, and it discriminates: the loop having already compacted
+    // leaves nothing new to apply. Had nothing called it, this same first call
+    // would report `triggered` against the threshold instead.
+    let report = runtime.cluster().maybe_trigger_snapshot().unwrap();
+    timer.stop();
+    assert!(
+        !report.triggered,
+        "the timer loop should have compacted already, got {report:?}"
+    );
+    assert_eq!(report.reason, "no_new_applied_logs");
+    assert!(report.last_snapshot_index >= 1);
+}
+
+#[test]
+fn a_zero_snapshot_check_interval_leaves_the_log_alone() {
+    // The negative control. Without it the test above could pass for reasons
+    // that have nothing to do with the timer loop.
+    let runtime = meta_runtime_for_snapshot_wiring(0, 17121);
+    runtime.cluster().register(RegisterShardRequest {
+        shard_id: 42,
+        server_addr: "server-timer-disabled".to_string(),
+    });
+    let timer = runtime.start_timer_loop();
+    std::thread::sleep(std::time::Duration::from_millis(400));
+
+    let report = runtime.cluster().maybe_trigger_snapshot().unwrap();
+    timer.stop();
+    assert!(
+        report.triggered,
+        "nothing should have compacted with checking disabled, got {report:?}"
+    );
+    assert_eq!(report.reason, "applied_log_bytes_threshold");
+    assert_eq!(report.last_snapshot_index, 0);
 }
 
 #[test]


### PR DESCRIPTION
## The problem

`maybe_trigger_snapshot` is fully implemented — byte threshold, detailed report, snapshot-floor handling — and `RaftConfig` already defaults to `can_trigger_snapshot: true` with `max_applied_log_bytes: 1 GiB`.

**Nothing calls it outside tests.** Neither the data raft timer loop nor the meta raft timer loop ever asks whether the log should be compacted, so the configured threshold is never consulted.

The applied raft log therefore grows for the life of the process, on both raft groups:

- disk grows without bound;
- restart replay time grows linearly with cluster lifetime;
- a peer being caught up must be shipped the entire history rather than a snapshot plus a tail.

This is a wiring omission rather than a design choice: the config expresses the intent to compact at a threshold, the threshold logic exists, and the call site is simply missing.

## The fix

Both timer loops now check on an interval, controlled by a new `snapshot_check_interval_ms` on each runtime's options. Checking is cheap — the byte threshold decides whether anything is actually taken — and it errors on a follower, so only the leader compacts.

`0` disables the check, which is the conventional way to spell "off" for an interval like this. `can_trigger_snapshot` remains the off switch for compaction itself, so no new gate is introduced.

| Variable | Default | Meaning |
|---|---|---|
| `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | `30000` | How often the meta raft loop checks |

Every test construction site is set to `0`, so no existing test changes behaviour.

## Tests

Two tests, and the pair is the point — one alone would not prove the wiring:

- **`meta_raft_timer_loop_compacts_the_applied_log`** — with a tiny threshold and a live timer loop, a single observation afterwards reports `no_new_applied_logs`, meaning the loop already compacted. Had nothing called it, that same first call would instead report `triggered` against the threshold.
- **`a_zero_snapshot_check_interval_leaves_the_log_alone`** — the negative control. With checking disabled the same setup reports `triggered` and `last_snapshot_index == 0`, so the first test cannot pass for reasons unrelated to the loop.

Verification:

- `cargo test -p temporalstore-rust --lib raft::tests::part4 -- --test-threads=1` — 66 passed, 0 failed.
- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — 213 passed, 0 failed.
- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — 18 passed, 0 failed.

Note on the wider raft suite: `raft::tests::part1::raft_rejects_electing_stale_replica_until_it_catches_up` and `raft::tests::part1::request_vote_higher_term_resets_prior_vote_before_decision` fail on this branch — and they fail identically on the unmodified base commit, which I checked before opening this. They are pre-existing and unrelated to this change, but they are real failures on `main` worth someone's attention.

