### PR TITLE
meta: a resource that comes back gets a fresh drop clock

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -3807,6 +3807,7 @@ mod tests {
                 node_id: 1,
                 location: "rack-1".to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             })
         };
         register();
@@ -3852,6 +3853,7 @@ mod tests {
                 node_id: 1,
                 location: "rack-1".to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             })
         };
         register();
@@ -3883,6 +3885,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         assert!(meta.drop_server(drop_of("node-a")).status.ok);
         let first = drop_clock(&meta, "server:node-a").expect("stamped");

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -3781,6 +3781,116 @@ mod tests {
         assert_eq!(topology.shards[0].replicas.len(), 2);
     }
 
+    fn drop_of(endpoint: &str) -> StateChangeRequest {
+        StateChangeRequest {
+            endpoint: endpoint.to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        }
+    }
+
+    fn drop_clock(meta: &SingleNodeMeta, key: &str) -> Option<u64> {
+        meta.export_snapshot().dropped_since_ms.get(key).copied()
+    }
+
+    #[test]
+    fn a_server_that_comes_back_starts_a_fresh_drop_clock() {
+        // stamp_dropped_since keeps the first time it is given, deliberately, so
+        // that re-dropping an already dropped resource cannot restart the clock.
+        // That is right for drop-then-drop and wrong across a revival: a server
+        // dropped, brought back, and dropped again much later would inherit the
+        // original time and be collected on the next round with no grace at all.
+        let meta = SingleNodeMeta::default();
+        let register = || {
+            meta.register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+        };
+        register();
+        assert!(meta.drop_server(drop_of("node-a")).status.ok);
+        assert!(drop_clock(&meta, "server:node-a").is_some());
+
+        register();
+        assert_eq!(
+            drop_clock(&meta, "server:node-a"),
+            None,
+            "the drop clock outlived the drop"
+        );
+    }
+
+    #[test]
+    fn a_proxy_that_comes_back_starts_a_fresh_drop_clock() {
+        let meta = SingleNodeMeta::default();
+        let register = || {
+            meta.register_proxy(RegisterProxyRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: String::new(),
+                location: "rack-1".to_string(),
+                config_version: 0,
+                binary_version: "v1".to_string(),
+            })
+        };
+        register();
+        assert!(meta.drop_proxy(drop_of("proxy-a")).status.ok);
+        assert!(drop_clock(&meta, "proxy:proxy-a").is_some());
+
+        register();
+        assert_eq!(drop_clock(&meta, "proxy:proxy-a"), None);
+    }
+
+    #[test]
+    fn a_revived_server_dropped_again_is_not_collected_immediately() {
+        // The whole point of the clock: a resource dropped a moment ago is
+        // inside its retention window and must be kept.
+        let meta = SingleNodeMeta::default();
+        let register = || {
+            meta.register_server(RegisterServerRequest {
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+        };
+        register();
+        assert!(meta.drop_server(drop_of("node-a")).status.ok);
+        register();
+        assert!(meta.drop_server(drop_of("node-a")).status.ok);
+
+        let plan = meta.plan_meta_retention_now(MetaRetentionOptions {
+            // An hour of grace. The second drop just happened, so nothing is
+            // eligible -- unless it is still being aged from the first one.
+            server_retention_ms: 60 * 60 * 1_000,
+            proxy_retention_ms: 60 * 60 * 1_000,
+            table_retention_ms: 60 * 60 * 1_000,
+            ..MetaRetentionOptions::default()
+        });
+        assert!(
+            plan.servers.is_empty(),
+            "a server dropped a moment ago was already eligible: {plan:?}"
+        );
+    }
+
+    #[test]
+    fn re_dropping_without_a_revival_still_keeps_the_first_clock() {
+        // The other direction, which the change must not break: repeatedly
+        // dropping an already dropped server cannot hold off collection.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        assert!(meta.drop_server(drop_of("node-a")).status.ok);
+        let first = drop_clock(&meta, "server:node-a").expect("stamped");
+        // The second drop is refused outright, and must leave the clock alone.
+        meta.drop_server(drop_of("node-a"));
+        assert_eq!(drop_clock(&meta, "server:node-a"), Some(first));
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -76,6 +76,18 @@ impl SingleNodeMeta {
                 shard_states: Vec::new(),
             },
         );
+        // Coming back clears the drop clock. Without this the tombstone
+        // outlives the drop it recorded: `stamp_dropped_since` keeps the first
+        // time it is given, deliberately, so that re-dropping an already
+        // dropped resource cannot restart the clock -- and a resource dropped,
+        // revived, and dropped again months later would inherit the original
+        // time and be collected on the next round with no grace at all.
+        stamp_dropped_since(
+            &mut state,
+            &dropped_key("server", &server_addr),
+            MetaEntityState::Normal,
+            now,
+        );
         record_topology_event(
             &mut state,
             "register_server",
@@ -238,6 +250,7 @@ impl SingleNodeMeta {
     pub(super) fn apply_register_proxy(&self, request: RegisterProxyRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
         self.counters.proxy_register_total.fetch_add(1, Ordering::Relaxed);
+        let proxy_addr = request.proxy_addr.clone();
         if let Some(existing) = state.proxies.get(&request.proxy_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -278,6 +291,18 @@ impl SingleNodeMeta {
                 boot_time_ms: 0,
                 restart_count: 0,
             },
+        );
+        // Coming back clears the drop clock. Without this the tombstone
+        // outlives the drop it recorded: `stamp_dropped_since` keeps the first
+        // time it is given, deliberately, so that re-dropping an already
+        // dropped resource cannot restart the clock -- and a resource dropped,
+        // revived, and dropped again months later would inherit the original
+        // time and be collected on the next round with no grace at all.
+        stamp_dropped_since(
+            &mut state,
+            &dropped_key("proxy", &proxy_addr),
+            MetaEntityState::Normal,
+            now_ms(),
         );
         AckResponse {
             status: Status::ok(),

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -1364,6 +1364,16 @@ mod tests {
         });
         assert!(report.plan.is_empty());
         assert_eq!(meta.list_servers().servers.len(), 1);
+        // Not collected while serving is guaranteed by the candidate filter on
+        // its own. What actually has to be true is that the clock is gone, so
+        // the next drop starts a fresh one.
+        assert!(
+            !meta
+                .export_snapshot()
+                .dropped_since_ms
+                .contains_key("server:node-a"),
+            "the drop clock outlived the drop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## A resource that comes back keeps the clock from the last time it left

`stamp_dropped_since` keeps the **first** time it is given:

```rust
// Keep the first drop time: re-dropping an already dropped resource
// must not restart its retention clock.
state.dropped_since_ms.entry(key.to_string()).or_insert(now_ms);
```

That is right for drop-then-drop. It is wrong across a revival, and re-registration never cleared the entry — so the tombstone outlived the drop it recorded.

The consequence shows up on the *second* drop, which is where nobody looks:

1. `node-a` is dropped in January. Clock stamped.
2. `node-a` comes back an hour later and serves for six months.
3. `node-a` is dropped again in July.
4. Retention reads the January stamp, computes an age of six months, and collects it **on the next round** — with none of the grace the retention window exists to give.

The grace period is what lets a node that comes back keep its identity. Here it was already spent.

## The fix

Re-registering a server or a proxy clears its drop clock, so the next drop starts a fresh one. Four lines across the two registration paths.

The other direction still holds and is pinned by its own test: repeatedly dropping an *already dropped* server cannot hold off collection.

## A test that did not test its own name

`a_resource_that_comes_back_loses_its_tombstone_clock` asserted only that the revived server was not collected. That was already guaranteed by the candidate filter, which requires state `Dropped` — the assertion passed with the clock untouched. It now checks the clock, which is what its name claims.

## Tests

4 new plus that strengthened one. Two of the new ones fail on `main`:

```
test a_server_that_comes_back_starts_a_fresh_drop_clock ... FAILED
test a_proxy_that_comes_back_starts_a_fresh_drop_clock  ... FAILED
```

The other two are the consequence (a revived server dropped again is not immediately eligible) and the guard (re-dropping without a revival still keeps the first clock).

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **256 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

Retention GC is off by default, so this changes nothing until it is switched on. It is worth fixing anyway: the wrong value is being recorded now, and it is recorded into snapshots that outlive the setting.
