### PR TITLE
Elect a new leader when one dies, and stop the WAL rewriting the whole log

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -267,12 +267,33 @@ fn raft_propose_serialize_on() -> bool {
 /// voted_for, commit_index, the log, membership, snapshots, or the apply/storage fences still
 /// flips the fingerprint and forces a durable persist.
 fn raft_durable_fingerprint(record: &RaftWalRecord) -> u64 {
-    let mut reduced = record.clone();
-    reduced.pipeline_state = RaftPeerPipelineRuntimeState::default();
-    reduced.read_safety_state = RaftReadSafetyRuntimeState::default();
+    // Everything Raft must persist participates, but the log is SUMMARISED rather than
+    // serialised. Hashing every entry made this check -- which runs on every persist, for
+    // every node -- cost O(log length), the very cost incremental WAL records exist to
+    // remove. A raft log only ever grows at the tail or has a suffix replaced, so its
+    // length together with the first and last (index, term) changes whenever it does.
+    let reduced = RaftWalRecord {
+        hard_state: record.hard_state.clone(),
+        membership: record.membership.clone(),
+        replica_role: record.replica_role,
+        joint_membership: record.joint_membership.clone(),
+        latest_external_snapshot_ref: record.latest_external_snapshot_ref.clone(),
+        installed_snapshot: record.installed_snapshot.clone(),
+        apply_snapshot_fence: record.apply_snapshot_fence.clone(),
+        storage_apply_fence: record.storage_apply_fence.clone(),
+        pipeline_state: RaftPeerPipelineRuntimeState::default(),
+        read_safety_state: RaftReadSafetyRuntimeState::default(),
+        membership_evidence: record.membership_evidence.clone(),
+        entries: Vec::new(),
+    };
     let bytes = serde_json::to_vec(&reduced).unwrap_or_default();
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     std::hash::Hasher::write(&mut hasher, &bytes);
+    std::hash::Hasher::write_u64(&mut hasher, record.entries.len() as u64);
+    for entry in [record.entries.first(), record.entries.last()].into_iter().flatten() {
+        std::hash::Hasher::write_u64(&mut hasher, entry.index);
+        std::hash::Hasher::write_u64(&mut hasher, entry.term);
+    }
     std::hash::Hasher::finish(&hasher)
 }
 
@@ -1065,13 +1086,28 @@ pub struct RaftWalRecord {
     pub apply_snapshot_fence: RaftApplySnapshotFence,
     #[serde(default)]
     pub storage_apply_fence: RaftStorageApplyFence,
-    #[serde(default)]
+    // Volatile runtime telemetry: excluded from `raft_durable_fingerprint` because it is
+    // not durability-relevant, and omitted from the encoding when it is at its default so
+    // an incremental record does not spend 2.4 KB restating counters.
+    #[serde(default, skip_serializing_if = "RaftPeerPipelineRuntimeState::is_default")]
     pub pipeline_state: RaftPeerPipelineRuntimeState,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "RaftReadSafetyRuntimeState::is_default")]
     pub read_safety_state: RaftReadSafetyRuntimeState,
     #[serde(default)]
     pub membership_evidence: RaftMembershipRuntimeEvidence,
     pub entries: Vec<RaftLogEntry>,
+}
+
+impl RaftPeerPipelineRuntimeState {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+impl RaftReadSafetyRuntimeState {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -1229,6 +1265,24 @@ struct RaftWalEnvelope {
     sequence: u64,
     checksum: String,
     record: RaftWalRecord,
+    /// Present on an incremental record: `record.entries` then carries ONLY the log
+    /// entries appended since `from_index`, and recovery folds it onto the most recent
+    /// full ("base") record. Absent on a base record, so a WAL written before this
+    /// field existed still reads back as a sequence of full snapshots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    delta: Option<RaftWalEntryDelta>,
+}
+
+/// Describes how to fold an incremental WAL record onto the running base.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+struct RaftWalEntryDelta {
+    /// The record's `entries` hold only indexes strictly greater than this.
+    from_index: u64,
+    /// First index the node's full log holds after this record (0 when the log is empty).
+    /// Anything below it was compacted away and must be dropped while folding.
+    log_first_index: u64,
+    /// Last index the node's full log holds after this record (0 when the log is empty).
+    log_last_index: u64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -1286,6 +1340,60 @@ struct NodeWalCursor {
     released_segment_count: u64,
     last_fsync_elapsed_ms: u64,
     slow_fsync_backpressure_observed: bool,
+    /// Encoded size of the full record that opened the active segment. Rotation waits
+    /// until the segment is a multiple of it, so the one O(log) base write per segment
+    /// stays a bounded fraction of the bytes that segment costs.
+    base_bytes: u64,
+    /// Last log index already written into the active segment, and the term at that
+    /// index. An incremental record is only sound while the in-memory log still agrees
+    /// with both; a conflict overwrite or a snapshot compaction re-bases instead.
+    persisted_last_index: u64,
+    persisted_last_term: u64,
+    /// False until a full base record has been written into the active segment.
+    has_base: bool,
+}
+
+/// A segment is never rotated below the size of the full record that opens it: a
+/// segment that cannot hold even one base record would re-base on every append, which
+/// is the O(log length) cost incremental records exist to remove. Above that floor the
+/// configured `max_segment_bytes` decides rotation, so retention keeps its meaning and
+/// the base cost is amortised over `max_segment_bytes / delta_size` appends.
+
+/// Consecutive failed AppendEntries before a leader marks a peer down.
+const RAFT_PEER_FAILURE_THRESHOLD: u32 = 3;
+/// Ticks of leader silence a follower tolerates before standing for election.
+const RAFT_ELECTION_TIMEOUT_BASE_TICKS: u64 = 8;
+/// Width of the random spread added to the election timeout.
+const RAFT_ELECTION_TIMEOUT_SPREAD_TICKS: u64 = 12;
+
+/// Draw a fresh election timeout. It must be re-drawn on every attempt: a timeout that is
+/// merely a fixed function of the node id puts two survivors a constant distance apart, so
+/// each one's campaign supersedes the other's brand-new leadership before its first
+/// heartbeat can land, and they trade the term back and forth indefinitely.
+pub(crate) fn randomized_election_timeout_ticks(node_id: RaftNodeId) -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+    hasher.write_u64(node_id);
+    hasher.write_u128(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos())
+            .unwrap_or_default(),
+    );
+    RAFT_ELECTION_TIMEOUT_BASE_TICKS + (hasher.finish() % RAFT_ELECTION_TIMEOUT_SPREAD_TICKS)
+}
+
+/// `TS_RAFT_WAL_DELTA_ENTRIES=0` restores the legacy full-log-per-record WAL payload.
+/// Note that a WAL containing incremental records cannot be read by a build that
+/// predates them, so roll the binary forward before flipping this back on.
+fn raft_wal_delta_entries_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !matches!(
+            std::env::var("TS_RAFT_WAL_DELTA_ENTRIES").ok().as_deref(),
+            Some("0") | Some("false") | Some("off")
+        )
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -3777,6 +3885,15 @@ struct RaftClusterInner {
     /// P4: whether anything was actually deferred, so a propose that persisted nothing flushes
     /// nothing.
     persist_dirty: bool,
+    /// Bumped on every accepted AppendEntries. A follower's timer loop watches it to
+    /// tell "the leader is quiet" from "the leader is fine"; nothing else in the data
+    /// raft path observes leader liveness at all.
+    leader_contact_epoch: u64,
+    /// True for the in-process cluster model, where `tick_election` may promote any
+    /// node from local shadow state. The production runtime clears it: there, an
+    /// election has to be won over the wire, so a local promotion of a *remote* node
+    /// would just make this process disagree with the rest of the group.
+    local_shadow_election: bool,
 }
 
 impl RaftCluster {
@@ -3838,6 +3955,8 @@ impl RaftCluster {
                 local_node_id: None,
                 persist_deferred_owner: None,
                 persist_dirty: false,
+                leader_contact_epoch: 0,
+                local_shadow_election: true,
             })),
         })
     }
