### PR TITLE
meta: let an operator stop, and forget, a whole namespace

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1571,6 +1571,17 @@ fn handle(
         ("POST", "/namespaces") => parse_or(&request.body, |req: AddNamespaceRequest| {
             backend_call!(meta, add_namespace, req)
         }),
+        ("POST", "/namespaces/freeze") => parse_or(&request.body, |req: AddNamespaceRequest| {
+            backend_call!(meta, freeze_namespace, req)
+        }),
+        ("POST", "/namespaces/unfreeze") => parse_or(&request.body, |req: AddNamespaceRequest| {
+            backend_call!(meta, unfreeze_namespace, req)
+        }),
+        ("POST", "/namespaces/delete") | ("DELETE", "/namespaces") => {
+            parse_or(&request.body, |req: AddNamespaceRequest| {
+                backend_call!(meta, drop_namespace, req)
+            })
+        }
         ("GET", "/namespaces") => json_response(200, &backend_call!(meta, list_namespaces)),
         ("POST", "/tables") => parse_or(&request.body, |req: AddTableRequest| {
             backend_call!(meta, add_table, req)

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -888,6 +888,8 @@ pub enum MetaMutation {
     /// and re-planning it during replay would purge a different set. Replaying
     /// the concrete list forgets exactly what the live round forgot.
     PurgeMeta(MetaRetentionPlan),
+    /// Freeze, unfreeze or drop a whole namespace.
+    SetNamespaceState(AddNamespaceRequest, MetaEntityState),
     /// Mute or resume metadata change. Recorded like any other mutation so it
     /// replays in order and reaches raft peers; the guard is deliberately not
     /// applied during replay, because the log only ever contains mutations that
@@ -1316,6 +1318,9 @@ impl SingleNodeMeta {
                     .status
             }
             MetaMutation::UpdateServer(request) => self.apply_update_server(request).status,
+            MetaMutation::SetNamespaceState(request, next) => {
+                self.apply_set_namespace_state(request, next).status
+            }
             MetaMutation::SetMetaChangeMuted(muted) => {
                 self.apply_set_meta_change_muted(muted).status
             }
@@ -3892,6 +3897,173 @@ mod tests {
         // The second drop is refused outright, and must leave the clock alone.
         meta.drop_server(drop_of("node-a"));
         assert_eq!(drop_clock(&meta, "server:node-a"), Some(first));
+    }
+
+    /// A namespace with two serving tables on one node.
+    fn namespaced_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string(),
+        });
+        for (index, table_name) in ["orders", "events"].into_iter().enumerate() {
+            meta.add_table(AddTableRequest {
+                namespace: "tenant".to_string(),
+                table_name: table_name.to_string(),
+                first_shard_id: index as ShardId + 1,
+                shard_count: 1,
+                replica_count: 1,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            });
+            meta.register(RegisterShardRequest {
+                shard_id: index as ShardId + 1,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        meta
+    }
+
+    fn namespace(name: &str) -> AddNamespaceRequest {
+        AddNamespaceRequest {
+            namespace: name.to_string(),
+        }
+    }
+
+    fn topology_status(meta: &SingleNodeMeta, table_name: &str) -> Status {
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "tenant".to_string(),
+            table_name: table_name.to_string(),
+            old_topology_version: 0,
+        })
+        .status
+    }
+
+    #[test]
+    fn freezing_a_namespace_stops_every_table_in_it() {
+        // The lever an operator reaches for is the tenant, not the table.
+        let meta = namespaced_meta();
+        assert!(topology_status(&meta, "orders").ok);
+        assert!(topology_status(&meta, "events").ok);
+
+        assert!(meta.freeze_namespace(namespace("tenant")).status.ok);
+        assert_eq!(topology_status(&meta, "orders").code, "resource_frozen");
+        assert_eq!(topology_status(&meta, "events").code, "resource_frozen");
+
+        assert!(meta.unfreeze_namespace(namespace("tenant")).status.ok);
+        assert!(topology_status(&meta, "orders").ok);
+        assert!(topology_status(&meta, "events").ok);
+    }
+
+    #[test]
+    fn a_table_cannot_be_created_into_a_frozen_namespace() {
+        // Otherwise a table created after the freeze serves straight through it,
+        // and the freeze does not mean what it says.
+        let meta = namespaced_meta();
+        assert!(meta.freeze_namespace(namespace("tenant")).status.ok);
+        let response = meta.add_table(AddTableRequest {
+            namespace: "tenant".to_string(),
+            table_name: "late".to_string(),
+            first_shard_id: 9,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        assert_eq!(response.status.code, "resource_frozen");
+    }
+
+    #[test]
+    fn a_namespace_that_still_holds_a_table_is_not_dropped() {
+        // Dropping the namespace out from under a live table would leave the
+        // table addressable by name but unreachable through its namespace.
+        let meta = namespaced_meta();
+        assert_eq!(
+            meta.drop_namespace(namespace("tenant")).status.code,
+            "namespace_not_empty"
+        );
+
+        for table_name in ["orders", "events"] {
+            assert!(
+                meta.delete_table(DeleteTableRequest {
+                    namespace: "tenant".to_string(),
+                    table_name: table_name.to_string(),
+                })
+                .status
+                .ok
+            );
+        }
+        assert!(meta.drop_namespace(namespace("tenant")).status.ok);
+    }
+
+    #[test]
+    fn a_dropped_namespace_can_be_brought_back() {
+        // Dropping is a tombstone, not an erasure, so it stays recoverable up
+        // until retention forgets it.
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(namespace("tenant"));
+        assert!(meta.drop_namespace(namespace("tenant")).status.ok);
+        assert_eq!(
+            meta.list_namespaces().namespaces[0].state,
+            MetaEntityState::Dropped
+        );
+        assert!(meta.unfreeze_namespace(namespace("tenant")).status.ok);
+        assert_eq!(
+            meta.list_namespaces().namespaces[0].state,
+            MetaEntityState::Normal
+        );
+    }
+
+    #[test]
+    fn namespace_state_changes_are_rejected_when_unknown_or_unchanged() {
+        let meta = namespaced_meta();
+        assert_eq!(
+            meta.freeze_namespace(namespace("nope")).status.code,
+            "namespace_not_found"
+        );
+        assert!(meta.freeze_namespace(namespace("tenant")).status.ok);
+        assert_eq!(
+            meta.freeze_namespace(namespace("tenant")).status.code,
+            "not_modified"
+        );
+    }
+
+    #[test]
+    fn a_muted_metaserver_will_not_change_a_namespace() {
+        let meta = namespaced_meta();
+        assert!(meta.set_meta_change_muted(true).status.ok);
+        assert_eq!(
+            meta.freeze_namespace(namespace("tenant")).status.code,
+            "meta_change_muted"
+        );
+    }
+
+    #[test]
+    fn namespace_state_survives_snapshot_and_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("namespace-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            meta.add_namespace(namespace("tenant"));
+            assert!(meta.freeze_namespace(namespace("tenant")).status.ok);
+            let snapshot = meta.export_snapshot();
+            let restored = SingleNodeMeta::default();
+            assert!(restored.install_snapshot(snapshot).status.ok);
+            assert_eq!(
+                restored.list_namespaces().namespaces[0].state,
+                MetaEntityState::Frozen
+            );
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert_eq!(
+            recovered.list_namespaces().namespaces[0].state,
+            MetaEntityState::Frozen
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -3907,6 +3907,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         meta.add_namespace(AddNamespaceRequest {
             namespace: "tenant".to_string(),
@@ -3940,6 +3941,7 @@ mod tests {
             namespace: "tenant".to_string(),
             table_name: table_name.to_string(),
             old_topology_version: 0,
+            client_location: String::new(),
         })
         .status
     }

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -39,6 +39,28 @@ impl SingleNodeMeta {
                 unchanged: false,
             };
         }
+        // A namespace freeze covers every table in it, including tables
+        // created after the freeze -- checking the table alone would let one
+        // slip through.
+        match state.namespaces.get(&request.namespace).copied() {
+            Some(MetaEntityState::Dropped) => {
+                return TableTopologyResponse {
+                    status: Status::error("table_not_found", "namespace is dropped"),
+                    table: Some(table.info.clone()),
+                    shards: Vec::new(),
+                    unchanged: false,
+                };
+            }
+            Some(MetaEntityState::Frozen) => {
+                return TableTopologyResponse {
+                    status: Status::error("resource_frozen", "namespace is frozen"),
+                    table: Some(table.info.clone()),
+                    shards: Vec::new(),
+                    unchanged: false,
+                };
+            }
+            _ => {}
+        }
         if request.old_topology_version >= table.info.topology_version {
             return TableTopologyResponse {
                 status: Status::ok(),

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -408,4 +408,95 @@ impl SingleNodeMeta {
         }
     }
 
+    /// Stop serving everything in a namespace.
+    ///
+    /// The blast radius an operator reaches for is usually a tenant, not one
+    /// table: freezing a namespace table by table takes as many calls as there
+    /// are tables, and races with any table created meanwhile.
+    pub fn freeze_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        self.set_namespace_state(request, MetaEntityState::Frozen)
+    }
+
+    /// Return a namespace to service. Also revives a dropped one, which is what
+    /// makes dropping recoverable up until retention forgets it.
+    pub fn unfreeze_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        self.set_namespace_state(request, MetaEntityState::Normal)
+    }
+
+    /// Tombstone a namespace. Refused while it still holds a table that is not
+    /// itself dropped, so dropping a namespace cannot strand one.
+    pub fn drop_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        self.set_namespace_state(request, MetaEntityState::Dropped)
+    }
+
+    fn set_namespace_state(
+        &self,
+        request: AddNamespaceRequest,
+        next: MetaEntityState,
+    ) -> AckResponse {
+        if let Some(status) = self.meta_change_refusal() {
+            return AckResponse { status };
+        }
+        {
+            let state = self.inner.read().expect("meta lock poisoned");
+            let Some(current) = state.namespaces.get(&request.namespace).copied() else {
+                return AckResponse {
+                    status: Status::error("namespace_not_found", "namespace not found"),
+                };
+            };
+            if current == next {
+                return AckResponse {
+                    status: Status::error("not_modified", "namespace state is unchanged"),
+                };
+            }
+            if next == MetaEntityState::Dropped {
+                let live = state.tables.values().any(|table| {
+                    table.info.namespace == request.namespace
+                        && table.info.state != MetaEntityState::Dropped
+                });
+                if live {
+                    return AckResponse {
+                        status: Status::error(
+                            "namespace_not_empty",
+                            "namespace still holds a table that is not dropped",
+                        ),
+                    };
+                }
+            }
+        }
+        self.record_mutation(MetaMutation::SetNamespaceState(request.clone(), next));
+        self.apply_set_namespace_state(request, next)
+    }
+
+    pub(crate) fn apply_set_namespace_state(
+        &self,
+        request: AddNamespaceRequest,
+        next: MetaEntityState,
+    ) -> AckResponse {
+        let mut state = self.inner.write().expect("meta lock poisoned");
+        let Some(current) = state.namespaces.get_mut(&request.namespace) else {
+            return AckResponse {
+                status: Status::error("namespace_not_found", "namespace not found"),
+            };
+        };
+        *current = next;
+        stamp_dropped_since(
+            &mut state,
+            &dropped_key("namespace", &request.namespace),
+            next,
+            now_ms(),
+        );
+        // Topology is derived on read, so the version bump is what makes clients
+        // notice that a namespace stopped, or resumed, serving.
+        record_topology_event(
+            &mut state,
+            "namespace_state",
+            format!("namespace:{}", request.namespace),
+            format!("state={}", next.as_str()),
+        );
+        AckResponse {
+            status: Status::ok(),
+        }
+    }
+
 }

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -32,6 +32,21 @@ impl SingleNodeMeta {
         }
         let mut state = self.inner.write().expect("meta lock poisoned");
         self.counters.table_create_total.fetch_add(1, Ordering::Relaxed);
+        // Creating a table into a namespace that is not serving would reopen
+        // exactly the hole a namespace freeze exists to close.
+        match state.namespaces.get(&request.namespace).copied() {
+            Some(MetaEntityState::Frozen) => {
+                return AckResponse {
+                    status: Status::error("resource_frozen", "namespace is frozen"),
+                };
+            }
+            Some(MetaEntityState::Dropped) => {
+                return AckResponse {
+                    status: Status::error("namespace_not_found", "namespace is dropped"),
+                };
+            }
+            _ => {}
+        }
         state
             .namespaces
             .entry(request.namespace.clone())

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -204,6 +204,33 @@ impl MetaRaftCluster {
         }
     }
 
+    pub fn freeze_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetNamespaceState(
+                request,
+                MetaEntityState::Frozen,
+            )),
+        }
+    }
+
+    pub fn unfreeze_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetNamespaceState(
+                request,
+                MetaEntityState::Normal,
+            )),
+        }
+    }
+
+    pub fn drop_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
+        AckResponse {
+            status: self.mutation_status(MetaMutation::SetNamespaceState(
+                request,
+                MetaEntityState::Dropped,
+            )),
+        }
+    }
+
     pub fn freeze_server(&self, request: StateChangeRequest) -> AckResponse {
         AckResponse {
             status: self.mutation_status(MetaMutation::FreezeServer(request)),


### PR DESCRIPTION
## A namespace has a state, and nothing ever reads it

`MetaEntityState` on a namespace is set to `Normal` when the namespace is created, carried through every snapshot, and reported by `GET /namespaces`. Nothing consults it. There is no call that changes it.

Two consequences:

**There is no tenant-level lever.** You can freeze one shard, one table, one server, one proxy. The unit an operator actually reaches for during an incident — *stop everything for this customer* — takes one call per table, and races with any table created while you are working through the list.

**A namespace is permanent.** Once created, including implicitly by `add_table`, it is in the meta state for the life of the cluster. Retention collects servers, proxies and tables; namespaces have nothing to collect them by.

## What this adds

`freeze_namespace`, `unfreeze_namespace`, `drop_namespace`, and `POST /namespaces/freeze`, `/namespaces/unfreeze`, `/namespaces/delete`. No new wire type — a namespace state change carries the same body as creating one.

## The part that matters: the freeze has to actually hold

A lever nothing respects is worse than no lever, so:

- **Topology** returns `resource_frozen` for every table in a frozen namespace, and `table_not_found` for a dropped one — checked against the namespace, not the tables, so a table created after the freeze is covered too.
- **`add_table` is refused** into a frozen or dropped namespace. Without this, a table created a second after the freeze serves straight through it.
- **`drop_namespace` is refused** while the namespace still holds a table that is not itself dropped (`namespace_not_empty`). Dropping the namespace out from under a live table would leave that table addressable by name but unreachable through its namespace.
- **The mute guard applies**, like every other recorded change.

Dropping is a tombstone, not an erasure: `unfreeze_namespace` revives a dropped namespace, so the drop stays recoverable up until retention forgets it. The drop is stamped into `dropped_since_ms` under a `namespace:` key, which is what a later retention round will age against — collecting dropped namespaces is a separate change, so this one does not touch retention.

Recorded as a mutation, so it replays and reaches raft peers; the raft backend gets the three matching operations.

## Tests

7 new: freezing a namespace stopping both its tables and unfreezing restoring them, a table refused into a frozen namespace, drop refused while a table is live and permitted once they are all dropped, a dropped namespace coming back, the unknown/unchanged rejections, the mute guard, and state surviving both a snapshot round trip and mutation-log replay.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **259 passed, 0 failed.**
- `--bin metaserver`, `--bin matrixark_rust_proxy`, `--lib client` — all green.
- `cargo build -p temporalstore-rust --bin metaserver` — clean.

No gate and no new configuration: namespaces are created `Normal` and stay that way until someone asks otherwise.
