### PR TITLE
meta: stop routing a shard to a server that is out of service

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2459,6 +2459,142 @@ mod tests {
         assert!(restored.is_meta_change_muted());
     }
 
+    /// One table, one shard, registered to node-a, with node-b also live.
+    fn owned_shard_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        for (addr, node_id, location) in [("node-a", 1, "rack-1"), ("node-b", 2, "rack-2")] {
+            meta.register_server(RegisterServerRequest {
+                server_addr: addr.to_string(),
+                node_id,
+                location: location.to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: "node-a".to_string(),
+        });
+        meta
+    }
+
+    fn routed_shard(meta: &SingleNodeMeta) -> TableShard {
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+        })
+        .shards
+        .into_iter()
+        .next()
+        .expect("one shard")
+    }
+
+    fn state_change(endpoint: &str) -> StateChangeRequest {
+        StateChangeRequest {
+            endpoint: endpoint.to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        }
+    }
+
+    #[test]
+    fn a_shard_is_not_routed_to_a_frozen_owner() {
+        // Placement already refuses to pick a server that is not Normal. The
+        // recorded owner is the one entry that reaches the topology without
+        // passing that filter, so freezing a server left every shard it owns
+        // pointing straight at it.
+        let meta = owned_shard_meta();
+        assert_eq!(routed_shard(&meta).primary, Some("node-a".to_string()));
+
+        assert!(meta.freeze_server(state_change("node-a")).status.ok);
+        let shard = routed_shard(&meta);
+        assert_eq!(shard.primary, None, "a frozen server is still being routed to");
+        assert!(
+            !shard.replicas.contains(&"node-a".to_string()),
+            "a frozen server is still listed as a replica"
+        );
+    }
+
+    #[test]
+    fn a_shard_is_not_routed_to_a_dropped_owner() {
+        // A dropped server is not coming back, so naming it is simply false.
+        let meta = owned_shard_meta();
+        assert!(meta.drop_server(state_change("node-a")).status.ok);
+        assert_eq!(routed_shard(&meta).primary, None);
+    }
+
+    #[test]
+    fn unfreezing_the_owner_puts_the_shard_back() {
+        let meta = owned_shard_meta();
+        assert!(meta.freeze_server(state_change("node-a")).status.ok);
+        assert_eq!(routed_shard(&meta).primary, None);
+        assert!(meta.unfreeze_server(state_change("node-a")).status.ok);
+        assert_eq!(routed_shard(&meta).primary, Some("node-a".to_string()));
+    }
+
+    #[test]
+    fn a_stale_route_does_not_get_a_stand_in_primary() {
+        // The candidate scan would happily nominate node-b, which has never
+        // loaded this shard: a client that followed the nomination would read
+        // an empty shard and believe it.
+        let meta = owned_shard_meta();
+        assert!(meta.freeze_server(state_change("node-a")).status.ok);
+        let shard = routed_shard(&meta);
+        assert_ne!(shard.primary, Some("node-b".to_string()));
+        assert_eq!(shard.primary, None);
+    }
+
+    #[test]
+    fn a_shard_with_no_owner_yet_still_gets_a_proposed_placement() {
+        // Guards the other direction: a table that nothing has registered
+        // against must still be told where its shards should go.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        assert_eq!(routed_shard(&meta).primary, Some("node-a".to_string()));
+    }
+
+    #[test]
+    fn a_route_naming_a_server_the_metaserver_has_never_heard_of_is_kept() {
+        // A route can outlive the server record it names. Treating an unknown
+        // address as out of service would unroute shards the metaserver has
+        // simply not been told about yet.
+        let meta = owned_shard_meta();
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: "node-ghost".to_string(),
+        });
+        assert_eq!(routed_shard(&meta).primary, Some("node-ghost".to_string()));
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -6,6 +6,19 @@
 use super::*;
 use std::collections::BTreeSet;
 
