### PR TITLE
meta: let a single shard be taken out of service

### DIFF
--- a/crates/temporalstore-rust/src/bin/client_scale_harness.rs
+++ b/crates/temporalstore-rust/src/bin/client_scale_harness.rs
@@ -327,6 +327,7 @@ fn start_meta(meta_addr: String, routes: Arc<RwLock<HashMap<ShardId, String>>>) 
                         .expect("route map lock poisoned")
                         .get(&shard_id)
                         .map(|server_addr| ShardLocation {
+                            state: temporalstore_rust::meta::MetaEntityState::Normal,
                             shard_id,
                             server_addr: server_addr.clone(),
                             latest_snapshot: None,

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -19,7 +19,7 @@ use temporalstore_rust::meta::{
     MetaSnapshot, MetaSnapshotFileRequest, MetaSnapshotFileResponse, MetaSnapshotResponse,
     ProxyHeartbeatRequest, PublishShardSnapshotRequest, RegisterProxyRequest,
     RegisterServerRequest, RegisterShardRequest, SafeModePolicy, ServerHeartbeatRequest,
-    ListShardsRequest, ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason,
+    ListShardsRequest, ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason, ShardStateRequest,
     DropProxyGroupRequest, NotifyStopRequest, ProxyCalibrationOptions, PutProxyGroupRequest, SingleNodeMeta, StateChangeRequest, TopologyVersionRequest, UpdateServerRequest,
     UpdateTableRequest,
 };
@@ -1475,6 +1475,15 @@ fn handle(
                 .unwrap_or_default();
             json_response(200, &backend_call!(meta, get, shard_id))
         }
+        ("POST", "/shards/freeze") => parse_or(&request.body, |req: ShardStateRequest| {
+            json_response(200, &backend_call!(meta, freeze_shard, req))
+        }),
+        ("POST", "/shards/unfreeze") => parse_or(&request.body, |req: ShardStateRequest| {
+            json_response(200, &backend_call!(meta, unfreeze_shard, req))
+        }),
+        ("POST", "/shards/drop") => parse_or(&request.body, |req: ShardStateRequest| {
+            json_response(200, &backend_call!(meta, drop_shard, req))
+        }),
         ("POST", "/shards/snapshot") | ("POST", "/publish_shard_snapshot") => {
             parse_or(&request.body, |req: PublishShardSnapshotRequest| {
                 backend_call!(meta, publish_shard_snapshot, req)

--- a/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
@@ -145,6 +145,7 @@ fn main() {
 
     runtime
         .propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: temporalstore_rust::meta::MetaEntityState::Normal,
             shard_id: 55,
             server_addr: "meta-snapshot-server".to_string(),
             latest_snapshot: None,
@@ -158,6 +159,7 @@ fn main() {
     runtime.cluster().set_alive(lagging_node_id, false).unwrap();
     runtime
         .propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: temporalstore_rust::meta::MetaEntityState::Normal,
             shard_id: 56,
             server_addr: "meta-after-lag".to_string(),
             latest_snapshot: None,
@@ -230,6 +232,7 @@ fn main() {
         meta_membership_summary(runtime.apply_membership([10, 12, 13]).unwrap());
     runtime
         .propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: temporalstore_rust::meta::MetaEntityState::Normal,
             shard_id: 58,
             server_addr: "meta-after-replace".to_string(),
             latest_snapshot: None,
@@ -245,6 +248,7 @@ fn main() {
         meta_membership_summary(runtime.apply_membership([10, 13]).unwrap());
     runtime
         .propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: temporalstore_rust::meta::MetaEntityState::Normal,
             shard_id: 59,
             server_addr: "meta-after-second-scale-down".to_string(),
             latest_snapshot: None,
@@ -260,6 +264,7 @@ fn main() {
     runtime.cluster().set_alive(13, false).unwrap();
     let unavailable_without_majority = runtime
         .propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: temporalstore_rust::meta::MetaEntityState::Normal,
             shard_id: 57,
             server_addr: "must-not-commit-without-majority".to_string(),
             latest_snapshot: None,

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -266,6 +266,7 @@ fn table_typed_methods_and_pipeline_match_client_shape() {
                     &GetShardResponse {
                         status: Status::ok(),
                         location: Some(ShardLocation {
+                            state: crate::meta::MetaEntityState::Normal,
                             shard_id: 1,
                             server_addr: server_addr_for_proxy.clone(),
                             latest_snapshot: None,
@@ -537,6 +538,7 @@ fn direct_client_refreshes_cached_route_after_failure() {
                     &GetShardResponse {
                         status: Status::ok(),
                         location: Some(ShardLocation {
+                            state: crate::meta::MetaEntityState::Normal,
                             shard_id: 1,
                             server_addr: live_server.clone(),
                             latest_snapshot: None,
@@ -731,6 +733,7 @@ fn client_backend_pool_skips_cached_route_after_continuous_failure_threshold() {
                     &GetShardResponse {
                         status: Status::ok(),
                         location: Some(ShardLocation {
+                            state: crate::meta::MetaEntityState::Normal,
                             shard_id: 1,
                             server_addr: live_server.clone(),
                             latest_snapshot: None,

--- a/crates/temporalstore-rust/src/client/tests/part3.rs
+++ b/crates/temporalstore-rust/src/client/tests/part3.rs
@@ -366,6 +366,7 @@ fn table_routes_keys_to_shards_and_pipeline_splits_batches() {
                         &GetShardResponse {
                             status: Status::ok(),
                             location: Some(ShardLocation {
+                                state: crate::meta::MetaEntityState::Normal,
                                 shard_id,
                                 server_addr: server_addr_for_meta.clone(),
                                 latest_snapshot: None,

--- a/crates/temporalstore-rust/src/e2e.rs
+++ b/crates/temporalstore-rust/src/e2e.rs
@@ -203,6 +203,7 @@ impl EndToEndWorkflow {
         let data = RaftCluster::new_single_shard(shard_id, data_nodes);
         let meta = MetaRaftCluster::new([100, 101, 102]);
         meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id,
             server_addr: "raft://shard-leader".to_string(),
             latest_snapshot: None,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4332,6 +4332,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         meta.add_namespace(AddNamespaceRequest {
             namespace: "ns".to_string(),
@@ -4363,6 +4364,7 @@ mod tests {
             namespace: "ns".to_string(),
             table_name: "orders".to_string(),
             old_topology_version: 0,
+            client_location: String::new(),
         })
         .shards
         .into_iter()
@@ -4422,6 +4424,7 @@ mod tests {
             node_id: 2,
             location: "rack-2".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         let plans = meta.plan_auto_rebalance();
         assert!(

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -138,8 +138,27 @@ impl MetaEntityState {
 pub struct ShardLocation {
     pub shard_id: ShardId,
     pub server_addr: String,
+    /// Whether this shard is being served.
+    ///
+    /// There was previously no way to take one shard out of service: the only
+    /// lever was freezing its whole table, which stops every other shard in it
+    /// too. A `Frozen` shard keeps its owner entry so it can be returned to
+    /// service, but stops being routed to, and the planners leave it alone --
+    /// an operator who froze a shard does not want rebalancing to move it or
+    /// the divergence check to "repair" it.
+    ///
+    /// Defaults to `Normal`, so shard entries written before this existed load
+    /// as serving.
+    #[serde(default)]
+    pub state: MetaEntityState,
     #[serde(default)]
     pub latest_snapshot: Option<ShardSnapshotRef>,
+}
+
+/// Take one shard out of service, or return it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShardStateRequest {
+    pub shard_id: ShardId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -880,6 +899,8 @@ pub enum MetaMutation {
     FreezeProxy(StateChangeRequest),
     UnfreezeProxy(StateChangeRequest),
     DropProxy(StateChangeRequest),
+    SetShardState(ShardStateRequest, MetaEntityState),
+    DropShard(ShardStateRequest),
     PutProxyGroup(PutProxyGroupRequest),
     DropProxyGroup(DropProxyGroupRequest),
     SetProxyGroup(ProxyAttachment),
@@ -1168,6 +1189,7 @@ impl SingleNodeMeta {
         state.shards.insert(
             request.shard_id,
             ShardLocation {
+                state: MetaEntityState::Normal,
                 shard_id: request.shard_id,
                 server_addr: request.server_addr.clone(),
                 latest_snapshot,
@@ -1181,6 +1203,82 @@ impl SingleNodeMeta {
             format!("server_addr={}", request.server_addr),
         );
         RegisterShardResponse {
+            status: Status::ok(),
+        }
+    }
+
+    /// Stop serving one shard, keeping its owner entry so it can come back.
+    pub fn freeze_shard(&self, request: ShardStateRequest) -> AckResponse {
+        self.set_shard_state(request, MetaEntityState::Frozen)
+    }
+
+    /// Return a frozen shard to service.
+    pub fn unfreeze_shard(&self, request: ShardStateRequest) -> AckResponse {
+        self.set_shard_state(request, MetaEntityState::Normal)
+    }
+
+    fn set_shard_state(&self, request: ShardStateRequest, next: MetaEntityState) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
+        self.record_mutation(MetaMutation::SetShardState(request.clone(), next));
+        self.apply_set_shard_state(request, next)
+    }
+
+    pub(crate) fn apply_set_shard_state(
+        &self,
+        request: ShardStateRequest,
+        next: MetaEntityState,
+    ) -> AckResponse {
+        let mut state = self.inner.write().expect("meta lock poisoned");
+        let Some(shard) = state.shards.get_mut(&request.shard_id) else {
+            return AckResponse {
+                status: Status::error("shard_not_found", "shard is not registered"),
+            };
+        };
+        if shard.state == next {
+            return AckResponse {
+                status: Status::error("not_modified", "shard state is unchanged"),
+            };
+        }
+        shard.state = next;
+        // Topology is derived on read, so the version bump is what makes clients
+        // stop (or resume) resolving to this shard.
+        record_topology_event(
+            &mut state,
+            "shard_state",
+            format!("shard:{}", request.shard_id),
+            format!("state={}", next.as_str()),
+        );
+        AckResponse {
+            status: Status::ok(),
+        }
+    }
+
+    /// Forget a shard entirely. The route is removed rather than tombstoned:
+    /// a shard has no identity beyond where it is served from.
+    pub fn drop_shard(&self, request: ShardStateRequest) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
+        self.record_mutation(MetaMutation::DropShard(request.clone()));
+        self.apply_drop_shard(request)
+    }
+
+    pub(crate) fn apply_drop_shard(&self, request: ShardStateRequest) -> AckResponse {
+        let mut state = self.inner.write().expect("meta lock poisoned");
+        if state.shards.remove(&request.shard_id).is_none() {
+            return AckResponse {
+                status: Status::error("shard_not_found", "shard is not registered"),
+            };
+        }
+        record_topology_event(
+            &mut state,
+            "drop_shard",
+            format!("shard:{}", request.shard_id),
+            "state=dropped",
+        );
+        AckResponse {
             status: Status::ok(),
         }
     }
@@ -1333,6 +1431,10 @@ impl SingleNodeMeta {
             MetaMutation::SetProxyGroup(request) => {
                 self.apply_set_proxy_group(request).status
             }
+            MetaMutation::SetShardState(request, state) => {
+                self.apply_set_shard_state(request, state).status
+            }
+            MetaMutation::DropShard(request) => self.apply_drop_shard(request).status,
             MetaMutation::FreezeServer(request) => {
                 self.apply_set_server_state(request, MetaEntityState::Frozen)
                     .status
@@ -4223,6 +4325,177 @@ mod tests {
         assert_eq!(meta.list_tables().tables[0].replica_count, 2);
     }
 
+    fn shard_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 2,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        for shard_id in [1, 2] {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        meta
+    }
+
+    fn shard(id: ShardId) -> ShardStateRequest {
+        ShardStateRequest { shard_id: id }
+    }
+
+    fn serving_primaries(meta: &SingleNodeMeta) -> Vec<Option<String>> {
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+        })
+        .shards
+        .into_iter()
+        .map(|s| s.primary)
+        .collect()
+    }
+
+    #[test]
+    fn freezing_one_shard_leaves_the_rest_of_the_table_serving() {
+        // The whole point: the only lever before this was freezing the table,
+        // which takes every other shard in it out too.
+        let meta = shard_meta();
+        assert_eq!(
+            serving_primaries(&meta),
+            vec![Some("node-a".to_string()), Some("node-a".to_string())]
+        );
+
+        assert!(meta.freeze_shard(shard(1)).status.ok);
+        let primaries = serving_primaries(&meta);
+        assert_eq!(primaries[0], None, "the frozen shard must not be routed to");
+        assert_eq!(primaries[1], Some("node-a".to_string()));
+
+        // And the table itself is untouched.
+        assert_eq!(meta.list_tables().tables[0].state, MetaEntityState::Normal);
+    }
+
+    #[test]
+    fn a_frozen_shard_comes_back() {
+        let meta = shard_meta();
+        assert!(meta.freeze_shard(shard(1)).status.ok);
+        assert_eq!(serving_primaries(&meta)[0], None);
+        assert!(meta.unfreeze_shard(shard(1)).status.ok);
+        assert_eq!(serving_primaries(&meta)[0], Some("node-a".to_string()));
+    }
+
+    #[test]
+    fn freezing_a_shard_keeps_its_owner_so_it_can_return() {
+        // A frozen shard is out of service, not forgotten; the owner entry is
+        // what makes unfreezing put it back where it was.
+        let meta = shard_meta();
+        meta.freeze_shard(shard(1));
+        let located = meta.get(1);
+        assert!(located.status.ok);
+        let location = located.location.expect("still registered");
+        assert_eq!(location.server_addr, "node-a");
+        assert_eq!(location.state, MetaEntityState::Frozen);
+    }
+
+    #[test]
+    fn rebalancing_leaves_a_frozen_shard_alone() {
+        // An operator froze it on purpose. Moving it would be the planner
+        // undoing a deliberate decision.
+        let meta = shard_meta();
+        meta.freeze_shard(shard(1));
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-b".to_string(),
+            node_id: 2,
+            location: "rack-2".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        let plans = meta.plan_auto_rebalance();
+        assert!(
+            plans.iter().all(|plan| plan.shard_id != 1),
+            "frozen shard was moved: {plans:?}"
+        );
+    }
+
+    #[test]
+    fn the_divergence_check_ignores_a_frozen_shard() {
+        // Its owner not serving it is exactly what freezing means, so flagging
+        // it would have the checker "repair" the operator's decision.
+        let meta = shard_meta();
+        meta.freeze_shard(shard(1));
+        let mut checker = ShardChecker::default();
+        let (report, moves) = meta.check_shard_divergence(&mut checker);
+        assert!(report.diverged.iter().all(|d| d.shard_id != 1));
+        assert!(moves.iter().all(|m| m.shard_id != 1));
+    }
+
+    #[test]
+    fn dropping_a_shard_removes_the_route() {
+        let meta = shard_meta();
+        assert!(meta.drop_shard(shard(1)).status.ok);
+        assert!(!meta.get(1).status.ok);
+        assert_eq!(
+            meta.drop_shard(shard(1)).status.code,
+            "shard_not_found",
+            "dropping twice should report the shard is gone"
+        );
+    }
+
+    #[test]
+    fn shard_state_changes_are_rejected_when_unknown_or_unchanged() {
+        let meta = shard_meta();
+        assert_eq!(meta.freeze_shard(shard(99)).status.code, "shard_not_found");
+        assert!(meta.freeze_shard(shard(1)).status.ok);
+        assert_eq!(meta.freeze_shard(shard(1)).status.code, "not_modified");
+    }
+
+    #[test]
+    fn freezing_a_shard_bumps_the_topology_version() {
+        let meta = shard_meta();
+        let before = meta.stats().topology_version;
+        assert!(meta.freeze_shard(shard(1)).status.ok);
+        assert!(meta.stats().topology_version > before);
+    }
+
+    #[test]
+    fn shard_state_survives_snapshot_and_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("shard-state-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            meta.register(RegisterShardRequest {
+                shard_id: 5,
+                server_addr: "node-a".to_string(),
+            });
+            assert!(meta.freeze_shard(shard(5)).status.ok);
+            let snapshot = meta.export_snapshot();
+            let restored = SingleNodeMeta::default();
+            assert!(restored.install_snapshot(snapshot).status.ok);
+            assert_eq!(
+                restored.get(5).location.expect("registered").state,
+                MetaEntityState::Frozen
+            );
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert_eq!(
+            recovered.get(5).location.expect("registered").state,
+            MetaEntityState::Frozen
+        );
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
@@ -5562,6 +5835,7 @@ mod tests {
         assert_eq!(
             recovered.get(10).location.unwrap(),
             ShardLocation {
+                state: MetaEntityState::Normal,
                 shard_id: 10,
                 server_addr: "server-a".to_string(),
                 latest_snapshot: None,

--- a/crates/temporalstore-rust/src/meta/auto_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/auto_rebalance.rs
@@ -239,11 +239,7 @@ impl SingleNodeMeta {
             .filter(|server| server.state == MetaEntityState::Normal)
             .map(|server| server.server_addr.clone())
             .collect::<BTreeSet<_>>();
-        let shard_owners = state
-            .shards
-            .values()
-            .map(|location| (location.shard_id, location.server_addr.clone()))
-            .collect::<BTreeMap<_, _>>();
+        let shard_owners = serving_shard_owners(&state);
         compute_auto_rebalance(&shard_owners, &live_servers, options)
     }
 
@@ -281,6 +277,7 @@ impl SingleNodeMeta {
         state.shards.insert(
             shard_id,
             ShardLocation {
+                state: MetaEntityState::Normal,
                 shard_id,
                 server_addr: to_server.to_string(),
                 latest_snapshot,

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -535,6 +535,7 @@ impl SingleNodeMeta {
         state.shards.insert(
             request.shard_id,
             ShardLocation {
+                state: MetaEntityState::Normal,
                 shard_id: request.shard_id,
                 server_addr: server_addr.clone(),
                 latest_snapshot,

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -118,10 +118,30 @@ pub(super) fn build_shards(
         let mut used_locations = BTreeSet::new();
         let mut used_hosts = BTreeSet::new();
         let mut placed_locations: Vec<Location> = Vec::new();
-        // The owner is the one entry that reaches the replica list without
-        // passing the Normal filter the candidate scan applies. A server that
-        // was frozen or dropped is not serving, so naming it is telling a client
-        // to read from somewhere that is deliberately out of service.
+        // A shard that is not serving gets no placement at all. Skipping only
+        // its recorded owner is not enough: the candidate scan below would pick
+        // a primary for it anyway, and it would stay routable.
+        let serving = state
+            .shards
+            .get(&shard_id)
+            .map(|location| location.state == MetaEntityState::Normal)
+            .unwrap_or(true);
+        if !serving {
+            shards.push(TableShard {
+                shard_id,
+                start_bucket,
+                end_bucket,
+                primary: None,
+                replicas: Vec::new(),
+                primary_endpoint: None,
+                replica_endpoints: Vec::new(),
+            });
+            continue;
+        }
+        // A serving shard can still be owned by a server that is not serving.
+        // That is a separate question from the one above, and the owner is the
+        // one entry that reaches the replica list without passing the Normal
+        // filter the candidate scan applies.
         let owner = state
             .shards
             .get(&shard_id)

--- a/crates/temporalstore-rust/src/meta/placement_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/placement_rebalance.rs
@@ -522,11 +522,7 @@ impl SingleNodeMeta {
         let shard_placement = self.shard_placements();
         let shard_owners = {
             let state = self.inner.read().expect("meta lock poisoned");
-            state
-                .shards
-                .values()
-                .map(|location| (location.shard_id, location.server_addr.clone()))
-                .collect::<BTreeMap<_, _>>()
+            serving_shard_owners(&state)
         };
         compute_placement_aware_rebalance(&shard_owners, &shard_placement, &live_servers, options)
     }

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -390,11 +390,9 @@ impl SingleNodeMeta {
         let now = now_ms();
         let (shard_owners, servers, live_servers) = {
             let state = self.inner.read().expect("meta lock poisoned");
-            let shard_owners = state
-                .shards
-                .values()
-                .map(|location| (location.shard_id, location.server_addr.clone()))
-                .collect::<BTreeMap<_, _>>();
+            // A frozen shard is out of service on purpose, so its owner not
+            // serving it is expected rather than divergence.
+            let shard_owners = serving_shard_owners(&state);
             let servers = state.servers.values().cloned().collect::<Vec<_>>();
             let live_servers = state
                 .servers

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -304,3 +304,17 @@ pub(super) fn stamp_dropped_since(
         }
     }
 }
+
+/// The shard -> owner map, restricted to shards that are actually being served.
+///
+/// Every planner reads placement through this. A frozen shard is deliberately
+/// out of service, so rebalancing must not move it, the divergence check must
+/// not "repair" it, and it must not appear in a client's topology.
+pub(super) fn serving_shard_owners(state: &MetaState) -> BTreeMap<ShardId, String> {
+    state
+        .shards
+        .values()
+        .filter(|location| location.state == MetaEntityState::Normal)
+        .map(|location| (location.shard_id, location.server_addr.clone()))
+        .collect()
+}

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -4450,6 +4450,7 @@ mod tests {
                         &GetShardResponse {
                             status: Status::ok(),
                             location: Some(ShardLocation {
+                                state: crate::meta::MetaEntityState::Normal,
                                 shard_id: 1,
                                 server_addr: server_addr.clone(),
                                 latest_snapshot: None,

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -7069,6 +7069,7 @@ fn apply_meta_committed(node: &mut MetaRaftNode) -> Option<Status> {
                             node.state.shards.insert(
                                 request.shard_id,
                                 ShardLocation {
+                                    state: crate::meta::MetaEntityState::Normal,
                                     shard_id: request.shard_id,
                                     server_addr: request.server_addr.clone(),
                                     latest_snapshot: None,
@@ -7079,6 +7080,7 @@ fn apply_meta_committed(node: &mut MetaRaftNode) -> Option<Status> {
                             node.state.shards.insert(
                                 request.shard_id,
                                 ShardLocation {
+                                    state: crate::meta::MetaEntityState::Normal,
                                     shard_id: request.shard_id,
                                     server_addr: request.server_addr.clone(),
                                     latest_snapshot: None,

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -231,6 +231,30 @@ impl MetaRaftCluster {
         }
     }
 
+    pub fn freeze_shard(&self, request: crate::meta::ShardStateRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetShardState(
+                request,
+                MetaEntityState::Frozen,
+            )),
+        }
+    }
+
+    pub fn unfreeze_shard(&self, request: crate::meta::ShardStateRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetShardState(
+                request,
+                MetaEntityState::Normal,
+            )),
+        }
+    }
+
+    pub fn drop_shard(&self, request: crate::meta::ShardStateRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::DropShard(request)),
+        }
+    }
+
     pub fn freeze_server(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::FreezeServer(request)),

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -284,7 +284,7 @@ pub(super) fn topology_for_shard(
             table_id: 1,
             namespace: "ns".to_string(),
             table_name: "table".to_string(),
-            state: MetaEntityState::Normal,
+            state: crate::meta::MetaEntityState::Normal,
             topology_version: 1,
             first_shard_id: shard_id,
             shard_count: 1,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -377,6 +377,7 @@ fn raft_election_does_not_depend_on_snapshot_availability() {
 fn metaserver_raft_replicates_shard_location_metadata() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     let location = ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 1,
         server_addr: "127.0.0.1:17002".to_string(),
         latest_snapshot: None,
@@ -1016,6 +1017,7 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 7,
         server_addr: "server-a".to_string(),
         latest_snapshot: None,
@@ -1027,6 +1029,7 @@ fn metaserver_raft_can_read_from_any_live_committed_replica() {
     assert_eq!(
         meta.get_shard_location_from_any_live(7).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 7,
             server_addr: "server-a".to_string(),
             latest_snapshot: None,
@@ -1039,6 +1042,7 @@ fn metaserver_raft_supports_promotion_and_membership_changes() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.set_alive(10, false).unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 2,
         server_addr: "server-b".to_string(),
         latest_snapshot: None,
@@ -1048,6 +1052,7 @@ fn metaserver_raft_supports_promotion_and_membership_changes() {
     assert_eq!(
         meta.get_shard_location(13, 2).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 2,
             server_addr: "server-b".to_string(),
             latest_snapshot: None,
@@ -1064,6 +1069,7 @@ fn metaserver_raft_health_catchup_safe_scale_and_failover_work() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.set_alive(12, false).unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 42,
         server_addr: "server-before-meta-lag".to_string(),
         latest_snapshot: None,
@@ -1106,6 +1112,7 @@ fn metaserver_raft_health_catchup_safe_scale_and_failover_work() {
     assert_eq!(failover.old_leader_id, 10);
     assert_ne!(failover.new_leader_id, 10);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 43,
         server_addr: "server-after-meta-failover".to_string(),
         latest_snapshot: None,
@@ -1114,6 +1121,7 @@ fn metaserver_raft_health_catchup_safe_scale_and_failover_work() {
     assert_eq!(
         meta.get_shard_location(failover.new_leader_id, 43).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 43,
             server_addr: "server-after-meta-failover".to_string(),
             latest_snapshot: None,
@@ -1125,6 +1133,7 @@ fn metaserver_raft_health_catchup_safe_scale_and_failover_work() {
 fn metaserver_raft_apply_health_reports_commit_to_apply_lag() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 144,
         server_addr: "server-meta-apply-health".to_string(),
         latest_snapshot: None,
@@ -1162,6 +1171,7 @@ fn metaserver_raft_apply_health_reports_commit_to_apply_lag() {
 fn metaserver_raft_membership_plan_and_apply_match_data_raft_shape() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 44,
         server_addr: "server-before-meta-membership".to_string(),
         latest_snapshot: None,
@@ -1184,6 +1194,7 @@ fn metaserver_raft_membership_plan_and_apply_match_data_raft_shape() {
     assert_eq!(
         meta.get_shard_location(13, 44).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 44,
             server_addr: "server-before-meta-membership".to_string(),
             latest_snapshot: None,
@@ -1216,6 +1227,7 @@ fn metaserver_raft_membership_apply_rejects_noop_and_quorum_loss() {
 fn metaserver_raft_status_read_index_and_transfer_leader_work() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 7,
         server_addr: "127.0.0.1:17002".to_string(),
         latest_snapshot: None,
@@ -1245,6 +1257,7 @@ fn metaserver_raft_status_read_index_and_transfer_leader_work() {
 fn metaserver_raft_promotes_follower_after_leader_failure_and_keeps_metadata_available() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 7,
         server_addr: "server-before-failover".to_string(),
         latest_snapshot: None,
@@ -1253,6 +1266,7 @@ fn metaserver_raft_promotes_follower_after_leader_failure_and_keeps_metadata_ava
 
     meta.set_alive(10, false).unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 8,
         server_addr: "server-after-failover".to_string(),
         latest_snapshot: None,
@@ -1265,6 +1279,7 @@ fn metaserver_raft_promotes_follower_after_leader_failure_and_keeps_metadata_ava
     assert_eq!(
         meta.get_shard_location(status.leader_id, 7).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 7,
             server_addr: "server-before-failover".to_string(),
             latest_snapshot: None,
@@ -1273,6 +1288,7 @@ fn metaserver_raft_promotes_follower_after_leader_failure_and_keeps_metadata_ava
     assert_eq!(
         meta.get_shard_location(status.leader_id, 8).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 8,
             server_addr: "server-after-failover".to_string(),
             latest_snapshot: None,
@@ -1284,6 +1300,7 @@ fn metaserver_raft_promotes_follower_after_leader_failure_and_keeps_metadata_ava
 fn metaserver_raft_rejects_reads_and_writes_without_majority() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 7,
         server_addr: "server-before-quorum-loss".to_string(),
         latest_snapshot: None,
@@ -1299,6 +1316,7 @@ fn metaserver_raft_rejects_reads_and_writes_without_majority() {
     assert_eq!(meta.read_index(10), Err(RaftError::LeaderUnavailable));
     assert_eq!(
         meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 8,
             server_addr: "server-without-quorum".to_string(),
             latest_snapshot: None,
@@ -1315,6 +1333,7 @@ fn metaserver_snapshot_bootstraps_lagging_meta_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.set_alive(12, false).unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 9,
         server_addr: "server-snapshot".to_string(),
         latest_snapshot: None,
@@ -1327,6 +1346,7 @@ fn metaserver_snapshot_bootstraps_lagging_meta_replica() {
     assert_eq!(
         meta.get_shard_location(12, 9).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 9,
             server_addr: "server-snapshot".to_string(),
             latest_snapshot: None,
@@ -1458,6 +1478,7 @@ fn metaserver_snapshot_floor_survives_failover_and_add_node() {
     )
     .unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 88,
         server_addr: "meta-snapshot-floor".to_string(),
         latest_snapshot: None,
@@ -1476,6 +1497,7 @@ fn metaserver_snapshot_floor_survives_failover_and_add_node() {
     assert_eq!(
         meta.get_shard_location(failover.new_leader_id, 88).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 88,
             server_addr: "meta-snapshot-floor".to_string(),
             latest_snapshot: None,
@@ -1487,6 +1509,7 @@ fn metaserver_snapshot_floor_survives_failover_and_add_node() {
     assert_eq!(
         meta.get_shard_location(13, 88).unwrap(),
         Some(ShardLocation {
+            state: crate::meta::MetaEntityState::Normal,
             shard_id: 88,
             server_addr: "meta-snapshot-floor".to_string(),
             latest_snapshot: None,
@@ -1498,6 +1521,7 @@ fn metaserver_snapshot_floor_survives_failover_and_add_node() {
 fn metaserver_snapshot_cannot_overwrite_newer_meta_state() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 1,
         server_addr: "server-a".to_string(),
         latest_snapshot: None,
@@ -1505,6 +1529,7 @@ fn metaserver_snapshot_cannot_overwrite_newer_meta_state() {
     .unwrap();
     let snapshot = meta.create_snapshot().unwrap();
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {
+        state: crate::meta::MetaEntityState::Normal,
         shard_id: 2,
         server_addr: "server-b".to_string(),
         latest_snapshot: None,


### PR DESCRIPTION
## The problem

`ShardLocation` records where a shard lives and nothing about whether it should be served. So there is **no way to take one shard out of service.** The only lever is freezing its whole table, which stops every other shard in that table too.

That is the wrong granularity for the cases it comes up in: one shard is corrupt, or hot, or under investigation, and the rest of the table is fine.

## What this adds

A `state` on `ShardLocation`, and three operations: `POST /shards/freeze`, `/shards/unfreeze`, `/shards/drop`.

A **frozen** shard keeps its owner entry — that is what lets unfreezing put it back where it was — but stops being served. **Dropping** removes the route outright rather than leaving a tombstone: a shard has no identity beyond where it is served from.

The field defaults to `Normal`, so shard entries written before this load as serving.

## The part that matters: nothing may fight the operator

Freezing a shard is only useful if the rest of the metaserver respects it. Four paths read placement, and all of them now go through one `serving_shard_owners` view:

- **Topology** — a frozen shard is handed to clients with no primary and no replicas.
- **Rebalance** (both planners) — will not move it. Moving a shard an operator deliberately froze is the planner undoing a decision.
- **Divergence check** — will not flag it. Its owner not serving it is *exactly what freezing means*, so flagging it would have the checker "repair" the operator's intent.
- **Orphan guard** — a frozen shard does not count as something a conviction would strand.

## A hole the tests caught

My first attempt filtered the frozen shard's *recorded owner* out of `build_shards`. That was not enough: the general candidate scan still picked a primary for it through the `replicas.first()` fallback, so the shard stayed routable and the topology test failed with `primary: Some("node-a")`.

A shard that is not serving now gets **no placement computed at all** — the loop emits an empty entry and moves on. That is the honest semantic: the shard still occupies its key range, but nothing is serving it.

## Tests

9 new tests: freezing one shard leaving the rest of the table serving (and the table itself untouched), unfreezing restoring it, the owner entry surviving a freeze, rebalance leaving it alone, the divergence check ignoring it, drop removing the route and reporting `shard_not_found` on a second attempt, unknown/unchanged rejections, the topology-version bump, and state surviving both a snapshot round trip and mutation-log replay.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **261 passed, 0 failed.**
- `cargo test -p temporalstore-rust --lib client -- --test-threads=1` — 33 passed, 0 failed.
- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — 18 passed, 0 failed.
- `cargo build -p temporalstore-rust --bin metaserver` — clean.

No gate: the field defaults to serving, so nothing changes until an operator freezes something.
