### PR TITLE
Proxy: let its configured location actually pick replicas

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -2687,6 +2687,36 @@ mod tests {
         assert!(!proxy_off.client_options_snapshot().refresh_route_on_backend_error);
     }
     #[test]
+    fn proxy_location_reaches_replica_selection() {
+        // The proxy has always accepted a location, reported it to the metaserver and shown
+        // it in its own status -- but never handed it to the client, whose `local_location`
+        // is the fallback used when a table does not name a preferred_location, and which is
+        // what actually picks a replica. So a proxy told it lives in zone-a read cross-zone.
+        let located = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            location: "zone-a".to_string(),
+            ..ProxyOptions::default()
+        });
+        assert_eq!(located.client_options_snapshot().local_location, "zone-a");
+
+        // An unset location stays unset rather than inventing a preference.
+        let unlocated = ProxyService::new(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            ..ProxyOptions::default()
+        });
+        assert!(unlocated.client_options_snapshot().local_location.is_empty());
+
+        // A config push that changes the location has to reach the client too, otherwise the
+        // proxy would report one location and route by another.
+        let _ = located.update_options_report(ProxyOptions {
+            meta_addr: "127.0.0.1:1".to_string(),
+            location: "zone-b".to_string(),
+            config_version: 99,
+            ..ProxyOptions::default()
+        });
+        assert_eq!(located.client_options_snapshot().local_location, "zone-b");
+    }
+    #[test]
     fn proxy_policy_blocks_writes_not_serving_and_drop_percent() {
         let readonly = ProxyService::new(ProxyOptions {
             meta_addr: "127.0.0.1:1".to_string(),

--- a/crates/temporalstore-rust/src/proxy/config.rs
+++ b/crates/temporalstore-rust/src/proxy/config.rs
@@ -59,6 +59,12 @@ pub(super) fn proxy_client_from_options(options: &ProxyOptions) -> TemporalStore
         // hash, while the client refreshed unconditionally. Setting it to false changed
         // nothing and said nothing.
         refresh_route_on_backend_error: options.refresh_route_on_backend_error,
+        // Where this proxy is. The client falls back to it when a table does not name its
+        // own `preferred_location`, and that value is what `choose_cached_route` uses to
+        // pick a replica -- so without it a proxy configured with a location got no locality
+        // preference at all and read cross-zone. The proxy already reported this location to
+        // the metaserver and in its own status; it just never reached the thing that routes.
+        local_location: options.location.clone(),
         ..ClientOptions::default()
     })
 }


### PR DESCRIPTION
The proxy has always accepted a location. It reads TS_PROXY_LOCATION, reports
it when registering, sends it in heartbeats and shows it in its own status
reports -- and never handed it to the client that does the routing.

The client falls back to `local_location` whenever a table does not name its own
`preferred_location`, and that value is what `choose_cached_route` uses to pick
a replica. `proxy_client_from_options` never set it, so it was always empty for
proxy-routed traffic. An operator who set TS_PROXY_LOCATION=zone-a to keep reads
local got no locality preference at all for any table that did not carry its own
preferred_location, and read cross-zone while every status surface cheerfully
reported the proxy as living in zone-a.

Now passed through. A table that names its own preferred_location still wins --
this only supplies the fallback, which is the case that was silently empty.

Three things the test pins: a configured location reaches the client, an unset
one stays unset rather than inventing a preference, and a config push that
changes the location reaches the client too -- otherwise a proxy would report
one location and route by another, which is worse than not having the setting.

This is the second option found this way. `refresh_route_on_backend_error` had
the same shape: accepted, defaulted, environment-readable, in the config hash,
and never delivered to the component that would act on it. After both, a sweep
of every remaining ProxyOptions field found a real consumer for each. Two that
looked suspicious and are fine: `max_retries` drives transport-level retries in
HttpRequestOptions while max_read_retries/max_write_retries drive the
command-level budget from TableOptions -- different layers, both live.

Full serial suite (--test-threads=1): 732 passed, 1 failed. The one failure is
the known jitter-backoff test, which fails the same way on main.