### PR TITLE
meta: make retention GC actually collect, and make it stick

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -800,6 +800,11 @@ pub enum MetaMutation {
     PutProxyGroup(PutProxyGroupRequest),
     DropProxyGroup(DropProxyGroupRequest),
     SetProxyGroup(ProxyAttachment),
+    /// One applied retention round. The *outcome* is recorded rather than the
+    /// intent to run a round, because retention is computed from the wall clock
+    /// and re-planning it during replay would purge a different set. Replaying
+    /// the concrete list forgets exactly what the live round forgot.
+    PurgeMeta(MetaRetentionPlan),
     /// Mute or resume metadata change. Recorded like any other mutation so it
     /// replays in order and reaches raft peers; the guard is deliberately not
     /// applied during replay, because the log only ever contains mutations that
@@ -1212,6 +1217,10 @@ impl SingleNodeMeta {
             MetaMutation::DropProxy(request) => {
                 self.apply_set_proxy_state(request, MetaEntityState::Dropped)
                     .status
+            }
+            MetaMutation::PurgeMeta(plan) => {
+                self.apply_meta_purge(&plan);
+                Status::ok()
             }
         }
     }

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -290,6 +290,21 @@ impl SingleNodeMeta {
                 plan,
             };
         }
+        // Recorded before it is applied, so a restart does not resurrect what
+        // this round forgot. Without this the log still holds the register and
+        // drop of every purged resource, replay brings them all back, and the
+        // GC has to forget them again on every boot.
+        self.record_mutation(MetaMutation::PurgeMeta(plan.clone()));
+        self.apply_meta_purge(&plan);
+        MetaRetentionReport {
+            status: Status::ok(),
+            plan,
+        }
+    }
+
+    /// Forget exactly what `plan` names. Takes the plan rather than recomputing
+    /// one so that replay and the live round agree.
+    pub(crate) fn apply_meta_purge(&self, plan: &MetaRetentionPlan) {
         let mut state = self.inner.write().expect("meta lock poisoned");
         for addr in &plan.proxies {
             state.proxies.remove(addr);
@@ -323,10 +338,6 @@ impl SingleNodeMeta {
                 format!("server:{addr}"),
                 "reason=retention",
             );
-        }
-        MetaRetentionReport {
-            status: Status::ok(),
-            plan,
         }
     }
 
