### PR TITLE
meta: pin a table's shard count once its shards are registered

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4077,6 +4077,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         meta.add_namespace(AddNamespaceRequest {
             namespace: "ns".to_string(),
@@ -4104,6 +4105,7 @@ mod tests {
             namespace: "ns".to_string(),
             table_name: "orders".to_string(),
             old_topology_version: 0,
+            client_location: String::new(),
         })
         .shards
         .into_iter()

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4068,6 +4068,159 @@ mod tests {
         );
     }
 
+    /// A two-shard table whose shards are both registered to a live server --
+    /// that is, a table that is holding data.
+    fn live_two_shard_table() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 100,
+            shard_count: 2,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        for shard_id in [100, 101] {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        meta
+    }
+
+    fn bucket_ranges(meta: &SingleNodeMeta) -> Vec<(ShardId, u64, u64)> {
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+        })
+        .shards
+        .into_iter()
+        .map(|shard| (shard.shard_id, shard.start_bucket, shard.end_bucket))
+        .collect()
+    }
+
+    fn grow_to(meta: &SingleNodeMeta, shard_count: u64) -> Status {
+        meta.update_table(UpdateTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            shard_count: Some(shard_count),
+            replica_count: None,
+            first_shard_id: None,
+            partition_version: None,
+            serving_options: None,
+        })
+        .status
+    }
+
+    #[test]
+    fn a_registered_shards_key_range_never_moves() {
+        // Bucket ranges are derived from shard_count on every read, so raising
+        // it renumbers the whole key space. Nothing rehashes: the data for the
+        // buckets that moved is still sitting on the old shard, while the
+        // routing table now sends those keys to a shard that has never seen
+        // them, and the reads come back as misses rather than errors.
+        let meta = live_two_shard_table();
+        let before = bucket_ranges(&meta);
+        assert_eq!(before.len(), 2);
+
+        grow_to(&meta, 4);
+
+        let after = bucket_ranges(&meta);
+        let (_, start, end) = before[0];
+        let moved = after
+            .iter()
+            .find(|(shard_id, _, _)| *shard_id == before[0].0)
+            .map(|(_, new_start, new_end)| (*new_start, *new_end));
+        assert_eq!(
+            moved,
+            Some((start, end)),
+            "shard {} owned buckets {start}..={end} and now owns {moved:?}",
+            before[0].0
+        );
+    }
+
+    #[test]
+    fn a_key_does_not_change_shard_underneath_the_data() {
+        // The same defect stated as the client sees it: pick a bucket the first
+        // shard owns, and check it still resolves to that shard afterwards.
+        let meta = live_two_shard_table();
+        let before = bucket_ranges(&meta);
+        let probe = before[0].2; // the last bucket of the first shard
+        let owner_of = |ranges: &[(ShardId, u64, u64)], bucket: u64| {
+            ranges
+                .iter()
+                .find(|(_, start, end)| bucket >= *start && bucket <= *end)
+                .map(|(shard_id, _, _)| *shard_id)
+        };
+        assert_eq!(owner_of(&before, probe), Some(before[0].0));
+
+        grow_to(&meta, 4);
+
+        assert_eq!(
+            owner_of(&bucket_ranges(&meta), probe),
+            Some(before[0].0),
+            "bucket {probe} was rehomed to a shard that has never held it"
+        );
+    }
+
+    #[test]
+    fn growing_a_table_that_already_owns_shards_is_refused() {
+        let meta = live_two_shard_table();
+        assert_eq!(grow_to(&meta, 4).code, "shards_registered");
+        assert_eq!(meta.list_tables().tables[0].shard_count, 2);
+    }
+
+    #[test]
+    fn growing_a_table_before_anything_registers_is_still_allowed() {
+        // The legitimate case, and the one the existing suite covers: correcting
+        // the shard count of a table that is not yet holding anything.
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 100,
+            shard_count: 2,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        assert!(grow_to(&meta, 4).ok);
+        assert_eq!(meta.list_tables().tables[0].shard_count, 4);
+    }
+
+    #[test]
+    fn a_registered_table_can_still_change_its_other_options() {
+        // The refusal is about shard_count alone: replica count and serving
+        // options do not move any key.
+        let meta = live_two_shard_table();
+        let response = meta.update_table(UpdateTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            shard_count: None,
+            replica_count: Some(2),
+            first_shard_id: None,
+            partition_version: None,
+            serving_options: None,
+        });
+        assert!(response.status.ok, "{response:?}");
+        assert_eq!(meta.list_tables().tables[0].replica_count, 2);
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
@@ -5322,10 +5475,6 @@ mod tests {
             location: "zone-a".to_string(),
             binary_version: "v1".to_string(),
         });
