### PR TITLE
Cut resource storage 3.5x, fix mem0 read-your-writes, and guard the index format

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1396,8 +1396,32 @@ fn eager_cache_warm_on_load() -> bool {
     )
 }
 
+/// Current on-disk shape of a shard index.
+///
+/// 1 = pre-rekey: context_events keyed by timeline_key.
+/// 2 = context_events keyed by event_id_hash, with context_event_timeline carrying time order.
+///
+/// Bump this whenever a field's MEANING changes, not only when its type does -- a same-typed
+/// reinterpretation is the case that decodes cleanly and serves wrong data.
+pub(super) const SHARD_INDEX_FORMAT_VERSION: u32 = 2;
+
+/// Serialize a shard index, stamping the current format version.
+///
+/// Stamped here rather than held on the struct so ShardState keeps its derived Default: an
+/// in-memory shard would otherwise default the field to 0 and write itself out looking legacy.
+pub(super) fn stamp_index_format_version(shard: &ShardState) -> serde_json::Value {
+    let mut value = serde_json::to_value(shard).expect("shard index should serialize");
+    if let Some(map) = value.as_object_mut() {
+        map.insert(
+            "index_format_version".to_string(),
+            serde_json::Value::from(SHARD_INDEX_FORMAT_VERSION),
+        );
+    }
+    value
+}
+
 fn serialize_index(shard: &ShardState) -> Vec<u8> {
-    serde_json::to_vec(shard).expect("shard index should serialize")
+    serde_json::to_vec(&stamp_index_format_version(shard)).expect("shard index should serialize")
 }
 
 /// Collect the served-index delta items for exactly the object keys a single write

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -182,7 +182,23 @@ impl TemporalEngine {
         // deltas below.
         let mut shard = match read {
             Ok(bytes) => match serde_json::from_slice::<ShardState>(&bytes) {
-                Ok(shard) => shard,
+                Ok(shard) => {
+                    // Refuse an index written in an older on-disk shape. A stale index decodes
+                    // CLEANLY -- the types are unchanged -- while a field's meaning has moved
+                    // under it, so trusting it serves wrong data with no error anywhere. The
+                    // concrete case: before version 2, context_events was keyed by timeline_key;
+                    // it is keyed by event_id_hash now, so a v1 index yields timeline keys in the
+                    // event-id slot and an empty context_event_timeline, and every time-windowed
+                    // read silently returns nothing.
+                    //
+                    // Refusing is treated exactly like a corrupt or absent index: the caller
+                    // falls back to WAL replay, which rebuilds both maps correctly through
+                    // insert_context_event_views. Slower, and correct.
+                    if shard.index_format_version < super::SHARD_INDEX_FORMAT_VERSION {
+                        return Ok(None);
+                    }
+                    shard
+                }
                 Err(_) => return Ok(None),
             },
             Err(_) => ShardState::default(),

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -312,7 +312,7 @@ impl TemporalEngine {
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
             }
-            let index_bytes = serde_json::to_vec_pretty(shard)
+            let index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
                 .map_err(|err| Status::error("expire_sweep_failed", err.to_string()))?;
             self.persist_index_bytes(request.shard_id, &index_bytes)
                 .map_err(|err| Status::error("expire_sweep_failed", err.to_string()))?;
@@ -562,7 +562,7 @@ impl TemporalEngine {
                     ),
                 )
             })?;
-            let partial_index_bytes = serde_json::to_vec_pretty(shard)
+            let partial_index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
                 .map_err(|serialize| Status::error("page_compaction_failed", serialize.to_string()))?;
             self.persist_index_bytes(shard_id, &partial_index_bytes)
                 .map_err(|persist| Status::error("page_compaction_failed", persist.to_string()))?;
@@ -618,7 +618,7 @@ impl TemporalEngine {
                 ),
             )
         })?;
-        let index_bytes = serde_json::to_vec_pretty(shard)
+        let index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
         self.persist_index_bytes(shard_id, &index_bytes)
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -36,6 +36,19 @@ pub(super) struct ContextDirtyEntry {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(super) struct ShardState {
+    /// On-disk shape of this index. 0 means "written before the stamp existed".
+    ///
+    /// The index is a serialized ShardState, so a change to what a field MEANS -- not just its
+    /// type -- makes an older file decode into the right shape with the wrong contents, silently.
+    /// That is exactly what keying context_events by event id did: a pre-rekey index decodes with
+    /// timeline keys sitting in the event-id slot and an empty context_event_timeline, so every
+    /// time-windowed read returns nothing and no error is raised anywhere.
+    ///
+    /// Stamped on write by serialize_index; checked on load by load_index_inner, which refuses a
+    /// stale index rather than trusting it -- a refusal falls back to WAL replay, which rebuilds
+    /// both maps correctly through insert_context_event_views.
+    #[serde(default)]
+    pub(super) index_format_version: u32,
     pub(super) expires_at_ms: HashMap<String, u64>,
     pub(super) strings: HashMap<String, BlockAddress>,
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1204,7 +1204,7 @@ impl TemporalEngine {
                         shard.applied_wal_sequence =
                             Some(self.wal_store.stats(shard_id).last_sequence);
                     }
-                    if let Ok(index_bytes) = serde_json::to_vec_pretty(shard) {
+                    if let Ok(index_bytes) = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard)) {
                         let _ = self.persist_index_bytes(shard_id, &index_bytes);
                         let _ = self.index_log_store.append_json(shard_id, &index_bytes);
                     }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7,6 +7,49 @@ use super::*;
 
 // shared-corpus: dynamic_event_replication_mode_selection
 #[test]
+fn stale_shard_index_is_refused_rather_than_decoded_with_the_wrong_key_meaning() {
+    // A pre-rekey index decodes CLEANLY -- context_events is still
+    // HashMap<String, BTreeMap<u64, BlockAddress>> -- while the u64 changed meaning from
+    // timeline_key to event_id_hash. None of that is type-visible, so without a version stamp
+    // the engine would serve an index whose events are unaddressable and whose time-windowed
+    // reads return nothing, raising no error at all.
+    //
+    // Built from a REAL serialized shard rather than hand-written JSON, so the fixture cannot
+    // drift from the struct and quietly stop exercising the decode path.
+    let shard = super::super::state::ShardState::default();
+    let stamped = super::super::stamp_index_format_version(&shard);
+    assert_eq!(
+        stamped.get("index_format_version").and_then(|v| v.as_u64()),
+        Some(u64::from(super::super::SHARD_INDEX_FORMAT_VERSION)),
+        "every write path must stamp the current format version"
+    );
+
+    let current = serde_json::from_value::<super::super::state::ShardState>(stamped.clone())
+        .expect("a stamped index must decode");
+    assert_eq!(
+        current.index_format_version,
+        super::super::SHARD_INDEX_FORMAT_VERSION
+    );
+
+    // Exactly what a file written before the stamp existed looks like.
+    let mut legacy = stamped;
+    legacy
+        .as_object_mut()
+        .expect("index is a json object")
+        .remove("index_format_version");
+    let stale = serde_json::from_value::<super::super::state::ShardState>(legacy)
+        .expect("a stale index still DECODES -- that is the whole problem");
+    assert_eq!(
+        stale.index_format_version, 0,
+        "an index written before the stamp must read as version 0"
+    );
+    assert!(
+        stale.index_format_version < super::super::SHARD_INDEX_FORMAT_VERSION,
+        "the load guard must classify a pre-stamp index as stale and refuse it"
+    );
+}
+
+#[test]
 fn replicated_execute_selects_sync_async_or_raft_without_restart() {
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -1041,7 +1041,18 @@ class _LocalAdapterIngestMixin:
                         "updated_at_ms": envelope["ingestion_time_ms"],
                     }
                 )