@@ -3961,6 +4080,8 @@ impl RaftCluster {
                 local_node_id: None,
                 persist_deferred_owner: None,
                 persist_dirty: false,
+                leader_contact_epoch: 0,
+                local_shadow_election: true,
             })),
         })
     }
@@ -4795,13 +4916,44 @@ fn refresh_all_pipeline_states(
     leader_id: RaftNodeId,
     config: &RaftConfig,
 ) {
+    // This runs on every propose and every accepted AppendEntries. Cloning the leader's
+    // whole log here and re-scanning all of it per node made each of those O(log length),
+    // which is exactly the growth incremental WAL records were meant to remove. The log is
+    // index-ordered, so the bytes still owed to a peer are a suffix: find where that suffix
+    // starts and sum only it, against a borrowed log.
     let Some(leader) = nodes.get(&leader_id) else {
         return;
     };
-    let leader_log = leader.log.clone();
     let leader_commit_index = leader.commit_index;
+    let progress = nodes
+        .iter()
+        .map(|(node_id, node)| {
+            (
+                *node_id,
+                node.commit_index.max(node.pipeline_state.match_index),
+            )
+        })
+        .collect::<Vec<_>>();
+    let inflight_bytes = {
+        let leader_log = &nodes
+            .get(&leader_id)
+            .expect("leader present, checked above")
+            .log;
+        progress
+            .into_iter()
+            .map(|(node_id, known_progress)| {
+                let start = leader_log.partition_point(|entry| entry.index <= known_progress);
+                let bytes = leader_log[start..]
+                    .iter()
+                    .map(|entry| command_size_bytes(&entry.command))
+                    .sum::<u64>();
+                (node_id, bytes)
+            })
+            .collect::<BTreeMap<_, _>>()
+    };
     for node in nodes.values_mut() {
-        refresh_node_pipeline_state(node, leader_id, leader_commit_index, &leader_log, config);
+        let bytes = inflight_bytes.get(&node.id).copied().unwrap_or_default();
+        refresh_node_pipeline_state(node, leader_id, leader_commit_index, bytes, config);
     }
 }
 
