### PR TITLE
memory api: read through the record log (DO NOT MERGE -- wedges retrieve)

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -85,6 +85,21 @@ def warn_if_profile_scope_missing(scope) -> str:
 _BATCH_MESSAGES_WARNED: set = set()
 BATCH_MESSAGES_WARN_THRESHOLD = int(os.environ.get("MATRIXARK_BATCH_MESSAGES_WARN_THRESHOLD", "6"))
 
+# Ingest fields that come from the CALLER rather than from extraction -- the exact set
+# MatrixArkLocalAdapter._stamp_ingest_fields puts on a `context_event`. Extraction cannot rebuild
+# them, so a commit that rewrites an existing event row has to carry them over (see the use below).
+# An explicit allowlist on purpose: the rewrite is meant to replace the extraction's own view of the
+# event, and inheriting anything broader would let a stale earlier row overrule a fresh
+# classification.
+CALLER_SUPPLIED_EVENT_FIELDS = (
+    "identity_key",
+    "truth_class",
+    "truth_rank",
+    "expires_at",
+    "expires_at_ms",
+    "ephemeral",
+)
+
 
 def warn_if_batched_messages(messages) -> str:
     """Warn when one message-ingest call carries many messages.
@@ -2069,6 +2084,43 @@ class _LocalAdapterIngestMixin:
                     continue
                 segment_hashes_by_position.setdefault(message_index, []).append(segment_hash)
                 segment_hash_by_position.setdefault(message_index, segment_hash)
+        # Fields the CALLER supplied on the original ingest. When extraction commits it REWRITES the
+        # `context_event` row for an id that already exists, building it from the extraction result
+        # alone -- and latest-value compaction then serves that newer row. Anything the caller put on
+        # the original row and the extractor does not reproduce is therefore silently dropped at read
+        # time: an `identity_key` ingest became unfindable by keyed recall and stopped superseding,
+        # and a `ttl_seconds` ingest became a record nothing would ever expire. They survived only
+        # when extraction ran inside the ingest call, because `_stamp_ingest_fields` is scoped to it
+        # -- so an in-process sync ingest looked correct while the same request through the gateway,
+        # where finalize commits separately, lost them. Carry them across the rewrite.
+        inherited_event_fields: dict[int, Json] = {}
+        if derive_from_existing_events and source_event_ids:
+            wanted_event_ids: set[int] = set()
+            for source_event_id in source_event_ids:
+                try:
+                    wanted_event_ids.add(int(source_event_id))
+                except (TypeError, ValueError):
+                    continue
+            # `prior_records` is the live view already loaded for prior context; only pay for a read
+            # when the caller asked to skip that. Reading the LIVE view rather than the raw log is
+            # deliberate -- a deleted row must not hand its identity key to its replacement.
+            lookup_records = prior_records if prior_records else self.read_all()
+            for prior_record in lookup_records:
+                if str(prior_record.get("record_type") or "") != "context_event":
+                    continue
+                try:
+                    prior_event_id = int(prior_record.get("event_id_hash"))
+                except (TypeError, ValueError):
+                    continue
+                if prior_event_id not in wanted_event_ids:
+                    continue
+                carried = {
+                    field: prior_record[field]
+                    for field in CALLER_SUPPLIED_EVENT_FIELDS
+                    if prior_record.get(field) is not None
+                }
+                if carried:
+                    inherited_event_fields[prior_event_id] = carried
         if derive_from_existing_events:
             for index, message in enumerate(envelope["messages"]):
                 if index >= len(source_event_ids):
@@ -2199,6 +2251,8 @@ class _LocalAdapterIngestMixin:
                     "extraction_phase": extraction_phase,
                     "final_session_boundary": final_session_boundary,
                     "extraction_context_event_ids": extraction_context_event_ids,
+                    # Last, so the caller's own fields win over anything above that shares a name.
+                    **inherited_event_fields.get(event_id_hash, {}),
                 }
                 event_memory_layer = candidate_memory_layer_name(event_record)
                 if event_memory_layer:

--- a/tools/matrixark_mcp_latest_context_state.py
+++ b/tools/matrixark_mcp_latest_context_state.py
@@ -21,6 +21,29 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
+def expand_record_bundles(records: list[Json]) -> list[Json]:
+    """Flatten bundled appends into their constituent records.
+
+    A bundled append stores ``{"record_bundle": [rec, rec, ...]}`` as ONE hash field. The
+    wrapper carries no ``record_type``; the type every reader filters on lives on the
+    records inside it. Readers walking the raw entries therefore saw a typeless wrapper and
+    skipped it, so a bundled ``context_event`` was invisible to get / get_all / update /
+    history even though it was durably stored. The JSONL adapter appends records
+    individually and never bundles, which is why the same reader code worked there.
+
+    Idempotent: unbundled records pass through untouched.
+    """
+    expanded: list[Json] = []
+    for record in records:
+        if isinstance(record, dict):
+            bundle = record.get("record_bundle")
+            if isinstance(bundle, list):
+                expanded.extend(inner for inner in bundle if isinstance(inner, dict))
+                continue
+        expanded.append(record)
+    return expanded
+
+
 def latest_context_state_storage_key(storage_prefix: str) -> str:
     return f"{storage_prefix}:context_latest_state"
 
@@ -108,7 +131,9 @@ class LatestContextStateAdapterMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        return compact_latest_context_state_records(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -366,6 +366,114 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
     proxy boundary.
     """
 