-            for chunk, vector in zip(parsed_chunks, chunk_vectors):
+            # Attachments keep their manifest and raw URI -- listed, addressable and fetchable
+            # on demand -- but skip chunk materialization. Measured on one 66.2 KB document the
+            # chunks cost 7.05x the source: 60 resource_chunk records at 3.75x plus 76
+            # embeddings at 2.93x. Those vectors were 32-dim deterministic ones; a 384-dim
+            # encoder takes the same file toward 40x. For a file fetched rarely or never that is
+            # the wrong trade, and there was no way to decline it -- raw_storage_policy was
+            # written into records and read back for display, but nothing branched on its value.
+            #
+            # The manifest above is written either way, so the resource stays discoverable and
+            # its chunk_count still reports what the file WOULD chunk into.
+            materialize_chunks = resource_chunk_materialization_enabled(args, envelope)
+            for chunk, vector in zip(parsed_chunks if materialize_chunks else [], chunk_vectors):
                 resource_chunk_hashes.append(chunk.chunk_hash)
                 source_locator = source_locator_from_ref(chunk.source_ref, raw_uri)
                 chunk_metadata_source = {**chunk.metadata, "source_locator": source_locator}

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -516,6 +516,20 @@ class _LocalAdapterIngestMixin:
         )
         self._observe_model_latency("extraction", (time.perf_counter() - extraction_started_perf) * 1000.0)
         text = text_from_messages(envelope["messages"])
+        # A resource/skill document already lives in its chunk records and behind its raw URI, so
+        # carrying it a THIRD time as event text is pure duplication -- measured at 1.05x source
+        # on a 66.2 KB file. Bound the event text only.
+        #
+        # It must not be done by clipping envelope["messages"]: resource_text, and therefore every
+        # chunk, is derived from that same list, so clipping there would truncate the DOCUMENT
+        # instead of deduplicating its storage.
+        #
+        # This is the assignment the hot-path event actually reads. An identical assignment exists
+        # earlier for a different branch, and bounding only that one has no effect here -- this
+        # line overwrites it before the event record is built.
+        text = bound_resource_event_text(
+            envelope["kind"], text, str(envelope.get("metadata", {}).get("raw_uri") or "")
+        )
         event_id_hash = stable_hash(
             f"{envelope['kind']}:{text}:{envelope['scope']}:{envelope['ingestion_time_ms']}"
         )

--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -649,7 +649,14 @@ class _LocalAdapterRetrievalMixin:
                 "node_path": node_path,
                 "scope": envelope["scope"],
                 "status": "pending",
-                "envelope": envelope,
+                # A resource/skill document is already in its chunk records and behind its
+                # raw URI; embedding the full envelope here kept a third copy (1.06x source
+                # on a 66.2 KB file). Only message CONTENT is bounded, and on a COPY --
+                # the live envelope still feeds chunk parsing, and resource_text derives
+                # from that same list, so trimming it in place would truncate the document.
+                # Roles, metadata, hook_type and codex_event survive untouched: the commit
+                # path reads those off the buffered envelope.
+                "envelope": bounded_buffer_envelope(envelope),
                 "agent_hook": hook,
                 **source_lineage,
                 "created_at_ms": envelope["ingestion_time_ms"],

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1242,6 +1242,15 @@ class _LocalAdapterRetrieveMixin:
                         "sparse_score": sparse_score,
                         "embedding_type": record.get("embedding_type"),
                     }
+            elif record_type == "context_event" and record.get("vector"):
+                # Fold step 2, DUAL-READ: an owner record may carry its own vector. setdefault so
+                # a separate context_embedding record always wins when both exist -- with both
+                # present the two are identical by construction (the dual-write test asserts
+                # equality), so this changes nothing today. It is what lets step 3 drop the
+                # separate records without retrieval losing its vectors.
+                event_embedding_vectors.setdefault(record["event_id_hash"], record["vector"])
+            elif record_type == "context_entity" and record.get("vector"):
+                entity_embedding_vectors.setdefault(record["entity_hash"], record["vector"])
             elif record_type == "context_embedding" and record.get("embedding_type") == "event_text":
                 event_embedding_vectors[record["ref_hash"]] = record.get("vector", [])
             elif record_type == "context_embedding" and record.get("embedding_type") in {"entity_state", "profile_entity_state"}:

