### PR TITLE
Make a lagging follower converge instead of rejecting forever

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
+++ b/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command as ProcessCommand, Stdio};
+use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -239,6 +240,7 @@ fn main() {
     for node in &nodes {
         wait_for_http(&node.addr);
     }
+    let _ = NODE_ADDRS.set(nodes.iter().map(|node| (node.node_id, node.addr.clone())).collect());
     initialize_liveness(&nodes);
 
     let writes = vec![propose(&nodes[0], "secondary-before-restart", "v1")];
@@ -1231,8 +1233,10 @@ fn elect_leader(node: &ProductionRaftNode, leader_id: RaftNodeId) {
     .expect("elect admin request failed");
     assert!(
         response.status.ok,
-        "elect admin request failed: {:?}",
-        response.status
+        "elect of node {leader_id} on node {} failed: {:?};{}",
+        node.node_id,
+        response.status,
+        cluster_wide_status()
     );
 }
 
@@ -1423,6 +1427,46 @@ fn bootstrap_external_snapshot(
     );
 }
 
+/// Every node's address, so a failing wait can ask each one about itself. A replica's own status
+/// describes its peers only as this process's shadows of them, which can be arbitrarily stale.
+static NODE_ADDRS: OnceLock<Vec<(RaftNodeId, String)>> = OnceLock::new();
+
+fn cluster_wide_status() -> String {
+    let Some(addrs) = NODE_ADDRS.get() else {
+        return "(node registry not initialised)".to_string();
+    };
+    addrs
+        .iter()
+        .map(|(node_id, addr)| {
+            let status: Result<RaftClusterStatus, _> =
+                get_json_with_options(addr, "/raft/status", request_options());
+            match status {
+                Ok(status) => {
+                    let peers = status
+                        .nodes
+                        .iter()
+                        .map(|node| {
+                            format!(
+                                "
+      [{}] role={:?} term={} commit={} last_log={} applied={} alive={} lag={}",
+                                node.node_id, node.role, node.current_term, node.commit_index,
+                                node.last_log_index, node.applied_index, node.alive, node.lag
+                            )
+                        })
+                        .collect::<String>();
+                    format!(
+                        "
+  node {node_id} says: leader={} term={} commit={}{peers}",
+                        status.leader_id, status.current_term, status.commit_index
+                    )
+                }
+                Err(err) => format!("
+  node {node_id} status unavailable: {err}"),
+            }
+        })
+        .collect::<String>()
+}
+
 fn wait_for_value(
     node: &ProductionRaftNode,
     node_id: RaftNodeId,
@@ -1435,11 +1479,12 @@ fn wait_for_value(
         if read.value.as_deref() == Some(expected) {
             return read;
         }
-        assert!(
-            Instant::now() < deadline,
-            "node {node_id} did not return {key}={expected}; last response: {:?}",
-            read
-        );
+        if Instant::now() >= deadline {
+            panic!(
+                "node {node_id} did not return {key}={expected}; last response: {read:?};{}",
+                cluster_wide_status()
+            );
+        }
         thread::sleep(Duration::from_millis(50));
     }
 }

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -656,6 +656,10 @@ pub struct MatrixRaftPeerPipelineState {
     pub reorder_dropped_packages: u64,
     #[serde(default)]
     pub stale_term_rejections: u64,
+    /// Sends to this peer that failed outright, producing no response at all. Each one released a
+    /// reservation that would otherwise have been held forever.
+    #[serde(default)]
+    pub append_send_failures: u64,
     pub snapshot_sending: bool,
     pub snapshot_installing: bool,
     pub snapshot_installed_index: u64,
@@ -1106,6 +1110,10 @@ pub struct RaftPeerPipelineRuntimeState {
     pub reorder_dropped_packages: u64,
     #[serde(default)]
     pub stale_term_rejections: u64,
+    /// Sends to this peer that failed outright, producing no response. Each released a reservation
+    /// that would otherwise have been held forever.
+    #[serde(default)]
+    pub append_send_failures: u64,
     pub snapshot_sending: bool,
     pub snapshot_installing: bool,
     pub snapshot_installed_index: u64,
@@ -4340,7 +4348,10 @@ impl RaftCluster {
                     let _ = self.record_append_entries_response(target_id, &response);
                     failed_targets.push(target_id);
                 }
-                Err(_) => failed_targets.push(target_id),
+                Err(_) => {
+                    let _ = self.record_append_entries_send_failure(target_id);
+                    failed_targets.push(target_id);
+                }
             }
         }
         while let Ok((target_id, result)) = rx.try_recv() {
@@ -4358,6 +4369,7 @@ impl RaftCluster {
                     }
                 }
                 Err(_) => {
+                    let _ = self.record_append_entries_send_failure(target_id);
                     if !failed_targets.contains(&target_id) {
                         failed_targets.push(target_id);
                     }

--- a/crates/temporalstore-rust/src/raft/cluster_inner_admin_report.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner_admin_report.rs
@@ -63,6 +63,7 @@ impl RaftClusterInner {
                     append_requests: pipeline.append_requests,
                     append_accepted: pipeline.append_accepted,
                     append_rejected: pipeline.append_rejected,
+                    append_send_failures: pipeline.append_send_failures,
                     inflight_entries: pipeline.inflight_entries,
                     inflight_bytes: pipeline.inflight_bytes,
                     append_queue_depth: pipeline.append_queue_depth,

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -153,7 +153,13 @@ impl RaftCluster {
                 });
             }
         }