@@ -600,6 +611,207 @@ mod tests {
 
     fn aging(options: FreezeAgingOptions) -> FreezeAgingOptions {
         options
+    }
+
+    /// A meta with a mutation log, holding one dropped server, one dropped
+    /// proxy and one dropped table, all with expired tombstones.
+    fn purgeable(log_path: &std::path::Path) -> crate::meta::SingleNodeMeta {
+        use crate::meta::*;
+        let meta = SingleNodeMeta::with_mutation_log(log_path).unwrap();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: String::new(),
+            location: "rack-1".to_string(),
+            config_version: 0,
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        let drop_request = |endpoint: &str| StateChangeRequest {
+            endpoint: endpoint.to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        };
+        assert!(meta.drop_server(drop_request("node-a")).status.ok);
+        assert!(meta.drop_proxy(drop_request("proxy-a")).status.ok);
+        assert!(
+            meta.delete_table(DeleteTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+            })
+            .status
+            .ok
+        );
+        meta
+    }
+
+    fn purge_everything() -> MetaRetentionOptions {
+        MetaRetentionOptions {
+            server_retention_ms: 0,
+            proxy_retention_ms: 0,
+            table_retention_ms: 0,
+            ..MetaRetentionOptions::default()
+        }
+    }
+
+    #[test]
+    fn a_dropped_table_is_eventually_forgotten() {
+        // Dropping a table is the one path that does not go through the shared
+        // state setter, so it was the one path that recorded no drop time. A
+        // table with no drop time is never eligible, which left every dropped
+        // table -- and every shard route under it -- in the state and in every
+        // exported snapshot for the life of the cluster.
+        use crate::meta::*;
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        assert!(
+            meta.delete_table(DeleteTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+            })
+            .status
+            .ok
+        );
+
+        let plan = meta.plan_meta_retention_now(purge_everything());
+        assert_eq!(plan.tables, vec!["ns/orders"]);
+    }
+
+    #[test]
+    fn dropping_a_table_twice_does_not_restart_its_clock() {
+        // The retention clock must measure since the first drop; restarting it
+        // would let a repeated no-op drop keep a table alive indefinitely.
+        use crate::meta::*;
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        let request = DeleteTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+        };
+        assert!(meta.delete_table(request.clone()).status.ok);
+        let first = meta.export_snapshot().dropped_since_ms["table:ns/orders"];
+        // The second drop is refused, and must leave the clock where it was.
+        assert!(!meta.delete_table(request).status.ok);
+        assert_eq!(
+            meta.export_snapshot().dropped_since_ms["table:ns/orders"],
+            first
+        );
+    }
+
+    #[test]
+    fn a_purge_is_not_undone_by_a_restart() {
+        // The log still holds the register and the drop of everything this
+        // round forgets. If the purge itself is not recorded, replay brings all
+        // of it back and the GC has to forget it again on every boot -- so the
+        // state it exists to bound never actually shrinks.
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("purge-mutations.jsonl");
+        {
+            let meta = purgeable(&log_path);
+            let report = meta.purge_expired_meta(purge_everything());
+            assert!(report.status.ok);
+            assert_eq!(report.plan.servers, vec!["node-a"]);
+            assert_eq!(report.plan.proxies, vec!["proxy-a"]);
+            assert_eq!(report.plan.tables, vec!["ns/orders"]);
+            assert!(meta.list_servers().servers.is_empty());
+        }
+
+        let recovered = crate::meta::SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert!(
+            recovered.list_servers().servers.is_empty(),
+            "the purged server came back"
+        );
+        assert!(
+            recovered.list_proxies().proxies.is_empty(),
+            "the purged proxy came back"
+        );
+        assert!(
+            recovered.list_tables().tables.is_empty(),
+            "the purged table came back"
+        );
+    }
+
+    #[test]
+    fn a_replayed_purge_forgets_exactly_what_the_live_round_forgot() {
+        // Retention is computed from the wall clock, so replay must apply the
+        // recorded list rather than re-plan: re-planning at a later `now` would
+        // purge a superset, and at a stricter setting a subset.
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("selective-mutations.jsonl");
+        {
+            let meta = purgeable(&log_path);
+            let report = meta.purge_expired_meta(MetaRetentionOptions {
+                // Only the proxy is old enough to forget this round.
+                server_retention_ms: u64::MAX,
+                table_retention_ms: u64::MAX,
+                proxy_retention_ms: 0,
+                ..MetaRetentionOptions::default()
+            });
+            assert_eq!(report.plan.proxies, vec!["proxy-a"]);
+            assert!(report.plan.servers.is_empty());
+        }
+
+        let recovered = crate::meta::SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert!(recovered.list_proxies().proxies.is_empty());
+        assert_eq!(
+            recovered.list_servers().servers.len(),
+            1,
+            "a server the live round kept must survive replay"
+        );
+        assert_eq!(recovered.list_tables().tables.len(), 1);
+    }
+
+    #[test]
+    fn an_empty_round_records_nothing() {
+        // A GC that ticks every minute must not append a log entry per tick,
+        // or the log grows faster than the state it is bounding.
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("empty-round-mutations.jsonl");
+        let meta = crate::meta::SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        let before = std::fs::read_to_string(&log_path).unwrap_or_default();
+        for _ in 0..5 {
+            assert!(meta.purge_expired_meta(purge_everything()).status.ok);
+        }
+        let after = std::fs::read_to_string(&log_path).unwrap_or_default();
+        assert_eq!(before, after, "an empty retention round wrote to the log");
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -113,6 +113,16 @@ impl SingleNodeMeta {
             .expect("table exists after state check");
         table.info.state = MetaEntityState::Dropped;
         table.info.topology_version = topology_version;
+        // Servers and proxies are dropped through `apply_set_*_state`, which
+        // stamps for them. Tables have their own path, and without the stamp a
+        // dropped table has no drop time -- so retention, which treats a missing
+        // time as "predates this feature, leave alone", never collects one.
+        stamp_dropped_since(
+            &mut state,
+            &dropped_key("table", &key),
+            MetaEntityState::Dropped,
+            now_ms(),
+        );
         AckResponse {
             status: Status::ok(),
         }


### PR DESCRIPTION
Retention GC — the thing that stops meta state growing for the life of the cluster — did not work. Two independent reasons, one commit each.

## 1. A dropped table was never eligible to be forgotten

Servers and proxies are dropped through the shared state setter, which stamps a drop time. Tables have their own path, `apply_delete_table`, and it never stamped one.

Retention deliberately treats a missing drop time as *"this tombstone predates the feature, leave it alone"* — otherwise the first round after an upgrade would purge the entire history. So a table dropped through the only path anyone uses looked exactly like a pre-upgrade tombstone, and **no dropped table was ever collected.** Neither were the shard routes underneath it, which retention only purges along with their table.

One line, next to where the state is set. The stamp keeps the *first* drop time, so a repeated drop cannot restart the clock.

Worth knowing while reading this: `add_table` rejects a key that already exists, dropped included. So until retention actually collects a table, its name stays permanently unusable — dropping and re-creating a table was not possible.

## 2. A purge did not survive a restart

`purge_expired_meta` edited state directly and recorded no mutation.

The log still holds the register and the drop of everything the round forgot, so on the next start replay brought all of it back, tombstone timestamps included. The GC would forget it again, then again on the next boot. The state it exists to bound never actually shrank, and a snapshot exported after a restart carried resources that had already been collected.

The round now records what it applied. The **outcome** is recorded rather than the intent to run a round, because retention is computed from the wall clock — re-planning during replay would forget a different set. `age_frozen_meta` already had this shape, routing its drops through the ordinary recorded setters; this brings purge in line.

An empty round records nothing, which matters when the loop ticks every minute.

## Tests

5 new, in `meta/retention.rs`:

- a dropped table becomes eligible (fails on `main`: the plan comes back empty)
- dropping twice does not restart the clock
- a purge is not undone by a restart (fails on `main`: the server, proxy and table all come back)
- a replayed purge forgets exactly what the live round forgot — a resource the round deliberately kept survives replay
- an empty round writes nothing to the log

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **257 passed, 0 failed.**
- `cargo test -p temporalstore-rust --lib client -- --test-threads=1` and `--bin metaserver` — both green.
- `cargo build -p temporalstore-rust --bin metaserver` — clean.

No new configuration. Retention GC is still off by default (`TS_META_RETENTION_GC`), because forgetting a resource is not reversible — this only means that when it is switched on, it does what it says.