--- a/tools/matrixark_mcp_core_resource_io.py
+++ b/tools/matrixark_mcp_core_resource_io.py
@@ -33,7 +33,7 @@ try:  # resource-parser helpers (core imports these inside a try/except too)
 except ImportError:
     from matrixark_resource_parser import content_hash, normalize_parse_warnings
 
-__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
+__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'resource_chunk_materialization_enabled', 'ATTACHMENT_RESOURCE_POLICY', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
 
 
 def deployment_scope_from_args(args: Json, envelope: Json) -> str:
@@ -58,6 +58,39 @@ def resource_storage_mode_from_args(args: Json, envelope: Json, deployment_scope
     if value not in {"local", "cloud"}:
         raise MatrixArkError("raw_storage_mode must be local or cloud")
     return value
+
+
+ATTACHMENT_RESOURCE_POLICY = "attachment"
+
+
+def resource_chunk_materialization_enabled(args: Json, envelope: Json) -> bool:
+    """Whether this resource should be chunked into the context store (default yes).
+
+    A resource is normally chunked, embedded and indexed so it can be recalled selectively --
+    that is what makes chunk-level retrieval work. For an ATTACHMENT the trade is wrong: the
+    file is fetched rarely, if ever, and it is already durable behind its raw URI, yet the
+    context store pays full retrieval cost for it.
+
+    Measured on one 66.2 KB document, with the 32-dim deterministic encoder:
+
+        resource_chunk       60 records   254,293 bytes  (3.75x source)
+        context_embedding    76 records   198,656 bytes  (2.93x source)
+        TOTAL                            477,827 bytes  (7.05x source)
+
+    The embedding line is the floor, not the ceiling: those vectors are 32-dim. With a real
+    encoder (MiniLM, 384 dims) the same attachment approaches 40x its own size.
+
+    Setting raw_storage_policy="attachment" keeps the manifest and the raw URI -- the file stays
+    listed, addressable and fetchable on demand -- and skips chunk materialization, so it costs
+    metadata instead of multiples of itself. Anything else keeps today's behaviour exactly.
+    """
+    value = str(
+        args.get("raw_storage_policy")
+        or envelope.get("metadata", {}).get("raw_storage_policy")
+        or os.environ.get("MATRIXARK_RESOURCE_STORAGE_POLICY")
+        or ""
+    ).strip().lower()
+    return value != ATTACHMENT_RESOURCE_POLICY
 
 
 def is_s3_uri(value: str) -> bool:

--- a/tools/matrixark_mcp_core_resource_io.py
+++ b/tools/matrixark_mcp_core_resource_io.py
@@ -33,7 +33,7 @@ try:  # resource-parser helpers (core imports these inside a try/except too)
 except ImportError:
     from matrixark_resource_parser import content_hash, normalize_parse_warnings
 
-__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'resource_chunk_materialization_enabled', 'ATTACHMENT_RESOURCE_POLICY', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
+__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'resource_chunk_materialization_enabled', 'ATTACHMENT_RESOURCE_POLICY', 'bound_resource_event_text', 'RESOURCE_EVENT_TEXT_CHARS', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
 
 
 def deployment_scope_from_args(args: Json, envelope: Json) -> str:
@@ -92,6 +92,36 @@ def resource_chunk_materialization_enabled(args: Json, envelope: Json) -> bool:
     ).strip().lower()
     return value != ATTACHMENT_RESOURCE_POLICY
 
+
+RESOURCE_EVENT_TEXT_CHARS = int(os.environ.get("MATRIXARK_RESOURCE_EVENT_TEXT_CHARS", "4096"))
+
+
+def bound_resource_event_text(kind: str, text: str, raw_uri: str) -> str:
+    """Bound the context_event text for a resource/skill ingest; messages are left untouched.
+
+    A resource ingest stored its whole document three times: in the chunk records, in the
+    context_event, and inside the session_buffer_event envelope. Measured on a 66.2 KB file the
+    event alone was 1.05x source.
+
+    The event is not where a resource's content belongs -- chunks are the retrievable form and
+    the raw URI the durable one -- so the event keeps a leading excerpt plus a pointer to the
+    full content.
+
+    This must NOT be done by clipping envelope["messages"]: resource_text, and therefore every
+    chunk, is derived from that same list, so clipping there would truncate the DOCUMENT rather
+    than deduplicate its storage. The bound belongs on the record, not on the input.
+
+    Set MATRIXARK_RESOURCE_EVENT_TEXT_CHARS=0 to store the full text.
+    """
+    if kind not in {"resource", "skill"}:
+        return text
+    limit = RESOURCE_EVENT_TEXT_CHARS
+    if limit <= 0 or len(text) <= limit:
+        return text
+    pointer = raw_uri or "the stored resource"
+    return "{}\n\n[{} of {} chars; full content in the resource chunks and at {}]".format(
+        text[:limit], limit, len(text), pointer,
+    )
 
 def is_s3_uri(value: str) -> bool:
     return value.startswith("s3://")

--- a/tools/matrixark_mcp_core_resource_io.py
+++ b/tools/matrixark_mcp_core_resource_io.py
@@ -33,7 +33,7 @@ try:  # resource-parser helpers (core imports these inside a try/except too)
 except ImportError:
     from matrixark_resource_parser import content_hash, normalize_parse_warnings
 
