### PR TITLE
Stop allocating the whole raft log on every WAL append

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -671,12 +671,14 @@ impl RaftClusterInner {
         // an RPC, and re-learns the rest from AppendEntries on restart. Persist only our own
         // record. Unset -- the in-process test cluster -- keeps persisting every node.
         let local_only = self.local_node_id;
-        for (node_id, record) in self.wal_records() {
-            if let Some(local) = local_only {
-                if node_id != local {
-                    continue;
-                }
-            }
+        // Build ONLY the record we are going to persist. Building every node's record and then
+        // skipping all but one clones the whole log once per node and discards the rest, which
+        // is O(log length) of pure waste on every persist.
+        let records = match local_only {
+            Some(local) => self.wal_record_for(local).into_iter().collect::<Vec<_>>(),
+            None => self.wal_records(),
+        };
+        for (node_id, record) in records {
             // P1: when coalescing is enabled, skip the fdatasync for a node whose durability-
             // relevant state is byte-identical to what we last persisted. A false "changed" only
             // costs a redundant (safe) fsync; the skip fires ONLY when nothing Raft must persist
@@ -728,16 +730,29 @@ impl RaftClusterInner {
     }
 
     pub(super) fn wal_records(&self) -> Vec<(RaftNodeId, RaftWalRecord)> {
+        self.nodes
+            .keys()
+            .copied()
+            .filter_map(|node_id| self.wal_record_for(node_id))
+            .collect()
+    }
+
+    /// Build the WAL record for ONE node. Cloning a node's log is O(log length), so a caller
+    /// that will persist a single node must not pay for the others.
+    pub(super) fn wal_record_for(
+        &self,
+        node_id: RaftNodeId,
+    ) -> Option<(RaftNodeId, RaftWalRecord)> {
         let membership = RaftMembership {
             shard_id: self.shard_id,
             voters: self.voting_node_ids(),
             leader_id: self.leader_id,
         };
         self.nodes
-            .iter()
-            .map(|(node_id, node)| {
+            .get(&node_id)
+            .map(|node| {
                 (
-                    *node_id,
+                    node_id,
                     RaftWalRecord {
                         hard_state: RaftHardState {
                             current_term: node.current_term,
@@ -758,7 +773,6 @@ impl RaftClusterInner {
                     },
                 )
             })
-            .collect()
     }
 
     pub(super) fn leader_commit_index(&self) -> u64 {

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -143,13 +143,29 @@ impl LocalRaftWal {
         let encode = |as_delta: bool| -> io::Result<Vec<u8>> {
             let envelope = if as_delta {
                 let from_index = cursor.persisted_last_index;
-                let mut delta_record = record.clone();
-                delta_record.entries.retain(|entry| entry.index > from_index);
-                // Telemetry counters are not durability-relevant (the fingerprint zeroes
-                // them), and they were more than half the bytes of every record. Recovery
-                // keeps whatever the base record carried.
-                delta_record.pipeline_state = RaftPeerPipelineRuntimeState::default();
-                delta_record.read_safety_state = RaftReadSafetyRuntimeState::default();
+                // Only the entries above `from_index`, taken as a slice. Cloning the record
+                // and filtering afterwards allocated the whole log on every append, which is
+                // the cost incremental records exist to remove.
+                let tail_start = record
+                    .entries
+                    .partition_point(|entry| entry.index <= from_index);
+                let delta_record = RaftWalRecord {
+                    hard_state: record.hard_state.clone(),
+                    membership: record.membership.clone(),
+                    replica_role: record.replica_role,
+                    joint_membership: record.joint_membership.clone(),
+                    latest_external_snapshot_ref: record.latest_external_snapshot_ref.clone(),
+                    installed_snapshot: record.installed_snapshot.clone(),
+                    apply_snapshot_fence: record.apply_snapshot_fence.clone(),
+                    storage_apply_fence: record.storage_apply_fence.clone(),
+                    // Telemetry counters are not durability-relevant (the fingerprint zeroes
+                    // them), and they were more than half the bytes of every record. Recovery
+                    // keeps whatever the base record carried.
+                    pipeline_state: RaftPeerPipelineRuntimeState::default(),
+                    read_safety_state: RaftReadSafetyRuntimeState::default(),
+                    membership_evidence: record.membership_evidence.clone(),
+                    entries: record.entries[tail_start..].to_vec(),
+                };
                 RaftWalEnvelope {
                     sequence,
                     checksum: raft_wal_checksum(&delta_record)?,


### PR DESCRIPTION
Two allocations on the persist path still scaled with the length of the raft log, long after
the bytes written stopped doing so. Both showed up as `malloc` dominating a profile of a
leader under write load.

- A deployed process persists only its own node, but the persist loop still built a record
  for **every** node first — each one cloning that node's whole log — and then skipped all
  but one. On a three-node group that is three full-log clones per persist, two of them
  thrown away. It now builds only the record it is going to write.
- Encoding an incremental record cloned the entire record and then retained the handful of
  entries that were actually new. Entries are index-ordered, so the new ones are a binary
  search and a slice away.

## Measured

Three c7i.large, 3 shards × 3 replicas, 30-byte values. The store is held at a fixed 100
keys so that only the log grows — otherwise the store getting larger is measured too.

| | before this change | after |
|---|--:|--:|
| growth in write p50, per log entry | 0.0030 ms | **0.0020 ms** |
| fdatasync per sync write | 2.4 | **2.1** |
| write p50, single writer | 26.2 ms | 26.0 ms |

For scale: the same measurement before any of the incremental-record work grew at 0.0535 ms
per entry, so what is left is under a twentieth of it. In an ordinary workload the remaining
growth is mostly the store getting larger rather than the log — a profile points at the
storage engine's per-write bucket bookkeeping, which is a separate thing to chase.

Also verified unchanged on the same cluster: a killed leader is replaced and writes resume in
25 ms, all acknowledged keys stay readable on both survivors, and all nine replicas serve
byte-exact reads.

Raft suite: 193 passed, 1 failed — the failure is `http_raft_transport_sends_append_vote_and_snapshot_over_tcp`,
which binds a fixed port and passes on its own (2/2); the suite's fixed ports make it flaky
under a full run.