@@ -4809,22 +4961,35 @@ fn refresh_node_pipeline_state(
     node: &mut RaftNode,
     leader_id: RaftNodeId,
     leader_commit_index: u64,
-    leader_log: &[RaftLogEntry],
+    inflight_bytes: u64,
     config: &RaftConfig,
 ) {
-    let inflight_entries = leader_commit_index.saturating_sub(node.commit_index);
-    let inflight_bytes = leader_log
-        .iter()
-        .filter(|entry| entry.index > node.commit_index)
-        .map(|entry| command_size_bytes(&entry.command))
-        .sum();
+    // How far this peer has actually got, as far as THIS leader knows. `commit_index` is
+    // a shadow copy that is only ever updated for peers this process replicated to
+    // itself, so a leader that was just promoted still reads 0 there and would conclude
+    // its whole log is in flight -- enough to trip the backpressure limit on its first
+    // append and leave the shard unable to commit. `match_index` is what AppendEntries
+    // responses actually confirm, so take the better of the two.
+    let known_progress = node.commit_index.max(node.pipeline_state.match_index);
+    let inflight_entries = leader_commit_index.saturating_sub(known_progress);
     let snapshot_installed_index = node
         .installed_snapshot
         .as_ref()
         .map(|snapshot| snapshot.last_included_index)
         .unwrap_or_default();
-    node.pipeline_state.match_index = node.commit_index;
-    node.pipeline_state.next_index = node_next_log_index(node);
+    // Never walk a confirmed cursor backwards. `commit_index` here is this process's
+    // shadow copy of the peer, which is 0 for any peer it has not itself replicated to --
+    // a newly promoted leader would otherwise forget everything the send/ack path had
+    // already confirmed and re-ship the whole log on every heartbeat.
+    node.pipeline_state.match_index = node.commit_index.max(node.pipeline_state.match_index);
+    // `match_index` is only ever set from a SUCCESSFUL append, so it is authoritative:
+    // the next entry to send is never below it. Deriving `next_index` purely from the
+    // peer's shadow log (empty on a node this process never replicated to) reset a newly
+    // promoted leader's cursor to 1, making every heartbeat look like a full-log catch-up
+    // and tripping backpressure. Clamping keeps the in-process model's behaviour, where
+    // the shadow log IS the peer's log.
+    node.pipeline_state.next_index = node_next_log_index(node)
+        .max(node.pipeline_state.match_index.saturating_add(1));
     node.pipeline_state.inflight_entries = inflight_entries;
     node.pipeline_state.inflight_bytes = inflight_bytes;
     node.pipeline_state.append_queue_depth = inflight_entries;

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -4058,7 +4058,7 @@ impl RaftCluster {
                 .pending_joint_consensus_restore_count
                 .saturating_add(1);
         }
-        refresh_all_pipeline_states(&mut nodes, leader_id, &config);
+        refresh_all_pipeline_states(&mut nodes, leader_id, None, &config);
         let leader_lease_deadline_ms = initial_leader_lease_deadline_ms(&config);
         Ok(Self {
             inner: Arc::new(RwLock::new(RaftClusterInner {
@@ -4221,7 +4221,8 @@ impl RaftCluster {
             }
         }
         let config = inner.config.clone();
-        refresh_all_pipeline_states(&mut inner.nodes, leader_id, &config);
+        let local_node_id_for_refresh = inner.local_node_id;
+        refresh_all_pipeline_states(&mut inner.nodes, leader_id, local_node_id_for_refresh, &config);
         inner.renew_leader_lease();
         inner.persist_configured_wal()?;
         Ok(leader_response)
@@ -4914,8 +4915,11 @@ fn merge_membership_evidence(
 fn refresh_all_pipeline_states(
     nodes: &mut BTreeMap<RaftNodeId, RaftNode>,
     leader_id: RaftNodeId,
+    local_node_id: Option<RaftNodeId>,
     config: &RaftConfig,
 ) {
+    // `local_node_id` is set only by the deployed runtime, which hosts exactly ONE node.
+    let deployed = local_node_id.is_some();
     // This runs on every propose and every accepted AppendEntries. Cloning the leader's
     // whole log here and re-scanning all of it per node made each of those O(log length),
     // which is exactly the growth incremental WAL records were meant to remove. The log is
@@ -4925,6 +4929,7 @@ fn refresh_all_pipeline_states(
         return;
     };
     let leader_commit_index = leader.commit_index;
+    let leader_next_index = node_next_log_index(leader);
     let progress = nodes
         .iter()
         .map(|(node_id, node)| {
@@ -4953,7 +4958,15 @@ fn refresh_all_pipeline_states(
     };
     for node in nodes.values_mut() {
         let bytes = inflight_bytes.get(&node.id).copied().unwrap_or_default();
-        refresh_node_pipeline_state(node, leader_id, leader_commit_index, bytes, config);
+        refresh_node_pipeline_state(
+            node,
+            leader_id,
+            leader_commit_index,
+            bytes,
+            leader_next_index,
+            deployed,
+            config,
+        );
     }
 }
 
@@ -4962,6 +4975,8 @@ fn refresh_node_pipeline_state(
     leader_id: RaftNodeId,
     leader_commit_index: u64,
     inflight_bytes: u64,
+    leader_next_index: u64,
+    deployed: bool,
     config: &RaftConfig,
 ) {
     // How far this peer has actually got, as far as THIS leader knows. `commit_index` is
@@ -4988,8 +5003,26 @@ fn refresh_node_pipeline_state(
     // promoted leader's cursor to 1, making every heartbeat look like a full-log catch-up
     // and tripping backpressure. Clamping keeps the in-process model's behaviour, where
     // the shadow log IS the peer's log.
-    node.pipeline_state.next_index = node_next_log_index(node)
-        .max(node.pipeline_state.match_index.saturating_add(1));
+    if deployed && node.id != leader_id {
+        // Deployed, this process hosts ONE node, so a peer's `log` here is an empty
+        // placeholder -- deriving `next_index` from it starts every catch-up at index 1 and
+        // re-ships a log the follower already has. Raft starts a peer optimistically at the
+        // leader's next index and lets rejections walk it back, so only INITIALISE it here;
+        // the send/ack path owns it from then on.
+        // "No progress established yet" is next_index <= 1 with nothing confirmed -- 1 is
+        // the default a fresh RaftNode carries, not evidence that the follower is empty.
+        if node.pipeline_state.match_index == 0 && node.pipeline_state.next_index <= 1 {
+            node.pipeline_state.next_index = leader_next_index;
+        }
+        node.pipeline_state.next_index = node
+            .pipeline_state
+            .next_index
+            .max(node.pipeline_state.match_index.saturating_add(1));
+    } else {
+        // In-process cluster: the shadow log IS the peer's log, so derive as before.
+        node.pipeline_state.next_index = node_next_log_index(node)
+            .max(node.pipeline_state.match_index.saturating_add(1));
+    }
     node.pipeline_state.inflight_entries = inflight_entries;
     node.pipeline_state.inflight_bytes = inflight_bytes;
     node.pipeline_state.append_queue_depth = inflight_entries;

--- a/crates/temporalstore-rust/src/raft/cluster_election.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_election.rs
@@ -5,6 +5,177 @@
 use super::*;
 
 impl RaftCluster {
+    /// Monotonic counter of AppendEntries accepted from a leader. A follower that sees
+    /// it stall for an election timeout concludes the leader is gone.
+    pub fn leader_contact_epoch(&self) -> u64 {
+        self.inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .leader_contact_epoch
+    }
+
+    /// True only when this node both believes it is the leader AND still holds the
+    /// leader role. A restarted node initialises `leader_id` to the lowest node id, so
+    /// `leader_id == me` on its own is not evidence that this node still leads.
+    pub fn is_local_leader(&self, node_id: RaftNodeId) -> bool {
+        let inner = self.inner.read().expect("raft cluster lock poisoned");
+        inner.leader_id == node_id
+            && inner
+                .nodes
+                .get(&node_id)
+                .map(|node| node.role == RaftRole::Leader)
+                .unwrap_or(false)
+    }
+
+    /// Give up leadership locally. Used when a leader can no longer reach a quorum, or
+    /// learns a peer has moved to a newer term: it must stop acting as leader before it
+    /// can serve another write.
+    pub fn step_down_local(&self, node_id: RaftNodeId) -> Result<(), RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let stepped = {
+            let node = inner
+                .nodes
+                .get_mut(&node_id)
+                .ok_or(RaftError::NodeNotFound(node_id))?;
+            if node.role == RaftRole::Leader {
+                node.role = RaftRole::Follower;
+                true
+            } else {
+                false
+            }
+        };
+        if stepped {
+            inner.leader_lease_deadline_ms = 0;
+            inner.persist_configured_wal()?;
+        }
+        Ok(())
+    }
+
+    /// Production runtimes clear this: leadership there is decided by real RequestVote
+    /// RPCs, so `tick_election` must not promote a node from local shadow state.
+    pub fn set_local_shadow_election(&self, enabled: bool) {
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .local_shadow_election = enabled;
+    }
+
+    /// Step one of a networked election: bump this node's term, record its self-vote,
+    /// and get both durable BEFORE any vote is requested. Returns the RequestVote to
+    /// send to each peer (`target_id` is filled in per peer by the caller).
+    pub fn prepare_campaign(&self, candidate_id: RaftNodeId) -> Result<VoteRequest, RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        if inner.config.prohibits_election {
+            return Err(RaftError::ElectionProhibited);
+        }
+        if !inner
+            .nodes
+            .get(&candidate_id)
+            .map(|node| node.alive && node.replica_role.can_be_leader())
+            .unwrap_or(false)
+        {
+            return Err(RaftError::NodeNotFound(candidate_id));
+        }
+        let shard_id = inner.shard_id;
+        let term = inner
+            .nodes
+            .values()
+            .map(|node| node.current_term)
+            .max()
+            .unwrap_or_default()
+            .saturating_add(1);
+        let (last_log_index, last_log_term) = {
+            let candidate = inner
+                .nodes
+                .get(&candidate_id)
+                .ok_or(RaftError::NodeNotFound(candidate_id))?;
+            let index = node_last_log_or_snapshot_index(candidate);
+            (
+                index,
+                node_term_at_log_or_snapshot_index(candidate, index).unwrap_or_default(),
+            )
+        };
+        {
+            let candidate = inner
+                .nodes
+                .get_mut(&candidate_id)
+                .ok_or(RaftError::NodeNotFound(candidate_id))?;
+            candidate.current_term = term;
+            candidate.voted_for = Some(candidate_id);
+            candidate.role = RaftRole::Follower;
+        }
+        inner.election_elapsed_tick = 0;
+        inner.persist_configured_wal()?;
+        Ok(VoteRequest {
+            rpc: None,
+            shard_id,
+            term,
+            candidate_id,
+            target_id: candidate_id,
+            last_log_index,
+            last_log_term,
+        })
+    }
+
+    /// Step two: promote locally iff a majority of voters granted `term`. `grants`
+    /// includes the durable self-vote taken in `prepare_campaign`.
+    pub fn conclude_campaign(
+        &self,
+        candidate_id: RaftNodeId,
+        term: u64,
+        grants: usize,
+    ) -> Result<bool, RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        // Votes are collected over the wire, so a newer term can land between
+        // `prepare_campaign` and here. The grants would then be for a term this node has
+        // already abandoned, and installing them would resurrect a superseded leader.
+        let campaign_still_live = inner
+            .nodes
+            .get(&candidate_id)
+            .map(|node| node.current_term == term && node.voted_for == Some(candidate_id))
+            .unwrap_or(false);
+        if !campaign_still_live {
+            return Ok(false);
+        }
+        let required = inner.required_majority();
+        if grants < required {
+            if let Some(candidate) = inner.nodes.get_mut(&candidate_id) {
+                candidate.role = RaftRole::Follower;
+            }
+            inner.persist_configured_wal()?;
+            return Ok(false);
+        }
+        inner.promote_elected_leader(candidate_id, term)?;
+        inner.persist_configured_wal()?;
+        Ok(true)
+    }
+
+    /// A peer answered with a newer term: abandon the campaign and step down, so this
+    /// node cannot go on to install itself as a stale-term leader.
+    pub fn observe_higher_term(&self, node_id: RaftNodeId, term: u64) -> Result<(), RaftError> {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let bumped = {
+            let node = inner
+                .nodes
+                .get_mut(&node_id)
+                .ok_or(RaftError::NodeNotFound(node_id))?;
+            if term > node.current_term {
+                node.current_term = term;
+                node.voted_for = None;
+                // Dropping the role (not just the term) is what actually stops the timer
+                // loop from continuing to act as leader on a superseded term.
+                node.role = RaftRole::Follower;
+                true
+            } else {
+                false
+            }
+        };
+        if bumped {
+            inner.persist_configured_wal()?;
+        }
+        Ok(())
+    }
+
     pub fn elect_leader(&self, node_id: RaftNodeId) -> Result<(), RaftError> {
         let mut inner = self.inner.write().expect("raft cluster lock poisoned");
         inner.elect_leader(node_id)?;
@@ -165,7 +336,9 @@ impl RaftCluster {
 
         inner.election_elapsed_tick += 1;
         let timeout_tick = u64::from(inner.config.election_cycle_tick);
-        if inner.election_elapsed_tick < timeout_tick {
+        if inner.election_elapsed_tick < timeout_tick || !inner.local_shadow_election {
+            // With shadow election off, the runtime's own campaign owns promotion; all
+            // this tick still does is age the election clock.
             return Ok(RaftTickOutcome::ElectionPending {
                 elapsed_tick: inner.election_elapsed_tick,
                 timeout_tick,

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -599,6 +599,54 @@ impl RaftClusterInner {
         Ok(())
     }
 
+    /// Install `node_id` as leader at `term` after it won a networked election.
+    /// Unlike `elect_leader` this does not synthesise peer votes from local shadow
+    /// state -- the grants were already collected over the wire.
+    pub(super) fn promote_elected_leader(
+        &mut self,
+        node_id: RaftNodeId,
+        term: u64,
+    ) -> Result<(), RaftError> {
+        if !self.nodes.contains_key(&node_id) {
+            return Err(RaftError::NodeNotFound(node_id));
+        }
+        self.leader_id = node_id;
+        for node in self.nodes.values_mut() {
+            node.role = if node.id == node_id {
+                RaftRole::Leader
+            } else {
+                RaftRole::Follower
+            };
+            node.current_term = node.current_term.max(term);
+        }
+        if let Some(leader) = self.nodes.get_mut(&node_id) {
+            leader.alive = true;
+            leader.voted_for = Some(node_id);
+        }
+        self.election_elapsed_tick = 0;
+        self.renew_leader_lease();
+        // Raft's fresh-leader state: optimistic `next_index`, unknown `match_index`, and
+        // nothing in flight. The first AppendEntries is then a probe that discovers where
+        // each follower really is, and rejections walk `next_index` back. Re-deriving the
+        // pipeline from shadow peer state here instead would immediately re-inflate the
+        // in-flight window and reject that probe.
+        let next_index = self
+            .nodes
+            .get(&node_id)
+            .map(node_next_log_index)
+            .unwrap_or(1);
+        for node in self.nodes.values_mut() {
+            if node.id == node_id {
+                continue;
+            }
+            node.pipeline_state.next_index = next_index;
+            node.pipeline_state.inflight_entries = 0;
+            node.pipeline_state.inflight_bytes = 0;
+            node.pipeline_state.append_queue_depth = 0;
+        }
+        Ok(())
+    }
+
     pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
         // P4: this thread owes a barrier rather than skipping one -- `flush_deferred_persist`
         // takes it before the propose acks. Only the thread that opened the deferral defers, so

--- a/crates/temporalstore-rust/src/raft/cluster_membership.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_membership.rs
@@ -340,7 +340,8 @@ impl RaftCluster {
             .learner_catchup_count
             .saturating_add(1);
         let config = inner.config.clone();
-        refresh_all_pipeline_states(&mut inner.nodes, leader_id, &config);
+        let local_node_id_for_refresh = inner.local_node_id;
+        refresh_all_pipeline_states(&mut inner.nodes, leader_id, local_node_id_for_refresh, &config);
         inner.persist_configured_wal()?;
         Ok(())
     }

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -117,6 +117,11 @@ impl RaftCluster {
             .get(&inner.leader_id)
             .map(|leader| leader.commit_index)
             .unwrap_or_default();
+        let leader_last_index = inner
+            .nodes
+            .get(&inner.leader_id)
+            .map(node_last_log_or_snapshot_index)
+            .unwrap_or_default();
         if let Some(target) = inner.nodes.get_mut(&target_id) {
             if target.commit_index >= leader_commit_for_drain
                 && (target.pipeline_state.inflight_entries > 0
@@ -130,8 +135,14 @@ impl RaftCluster {
                 target.pipeline_state.append_requests.saturating_add(1);
             current_inflight_entries = target.pipeline_state.inflight_entries;
             current_inflight_bytes = target.pipeline_state.inflight_bytes;
-            if target.pipeline_state.inflight_entries >= entry_limit
-                || target.pipeline_state.inflight_bytes >= byte_limit
+            // A request with nothing to send buffers nothing, so the in-flight limits
+            // do not apply to it. This is the heartbeat -- and the probe a newly promoted
+            // leader sends to find out where a follower really is. Blocking it leaves the
+            // new leader unable to contact anyone, which reads as a leaderless shard.
+            let carries_entries = target.pipeline_state.next_index <= leader_last_index;
+            if carries_entries
+                && (target.pipeline_state.inflight_entries >= entry_limit
+                    || target.pipeline_state.inflight_bytes >= byte_limit)
             {
                 target.pipeline_state.append_rejected =
                     target.pipeline_state.append_rejected.saturating_add(1);
@@ -566,6 +577,9 @@ impl RaftCluster {
             (node.current_term, last_index)
         };
         inner.leader_id = leader_id;
+        // Proof of life from the leader. A follower's timer loop diffs this to decide
+        // whether the leader has gone quiet and it should stand for election.
+        inner.leader_contact_epoch = inner.leader_contact_epoch.saturating_add(1);
         for (node_id, peer) in inner.nodes.iter_mut() {
             if *node_id != leader_id && peer.role == RaftRole::Leader {
                 peer.role = RaftRole::Follower;
@@ -718,6 +732,10 @@ impl RaftCluster {
         node.voted_for = Some(request.candidate_id);
         node.role = RaftRole::Follower;
         let term = node.current_term;
+        // Raft resets the election timer when it grants a vote: granting one means someone
+        // else is already standing, and campaigning against them in the same window is what
+        // turns a split vote into a livelock the cluster never escapes.
+        inner.leader_contact_epoch = inner.leader_contact_epoch.saturating_add(1);
         inner.persist_configured_wal()?;
         Ok(VoteResponse {
             term,

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -368,6 +368,20 @@ impl RaftCluster {
             .iter()
             .map(|entry| command_size_bytes(&entry.command))
             .sum::<u64>();
+        // A leader that is merely out of sync with this follower's log is still ALIVE.
+        // Only a stale-term request (from a superseded leader) leaves the election timer
+        // running. Counting only ACCEPTED appends as contact meant a follower being caught
+        // up kept timing out and campaigning, which bumped the term, which made the
+        // leader's in-flight appends stale, which got them rejected -- catch-up and
+        // election fighting each other instead of converging.
+        let local_current_term = inner
+            .nodes
+            .get(&target_id)
+            .map(|node| node.current_term)
+            .unwrap_or_default();
+        if term >= local_current_term {
+            inner.leader_contact_epoch = inner.leader_contact_epoch.saturating_add(1);
+        }
         let enable_reorder_queue = inner.config.enable_reorder_queue;
         let reorder_window_size = inner.config.reorder_window_size;
         let max_apply_batch_bytes = inner.config.max_apply_batch_bytes;
@@ -600,7 +614,8 @@ impl RaftCluster {
             }
         }
         let config = inner.config.clone();
-        refresh_all_pipeline_states(&mut inner.nodes, leader_id, &config);
+        let local_node_id_for_refresh = inner.local_node_id;
+        refresh_all_pipeline_states(&mut inner.nodes, leader_id, local_node_id_for_refresh, &config);
         inner.renew_leader_lease();
         inner.persist_configured_wal()?;
         Ok(AppendEntriesResponse {

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -36,6 +36,8 @@ impl LocalRaftWal {
             sequence: recovery.valid_records as u64 + 1,
             checksum: raft_wal_checksum(record)?,
             record: record.clone(),
+            // The single-file (non-segmented) path always writes full records.
+            delta: None,
         };
         let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
         serde_json::to_writer(&mut file, &envelope).map_err(io::Error::other)?;
@@ -103,14 +105,77 @@ impl LocalRaftWal {
             .expect("cursor seeded above");
 
         let sequence = cursor.next_sequence;
-        let envelope = RaftWalEnvelope {
-            sequence,
-            checksum: raft_wal_checksum(record)?,
-            record: record.clone(),
+
+        // The record Raft hands us always carries the node's WHOLE log. Writing that on
+        // every append makes each append cost O(log length) and the WAL O(n^2) overall,
+        // which shows up as write latency that climbs with the log. Write the entries
+        // that are actually new instead, and re-base with a full record only when a
+        // delta could not be folded back (start of a segment, or the log moved under us).
+        let delta_enabled = raft_wal_delta_entries_enabled();
+        let log_first_index = record
+            .entries
+            .first()
+            .map(|entry| entry.index)
+            .unwrap_or_default();
+        let log_last_index = record
+            .entries
+            .last()
+            .map(|entry| entry.index)
+            .unwrap_or_default();
+        let log_last_term = record
+            .entries
+            .last()
+            .map(|entry| entry.term)
+            .unwrap_or_default();
+        // A delta is only sound while the log still contains the exact entry we last
+        // wrote, at the same term. A conflict overwrite (raft truncating a divergent
+        // suffix) or a snapshot compaction (dropping a prefix) breaks that.
+        let delta_safe = delta_enabled
+            && cursor.has_base
+            && cursor.persisted_last_index > 0
+            && log_last_index >= cursor.persisted_last_index
+            && log_first_index > 0
+            && log_first_index <= cursor.persisted_last_index
+            && record.entries.iter().any(|entry| {
+                entry.index == cursor.persisted_last_index && entry.term == cursor.persisted_last_term
+            });
+
+        let encode = |as_delta: bool| -> io::Result<Vec<u8>> {
+            let envelope = if as_delta {
+                let from_index = cursor.persisted_last_index;
+                let mut delta_record = record.clone();
+                delta_record.entries.retain(|entry| entry.index > from_index);
+                // Telemetry counters are not durability-relevant (the fingerprint zeroes
+                // them), and they were more than half the bytes of every record. Recovery
+                // keeps whatever the base record carried.
+                delta_record.pipeline_state = RaftPeerPipelineRuntimeState::default();
+                delta_record.read_safety_state = RaftReadSafetyRuntimeState::default();
+                RaftWalEnvelope {
+                    sequence,
+                    checksum: raft_wal_checksum(&delta_record)?,
+                    record: delta_record,
+                    delta: Some(RaftWalEntryDelta {
+                        from_index,
+                        log_first_index,
+                        log_last_index,
+                    }),
+                }
+            } else {
+                RaftWalEnvelope {
+                    sequence,
+                    checksum: raft_wal_checksum(record)?,
+                    record: record.clone(),
+                    delta: None,
+                }
+            };
+            let mut buf = Vec::new();
+            serde_json::to_writer(&mut buf, &envelope).map_err(io::Error::other)?;
+            buf.push(b'\n');
+            Ok(buf)
         };
-        let mut encoded = Vec::new();
-        serde_json::to_writer(&mut encoded, &envelope).map_err(io::Error::other)?;
-        encoded.push(b'\n');
+
+        let mut wrote_base = !delta_safe;
+        let mut encoded = encode(delta_safe)?;
 
         let mut active_segment_id = cursor
             .segments
@@ -122,9 +187,23 @@ impl LocalRaftWal {
             .last()
             .map(|segment| segment.bytes)
             .unwrap_or_default();
-        let rotate = active_len > 0 && active_len + encoded.len() as u64 > max_segment_bytes;
+        // Every segment opens with a full base record, so pruning whole segments can
+        // never orphan a delta. Rotation still honours `max_segment_bytes`; it is only
+        // clamped up to one base record so a segment can always hold the record that
+        // opens it.
+        let rotate_threshold = if delta_enabled {
+            max_segment_bytes.max(cursor.base_bytes)
+        } else {
+            max_segment_bytes
+        };
+        let rotate = active_len > 0 && active_len + encoded.len() as u64 > rotate_threshold;
         if rotate {
             active_segment_id += 1;
+            if !wrote_base {
+                // Opening a new segment: it must start self-sufficient.
+                encoded = encode(false)?;
+                wrote_base = true;
+            }
         }
         let active_path = self.node_segment_path(shard_id, node_id, active_segment_id);
 
@@ -173,6 +252,12 @@ impl LocalRaftWal {
         }
         // One more record is now durable on disk.
         cursor.next_sequence = cursor.next_sequence.saturating_add(1);
+        if wrote_base {
+            cursor.base_bytes = encoded.len() as u64;
+            cursor.has_base = true;
+        }
+        cursor.persisted_last_index = log_last_index;
+        cursor.persisted_last_term = log_last_term;
 
         // Prune the oldest segments, keeping at least `min_keep_segments`. Removing a
         // segment drops its records from the retained window, so the next sequence
@@ -222,6 +307,13 @@ impl LocalRaftWal {
             released_segment_count: runtime_state.released_segment_count,
             last_fsync_elapsed_ms: runtime_state.last_fsync_elapsed_ms,
             slow_fsync_backpressure_observed: runtime_state.slow_fsync_backpressure_observed,
+            // A freshly seeded cursor has written nothing in this process, so the first
+            // append re-bases. That keeps recovery independent of whatever the previous
+            // process had in memory.
+            base_bytes: 0,
+            persisted_last_index: 0,
+            persisted_last_term: 0,
+            has_base: false,
         })
     }
 
@@ -315,7 +407,38 @@ impl LocalRaftWal {
                     break;
                 }
                 valid_records += 1;
-                last_record = Some(envelope.record);
+                last_record = match envelope.delta {
+                    // A base record replaces everything before it outright.
+                    None => Some(envelope.record),
+                    Some(delta) => {
+                        // Fold the appended entries onto the running record. Entries above
+                        // `from_index` were superseded (conflict overwrite), and anything
+                        // below `log_first_index` was compacted away.
+                        let mut merged = envelope.record;
+                        let appended = std::mem::take(&mut merged.entries);
+                        let base = last_record;
+                        // An incremental record omits the volatile telemetry blocks; carry
+                        // the base's forward rather than resetting them to zero.
+                        if let Some(base) = base.as_ref() {
+                            if merged.pipeline_state == RaftPeerPipelineRuntimeState::default() {
+                                merged.pipeline_state = base.pipeline_state.clone();
+                            }
+                            if merged.read_safety_state == RaftReadSafetyRuntimeState::default() {
+                                merged.read_safety_state = base.read_safety_state.clone();
+                            }
+                        }
+                        let mut entries = base
+                            .map(|base| base.entries)
+                            .unwrap_or_default();
+                        entries.retain(|entry| entry.index <= delta.from_index);
+                        entries.extend(appended);
+                        if delta.log_first_index > 0 {
+                            entries.retain(|entry| entry.index >= delta.log_first_index);
+                        }
+                        merged.entries = entries;
+                        Some(merged)
+                    }
+                };
                 valid_until = offset + line_len;
                 offset += line_len;
             }

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -348,7 +348,11 @@ impl ProductionRaftRuntime {
         let election_tick = Duration::from_millis(self.options.election_tick_ms);
         let max_catchup_entries_per_heartbeat = self.options.max_catchup_entries_per_heartbeat;
         let peer_map = self.options.peer_map();
-        let peer_ids = peer_map.keys().copied().collect::<Vec<_>>();
+        let peer_ids = peer_map
+            .keys()
+            .copied()
+            .filter(|peer_id| *peer_id != self.options.local_node_id)
+            .collect::<Vec<_>>();
         let http_options = HttpRequestOptions {
             connect_timeout_ms: self.options.rpc.deadline_ms,
             io_timeout_ms: self.options.rpc.deadline_ms,
@@ -364,9 +368,27 @@ impl ProductionRaftRuntime {
             .expect("validated production raft auth token");
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
+        // Leadership here is decided by real RequestVote RPCs below, so the in-process
+        // shadow election must not promote anyone: it can only see this process's copy
+        // of peer state and would install a leader the rest of the group never agreed to.
+        cluster.set_local_shadow_election(false);
+        // Consecutive failed AppendEntries before a leader gives up on a peer. Nothing
+        // else in this path ever marks a peer down, so without it `live_voters` and
+        // `has_majority` stay optimistic forever after a peer dies.
+        let peer_failure_threshold = RAFT_PEER_FAILURE_THRESHOLD;
+        // Ticks of leader silence a follower tolerates before standing for election;
+        // re-drawn after every attempt so two survivors do not stay locked in step.
+        // Voters that must acknowledge for this node to keep leading (this node included).
+        let majority_size = self.options.nodes.len() / 2 + 1;
         let handle = thread::spawn(move || {
             let mut last_heartbeat = InstantCompat::now();
             let mut last_tick = InstantCompat::now();
+            let mut last_contact_epoch = cluster.leader_contact_epoch();
+            let mut silent_ticks = 0u64;
+            let mut peer_failures: BTreeMap<RaftNodeId, u32> = BTreeMap::new();
+            let mut force_heartbeat = false;
+            let mut quorum_misses = 0u32;
+            let mut election_timeout_ticks = randomized_election_timeout_ticks(local_node_id);
             let mut last_snapshot_check = InstantCompat::now();
             while !stop_thread.load(Ordering::SeqCst) {
                 if snapshot_check_interval > 0
@@ -388,20 +410,20 @@ impl ProductionRaftRuntime {
                     }
                     last_snapshot_check = InstantCompat::now();
                 }
-                // Move the cluster's clock forward by the time that actually passed. The
-                // recovery timeouts -- stalled snapshot send, offline peer, abandoned leader
-                // transfer -- are refreshed from here and from nowhere else, so a clock that
-                // never advances leaves them unable to fire: a snapshot send that stalls keeps
-                // its peer flagged as sending, and every proposal to that peer is rejected with
-                // backpressure until the process restarts.
+                // Nothing else advances the raft clock in a live process, so without this
+                // every lease / offline / snapshot-send / leader-transfer timeout is
+                // unreachable and the failure detectors that depend on them never fire.
                 let elapsed_ms = last_tick.elapsed().as_millis() as u64;
+                last_tick = InstantCompat::now();
                 if elapsed_ms > 0 {
                     cluster.advance_time_ms(elapsed_ms);
-                    last_tick = InstantCompat::now();
                 }
-                let _ = cluster.tick_election();
-                if last_heartbeat.elapsed() >= heartbeat_interval {
-                    if cluster.leader_id() == local_node_id {
+
+                if cluster.is_local_leader(local_node_id) {
+                    silent_ticks = 0;
+                    last_contact_epoch = cluster.leader_contact_epoch();
+                    if force_heartbeat || last_heartbeat.elapsed() >= heartbeat_interval {
+                        force_heartbeat = false;
                         let transport = RaftRpcRuntime::with_auth_token(
                             AuthenticatedRaftTransport::new(
                                 HttpRaftTransport::with_options(peer_map.clone(), http_options),
@@ -411,6 +433,7 @@ impl ProductionRaftRuntime {
                             Some(auth_token.clone()),
                         );
                         let mut sent = 0;
+                        let mut reached = 1usize; // self
                         for target_id in &peer_ids {
                             if sent >= max_catchup_entries_per_heartbeat {
                                 break;
@@ -434,44 +457,104 @@ impl ProductionRaftRuntime {
                             match transport.append_entries(request) {
                                 Ok(response) => {
                                     let success = response.success;
-                                    if !success {
-                                        // A rejection is an Ok response, so this path was silent
-                                        // too: a peer can reject every heartbeat forever and the
-                                        // leader reports it only as "lagging".
-                                        tracing::warn!(
-                                            kind = "data",
-                                            target_id = *target_id,
-                                            reject_reason = ?response.reject_reason,
-                                            peer_match_index = response.match_index,
-                                            peer_term = response.term,
-                                            "raft: peer rejected append entries"
-                                        );
-                                    }
+                                    let peer_term = response.term;
                                     let _ = cluster
                                         .record_append_entries_response(*target_id, &response);
+                                    peer_failures.insert(*target_id, 0);
+                                    reached += 1;
+                                    let _ = cluster.set_alive(*target_id, true);
                                     if success {
                                         sent += entry_count.max(1);
+                                    } else if peer_term > 0 {
+                                        // A peer that has moved to a newer term has seen a
+                                        // different leader; stand down rather than keep
+                                        // appending as a superseded leader.
+                                        let _ =
+                                            cluster.observe_higher_term(local_node_id, peer_term);
                                     }
                                 }
-                                // No response at all. Give back what the request reserved --
-                                // otherwise a peer whose process is down accumulates one leaked
-                                // reservation per heartbeat and is never sent to again, including
-                                // after it comes back.
-                                Err(err) => {
-                                    tracing::warn!(
-                                        kind = "data",
-                                        target_id = *target_id,
-                                        error = %err,
-                                        "raft: append entries send to peer failed"
-                                    );
-                                    let _ =
-                                        cluster.record_append_entries_send_failure(*target_id);
+                                Err(_) => {
+                                    let failures =
+                                        peer_failures.entry(*target_id).or_insert(0);
+                                    *failures = failures.saturating_add(1);
+                                    if *failures >= peer_failure_threshold {
+                                        let _ = cluster.set_alive(*target_id, false);
+                                    }
                                 }
                             }
                         }
+                        // Check-quorum: a leader that can no longer reach a majority has
+                        // been superseded (or partitioned away) and must stop acting as
+                        // one, otherwise it keeps accepting writes only it can see.
+                        if reached < majority_size {
+                            quorum_misses = quorum_misses.saturating_add(1);
+                            if quorum_misses >= peer_failure_threshold {
+                                quorum_misses = 0;
+                                let _ = cluster.step_down_local(local_node_id);
+                            }
+                        } else {
+                            quorum_misses = 0;
+                        }
+                        last_heartbeat = InstantCompat::now();
                     }
-                    last_heartbeat = InstantCompat::now();
+                } else {
+                    // Follower. A live leader bumps the contact epoch on every accepted
+                    // AppendEntries; when it stalls for a full election timeout, campaign.
+                    let epoch = cluster.leader_contact_epoch();
+                    if epoch != last_contact_epoch {
+                        last_contact_epoch = epoch;
+                        silent_ticks = 0;
+                    } else {
+                        silent_ticks = silent_ticks.saturating_add(1);
+                    }
+                    if silent_ticks >= election_timeout_ticks {
+                        silent_ticks = 0;
+                        election_timeout_ticks =
+                            randomized_election_timeout_ticks(local_node_id);
+                        let stale_leader = cluster.leader_id();
+                        if stale_leader != local_node_id && stale_leader != 0 {
+                            let _ = cluster.set_alive(stale_leader, false);
+                        }
+                        if let Ok(template) = cluster.prepare_campaign(local_node_id) {
+                            let transport = RaftRpcRuntime::with_auth_token(
+                                AuthenticatedRaftTransport::new(
+                                    HttpRaftTransport::with_options(peer_map.clone(), http_options),
+                                    auth_token.clone(),
+                                ),
+                                rpc_options,
+                                Some(auth_token.clone()),
+                            );
+                            // The self-vote was made durable by prepare_campaign.
+                            let mut grants = 1usize;
+                            let mut highest_term = template.term;
+                            for target_id in &peer_ids {
+                                let mut request = template.clone();
+                                request.target_id = *target_id;
+                                if let Ok(response) = transport.request_vote(request) {
+                                    if response.vote_granted {
+                                        grants += 1;
+                                    }
+                                    highest_term = highest_term.max(response.term);
+                                }
+                            }
+                            if highest_term > template.term {
+                                let _ =
+                                    cluster.observe_higher_term(local_node_id, highest_term);
+                            } else if matches!(
+                                cluster.conclude_campaign(local_node_id, template.term, grants),
+                                Ok(true)
+                            ) {
+                                // Won: heartbeat at once, in this same iteration, so the
+                                // peers learn the new leader before their own election
+                                // timeouts fire and supersede it.
+                                force_heartbeat = true;
+                                last_contact_epoch = cluster.leader_contact_epoch();
+                                continue;
+                            }
+                        }
+                    }
                 }
+                let _ = cluster.tick_election();
                 thread::sleep(election_tick);
             }
         });

--- a/crates/temporalstore-rust/src/raft/tests.rs
+++ b/crates/temporalstore-rust/src/raft/tests.rs
@@ -20,3 +20,4 @@ mod part1;
 mod part2;
 mod part3;
 mod part4;
+mod part5;

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Test part 5: incremental raft WAL records, and the networked-election primitives
+//! the production timer loop drives.
+#![allow(clippy::all)]
+use super::helpers::*;
+use super::*;
+
+fn wal_dir_bytes(root: &std::path::Path) -> u64 {
+    fn walk(path: &std::path::Path, total: &mut u64) {
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                walk(&entry.path(), total);
+            } else {
+                *total += meta.len();
+            }
+        }
+    }
+    let mut total = 0;
+    walk(root, &mut total);
+    total
+}
+
+fn propose_range(cluster: &RaftCluster, from: usize, to: usize) {
+    for i in from..to {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("wal-cost-{i}"),
+                value: vec![7u8; 32],
+            })
+            .unwrap();
+    }
+}
+
+/// The WAL record Raft hands to `persist_configured_wal` carries the node's whole log.
+/// Writing that verbatim on every append makes each append cost O(log length), which is
+/// what made write latency climb with the log. Appends must instead cost about the same
+/// no matter how long the log already is.
+#[test]
+fn wal_append_cost_stays_flat_as_the_log_grows() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 91, [1], RaftConfig::default()).unwrap();
+
+    propose_range(&cluster, 0, 50);
+    let before_early = wal_dir_bytes(dir.path());
+    propose_range(&cluster, 50, 100);
+    let early_block = wal_dir_bytes(dir.path()) - before_early;
+
+    propose_range(&cluster, 100, 450);
+    let before_late = wal_dir_bytes(dir.path());
+    propose_range(&cluster, 450, 500);
+    let late_block = wal_dir_bytes(dir.path()) - before_late;
+
+    // With a full-log payload the later block rewrites a log ~6x longer on every append,
+    // so it costs ~6x the earlier block. Incremental records keep the two comparable.
+    assert!(
+        late_block < early_block * 2,
+        "50 appends at log length ~450 cost {late_block} bytes vs {early_block} at length ~50; \
+         the payload is still growing with the log"
+    );
+}
+
+/// Folding incremental records back together has to reproduce the log exactly, including
+/// across the segment rotations that write a fresh base record.
+#[test]
+fn incremental_wal_records_recover_the_whole_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = RaftConfig::default();
+    // Small segments so the run crosses several rotations.
+    config.max_segment_bytes = 4096;
+    config.min_keep_segment_num = 64;
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 92, [1], config.clone()).unwrap();
+    for i in 0..200 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("recover-{i}"),
+                value: format!("value-{i}").into_bytes(),
+            })
+            .unwrap();
+    }
+    let expected = cluster.status().commit_index;
+    assert_eq!(expected, 200);
+
+    let restored =
+        RaftCluster::restore_single_shard_from_wal(dir.path(), 92, [1], config).unwrap();
+    assert_eq!(restored.status().commit_index, expected);
+    let response = restored
+        .read_local(
+            1,
+            Command::StringGet {
+                key: "recover-199".to_string(),
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        response,
+        CommandResponse::Bytes {
+            value: Some(b"value-199".to_vec())
+        }
+    );
+    let wal = LocalRaftWal::new(dir.path());
+    let record = wal.load_node(92, 1).unwrap().unwrap();
+    assert_eq!(record.entries.len(), 200);
+    assert_eq!(record.entries.last().unwrap().index, 200);
+}
+
+/// A raft leader change can truncate a divergent suffix. The entry the WAL last wrote is
+/// then gone, so an incremental record would fold onto a log that no longer exists --
+/// the writer has to notice and re-base instead.
+#[test]
+fn wal_rebases_when_the_log_suffix_is_overwritten() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 93, [1], RaftConfig::default()).unwrap();
+    for i in 0..20 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("conflict-{i}"),
+                value: vec![1u8; 8],
+            })
+            .unwrap();
+    }
+    let wal = LocalRaftWal::new(dir.path());
+    let mut record = wal.load_node(93, 1).unwrap().unwrap();
+    assert_eq!(record.entries.len(), 20);
+
+    // Simulate a new leader overwriting indexes 11..=15 at a higher term.
+    record.entries.truncate(10);
+    for index in 11..=15u64 {
+        record.entries.push(RaftLogEntry {
+            term: 9,
+            index,
+            shard_id: 93,
+            command: Command::StringSet {
+                key: format!("overwritten-{index}"),
+                value: vec![2u8; 8],
+            },
+        });
+    }
+    record.hard_state.commit_index = 15;
+    wal.persist_node_segmented(93, 1, &record, 1024 * 1024, 8)
+        .unwrap();
+
+    let recovered = wal.recover_node_segmented(93, 1).unwrap().record.unwrap();
+    assert_eq!(recovered.entries.len(), 15);
+    assert_eq!(recovered.entries.last().unwrap().index, 15);
+    assert_eq!(recovered.entries.last().unwrap().term, 9);
+    assert!(recovered
+        .entries
+        .iter()
+        .all(|entry| entry.index <= 10 || entry.term == 9));
+}
+
+/// A snapshot compaction drops a prefix of the log. Recovery must drop it too rather
+/// than resurrect entries from the base record it folded onto.
+#[test]
+fn wal_recovery_drops_entries_compacted_away() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 94, [1], RaftConfig::default()).unwrap();
+    for i in 0..20 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("compact-{i}"),
+                value: vec![3u8; 8],
+            })
+            .unwrap();
+    }
+    let wal = LocalRaftWal::new(dir.path());
+    let mut record = wal.load_node(94, 1).unwrap().unwrap();
+    // Keep only the tail, as a snapshot install would.
+    record.entries.retain(|entry| entry.index > 12);
+    wal.persist_node_segmented(94, 1, &record, 1024 * 1024, 8)
+        .unwrap();
+
+    let recovered = wal.recover_node_segmented(94, 1).unwrap().record.unwrap();
+    assert_eq!(recovered.entries.first().unwrap().index, 13);
+    assert_eq!(recovered.entries.len(), 8);
+}
+
+/// `prepare_campaign` must make the term bump and self-vote durable before any vote is
+/// requested, and `conclude_campaign` must refuse to install a minority leader.
+#[test]
+fn networked_campaign_promotes_only_with_a_majority() {
+    let cluster = RaftCluster::new_single_shard(95, [1, 2, 3]);
+    assert_eq!(cluster.leader_id(), 1);
+    let before_term = cluster.status().current_term;
+
+    let template = cluster.prepare_campaign(2).unwrap();
+    assert_eq!(template.candidate_id, 2);
+    assert_eq!(template.shard_id, 95);
+    assert!(template.term > before_term);
+
+    // One grant (its own) out of three voters is a minority.
+    assert!(!cluster.conclude_campaign(2, template.term, 1).unwrap());
+    assert_eq!(
+        cluster.leader_id(),
+        1,
+        "a minority campaign must not install a leader"
+    );
+
+    // Two of three is a majority.
+    assert!(cluster.conclude_campaign(2, template.term, 2).unwrap());
+    assert_eq!(cluster.leader_id(), 2);
+    assert_eq!(cluster.status().current_term, template.term);
+}
+
+/// A peer answering with a newer term means someone else has already moved on; the
+/// candidate has to step down instead of installing itself at a stale term.
+#[test]
+fn campaign_stands_down_on_a_newer_peer_term() {
+    let cluster = RaftCluster::new_single_shard(96, [1, 2, 3]);
+    let template = cluster.prepare_campaign(3).unwrap();
+    let candidate_term = |cluster: &RaftCluster| {
+        cluster
+            .status()
+            .nodes
+            .into_iter()
+            .find(|node| node.node_id == 3)
+            .map(|node| node.current_term)
+            .unwrap()
+    };
+    assert_eq!(candidate_term(&cluster), template.term);
+
+    cluster.observe_higher_term(3, template.term + 5).unwrap();
+    assert_eq!(candidate_term(&cluster), template.term + 5);
+
+    // Votes arrive over the network, so they can land after the candidate has already
+    // stepped down. A unanimous tally for the abandoned term must not install it.
+    assert!(
+        !cluster.conclude_campaign(3, template.term, 3).unwrap(),
+        "grants for an abandoned term must not promote"
+    );
+    assert_eq!(cluster.leader_id(), 1);
+}
+
+/// The follower side of failure detection: a leader's AppendEntries is the only signal
+/// that it is still there, so accepting one has to be observable.
+#[test]
+fn leader_contact_epoch_advances_on_append_entries() {
+    let cluster = RaftCluster::new_single_shard(97, [1, 2, 3]);
+    cluster
+        .propose(Command::StringSet {
+            key: "contact".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+    let before = cluster.leader_contact_epoch();
+    let request = cluster.build_append_entries_request(2).unwrap();
+    cluster.receive_append_entries(request).unwrap();
+    assert!(
+        cluster.leader_contact_epoch() > before,
+        "accepting AppendEntries must record leader contact"
+    );
+}
+
+/// With shadow election off, `tick_election` may age the election clock but must never
+/// promote: in a real deployment this process only sees its own copy of peer state, and
+/// promoting a remote node here would just make it disagree with the rest of the group.
+#[test]
+fn shadow_election_off_never_promotes_locally() {
+    let guarded = RaftCluster::new_single_shard(98, [1, 2, 3]);
+    guarded.set_local_shadow_election(false);
+    guarded.set_alive(1, false).unwrap();
+    for _ in 0..32 {
+        let _ = guarded.tick_election();
+    }
+    assert_eq!(
+        guarded.leader_id(),
+        1,
+        "a production runtime must decide leadership over the wire, not locally"
+    );
+
+    // The in-process model keeps its old behavior.
+    let shadow = RaftCluster::new_single_shard(99, [1, 2, 3]);
+    shadow.set_alive(1, false).unwrap();
+    for _ in 0..32 {
+        let _ = shadow.tick_election();
+    }
+    assert_ne!(shadow.leader_id(), 1);
+}
+
+/// A leader promoted by a networked election has never replicated to its peers, so this
+/// process knows nothing about how far they got. It must still be able to send the probe
+/// that discovers it. When the pipeline instead assumed the whole log was in flight, that
+/// probe was rejected with backpressure, the new leader could never commit in its own
+/// term, and the surviving replicas duelled for leadership indefinitely.
+#[test]
+fn promoted_leader_can_reach_peers_it_knows_nothing_about() {
+    let cluster = RaftCluster::new_single_shard(100, [1, 2, 3]);
+    for i in 0..2000 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("backpressure-{i}"),
+                value: vec![9u8; 16],
+            })
+            .unwrap();
+    }
+    // A process that was never leader has no confirmed progress for its peers: it only
+    // ever learns that from AppendEntries responses it sent itself.
+    {
+        let mut inner = cluster.inner.write().unwrap();
+        for node in inner.nodes.values_mut() {
+            if node.id != 2 {
+                node.commit_index = 0;
+                node.applied_index = 0;
+                node.pipeline_state.match_index = 0;
+            }
+        }
+    }
+
+    let template = cluster.prepare_campaign(2).unwrap();
+    assert!(cluster.conclude_campaign(2, template.term, 2).unwrap());
+    assert_eq!(cluster.leader_id(), 2);
+
+    // Anything that refreshes the pipeline (an incoming AppendEntries, a propose) runs
+    // before the new leader gets its first response back, and must not conclude that the
+    // whole log is in flight merely because the peer's progress is unknown.
+    {
+        let mut inner = cluster.inner.write().unwrap();
+        let config = inner.config.clone();
+        refresh_all_pipeline_states(&mut inner.nodes, 2, &config);
+    }
+
+    for target in [1u64, 3u64] {
+        let request = cluster
+            .build_append_entries_request(target)
+            .unwrap_or_else(|err| panic!("new leader cannot even probe node {target}: {err}"));
+        assert_eq!(request.leader_id, 2);
+        assert_eq!(request.target_id, target);
+    }
+}

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -326,7 +326,7 @@ fn promoted_leader_can_reach_peers_it_knows_nothing_about() {
     {
         let mut inner = cluster.inner.write().unwrap();
         let config = inner.config.clone();
-        refresh_all_pipeline_states(&mut inner.nodes, 2, &config);
+        refresh_all_pipeline_states(&mut inner.nodes, 2, None, &config);
     }
 
     for target in [1u64, 3u64] {


### PR DESCRIPTION
Two independent problems in the data-node raft path, both reachable from a running
three-node deployment.

## A raft WAL record carried the node's entire log

`wal_records` built each record with `entries: node.log.clone()`, so every persist appended
the whole log again — for every node id the process tracked. Appending cost O(log length),
the WAL grew O(n²), and a write's latency climbed steadily with the number of entries
already in the shard.

Records are now incremental. Each segment opens with one full base record and the records
after it carry only the entries appended since the last one; recovery folds them back onto
that base. The writer re-bases whenever the in-memory log no longer agrees with what it last
wrote — a conflict overwrite that replaced a suffix, or a snapshot compaction that dropped a
prefix — so a fold can never reconstruct a log that never existed. Because every segment
starts self-sufficient, retention can still drop whole segments without orphaning anything.

Dumping the bytes a live node actually wrote turned up three more costs that scaled with the
log and had nothing to do with entries:

- the durability fingerprint cloned the record and serialised it in full, so the check for
  "did anything change?" was itself proportional to the log; it now summarises the log
- `pipeline_state` and `read_safety_state` were 2.4 KB of a 3.4 KB record — runtime counters
  the fingerprint already excludes as not durability-relevant; incremental records omit them
- the pipeline refresh cloned the leader's log and rescanned all of it per node on every
  propose; it now borrows and sums only the suffix a peer has not received

Measured on three c7i.large, 3 shards × 3 replicas, 30-byte values:

| | before | after |
|---|--:|--:|
| WAL bytes per write | 27,883 | 9,601 |
| WAL record size | 3,468 B | 1,189 B |
| write p50 at 2,700 entries | 211.5 ms | 96.1 ms |
| growth in p50 per entry | 0.0535 ms | 0.0113 ms |

Flatter, not flat: some cost still scales with the log and is worth profiling separately.

## A dead leader was never noticed

Killing a data-node raft leader left the shard writable by nobody. Nothing ever marked a peer
down, so the tick that would have started an election always saw the leader as alive, and the
logical clock those timeouts hang off was advanced from nowhere in a deployed process.

Leadership is now settled over the wire. A follower that stops hearing from the leader stands
for election, collects real RequestVote grants, and promotes itself only on a majority. The
in-process cluster model is untouched — it genuinely hosts every node, so it can still resolve
an election from local state, and that is what keeps the existing tests meaningful.

Three things had to be fixed before an election could converge:

- A promoted leader knows nothing about its peers' progress. Deriving the replication cursor
  from this process's own copy of a peer reset it to the start of the log, so every heartbeat
  looked like a full catch-up and was refused as backpressure. Cursors now start where Raft
  says they start and move only on confirmed progress.
- A request carrying no entries buffers nothing, so the in-flight limits must not apply to it.
  Refusing that probe left a new leader unable to contact anyone at all.
- An append refused because the logs disagree still proves the leader is alive. Counting only
  accepted appends as contact left a follower campaigning while it was being caught up, which
  bumped the term, which made the leader's in-flight appends stale — catch-up and election
  fighting each other instead of converging.

Election timeouts are drawn fresh per attempt and granting a vote defers the voter's own
campaign, so two survivors stop trading the term back and forth.

Measured, killing a shard leader with `kill -9`:

| | before | after |
|---|---|---|
| new leader elected | never (60 s, survivors still reported the dead node as leader) | yes |
| writes resume | never | 1.07 s |
| acknowledged keys readable on survivors | 400/400 | 400/400 |

## Still open

With a long log the surviving replicas agree on the new leader and no acknowledged data is
lost, but the catch-up that follows does not always finish promptly, and one survivor can
keep a stale view of who leads. That is the next thing to chase, on top of the replication
convergence work already on main.

## Tests

`src/raft/tests/part5.rs` adds nine tests: that append cost stops growing with the log, that
folded records reproduce the log across segment rotations, that a replaced suffix and a
compacted prefix both recover correctly, that a campaign promotes only on a majority and
stands down on a newer term, that granting contact is observable, and that a promoted leader
can still reach a peer whose progress it knows nothing about. Each was checked to fail without
its fix — the backpressure one reproduces the exact error a live node reported.