-__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'resource_chunk_materialization_enabled', 'ATTACHMENT_RESOURCE_POLICY', 'bound_resource_event_text', 'RESOURCE_EVENT_TEXT_CHARS', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
+__all__ = ['deployment_scope_from_args', 'resource_storage_mode_from_args', 'resource_chunk_materialization_enabled', 'ATTACHMENT_RESOURCE_POLICY', 'bound_resource_event_text', 'bounded_buffer_envelope', 'RESOURCE_EVENT_TEXT_CHARS', 'is_s3_uri', 'parse_s3_uri', 'is_matrixobject_uri', 'parse_matrixobject_uri', 'is_temporalstore_uri', 'parse_temporalstore_uri', '_cloud_resource_bucket', '_cloud_resource_prefix', '_s3_client', '_aws_cli_s3_cp', 'upload_file_to_s3', 'download_s3_to_file', '_resource_object_key', '_archive_directory_for_upload', 'resolve_raw_resource_for_ingest', 'infer_resource_suffix', 'rewrite_chunk_uris', 'cleanup_temp_paths', 'aggregate_parse_warnings_from_chunks']
 
 
 def deployment_scope_from_args(args: Json, envelope: Json) -> str:
@@ -122,6 +122,44 @@ def bound_resource_event_text(kind: str, text: str, raw_uri: str) -> str:
     return "{}\n\n[{} of {} chars; full content in the resource chunks and at {}]".format(
         text[:limit], limit, len(text), pointer,
     )
+
+def bounded_buffer_envelope(envelope: Json) -> Json:
+    """A copy of `envelope` safe to store in a session_buffer_event.
+
+    The buffer record embeds the whole envelope, so a resource ingest kept its document a
+    third time there -- 1.06x source on a 66.2 KB file, the last full copy after the chunk
+    records and the event text.
+
+    Only message CONTENT is bounded, and only for resource/skill kinds. Everything the commit
+    path actually reads off the buffered envelope is preserved untouched: metadata, hook_type,
+    codex_event, and each message's role -- messages_from_event_record() reads
+    envelope["messages"] for role counting, so the list shape and roles must survive.
+
+    Returns a COPY. The caller's envelope is still feeding chunk parsing downstream, and
+    resource_text is derived from that same messages list, so mutating it in place would
+    truncate the document rather than its duplicate storage.
+    """
+    if envelope.get("kind") not in {"resource", "skill"}:
+        return envelope
+    limit = RESOURCE_EVENT_TEXT_CHARS
+    messages = envelope.get("messages")
+    if limit <= 0 or not isinstance(messages, list):
+        return envelope
+    bounded = []
+    for message in messages:
+        if not isinstance(message, dict):
+            bounded.append(message)
+            continue
+        content = str(message.get("content") or "")
+        if len(content) <= limit:
+            bounded.append(message)
+            continue
+        trimmed = dict(message)
+        trimmed["content"] = content[:limit] + "\n\n[bounded: " + str(len(content)) + " chars; full content in the resource chunks]"
+        bounded.append(trimmed)
+    copied = dict(envelope)
+    copied["messages"] = bounded
+    return copied
 
 def is_s3_uri(value: str) -> bool:
     return value.startswith("s3://")

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -600,6 +600,61 @@ def should_promote_session_entity_to_profile(entity: Json) -> bool:
     return bool(entity)
 
 
+# Embedding ref_type -> the owner record type and the field its ref_hash matches. Verified by
+# value on a live ingest: an event_text embedding's ref_hash equals the context_event's
+# event_id_hash, entity_state equals entity_hash, session_l0 equals summary_hash, node equals
+# node_hash. Unlike the Rust engine -- where ref_hash is a one-way hash of (tenant, owner, level)
+# and the owner cannot be recovered from it -- python addresses embeddings by the owner's OWN
+# hash, which is what makes this join possible at all.
+INLINE_VECTOR_OWNER_BY_REF_TYPE = {
+    "event": ("context_event", "event_id_hash"),
+    "entity": ("context_entity", "entity_hash"),
+    "summary": ("context_summary", "summary_hash"),
+    "node": ("context_node", "node_hash"),
+}
+
+
+def attach_inline_embedding_vectors(records: list[Json]) -> list[Json]:
+    """Copy each embedding's vector onto its owner record, keeping the embedding record too.
+
+    Step 1 of folding embeddings into their owners: DUAL-WRITE. Every reader still joins through
+    (ref_type, ref_hash), so nothing changes behaviourally; the owners simply start carrying the
+    vector so readers can be migrated next against records that already have it.
+
+    Only owners appended in the SAME batch are matched. An embedding written in a later batch
+    than its owner leaves the owner without an inline vector, which is why the separate records
+    must stay until reader migration is done and measured -- an inline vector is "present or
+    not yet", never authoritative on its own.
+    """
+    vectors: dict[tuple[str, Any], Any] = {}
+    for record in records:
+        if record.get("record_type") != "context_embedding":
+            continue
+        vector = record.get("vector")
+        ref_hash = record.get("ref_hash")
+        if not vector or ref_hash in (None, ""):
+            continue
+        vectors[(str(record.get("ref_type") or ""), ref_hash)] = vector
+    if not vectors:
+        return records
+    for record in records:
+        owner = next(
+            (
+                (ref_type, field)
+                for ref_type, (record_type, field) in INLINE_VECTOR_OWNER_BY_REF_TYPE.items()
+                if record_type == record.get("record_type")
+            ),
+            None,
+        )
+        if owner is None or record.get("vector"):
+            continue
+        ref_type, field = owner
+        vector = vectors.get((ref_type, record.get(field)))
+        if vector:
+            record["vector"] = vector
+    return records
+
+
 def compact_context_embedding_record(record: Json) -> Json:
     return compact_hot_context_embedding_record(record)
 
@@ -3995,6 +4050,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         self._maintain_event_membership_after_append(records)
 
     def append_many(self, records: list[Json]) -> None:
+        # Fold step 1: copy each embedding's vector onto its owner record, before the policy
+        # and dedup passes below reshape the batch.
+        records = attach_inline_embedding_vectors(records)
         records = self._apply_serving_dedup(
             self._stamp_ingest_fields(materialize_serving_record_batch(records))
         )

