### PR TITLE
Client: honour refresh_route_on_backend_error instead of ignoring it

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -78,6 +78,12 @@ pub struct ClientOptions {
     pub meta_sync_jitter_percent: u8,
     pub local_location: String,
     pub drop_percent: u8,
+    /// Re-resolve a shard's route and retry once when its backend fails, rather than
+    /// surfacing the error against the address we already had. This is what recovers a
+    /// request whose shard has moved, so it defaults ON; turning it off is for deployments
+    /// that would rather see the failure immediately than pay a metaserver round-trip and a
+    /// second attempt on every backend blip.
+    pub refresh_route_on_backend_error: bool,
 }
 
 impl ClientOptions {
@@ -125,6 +131,7 @@ impl Default for ClientOptions {
             meta_sync_jitter_percent: 20,
             local_location: String::new(),
             drop_percent: 0,
+            refresh_route_on_backend_error: true,
         }
     }
 }
@@ -661,6 +668,12 @@ struct BackendFailureState {
 impl TemporalStoreClient {
     pub fn new(proxy_addr: impl Into<String>) -> Self {
         Self::with_options(ClientOptions::proxy(proxy_addr))
+    }
+
+    /// The options this client is actually running with. Useful for confirming that a
+    /// configured knob was carried through rather than merely accepted.
+    pub fn client_options(&self) -> ClientOptions {
+        self.inner.options.clone()
     }
 
     pub fn with_options(options: ClientOptions) -> Self {

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -35,7 +35,7 @@ impl TemporalStoreClient {
         if self.inner.options.meta_addr.is_some() {
             let server_addr = self.resolve_route(request.shard_id, false, None)?;
             return post_json_with_options(&server_addr, "/batch_execute", &request, http_options)
-                .or_else(|_| {
+                .or_else(|err| {
                     let became_continuous = self.record_backend_failure(
                         &server_addr,
                         self.inner.options.topo_error_retry_interval_ms,
@@ -45,6 +45,9 @@ impl TemporalStoreClient {
                         .lock()
                         .expect("client stats lock poisoned")
                         .record_backend_error(became_continuous);
+                    if !self.inner.options.refresh_route_on_backend_error {
+                        return Err(err.into());
+                    }
                     let refreshed = self.resolve_route(request.shard_id, true, None)?;
                     Ok(post_json_with_options(
                         &refreshed,
@@ -126,7 +129,7 @@ impl TemporalStoreClient {
                 preferred_location,
             )?;
             return post_json_with_options(&server_addr, "/execute", &request, http_options)
-                .or_else(|_| {
+                .or_else(|err| {
                     let became_continuous = self.record_backend_failure(
                         &server_addr,
                         continuous_failed_time_ms
@@ -137,6 +140,9 @@ impl TemporalStoreClient {
                         .lock()
                         .expect("client stats lock poisoned")
                         .record_backend_error(became_continuous);
+                    if !self.inner.options.refresh_route_on_backend_error {
+                        return Err(err.into());
+                    }
                     let refreshed = self.resolve_route_with_policy(
                         request.shard_id,
                         true,
@@ -175,7 +181,7 @@ impl TemporalStoreClient {
             let server_addr =
                 self.resolve_route(request.shard_id, false, continuous_failed_time_ms)?;
             return post_json_with_options(&server_addr, "/batch_execute", &request, http_options)
-                .or_else(|_| {
+                .or_else(|err| {
                     let became_continuous = self.record_backend_failure(
                         &server_addr,
                         continuous_failed_time_ms
@@ -186,6 +192,9 @@ impl TemporalStoreClient {
                         .lock()
                         .expect("client stats lock poisoned")
                         .record_backend_error(became_continuous);
+                    if !self.inner.options.refresh_route_on_backend_error {
+                        return Err(err.into());
+                    }
                     let refreshed =
                         self.resolve_route(request.shard_id, true, continuous_failed_time_ms)?;
                     let response = post_json_with_options(

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1263,6 +1263,12 @@ impl ProxyService {
             .map_err(|rejection| self.reject(rejection.status(), ProxyRejectionKind::Inflight))
     }
 
+    /// The options the proxy actually handed its client, so callers (and tests) can see what
+    /// was carried through rather than what was merely configured.
+    pub fn client_options_snapshot(&self) -> crate::client::ClientOptions {
+        self.client().client_options()
+    }
+
     pub(super) fn inflight_snapshot(&self) -> (u64, u64) {
         self.inner.inflight.snapshot()
     }
@@ -2640,6 +2646,31 @@ mod tests {
         let (code, _) = post(&drained, "/context/ingest", context_ingest_body("acct", "t"));
         assert_eq!(code, 503);
         assert_eq!(drained.preflight_report().stats.context_ingest_requests, 1);
+    }
+    #[test]
+    fn refresh_route_on_backend_error_flag_reaches_the_client() {
+        // The proxy accepted this option, defaulted it, read it from the environment and
+        // folded it into the config hash -- while never passing it to the client, which
+        // refreshed unconditionally. Setting it to false changed nothing and reported
+        // nothing. Pin that it is actually carried now.
+        let on = ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            ..ProxyOptions::default()
+        };
+        assert!(on.refresh_route_on_backend_error, "default stays on");
+
+        let off = ProxyOptions {
+            refresh_route_on_backend_error: false,
+            ..on.clone()
+        };
+        // It already moved the config hash, which is how a rollout notices the change; the
+        // point of this test is the half that was missing.
+        assert_ne!(proxy_config_version(&on), proxy_config_version(&off));
+
+        let proxy_on = ProxyService::new(on);
+        let proxy_off = ProxyService::new(off);
+        assert!(proxy_on.client_options_snapshot().refresh_route_on_backend_error);
+        assert!(!proxy_off.client_options_snapshot().refresh_route_on_backend_error);
     }
     #[test]
     fn proxy_policy_blocks_writes_not_serving_and_drop_percent() {

--- a/crates/temporalstore-rust/src/proxy/config.rs
+++ b/crates/temporalstore-rust/src/proxy/config.rs
@@ -54,6 +54,11 @@ pub(super) fn proxy_client_from_options(options: &ProxyOptions) -> TemporalStore
         route_cache_ttl_ms: options.route_cache_ttl_ms,
         topo_error_retry_interval_ms: options.backend_continuous_failed_time_ms,
         drop_percent: options.drop_percent.min(100),
+        // Previously never passed through: the proxy accepted this option, defaulted it,
+        // read it from TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR and folded it into the config
+        // hash, while the client refreshed unconditionally. Setting it to false changed
+        // nothing and said nothing.
+        refresh_route_on_backend_error: options.refresh_route_on_backend_error,
         ..ClientOptions::default()
     })
 }


### PR DESCRIPTION
Client: honour refresh_route_on_backend_error instead of ignoring it

The proxy has always accepted this option. It is declared on ProxyOptions,
defaults to true, is read from TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR, and is
folded into the config hash so a rollout can watch it change. It was never
passed to the client, and the client refreshed unconditionally -- so an operator
who set it to false got no change in behaviour and no indication that the
setting had been dropped on the floor.

The behaviour it names is real: when a shard's backend fails, the client
re-resolves that shard's route and retries once against the new address. That is
what recovers a request whose shard has moved, which is why it defaults on.
Turning it off is for deployments that would rather see the failure immediately
than pay a metaserver round-trip and a second attempt on every backend blip.

ClientOptions now carries the flag and all three backend-error sites in
client_routing.rs consult it -- batch_execute over the meta path, execute, and
batch_execute with an explicit continuous-failure window. When it is off, the
original transport error surfaces instead of the refresh-and-retry. Failure
recording is unchanged either way: the backend is still marked failed and the
continuous-failure streak still advances, so the health signal does not depend
on this setting.

Default is unchanged, so this is inert for anyone who has not set it; the only
behaviour that changes belongs to someone who explicitly asked for it.

Testing this needed a `client_options()` accessor, because the client's options
were private with no way to observe them -- part of why a dropped option went
unnoticed for so long. The test pins that the flag reaches the client in both
positions, not merely that the proxy accepted it.

Full serial suite: 731 passed, at load average 5 with no other test processes.
The single failure is the storage-manager jitter test, known-failing on main.