+/// Whether the server a shard is registered to is in service.
+///
+/// An unknown address counts as serving: a route can outlive the server record
+/// it names, and treating that as out of service would silently unroute shards
+/// the metaserver simply has not heard about yet.
+fn owner_is_serving(state: &MetaState, server_addr: &str) -> bool {
+    state
+        .servers
+        .get(server_addr)
+        .map(|server| server.state == MetaEntityState::Normal)
+        .unwrap_or(true)
+}
+
 pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<TableShard> {
     #[derive(Debug)]
     struct PlacementCandidate {
@@ -100,7 +113,15 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
         let mut used_locations = BTreeSet::new();
         let mut used_hosts = BTreeSet::new();
         let mut placed_locations: Vec<Location> = Vec::new();
-        if let Some(location) = state.shards.get(&shard_id) {
+        // The owner is the one entry that reaches the replica list without
+        // passing the Normal filter the candidate scan applies. A server that
+        // was frozen or dropped is not serving, so naming it is telling a client
+        // to read from somewhere that is deliberately out of service.
+        let owner = state
+            .shards
+            .get(&shard_id)
+            .filter(|location| owner_is_serving(state, &location.server_addr));
+        if let Some(location) = owner {
             if let Some(server) = state.servers.get(&location.server_addr) {
                 placed_locations.push(Location::parse(&server.location));
             }
@@ -163,11 +184,18 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
                 &candidate.server_addr,
             );
         }
-        let primary = state
-            .shards
-            .get(&shard_id)
-            .map(|location| location.server_addr.clone())
-            .or_else(|| replicas.first().cloned());
+        let primary = match state.shards.get(&shard_id) {
+            // A recorded owner that is not serving leaves the shard with no
+            // primary. Falling through to the candidate scan would nominate a
+            // server that never loaded this shard, and a client that followed
+            // the nomination would read an empty shard and believe it.
+            Some(location) => {
+                owner_is_serving(state, &location.server_addr).then(|| location.server_addr.clone())
+            }
+            // No owner recorded yet: propose a placement, which is how a new
+            // table gets one before anything registers.
+            None => replicas.first().cloned(),
+        };
         let primary_endpoint = primary
             .as_ref()
             .map(|server_addr| server_endpoint(state, server_addr));


### PR DESCRIPTION
## Freezing a server did not stop clients being sent to it

`build_shards` builds its placement candidates from servers whose state is `Normal`. The **recorded owner** of a shard is the one entry that reaches the topology without passing that filter — it is pushed straight in as a replica, and taken verbatim as the primary.

So for every shard a server owns, freezing or dropping that server changed nothing about where clients were told to read. The lever exists, the metaserver reports the server as frozen, and the routing table keeps pointing at it.

The dropped case is the plainer one: a dropped server is not coming back, and naming it is simply false. The rest of the metaserver already agrees — `finish_load` rejects a frozen server, placement skips it, the divergence check treats only `Normal` servers as live, and retention refuses to forget a dropped server that still owns a shard *because "the route names it, so forgetting the server strands the route"*. Every one of those paths knows a route to a non-serving server is a problem. The routing table itself did not.

## The fix, and the two edges it has to not break

A shard whose owner is not serving is reported with **no primary and no replica entry for that server**.

**It does not fall through to another candidate.** The old code ended in `.or_else(|| replicas.first().cloned())`, and letting a stale route land there would nominate a server that has never loaded this shard. A client that followed the nomination would read an empty shard and believe it. No primary is the honest answer: the shard exists, and nothing is currently serving it.

Two cases must keep working, and both are pinned by tests:

- **A shard with no owner recorded yet** still gets a proposed placement. That is how a new table is told where its shards should go, and it is a different situation from a route that names someone specific.
- **A route naming a server the metaserver has no record of** is kept. A route can outlive the server record it names, and treating unknown as out-of-service would silently unroute shards the metaserver has simply not been told about yet.

## Tests

6 new. Four of them fail on `main` exactly as you would expect:

```
test a_shard_is_not_routed_to_a_dropped_owner   ... FAILED
test a_shard_is_not_routed_to_a_frozen_owner    ... FAILED
test a_stale_route_does_not_get_a_stand_in_primary ... FAILED
test unfreezing_the_owner_puts_the_shard_back   ... FAILED
```

The other two — proposed placement for an unowned shard, and an unknown owner being kept — pass before and after; they are there to hold the edges down.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **258 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

## What this is not

This does not move the shard. Getting it served again is rebalance's job, or an operator's. This only stops the metaserver naming a server it has itself marked out of service.

The full `--lib` run is 997 passed / 4 failed; those four (`raft::tests::part1::raft_rejects_electing_stale_replica_until_it_catches_up`, `request_vote_higher_term_resets_prior_vote_before_decision`, `engine::tests::part3::recovery_validates_all_timestamped_kv_page_families`, `data_node::tests::part3::storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`) fail identically on a branch that touches none of those areas, so they are not from this change.