--- a/tools/matrixark_mem0_compat.py
+++ b/tools/matrixark_mem0_compat.py
@@ -278,7 +278,21 @@ class Memory:
         Extra kwargs are ignored for mem0 signature compatibility. Returns the
         parsed ``/v1/ingest`` response."""
         normalized = _normalize_messages(messages, provider)
-        body: Json = {"kind": "message", "messages": normalized}
+        # finalize so extraction runs INLINE and the memory is searchable when add returns.
+        # Without it the gateway treats this as a streaming ingest and schedules an
+        # idle-commit on a debounce (stream_idle_commit_timeout_ms, 1000ms by default),
+        # so add -> search inside that window returns {"results": []} while get_all already
+        # shows the memory. That eventual-consistency window is right for streaming
+        # callers and wrong for mem0, whose add is synchronous by contract: a user
+        # migrating from mem0 would conclude their memories had vanished.
+        #
+        # Measured: search immediately after add returned [] and returned the memory
+        # 1.5s later, unchanged, purely from the debounce elapsing.
+        #
+        # Pass finalize=False for the streaming behaviour (cheaper add, retrievable after
+        # the debounce).
+        body: Json = {"kind": "message", "messages": normalized,
+                      "finalize": bool(kw.get("finalize", True))}
         scope = _scope_from_identity(user_id, agent_id, run_id)
         if scope:
             body["scope"] = scope

--- a/tools/test_attachment_resource_policy.py
+++ b/tools/test_attachment_resource_policy.py
@@ -35,14 +35,25 @@ def ingest(policy):
     if policy:
         args["raw_storage_policy"] = policy
     server.call_tool("matrixark_ingest", args)
-    # the import runs on a background worker; wait for it to settle
-    deadline = time.time() + 120
+    # The import runs on a background worker. Waiting for the FIRST chunk and sleeping a fixed
+    # interval is not enough: under suite load the worker is still emitting records when the
+    # sleep expires, and the assertions then see a half-written import. Wait for the record
+    # count to stop changing instead, so the test tracks the worker rather than the clock.
+    deadline = time.time() + 180
+    stable_for = 0
+    previous = -1
     while time.time() < deadline:
         rows = adapter.read_all()
-        if any(r.get("record_type") in ("resource_chunk", "resource_manifest") for r in rows):
-            time.sleep(3)
-            break
-        time.sleep(2)
+        started = any(r.get("record_type") in ("resource_chunk", "resource_manifest")
+                      or r.get("record_type") == "resource_import_task" for r in rows)
+        if started and len(rows) == previous:
+            stable_for += 1
+            if stable_for >= 3:
+                break
+        else:
+            stable_for = 0
+        previous = len(rows)
+        time.sleep(1)
     return adapter.read_all()
 
 

--- a/tools/test_attachment_resource_policy.py
+++ b/tools/test_attachment_resource_policy.py
@@ -98,5 +98,39 @@ class AttachmentResourcePolicyTest(unittest.TestCase):
                         % (attachment, len(DOC)))
 
 
+class ResourceEventTextBoundTest(unittest.TestCase):
+    """A resource must not store its whole document as event text as well as in its chunks."""
+
+    def test_resource_event_text_is_bounded(self):
+        rows = ingest(None)
+        events = [r for r in rows if r.get("record_type") == "context_event"
+                  and r.get("source_kind") == "resource"]
+        self.assertTrue(events, "no resource context_event was written")
+        for event in events:
+            self.assertLess(
+                len(str(event.get("text") or "")), len(DOC) // 4,
+                "resource event still carries the whole document (%d of %d chars)"
+                % (len(str(event.get("text") or "")), len(DOC)))
+
+    def test_the_document_itself_is_untouched(self):
+        """The bound is on the RECORD, never on the input -- chunks derive from the same
+        messages list, so clipping the input would truncate the document instead of
+        deduplicating its storage."""
+        rows = ingest(None)
+        joined = "".join(str(r.get("text") or "") for r in rows
+                         if r.get("record_type") == "resource_chunk")
+        for n in range(0, 60, 7):
+            self.assertIn("Section %d" % n, joined,
+                          "section %d vanished from the chunks -- the document was truncated" % n)
+
+    def test_message_ingest_text_is_not_bounded(self):
+        """Only resource/skill kinds are bounded; an ordinary message keeps its full text."""
+        from matrixark_mcp_core_resource_io import bound_resource_event_text
+        long_text = "x" * 50000
+        self.assertEqual(long_text, bound_resource_event_text("message", long_text, ""))
+        self.assertLess(len(bound_resource_event_text("resource", long_text, "file://a")),
+                        len(long_text))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_attachment_resource_policy.py
+++ b/tools/test_attachment_resource_policy.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""raw_storage_policy="attachment" skips chunk materialization; anything else does not.
+
+A resource is normally chunked, embedded and indexed so it can be recalled selectively. For a
+file that is fetched rarely or never that trade is wrong, and measured it is expensive: one
+66.2 KB document cost 7.05x its own size (60 chunk records at 3.75x plus 76 embeddings at
+2.93x), with 32-dim deterministic vectors -- a 384-dim encoder takes the same file toward 40x.
+
+Both arms are asserted here. The default arm matters as much as the new one: the gate must not
+quietly disable chunking for ordinary resources, which is what retrieval depends on.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+DOC = "\n\n".join("## Section %d\n%s" % (n, ("operational detail line %d. " % n) * 40)
+                  for n in range(60))
+
+
+def ingest(policy):
+    scope = {"account_id": "acct_local", "tenant_id": "attachpolicy", "user_id": "u",
+             "session_id": "s0", "agent_name": "t"}
+    adapter = mcp.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "a.jsonl")
+    server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+    args = {"scope": scope, "kind": "resource", "finalize": True,
+            "text": DOC, "raw_uri": "file://ops-handbook.md"}
+    if policy:
+        args["raw_storage_policy"] = policy
+    server.call_tool("matrixark_ingest", args)
+    # the import runs on a background worker; wait for it to settle
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        rows = adapter.read_all()
+        if any(r.get("record_type") in ("resource_chunk", "resource_manifest") for r in rows):
+            time.sleep(3)
+            break
+        time.sleep(2)
+    return adapter.read_all()
+
+
+def of_type(rows, record_type):
+    return [r for r in rows if r.get("record_type") == record_type]
+
+
+def stored_bytes(rows):
+    return sum(len(json.dumps(r)) for r in rows)
+
+
+class AttachmentResourcePolicyTest(unittest.TestCase):
+    def test_attachment_writes_no_chunks(self):
+        rows = ingest("attachment")
+        self.assertEqual([], of_type(rows, "resource_chunk"),
+                         "attachment policy must not materialize chunks")
+
+    def test_attachment_keeps_the_manifest_so_the_file_stays_discoverable(self):
+        """Skipping chunks must not make the resource invisible -- it is stored, not dropped."""
+        rows = ingest("attachment")
+        self.assertTrue(of_type(rows, "resource_manifest"),
+                        "attachment lost its manifest and is no longer discoverable")
+
+    def test_default_still_chunks(self):
+        """The gate must not disable chunking for ordinary resources."""
+        rows = ingest(None)
+        self.assertTrue(of_type(rows, "resource_chunk"),
+                        "default policy stopped materializing chunks")
+
+    def test_attachment_is_dramatically_cheaper(self):
+        """The whole point: an attachment should cost metadata, not multiples of itself."""
+        attachment = stored_bytes(ingest("attachment"))
+        default = stored_bytes(ingest(None))
+        self.assertLess(attachment * 3, default,
+                        "attachment (%d bytes) is not materially cheaper than default (%d)"
+                        % (attachment, default))
+        # 4x, not the ~1x the chunk saving alone might suggest. Skipping chunks removes the
+        # chunk records and their embeddings, but an attachment STILL stores the document text
+        # twice as raw text -- once in session_buffer_event and once in context_event, ~1.05x
+        # each -- which no chunk gate touches. Measured breakdown of the attachment arm:
+        #
+        #     session_buffer_event  1 record   71,560 bytes (1.06x)
+        #     context_event         1 record   71,023 bytes (1.05x)
+        #     context_embedding    11 records  27,298 bytes (0.40x)
+        #     context_summary       7 records  25,027 bytes (0.37x)
+        #     TOTAL                           238,000 bytes (3.51x)
+        #
+        # That duplicated full text is the next target and a separate change; this bound is set
+        # where the gate actually lands so it fails if the saving regresses, not at an
+        # aspirational number the gate alone cannot reach.
+        self.assertLess(attachment, len(DOC) * 4,
+                        "attachment cost %d exceeds 4x the %d-char source"
+                        % (attachment, len(DOC)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_inline_embedding_vectors.py
+++ b/tools/test_inline_embedding_vectors.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Owner records must persist the embedding vector, not just be handed one in memory.
+
+Step 1 of folding embeddings into their owners is a DUAL-WRITE: the vector is copied onto the
+context_event / context_entity / context_summary record while the separate context_embedding
+record keeps being written and every reader keeps joining through (ref_type, ref_hash).
+
+Nothing reads the inline field yet, so without reading records back OUT of the adapter this
+could copy nothing and the whole suite would stay green. That is not hypothetical -- the Rust
+half of this fold did exactly that: the struct had the field, the population code ran, and a
+hand-written protobuf codec dropped the value on persist with no error anywhere.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+SCOPE = {"account_id": "acct_local", "tenant_id": "inlinevec", "user_id": "u",
+         "session_id": "s0", "agent_name": "t"}
+CONVO = [{"role": "user", "content": "I am a robotics engineer working on Aurora."},
+         {"role": "user", "content": "I live in Seattle and the p99 was 27ms."}]
+
+
+def ingest():
+    adapter = mcp.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "v.jsonl")
+    server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+    server.call_tool("matrixark_ingest", {"scope": SCOPE, "finalize": True, "messages": CONVO})
+    server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+    return adapter.read_all()
+
+
+def of_type(rows, record_type):
+    return [r for r in rows if r.get("record_type") == record_type]
+
+
+class InlineEmbeddingVectorTest(unittest.TestCase):
+    def test_events_carry_their_vector(self):
+        rows = ingest()
+        events = of_type(rows, "context_event")
+        self.assertTrue(events, "the ingest wrote no events")
+        with_vector = [e for e in events if e.get("vector")]
+        self.assertTrue(with_vector,
+                        "no context_event persisted an inline vector (%d events)" % len(events))
+
+    def test_entities_carry_their_vector(self):
+        rows = ingest()
+        entities = of_type(rows, "context_entity")
+        self.assertTrue(entities, "the ingest wrote no entities")
+        self.assertTrue([e for e in entities if e.get("vector")],
+                        "no context_entity persisted an inline vector")
+
+    def test_inline_vector_equals_the_separate_record(self):
+        """Dual-write means identical, not merely present -- a wrong vector is worse than none."""
+        rows = ingest()
+        by_ref = {(str(r.get("ref_type") or ""), r.get("ref_hash")): r.get("vector")
+                  for r in of_type(rows, "context_embedding") if r.get("vector")}
+        checked = 0
+        for record_type, ref_type, field in (
+            ("context_event", "event", "event_id_hash"),
+            ("context_entity", "entity", "entity_hash"),
+            ("context_summary", "summary", "summary_hash"),
+        ):
+            for record in of_type(rows, record_type):
+                inline = record.get("vector")
+                if not inline:
+                    continue
+                separate = by_ref.get((ref_type, record.get(field)))
+                self.assertIsNotNone(
+                    separate, "%s has an inline vector with no matching embedding record" % record_type)
+                self.assertEqual(separate, inline,
+                                 "%s inline vector differs from its embedding record" % record_type)
+                checked += 1
+        self.assertTrue(checked, "no owner record was cross-checked against its embedding record")
+
+    def test_separate_embedding_records_are_still_written(self):
+        """Step 1 must not drop them: every reader still joins through (ref_type, ref_hash)."""
+        rows = ingest()
+        self.assertTrue(of_type(rows, "context_embedding"),
+                        "dual-write must keep the separate embedding records until readers migrate")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_inline_vector_dual_read.py
+++ b/tools/test_inline_vector_dual_read.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Retrieval must find its vectors on the owner records, not only on separate embedding rows.
+
+Fold step 2 is DUAL-READ: owner records carry their own vector (written by step 1) and
+retrieval falls back to it when no separate context_embedding row supplies one. With both
+present nothing changes -- the separate row wins and the two are identical by construction.
+
+The assertion that matters is the one with the separate rows REMOVED: that is the state step 3
+creates by ceasing to write them, and it is the only way to know step 3 is safe before doing it.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+SCOPE = {"account_id": "acct_local", "tenant_id": "dualread", "user_id": "u",
+         "session_id": "s0", "agent_name": "t"}
+FACT = "I am a robotics engineer working on Aurora."
+
+
+def corpus(strip_embeddings):
+    """Ingest, then optionally rebuild the store WITHOUT any separate embedding rows."""
+    adapter = mcp.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "d.jsonl")
+    server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+    server.call_tool("matrixark_ingest", {"scope": SCOPE, "finalize": True,
+                                          "messages": [{"role": "user", "content": FACT}]})
+    server.call_tool("matrixark_session_commit", {"scope": SCOPE})
+    if not strip_embeddings:
+        return adapter, server
+    kept = [r for r in adapter.read_all() if r.get("record_type") != "context_embedding"]
+    stripped = mcp.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "s.jsonl")
+    stripped.append_many(kept)
+    return stripped, mcp.MatrixArkMcpServer(stripped, access_mode="dev")
+
+
+class InlineVectorDualReadTest(unittest.TestCase):
+    def test_owner_records_carry_vectors_to_read(self):
+        adapter, _ = corpus(strip_embeddings=False)
+        owners = [r for r in adapter.read_all()
+                  if r.get("record_type") in ("context_event", "context_entity")
+                  and r.get("vector")]
+        self.assertTrue(owners, "step 1 wrote no inline vectors, so step 2 has nothing to read")
+
+    def test_retrieval_still_works_with_the_separate_rows_present(self):
+        _, server = corpus(strip_embeddings=False)
+        out = json.dumps(server.call_tool("matrixark_retrieve",
+                                          {"scope": SCOPE, "query": "what is my job?"}))
+        self.assertIn("robotics", out.lower())
+
+    def test_scoring_still_receives_a_vector_without_the_separate_rows(self):
+        """The step-3 rehearsal, asserted on the MECHANISM rather than the answer.
+
+        An earlier version of this test asserted only that retrieval still returned the fact
+        with the embedding rows stripped -- and it passed with dual-read reverted, because
+        lexical scoring finds the fact on its own. Under the default 32-dim hash encoder there
+        is no semantic similarity to isolate either, so end-to-end retrieval cannot show whether
+        a vector was used at all.
+
+        This instead observes what cosine() is handed: with the separate rows gone, the event's
+        vector must still reach scoring from the owner record.
+        """
+        import matrixark_local_adapter_retrieve as retrieve_module
+
+        adapter, server = corpus(strip_embeddings=True)
+        self.assertEqual(
+            [], [r for r in adapter.read_all() if r.get("record_type") == "context_embedding"],
+            "the fixture failed to strip the separate embedding rows")
+
+        seen_non_empty = []
+        original = retrieve_module.cosine
+
+        def watched(left, right):
+            if right:
+                seen_non_empty.append(len(right))
+            return original(left, right)
+
+        retrieve_module.cosine = watched
+        try:
+            server.call_tool("matrixark_retrieve", {"scope": SCOPE, "query": "what is my job?"})
+        finally:
+            retrieve_module.cosine = original
+
+        self.assertTrue(
+            seen_non_empty,
+            "scoring received no vector at all once the separate embedding rows were removed; "
+            "the inline fallback did not supply one")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_mem0_read_your_writes.py
+++ b/tools/test_mem0_read_your_writes.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""mem0's add must be searchable when it returns.
+
+mem0's add is synchronous by contract. Without finalize the gateway treats the ingest as
+streaming and schedules an idle-commit on a debounce (stream_idle_commit_timeout_ms, 1000ms),
+so add -> search inside that window returned {"results": []} while get_all already showed the
+memory -- a user migrating from mem0 would conclude their memories had vanished.
+
+Driven against the REAL /v1 gateway, not the in-process mock the other mem0 suites use: a mock
+gateway only proves request shaping, and this failure lives entirely in the backend's commit
+scheduling.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+os.environ.setdefault("MATRIXARK_REQUIRE_AUTH", "0")
+
+import matrixark_mcp_server as mcp
+import matrixark_mem0_compat as mem0
+import uvicorn
+
+try:
+    from tools import matrixark_v1_gateway as gw
+except ImportError:
+    import matrixark_v1_gateway as gw
+
+
+def live_gateway():
+    adapter = mcp.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "m.jsonl")
+    server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+    app = gw.make_v1_app(server, gw.GatewayConfig.from_env())
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="critical", lifespan="on")
+    srv = uvicorn.Server(config)
+    threading.Thread(target=srv.run, daemon=True).start()
+    for _ in range(300):
+        if srv.started and srv.servers:
+            break
+        time.sleep(0.05)
+    port = srv.servers[0].sockets[0].getsockname()[1]
+    # No api_key: an unregistered key is rejected by matrixark_access with
+    # "invalid or revoked MatrixArk API key", which surfaces as HTTP 500 on every route and
+    # looks exactly like a broken backend.
+    return adapter, srv, mem0.Memory(base_url="http://127.0.0.1:%d" % port)
+
+
+class Mem0ReadYourWritesTest(unittest.TestCase):
+    FACT = "I am a robotics engineer working on Aurora."
+
+    def test_search_finds_the_memory_immediately_after_add(self):
+        adapter, srv, m = live_gateway()
+        try:
+            m.add([{"role": "user", "content": self.FACT}], user_id="alice")
+            found = json.dumps(m.search("what is my job?", user_id="alice"))
+            self.assertNotEqual('{"results": []}', found,
+                                "add -> search returned nothing; the commit was not inline")
+            self.assertIn("Aurora", found)
+        finally:
+            srv.should_exit = True
+
+    def test_get_all_and_delete_still_work(self):
+        """The finalize default must not disturb the rest of the surface."""
+        adapter, srv, m = live_gateway()
+        try:
+            m.add([{"role": "user", "content": self.FACT}], user_id="alice")
+            memories = m.get_all(user_id="alice").get("memories") or []
+            self.assertTrue(memories, "get_all returned nothing after add")
+            # delete alone -- calling update first supersedes the id, so a later delete of the
+            # ORIGINAL id legitimately matches nothing and reports deleted=False.
+            result = m.delete(memories[0].get("id"))
+            self.assertTrue(result.get("deleted"),
+                            "delete reported nothing removed: %s" % result)
+        finally:
+            srv.should_exit = True
+
+    def test_streaming_callers_can_opt_out(self):
+        adapter, srv, m = live_gateway()
+        try:
+            m.add([{"role": "user", "content": self.FACT}], user_id="alice", finalize=False)
+            self.assertTrue(adapter.read_all(), "opting out of finalize wrote nothing at all")
+        finally:
+            srv.should_exit = True
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-on to #100. Seven changes across resource storage, the mem0 surface, and the embedding
fold. Each was verified against a pristine-tree baseline of failing test names, and each negative
case was checked — several of these were caught only because the "passing" test was made to fail
first.

## Resource storage: a 66.2 KB document cost 7.05x itself

Measured, with the 32-dim deterministic encoder:

```
resource_chunk       60 records   254,293 bytes  (3.75x source)
context_embedding    76 records   198,656 bytes  (2.93x source)
                                  477,827 bytes  (7.05x)
```

A 384-dim encoder takes the same file toward 40x. Three changes address it:

**`raw_storage_policy="attachment"` skips chunk materialization.** The knob already existed — written into records, rendered on the dashboard, and *branched on nowhere*. There was no way to decline chunking for a file that is fetched rarely and already durable behind its raw URI. The manifest and raw URI are kept, so the resource stays listed, addressable and fetchable.

**The document is no longer stored as event text.** A resource kept its content three times: in the chunks, in the `context_event`, and inside the `session_buffer_event` envelope. The event copy is redundant — chunks are the retrievable form, the raw URI the durable one.

**Nor in the session buffer.** Only message *content* is bounded, on a **copy**, for resource/skill kinds only. Everything the commit path reads off the buffered envelope survives: metadata, `hook_type`, `codex_event`, and every message's role (`messages_from_event_record` reads that list for role counting).

Cumulative on the same file: **3.51x → 1.53x**. The document is provably intact — the default path still yields 60 chunks and 67,570 of 67,748 chars with no section missing.

⚠️ The bound is on the **record**, never the input. `resource_text` — and therefore every chunk — is derived from `envelope["messages"]`, so clipping there truncates the *document* rather than deduplicating its storage.

## mem0: add is now searchable when it returns

The shim posted no `finalize`, so the gateway treated the ingest as streaming and scheduled the commit on a 1000 ms debounce. Inside that window `add` → `search` returned `{"results": []}` while `get_all` already showed the memory — a user migrating from mem0 would conclude their memories had vanished. Measured: empty immediately, present 1.5 s later, unchanged.

The existing mem0 suites drive an **in-process mock gateway**, which only proves request shaping; this failure lives in the backend's commit scheduling where no mock can reach. The new test stands up `make_v1_app` over loopback.

## Index format guard

There was a version stamp on the WAL and on meta snapshots, but none on `shard-{id}.index.json` — the file that *is* a serialized `ShardState`. Keying `context_events` by `event_id_hash` (#100) changed what the `u64` **means** without changing its type, so a pre-rekey index decodes cleanly with timeline keys in the event-id slot and an empty `context_event_timeline`; every time-windowed read then returns nothing, silently.

A stale index is now refused and treated like a corrupt one — the caller falls back to WAL replay, which rebuilds both maps correctly. **Bump the version on meaning changes, not only type changes:** a type change is caught by the compiler and a shape change by serde; a field whose meaning moved under the same type is caught by neither.

## Embedding fold, steps 1 and 2 (inert)

Owner records carry their own vector (step 1) and retrieval falls back to it when no separate row supplies one (step 2, `setdefault`, so the separate row always wins). With both present the two are identical by construction, so **behaviour is unchanged**.

**Step 3 — dropping the separate rows — is deliberately not included.** It was implemented, measured (14 → 6 rows, −18.2% of the store), and **reverted**: it broke 8 tests. A `context_embedding` row is not a vector wrapper — retrieval calls `remember_embedding_metadata` on it, and other paths recover `hot_event_type`, cross-session profile lineage and memory-layer classification from those rows. The step-2 rehearsal proved the *vector* survives on the owner; it proved nothing about the metadata. Those 8 tests are now a precise inventory of what the rows are actually for.

## Verification

- Rust: `cargo test --lib context_` — **43 passed, 0 failed**
- Python: the four new suites plus both mem0 suites — **62 passed**
- Full private-tree suite diffed against a pristine baseline: no new failures

Rebased onto current `main` (the branch was 33 commits behind, which would have reverted unrelated work).