-        let available_entries = entry_limit.saturating_sub(current_inflight_entries);
+        // Never build a batch larger than a receiver will accept in one request: a follower
+        // refuses anything over its apply limit, so a bigger batch is not throughput, it is a
+        // request that can only be rejected.
+        let apply_limit = inner.config.max_inflights_apply_task.max(1);
+        let available_entries = entry_limit
+            .saturating_sub(current_inflight_entries)
+            .min(apply_limit);
         let available_bytes = byte_limit.saturating_sub(current_inflight_bytes);
         let leader = inner
             .nodes
@@ -168,8 +174,18 @@ impl RaftCluster {
             .get(&target_id)
             .ok_or(RaftError::NodeNotFound(target_id))?;
         let enable_reorder_queue = inner.config.enable_reorder_queue;
-        let target_last_index = node_last_log_or_snapshot_index(target);
-        let prev_log_index = target_last_index.min(node_last_log_or_snapshot_index(leader));
+        let leader_last_index = node_last_log_or_snapshot_index(leader);
+        // Where to resume from. `next_index` is the peer's own answer -- lowered by every
+        // rejection, set from the peer's match index on success -- so it is what makes a mismatch
+        // converge. Falling back to the local shadow of the peer is only for a peer that has not
+        // answered yet, because the shadow does not move when a peer rejects, and asking about the
+        // same index forever is exactly how a diverged follower stays stuck.
+        let target_next_index = target.pipeline_state.next_index;
+        let prev_log_index = if target_next_index > 0 {
+            target_next_index.saturating_sub(1).min(leader_last_index)
+        } else {
+            node_last_log_or_snapshot_index(target).min(leader_last_index)
+        };
         let prev_log_term =
             node_term_at_log_or_snapshot_index(leader, prev_log_index).unwrap_or_default();
         let mut entries = Vec::new();
@@ -264,9 +280,57 @@ impl RaftCluster {
         } else {
             target.pipeline_state.append_rejected =
                 target.pipeline_state.append_rejected.saturating_add(1);
-            target.pipeline_state.next_index =
-                target.pipeline_state.next_index.saturating_sub(1).max(1);
+            // Retreat only when the peer is telling us the logs disagree. A peer that refused
+            // because the request was too big to apply at once has the prefix we sent; going
+            // further back would only make the next request bigger and refused again.
+            if Self::rejection_means_logs_disagree(response.reject_reason.as_deref()) {
+                target.pipeline_state.next_index =
+                    target.pipeline_state.next_index.saturating_sub(1).max(1);
+            }
         }
+        inner.persist_configured_wal()
+    }
+
+    /// Whether a rejection means the two logs disagree about a prefix, which is the only thing
+    /// retreating to an earlier entry can repair.
+    ///
+    /// The others are refusals of THIS request, not of the position: too many entries to apply at
+    /// once, too many bytes, a stale term, the wrong shard. Retreating on those sends more next
+    /// time, so it turns a transient refusal into a permanent one. An unrecognised reason retreats,
+    /// which is the conservative reading and what the code did for every reason before.
+    fn rejection_means_logs_disagree(reject_reason: Option<&str>) -> bool {
+        !matches!(
+            reject_reason,
+            Some("apply_inflight_backpressure")
+                | Some("apply_batch_backpressure")
+                | Some("stale_term")
+                | Some("shard_mismatch")
+        )
+    }
+
+    /// Release what a request reserved when the send failed outright.
+    ///
+    /// A response -- success or rejection -- clears the reservation. A send that never reaches the
+    /// peer produces no response, so without this the reservation is held forever, and once enough
+    /// have leaked the peer is refused by its own backpressure limit on every future attempt. It
+    /// cannot catch up (nothing is sent to it) and so cannot drain the reservation (which only
+    /// drains on catching up), which makes the exclusion permanent.
+    pub fn record_append_entries_send_failure(
+        &self,
+        target_id: RaftNodeId,
+    ) -> Result<(), RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let target = inner
+            .nodes
+            .get_mut(&target_id)
+            .ok_or(RaftError::NodeNotFound(target_id))?;
+        target.pipeline_state.inflight_entries = 0;
+        target.pipeline_state.inflight_bytes = 0;
+        target.pipeline_state.append_queue_depth = 0;
+        target.pipeline_state.append_send_failures = target
+            .pipeline_state
+            .append_send_failures
+            .saturating_add(1);
         inner.persist_configured_wal()
     }
 

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -282,6 +282,11 @@ impl ProductionRaftRuntime {
                 }
             }
             _ => {
+                // The append never got a response, so release what it reserved before falling
+                // back to a snapshot.
+                let _ = self
+                    .cluster
+                    .record_append_entries_send_failure(target_id);
                 let snapshot = self.cluster.build_install_snapshot_request(target_id)?;
                 let response = transport.install_snapshot(snapshot)?;
                 if !response.success {
@@ -410,17 +415,57 @@ impl ProductionRaftRuntime {
                             if sent >= max_catchup_entries_per_heartbeat {
                                 break;
                             }
-                            let Ok(request) = cluster.build_append_entries_request(*target_id)
-                            else {
-                                continue;
+                            let request = match cluster.build_append_entries_request(*target_id)
+                            {
+                                Ok(request) => request,
+                                Err(err) => {
+                                    // Skipping here is how a peer silently stops being replicated
+                                    // to, so it must not be silent.
+                                    tracing::warn!(
+                                        kind = "data",
+                                        target_id = *target_id,
+                                        error = %err,
+                                        "raft: could not build append entries for peer"
+                                    );
+                                    continue;
+                                }
                             };
                             let entry_count = request.entries.len() as u64;
-                            if let Ok(response) = transport.append_entries(request) {
-                                let success = response.success;
-                                let _ =
-                                    cluster.record_append_entries_response(*target_id, &response);
-                                if success {
-                                    sent += entry_count.max(1);
+                            match transport.append_entries(request) {
+                                Ok(response) => {
+                                    let success = response.success;
+                                    if !success {
+                                        // A rejection is an Ok response, so this path was silent
+                                        // too: a peer can reject every heartbeat forever and the
+                                        // leader reports it only as "lagging".
+                                        tracing::warn!(
+                                            kind = "data",
+                                            target_id = *target_id,
+                                            reject_reason = ?response.reject_reason,
+                                            peer_match_index = response.match_index,
+                                            peer_term = response.term,
+                                            "raft: peer rejected append entries"
+                                        );
+                                    }
+                                    let _ = cluster
+                                        .record_append_entries_response(*target_id, &response);
+                                    if success {
+                                        sent += entry_count.max(1);
+                                    }
+                                }
+                                // No response at all. Give back what the request reserved --
+                                // otherwise a peer whose process is down accumulates one leaked
+                                // reservation per heartbeat and is never sent to again, including
+                                // after it comes back.
+                                Err(err) => {
+                                    tracing::warn!(
+                                        kind = "data",
+                                        target_id = *target_id,
+                                        error = %err,
+                                        "raft: append entries send to peer failed"
+                                    );
+                                    let _ =
+                                        cluster.record_append_entries_send_failure(*target_id);
                                 }
                             }
                         }

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2988,3 +2988,158 @@ fn r8_snapshot_install_with_matching_boundary_retains_tail() {
         "a term-matching boundary must retain the tail past the snapshot"
     );
 }
+
+/// A peer whose sends keep failing must not be locked out of replication forever.
+///
+/// Building an AppendEntries request reserves inflight capacity against the target, and a response
+/// -- success or rejection -- releases it. A send that never reaches the peer produces no response.
+/// Without releasing that reservation the leader leaks one per attempt, and once the peer is over
+/// its inflight limit every future request for it is refused: it cannot catch up, because nothing
+/// is sent to it, and so it cannot drain the reservation, because that only drains on catching up.
+///
+/// That is a follower whose process dies while the leader keeps heartbeating at it: when it comes
+/// back the leader never speaks to it again. It then serves reads from a stale log while reporting
+/// no lag, because the only leader it can compare itself against is its own stale shadow.
+#[test]
+fn a_peer_whose_sends_fail_is_not_locked_out_of_replication() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    // Node 3's process is down, so it falls behind what the majority commits.
+    cluster.set_alive(3, false).unwrap();
+    for index in 0..4 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("committed-{index}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+
+    // The leader heartbeats at the dead process. Every send fails, exactly as the timer loop sees
+    // it: a request is built, the send returns an error, and no response is ever recorded.
+    let limit = RaftConfig::default().max_inflights_replicate.max(1);
+    for _ in 0..(limit * 4) {
+        if cluster.build_append_entries_request(3).is_ok() {
+            cluster.record_append_entries_send_failure(3).unwrap();
+        }
+    }
+
+    // Node 3 is back. The leader must still be willing to send to it.
+    let outcome = cluster.build_append_entries_request(3);
+    assert!(
+        outcome.is_ok(),
+        "a peer must not be permanently excluded from replication by failed sends; got {outcome:?}"
+    );
+    let request = outcome.unwrap();
+    assert!(
+        !request.entries.is_empty(),
+        "the request should carry the entries the peer is missing, got {request:?}"
+    );
+}
+
+/// A failed send leaves the reservation exactly as a response would have: released.
+///
+/// The counterpart is the accumulation the backpressure limit depends on, which is unchanged --
+/// consecutive builds with no response and no failure still reserve, and still eventually refuse.
+#[test]
+fn a_failed_send_releases_its_reservation() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_alive(3, false).unwrap();
+    for index in 0..4 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("committed-{index}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+
+    // Reserve right up to the limit, the way repeated un-answered sends do.
+    let limit = RaftConfig::default().max_inflights_replicate.max(1);
+    let mut refused = false;
+    for _ in 0..(limit * 4) {
+        if cluster.build_append_entries_request(3).is_err() {
+            refused = true;
+            break;
+        }
+    }
+    assert!(
+        refused,
+        "un-answered builds should accumulate into backpressure -- that guard is deliberate"
+    );
+
+    // Reporting the send failure releases it, and the very next build succeeds.
+    cluster.record_append_entries_send_failure(3).unwrap();
+    cluster
+        .build_append_entries_request(3)
+        .expect("a released reservation should let the next request through");
+}
+
+/// A rejected AppendEntries must make the next attempt ask about an EARLIER entry.
+///
+/// That retreat is the only way two diverged logs ever agree again. The leader lowers `next_index`
+/// on a rejection, but the request builder used to derive `prev_log_index` from this process's
+/// shadow of the peer, which a rejection does not move -- so every retry asked about the same
+/// index and was rejected again. A follower whose log disagreed with the leader could never be
+/// repaired: it rejected every heartbeat forever while the leader reported it as alive and merely
+/// lagging, and it went on serving reads from its stale log.
+#[test]
+fn a_rejected_append_retreats_to_an_earlier_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+
+    // The peer keeps up for a while, so the leader has a real position for it...
+    for index in 0..3 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("early-{index}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+    // ...and then falls behind.
+    cluster.set_alive(3, false).unwrap();
+    for index in 0..3 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("later-{index}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+
+    let first = cluster.build_append_entries_request(3).unwrap();
+    assert!(
+        first.prev_log_index > 1,
+        "the peer needs somewhere to retreat to for this to mean anything, got {}",
+        first.prev_log_index
+    );
+
+    // The peer says its log does not match at that point.
+    cluster
+        .record_append_entries_response(
+            3,
+            &AppendEntriesResponse {
+                term: first.term,
+                success: false,
+                match_index: first.prev_log_index,
+                reject_reason: Some("log_mismatch".to_string()),
+            },
+        )
+        .unwrap();
+
+    let second = cluster.build_append_entries_request(3).unwrap();
+    assert!(
+        second.prev_log_index < first.prev_log_index,
+        "a rejection must lower the point the next request asks about, but it stayed at {} --          the retry is identical, so the peer can never converge",
+        second.prev_log_index
+    );
+}


### PR DESCRIPTION
`raft_secondary_replication_harness` failed on every run. Three defects, each hidden by a silent path in the replication loop, kept a follower that had fallen behind from ever catching up.

## What was wrong

**A failed send leaked the capacity it reserved.** Building a request reserves inflight capacity against the target; a *response* — success or rejection — releases it. A send that never reaches the peer produces no response, and the loop discarded that error, so each failed attempt leaked a reservation. Once the peer sat above its inflight limit, every future request for it was refused: it could not catch up because nothing was being sent to it, and could not release the reservation because that only drains on catching up.

**The retreat after a rejection was computed but never used.** A rejected append is supposed to make the leader retry from an earlier entry until the logs agree. `record_append_entries_response` lowered `next_index` correctly — but the request builder derived `prev_log_index` from *this process's shadow of the peer*, which a rejection does not move. Every retry asked about the same index. Observed directly: **671 consecutive `log_mismatch` rejections**, the follower pinned at term 1 while the cluster ran on to term 3.

**A leader batched more than a follower would accept.** A follower refuses a request carrying more entries than `max_inflights_apply_task` (5); a leader batches up to `max_inflights_replicate` (128). Any catch-up longer than five entries was refused outright — and the leader read that refusal as a log disagreement and retreated, which makes the *next* batch larger and guarantees the next refusal. Observed as **628 consecutive `apply_inflight_backpressure` rejections**.

## What changed

- A failed send releases its reservation, exactly as a response would, and is counted (`append_send_failures`).
- `prev_log_index` follows `next_index` — the peer's own answer — falling back to the local shadow only for a peer that has not answered yet.
- Retreating is confined to rejections that mean the logs disagree. "Too much at once" is answered by sending less, not by going further back.
- A batch is never larger than a receiver will accept in one request.
- The loop reports the paths it used to swallow. A request that cannot be built, a send that fails, and a peer that rejects were all silent; a peer could stop being replicated to entirely and nothing anywhere said so, because the leader's own status still described it as alive and merely lagging. This is what made the failure take so long to place, and it is the part I would keep even if the rest were reverted.

## Tests

Three, each verified to fail before the change and pass after — I reverted the fix to confirm rather than assuming:

- a peer whose sends keep failing is not locked out of replication
- a failed send releases its reservation, while the deliberate accumulation that backpressure depends on is unchanged
- a rejected append retreats to an earlier entry (without the fix: *"it stayed at 3 — the retry is identical, so the peer can never converge"*)

## Testing

Library suite: **956 passed, 10 failed**, and **no name fails here that does not also fail on `main`** — the set difference against `main` is empty.

## Honest status of the harness

It is **not yet green**. It now gets much further: the follower that could never catch up now converges (term 11, commit 9, applied 9, lag 0), and the run proceeds through the restart, membership and partition phases into the third rolling restart, where it fails on an `elect` reporting `live=1, required=2` — on a node whose own status reports all three peers alive. That is a different problem, in liveness or membership accounting after a leader is restarted, and I did not want to hold three verified fixes behind it.
