### PR TITLE
Proxy: stop deep-copying the options on every request

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -797,7 +797,12 @@ pub struct ProxyService {
 
 #[derive(Debug)]
 struct ProxyInner {
-    options: RwLock<ProxyOptions>,
+    /// Behind an `Arc` so reading the live options is a refcount bump rather than a deep
+    /// copy. `ProxyOptions` carries six heap strings, and `options()` is called on the
+    /// request path -- admission reads it for every command and every `/context/*` call --
+    /// so cloning it per request meant six allocations to look at a handful of scalars.
+    /// Writers swap in a whole new `Arc`, so a reader never observes a half-updated config.
+    options: RwLock<Arc<ProxyOptions>>,
     client: RwLock<TemporalStoreClient>,
     last_client_stats: RwLock<ClientStats>,
     stats: RwLock<ProxyStats>,
@@ -811,7 +816,7 @@ impl ProxyService {
         Self {
             inner: Arc::new(ProxyInner {
                 client: RwLock::new(proxy_client_from_options(&options)),
-                options: RwLock::new(options),
+                options: RwLock::new(Arc::new(options)),
                 last_client_stats: RwLock::default(),
                 stats: RwLock::default(),
                 service_discovery: RwLock::default(),
@@ -1022,7 +1027,7 @@ impl ProxyService {
         };
         let current = self.options();
         if !supplied.contains_key("ingestion_account") {
-            options.ingestion_account = current.ingestion_account;
+            options.ingestion_account = current.ingestion_account.clone();
         }
         if !supplied.contains_key("enforce_ingestion_account") {
             options.enforce_ingestion_account = current.enforce_ingestion_account;
@@ -1073,7 +1078,7 @@ impl ProxyService {
             .inner
             .options
             .write()
-            .expect("proxy options lock poisoned") = options;
+            .expect("proxy options lock poisoned") = Arc::new(options);
         report.applied = true;
         report.reason = "config_changed".to_string();
         report
@@ -1135,12 +1140,21 @@ impl ProxyService {
         *last = current;
     }
 
-    fn options(&self) -> ProxyOptions {
-        self.inner
-            .options
-            .read()
-            .expect("proxy options lock poisoned")
-            .clone()
+    /// The live options. Cheap: clones an `Arc`, not the six strings inside it. Callers that
+    /// need to MUTATE take an owned copy explicitly via `options_owned`.
+    fn options(&self) -> Arc<ProxyOptions> {
+        Arc::clone(
+            &self
+                .inner
+                .options
+                .read()
+                .expect("proxy options lock poisoned"),
+        )
+    }
+
+    /// An owned, mutable copy of the live options, for the config-update paths.
+    fn options_owned(&self) -> ProxyOptions {
+        (*self.options()).clone()
     }
 
     fn reject(&self, status: Status, kind: ProxyRejectionKind) -> Status {
@@ -1239,7 +1253,7 @@ impl ProxyService {
     /// Read-only view of the live options, for tests and callers that need to see what the
     /// metaserver has granted this proxy.
     pub fn config_snapshot(&self) -> ProxyOptions {
-        self.options()
+        self.options_owned()
     }
 
     /// Admission for `open_table`: account scope, serving mode, then an in-flight slot. There

--- a/crates/temporalstore-rust/src/proxy/handle.rs
+++ b/crates/temporalstore-rust/src/proxy/handle.rs
@@ -66,7 +66,7 @@ impl ProxyService {
                     .read()
                     .expect("proxy options lock poisoned")
                     .clone();
-                json_response(200, &options)
+                json_response(200, &*options)
             }
             ("POST", "/proxy/config") | ("POST", "/ProxyService/UpdateConfig") => {
                 match parse_json::<ProxyOptions>(&request.body) {

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -189,7 +189,7 @@ impl ProxyService {
         if !response.config_changed && !policy_changed {
             return;
         }
-        let mut options = self.options();
+        let mut options = self.options_owned();
         if !response.namespace.is_empty() {
             options.namespace = response.namespace.clone();
         }
@@ -214,7 +214,7 @@ impl ProxyService {
         if options.namespace.is_empty() && options.config_version == 0 {
             return;
         }
-        let mut cleared = options;
+        let mut cleared = (*options).clone();
         cleared.namespace = String::new();
         cleared.config_version = 0;
         let _ = self.update_options_report(cleared);

--- a/crates/temporalstore-rust/src/proxy/reports.rs
+++ b/crates/temporalstore-rust/src/proxy/reports.rs
@@ -9,7 +9,7 @@ impl ProxyService {
         let options = self.options();
         ProxyInfo {
             status: Status::ok(),
-            meta_addr: options.meta_addr,
+            meta_addr: options.meta_addr.clone(),
             route_cache_size: self.client().route_cache_size(),
             stats: *self.inner.stats.read().expect("proxy stats lock poisoned"),
             boot_time_ms: self.inner.boot_time_ms,
@@ -98,9 +98,9 @@ impl ProxyService {
         let policy = self.policy_report();
         ProxyPreflightReport {
             status,
-            meta_addr: options.meta_addr,
-            proxy_addr: options.proxy_addr,
-            namespace: options.namespace,
+            meta_addr: options.meta_addr.clone(),
+            proxy_addr: options.proxy_addr.clone(),
+            namespace: options.namespace.clone(),
             config_version,
             route_cache_size,
             authoritative_topology_version,
@@ -191,7 +191,7 @@ impl ProxyService {
         let listen_port = proxy_addr_port(&options.proxy_addr);
         ProxyPortsReport {
             listen_addr: options.proxy_addr.clone(),
-            announce_addr: options.proxy_addr,
+            announce_addr: options.proxy_addr.clone(),
             listen_port,
             announce_port: listen_port,
         }
@@ -202,8 +202,8 @@ impl ProxyService {
         ProxyConsulNamesReport {
             legacy_consul_in_scope: false,
             rust_service_registry_names: self.rust_service_registry_names_with_options(&options),
-            namespace: options.namespace,
-            location: options.location,
+            namespace: options.namespace.clone(),
+            location: options.location.clone(),
         }
     }
 


### PR DESCRIPTION
Proxy: stop deep-copying the options on every request

ProxyOptions carries six heap strings, and `options()` cloned all of them on
every call. It is called on the request path -- admission reads it for every
command and for every /context/* call, and open_table reads it too -- so serving
a request meant six allocations just to look at a handful of scalars and an
enum.

It now lives behind an Arc: reading is a refcount bump, and writers swap in a
whole new Arc so a reader never observes a half-updated config. The few callers
that genuinely need an owned, mutable copy -- the config-update paths -- say so
explicitly through `options_owned()`.

Measured on the admission path, 200k admissions, same loop, only this change
differing between the two halves:

    clone per call   67 / 61 / 80 ms
    refcounted       29 / 24 / 25 ms

About 2.6x, which is roughly 0.21 microseconds per request. Worth being plain
that this is sub-microsecond in absolute terms: it removes real allocation
pressure from the hot path, but it is not going to move throughput on its own.

The compiler found the eight places this actually matters: the config write
sites, serializing the live options for GET /proxy/config, and six field moves
out of the Arc in the report builders, which now clone explicitly. That is the
honest cost of the change -- reads got cheaper, and the places that really do
need an owned copy are now visible as such rather than hidden behind a clone
everybody paid for.

Full serial suite: 731 passed, at load average 7 with no other test processes.
The single failure is the storage-manager jitter test, known-failing on main.