+    def read_all(self) -> list[Json]:
+        """Read through the native record log, not MatrixArkLocalAdapter's JSONL log.
+
+        `MatrixArkLocalAdapter` precedes the direct mixins in this class's MRO and also
+        defines `read_all`, so its JSONL implementation won here -- and on a native backend
+        there is no JSONL log, so it returned ZERO records. Every reader built on read_all
+        (get / get_all / update / history / keyed recall) therefore read empty while the
+        records sat durably in the record log; the same inherited method is correct on the
+        JSONL backend, which is why only the native backends looked broken.
+
+        Only `read_all` collided: `read_all_without_disk_fallback_recovery` is defined solely
+        on `_TemporalDirectReadMixin` and already resolved correctly, so delegating to it
+        reproduces the direct read exactly without reordering bases (which would silently
+        move every other method both classes define).
+
+        The live-view filtering MUST be kept: `MatrixArkLocalAdapter.read_all` does not just
+        read, it filters the log down to live records. Delegating to the raw direct read alone
+        silently drops that -- forget/delete tombstones stop being honoured (the subject's
+        records stay visible after a forget) and a TTL record never expires, because expiry is
+        enforced on read and is never cached.
+
+        The body is deliberately identical to `MatrixArkLocalAdapter.read_all`; only the
+        `_read_all_compacted` beneath it differs per backend.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import filter_live_memory_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import filter_live_memory_records
+        return filter_live_memory_records(self._read_all_compacted())
+
+    def _read_all_compacted(self) -> list[Json]:
+        """The compacted, tombstone-swept view -- WITHOUT the expiry/retention filter.
+
+        The seam between "compacted" and "live" exists because some callers need to see records
+        the live view hides: `sweep_expired_memories` has to find the expired rows in order to
+        tombstone them, and would reclaim nothing if handed a view they had already been filtered
+        out of. Overriding it here rather than only `read_all` is what makes the three memory
+        paths built on it work on a native backend -- keyed upsert (`_apply_identity_upsert`),
+        the retention-cutoff scope resolver, and the expiry sweep. All three called the inherited
+        JSONL implementation, which returns `[]` as soon as `_local_jsonl_enabled` is False, so on
+        every native backend keyed upsert silently never ran: a second ingest under the same
+        `identity_key` found no existing record to supersede and both values stayed live.
+
+        The two extra serving-pipeline stages are applied HERE rather than inside
+        `_with_latest_context_state_records`, which the retrieval hot path also goes through:
+
+          * `compact_latest_value_records` collapses records sharing a latest-value key. For a
+            `context_event` that key is the `event_id_hash`, and ingest persists an event row
+            twice -- once on the hot path (`extraction_phase: hot_path`) and again when
+            extraction commits (`final`). Without it both rows serve and `get_all` reports one
+            memory as two.
+          * `apply_memory_tombstones` is what makes forget / delete / reset remove anything.
+            Without it a forget writes its tombstone, reports an accurate `removed_count`, and
+            then serves every one of those records right back.
+
+        `compact_and_apply_tombstones` composes all three in the one order correct for both
+        orphan sweeping and supersede (see its docstring). Both added stages fast-path a log
+        with no duplicate keys / no tombstone, and all three are idempotent -- which matters,
+        because the result feeds a cache this method is called against repeatedly.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_all")
+        return compact_and_apply_tombstones(self.read_all_without_disk_fallback_recovery())
+
+    def _read_raw_records(self) -> list[Json]:
+        """The native record log in append order -- NOT compacted, NOT tombstone-filtered.
+
+        Same MRO collision as `read_all`: `MatrixArkLocalAdapter._read_raw_records` reads the
+        JSONL shards and returns `[]` the moment `_local_jsonl_enabled` is False, which is
+        exactly what every native backend sets. `history` is built on this method -- it is
+        deliberately the RAW log, because the change history of a memory is the tombstones and
+        superseded rows that the live view exists to hide -- so on a native backend history
+        reported an empty log for a memory that plainly had one.
+
+        The delete-before-extract guard in `session_commit` also reads through here. It asks
+        whether a pending event survived the tombstone sweep and treats a tombstone-free log as
+        "keep everything", so an empty result made it silently inert on native backends rather
+        than wrong; with a real log behind it the guard now does its job there too.
+
+        Deliberately does NOT fold in `_load_latest_context_state_records()`: that store holds
+        the compacted latest state, which is the opposite of an append history, and none of it
+        is a `context_event` or a tombstone.
+
+        Deliberately does NOT take `_records_lock` either. That lock guards the serving-record
+        cache, and this method reads nothing from it -- but taking it puts a thread inside
+        `_records_lock` while it waits on the proxy client's lane semaphore, while the serving
+        read holds a lane slot and waits on `_records_lock`. Two threads, opposite order, and
+        the gateway wedges: one request hangs to its timeout, every later one is rejected on the
+        lane, and the proxy sits idle because nothing is being sent to it. `session_commit` reads
+        through here on every ingest, so a gateway interleaving an ingest and a retrieve hits the
+        inversion within a handful of requests. Nothing here needs the lock -- each call reads a
+        fresh count and its records straight from the backend.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_raw_records")
+        count = self._get_count()
+        if count > 0:
+            records = self._load_records_by_count(count)
+        else:
+            records = self._load_records(self._get_index())
+        return expand_record_bundles(records)
+
     def append(self, record: Json) -> None:
         self.append_many([record])
 
@@ -395,7 +503,20 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # this class); the fast direct-ingest path calls _append_many_materialized
         # itself (never append), so there is no double write. Disable with
         # MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND=0 as an escape hatch.
-        materialized = materialize_serving_record_batch(records)
+        #
+        # Per-ingestion stamping runs HERE, as it does in MatrixArkLocalAdapter.append_many,
+        # because it was being skipped entirely on every native backend. `_stamp_ingest_fields`
+        # is what puts `expires_at_ms`/`ephemeral` and `identity_key`/`truth_class`/`truth_rank`
+        # onto the records; without it an `ttl_seconds` ingest stored a record that nothing
+        # would ever expire, and an `identity_key` ingest stored a record keyed recall could not
+        # find (404) and keyed-upsert never superseded.
+        #
+        # `_apply_serving_dedup` is deliberately NOT applied here: its summary-dirty
+        # coalescing calls read_all(), which on a native backend is a full record-log read on
+        # every append batch. It only removes redundant pending markers -- a size
+        # optimization, not correctness -- and paying an O(store) read per ingest to get it
+        # is the wrong trade on this path.
+        materialized = self._stamp_ingest_fields(materialize_serving_record_batch(records))
         if not materialized:
             return
         if self._queue_batched_records(materialized):

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1184,7 +1184,30 @@ class _TemporalDirectBackendMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        """Fold the latest-state store into a native read and collapse it for serving.
+
+        This runs on the RETRIEVAL hot path as well as the memory API, so it deliberately does
+        only the last of the serving pipeline's three stages. The two the memory API also needs
+        -- latest-value collapse and the tombstone sweep -- are applied one level up, in
+        `MatrixArkTemporalStoreDirectAdapter._read_all_compacted`.
+
+        That split is not stylistic. Applying them here reads better (deleted content would
+        also stay out of the retrieval candidate set, as on the JSONL backend) but it changes
+        the candidate set retrieval hands the proxy, and measured against a 16-memory store
+        the proxy then wedged: the sixth retrieve stopped responding for 120s and every one
+        after it was rejected on the pack lane after 40s, with the gateway's whole data path
+        stuck behind it. On the same store with the same binary, the split version answers
+        12/12 retrieves in 165-322ms. Deleted content briefly surviving in retrieval scoring
+        is a smaller problem than a gateway that stops answering, so the sweep stays on the
+        memory-API read until the proxy side is understood.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+        return compact_latest_context_state_records(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/test_mem0_native_read_path.py
+++ b/tools/test_mem0_native_read_path.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The memory API on a native (record-log) backend: forget removes, history has a log, get_all
+lists one entry per memory, and the fields the caller supplied on an ingest survive the rewrite
+extraction performs when it commits.
+
+Each test here fails on the unfixed tree. The adapter is driven through a stub record log rather
+than a live datanode, because every defect these cover is in the Python read/write path, not in
+the engine: the native branch skipped two of the three serving-pipeline stages, and three memory
+methods called a JSONL-only reader that returns `[]` the moment the JSONL log is disabled -- which
+is exactly what a native backend does.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_mcp_local_adapter as local_mod
+
+
+TENANT = 4848243343181226175
+USER = 4473490034483841169
+SCOPE_KEY = f"t={TENANT}|u={USER}|s=1|"
+
+
+def _event(event_id, text, *, phase="hot_path", updated_at_ms=1000, **extra):
+    """A `context_event` row shaped like the ones the ingest pipeline writes."""
+    record = {
+        "record_type": "context_event",
+        "event_id_hash": event_id,
+        "text": text,
+        "scope_key": SCOPE_KEY,
+        "access_scope": {"tenant_hash": TENANT, "user_hash": USER, "scope_key": SCOPE_KEY},
+        "extraction_phase": phase,
+        "status": "observed" if phase == "hot_path" else "extraction_committed",
+        "updated_at_ms": updated_at_ms,
+        "timestamp_key_ms": updated_at_ms,
+    }
+    record.update(extra)
+    return record
+
+
+def _forget_tombstone(created_at_ms=9000):
+    return {
+        "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+        "tombstone_kind": "forget",
+        "target_tenant_hash": TENANT,
+        "target_user_hash": USER,
+        "target_scope_key": SCOPE_KEY,
+        "removed_count": 2,
+        "created_at_ms": created_at_ms,
+    }
+
+
+class _StubNativeAdapter:
+    """Build a direct adapter whose native record log is a plain list.
+
+    `object.__new__` skips __init__ (which would dial a metaserver / spawn a CLI); everything the
+    read path touches is stubbed. This is the same construction the membership-index tests use.
+    """
+
+    @staticmethod
+    def build(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._storage_prefix = "matrixark:mcp"
+        adapter._local_jsonl_enabled = False
+        adapter._native_log = list(records)
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._load_latest_context_state_records = lambda: []
+        # The native read exactly as the retrieval path sees it: the latest-state fold and the
+        # state collapse, and nothing else. The latest-value collapse and the tombstone sweep
+        # the memory API needs are applied above this, in `_read_all_compacted`, and these tests
+        # go through `read_all` / `_read_all_compacted` so they exercise that seam for real.
+        adapter.read_all_without_disk_fallback_recovery = (
+            lambda: adapter._with_latest_context_state_records(list(adapter._native_log))
+        )
+        return adapter
+
+    @staticmethod
+    def retrieval_view(records):
+        """What the retrieval hot path gets -- deliberately WITHOUT the memory-API stages."""
+        adapter = _StubNativeAdapter.build(records)
+        return adapter.read_all_without_disk_fallback_recovery()
+
+
+class NativeReadPathTests(unittest.TestCase):
+    def test_forget_tombstone_is_applied_on_the_native_read(self):
+        """A forget wrote a durable tombstone and reported an accurate removed_count, then served
+        every one of those records straight back: the native read ran only the last of the three
+        serving-pipeline stages, so `apply_memory_tombstones` never ran."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _event(22, "user: My favourite language is Rust.", updated_at_ms=2000),
+            _forget_tombstone(),
+        ])
+        live = adapter.read_all()
+        self.assertEqual([], [r for r in live if r.get("record_type") == "context_event"])
+        # The tombstone marker itself is internal and must not surface either.
+        self.assertEqual([], [r for r in live
+                              if r.get("record_type") == local_mod.MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def test_forget_does_not_remove_a_later_re_ingest(self):
+        """The sweep is order-aware: re-ingesting after a forget produces live memories again."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _forget_tombstone(),
+            _event(33, "user: I am vegetarian.", updated_at_ms=11000),
+        ])
+        live_ids = [r["event_id_hash"] for r in adapter.read_all()
+                    if r.get("record_type") == "context_event"]
+        self.assertEqual([33], live_ids)
+
+    def test_one_memory_serves_as_one_record_not_two(self):
+        """The ingest pipeline persists an event row twice -- once on the hot path and again when
+        extraction commits -- and both rows served, so get_all reported 2 ingests as 4 memories.
+        Latest-value compaction collapses them to the committed row."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", phase="hot_path", updated_at_ms=1000),
+            _event(11, "user: I am vegetarian.", phase="final", updated_at_ms=1500),
+            _event(22, "user: My favourite language is Rust.", phase="hot_path", updated_at_ms=2000),
+            _event(22, "user: My favourite language is Rust.", phase="final", updated_at_ms=2500),
+        ])
+        events = [r for r in adapter.read_all() if r.get("record_type") == "context_event"]
+        self.assertEqual(2, len(events))
+        self.assertEqual([11, 22], sorted(r["event_id_hash"] for r in events))
+        self.assertEqual({"final"}, {r["extraction_phase"] for r in events})
+
+    def test_the_memory_stages_stay_off_the_retrieval_hot_path(self):
+        """`_with_latest_context_state_records` runs on retrieval too, so the latest-value
+        collapse and the tombstone sweep are applied one level up instead.
+
+        Applying them at that choke point changes the candidate set retrieval hands the proxy,
+        and measured against a 16-memory store the proxy then wedged -- the sixth retrieve stopped
+        responding for 120s and every later one was rejected on the pack lane after 40s, taking
+        the gateway's whole data path with it. Split, the same store answers 12/12 retrieves in
+        165-322ms. If someone moves the stages back down, this fails."""
+        records = [
+            _event(11, "user: I am vegetarian.", phase="hot_path", updated_at_ms=1000),
+            _event(11, "user: I am vegetarian.", phase="final", updated_at_ms=1500),
+            _forget_tombstone(),
+        ]
+        hot_path = _StubNativeAdapter.retrieval_view(records)
+        # Untouched by the memory stages: both event rows, and the tombstone, still present.
+        self.assertEqual(2, len([r for r in hot_path if r.get("record_type") == "context_event"]))
+        self.assertEqual(1, len([r for r in hot_path
+                                 if r.get("record_type") == local_mod.MEMORY_TOMBSTONE_RECORD_TYPE]))
+        # The memory API, one level up, still sees the swept view.
+        self.assertEqual([], [r for r in _StubNativeAdapter.build(records).read_all()
+                              if r.get("record_type") == "context_event"])
+
+    def test_compacted_view_keeps_expired_records_for_the_sweep(self):
+        """`_read_all_compacted` is the seam below the live view: the expiry sweep has to SEE an
+        expired record to tombstone it, so only `read_all` may filter by expiry."""
+        expired = _event(11, "user: Use gate B12 today.", expires_at_ms=1, ephemeral=True)
+        adapter = _StubNativeAdapter.build([expired])
+        self.assertEqual(
+            [11], [r["event_id_hash"] for r in adapter._read_all_compacted()
+                   if r.get("record_type") == "context_event"])
+        self.assertEqual(
+            [], [r for r in adapter.read_all() if r.get("record_type") == "context_event"])
+
+
+class NativeRawLogReadTests(unittest.TestCase):
+    """`history` reads the RAW log on purpose -- a memory's change history IS the tombstones and
+    superseded rows the live view exists to hide. The inherited reader is JSONL-only, so on a
+    native backend history reported an empty log for a memory that plainly had one."""
+
+    @staticmethod
+    def _adapter(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._records_lock = __import__("threading").RLock()
+        adapter._get_count = lambda: len(records)
+        adapter._load_records_by_count = lambda count: list(records[:count])
+        adapter._load_records = lambda index: list(records)
+        adapter._get_index = lambda: []
+        return adapter
+
+    def test_raw_records_read_the_native_log(self):
+        records = [_event(11, "user: I am vegetarian."), _forget_tombstone()]
+        self.assertEqual(2, len(self._adapter(records)._read_raw_records()))
+
+    def test_raw_records_expand_a_bundled_append(self):
+        """A bundled append stores several records as ONE hash field; the wrapper carries no
+        record_type, which is what every reader filters on."""
+        bundled = [{"record_bundle": [_event(11, "user: a"), _event(22, "user: b")]}]
+        raw = self._adapter(bundled)._read_raw_records()
+        self.assertEqual([11, 22], [r["event_id_hash"] for r in raw])
+
+    def test_history_reports_ingest_and_supersede_from_the_raw_log(self):
+        adapter = self._adapter([
+            _event(11, "user: I am vegetarian."),
+            {
+                "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+                "tombstone_kind": "delete",
+                "target_memory_id": "11",
+                "tombstone_reason": "supersede",
+                "superseded_by": 22,
+                "created_at_ms": 5000,
+            },
+        ])
+        history = adapter.history({"memory_id": "11"})
+        self.assertEqual(2, history["count"])
+        self.assertEqual(["ingested", "superseded"], [entry["event"] for entry in history["history"]])
+        self.assertEqual(22, history["history"][1]["superseded_by"])
+
+
+class CallerSuppliedFieldsSurviveExtractionTests(unittest.TestCase):
+    """`identity_key` / TTL come from the CALLER; extraction cannot rebuild them. When extraction
+    commits it rewrites the event row for an id that already exists and latest-value compaction
+    serves that newer row, so anything the extractor does not reproduce was silently dropped at
+    read time -- keyed recall 404'd and a TTL record never expired. They survived only when
+    extraction happened to run inside the ingest call, which is why an in-process sync ingest
+    looked correct while the same request through the gateway did not."""
+
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.adapter = local_mod.MatrixArkLocalAdapter(
+            __import__("pathlib").Path(self._dir.name) / "events.jsonl")
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def _scope(self):
+        return {"tenant_id": "t1", "user_id": "u1", "session_id": "s1"}
+
+    def _live_event(self, event_id):
+        for record in self.adapter.read_all():
+            if (str(record.get("record_type") or "") == "context_event"
+                    and str(record.get("event_id_hash")) == str(event_id)):
+                return record
+        return None
+
+    def test_identity_key_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "identity_key": "pref.seat",
+            "truth_class": "asserted",
+        })
+        event_id = result["event_id_hash"]
+        self.assertEqual("pref.seat", self._live_event(event_id).get("identity_key"))
+        # Commit extraction OUTSIDE the ingest call -- what a finalize through the gateway does.
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served, "the event must still serve after extraction commits")
+        self.assertEqual("pref.seat", served.get("identity_key"))
+        self.assertEqual("asserted", served.get("truth_class"))
+
+    def test_ttl_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "ttl_seconds": 3600,
+        })
+        event_id = result["event_id_hash"]
+        expires_at_ms = self._live_event(event_id).get("expires_at_ms")
+        self.assertTrue(expires_at_ms, "the ingest must stamp an expiry")
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served)
+        self.assertEqual(expires_at_ms, served.get("expires_at_ms"))
+        self.assertTrue(served.get("ephemeral"))
+
+
+class NativeWritePathStampTests(unittest.TestCase):
+    """The native writer built its own record batch and skipped the per-ingestion stamp the
+    JSONL writer applies, so those fields never reached the store at all."""
+
+    def test_append_many_stamps_like_the_jsonl_writer(self):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        written = []
+        adapter._append_many_materialized = lambda records, allow_queue=True: written.extend(records)
+        adapter._queue_batched_records = lambda records: False
+        adapter._update_latest_entity_cache = lambda records: None
+        adapter._maintain_event_membership_after_append = lambda records: None
+        adapter._push_ingest_stamp({"identity_key": "pref.seat", "truth_class": "asserted"})
+        try:
+            adapter.append_many([_event(11, "user: Preferred seat: aisle")])
+        finally:
+            adapter._pop_ingest_stamp()
+        events = [r for r in written if r.get("record_type") == "context_event"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("pref.seat", events[0].get("identity_key"))
+        self.assertEqual("asserted", events[0].get("truth_class"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
memory api: read through the record log (DO NOT MERGE -- wedges retrieve)

Correct on the memory surface, wrong on the system. Opened for review and to hold the work; it
must not land until the retrieve wedge below is explained.

## What it fixes

Every memory method except ingest and retrieve misbehaves on the record-log backends -- the ones
that ship -- while looking correct on the JSONL one. Five problems, one shape: a method either
resolves to the JSONL adapter's implementation on a backend with no JSONL log, or the native read
skips a stage of the serving pipeline the JSONL read runs.

* read_all resolved to the JSONL implementation. MatrixArkLocalAdapter precedes the direct mixins
  in the adapter's MRO and also defines read_all, so on a native backend it returned ZERO records
  and every reader built on it -- get, get_all, update, history, keyed recall -- read empty while
  the records sat durably in the record log.

* A bundled append stores several records as ONE hash field. The wrapper carries no record_type,
  which is what every reader filters on, so bundled records were skipped even once they were read.

* The native read ran only the LAST of the serving pipeline's three stages:
    - apply_memory_tombstones is what makes forget / delete / reset remove anything. Without it a
      forget wrote its tombstone, reported an accurate removed_count, and served every one of
      those records right back.
    - compact_latest_value_records collapses rows sharing a latest-value key, which for a
      context_event is the event id. Ingest persists an event row twice (hot path, then again when
      extraction commits), so without it both rows serve and one memory lists as two.

* history reads the RAW log on purpose -- a memory's change history IS the tombstones and
  superseded rows the live view hides -- but called the inherited reader, which returns empty as
  soon as the JSONL log is disabled. The delete-before-extract guard in session_commit reads
  through the same method and was inert on native backends for the same reason.

* Keyed upsert never ran: three memory paths read the compacted seam directly, so overriding only
  read_all leaves a second ingest under the same identity_key finding nothing to supersede.

* The native writer skipped the per-ingestion stamp, so identity_key / truth_class and
  expires_at / ephemeral never reached the store; and extraction, rewriting an event row that
  already exists, rebuilt it from the extraction result alone and dropped them again.

Measured over a single-worker gateway, 20-operation sweep, 5 memories: get 404 -> the memory;
get_all 0 then 10-for-5 -> 5; update 500 -> updated; get_all after forget every record -> 0;
reset did not wipe -> wipes; history empty -> ingested/superseded/deleted; keyed recall 404 ->
the current value with upsert superseding; ttl never expired -> expires. 16/20 -> 19/20.
105 tests green, 10 of them new and every one failing without this.

## Why it must not merge yet

With a 16-memory store behind a single-worker gateway, the sixth retrieve stops responding for
120s and every retrieve after it is rejected on the proxy pack lane after 40s. The gateway's
whole data path goes with it -- a get_all for a user with NO memories does not return in 60s
while /v1/healthz answers in 3ms -- and it never recovers. Idle host, freshly built matching
binary, no orphaned proxy workers, arms back to back, 16 ingests then 12 retrieves:

    without this change    12/12 retrieves, 165-322 ms
    with this change       5 fast, then 120s, then 40s rejections to the end of the run

## Refuted, so nobody spends the time again

* A stale proxy binary -- rebuilt from the same tree; reproduces.
* Host CPU contention -- idle host, load 1.0; reproduces.
* Orphaned proxy workers holding a store open -- this DID contaminate one round; cleaned;
  reproduces.
* The pipeline's own cost -- 0.12 -> 0.64 ms per read at 160 records, 1.37 -> 4.73 ms at 1200,
  and only 3-7% of an ingest. Orders of magnitude too small.
* The retrieval candidate set -- second commit here moves the two added stages off the shared
  choke point onto the memory-API read alone. Same failure, same retrieve.
* A lock-order inversion on the raw read -- third commit here drops a records_lock held across a
  proxy call. Same failure, same retrieve. (Kept anyway: the lock buys nothing there.)
* It does NOT reproduce in-process: 10 retrieves against the same adapter without the gateway run
  46-855 ms.

The proxy worker sits at ~3% CPU with zero sockets open while a retrieve hangs -- blocked, not
working. Next place to look is what the gateway does around a retrieve that an in-process call
does not: the audit and summary-dirty writes land on the same single proxy lane.

## Note on ingest latency

Ingest looks ~2x slower with this change (16 sequential into one scope: 414 -> 2884 ms before,
347 -> 5584 ms after). That is not overhead. Pointing both trees at the same store, the current
tree's read_all() returns 0 records from a store holding 197; this one returns 112. Ingest was
cheap because it read nothing -- the same defect that made forget serve everything back.
