### PR TITLE
Set the snapshot check interval at the data-node construction sites

### DIFF
--- a/crates/temporalstore-rust/src/bin/distributed_raft_harness.rs
+++ b/crates/temporalstore-rust/src/bin/distributed_raft_harness.rs
@@ -1289,6 +1289,8 @@ fn runtime_options(
     local_node_id: RaftNodeId,
 ) -> ProductionRaftRuntimeOptions {
     ProductionRaftRuntimeOptions {
+        // Off, as in the tests: a chaos run is seconds long.
+        snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         shard_id: options.shard_id,
         local_node_id,

--- a/crates/temporalstore-rust/src/bin/raft_node.rs
+++ b/crates/temporalstore-rust/src/bin/raft_node.rs
@@ -613,6 +613,8 @@ fn runtime_options_from_env() -> ProductionRaftRuntimeOptions {
         env_bool("TS_RAFT_ALLOW_PLAINTEXT", true),
     );
     ProductionRaftRuntimeOptions {
+        // The cadence the metaserver already uses; 0 disables the check.
+        snapshot_check_interval_ms: env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000),
         engine: ProductionRaftEngineKind::TemporalRaft,
         shard_id,
         local_node_id,
@@ -692,6 +694,8 @@ mod tests {
     fn test_runtime_for_node(local_node_id: RaftNodeId) -> ProductionRaftRuntime {
         let dir = tempfile::tempdir().unwrap().into_path();
         ProductionRaftRuntime::start(ProductionRaftRuntimeOptions {
+            // The cadence the metaserver already uses; 0 disables the check.
+            snapshot_check_interval_ms: env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000),
             engine: ProductionRaftEngineKind::TemporalRaft,
             shard_id: 55,
             local_node_id,

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -2315,6 +2315,8 @@ fn start_server_raft_from_env(
     // loader in scope here, so the `[raft]` file equivalents are not read at this layer.)
     let raft_config = raft_config_from_env();
     let runtime = ProductionRaftRuntime::start(ProductionRaftRuntimeOptions {
+        // The cadence the metaserver already uses; 0 disables the check.
+        snapshot_check_interval_ms: env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000),
         engine: ProductionRaftEngineKind::TemporalRaft,
         shard_id: raft_shard_id,
         local_node_id,
@@ -3546,6 +3548,8 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let runtime = ProductionRaftRuntime::start(ProductionRaftRuntimeOptions {
+            // The cadence the metaserver already uses; 0 disables the check.
+            snapshot_check_interval_ms: env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000),
             engine: ProductionRaftEngineKind::TemporalRaft,
             shard_id: 1,
             local_node_id,


### PR DESCRIPTION
`cargo check --all-targets` does not compile on `main`.

The runtime option that controls how often the applied log is checked for compaction is read by the timer loop and set by the metaserver entrypoint, but the equivalent data-node entrypoints were never updated. Five initializers are missing the field, so `server`, `matrixark_rust_datanode`, `raft_node` and `distributed_raft_harness` all fail to build, along with their test targets.

## Values

| site | value | why |
|---|---|---|
| `server.rs` (2) | `env_u64("TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS", 30_000)` | long-lived processes — the ones whose applied log would otherwise grow for the life of the process, which is what the check is for |
| `raft_node.rs` (2) | same | same |
| `distributed_raft_harness.rs` (1) | `0` | off, as in the tests: a chaos run lasts seconds, and a periodic check would only add timing noise |

The 30s cadence and the environment variable mirror what the metaserver entrypoint already does. Setting the variable to 0 disables the check.

## Verified

`cargo check --all-targets` exits 0. No behaviour change beyond the data-node processes now performing the check the option was added to perform.

## The recurring cause

This is the third break of this exact shape on `main` today — after a field added to a state-change request, and a vector field added to a context record. The pattern each time: **one PR adds a field, another PR adds or keeps a caller, each passes CI alone, and the combination breaks.** The library builds either way, so only `--all-targets` sees it, and a PR's green check reflects the merge base it was tested against rather than the one it lands on.

Worth considering: require branches to be up to date before merging, so a stale green result cannot merge. That converts all three of these from post-merge breakage into a pre-merge re-run.
