### PR TITLE
Stop re-writing a pipeline task state it already reached

### DIFF
--- a/tools/matrixark_mcp_summary_runtime.py
+++ b/tools/matrixark_mcp_summary_runtime.py
@@ -614,6 +614,46 @@ def async_summary_progress_records(
         for stage in (completed_followup_stages or ["summary"])
         if str(stage or "")
     ]
+    def progress_identity(task_hash: object, completed: list[str]) -> tuple:
+        """What makes one summary-progress row different from another.
+
+        Deliberately excludes the timestamps and ``summary_dirty_hash``: those change on every
+        refresh, nothing reads the dirty hash back off a task row, and including them would
+        make every row unique and defeat the point.
+        """
+        return (
+            str(task_hash),
+            tuple(sorted(set(completed))),
+            int(node_hash or 0),
+            tuple(sorted(set(generated_summary_types or []))),
+        )
+
+    # Tasks already recorded as summary_completed. Re-stamping a task with a state it is
+    # ALREADY recorded as having reached is the single largest source of rows in the store --
+    # a resident-memory census measured 193 rows for 25 tasks, 168 of them exactly this.
+    # Serving already collapses them (matrixark_pipeline_task_slim, Lever A) but the write
+    # still costs a round trip and permanent growth, and on a record-log backend that growth
+    # is what turns a busy store into one where a retrieve cannot finish. Skip the write when
+    # nothing about the task actually changed; a genuinely new state still lands.
+    already_recorded: set[tuple] = set()
+    for record in records:
+        if record.get("record_type") != "matrixark_async_pipeline_task":
+            continue
+        if str(record.get("status") or "") != "summary_completed":
+            continue
+        if not compatible_scope(candidate_access_scope(record), scope):
+            continue
+        existing_completed = [
+            str(stage)
+            for stage in (
+                record.get("completed_stages")
+                if isinstance(record.get("completed_stages"), list)
+                else []
+            )
+            if str(stage or "")
+        ]
+        already_recorded.add(progress_identity(record.get("task_hash"), existing_completed))
+
     progress_records: list[Json] = []
     for record in records:
         if record.get("record_type") != "matrixark_async_pipeline_task":
@@ -642,6 +682,14 @@ def async_summary_progress_records(
             for stage in (record.get("remaining_stages") if isinstance(record.get("remaining_stages"), list) else [])
             if str(stage or "") and str(stage) not in completed_stage_set
         ]
+        if (
+            progress_identity(
+                record.get("task_hash", stable_hash(f"async_pipeline:{event_id_hash}")),
+                completed,
+            )
+            in already_recorded
+        ):
+            continue  # already recorded in this state; the row would be a pure duplicate
         progress_records.append(
             {
                 **record,


### PR DESCRIPTION
Stop re-writing a pipeline task state it already reached

Every summary refresh re-appended a `summary_completed` row for each task it touched, whether or
not that task was already recorded as having completed its summary. Nothing about the task had
changed; the row was a duplicate of one already in the log.

Serving already knew this and collapsed them on read (matrixark_pipeline_task_slim, Lever A --
its own notes measured 193 rows for 25 tasks, 168 of them exactly these re-stamps, making it the
largest record type in the store). But collapsing on read does not stop the write: each duplicate
still costs a round trip to the backend and permanent growth in the record log, and on a
record-log backend that growth is paid again by every later scan.

So skip the write when the task is already recorded in that state. A genuinely new state, a
different node, or a different set of generated summary types all still land -- the identity
deliberately excludes the timestamps and `summary_dirty_hash`, which change on every refresh,
are not read back off a task row, and would otherwise make every row unique and defeat the point.

Measured, 16 ingests through the gateway on the record-log backend:

  matrixark_async_pipeline_task rows   285 -> 80   (-72%)
  total records in the store          1613 -> 1409

Retrieve is unaffected and slightly cheaper: 12/12 answered, 109-204 ms, ingest 307 -> 2024 ms
across the run versus 427 -> 2417 ms without this.

Suites: the failing set is identical to this branch point, with one exception --
`test_background_worker_refreshes_dirty_nodes_and_embeddings` now passes where it errored before.
Nothing new fails.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
