### PR TITLE
Stop writing byte payloads as arrays of decimal numbers

### DIFF
--- a/crates/temporalstore-rust/src/bytes_serde.rs
+++ b/crates/temporalstore-rust/src/bytes_serde.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Encoding for byte payloads inside a JSON document.
+//!
+//! A JSON document has no byte type, so a `Vec<u8>` serialized as a sequence becomes an array of
+//! decimal numbers -- three or four characters for every byte. Base64 is a flat 1.33x instead,
+//! whatever the bytes are.
+//!
+//! Both shapes decode. Anything written before this still loads, and a client that sends the array
+//! shape is still understood.
+
+use std::cell::Cell;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use serde::de::{Deserializer, Error, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::Serializer;
+
+thread_local! {
+    /// 0 = not yet resolved, 1 = encoded, 2 = the array shape.
+    ///
+    /// Per thread, not per process. Serialization happens on the thread doing the work, so this is
+    /// the right scope -- and it means a test that drives the shape cannot change what every other
+    /// test in the process writes while it runs.
+    static SHAPE: Cell<u8> = const { Cell::new(0) };
+}
+
+/// TS_LEGACY_ARRAY_BYTES: write byte payloads as an array of numbers, as they were written before.
+///
+/// Default off. The array shape costs three to four characters per byte; the escape hatch exists
+/// for a consumer that reads records directly and has not moved to the encoded shape.
+fn writes_the_array_shape() -> bool {
+    SHAPE.with(|shape| match shape.get() {
+        1 => false,
+        2 => true,
+        _ => {
+            let legacy = matches!(
+                std::env::var("TS_LEGACY_ARRAY_BYTES")
+                    .unwrap_or_default()
+                    .trim()
+                    .to_ascii_lowercase()
+                    .as_str(),
+                "1" | "true" | "yes" | "on"
+            );
+            shape.set(if legacy { 2 } else { 1 });
+            legacy
+        }
+    })
+}
+
+/// Choose the shape for THIS THREAD. Exists so the two can be compared in one run; the
+/// environment variable is the supported way to set it.
+pub fn set_array_shape_for_measurement(array_shape: bool) {
+    SHAPE.with(|shape| shape.set(if array_shape { 2 } else { 1 }));
+}
+
+pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+    if writes_the_array_shape() {
+        let mut seq = serializer.serialize_seq(Some(bytes.len()))?;
+        for byte in bytes {
+            seq.serialize_element(byte)?;
+        }
+        return seq.end();
+    }
+    serializer.serialize_str(&STANDARD.encode(bytes))
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+    deserializer.deserialize_any(EitherShape)
+}
+
+/// Accepts the encoded string, or the array of numbers written before it.
+pub(crate) struct EitherShape;
+
+impl<'de> Visitor<'de> for EitherShape {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("encoded bytes, or the array of bytes written before")
+    }
+
+    fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+        STANDARD
+            .decode(value)
+            .map_err(|err| E::custom(format!("bytes are not valid base64: {err}")))
+    }
+
+    fn visit_bytes<E: Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+        Ok(value.to_vec())
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or_default());
+        while let Some(byte) = seq.next_element::<u8>()? {
+            bytes.push(byte);
+        }
+        Ok(bytes)
+    }
+}
+
+/// The same encoding for a list of (name, bytes) pairs.
+pub mod pairs {
+    use super::*;
+
+    struct Bytes(Vec<u8>);
+
+    impl<'de> serde::Deserialize<'de> for Bytes {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            deserializer.deserialize_any(EitherShape).map(Bytes)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(
+        pairs: &[(String, Vec<u8>)],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(pairs.len()))?;
+        for (name, bytes) in pairs {
+            if super::writes_the_array_shape() {
+                seq.serialize_element(&(name, bytes))?;
+            } else {
+                seq.serialize_element(&(name, STANDARD.encode(bytes)))?;
+            }
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<(String, Vec<u8>)>, D::Error> {
+        let pairs = <Vec<(String, Bytes)> as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(pairs
+            .into_iter()
+            .map(|(name, bytes)| (name, bytes.0))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::Command;
+
+    /// A record written before this encoding existed still loads.
+    ///
+    /// This is the whole migration story: nothing rewrites logs, so the reader has to accept both
+    /// shapes forever. The array shape below is exactly what the previous code emitted.
+    #[test]
+    fn the_array_shape_written_before_still_loads() {
+        let legacy = r#"{"kind":"string_set","key":"k","value":[104,105]}"#;
+        let decoded: Command = serde_json::from_str(legacy).expect("the array shape must load");
+        assert_eq!(
+            decoded,
+            Command::StringSet {
+                key: "k".to_string(),
+                value: b"hi".to_vec(),
+            }
+        );
+    }
+
+    /// ...including inside a list of pairs, which encodes separately.
+    #[test]
+    fn the_array_shape_still_loads_inside_pairs() {
+        let legacy = r#"{"kind":"hash_multi_set","key":"k","entries":[["f",[104,105]]]}"#;
+        let decoded: Command = serde_json::from_str(legacy).expect("the array shape must load");
+        assert_eq!(
+            decoded,
+            Command::HashMultiSet {
+                key: "k".to_string(),
+                entries: vec![("f".to_string(), b"hi".to_vec())],
+            }
+        );
+    }
+
+    /// Every payload survives the round trip byte for byte, including bytes that are not text.
+    #[test]
+    fn every_byte_survives_the_round_trip() {
+        let all_bytes: Vec<u8> = (0..=255u8).collect();
+        for command in [
+            Command::StringSet {
+                key: "k".to_string(),
+                value: all_bytes.clone(),
+            },
+            Command::HashMultiSet {
+                key: "k".to_string(),
+                entries: vec![("f".to_string(), all_bytes.clone())],
+            },
+            Command::SetAdd {
+                key: "k".to_string(),
+                member: all_bytes.clone(),
+            },
+        ] {
+            let encoded = serde_json::to_vec(&command).unwrap();
+            let decoded: Command = serde_json::from_slice(&encoded).unwrap();
+            assert_eq!(decoded, command, "payload changed across the round trip");
+        }
+    }
+
+    /// The escape hatch really does restore the old shape, and it still reads back.
+    #[test]
+    fn the_escape_hatch_restores_the_array_shape() {
+        let command = Command::StringSet {
+            key: "k".to_string(),
+            value: b"hi".to_vec(),
+        };
+        super::set_array_shape_for_measurement(true);
+        let as_array = serde_json::to_string(&command).unwrap();
+        super::set_array_shape_for_measurement(false);
+        let as_encoded = serde_json::to_string(&command).unwrap();
+
+        assert!(
+            as_array.contains("[104,105]"),
+            "the escape hatch should write the array shape, got {as_array}"
+        );
+        assert!(
+            !as_encoded.contains("[104,105]"),
+            "the default should not write the array shape, got {as_encoded}"
+        );
+        assert!(
+            as_encoded.len() < as_array.len(),
+            "the default should be the smaller of the two"
+        );
+        for shape in [as_array, as_encoded] {
+            let decoded: Command = serde_json::from_str(&shape).unwrap();
+            assert_eq!(decoded, command);
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 
+pub mod bytes_serde;
 pub mod block_store;
 pub mod checksum;
 pub mod client;

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1182,15 +1182,18 @@ pub enum Command {
     },
     StringSet {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
     },
     StringSetEx {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
         ttl_ms: u64,
     },
     StringSetConditional {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
         #[serde(default)]
         ttl_ms: Option<u64>,
@@ -1206,6 +1209,7 @@ pub enum Command {
     HashSet {
         key: String,
         field: String,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
     },
     HashGet {
@@ -1218,6 +1222,7 @@ pub enum Command {
     },
     HashMultiSet {
         key: String,
+        #[serde(with = "crate::bytes_serde::pairs")]
         entries: Vec<(String, Vec<u8>)>,
     },
     HashIncrBy {
@@ -1237,6 +1242,7 @@ pub enum Command {
     },
     SetAdd {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         member: Vec<u8>,
     },
     SetMembers {
@@ -1244,6 +1250,7 @@ pub enum Command {
     },
     SetRemove {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         member: Vec<u8>,
     },
     FeatureAppend {
@@ -1320,6 +1327,7 @@ pub enum Command {
     ControlStateChangeAdd {
         key: String,
         timestamp_ms: u64,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
         #[serde(default)]
         precision_ms: Option<u64>,
@@ -1389,6 +1397,7 @@ pub enum Command {
     #[serde(alias = "control_state_fol_set")]
     ControlStateSelectionSet {
         key: String,
+        #[serde(with = "crate::bytes_serde")]
         value: Vec<u8>,
         occur_time_ms: u64,
         ttl_ms: u64,

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2651,4 +2651,71 @@ mod tests {
         // The prefix has grown past a quarter of what the pass must copy.
         assert!(reclaim_is_worth_rewriting(25 * MB, retained, floor, 25));
     }
+
+    /// What a write costs on disk and in time, comparing the two payload shapes in ONE run.
+    ///
+    /// Both are measured back to back in the same process, alternating, because a timing taken
+    /// from a separate run on a shared machine mostly measures what else was running then. The
+    /// byte counts are deterministic; the timings are not, so they are reported as a ratio
+    /// between two shapes measured together rather than as absolute figures.
+    #[test]
+    fn payload_shape_footprint_and_latency() {
+        fn run(array_shape: bool, value_len: usize, records: u64) -> (u64, f64) {
+            crate::bytes_serde::set_array_shape_for_measurement(array_shape);
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let started = std::time::Instant::now();
+            for index in 0..records {
+                store
+                    .append_with_sync(
+                        1,
+                        Command::StringSet {
+                            key: format!("bench-key-{index:08}"),
+                            value: vec![118u8; value_len],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+            let micros = started.elapsed().as_secs_f64() * 1e6 / records as f64;
+            let bytes = std::fs::metadata(write_ahead_log_path(dir.path(), 1))
+                .unwrap()
+                .len();
+            (bytes, micros)
+        }
+
+        let median = |mut values: Vec<f64>| {
+            values.sort_by(|left, right| left.partial_cmp(right).unwrap());
+            values[values.len() / 2]
+        };
+
+        for value_len in [64usize, 256, 1024, 4096] {
+            let records = 200u64;
+            let (array_bytes, _) = run(true, value_len, records);
+            let (encoded_bytes, _) = run(false, value_len, records);
+            let mut array_us = Vec::new();
+            let mut encoded_us = Vec::new();
+            // Alternate, so a burst of load on the machine lands on both and not just one.
+            for _ in 0..3 {
+                array_us.push(run(true, value_len, records).1);
+                encoded_us.push(run(false, value_len, records).1);
+            }
+            let array_us = median(array_us);
+            let encoded_us = median(encoded_us);
+            let user = records * value_len as u64;
+            println!(
+                "  value {value_len:>5}B: array {array_bytes:>9} B ({:.2}x user, {array_us:>7.1} us/write)   encoded {encoded_bytes:>9} B ({:.2}x user, {encoded_us:>7.1} us/write)   -> {:.2}x smaller, {:.2}x faster",
+                array_bytes as f64 / user as f64,
+                encoded_bytes as f64 / user as f64,
+                array_bytes as f64 / encoded_bytes as f64,
+                array_us / encoded_us
+            );
+            assert!(
+                encoded_bytes < array_bytes,
+                "the encoded shape must be smaller at {value_len}B"
+            );
+        }
+        // Leave the process on the default for whatever test runs next.
+        crate::bytes_serde::set_array_shape_for_measurement(false);
+    }
 }


### PR DESCRIPTION
A JSON document has no byte type, so a `Vec<u8>` serialized as a sequence becomes `[118,118,...]` — three or four characters for every byte, before framing, metadata or key names are counted at all. Every one of those bytes is written and fsynced.

The block images carried in the same records already avoided this: they encode as base64, a flat 1.33x whatever the bytes are. This applies the same encoding to the command's own payloads, which is where the remaining amplification lived.

## Measured

Through the real append path — writing records and weighing the file, not comparing two encodings of a synthetic struct. Both shapes are measured **in one process, alternating**, because a timing taken from a separate run on a shared machine mostly measures what else was running then.

| value | amplification | size | latency |
|---:|---|---|---|
| 64 B | 6.68x → **4.07x** | 1.64x smaller | 1.15x faster |
| 256 B | 4.67x → **2.02x** | 2.32x smaller | 1.48x faster |
| 1 KiB | 4.17x → **1.51x** | 2.77x smaller | 2.12x faster |
| 4 KiB | 4.04x → **1.38x** | 2.94x smaller | 2.41x faster |

At 4 KiB a record went from 16,557 bytes on disk to 5,637. The byte counts are deterministic; the timings are not, so they are given as a ratio between two shapes measured together rather than as absolute figures.

The small-value case is the least improved and worth being clear about: at 64 B the record is mostly key text and framing, so 4.07x is what remains after the payload stops being the problem.

## Migration

Nothing rewrites existing logs, so the reader accepts both shapes — permanently, not as a transition. That is the same either-shape reader the staged pages have used since they were introduced. `TS_LEGACY_ARRAY_BYTES` restores the old shape for a consumer that reads records directly.

The one thing to know: commands also travel between nodes, so a node running this can read an older node's writes, but not the reverse. Upgrade readers first.

## Tests

- a record written in the array shape still loads — plain, and inside a list of pairs, which encodes separately
- every byte value 0–255 survives the round trip in each payload-carrying shape
- the escape hatch really does restore the old shape, and both shapes read back

## Testing

Library suite: **988 passed, 12 failed**, and **no name fails here that does not also fail on `main`** — the set difference is empty.

An earlier revision of this change did break two tests, `shared_store_restore_before_load_auto_serves_but_load_before_restore_does_not` and `shared_store_sync_storage_publishes_and_cursor_replay_resumes`. The cause was mine: the measurement switch was process-wide, so while the measurement ran, every other test in the process wrote the other shape. It is per-thread now, which is the correct scope — serialization happens on the thread doing the work — and both tests pass.

## On the replication harness

`raft_secondary_replication_harness` is currently unreliable on `main`, and not because of this change: **3/5 on this branch, 0/5 on `main`**, with the same failure modes on both (`membership apply … leader is not available`). It passed 3/3 when I last touched it a few merges ago, so something in between destabilised it. Chasing that separately.
