### PR TITLE
Let an isolated node rejoin, and elect through the real path

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
+++ b/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
@@ -668,9 +668,7 @@ fn run_partition_phase(nodes: &[ProductionRaftNode]) -> PartitionSummary {
         .find(|node| node.node_id == 1)
         .expect("leader should exist");
     initialize_liveness(nodes);
-    for node in nodes {
-        elect_leader(node, leader.node_id);
-    }
+    establish_leader(nodes, leader.node_id);
     for follower in nodes
         .iter()
         .filter(|node| node.node_id != leader.node_id && node.node_id != isolated_node)
@@ -717,9 +715,7 @@ fn run_partition_phase(nodes: &[ProductionRaftNode]) -> PartitionSummary {
         block_peer(isolated, peer.node_id, false);
     }
     initialize_liveness(nodes);
-    for node in nodes {
-        elect_leader(node, leader.node_id);
-    }
+    establish_leader(nodes, leader.node_id);
     wait_for_local_catch_up(isolated, isolated_node);
     let healed_read = wait_for_value(isolated, isolated_node, "partition-majority", "v-partition");
     PartitionSummary {
@@ -770,9 +766,7 @@ fn run_lagging_follower_phase(nodes: &[ProductionRaftNode]) -> LaggingFollowerSu
         block_peer(follower, peer.node_id, false);
     }
     initialize_liveness(nodes);
-    for node in nodes {
-        elect_leader(node, leader.node_id);
-    }
+    establish_leader(nodes, leader.node_id);
     wait_for_local_catch_up(follower, follower_node);
     let catchup_reads = (0..3)
         .map(|index| {
@@ -954,12 +948,7 @@ fn run_rolling_restart_phase(
                 .expect("rolling restart should have a surviving leader candidate")
                 .node_id;
             active_leader_id = promoted_leader_id;
-            for survivor in nodes
-                .iter()
-                .filter(|node| node.node_id != restarted_node_id)
-            {
-                elect_leader(survivor, promoted_leader_id);
-            }
+            elect_leader(node_by_id(nodes, promoted_leader_id), promoted_leader_id);
             let failover = trigger_failover(node_by_id(nodes, promoted_leader_id));
             assert!(
                 failover.status.ok,
@@ -973,9 +962,7 @@ fn run_rolling_restart_phase(
         wait_for_http(&restarted.addr);
         initialize_liveness(nodes);
         let active_leader = node_by_id(nodes, active_leader_id);
-        for node in nodes {
-            elect_leader(node, active_leader_id);
-        }
+        establish_leader(nodes, active_leader_id);
         if restarted_node_id != active_leader_id {
             elect_leader(active_leader, active_leader_id);
             wait_for_local_catch_up(restarted, restarted_node_id);
@@ -995,9 +982,7 @@ fn run_rolling_restart_phase(
 
         if restarting_active_leader && active_leader_id != leader_node_id {
             wait_for_local_catch_up(original_leader, leader_node_id);
-            for node in nodes {
-                elect_leader(node, leader_node_id);
-            }
+            establish_leader(nodes, leader_node_id);
             active_leader_id = leader_node_id;
         }
     }
@@ -1221,6 +1206,32 @@ fn block_peer(node: &ProductionRaftNode, peer_id: RaftNodeId, blocked: bool) {
         "block peer admin request failed: {:?}",
         response.status
     );
+}
+
+/// Make `leader_id` the leader and wait for the rest of the cluster to see it.
+///
+/// The election runs on the candidate's own process, which is the only one holding the candidate's
+/// real log; the other nodes are not asked to simulate it against their stale shadows of the
+/// candidate, they observe the result over AppendEntries as they would in production.
+fn establish_leader(nodes: &[ProductionRaftNode], leader_id: RaftNodeId) {
+    elect_leader(node_by_id(nodes, leader_id), leader_id);
+    for node in nodes.iter().filter(|node| node.node_id != leader_id) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        loop {
+            let observed: Result<RaftClusterStatus, _> =
+                get_json_with_options(&node.addr, "/raft/status", request_options());
+            if matches!(observed, Ok(status) if status.leader_id == leader_id) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "node {} never observed node {leader_id} as leader;{}",
+                node.node_id,
+                cluster_wide_status()
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
 }
 
 fn elect_leader(node: &ProductionRaftNode, leader_id: RaftNodeId) {

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -266,6 +266,25 @@ impl RaftCluster {
         response: &AppendEntriesResponse,
     ) -> Result<(), RaftError> {
         let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        // A reply from a newer term means this leader is stale -- step down rather than keep
+        // sending requests that can only be refused. A peer that was isolated returns with a term
+        // well ahead of ours, and without this it rejects every append forever while we stay
+        // leader at the old term, so it can never rejoin.
+        let local_leader_id = inner.leader_id;
+        let stepped_down = inner
+            .nodes
+            .get_mut(&local_leader_id)
+            .map(|leader| {
+                if response.term > leader.current_term {
+                    leader.current_term = response.term;
+                    leader.voted_for = None;
+                    leader.role = RaftRole::Follower;
+                    true
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false);
         let target = inner
             .nodes
             .get_mut(&target_id)
@@ -273,6 +292,11 @@ impl RaftCluster {
         target.pipeline_state.inflight_entries = 0;
         target.pipeline_state.inflight_bytes = 0;
         target.pipeline_state.append_queue_depth = 0;
+        if stepped_down {
+            target.current_term = target.current_term.max(response.term);
+            inner.persist_configured_wal()?;
+            return Ok(());
+        }
         if response.success {
             target.pipeline_state.match_index =
                 target.pipeline_state.match_index.max(response.match_index);

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -3143,3 +3143,52 @@ fn a_rejected_append_retreats_to_an_earlier_entry() {
         second.prev_log_index
     );
 }
+
+/// A reply carrying a newer term makes the leader step down.
+///
+/// A node that was isolated keeps calling elections, so it rejoins with a term far ahead of the
+/// leader's and refuses every append as a stale term -- correctly. If the leader ignores the term
+/// in that reply it stays leader at the old term and keeps sending the same doomed request, so the
+/// rejoining node can never be reintegrated and goes on serving reads missing committed data.
+#[test]
+fn a_reply_from_a_newer_term_makes_the_leader_step_down() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster
+        .propose(Command::StringSet {
+            key: "committed".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+    let leader_term = cluster.status().current_term;
+
+    // The peer was isolated and called elections of its own while away.
+    cluster
+        .record_append_entries_response(
+            3,
+            &AppendEntriesResponse {
+                term: leader_term + 5,
+                success: false,
+                match_index: 0,
+                reject_reason: Some("stale_term".to_string()),
+            },
+        )
+        .unwrap();
+
+    let status = cluster.status();
+    assert!(
+        status.current_term >= leader_term + 5,
+        "the leader must adopt the newer term, stayed at {}",
+        status.current_term
+    );
+    let still_leader = status
+        .nodes
+        .iter()
+        .any(|node| node.node_id == 1 && node.role == RaftRole::Leader);
+    assert!(
+        !still_leader,
+        "the leader must step down rather than keep sending requests that can only be refused"
+    );
+}


### PR DESCRIPTION
`raft_secondary_replication_harness` **now passes end to end** — 3 consecutive clean runs. This is the last two defects behind it.

## A leader ignored a newer term in a reply

A node that was isolated keeps calling elections, so it returns with a term well ahead of the leader's and refuses every append as a stale term. That refusal is correct — it must not accept a leader from an older term. But the leader never looked at the term in the reply: it stayed leader at the old term and kept sending the same doomed request. The rejoining node could never be reintegrated, and went on serving reads missing committed data with an `ok` status.

Observed directly: the leader at term 20 with commit 11, the rejoining node at **term 26** and missing the entry, converging never.

Raft's rule is unconditional and covers responses as well as requests — a term greater than ours means we are behind, so adopt it and step down. The request half was already handled; this is the response half.

## The harness forced the same election on every node

An election run through the local admin path is evaluated against the state *that* process holds, and a process holds real state only for its own node. Its peers are shadows, and a peer that is not the leader is never updated — nothing in the protocol tells one follower what another follower's log looks like.

So asking node 3 to elect node 2 judged node 2 by a stale shadow reading 5 entries when node 2 really had 9, and node 3 refused to vote for a candidate that was perfectly up to date. That is the right call from a node that cannot verify the candidate; the mistake was asking it.

Elections now run on the candidate's own process — the only one holding the candidate's real log — and the other nodes observe the result over AppendEntries, as they would in production. The test exercises the real mechanism instead of simulating it three times over.

A note on the error that led here: it read `not enough live replicas for majority: live=1, required=2`, but that `live` is the count of **vote grants**, not live replicas, and every node involved was alive. It cost real time. Worth renaming, but not in this change.

## Tests

`a_reply_from_a_newer_term_makes_the_leader_step_down` — the leader must adopt the term and stop being leader, rather than keep sending requests that can only be refused.

## Testing

- **Harness: 3/3 clean runs**, having previously failed on every run.
- Library suite: **969 passed, 13 failed**. One name fails here that is not in the `main` comparison set — `proxy_multi_proxy_converges_under_topology_churn_stale_cache_and_recovery` — and it is a load flake, not a regression: **5/5 isolated on this branch and 5/5 on `main`**. The suite run that surfaced it took 363s against a 194s baseline, on a contended box.
- `cargo check --all-targets` exits 0.