-        meta.register(RegisterShardRequest {
-            shard_id: 10,
-            server_addr: "server-a".to_string(),
-        });
         meta.register_proxy(RegisterProxyRequest {
             proxy_addr: "proxy-a".to_string(),
             namespace: "ns".to_string(),
@@ -5362,6 +5511,14 @@ mod tests {
             .status
             .ok
         );
+        // Registered after the table is sized, because shard_count is pinned
+        // once a shard is registered against it. Where this sits is incidental
+        // to what this test checks: the mutation count and the recovered state
+        // are the same either way.
+        meta.register(RegisterShardRequest {
+            shard_id: 10,
+            server_addr: "server-a".to_string(),
+        });
         assert!(
             meta.add_table(AddTableRequest {
                 namespace: "ns".to_string(),

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -212,6 +212,27 @@ impl SingleNodeMeta {
                     status: Status::error("bad_request", "shard_count cannot shrink"),
                 };
             }
+            // Bucket ranges are derived from shard_count on every read, so
+            // raising it renumbers the whole key space -- and nothing rehashes.
+            // The data for the buckets that moved is still on the old shard,
+            // while the routing table now sends those keys to a shard that has
+            // never seen them, so the reads come back as misses rather than as
+            // errors. partition_version and first_shard_id are already pinned
+            // after creation for the same reason; this is the third knob that
+            // moves keys.
+            //
+            // Growth before anything registers is the legitimate case -- fixing
+            // the shard count of a table that is not yet holding anything -- and
+            // stays allowed.
+            if shard_count != existing.shard_count && table_owns_registered_shards(&state, &existing)
+            {
+                return AckResponse {
+                    status: Status::error(
+                        "shards_registered",
+                        "shard_count cannot change once the table's shards are registered:                          the key range of every existing shard would move, and nothing                          redistributes the data that moved with it",
+                    ),
+                };
+            }
         }
         if let Some(partition_version) = request.partition_version {
             if partition_version != existing.partition_version {
@@ -275,4 +296,14 @@ impl SingleNodeMeta {
             status: Status::ok(),
         }
     }
+}
+
+/// Whether any of a table's shards has been registered to a server, which is
+/// the metaserver's evidence that the table is holding data.
+fn table_owns_registered_shards(state: &MetaState, table: &TableMetaInfo) -> bool {
+    (0..table.shard_count).any(|offset| {
+        table_shard_id(table, offset)
+            .map(|shard_id| state.shards.contains_key(&shard_id))
+            .unwrap_or(false)
+    })
 }

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -537,10 +537,13 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
     assert_eq!(topology.shards.len(), 2);
     assert_eq!(topology.shards[0].primary.as_deref(), Some("server-a"));
 
+    // A replica-count change, because shard_count is pinned once a shard is
+    // registered against the table -- and this test is about UpdateTable
+    // reaching every peer, which either change demonstrates.
     let updated = meta.update_table(UpdateTableRequest {
         namespace: "feature".to_string(),
         table_name: "user_seq".to_string(),
-        shard_count: Some(3),
+        shard_count: None,
         replica_count: Some(2),
         first_shard_id: None,
         partition_version: None,
@@ -558,9 +561,9 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
     });
     assert!(updated_topology.status.ok, "{updated_topology:?}");
     let updated_table = updated_topology.table.unwrap();
-    assert_eq!(updated_table.shard_count, 3);
+    assert_eq!(updated_table.shard_count, 2);
     assert_eq!(updated_table.replica_count, 2);
-    assert_eq!(updated_topology.shards.len(), 3);
+    assert_eq!(updated_topology.shards.len(), 2);
 
     let duplicate = meta.add_table(AddTableRequest {
         namespace: "feature".to_string(),


### PR DESCRIPTION
## Raising a table's shard count silently moves data out of reach

Bucket ranges are not stored. `build_shards` derives them from `shard_count` on every read:

```rust
let start_bucket = bucket_count * offset / table.shard_count;
let end_bucket = (bucket_count * (offset + 1) / table.shard_count).saturating_sub(1);
```

So raising `shard_count` renumbers the entire key space — and **nothing rehashes**. There is no split, repartition or redistribute anywhere in the tree; `shard_id` is just `first_shard_id + offset`.

The data for the buckets that moved is still sitting on the old shard. The routing table now sends those keys to a shard that has never seen them. The reads come back as **misses, not errors**.

Two tests print exactly what happens on a two-shard table grown to four:

```
shard 100 owned buckets 0..=536870911 and now owns Some((0, 268435455))
bucket 536870911 was rehomed to a shard that has never held it
```

Half of shard 100's key space, handed to a shard with none of the data.

`partition_version` and `first_shard_id` are already pinned after creation, and the guard sitting immediately above this one refuses to *shrink*. `shard_count` is the third knob that moves keys, and it was the one left open.

## The fix

`shard_count` cannot change once any of the table's shards is registered. Registration is the metaserver's evidence that the table is holding data.

Growth **before** anything registers stays allowed — correcting the shard count of a table that is not yet holding anything is the legitimate use, and it is the one the existing suite already covered. Replica count and serving options are untouched: neither moves a key.

## Please push back on this if online growth is meant to be supported

Two existing tests grew a table that already had a registered shard. Neither is *about* growth — one is about mutation-log recovery, the other about the mutation API replicating through raft — and both are adjusted here to keep testing what they test:

- `metaserver_mutation_log_recovers_routes_tables_and_state_changes` — the shard is now registered after the table is sized. Where that call sits is incidental; the mutation count and the recovered state are identical either way. No assertion changed.
- `metaserver_raft_replicates_full_metadata_mutation_api` — now updates the replica count instead, which demonstrates UpdateTable reaching every peer exactly as well. Two assertions changed with it.

I am flagging this rather than quietly absorbing it. If growing a live table is intended to be supported, then **this is the wrong fix** and what is actually needed is a redistribution step — the guard would then belong on "grow without redistributing" rather than on growth itself. What is not defensible is the current state, where the operation succeeds, reports success, and loses reachability without saying so.

## Tests

5 new. Three fail on `main`:

```
test a_registered_shards_key_range_never_moves        ... FAILED
test a_key_does_not_change_shard_underneath_the_data  ... FAILED
test growing_a_table_that_already_owns_shards_is_refused ... FAILED
```

The other two are the edges: growth before registration is still allowed, and a registered table can still change its other options.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **257 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.
