### PR TITLE
tools: publish the tooling behind index growth, task slimming and tenant policy

### DIFF
--- a/tools/matrixark_index_growth_bound.py
+++ b/tools/matrixark_index_growth_bound.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Secondary-index growth bound: temporal compaction, per-scope cap, hard ceiling.
+
+Even after term/posting pruning, every ingested turn appends secondary-index postings, so a
+subject's TOTAL ``context_index`` footprint grows LINEARLY over its lifetime. This module bounds
+that growth in three layers, applied in this order:
+
+1. **Temporal index compaction** (``MATRIXARK_INDEX_COMPACT_ON_SUMMARY``, default ON) -- principled
+   and recall-preserving. Once an event has been rolled up into an L0/L1 ``context_summary``, its
+   PER-EVENT postings are redundant with the summary's own postings, so the summary emits an
+   ``index_compact`` tombstone naming exactly the events it covers and the serving sweep drops those
+   event postings. The index stays dense for recent turns and sparse-summarized for old ones; old
+   content stays retrievable through its summary.
+
+0. **Lossless dedup** (``MATRIXARK_DEDUPE_INDEX_POSTINGS``, default ON) -- collapse postings that
+   repeat an identical (scope, term, ref set) across time buckets. Costs nothing and shrinks the
+   index enough that the budgets below rarely have to bind.
+
+2. **Per-session budget** (``MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION``, default ``128``,
+   0 = unlimited) -- how many postings one session's index may hold.
+
+3. **Per-tenant budget** (``MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_TENANT``, default ``1024``,
+   0 = unlimited) -- how many that tenant may hold across all its sessions.
+
+   128 is the measured floor: with lever 0 running, a 40-turn session holds recall 5/5 at 128
+   postings (177 live) and loses a fact at 96. Before lever 0 the same floor was 256 -- deduping
+   first is what bought the halving.
+
+There is deliberately **no store-wide total**. A global budget in a multi-tenant process makes one
+tenant's growth evict another tenant's memory -- a cross-tenant side effect, not a memory policy.
+Every budget stops at a tenant boundary; the process bounds memory by bounding each tenant.
+
+**They can cost recall, and the eviction order is built to minimize that.** Lever 1 has already
+removed every posting that was purely redundant, so whatever a cap evicts on top of it is a live
+lookup path. Postings are therefore evicted in RECALL-PRIORITY order, oldest first within each
+class:
+
+    event -> segment -> node/other -> entity -> summary
+
+``summary`` postings go LAST because they are exactly what lever 1 leaves behind as the surviving
+route to compacted old content -- evicting them by age (the naive rule) throws away the recall path
+lever 1 worked to preserve, which is what a measured 5/5 -> 4/5 recall drop at cap=150 looked like.
+``entity`` postings are next-to-last for the same reason: an entity is the durable distillation of
+an event, so it out-recalls the raw event posting per byte.
+
+Both layers log exactly what they dropped, per class -- never a silent truncation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable, Iterable
+
+Json = dict[str, Any]
+
+try:
+    from tools.matrixark_mcp_identity import now_ms
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_mcp_identity import now_ms
+
+try:
+    from tools.matrixark_tenant_policy import resolve as resolve_tenant_policy
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_tenant_policy import resolve as resolve_tenant_policy
+
+try:
+    from tools.matrixark_tenant_policy import tenant_of as tenant_of_scope
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_tenant_policy import tenant_of as tenant_of_scope
+
+
+LOGGER = logging.getLogger("matrixark.index_growth_bound")
+
+# The bounds run on EVERY serving recompute, so a binding cap would otherwise emit an identical
+# WARNING per read. Log only when the eviction picture actually changes -- still no silent
+# truncation, just no spam.
+_LAST_EVICTION_SIGNATURE: tuple | None = None
+
+# Mirrors ``matrixark_mcp_local_adapter.MEMORY_TOMBSTONE_RECORD_TYPE``. Duplicated (not imported) so
+# this module stays leaf-level: the adapter imports it, not the other way round.
+MEMORY_TOMBSTONE_RECORD_TYPE = "matrixark_memory_tombstone"
+INDEX_COMPACT_TOMBSTONE_KIND = "index_compact"
+
+# Small and ON: the index must not grow linearly with turns. See the docstring for the recall
+# trade-off and the eviction priority that limits it. 0 disables either layer.
+DEFAULT_MAX_INDEX_RECORDS_PER_SCOPE = 128
+DEFAULT_INDEX_HARD_CEILING = 1024
+
+# Lower evicts first. summary postings are the surviving recall path for content lever 1 compacted,
+# so they are the last thing given up; entities outrank raw events because they are the distilled,
+# longer-lived form of the same fact.
+EVICTION_PRIORITY_BY_REF_TYPE = {
+    "event": 0,
+    "segment": 1,
+    "compression": 2,
+    "node": 3,
+    "": 3,
+    "entity": 4,
+    "summary": 5,
+}
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return max(0, value)
+
+
+def index_compact_on_summary_enabled(scope: Any = None) -> bool:
+    """Lever 1 gate, resolved for `scope`'s tenant (tenant override -> env -> default ON)."""
+    return bool(resolve_tenant_policy("compact_index_on_summary", scope))
+
+
+def extract_segments_enabled(scope: Any = None) -> bool:
+    """Whether ingest materializes ``context_segment`` rows (default OFF).
+
+    A segment is a restatement of its event -- same text up to a role/index prefix -- so each one
+    costs a record, an embedding and a set of index postings to store what the event already holds.
+    Entities remain the distillation of a turn; segments are the redundant middle layer. Set
+    ``MATRIXARK_EXTRACT_SEGMENTS=1`` to restore them -- or set ``extract_segments`` for one tenant,
+    since whether a tenant wants segments is a per-tenant decision, not a process-wide one."""
+    return bool(resolve_tenant_policy("extract_segments", scope))
+
+
+def pack_drop_redundant_items_enabled(scope: Any = None) -> bool:
+    """Whether a pack drops items whose content another item in the same pack already carries."""
+    return bool(resolve_tenant_policy("pack_drop_redundant_items", scope))
+
+
+def recall_reinforcement_enabled(scope: Any = None) -> bool:
+    """Whether retrieval writes protection markers for the refs it selected."""
+    return bool(resolve_tenant_policy("recall_reinforcement", scope))
+
+
+def skill_chunks_per_skill(scope: Any = None) -> int:
+    """Sections returned from one skill, ranked by match against the query (0 = all)."""
+    return int(resolve_tenant_policy("skill_chunks_per_skill", scope))
+
+
+def skill_description_always(scope: Any = None) -> bool:
+    """Whether every visible skill contributes its name + description to the pack."""
+    return bool(resolve_tenant_policy("skill_description_always", scope))
+
+
+def skill_reserved_refs(scope: Any = None) -> int:
+    """Pack slots reserved for skills, admitted by policy rather than by score."""
+    return int(resolve_tenant_policy("skill_reserved_refs", scope))
+
+
+def traverse_sibling_sessions_enabled(scope: Any = None) -> bool:
+    """Whether retrieval descends into sessions other than the current one."""
+    return bool(resolve_tenant_policy("traverse_sibling_sessions", scope))
+
+
+def top_k_per_layer(scope: Any = None) -> int:
+    """Child nodes each parent contributes to the next frontier, for `scope`'s tenant."""
+    return int(resolve_tenant_policy("top_k_per_layer", scope))
+
+
+def max_candidates_per_node(scope: Any = None) -> int:
+    """Candidate refs admitted from one node."""
+    return int(resolve_tenant_policy("max_candidates_per_node", scope))
+
+
+def max_global_candidates(scope: Any = None) -> int:
+    """Total candidates gathered across the traversal."""
+    return int(resolve_tenant_policy("max_global_candidates", scope))
+
+
+def max_selected_refs(scope: Any = None) -> int:
+    """Refs allowed into the pack after scoring."""
+    return int(resolve_tenant_policy("max_selected_refs", scope))
+
+
+def cross_session_profile_max_candidates(scope: Any = None) -> int:
+    """Candidates drawn from the durable profile."""
+    return int(resolve_tenant_policy("cross_session_profile_max_candidates", scope))
+
+
+def share_serving_values_enabled(scope: Any = None) -> bool:
+    """Whether the serving pipeline re-points records at one shared object per distinct value."""
+    return bool(resolve_tenant_policy("share_serving_values", scope))
+
+
+def return_all_candidates_enabled(scope: Any = None) -> bool:
+    """Whether `scope`'s tenant always returns every candidate (no prefilter, no scoring)."""
+    return bool(resolve_tenant_policy("return_all_candidates", scope))
+
+
+def return_all_candidate_threshold(scope: Any = None) -> int:
+    """Candidate count at or below which retrieval returns everything; ``0`` disables the rule."""
+    return int(resolve_tenant_policy("return_all_candidate_threshold", scope))
+
+
+def node_path_embeddings_enabled(scope: Any = None) -> bool:
+    """Whether to store a `context_node` embedding of the node path (default OFF)."""
+    return bool(resolve_tenant_policy("node_path_embeddings", scope))
+
+
+def embed_node_path_prefix_enabled(scope: Any = None) -> bool:
+    """Whether node-summary embeddings include the node path in their source text (default OFF)."""
+    return bool(resolve_tenant_policy("embed_node_path_prefix", scope))
+
+
+def joined_summary_source_text(parts: Any) -> str:
+    """Join a node summary's source pieces, dropping SENTENCES an earlier piece already carried.
+
+    A node's summary is assembled from child summaries + entity states + operator states + events,
+    in that order -- but each child summary is itself built from those same events, so one sentence
+    arrives several times: "... :: user: I live in Kyoto. user: I live in Kyoto. user: ...". Two
+    sibling child summaries carry the same sentence behind different prefixes, so whole-piece
+    deduplication does not catch it (measured: it changed nothing). Dedup therefore runs at sentence
+    granularity.
+
+    Order is preserved -- children first, events last -- and a sentence is dropped only when the
+    identical normalized sentence has already been kept, so the first occurrence always survives.
+    Very short fragments are never judged as repeats: they are labels and prefixes, not content."""
+    kept: list[str] = []
+    seen: set[str] = set()
+    for part in parts or ():
+        text = str(part or "").strip()
+        if not text:
+            continue
+        piece: list[str] = []
+        for raw in text.replace(chr(10), ". ").split(". "):
+            sentence = raw.strip()
+            if not sentence:
+                continue
+            normalized = " ".join(sentence.split()).lower().rstrip(".")
+            if len(normalized) < 8:
+                piece.append(sentence)
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            piece.append(sentence)
+        joined = ". ".join(piece).strip()
+        if joined:
+            kept.append(joined if joined.endswith(".") else joined + ".")
+    return " ".join(kept).strip()
+
+
+def summary_embedding_text(summary_text: str, node_path: Any = None, *, scope: Any = None) -> str:
+    """The text a node summary is EMBEDDED from.
+
+    The stored ``summary_text`` keeps its ``"<path> :: "`` prefix for humans and for the LLM, but the
+    vector is built from content alone unless a tenant asks otherwise: every sibling shares almost
+    the same path, so prefixing adds a constant component to each node vector and pulls unrelated
+    nodes together -- exactly the distances the traversal depends on."""
+    text = str(summary_text or "")
+    if embed_node_path_prefix_enabled(scope):
+        parts = [str(part) for part in (node_path or []) if str(part or "")]
+        return " ".join([*parts, text]).strip()
+    marker = " :: "
+    if marker in text:
+        head, _, tail = text.partition(marker)
+        # only strip when the head really is the node path, not prose containing "::"
+        if head.count(" ") <= 8 and all(":" in token for token in head.split(" / ") if token.strip()):
+            return tail.strip() or text
+    # node_l1 uses a different shell: "Context node <path>. Rich overview: <content>"
+    lead = "Context node "
+    if text.startswith(lead):
+        for phrase in (". Rich overview: ", ". Rich overview:"):
+            if phrase in text:
+                return text.split(phrase, 1)[1].strip() or text
+    return text
+
+
+def generate_l1_summaries_enabled(scope: Any = None) -> bool:
+    """Legacy boolean form of the L1 gate; ``summary_levels`` is the explicit control."""
+    return bool(resolve_tenant_policy("generate_l1_summaries", scope))
+
+
+def retrieval_budget(name: str, scope: Any = None) -> int:
+    """Per-tenant retrieval budget: top_k_per_layer | max_global_candidates | max_selected_refs.
+
+    Defaults match matrixark_mcp_runtime_config (24 / 2048 / 1000), which is the single source of
+    truth for the process-wide values; a tenant override wins over the env var, as everywhere else."""
+    if name not in {"top_k_per_layer", "max_global_candidates", "max_selected_refs"}:
+        raise KeyError(f"not a retrieval budget: {name}")
+    return int(resolve_tenant_policy(name, scope))
+
+
+def summary_levels(scope: Any = None) -> str:
+    """Which node summary levels `scope`'s tenant generates: auto | l0 | l0_l1 | none.
+
+    ``auto`` is the historical behavior (L0 always, L1 by content rule). The explicit values exist
+    because the content rule can only be subtracted from otherwise -- there was no way to say
+    "always both" or "never any"."""
+    level = str(resolve_tenant_policy("summary_levels", scope) or "auto")
+    if level == "auto" and not generate_l1_summaries_enabled(scope):
+        # honor the older boolean knob when a deployment still sets it
+        return "l0"
+    return level
+
+
+def audit_payload_retain_per_scope(scope: Any = None) -> int:
+    """How many audit/commit records per scope keep their diagnostic payload (0 = all)."""
+    return int(resolve_tenant_policy("audit_payload_retain_per_scope", scope))
+
+
+def summarize_aggregation_only_nodes_enabled(scope: Any = None) -> bool:
+    """Whether nodes with no direct events still get summaries (default OFF)."""
+    return bool(resolve_tenant_policy("summarize_aggregation_only_nodes", scope))
+
+
+def node_summary_plan(scope: Any = None, *, conditional_l1: bool, has_direct_events: bool = True) -> tuple[bool, bool]:
+    """Return ``(generate_l0, generate_l1)`` for `scope`'s tenant given the content rule's verdict.
+
+    A node with NO direct events (tenant / user / profile -- the spine) is skipped by default. Two
+    facts make that safe: the traversal reaches those nodes unconditionally, so a summary cannot
+    change which subtree is chosen; and index compaction tombstones are built from a node's OWN
+    ``source_event_ids``, which is empty for them, so no posting cleanup depends on their summary.
+    A session node -- which does hold events, and whose summary IS what lets lever 1 drop the
+    per-event postings -- is never affected by this rule."""
+    if not has_direct_events and not summarize_aggregation_only_nodes_enabled(scope):
+        return (False, False)
+    level = summary_levels(scope)
+    if level == "none":
+        return (False, False)
+    if level == "l0":
+        return (True, False)
+    if level == "l0_l1":
+        return (True, True)
+    return (True, bool(conditional_l1))
+
+
+def generate_embeddings_enabled(scope: Any = None) -> bool:
+    """Whether `scope`'s tenant stores embedding vectors (default ON -- a tenant opts out)."""
+    return bool(resolve_tenant_policy("generate_embeddings", scope))
+
+
+def store_event_summary_text_enabled(scope: Any = None) -> bool:
+    """Whether a ``context_event`` carries its own ``summary_text`` (default OFF for `scope`'s tenant).
+
+    ``summarize_text`` is whitespace-collapse + truncate(220), not an LLM call, so for any event
+    under the limit it produced a byte-identical copy of ``text``. Every event-path reader is written
+    as ``summary_text or text`` (or lists ``text`` first), so omitting it changes no lookup."""
+    return bool(resolve_tenant_policy("store_event_summary_text", scope))
+
+
+def max_summary_text_chars(scope: Any = None, *, default: int) -> int:
+    """Summary-text budget for `scope`'s tenant, falling back to the level's built-in budget."""
+    configured = int(resolve_tenant_policy("max_summary_text_chars", scope))
+    return configured if configured > 0 else default
+
+
+def max_event_text_chars(scope: Any = None) -> int:
+    """Pre-extraction clip for `scope`'s tenant; ``0`` (the default) leaves text unbounded."""
+    return int(resolve_tenant_policy("max_event_text_chars", scope))
+
+
+def clip_messages_for_ingest(messages: list, limit: int) -> tuple[list, int]:
+    """Clip each message's content to `limit` chars. Returns (messages, clipped_count).
+
+    Applied ONCE at the ingest boundary, before extraction reads the messages, so the event text,
+    the extraction, the embedding and the index postings all describe the same bounded content --
+    clipping after extraction would leave derivatives quoting text the stored event no longer has.
+    Truncation is recorded on the message (``text_truncated`` / ``text_original_chars``), never
+    silent."""
+    if limit <= 0 or not isinstance(messages, list):
+        return messages, 0
+    clipped: list = []
+    count = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            clipped.append(message)
+            continue
+        content = message.get("content")
+        if not isinstance(content, str) or len(content) <= limit:
+            clipped.append(message)
+            continue
+        trimmed = dict(message)
+        trimmed["content"] = content[:limit].rstrip()
+        trimmed["text_truncated"] = True
+        trimmed["text_original_chars"] = len(content)
+        clipped.append(trimmed)
+        count += 1
+    return clipped, count
+
+
+def max_index_records_per_scope(scope: Any = None) -> int:
+    """Lever 2 cap for `scope`'s tenant (default 256); ``0`` disables it."""
+    return int(resolve_tenant_policy("max_secondary_index_records_per_session", scope))
+
+
+def index_hard_ceiling(scope: Any = None) -> int:
+    """Lever 3 ceiling for `scope`'s tenant (default 2048); ``0`` disables it.
+
+    Enforced PER TENANT, not store-wide: a store-wide ceiling in a multi-tenant process lets a busy
+    tenant's postings evict a quiet tenant's index, which is a cross-tenant isolation break, not a
+    memory policy. Scopes with no resolvable tenant share one bucket and behave as before."""
+    return int(resolve_tenant_policy("max_secondary_index_records_per_tenant", scope))
+
+
+def index_compaction_tombstone(
+    *,
+    source_event_ids: Iterable[Any],
+    scope: Json | None = None,
+    scope_key: str = "",
+    summary_hash: Any = None,
+    created_at_ms: Any = None,
+) -> Json | None:
+    """Build the ``index_compact`` tombstone for the events a summary now covers.
+
+    Returns ``None`` when there is nothing to compact, so the caller appends nothing and a
+    compaction-free log stays byte-identical to pre-Lever-1 behavior."""
+    targets = sorted({str(value) for value in source_event_ids or () if value not in (None, "")})
+    if not targets:
+        return None
+    tombstone: Json = {
+        "record_type": MEMORY_TOMBSTONE_RECORD_TYPE,
+        "tombstone_kind": INDEX_COMPACT_TOMBSTONE_KIND,
+        "target_ref_ids": targets,
+        "target_ref_count": len(targets),
+        "tombstone_reason": "summary_rollup",
+        "created_at_ms": int(created_at_ms or now_ms()),
+    }
+    if summary_hash is not None:
+        tombstone["superseded_by"] = summary_hash
+    if scope:
+        tombstone["scope"] = scope
+        resolved_scope_key = str(scope.get("scope_key") or "") if isinstance(scope, dict) else ""
+        if resolved_scope_key:
+            tombstone["scope_key"] = resolved_scope_key
+    if scope_key:
+        tombstone["scope_key"] = scope_key
+    return tombstone
+
+
+def _posting_ref_hashes(record: Json) -> list[Any]:
+    refs = record.get("ref_hashes")
+    if isinstance(refs, list) and refs:
+        return [ref for ref in refs if ref is not None]
+    legacy = record.get("ref_hash")
+    return [legacy] if legacy not in (None, "") else []
+
+
+def index_compact_tombstone_kills_record(tombstone: Json, record: Json) -> bool:
+    """True when an ``index_compact`` tombstone removes `record`.
+
+    Only ``context_index`` postings whose ``ref_type`` is ``event`` are ever matched, and only when
+    EVERY ref the posting carries is covered by the summary. A coalesced posting that still points at
+    an unsummarized event survives intact -- partial compaction is correct, partial loss is not."""
+    if str(tombstone.get("tombstone_kind") or "") != INDEX_COMPACT_TOMBSTONE_KIND:
+        return False
+    if str(record.get("record_type") or "") != "context_index":
+        return False
+    if str(record.get("ref_type") or "") != "event":
+        return False
+    targets = tombstone.get("target_ref_ids")
+    if not targets:
+        return False
+    target_set = targets if isinstance(targets, (set, frozenset)) else {str(value) for value in targets}
+    tombstone_scope_key = str(tombstone.get("scope_key") or "")
+    record_scope_key = str(record.get("scope_key") or "")
+    if tombstone_scope_key and record_scope_key and tombstone_scope_key != record_scope_key:
+        return False
+    refs = _posting_ref_hashes(record)
+    if not refs:
+        return False
+    return all(str(ref) in target_set for ref in refs)
+
+
+def _tenant_of_scope_key(scope_key: str) -> str:
+    """Tenant identity for a posting's scope_key ("" when the key carries no tenant)."""
+    return tenant_of_scope(scope_key)
+
+
+def _sample_scope_for(by_scope: dict[str, list[tuple[int, Json]]], scope_keys: list[str]) -> Any:
+    """A representative record scope for policy resolution -- any posting of this tenant will do,
+    and a full scope dict resolves a tenant_id where the bare scope_key only has the hash."""
+    for scope_key in scope_keys:
+        for _position, record in by_scope.get(scope_key, ()):
+            scope = record.get("scope") if isinstance(record.get("scope"), dict) else None
+            if scope:
+                return scope
+    return scope_keys[0] if scope_keys else ""
+
+
+def dedupe_index_postings_enabled() -> bool:
+    """Lever 0 gate (default ON). Lossless, so it runs before any lever that can cost recall."""
+    return _env_flag("MATRIXARK_DEDUPE_INDEX_POSTINGS", True)
+
+
+def dedupe_index_postings(records: list[Json]) -> list[Json]:
+    """Collapse postings that repeat an identical (scope, index_name, ref_type, ref set).
+
+    Postings are keyed by time bucket, so every summary refresh and every entity re-stamp mints a
+    NEW posting row carrying the same index term pointing at the same refs. Measured on a 30-turn
+    store: entity postings 180 rows for 30 distinct terms (83% duplicates), summary postings 191
+    rows for 108 (43%). The duplicates buy nothing -- a lookup on that term reaches the same refs
+    through any one of them -- so the newest row (freshest timestamp) is kept and the rest dropped.
+
+    Lossless, and therefore the FIRST bound applied: it shrinks the index without touching any
+    lookup path, which is what makes a genuinely small per-session budget affordable.
+
+    Returns `records` itself (identity) when disabled or nothing is duplicated."""
+    if not dedupe_index_postings_enabled():
+        return records
+    newest: dict[tuple, int] = {}
+    duplicates = 0
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") != "context_index":
+            continue
+        refs = tuple(sorted(str(ref) for ref in _posting_ref_hashes(record)))
+        if not refs:
+            continue
+        key = (
+            str(record.get("scope_key") or ""),
+            str(record.get("index_name") or ""),
+            str(record.get("ref_type") or ""),
+            str(record.get("capability") or ""),
+            str(record.get("data_model") or ""),
+            refs,
+        )
+        previous = newest.get(key)
+        if previous is None:
+            newest[key] = position
+            continue
+        duplicates += 1
+        current_time = _posting_time(record)
+        previous_time = _posting_time(records[previous])
+        if (current_time, position) >= (previous_time, previous):
+            newest[key] = position
+    if not duplicates:
+        return records
+    keep = set(newest.values())
+    output: list[Json] = []
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") != "context_index":
+            output.append(record)
+            continue
+        refs = tuple(sorted(str(ref) for ref in _posting_ref_hashes(record)))
+        if not refs or position in keep:
+            output.append(record)
+    return output
+
+
+def _posting_time(record: Json) -> int:
+    try:
+        return int(record.get("timestamp_key_ms") or record.get("updated_at_ms") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def eviction_class(record: Json) -> int:
+    """Recall priority of a posting: lower is given up first. See EVICTION_PRIORITY_BY_REF_TYPE."""
+    return EVICTION_PRIORITY_BY_REF_TYPE.get(str(record.get("ref_type") or ""), 3)
+
+
+def _eviction_sort_key(entry: tuple[int, Json]) -> tuple[int, int, str, int]:
+    position, record = entry
+    try:
+        timestamp = int(record.get("timestamp_key_ms") or record.get("updated_at_ms") or 0)
+    except (TypeError, ValueError):
+        timestamp = 0
+    # (cheapest recall class first, then oldest, then a stable tiebreak so eviction is deterministic
+    # across processes / PYTHONHASHSEED -- index_hash is content-derived, position breaks the rest).
+    return (eviction_class(record), timestamp, str(record.get("index_hash") or ""), position)
+
+
+def enforce_secondary_index_bounds(
+    records: list[Json],
+    *,
+    on_drop: Callable[[Json], None] | None = None,
+) -> list[Json]:
+    """Apply Lever 2 (per-scope cap) then Lever 3 (store-wide ceiling) to `records`.
+
+    Input order is preserved for everything kept. Non-``context_index`` records are never touched.
+    Returns `records` itself (identity) when both levers are disabled or nothing is over budget, so
+    the disabled path is byte-identical."""
+    # Lossless first: drop repeated postings before any budget decides what to give up, so a
+    # budget is never spent on duplicates and never evicts a live lookup path it did not have to.
+    records = dedupe_index_postings(records)
+
+    postings: list[tuple[int, Json]] = [
+        (position, record)
+        for position, record in enumerate(records)
+        if str(record.get("record_type") or "") == "context_index"
+    ]
+    if not postings:
+        return records
+
+    # Budgets are per TENANT: each tenant's postings are counted, capped and evicted against that
+    # tenant's own policy, so one tenant can neither borrow nor consume another's index budget.
+    by_scope: dict[str, list[tuple[int, Json]]] = {}
+    for entry in postings:
+        by_scope.setdefault(str(entry[1].get("scope_key") or ""), []).append(entry)
+    by_tenant: dict[str, list[str]] = {}
+    for scope_key in by_scope:
+        by_tenant.setdefault(_tenant_of_scope_key(scope_key), []).append(scope_key)
+
+    dropped: set[int] = set()
+    dropped_by_scope: dict[str, int] = {}
+    dropped_by_ceiling = 0
+    caps_seen: set[int] = set()
+    ceilings_seen: set[int] = set()
+    for tenant, scope_keys in by_tenant.items():
+        sample_scope = _sample_scope_for(by_scope, scope_keys)
+        per_scope_cap = max_index_records_per_scope(sample_scope)
+        ceiling = index_hard_ceiling(sample_scope)
+        caps_seen.add(per_scope_cap)
+        ceilings_seen.add(ceiling)
+        if per_scope_cap <= 0 and ceiling <= 0:
+            continue
+        if per_scope_cap > 0:
+            for scope_key in scope_keys:
+                entries = by_scope[scope_key]
+                overflow = len(entries) - per_scope_cap
+                if overflow <= 0:
+                    continue
+                for position, _record in sorted(entries, key=_eviction_sort_key)[:overflow]:
+                    dropped.add(position)
+                dropped_by_scope[scope_key] = overflow
+        if ceiling > 0:
+            tenant_entries = [entry for scope_key in scope_keys for entry in by_scope[scope_key]]
+            survivors = [entry for entry in tenant_entries if entry[0] not in dropped]
+            overflow = len(survivors) - ceiling
+            if overflow > 0:
+                for position, _record in sorted(survivors, key=_eviction_sort_key)[:overflow]:
+                    dropped.add(position)
+                dropped_by_ceiling += overflow
+    per_scope_cap = max(caps_seen) if caps_seen else 0
+    ceiling = max(ceilings_seen) if ceilings_seen else 0
+
+    if not dropped:
+        return records
+
+    # No silent truncation: say exactly how much was dropped, by which lever, and -- because the
+    # recall cost depends entirely on WHICH postings went -- by ref_type.
+    dropped_by_ref_type: dict[str, int] = {}
+    for position, record in postings:
+        if position in dropped:
+            key = str(record.get("ref_type") or "")
+            dropped_by_ref_type[key] = dropped_by_ref_type.get(key, 0) + 1
+    global _LAST_EVICTION_SIGNATURE
+    signature = (
+        len(dropped),
+        per_scope_cap,
+        ceiling,
+        tuple(sorted(dropped_by_scope.items())),
+        dropped_by_ceiling,
+        tuple(sorted(dropped_by_ref_type.items())),
+    )
+    if signature != _LAST_EVICTION_SIGNATURE:
+        _LAST_EVICTION_SIGNATURE = signature
+        LOGGER.warning(
+            "secondary_index_bound_evicted total=%d per_scope_cap=%d ceiling=%d by_scope=%s by_ceiling=%d by_ref_type=%s",
+            len(dropped),
+            per_scope_cap,
+            ceiling,
+            dropped_by_scope,
+            dropped_by_ceiling,
+            dropped_by_ref_type,
+        )
+    kept: list[Json] = []
+    for position, record in enumerate(records):
+        if position in dropped:
+            if on_drop is not None:
+                on_drop(record)
+            continue
+        kept.append(record)
+    return kept
+
+
+def secondary_index_bound_stats(records: list[Json]) -> Json:
+    """Observability helper: live posting counts by scope and ref_type (used by the tests/harness)."""
+    total = 0
+    by_scope: dict[str, int] = {}
+    by_ref_type: dict[str, int] = {}
+    for record in records:
+        if str(record.get("record_type") or "") != "context_index":
+            continue
+        total += 1
+        scope_key = str(record.get("scope_key") or "")
+        by_scope[scope_key] = by_scope.get(scope_key, 0) + 1
+        ref_type = str(record.get("ref_type") or "")
+        by_ref_type[ref_type] = by_ref_type.get(ref_type, 0) + 1
+    return {
+        "context_index_total": total,
+        "by_scope": by_scope,
+        "by_ref_type": by_ref_type,
+        "per_scope_cap": max_index_records_per_scope(),
+        "hard_ceiling": index_hard_ceiling(),
+        "compact_on_summary": index_compact_on_summary_enabled(),
+    }
+
+
+def records_contain_index_compaction(records: list[Json]) -> bool:
+    for record in records:
+        if (
+            str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE
+            and str(record.get("tombstone_kind") or "") == INDEX_COMPACT_TOMBSTONE_KIND
+        ):
+            return True
+    return False
+
+
+def sweep_index_compaction(records: list[Json]) -> list[Json]:
+    """Apply every ``index_compact`` tombstone in ONE reverse pass and strip the tombstones.
+
+    Semantically identical to running ``index_compact_tombstone_kills_record`` for each tombstone
+    against each earlier record (order-aware: a tombstone only removes records that PRECEDE it), but
+    O(n) instead of O(tombstones x records) -- and summaries emit one of these per rollup, so the
+    quadratic form would dominate a long-lived store's serving recompute.
+
+    Returns `records` unchanged (identity) when the log carries no compaction tombstone."""
+    if not records_contain_index_compaction(records):
+        return records
+    targets_any: set[str] = set()
+    targets_by_scope: dict[str, set[str]] = {}
+    kept_reversed: list[Json] = []
+    for record in reversed(records):
+        record_type = str(record.get("record_type") or "")
+        if (
+            record_type == MEMORY_TOMBSTONE_RECORD_TYPE
+            and str(record.get("tombstone_kind") or "") == INDEX_COMPACT_TOMBSTONE_KIND
+        ):
+            ids = {str(value) for value in (record.get("target_ref_ids") or ()) if value not in (None, "")}
+            scope_key = str(record.get("scope_key") or "")
+            if scope_key:
+                targets_by_scope.setdefault(scope_key, set()).update(ids)
+            else:
+                targets_any.update(ids)
+            continue  # the tombstone itself never serves
+        if record_type == "context_index" and str(record.get("ref_type") or "") == "event":
+            refs = _posting_ref_hashes(record)
+            if refs:
+                record_scope_key = str(record.get("scope_key") or "")
+                if record_scope_key:
+                    visible = targets_any | targets_by_scope.get(record_scope_key, set())
+                else:
+                    # A posting with no scope cannot contradict any tombstone's scope, so every
+                    # target is in play (mirrors the per-tombstone scope guard).
+                    visible = set(targets_any)
+                    for scoped in targets_by_scope.values():
+                        visible |= scoped
+                if visible and all(str(ref) in visible for ref in refs):
+                    continue
+        kept_reversed.append(record)
+    kept_reversed.reverse()
+    return kept_reversed

--- a/tools/matrixark_pipeline_task_slim.py
+++ b/tools/matrixark_pipeline_task_slim.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Collapse re-stamped async-pipeline task rows, and (optionally) age out their diagnostic payload.
+
+A resident-memory census (deep ``sizeof``, shared objects charged once, 25-turn workload) put
+``matrixark_async_pipeline_task`` at **26-30% of everything the process holds** -- the largest record
+type in the store, ahead of embeddings. The reason is not that the rows are individually huge: it is
+that the SAME task state is re-appended over and over. Measured on that store: **193 rows for 25
+distinct ``task_hash`` values** -- 168 of them re-stamps of ``summary_completed``, one per task per
+summary refresh.
+
+## Lever A -- collapse re-stamps (``MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS``, default ON)
+
+Keep, per ``(task_hash, status)``, the NEWEST row by time and the newest by log position; drop the
+rest. Every distinct state a task passed through survives -- only duplicate stampings of a state the
+task is already recorded as having reached are removed.
+
+That specific rule (rather than a plain latest-value collapse on ``task_hash``) is forced by the
+consumers, which disagree about what "latest" means:
+
+* ``matrixark_mcp_async_readiness.latest_async_pipeline_rows`` -- max by (8-status rank, time)
+* ``matrixark_mcp_dashboard`` / ``matrixark_mcp_recovery`` -- max by (3-status rank, time)
+* ``drain_due_idle_session_commits`` -- max by LOG POSITION, and requires that row to be
+  ``idle_commit_scheduled``
+* ``matrixark_local_adapter_retrieve`` -- scans for ANY row with ``status == "extraction_committed"``,
+  not the latest one, to decide which events have been extracted
+
+A latest-value collapse on ``task_hash`` alone would keep one row -- typically ``summary_completed``
+-- and silently empty retrieve's ``extraction_committed`` set. Keeping the newest row per status
+preserves every one of those four answers exactly: each rank rule's winner is the newest row of its
+winning status; the positional rule's winner is kept explicitly; and every status stays present.
+
+## Lever B -- age out diagnostics (``MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS``, default OFF)
+
+Strips the dashboard-only payload (``memory_layers_written``, stage lists, lineage count maps) from
+finished tasks beyond the newest N per scope, marking them ``detail_slimmed``. Measured at only
+**-0.6% of resident memory** once Lever A has run, so it is off by default: the bytes were in the
+duplicate ROWS, not in the surviving rows' fields. Kept because it is a legitimate knob for a store
+that keeps very long task histories, but it is not the win and is not pretending to be.
+
+Both levers are serving-side only: the JSONL log keeps every row, so the durable audit trail is
+intact and either flag can be flipped back without a rewrite.
+"""
+
+from __future__ import annotations
+
+import json
+
+import os
+from typing import Any
+
+Json = dict[str, Any]
+
+PIPELINE_TASK_RECORD_TYPE = "matrixark_async_pipeline_task"
+
+# A task in one of these states has nothing left to run.
+FINISHED_STATUSES = frozenset({
+    "extraction_committed",
+    "idle_commit_committed",
+    "idle_commit_skipped",
+    "threshold_commit_committed",
+    "committed",
+    "completed",
+    "finalized",
+    "summary_completed",
+    "failed",
+    "error",
+    "timeout",
+    "skipped",
+})
+
+SLIMMED_FIELDS = (
+    "memory_layers_written",
+    "stages",
+    "completed_stages",
+    "remaining_stages",
+    "summary_node_path",
+    "generated_summary_types",
+    "source_roles",
+    "source_role_counts",
+    "source_hook_types",
+    "source_hook_type_counts",
+    "source_codex_events",
+    "source_codex_event_counts",
+    "source_memory_selection_policies",
+    "source_memory_selection_policy_counts",
+    "source_profile_promotion_policies",
+    "source_profile_promotion_blockers",
+    "source_entity_hashes",
+    "source_session_ids",
+)
+
+DEFAULT_DETAIL_RETAIN_PER_SCOPE = 50
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return max(0, int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return default
+
+
+def collapse_pipeline_task_rows_enabled() -> bool:
+    return _env_flag("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", True)
+
+
+def slim_terminal_pipeline_tasks_enabled() -> bool:
+    """Lever B is opt-in: measured at -0.6% once Lever A has collapsed the duplicate rows."""
+    return _env_flag("MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS", False)
+
+
+def pipeline_task_detail_retain_per_scope() -> int:
+    return _env_int("MATRIXARK_PIPELINE_TASK_DETAIL_RETAIN_PER_SCOPE", DEFAULT_DETAIL_RETAIN_PER_SCOPE)
+
+
+def _task_identity(record: Json) -> str:
+    identity = record.get("task_hash")
+    if identity in (None, ""):
+        identity = record.get("event_id_hash")
+    return str(identity if identity not in (None, "") else "")
+
+
+def _task_time(record: Json) -> int:
+    try:
+        return int(record.get("updated_at_ms") or record.get("created_at_ms") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def collapse_pipeline_task_rows(records: list[Json]) -> list[Json]:
+    """Drop re-stamps of a pipeline-task state, keeping every distinct (task, status) it reached.
+
+    Returns `records` itself (identity) when the flag is off or nothing is duplicated."""
+    if not collapse_pipeline_task_rows_enabled():
+        return records
+    newest_by_time: dict[tuple[str, str], int] = {}
+    newest_by_position: dict[tuple[str, str], int] = {}
+    duplicates = 0
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") != PIPELINE_TASK_RECORD_TYPE:
+            continue
+        identity = _task_identity(record)
+        if not identity:
+            continue  # unkeyable row: never dropped
+        key = (identity, str(record.get("status") or ""))
+        if key in newest_by_time:
+            duplicates += 1
+        else:
+            newest_by_time[key] = position
+            newest_by_position[key] = position
+            continue
+        if (_task_time(record), position) > (_task_time(records[newest_by_time[key]]), newest_by_time[key]):
+            newest_by_time[key] = position
+        newest_by_position[key] = position  # enumeration order == log order
+    if not duplicates:
+        return records
+    keep = set(newest_by_time.values()) | set(newest_by_position.values())
+    output: list[Json] = []
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") != PIPELINE_TASK_RECORD_TYPE:
+            output.append(record)
+            continue
+        if not _task_identity(record) or position in keep:
+            output.append(record)
+    return output
+
+
+def _task_scope_key(record: Json) -> str:
+    scope_key = record.get("scope_key")
+    if scope_key:
+        return str(scope_key)
+    scope = record.get("scope")
+    if isinstance(scope, dict):
+        return str(scope.get("scope_key") or f"{scope.get('tenant_id')}/{scope.get('user_id')}")
+    return ""
+
+
+def _recency_key(entry: tuple[int, Json]) -> tuple[int, int]:
+    position, record = entry
+    return (_task_time(record), position)
+
+
+def slim_terminal_pipeline_tasks(records: list[Json]) -> list[Json]:
+    """Lever B: strip the dashboard-only payload from aged-out finished tasks (identity when off)."""
+    if not slim_terminal_pipeline_tasks_enabled():
+        return records
+    retain = pipeline_task_detail_retain_per_scope()
+    finished: list[tuple[int, Json]] = []
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") != PIPELINE_TASK_RECORD_TYPE:
+            continue
+        if str(record.get("status") or "") not in FINISHED_STATUSES:
+            continue
+        if record.get("detail_slimmed"):
+            continue
+        if any(field in record for field in SLIMMED_FIELDS):
+            finished.append((position, record))
+    if not finished:
+        return records
+    by_scope: dict[str, list[tuple[int, Json]]] = {}
+    for entry in finished:
+        by_scope.setdefault(_task_scope_key(entry[1]), []).append(entry)
+    slim_positions: set[int] = set()
+    for entries in by_scope.values():
+        if retain <= 0:
+            slim_positions.update(position for position, _record in entries)
+            continue
+        for position, _record in sorted(entries, key=_recency_key, reverse=True)[retain:]:
+            slim_positions.add(position)
+    if not slim_positions:
+        return records
+    output: list[Json] = []
+    for position, record in enumerate(records):
+        if position not in slim_positions:
+            output.append(record)
+            continue
+        slimmed = {key: value for key, value in record.items() if key not in SLIMMED_FIELDS}
+        slimmed["detail_slimmed"] = True
+        output.append(slimmed)
+    return output
+
+
+AUDIT_PAYLOAD_RECORD_TYPES = frozenset({
+    "context_extraction_audit",
+    "context_batch_commit",
+    "context_entity_update_audit",
+    "matrixark_audit_log",
+})
+
+# Dropped from an aged-out audit row. Every field the ingest/retrieval paths actually read is
+# excluded: record_type, scope, scope_key, status, the *_hash identities, and the timestamps.
+# What goes is what only the dashboards render.
+AUDIT_PAYLOAD_FIELDS = (
+    "outputs",
+    "schema",
+    "profile_promotion_summary",
+    "memory_layers_written",
+    "summary_refresh",
+    "trigger_evidence",
+    "inputs",
+    "response",
+    "source_refs",
+    "extraction_debug",
+)
+
+
+def _audit_scope_key(record: Json) -> str:
+    scope_key = record.get("scope_key")
+    if scope_key:
+        return str(scope_key)
+    scope = record.get("scope")
+    if isinstance(scope, dict):
+        return str(scope.get("scope_key") or f"{scope.get('tenant_id')}/{scope.get('user_id')}")
+    return ""
+
+
+def slim_audit_payloads(records: list[Json]) -> list[Json]:
+    """Strip diagnostic payloads from audit/commit rows beyond the newest N per scope.
+
+    These rows are load-bearing for their IDENTITY -- session-commit and retrieval look them up by
+    record_type + scope, and the dashboards read the payload -- so the row itself always survives and
+    only the payload ages out. A field-level census put these payloads at ~11% of resident memory
+    (context_extraction_audit.outputs alone was 5.6%), with no retention policy of any kind: unlike
+    the debug-record knobs, which default OFF, these are written unconditionally.
+
+    Returns `records` itself (identity) when retention is disabled or nothing qualifies."""
+    try:
+        from tools.matrixark_index_growth_bound import audit_payload_retain_per_scope
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_index_growth_bound import audit_payload_retain_per_scope
+
+    candidates: list[tuple[int, Json]] = []
+    for position, record in enumerate(records):
+        if str(record.get("record_type") or "") not in AUDIT_PAYLOAD_RECORD_TYPES:
+            continue
+        if record.get("payload_slimmed"):
+            continue
+        if any(field in record for field in AUDIT_PAYLOAD_FIELDS):
+            candidates.append((position, record))
+    if not candidates:
+        return records
+
+    by_scope: dict[str, list[tuple[int, Json]]] = {}
+    for entry in candidates:
+        by_scope.setdefault(_audit_scope_key(entry[1]), []).append(entry)
+
+    slim_positions: set[int] = set()
+    for scope_key, entries in by_scope.items():
+        retain = audit_payload_retain_per_scope(entries[0][1].get("scope") or scope_key)
+        if retain <= 0:
+            continue
+        for position, _record in sorted(entries, key=_recency_key, reverse=True)[retain:]:
+            slim_positions.add(position)
+    if not slim_positions:
+        return records
+
+    output: list[Json] = []
+    for position, record in enumerate(records):
+        if position not in slim_positions:
+            output.append(record)
+            continue
+        slimmed = {key: value for key, value in record.items() if key not in AUDIT_PAYLOAD_FIELDS}
+        slimmed["payload_slimmed"] = True
+        output.append(slimmed)
+    return output
+
+
+# Near-constant dicts stamped on almost every record. A store holds a handful of distinct values
+# (measured: 3 storage_route, 12 storage_options, 3 scope) across hundreds of records.
+SHARED_VALUE_FIELDS = ("storage_route", "storage_options", "scope", "access_scope", "storage_options_ref")
+
+
+def canonicalize_shared_values(records: list[Json]) -> list[Json]:
+    """Point every record at ONE object per distinct routing/scope value.
+
+    Interned expansion canonicalizes what it expands, but records written inline never pass through
+    it, and ``scope`` / ``access_scope`` are not part of the intern bundle at all -- so the serving
+    view still held 50 objects for 3 route values and 44 for 3 scopes. This is the read-side sweep
+    that closes both gaps.
+
+    The records reaching this stage are NOT private copies: the upstream compaction stages pass a
+    record straight through when they have nothing to change, so they are the adapter's own cached
+    objects. Writing the shared value onto them therefore mutates cached state, which measurably
+    perturbed the store (a module that failed 0/12 runs on main failed 6/12 with an in-place sweep,
+    via background writes landing after teardown). So this is copy-on-write: a record whose value is
+    being re-pointed is shallow-copied first, and untouched records are returned by identity.
+
+    The VALUES are shared across the returned records, so a caller that needs to change one must copy
+    it first -- which is what ``attach_context_placement`` already does (``route = dict(route)``).
+    That is the invariant this function depends on; breaking it would let one record's placement leak
+    into every other record sharing the value. (Verified with a tripwire ``dict`` subclass over the
+    gateway/admin path: zero in-place writes to any shared value.)"""
+    try:
+        from tools.matrixark_index_growth_bound import share_serving_values_enabled
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_index_growth_bound import share_serving_values_enabled
+    if not share_serving_values_enabled(None):
+        return records
+
+    cache: dict[tuple[str, str], Any] = {}
+    output: list[Json] = []
+    for record in records:
+        if not isinstance(record, dict):
+            output.append(record)
+            continue
+        replacements: dict[str, Any] = {}
+        for field in SHARED_VALUE_FIELDS:
+            value = record.get(field)
+            if not isinstance(value, dict) or not value:
+                continue
+            try:
+                fingerprint = (field, json.dumps(value, sort_keys=True, separators=(",", ":"), default=str))
+            except (TypeError, ValueError):
+                continue
+            existing = cache.get(fingerprint)
+            if existing is None:
+                cache[fingerprint] = value
+            elif existing is not value:
+                replacements[field] = existing
+        if not replacements:
+            output.append(record)
+            continue
+        copied = dict(record)
+        copied.update(replacements)
+        output.append(copied)
+    return output
+
+
+def bound_pipeline_task_footprint(records: list[Json]) -> list[Json]:
+    """Lever A, lever B, audit-payload retention, then value sharing -- the serving pipeline's entry."""
+    return canonicalize_shared_values(
+        slim_audit_payloads(slim_terminal_pipeline_tasks(collapse_pipeline_task_rows(records)))
+    )
+
+
+def pipeline_task_footprint_stats(records: list[Json]) -> Json:
+    total = finished = slimmed = 0
+    identities: set[str] = set()
+    states: set[tuple[str, str]] = set()
+    for record in records:
+        if str(record.get("record_type") or "") != PIPELINE_TASK_RECORD_TYPE:
+            continue
+        total += 1
+        identity = _task_identity(record)
+        identities.add(identity)
+        states.add((identity, str(record.get("status") or "")))
+        if str(record.get("status") or "") in FINISHED_STATUSES:
+            finished += 1
+        if record.get("detail_slimmed"):
+            slimmed += 1
+    return {
+        "pipeline_tasks": total,
+        "distinct_tasks": len(identities),
+        "distinct_task_states": len(states),
+        "finished": finished,
+        "detail_slimmed": slimmed,
+        "collapse_enabled": collapse_pipeline_task_rows_enabled(),
+        "slim_enabled": slim_terminal_pipeline_tasks_enabled(),
+    }

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Per-tenant memory policy: what each tenant stores and how big its index may get.
+
+Until now every memory knob was a process-wide environment variable, which is wrong for a
+multi-tenant store: one tenant wanting segments, or a bigger index budget, forced that choice on
+everyone sharing the process. This module resolves each knob **per tenant**, in this order:
+
+    tenant override  ->  environment variable  ->  built-in default
+
+so an unconfigured deployment behaves exactly as it did before, and a tenant that needs something
+different says so without touching anyone else.
+
+## Where overrides come from
+
+1. A JSON policy file at ``MATRIXARK_TENANT_POLICY_PATH``::
+
+       {
+         "defaults":  {"extract_segments": false, "max_secondary_index_records_per_scope": 256},
+         "tenants": {
+           "acme":      {"extract_segments": true, "max_secondary_index_records_per_scope": 4096},
+           "starter-co": {"compact_index_on_summary": true, "max_secondary_index_records_per_scope": 64}
+         }
+       }
+
+   Re-read automatically when the file's mtime changes, so policy edits do not need a restart.
+
+2. ``matrixark_tenant_policy`` records in the store itself (durable, survives restart, and lets a
+   control-plane API set policy at runtime): ``{"record_type": "matrixark_tenant_policy",
+   "tenant_id": "acme", "policy": {...}}``. Registered through :func:`register_tenant_policy_records`.
+   A record overrides the file for that tenant, since it is the more recent statement of intent.
+
+## Tenant identity
+
+Any of these resolves: a scope dict (``tenant_id`` preferred, else ``tenant_hash``), a ``scope_key``
+string (``t=<hash>;u=<hash>``), or a bare tenant id. A scope with no resolvable tenant falls back to
+the global answer -- never to another tenant's policy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from typing import Any
+
+Json = dict[str, Any]
+
+LOGGER = logging.getLogger("matrixark.tenant_policy")
+
+TENANT_POLICY_RECORD_TYPE = "matrixark_tenant_policy"
+
+
+class Knob:
+    """One tunable: its type, its env var, and the value used when nobody configured it.
+
+    ``aliases`` / ``env_aliases`` keep an earlier name working after a rename, so an existing
+    deployment's config file or environment is not silently ignored."""
+
+    __slots__ = ("name", "kind", "env", "default", "description", "aliases", "env_aliases", "choices")
+
+    def __init__(self, name: str, kind: str, env: str, default: Any, description: str,
+                 aliases: tuple = (), env_aliases: tuple = (), choices: tuple = ()) -> None:
+        self.choices = frozenset(choices)
+        self.name = name
+        self.kind = kind
+        self.env = env
+        self.default = default
+        self.description = description
+        self.aliases = aliases
+        self.env_aliases = env_aliases
+
+    def coerce(self, value: Any) -> Any:
+        if self.kind == "choice":
+            text = str(value).strip().lower()
+            if text not in self.choices:
+                raise ValueError(f"{self.name} must be one of {sorted(self.choices)}")
+            return text
+        if self.kind == "bool":
+            if isinstance(value, bool):
+                return value
+            return str(value).strip().lower() not in {"0", "false", "no", "off", ""}
+        if self.kind == "int":
+            return max(0, int(str(value).strip()))
+        return value
+
+
+KNOBS: dict[str, Knob] = {
+    knob.name: knob
+    for knob in (
+        Knob("extract_segments", "bool", "MATRIXARK_EXTRACT_SEGMENTS", False,
+             "Materialize context_segment rows. Off by default: a segment restates its event."),
+        Knob("compact_index_on_summary", "bool", "MATRIXARK_INDEX_COMPACT_ON_SUMMARY", True,
+             "Drop an event's per-event index postings once a summary covers it (lossless)."),
+        Knob("max_secondary_index_records_per_session", "int",
+             "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION", 128,
+             "Per-session posting budget; 0 = unlimited. Measured with dedup on: 128 holds recall "
+             "5/5 (177 postings at 40 turns), 96 and below lose a fact.",
+             aliases=("max_secondary_index_records_per_scope",),
+             env_aliases=("MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE",)),
+        Knob("max_secondary_index_records_per_tenant", "int",
+             "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_TENANT", 1024,
+             "Per-tenant posting budget across all that tenant's sessions; 0 = unlimited. There is "
+             "no store-wide total on purpose: a global budget would let one tenant evict another.",
+             aliases=("secondary_index_hard_ceiling",),
+             env_aliases=("MATRIXARK_SECONDARY_INDEX_HARD_CEILING",)),
+        Knob("top_k_per_layer", "int", "MATRIXARK_TOP_K_PER_LAYER", 24,
+             "How many children each parent contributes to the next traversal frontier (applied "
+             "per parent, so a layer with P parents admits up to P x K)."),
+        Knob("max_global_candidates", "int", "MATRIXARK_MAX_GLOBAL_CANDIDATES", 2048,
+             "Ceiling on candidate records considered for the context pack."),
+        Knob("max_selected_refs", "int", "MATRIXARK_MAX_SELECTED_REFS", 1000,
+             "Ceiling on refs selected into the context pack (the token budget usually binds first)."),
+        Knob("summary_levels", "choice", "MATRIXARK_SUMMARY_LEVELS", "auto",
+             "Which node summaries to generate, explicitly: 'auto' keeps today's content-driven "
+             "rule (L0 always, L1 when the node has child summaries / >=3 events / >=180 tokens), "
+             "'l0' never generates L1, 'l0_l1' always generates both regardless of the rule, 'none' "
+             "generates neither. NOTE 'none' also disables index compaction, which only fires once "
+             "an event has been rolled up -- so per-event postings then live forever.",
+             choices=("auto", "l0", "l0_l1", "none")),
+        Knob("audit_payload_retain_per_scope", "int", "MATRIXARK_AUDIT_PAYLOAD_RETAIN_PER_SCOPE", 20,
+             "How many audit / batch-commit records per scope keep their diagnostic payload "
+             "(outputs, schema, profile_promotion_summary, memory_layers_written, summary_refresh, "
+             "trigger_evidence). Older rows keep identity, scope, status and timing -- which is all "
+             "the ingest and retrieval paths read -- and are marked payload_slimmed. 0 = keep every "
+             "payload forever. Measured: these payloads are ~11% of resident memory."),
+        Knob("summarize_aggregation_only_nodes", "bool", "MATRIXARK_SUMMARIZE_AGGREGATION_ONLY_NODES", True,
+             "Summarize nodes that hold no events of their own (tenant / user / profile). ON by "
+             "default, i.e. the skip is opt-in, because the first framing of this lever was wrong: "
+             "the argument was that the traversal visits these nodes unconditionally, so a summary "
+             "there cannot help it prune. True, but retrieval does not only use summaries to prune "
+             "-- it INJECTS them as their own memory layer, and the profile node's summary is what "
+             "carries cross-session memory into a fresh session pack. Worse, node_l1 is only ever "
+             "generated where child summaries exist, which is exactly these nodes, so skipping them "
+             "removed every L1 in the store (caught by three profile/L1 tests). Turn it off per "
+             "tenant to trade that layer for the memory: measured ~5 summaries per 3 sessions."),
+        Knob("pack_drop_redundant_items", "bool", "MATRIXARK_PACK_DROP_REDUNDANT_ITEMS", True,
+             "Drop a pack item whose content another item in the SAME pack already carries. An "
+             "entity is a projection of the event it was extracted from, so a pack routinely ships "
+             "both -- 'user: I live in Kyoto and my favorite drink is matcha.' alongside "
+             "'preference: preference = drink is matcha'. The reader pays tokens twice for one "
+             "fact. The longer item is kept, because it is the one that carries the surrounding "
+             "context; only the projection is dropped, and only when its value is literally "
+             "contained in the kept item."),
+        Knob("recall_reinforcement", "bool", "MATRIXARK_RECALL_REINFORCEMENT", True,
+             "Write a protection marker for every ref a retrieval selected, so recently recalled "
+             "memory survives raw-event pruning. It is genuinely useful -- recall is the signal "
+             "that something matters -- but it makes RETRIEVAL a writer: measured, 5 searches "
+             "produced 572 marker records, about 114 writes per query, and that write "
+             "amplification shows up in both search latency and storage (124.9 KB/message). A "
+             "tenant that prunes rarely, or values read latency over pruning accuracy, can turn it "
+             "off; a request can still override per call via ranking.recall_reinforcement."),
+        Knob("skill_chunks_per_skill", "int", "MATRIXARK_SKILL_CHUNKS_PER_SKILL", 3,
+             "Sections returned from ONE skill, chosen by how well each section matches the query "
+             "rather than by document order. A skill is chunked one section per heading, so a "
+             "40-chapter handbook is 41 independently embedded sections: returning all of them put "
+             "1385 tokens of operations procedure into a pack asking about a favourite drink. "
+             "Returning the best 3 costs about 60 tokens and is more accurate, because the three "
+             "relevant chapters beat forty of which thirty-seven are noise. 0 returns every "
+             "section (the old behaviour)."),
+        Knob("skill_description_always", "bool", "MATRIXARK_SKILL_DESCRIPTION_ALWAYS", True,
+             "Include each visible skill's name + description in every pack, even when no section "
+             "matches. This is what makes many skills affordable: a description is ~5-30 tokens, "
+             "so the model learns a skill EXISTS for a few tokens and its content is fetched only "
+             "when a chunk actually matches. Progressive disclosure, the same shape agent runtimes "
+             "use for their own skill listings."),
+        Knob("skill_reserved_refs", "int", "MATRIXARK_SKILL_RESERVED_REFS", 3,
+             "Pack slots held for SKILLS, admitted by policy rather than by similarity score. A "
+             "skill is instruction, not recollection: an incident runbook does not read like the "
+             "question 'how do I handle an incident', so on score alone it loses to any event that "
+             "happens to share wording -- measured, no skill reached a pack at all while both "
+             "session and profile memory did. Reserving slots is the same shape as guaranteeing "
+             "the current session: the thing that must be present is admitted, and ranking decides "
+             "the rest. 0 disables the reservation and returns skills to competing on score."),
+        Knob("traverse_sibling_sessions", "bool", "MATRIXARK_TRAVERSE_SIBLING_SESSIONS", True,
+             "Descend into other sessions' subtrees during retrieval. A pack is built from the "
+             "CURRENT session (matched by session_id, and admitted unconditionally) plus the "
+             "durable PROFILE, which is the aggregate that carries cross-session memory. Measured "
+             "over a 12-session store, every pack item came from one of those two and none from a "
+             "sibling session's events -- so scoring the siblings is a cosine per summary per query "
+             "whose result is discarded, and it grows with every conversation the user has ever "
+             "had. Left ON by default because turning it off changes what CAN be reached, not just "
+             "what costs; verify recall on a real corpus before switching it off for a tenant."),
+        Knob("top_k_per_layer", "int", "MATRIXARK_TOP_K_PER_LAYER", 240,
+             "How many child nodes each PARENT contributes to the next traversal frontier (the "
+             "name says layer, the code applies it per parent). Raised 24 -> 240: at 24 a user "
+             "with more sessions than that had the surplus discarded by node-summary score, and "
+             "the session most likely to lose is the newest one. The current session no longer "
+             "depends on this -- it is admitted unconditionally -- so this now governs only how "
+             "much of the cross-session history is explored."),
+        Knob("max_candidates_per_node", "int", "MATRIXARK_MAX_CANDIDATES_PER_NODE", 10240,
+             "Candidate refs (events + entities) admitted from a single node. Never applied to "
+             "child nodes -- a session holding 40 events returns them all; this is the ceiling on "
+             "how deep one node can go."),
+        Knob("max_global_candidates", "int", "MATRIXARK_MAX_GLOBAL_CANDIDATES", 20480,
+             "Total candidates gathered across the whole traversal before scoring."),
+        Knob("max_selected_refs", "int", "MATRIXARK_MAX_SELECTED_REFS", 10000,
+             "Refs allowed into the pack after scoring. The token budget is the limit that "
+             "actually binds in practice; this is the backstop."),
+        Knob("cross_session_profile_max_candidates", "int",
+             "MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", 2000,
+             "Candidates drawn from the durable profile -- the aggregation that carries "
+             "cross-session memory into a fresh session, rather than scanning every past session."),
+        Knob("share_serving_values", "bool", "MATRIXARK_SHARE_SERVING_VALUES", False,
+             "Point every served record at one shared object per distinct storage_route / "
+             "storage_options / scope / access_scope value. OFF by default: it saves real memory "
+             "(188 route objects for 3 values on a 3-session store) but it measurably perturbs the "
+             "store -- an HTTP module that fails 0/20 runs on main fails 7/20 with this on, via "
+             "background writes landing after test teardown, and that reproduced with the sweep "
+             "written copy-on-write as well as in place, so the trigger is not value mutation (a "
+             "tripwire dict recorded zero in-place writes to a shared value). Until that is "
+             "explained, the sharing on the INTERNED path -- which is on by default and verified "
+             "clean over the same 12 runs -- is the part that ships. Turn this on per tenant only "
+             "with the same background-write check."),
+        Knob("return_all_candidates", "bool", "MATRIXARK_RETURN_ALL_CANDIDATES", False,
+             "Always return every eligible candidate: skip the secondary-index prefilter and skip "
+             "scoring entirely, letting the token budget be the only limit. For a tenant whose whole "
+             "memory fits the budget, ranking can only lose facts it did not need to lose."),
+        Knob("return_all_candidate_threshold", "int", "MATRIXARK_RETURN_ALL_CANDIDATE_THRESHOLD", 0,
+             "Return every candidate when a broad scan yields at most this many event/entity "
+             "candidates; above it, fall back to the indexed + scored path. 0 = off. This is the "
+             "self-tuning form of return_all_candidates: small stores pay nothing for ranking, "
+             "large ones keep it."),
+        Knob("node_path_embeddings", "bool", "MATRIXARK_NODE_PATH_EMBEDDINGS", True,
+             "Embed a context_node's PATH when the node is created. ON by default, and turning it "
+             "off is a correctness risk, not just a memory trade.\n\n"
+             "A path is not content, so embedding it looked like pure waste -- it puts the "
+             "tenant/user/session spine into the vector of every node. But it is the only embedding "
+             "a node is guaranteed to have AT CREATION TIME. A node's other embedding comes from its "
+             "SUMMARY, which is written later by refresh_summaries, so switching this off leaves a "
+             "window in which a node cannot be scored at all. Retrieval then selects no node, the "
+             "traversal has nothing to descend, and the pack falls back to profile entities alone.\n\n"
+             "Measured: with this off, a 40-event store returned 1 pack item instead of 38 in 8 of "
+             "10 retrieves on a loaded machine (0 of 10 on the unmodified code). One retrieve per "
+             "fresh process is what exposes it -- 25 retrieves inside one process all succeed, "
+             "because the first one warms the state the rest rely on. Load widens the window; it "
+             "does not create it.\n\n"
+             "Turn it off only for a tenant whose nodes are always summarised before their first "
+             "retrieve, and verify with a cold-start check, not a warm one."),
+        Knob("embed_node_path_prefix", "bool", "MATRIXARK_EMBED_NODE_PATH_PREFIX", False,
+             "Include the node path in the text that node summaries are EMBEDDED from. Off by "
+             "default: the path is near-identical across siblings, so it injects a shared component "
+             "into every node vector -- measured, two nodes sharing nothing went from cos 0.0000 to "
+             "0.3636 once prefixed, and the right-node margin shrank in both queries tested. The "
+             "stored summary_text keeps the prefix; only the embedded text drops it."),
+        Knob("generate_l1_summaries", "bool", "MATRIXARK_GENERATE_L1_SUMMARIES", True,
+             "Generate the richer node_l1 overview alongside the mandatory node_l0. L0 is what "
+             "traversal needs; L1 adds routing detail for nodes with a lot under them. Node "
+             "summaries are bounded by tree size (3 + one per session), so this is a small, safe "
+             "knob -- the linear-growing summary is batch_l0, one per ingest batch."),
+        Knob("write_secondary_index", "bool", "MATRIXARK_WRITE_SECONDARY_INDEX", True,
+             "Store context_index postings at all. A tenant whose corpus is small enough to scan "
+             "can turn the index off entirely and pay nothing to maintain it."),
+        Knob("dedupe_index_postings", "bool", "MATRIXARK_DEDUPE_INDEX_POSTINGS", True,
+             "Collapse repeated postings for the same (scope, term, refs). Lossless."),
+        Knob("store_event_summary_text", "bool", "MATRIXARK_STORE_EVENT_SUMMARY_TEXT", False,
+             "Store a context_event's summary_text. Off by default: it is a whitespace-collapsed "
+             "truncation of text (no LLM), so it duplicates text for any event under the limit, and "
+             "every reader already falls back to text."),
+        Knob("max_summary_text_chars", "int", "MATRIXARK_MAX_SUMMARY_TEXT_CHARS", 0,
+             "Cap a context_summary's summary_text; 0 = the built-in budget (220 for L0, 1200 for "
+             "L1). Measured: this is where noisy tool output actually persists -- an event drops it, "
+             "the node summary keeps up to 1200 chars of it per row."),
+        Knob("max_event_text_chars", "int", "MATRIXARK_MAX_EVENT_TEXT_CHARS", 0,
+             "Clip each message's content to this many characters BEFORE extraction; 0 = unlimited. "
+             "Bounds what a noisy tool-output turn can cost across the event, its extraction, its "
+             "embedding and its index postings -- all of which read the clipped text."),
+        Knob("generate_embeddings", "bool", "MATRIXARK_GENERATE_EMBEDDINGS", True,
+             "Store context_embedding vectors. A small tenant can turn these off and retrieve "
+             "through the secondary index instead -- embeddings are ~13% of resident memory."),
+        Knob("collapse_pipeline_task_rows", "bool", "MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", True,
+             "Collapse re-stamped async pipeline task rows to the newest per (task, status)."),
+        Knob("slim_terminal_pipeline_tasks", "bool", "MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS", False,
+             "Age out finished pipeline tasks' dashboard-only payload."),
+    )
+}
+
+
+def tenant_hash_of(tenant_id: str, account_id: str = "") -> str:
+    """The ``t=`` hash a scope_key carries for `tenant_id`, so policy keyed by the human id also
+    resolves for records that were reduced to hashes. Mirrors
+    ``matrixark_mcp_identity.identity_hashes``; returns "" when identity helpers are unavailable."""
+    try:
+        try:
+            from tools.matrixark_mcp_identity import canonical_account_id, canonical_tenant_id, stable_hash
+        except ModuleNotFoundError:
+            from matrixark_mcp_identity import canonical_account_id, canonical_tenant_id, stable_hash
+    except Exception:  # identity layer not importable (pure-policy unit tests)
+        return ""
+    account = canonical_account_id(str(account_id or ""))
+    tenant = canonical_tenant_id(str(tenant_id or ""))
+    return str(stable_hash(f"{account}:{tenant}"))
+
+
+def _tenant_aliases(tenant_id: str) -> list[str]:
+    """Every identity a policy for `tenant_id` should answer to: the id itself and its scope hash."""
+    aliases = [str(tenant_id)]
+    hashed = tenant_hash_of(tenant_id)
+    if hashed and hashed not in aliases:
+        aliases.append(hashed)
+    return aliases
+
+
+_KNOBS_BY_ALIAS: dict[str, Knob] = {
+    alias: knob for knob in KNOBS.values() for alias in knob.aliases
+}
+
+_LOCK = threading.RLock()
+_FILE_CACHE: dict[str, Any] = {"path": None, "mtime_ns": -1, "defaults": {}, "tenants": {}}
+_RECORD_POLICIES: dict[str, Json] = {}
+
+
+def _validated(policy: Any, *, source: str, tenant: str) -> Json:
+    """Keep the knobs we know, coerced to their declared type; drop and log anything else."""
+    if not isinstance(policy, dict):
+        LOGGER.warning("tenant_policy_ignored source=%s tenant=%s reason=not_an_object", source, tenant)
+        return {}
+    clean: Json = {}
+    for key, value in policy.items():
+        knob = KNOBS.get(str(key)) or _KNOBS_BY_ALIAS.get(str(key))
+        if knob is None:
+            LOGGER.warning("tenant_policy_unknown_knob source=%s tenant=%s knob=%s", source, tenant, key)
+            continue
+        try:
+            clean[knob.name] = knob.coerce(value)
+        except (TypeError, ValueError):
+            LOGGER.warning("tenant_policy_bad_value source=%s tenant=%s knob=%s value=%r",
+                           source, tenant, key, value)
+    return clean
+
+
+def _load_file_policies() -> tuple[Json, dict[str, Json]]:
+    path = os.environ.get("MATRIXARK_TENANT_POLICY_PATH", "").strip()
+    if not path:
+        return {}, {}
+    try:
+        stat = os.stat(path)
+        # (mtime, size, inode): a rewrite inside one filesystem timestamp tick is invisible to mtime
+        # alone, which would serve a stale policy indefinitely.
+        mtime_ns = (stat.st_mtime_ns, stat.st_size, stat.st_ino)
+    except OSError:
+        if _FILE_CACHE["path"] == path:
+            LOGGER.warning("tenant_policy_file_unreadable path=%s (keeping last good policy)", path)
+            return _FILE_CACHE["defaults"], _FILE_CACHE["tenants"]
+        LOGGER.warning("tenant_policy_file_missing path=%s", path)
+        return {}, {}
+    with _LOCK:
+        if _FILE_CACHE["path"] == path and _FILE_CACHE["mtime_ns"] == mtime_ns:
+            return _FILE_CACHE["defaults"], _FILE_CACHE["tenants"]
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = json.load(handle)
+        except (OSError, ValueError) as error:
+            # A broken edit must not silently revert everyone to defaults mid-flight.
+            LOGGER.warning("tenant_policy_file_invalid path=%s error=%s (keeping last good policy)",
+                           path, error)
+            return _FILE_CACHE["defaults"], _FILE_CACHE["tenants"]
+        defaults = _validated(raw.get("defaults", {}), source=path, tenant="*")
+        tenants: dict[str, Json] = {}
+        for tenant, policy in (raw.get("tenants", {}) or {}).items():
+            clean = _validated(policy, source=path, tenant=str(tenant))
+            for alias in _tenant_aliases(str(tenant)):
+                tenants[alias] = clean
+        _FILE_CACHE.update({"path": path, "mtime_ns": mtime_ns, "defaults": defaults, "tenants": tenants})
+        LOGGER.info("tenant_policy_loaded path=%s tenants=%d", path, len(tenants))
+        return defaults, tenants
+
+
+def register_tenant_policy_records(records: list[Json]) -> int:
+    """Absorb ``matrixark_tenant_policy`` rows from the store (later rows win). Returns the count."""
+    found = 0
+    for record in records or ():
+        if str(record.get("record_type") or "") != TENANT_POLICY_RECORD_TYPE:
+            continue
+        tenant = str(record.get("tenant_id") or record.get("tenant_hash") or "").strip()
+        if not tenant:
+            continue
+        clean = _validated(record.get("policy"), source="store", tenant=tenant)
+        with _LOCK:
+            for alias in _tenant_aliases(tenant):
+                _RECORD_POLICIES[alias] = clean
+        found += 1
+    return found
+
+
+def set_tenant_policy(tenant_id: str, policy: Json, *, merge: bool = True) -> Json:
+    """Change one tenant's policy WHILE THE SERVICE IS RUNNING; returns the tenant's new override set.
+
+    Takes effect on the next resolution -- no restart, no reconnect, and no effect on any other
+    tenant. Callers that want it to survive a restart append the returned policy to the store as a
+    ``matrixark_tenant_policy`` record (``register_tenant_policy_records`` reads it back on load);
+    the in-memory update here is what makes the change immediate.
+
+    ``merge=False`` replaces the tenant's overrides outright instead of layering onto them."""
+    tenant = str(tenant_id or "").strip()
+    if not tenant:
+        raise ValueError("set_tenant_policy requires a tenant id")
+    clean = _validated(policy, source="runtime", tenant=tenant)
+    with _LOCK:
+        if merge:
+            current = dict(_RECORD_POLICIES.get(tenant, {}))
+            current.update(clean)
+            merged = current
+        else:
+            merged = clean
+        # Registered under the human id AND its scope hash: a served record usually carries only the
+        # hash, so a policy that answered to just the id would silently miss every such record.
+        for alias in _tenant_aliases(tenant):
+            _RECORD_POLICIES[alias] = merged
+        result = dict(merged)
+    LOGGER.info("tenant_policy_set tenant=%s knobs=%s merge=%s", tenant, sorted(clean), merge)
+    return result
+
+
+def tenant_policy_record(tenant_id: str, policy: Json) -> Json:
+    """The durable record form of a policy change, for appending to the store."""
+    return {
+        "record_type": TENANT_POLICY_RECORD_TYPE,
+        "tenant_id": str(tenant_id),
+        "policy": _validated(policy, source="runtime", tenant=str(tenant_id)),
+    }
+
+
+def clear_tenant_policy_cache() -> None:
+    """Drop every cached policy (tests, and after a control-plane rewrite)."""
+    with _LOCK:
+        _FILE_CACHE.update({"path": None, "mtime_ns": -1, "defaults": {}, "tenants": {}})
+        _RECORD_POLICIES.clear()
+
+
+def tenant_of(scope: Any) -> str:
+    """Best-effort tenant identity from a scope dict, a scope_key, or a bare id ("" if none)."""
+    if scope in (None, "", {}):
+        return ""
+    if isinstance(scope, dict):
+        for field in ("tenant_id", "tenant", "tenant_hash"):
+            value = scope.get(field)
+            if value not in (None, "", 0):
+                return str(value)
+        return tenant_of(scope.get("scope_key") or "")
+    text = str(scope)
+    if "=" in text:  # scope_key form: t=<hash>|u=<hash>|s=<hash>
+        for part in text.replace("|", ";").replace(",", ";").split(";"):
+            key, _, value = part.partition("=")
+            if key.strip() in {"t", "tenant", "tenant_hash"} and value.strip():
+                return value.strip()
+        return ""
+    return text.strip()
+
+
+def tenant_scope_from_node_path(node_path: Any) -> Json:
+    """Recover a tenant identity from a context node path (``["tenant:acme", "user:u1", ...]``).
+
+    A background summary refresh can run with no scope argument, against a dirty marker whose own
+    scope was stripped by serving materialization -- but the node path always names the tenant, so
+    per-tenant policy has a last-resort identity instead of failing open."""
+    if not isinstance(node_path, (list, tuple)):
+        return {}
+    for part in node_path:
+        text = str(part or "")
+        if text.startswith("tenant:") and len(text) > 7:
+            return {"tenant_id": text[7:]}
+    return {}
+
+
+def tenant_policy(scope: Any = None) -> Json:
+    """The merged override set for `scope`'s tenant (file defaults < file tenant < store record)."""
+    file_defaults, file_tenants = _load_file_policies()
+    tenant = tenant_of(scope)
+    merged: Json = dict(file_defaults)
+    if tenant:
+        merged.update(file_tenants.get(tenant, {}))
+        with _LOCK:
+            merged.update(_RECORD_POLICIES.get(tenant, {}))
+    return merged
+
+
+def resolve(name: str, scope: Any = None) -> Any:
+    """Resolve one knob for `scope`'s tenant: tenant override -> env var -> built-in default."""
+    knob = KNOBS.get(name) or _KNOBS_BY_ALIAS.get(name)
+    if knob is None:
+        raise KeyError(f"unknown tenant policy knob: {name}")
+    policy = tenant_policy(scope)
+    if knob.name in policy:
+        return policy[knob.name]
+    raw = os.environ.get(knob.env)
+    if raw is None or str(raw).strip() == "":
+        for legacy in knob.env_aliases:
+            candidate = os.environ.get(legacy)
+            if candidate is not None and str(candidate).strip() != "":
+                raw = candidate
+                break
+    if raw is not None and str(raw).strip() != "":
+        try:
+            return knob.coerce(raw)
+        except (TypeError, ValueError):
+            LOGGER.warning("tenant_policy_bad_env knob=%s value=%r", name, raw)
+    return knob.default
+
+
+def describe_effective_policy(scope: Any = None) -> Json:
+    """Every knob's effective value and where it came from -- for support and for the dashboard."""
+    policy = tenant_policy(scope)
+    out: Json = {"tenant": tenant_of(scope), "knobs": {}}
+    for name, knob in KNOBS.items():
+        if name in policy:
+            source = "tenant"
+        elif os.environ.get(knob.env, "").strip() != "" or any(
+            os.environ.get(legacy, "").strip() != "" for legacy in knob.env_aliases
+        ):
+            source = "env"
+        else:
+            source = "default"
+        out["knobs"][name] = {"value": resolve(name, scope), "source": source, "env": knob.env}
+    return out

--- a/tools/test_batch_event_integrity.py
+++ b/tools/test_batch_event_integrity.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A batch ingest must keep every message, not just the first.
+
+The sync-accept path writes ONE pending event for the whole envelope; the commit path re-emits one
+event PER MESSAGE from source_event_ids. When a batch arrives with a single source id, the commit
+loop used to skip every message past it -- and because the re-emitted event reused that same id,
+latest-value compaction replaced the full pending event with one holding only the first message.
+Ten ingested messages became one retrievable event, silently, on a call that reported success.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+SCOPE = {"account_id": "acct_local", "tenant_id": "batchtest", "user_id": "u",
+         "session_id": "s0", "agent_name": "t"}
+
+
+def build():
+    tmp = tempfile.mkdtemp()
+    adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "b.jsonl")
+    return adapter, mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+
+
+def events(adapter):
+    return [r for r in adapter.read_all() if r.get("record_type") == "context_event"]
+
+
+class BatchEventIntegrityCase(unittest.TestCase):
+    def test_every_batch_message_survives_commit(self):
+        adapter, server = build()
+        batch = [{"role": "user", "content": "Batch fact %d: token BRAVO-%02d." % (n, n)}
+                 for n in range(10)]
+        server.call_tool("matrixark_ingest", {"scope": SCOPE, "finalize": True,
+                                              "messages": batch})
+        server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+
+        stored = " ".join(str(e.get("text") or "") for e in events(adapter))
+        missing = [n for n in range(10) if ("BRAVO-%02d" % n) not in stored]
+        self.assertFalse(missing,
+                         "commit dropped %d of 10 batch messages from context_event: %s"
+                         % (len(missing), missing))
+
+    def test_batch_produces_one_event_per_message(self):
+        adapter, server = build()
+        batch = [{"role": "user", "content": "Message %d." % n} for n in range(6)]
+        server.call_tool("matrixark_ingest", {"scope": SCOPE, "finalize": True,
+                                              "messages": batch})
+        server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+        self.assertGreaterEqual(len(events(adapter)), 6,
+                                "a 6-message batch should leave at least 6 events, found %d"
+                                % len(events(adapter)))
+
+    def test_single_message_ingest_is_unchanged(self):
+        """The fix must not disturb the one-message case, which was always correct."""
+        adapter, server = build()
+        for n in range(3):
+            server.call_tool("matrixark_ingest", {
+                "scope": SCOPE, "finalize": True,
+                "messages": [{"role": "user", "content": "Single %d." % n}]})
+        server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+        stored = " ".join(str(e.get("text") or "") for e in events(adapter))
+        for n in range(3):
+            self.assertIn("Single %d." % n, stored)
+
+    def test_batch_event_ids_are_distinct(self):
+        """Reusing one id for many messages is what let compaction hide the loss."""
+        adapter, server = build()
+        batch = [{"role": "user", "content": "Distinct %d." % n} for n in range(5)]
+        server.call_tool("matrixark_ingest", {"scope": SCOPE, "finalize": True,
+                                              "messages": batch})
+        server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+        ids = [e.get("event_id_hash") for e in events(adapter)]
+        self.assertEqual(len(ids), len(set(ids)), "duplicate event_id_hash across batch events")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_cold_start_retrieval.py
+++ b/tools/test_cold_start_retrieval.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A node must be scoreable the moment it exists, not once something warms it.
+
+A context_node draws its embedding from two places: its PATH, written when the node is created, and
+its SUMMARY, written later by refresh_summaries. Only the first exists at creation time. Remove it
+and a node cannot be scored until a summary lands, so the traversal selects nothing and the pack
+degrades to profile entities alone -- a 40-event store returning 1 item instead of 38.
+
+Every test in this file retrieves ONCE against a freshly built store. That matters more than the
+assertions: 25 retrieves inside one process all pass even with the bug, because the first retrieve
+warms the state the rest depend on. A warm check cannot see this failure.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+
+def scope():
+    return {"account_id": "acct_local", "tenant_id": "cold", "user_id": "alice",
+            "session_id": "s0", "agent_name": "cold"}
+
+
+def build_store(turns=12):
+    tmp = tempfile.mkdtemp()
+    adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "cold.jsonl")
+    server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+    for index in range(turns):
+        server.call_tool("matrixark_ingest", {
+            "scope": scope(), "finalize": True,
+            "messages": [{"role": "user",
+                          "content": "Note %d: the widget code is W%03d." % (index, index)}]})
+    server.call_tool("matrixark_session_commit", {"scope": scope()})
+    server.call_tool("matrixark_refresh_summaries", {"scope": scope(), "limit": 200})
+    return adapter, server
+
+
+def pack_items(server):
+    pack = server.call_tool("matrixark_retrieve", {"scope": scope(), "query": "widget code"})
+    return [str(item.get("text") or "")
+            for group in pack.get("groups") or []
+            for item in group.get("items") or []]
+
+
+class ColdStartRetrievalCase(unittest.TestCase):
+    def test_first_retrieve_after_build_returns_the_events(self):
+        """The regression this guards returned exactly one item here."""
+        _adapter, server = build_store(turns=12)
+        items = pack_items(server)
+        self.assertGreater(len(items), 5,
+                           "a cold store returned %d items -- nodes were unscoreable at first "
+                           "retrieve, so the traversal selected nothing" % len(items))
+
+    def test_every_node_has_an_embedding_the_moment_it_exists(self):
+        adapter, _server = build_store(turns=6)
+        records = adapter.read_all()
+        nodes = {r.get("node_hash") for r in records
+                 if r.get("record_type") == "context_node"}
+        embedded = {r.get("ref_hash") for r in records
+                    if r.get("record_type") == "context_embedding"
+                    and str(r.get("embedding_type")) == "context_node"}
+        summary_nodes = {r.get("node_hash") for r in records
+                         if r.get("record_type") == "context_summary"}
+        unreachable = {n for n in nodes if n not in embedded and n not in summary_nodes}
+        self.assertFalse(unreachable,
+                         "%d node(s) have neither a path embedding nor a summary, so nothing can "
+                         "score them" % len(unreachable))
+
+    def test_events_reach_the_pack_and_are_not_capped_at_top_k(self):
+        """top_k_per_layer caps child NODES per parent, never events under one node."""
+        _adapter, server = build_store(turns=40)
+        items = pack_items(server)
+        self.assertGreater(len(items), 24,
+                           "events under a single node must not be bounded by top_k_per_layer "
+                           "(got %d)" % len(items))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_current_session_guarantee.py
+++ b/tools/test_current_session_guarantee.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The session a user is talking in must not have to out-rank its own history.
+
+top_k_per_layer is applied PER PARENT, so every session under a user competes for the same places.
+The current session is the newest and least summarised, which makes it the likeliest to lose -- and
+losing it means asking about something said minutes ago and being handed a two-year-old session
+instead. It is therefore admitted outside the ranking, and does not consume a ranked slot.
+"""
+from __future__ import annotations
+
+import unittest
+
+from matrixark_mcp_core_node_tree import tree_first_traversal
+
+
+def node(path, score):
+    return {"node_path": list(path), "score": score, "depth": len(path),
+            "node_hash": abs(hash(tuple(path))) % (10 ** 9)}
+
+
+def build(current_score=0.0, others=8):
+    """One user, several sessions. The current session scores WORST on purpose."""
+    scores = {}
+    for entry in [node(["tenant:t"], 0.9), node(["tenant:t", "user:u"], 0.9)]:
+        scores[entry["node_hash"]] = entry
+    for index in range(others):
+        entry = node(["tenant:t", "user:u", "session:s%02d" % index], 0.5 + index * 0.01)
+        scores[entry["node_hash"]] = entry
+    current = node(["tenant:t", "user:u", "session:current"], current_score)
+    scores[current["node_hash"]] = current
+    return scores, tuple(current["node_path"])
+
+
+class CurrentSessionGuaranteeCase(unittest.TestCase):
+    def test_worst_scoring_current_session_is_still_admitted(self):
+        scores, current_path = build(current_score=0.0, others=8)
+        result = tree_first_traversal(scores, top_k_per_layer=2,
+                                      max_children_scored_per_parent=1000,
+                                      guaranteed_path=current_path)
+        self.assertIn(current_path, result["selected_paths"],
+                      "the current session lost its place to higher-scoring history")
+
+    def test_without_the_guarantee_it_is_evicted(self):
+        """Documents the behaviour being fixed, so the guarantee cannot be quietly dropped."""
+        scores, current_path = build(current_score=0.0, others=8)
+        result = tree_first_traversal(scores, top_k_per_layer=2,
+                                      max_children_scored_per_parent=1000)
+        self.assertNotIn(current_path, result["selected_paths"])
+
+    def test_guaranteeing_does_not_steal_a_ranked_slot(self):
+        scores, current_path = build(current_score=0.0, others=8)
+        without = tree_first_traversal(scores, top_k_per_layer=3,
+                                       max_children_scored_per_parent=1000)
+        with_guarantee = tree_first_traversal(scores, top_k_per_layer=3,
+                                              max_children_scored_per_parent=1000,
+                                              guaranteed_path=current_path)
+        ranked_before = {p for p in without["selected_paths"] if p != current_path}
+        ranked_after = {p for p in with_guarantee["selected_paths"] if p != current_path}
+        self.assertTrue(ranked_before.issubset(ranked_after),
+                        "admitting the current session displaced a node that had earned its place")
+
+    def test_an_unknown_guaranteed_path_changes_nothing(self):
+        scores, _current = build(current_score=0.0, others=8)
+        absent = ("tenant:t", "user:u", "session:not-in-this-store")
+        plain = tree_first_traversal(scores, top_k_per_layer=2,
+                                     max_children_scored_per_parent=1000)
+        guarded = tree_first_traversal(scores, top_k_per_layer=2,
+                                       max_children_scored_per_parent=1000,
+                                       guaranteed_path=absent)
+        self.assertEqual(plain["selected_paths"], guarded["selected_paths"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_index_growth_bound.py
+++ b/tools/test_index_growth_bound.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Secondary-index growth bound: compaction is recall-preserving, caps are deterministic.
+
+The three levers (see ``matrixark_index_growth_bound``) each get a gate here:
+
+* Lever 1 -- an ``index_compact`` tombstone drops ONLY per-event postings whose every ref was rolled
+  up into a summary, and the one-pass sweep is equivalent to the per-tombstone predicate.
+* Lever 2 -- the per-scope cap evicts oldest-first, deterministically, per scope.
+* Lever 3 -- the store-wide ceiling applies AFTER the cap and is never exceeded.
+* Every lever is flag-reversible: with the gates off the input list is returned unchanged (identity).
+* End to end -- after a rollup the event postings are gone and the facts are still retrievable.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_index_growth_bound as bound
+
+
+def posting(ref_type: str, refs: list, *, scope_key: str = "s1", ts: int = 0, index_hash: str = "") -> dict:
+    return {
+        "record_type": "context_index",
+        "index_name": "keyword:x",
+        "ref_type": ref_type,
+        "ref_hashes": list(refs),
+        "scope_key": scope_key,
+        "timestamp_key_ms": ts,
+        "index_hash": index_hash or f"h{ts}-{refs}",
+    }
+
+
+class IndexCompactionTombstoneTest(unittest.TestCase):
+    def test_tombstone_is_none_when_nothing_was_rolled_up(self):
+        self.assertIsNone(bound.index_compaction_tombstone(source_event_ids=[]))
+
+    def test_kills_only_fully_covered_event_postings(self):
+        tombstone = bound.index_compaction_tombstone(source_event_ids=[1, 2, 3], scope={"scope_key": "s1"})
+        kills = lambda record: bound.index_compact_tombstone_kills_record(tombstone, record)
+        self.assertTrue(kills(posting("event", [1, 2])), "fully covered event posting must compact")
+        self.assertTrue(kills(posting("event", [3])))
+        self.assertFalse(kills(posting("event", [1, 99])), "partially covered posting must survive intact")
+        self.assertFalse(kills(posting("summary", [1])), "summary postings are the surviving recall path")
+        self.assertFalse(kills(posting("entity", [1])))
+        self.assertFalse(kills(posting("event", [1], scope_key="other")), "must not cross scopes")
+        self.assertFalse(kills({"record_type": "context_event", "event_id_hash": 1}), "never touches events")
+
+    def test_legacy_single_ref_field_is_matched(self):
+        tombstone = bound.index_compaction_tombstone(source_event_ids=[7])
+        legacy = {"record_type": "context_index", "ref_type": "event", "ref_hash": 7}
+        self.assertTrue(bound.index_compact_tombstone_kills_record(tombstone, legacy))
+
+
+class SweepEquivalenceTest(unittest.TestCase):
+    """The O(n) reverse pass must agree with applying the predicate tombstone-by-tombstone."""
+
+    def _reference_sweep(self, records: list[dict]) -> list[dict]:
+        live: list[dict] = []
+        for record in records:
+            if str(record.get("tombstone_kind") or "") == bound.INDEX_COMPACT_TOMBSTONE_KIND:
+                live = [kept for kept in live if not bound.index_compact_tombstone_kills_record(record, kept)]
+                continue
+            live.append(record)
+        return live
+
+    def test_matches_reference_and_is_order_aware(self):
+        log = [
+            posting("event", [1], ts=1),
+            posting("event", [2], ts=2),
+            posting("summary", [900], ts=3),
+            bound.index_compaction_tombstone(source_event_ids=[1, 2], scope={"scope_key": "s1"}),
+            posting("event", [3], ts=4),  # ingested AFTER the tombstone -> must survive
+        ]
+        swept = bound.sweep_index_compaction(log)
+        self.assertEqual(swept, self._reference_sweep(log))
+        self.assertEqual([str(r.get("ref_hashes")) for r in swept if r.get("ref_type") == "event"], ["[3]"])
+        self.assertFalse(any(r.get("tombstone_kind") for r in swept), "tombstones must not serve")
+
+    def test_multi_scope_targets_stay_isolated(self):
+        log = [
+            posting("event", [1], scope_key="a", ts=1),
+            posting("event", [1], scope_key="b", ts=1),
+            bound.index_compaction_tombstone(source_event_ids=[1], scope={"scope_key": "a"}),
+        ]
+        swept = bound.sweep_index_compaction(log)
+        self.assertEqual(swept, self._reference_sweep(log))
+        self.assertEqual([r["scope_key"] for r in swept], ["b"])
+
+    def test_no_tombstone_returns_input_identity(self):
+        log = [posting("event", [1]), posting("summary", [2])]
+        self.assertIs(bound.sweep_index_compaction(log), log)
+
+
+class BoundEnforcementTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            key: os.environ.get(key)
+            # Every env var these tests touch, including the legacy aliases -- an unrestored budget
+            # leaks into later tests and silently evicts their postings.
+            for key in (
+                "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION",
+                "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_TENANT",
+                "MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE",
+                "MATRIXARK_SECONDARY_INDEX_HARD_CEILING",
+                "MATRIXARK_INDEX_COMPACT_ON_SUMMARY",
+                "MATRIXARK_DEDUPE_INDEX_POSTINGS",
+            )
+        }
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_per_scope_cap_evicts_oldest_first_per_scope(self):
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "2"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "0"
+        records = [posting("event", [i], scope_key=scope, ts=i) for scope in ("a", "b") for i in (1, 2, 3)]
+        records.append({"record_type": "context_event", "event_id_hash": 1})
+        kept = bound.enforce_secondary_index_bounds(records)
+        by_scope = {}
+        for record in kept:
+            if record.get("record_type") == "context_index":
+                by_scope.setdefault(record["scope_key"], []).append(record["timestamp_key_ms"])
+        self.assertEqual(by_scope, {"a": [2, 3], "b": [2, 3]}, "each scope keeps its newest 2")
+        self.assertTrue(any(r.get("record_type") == "context_event" for r in kept), "non-index records untouched")
+
+    def test_tenant_budget_applies_after_the_session_budget(self):
+        """Per-session budget first, then the tenant's own budget across its sessions.
+
+        Deliberately NOT a store-wide total: the sessions below belong to one tenant, and the tenant
+        budget bounds their sum. A different tenant's sessions are accounted separately (covered in
+        test_tenant_policy), because a global total would let one tenant evict another."""
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SESSION"] = "3"
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_TENANT"] = "4"
+        records = [
+            posting("event", [f"{session}{i}"], scope_key=f"t=42|u=1|s={session}", ts=i)
+            for session in ("a", "b")
+            for i in (1, 2, 3, 4)
+        ]
+        kept = [r for r in bound.enforce_secondary_index_bounds(records) if r.get("record_type") == "context_index"]
+        self.assertEqual(len(kept), 4, "the tenant budget bounds the sum of its sessions")
+        self.assertEqual(sorted(r["timestamp_key_ms"] for r in kept), [3, 3, 4, 4], "newest survive")
+
+    def test_eviction_is_deterministic_across_repeats(self):
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "2"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "0"
+        records = [posting("event", [i], ts=0, index_hash=f"h{i}") for i in range(6)]
+        first = [r["index_hash"] for r in bound.enforce_secondary_index_bounds(list(records))]
+        for _ in range(5):
+            self.assertEqual([r["index_hash"] for r in bound.enforce_secondary_index_bounds(list(records))], first)
+
+    def test_eviction_gives_up_recall_paths_last(self):
+        """A binding cap must spend the cheap postings first: events before segments before
+        entities before summaries -- summaries are what lever 1 leaves as the route to compacted
+        old content, so evicting them by age alone is what turns a cap into a recall loss."""
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "2"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "0"
+        # The summary posting is the OLDEST, so a pure oldest-first rule would evict it first.
+        records = [
+            posting("summary", [1], ts=1),
+            posting("entity", [2], ts=2),
+            posting("segment", [3], ts=3),
+            posting("event", [4], ts=4),
+        ]
+        kept = [record["ref_type"] for record in bound.enforce_secondary_index_bounds(records)]
+        self.assertEqual(kept, ["summary", "entity"], "recall paths survive, raw postings go first")
+
+    def test_defaults_are_small_and_enabled(self):
+        for key in ("MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE", "MATRIXARK_SECONDARY_INDEX_HARD_CEILING"):
+            os.environ.pop(key, None)
+        self.assertEqual(bound.max_index_records_per_scope(), 128)
+        self.assertEqual(bound.index_hard_ceiling(), 1024)
+
+    def test_disabled_bounds_return_input_identity(self):
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "0"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "0"
+        records = [posting("event", [i], ts=i) for i in range(10)]
+        self.assertIs(bound.enforce_secondary_index_bounds(records), records)
+
+    def test_under_budget_returns_input_identity(self):
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "100"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "100"
+        records = [posting("event", [i], ts=i) for i in range(10)]
+        self.assertIs(bound.enforce_secondary_index_bounds(records), records)
+
+    def test_drop_callback_reports_every_eviction(self):
+        os.environ["MATRIXARK_MAX_SECONDARY_INDEX_RECORDS_PER_SCOPE"] = "1"
+        os.environ["MATRIXARK_SECONDARY_INDEX_HARD_CEILING"] = "0"
+        seen: list[dict] = []
+        records = [posting("event", [i], ts=i) for i in range(4)]
+        kept = bound.enforce_secondary_index_bounds(records, on_drop=seen.append)
+        self.assertEqual(len(seen), 3, "no silent truncation")
+        self.assertEqual(len(kept), 1)
+
+
+class EndToEndCompactionTest(unittest.TestCase):
+    """Ingest -> roll up -> the per-event postings are gone and the facts still come back."""
+
+    FACTS = ["I am allergic to peanuts.", "I live in Kyoto.", "My favorite drink is matcha."]
+
+    def _run(self, *, compact: str) -> dict:
+        import matrixark_mcp_server as mcp
+
+        saved = os.environ.get("MATRIXARK_INDEX_COMPACT_ON_SUMMARY")
+        os.environ["MATRIXARK_INDEX_COMPACT_ON_SUMMARY"] = compact
+        try:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+                adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+                server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+                scope = {"tenant_id": "acme", "user_id": "alice", "session_id": "s1"}
+                call = lambda name, args: server.call_tool(name, {**args, "scope": scope})
+                for turn, fact in enumerate(self.FACTS * 3):
+                    call("matrixark_ingest", {
+                        "messages": [{"role": "user", "content": f"turn {turn}: {fact}"}],
+                        "finalize": True,
+                    })
+                    call("matrixark_session_commit", {})
+                call("matrixark_refresh_summaries", {"limit": 200})
+                stats = bound.secondary_index_bound_stats(adapter.read_all())
+                import json as _json
+
+                found = {
+                    fact: fact.split()[-1].strip(".").lower()
+                    in _json.dumps(call("matrixark_retrieve", {"query": fact}), default=str).lower()
+                    for fact in self.FACTS
+                }
+                return {"stats": stats, "recall": found}
+        finally:
+            if saved is None:
+                os.environ.pop("MATRIXARK_INDEX_COMPACT_ON_SUMMARY", None)
+            else:
+                os.environ["MATRIXARK_INDEX_COMPACT_ON_SUMMARY"] = saved
+
+    def test_rollup_prunes_event_postings_without_losing_recall(self):
+        off = self._run(compact="0")
+        on = self._run(compact="1")
+        off_events = off["stats"]["by_ref_type"].get("event", 0)
+        on_events = on["stats"]["by_ref_type"].get("event", 0)
+        self.assertGreater(off_events, 0, "baseline must carry per-event postings to compact")
+        self.assertEqual(on_events, 0, "every rolled-up event's postings must be compacted")
+        self.assertGreater(on["stats"]["by_ref_type"].get("summary", 0), 0, "summary recall path survives")
+        # Recall is the whole point of Lever 1: compaction must not cost a single fact.
+        self.assertEqual(on["recall"], off["recall"])
+        self.assertTrue(all(on["recall"].values()), f"facts lost after compaction: {on['recall']}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_pipeline_task_slim.py
+++ b/tools/test_pipeline_task_slim.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Collapsing re-stamped pipeline-task rows must not change a single consumer's answer."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_pipeline_task_slim as slim
+from matrixark_mcp_async_readiness import latest_async_pipeline_rows as readiness_latest
+from matrixark_mcp_dashboard import latest_async_pipeline_rows as dashboard_latest
+
+
+def task(task_hash: int, status: str, *, updated: int, detail: bool = True) -> dict:
+    record = {
+        "record_type": "matrixark_async_pipeline_task",
+        "task_hash": task_hash,
+        "event_id_hash": 900 + task_hash,
+        "scope": {"scope_key": "s1"},
+        "scope_key": "s1",
+        "status": status,
+        "idle_commit_deadline_ms": 5,
+        "updated_at_ms": updated,
+    }
+    if detail:
+        record["memory_layers_written"] = {"context_events": 1, "secondary_indexes": 6}
+        record["stages"] = ["extraction", "summary"]
+    return record
+
+
+def positional_latest(rows: list[dict]) -> list[dict]:
+    latest: dict[str, dict] = {}
+    for row in rows:
+        latest[str(row.get("task_hash"))] = row
+    return list(latest.values())
+
+
+def fingerprint(rows: list[dict]) -> dict:
+    ident = lambda rs: sorted((str(r.get("task_hash")), str(r.get("status")), int(r.get("updated_at_ms") or 0))
+                              for r in rs)
+    return {
+        "readiness": ident(readiness_latest(rows)),
+        "dashboard": ident(dashboard_latest(rows)),
+        "positional": ident(positional_latest(rows)),
+        "extraction_committed": sorted({int(r.get("event_id_hash") or 0)
+                                        for r in rows if r.get("status") == "extraction_committed"}),
+        "states": sorted({(str(r.get("task_hash")), str(r.get("status"))) for r in rows}),
+    }
+
+
+class CollapseTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.get("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS")
+        os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = "1"
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", None)
+        else:
+            os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = self._saved
+
+    def test_restamps_collapse_but_every_state_survives(self):
+        rows = [task(1, "extraction_committed", updated=10)] + [
+            task(1, "summary_completed", updated=20 + stamp) for stamp in range(5)
+        ]
+        out = slim.collapse_pipeline_task_rows(rows)
+        self.assertEqual(len(out), 2, "one row per (task, status)")
+        self.assertEqual({r["status"] for r in out}, {"extraction_committed", "summary_completed"})
+        newest = [r for r in out if r["status"] == "summary_completed"][0]
+        self.assertEqual(newest["updated_at_ms"], 24, "the newest re-stamp is the one kept")
+
+    def test_every_consumer_rule_gives_the_same_answer(self):
+        rows = []
+        for task_hash in (1, 2, 3):
+            rows.append(task(task_hash, "pending", updated=1))
+            rows.append(task(task_hash, "extraction_committed", updated=5))
+            rows.extend(task(task_hash, "summary_completed", updated=10 + stamp) for stamp in range(4))
+        # a task whose extraction_committed lands AFTER its summary_completed (the ordering that
+        # makes the rank rules and the positional rule disagree)
+        rows.append(task(4, "summary_completed", updated=3))
+        rows.append(task(4, "extraction_committed", updated=9))
+        before = fingerprint(rows)
+        out = slim.collapse_pipeline_task_rows(rows)
+        self.assertLess(len(out), len(rows), "something must actually collapse")
+        self.assertEqual(fingerprint(out), before, "a consumer answer changed")
+
+    def test_rows_without_an_identity_are_never_dropped(self):
+        rows = [
+            {"record_type": "matrixark_async_pipeline_task", "status": "summary_completed", "updated_at_ms": 1},
+            {"record_type": "matrixark_async_pipeline_task", "status": "summary_completed", "updated_at_ms": 2},
+            task(1, "summary_completed", updated=1),
+            task(1, "summary_completed", updated=2),
+        ]
+        out = slim.collapse_pipeline_task_rows(rows)
+        unkeyed = [r for r in out if r.get("task_hash") is None]
+        self.assertEqual(len(unkeyed), 2, "unkeyable rows pass through untouched")
+
+    def test_other_record_types_and_order_are_preserved(self):
+        rows = [
+            {"record_type": "context_event", "event_id_hash": 1},
+            task(1, "summary_completed", updated=1),
+            {"record_type": "context_summary", "summary_hash": 2},
+            task(1, "summary_completed", updated=2),
+        ]
+        out = slim.collapse_pipeline_task_rows(rows)
+        self.assertEqual([r["record_type"] for r in out],
+                         ["context_event", "context_summary", "matrixark_async_pipeline_task"])
+
+    def test_collapse_is_idempotent(self):
+        rows = [task(1, "summary_completed", updated=stamp) for stamp in range(4)]
+        once = slim.collapse_pipeline_task_rows(rows)
+        self.assertIs(slim.collapse_pipeline_task_rows(once), once)
+
+    def test_nothing_duplicated_returns_input_identity(self):
+        rows = [task(1, "pending", updated=1), task(2, "summary_completed", updated=2)]
+        self.assertIs(slim.collapse_pipeline_task_rows(rows), rows)
+
+    def test_disabled_flag_returns_input_identity(self):
+        os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = "0"
+        rows = [task(1, "summary_completed", updated=stamp) for stamp in range(4)]
+        self.assertIs(slim.collapse_pipeline_task_rows(rows), rows)
+
+
+class SlimLeverTest(unittest.TestCase):
+    """Lever B is the small one and is opt-in; it must still be correct when switched on."""
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in
+                       ("MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS", "MATRIXARK_PIPELINE_TASK_DETAIL_RETAIN_PER_SCOPE")}
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_off_by_default(self):
+        os.environ.pop("MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS", None)
+        self.assertFalse(slim.slim_terminal_pipeline_tasks_enabled())
+        rows = [task(1, "summary_completed", updated=1)]
+        self.assertIs(slim.slim_terminal_pipeline_tasks(rows), rows)
+
+    def test_when_enabled_consumer_fields_survive(self):
+        os.environ["MATRIXARK_SLIM_TERMINAL_PIPELINE_TASKS"] = "1"
+        os.environ["MATRIXARK_PIPELINE_TASK_DETAIL_RETAIN_PER_SCOPE"] = "0"
+        rows = [task(1, "summary_completed", updated=1)]
+        aged = slim.slim_terminal_pipeline_tasks(rows)[0]
+        self.assertTrue(aged["detail_slimmed"])
+        self.assertNotIn("memory_layers_written", aged)
+        for field in ("task_hash", "event_id_hash", "scope", "status", "idle_commit_deadline_ms", "updated_at_ms"):
+            self.assertIn(field, aged)
+
+
+class EndToEndTest(unittest.TestCase):
+    def _run(self, *, collapse: str) -> dict:
+        import matrixark_mcp_server as mcp
+
+        saved = os.environ.get("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS")
+        os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = collapse
+        try:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+                adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+                server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+                scope = {"tenant_id": "acme", "user_id": "alice", "session_id": "s1"}
+                call = lambda name, args: server.call_tool(name, {**args, "scope": scope})
+                facts = ["I am allergic to peanuts.", "I live in Kyoto.", "My favorite drink is matcha."]
+                for turn, fact in enumerate(facts * 4):
+                    call("matrixark_ingest", {"messages": [{"role": "user", "content": f"turn {turn}: {fact}"}],
+                                              "finalize": True})
+                    call("matrixark_session_commit", {})
+                call("matrixark_refresh_summaries", {"limit": 500})
+                records = adapter.read_all()
+                tasks = [r for r in records if r.get("record_type") == "matrixark_async_pipeline_task"]
+                return {
+                    "stats": slim.pipeline_task_footprint_stats(records),
+                    "records": records,
+                    "fingerprint": fingerprint(tasks),
+                    "recall": {
+                        fact: fact.split()[-1].strip(".").lower()
+                        in json.dumps(call("matrixark_retrieve", {"query": fact}), default=str).lower()
+                        for fact in facts
+                    },
+                }
+        finally:
+            if saved is None:
+                os.environ.pop("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", None)
+            else:
+                os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = saved
+
+    def test_serving_view_collapses_without_changing_behavior(self):
+        off = self._run(collapse="0")
+        on = self._run(collapse="1")
+        self.assertEqual(on["recall"], off["recall"], "recall must not move")
+        # Counts across two ingest runs are not comparable -- async pipeline timing decides how many
+        # task rows each run produces -- so the survival claim is checked on ONE record set below.
+        # Two ingest runs mint different event ids, so the ids themselves are not comparable across
+        # arms -- the equivalence that matters is on ONE record set: collapsing the un-collapsed
+        # store must leave every consumer rule's answer bit-identical.
+        os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = "1"
+        try:
+            raw_tasks = [r for r in off["records"] if r.get("record_type") == "matrixark_async_pipeline_task"]
+            collapsed = slim.collapse_pipeline_task_rows(off["records"])
+            collapsed_tasks = [r for r in collapsed if r.get("record_type") == "matrixark_async_pipeline_task"]
+        finally:
+            os.environ.pop("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", None)
+        self.assertLess(len(collapsed_tasks), len(raw_tasks), "duplicate stampings must be removed")
+        states = lambda rows: {(str(r.get("task_hash")), str(r.get("status"))) for r in rows}
+        self.assertEqual(states(collapsed_tasks), states(raw_tasks),
+                         "every (task, status) the pipeline reached must survive the collapse")
+        self.assertEqual(fingerprint(collapsed_tasks), fingerprint(raw_tasks),
+                         "readiness / dashboard / positional / extraction-signal answers must be identical")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_tenant_policy.py
+++ b/tools/test_tenant_policy.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Per-tenant memory policy: resolution order, isolation between tenants, and live updates."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_tenant_policy as policy
+import matrixark_index_growth_bound as bound
+
+
+class ResolutionOrderTest(unittest.TestCase):
+    def setUp(self):
+        policy.clear_tenant_policy_cache()
+        self._env = {knob.env: os.environ.get(knob.env) for knob in policy.KNOBS.values()}
+        self._path = os.environ.get("MATRIXARK_TENANT_POLICY_PATH")
+        for knob in policy.KNOBS.values():
+            os.environ.pop(knob.env, None)
+        os.environ.pop("MATRIXARK_TENANT_POLICY_PATH", None)
+
+    def tearDown(self):
+        for name, value in self._env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        if self._path is None:
+            os.environ.pop("MATRIXARK_TENANT_POLICY_PATH", None)
+        else:
+            os.environ["MATRIXARK_TENANT_POLICY_PATH"] = self._path
+        policy.clear_tenant_policy_cache()
+
+    def test_builtin_defaults_when_nothing_is_configured(self):
+        self.assertFalse(policy.resolve("extract_segments"))
+        self.assertTrue(policy.resolve("generate_embeddings"))
+        self.assertEqual(policy.resolve("max_secondary_index_records_per_scope"), 128)
+
+    def test_env_overrides_default_and_tenant_overrides_env(self):
+        os.environ["MATRIXARK_EXTRACT_SEGMENTS"] = "1"
+        self.assertTrue(policy.resolve("extract_segments"), "env beats the built-in default")
+        self.assertTrue(policy.resolve("extract_segments", {"tenant_id": "acme"}))
+        policy.set_tenant_policy("acme", {"extract_segments": False})
+        self.assertFalse(policy.resolve("extract_segments", {"tenant_id": "acme"}), "tenant beats env")
+        self.assertTrue(policy.resolve("extract_segments", {"tenant_id": "other"}), "only that tenant moved")
+
+    def test_policy_file_is_read_and_hot_reloaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tenants.json"
+            path.write_text(json.dumps({
+                "defaults": {"max_secondary_index_records_per_scope": 512},
+                "tenants": {"acme": {"extract_segments": True, "max_secondary_index_records_per_scope": 4096}},
+            }), encoding="utf-8")
+            os.environ["MATRIXARK_TENANT_POLICY_PATH"] = str(path)
+            self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "acme"}), 4096)
+            self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "b"}), 512,
+                             "file defaults apply to tenants the file does not name")
+            self.assertTrue(policy.resolve("extract_segments", {"tenant_id": "acme"}))
+            # rewrite with a different mtime -- no restart, no cache clear
+            os.utime(path, ns=(0, 0))
+            path.write_text(json.dumps({"tenants": {"acme": {"max_secondary_index_records_per_scope": 32}}}),
+                            encoding="utf-8")
+            self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "acme"}), 32,
+                             "an edited policy file must take effect without a restart")
+
+    def test_a_broken_policy_file_keeps_the_last_good_policy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tenants.json"
+            path.write_text(json.dumps({"tenants": {"acme": {"max_secondary_index_records_per_scope": 99}}}),
+                            encoding="utf-8")
+            os.environ["MATRIXARK_TENANT_POLICY_PATH"] = str(path)
+            self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "acme"}), 99)
+            os.utime(path, ns=(0, 0))
+            path.write_text("{ this is not json", encoding="utf-8")
+            self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "acme"}), 99,
+                             "a bad edit must not silently reset every tenant to defaults")
+
+    def test_unknown_knobs_and_bad_values_are_dropped_not_fatal(self):
+        policy.set_tenant_policy("acme", {"not_a_knob": 1, "max_secondary_index_records_per_scope": "seventeen"})
+        self.assertEqual(policy.resolve("max_secondary_index_records_per_scope", {"tenant_id": "acme"}), 128)
+
+    def test_tenant_identity_from_every_scope_shape(self):
+        self.assertEqual(policy.tenant_of({"tenant_id": "acme"}), "acme")
+        self.assertEqual(policy.tenant_of({"tenant_hash": 42}), "42")
+        self.assertEqual(policy.tenant_of("t=42;u=7"), "42")
+        self.assertEqual(policy.tenant_of("acme"), "acme")
+        self.assertEqual(policy.tenant_of(None), "")
+        self.assertEqual(policy.tenant_of({}), "")
+
+    def test_store_records_register_policy(self):
+        found = policy.register_tenant_policy_records([
+            policy.tenant_policy_record("acme", {"generate_embeddings": False}),
+            {"record_type": "context_event", "event_id_hash": 1},
+        ])
+        self.assertEqual(found, 1)
+        self.assertFalse(policy.resolve("generate_embeddings", {"tenant_id": "acme"}))
+
+
+class PerTenantIndexBudgetTest(unittest.TestCase):
+    """One tenant's cap must never spend another tenant's index budget."""
+
+    def setUp(self):
+        policy.clear_tenant_policy_cache()
+
+    def tearDown(self):
+        policy.clear_tenant_policy_cache()
+
+    def _posting(self, tenant, ts):
+        return {
+            "record_type": "context_index",
+            "ref_type": "event",
+            "index_name": "keyword:x",
+            "ref_hashes": [ts],
+            "scope": {"tenant_id": tenant, "scope_key": f"t={tenant};u=1"},
+            "scope_key": f"t={tenant};u=1",
+            "timestamp_key_ms": ts,
+            "index_hash": f"{tenant}-{ts}",
+        }
+
+    def test_each_tenant_is_capped_by_its_own_policy(self):
+        policy.set_tenant_policy("big", {"max_secondary_index_records_per_scope": 0,
+                                         "secondary_index_hard_ceiling": 0})
+        policy.set_tenant_policy("small", {"max_secondary_index_records_per_scope": 2,
+                                           "secondary_index_hard_ceiling": 0})
+        records = [self._posting("big", ts) for ts in range(6)] + \
+                  [self._posting("small", ts) for ts in range(6)]
+        kept = bound.enforce_secondary_index_bounds(records)
+        by_tenant = {}
+        for record in kept:
+            by_tenant.setdefault(record["scope"]["tenant_id"], []).append(record["timestamp_key_ms"])
+        self.assertEqual(len(by_tenant["big"]), 6, "an uncapped tenant keeps everything")
+        self.assertEqual(by_tenant["small"], [4, 5], "the capped tenant keeps only its newest")
+
+    def test_a_busy_tenant_cannot_evict_a_quiet_tenants_index(self):
+        # The ceiling is per tenant: 'noisy' blowing past it must not touch 'quiet'.
+        policy.set_tenant_policy("noisy", {"max_secondary_index_records_per_scope": 0,
+                                           "secondary_index_hard_ceiling": 3})
+        policy.set_tenant_policy("quiet", {"max_secondary_index_records_per_scope": 0,
+                                           "secondary_index_hard_ceiling": 3})
+        records = [self._posting("noisy", ts) for ts in range(20)] + \
+                  [self._posting("quiet", ts) for ts in range(2)]
+        kept = bound.enforce_secondary_index_bounds(records)
+        counts = {}
+        for record in kept:
+            tenant = record["scope"]["tenant_id"]
+            counts[tenant] = counts.get(tenant, 0) + 1
+        self.assertEqual(counts["noisy"], 3, "the noisy tenant is held to its own ceiling")
+        self.assertEqual(counts["quiet"], 2, "the quiet tenant loses nothing to its neighbour")
+
+
+class LiveTenantPolicyEndToEndTest(unittest.TestCase):
+    """Two tenants in ONE store with different policies, then a policy change while it runs."""
+
+    def setUp(self):
+        policy.clear_tenant_policy_cache()
+
+    def tearDown(self):
+        policy.clear_tenant_policy_cache()
+
+    def _counts(self, records, tenant):
+        """Attribute rows to a tenant the way the store itself does.
+
+        A served record often has no scope dict -- interning reduces it to a scope_key holding the
+        tenant HASH -- so matching on tenant_id alone silently attributes nothing."""
+        identities = {tenant, policy.tenant_hash_of(tenant)}
+        out = {}
+        for record in records:
+            scope = record.get("scope") or record.get("access_scope") or record.get("scope_key")
+            if policy.tenant_of(scope) not in identities:
+                continue
+            key = str(record.get("record_type") or "")
+            out[key] = out.get(key, 0) + 1
+        return out
+
+    def test_two_tenants_one_store_get_different_storage(self):
+        import matrixark_mcp_server as mcp
+
+        policy.set_tenant_policy("enterprise", {"extract_segments": True, "generate_embeddings": True})
+        policy.set_tenant_policy("starter", {"extract_segments": False, "generate_embeddings": False})
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+
+            def ingest(tenant, text):
+                scope = {"tenant_id": tenant, "user_id": "u1", "session_id": "s1"}
+                server.call_tool("matrixark_ingest", {"scope": scope, "finalize": True,
+                                                      "messages": [{"role": "user", "content": text}]})
+                server.call_tool("matrixark_session_commit", {"scope": scope})
+
+            for turn in range(3):
+                ingest("enterprise", f"turn {turn}: I am allergic to peanuts and I live in Kyoto.")
+                ingest("starter", f"turn {turn}: I am allergic to peanuts and I live in Kyoto.")
+            records = adapter.read_all()
+
+            enterprise = self._counts(records, "enterprise")
+            starter = self._counts(records, "starter")
+            self.assertGreater(enterprise.get("context_embedding", 0), 0, "enterprise keeps its vectors")
+            self.assertEqual(starter.get("context_embedding", 0), 0, "starter stores no vectors")
+            self.assertGreater(enterprise.get("context_segment", 0), 0, "enterprise keeps segments")
+            self.assertEqual(starter.get("context_segment", 0), 0, "starter stores no segments")
+            self.assertGreater(starter.get("context_event", 0), 0, "starter still stores its memories")
+
+            # ---- flip the small tenant's embeddings ON with the service running
+            policy.set_tenant_policy("starter", {"generate_embeddings": True})
+            ingest("starter", "turn 99: My favorite drink is matcha.")
+            after = self._counts(adapter.read_all(), "starter")
+            self.assertGreater(after.get("context_embedding", 0), 0,
+                               "a live policy change must take effect with no restart")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Nine tooling files that exist internally but were never published, covering three features that **are** already public: the index growth bound, the pipeline-task slimming pass, and per-tenant memory policy.

Three drivers:

- `tools/matrixark_index_growth_bound.py`
- `tools/matrixark_pipeline_task_slim.py`
- `tools/matrixark_tenant_policy.py`

Six test scripts:

- `tools/test_index_growth_bound.py`
- `tools/test_pipeline_task_slim.py`
- `tools/test_tenant_policy.py`
- `tools/test_batch_event_integrity.py`
- `tools/test_cold_start_retrieval.py`
- `tools/test_current_session_guarantee.py`

Shipping the behaviour without the tooling that exercises it means nobody outside can reproduce or extend those checks. This is a straight addition — no existing file is touched.

## How these were selected

This is a filtered subset, not a bulk copy. Everything published here was checked to:

- contain **no** restricted tokens;
- reference **only** paths and sibling tools that already exist here, so nothing lands half-wired.

Deliberately **not** included:

- **An object-store smoke server.** It is enterprise-only and was previously removed from this repo on purpose; re-adding it would undo that.
- **17 benchmark run artefacts** — `.json`, `.stderr` and `.jsonl` dumps from one machine's local run. They are working output rather than documentation, and a snapshot of somebody's laptop is noise in a public tree.

## Verification

- Restricted-token sweep over all nine files: clean.
- Every sibling import and every repository path each script names resolves against this tree.
- The scripts were **not executed** here; several drive a live cluster.
