### PR TITLE
Proxy: route context requests the same way commands are routed

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -676,6 +676,33 @@ impl TemporalStoreClient {
         self.inner.options.clone()
     }
 
+    /// Resolve the datanode that currently owns `shard_id`, through this client's shared
+    /// route cache.
+    ///
+    /// Callers that forward raw HTTP to a shard (rather than going through `execute`) still
+    /// need an address, and without this they tend to grow their own metaserver lookup --
+    /// which then misses the cache, the TTL and the backend-failure accounting that every
+    /// other caller gets for free.
+    pub fn shard_primary_addr(
+        &self,
+        shard_id: ShardId,
+        force_refresh: bool,
+    ) -> Result<String, ClientError> {
+        self.resolve_route(shard_id, force_refresh, None)
+    }
+
+    /// Record that a request to `server_addr` failed, so a backend that keeps failing stops
+    /// being handed out from the route cache.
+    ///
+    /// This is the same accounting `execute` does; a caller that forwards on its own has to
+    /// report failures itself or the continuous-failure check never fires for its traffic.
+    pub fn note_backend_failure(&self, server_addr: &str) {
+        self.record_backend_failure(
+            server_addr,
+            self.inner.options.topo_error_retry_interval_ms,
+        );
+    }
+
     pub fn with_options(options: ClientOptions) -> Self {
         Self {
             inner: Arc::new(ClientInner {

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3958,6 +3958,165 @@ mod tests {
     }
 
     #[test]
+    fn context_route_lookup_uses_the_shared_route_cache() {
+        // The context routes are the whole of the gateway's traffic, and every one of them
+        // used to resolve its shard with a direct `/shards/{id}` GET -- no cache, no TTL, no
+        // backend-failure accounting. That put a metaserver round-trip in front of every
+        // ingest, extract and retrieve, and put the metaserver in the request path of all of
+        // them, while the command path had been caching the identical lookup all along.
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        start_context_server(test_addr(18_372), engine.clone());
+        start_meta(test_addr(18_373), test_addr(18_372));
+        wait_for_http(&test_addr(18_373));
+        wait_for_http(&test_addr(18_372));
+
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_373),
+            route_cache_ttl_ms: 60_000,
+            context_first_shard_id: 1,
+            context_shard_count: 1,
+            ..ProxyOptions::default()
+        });
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "scope": {"tenant_id": "team-alpha", "account_id": "acct_42"},
+            "messages": [{"role": "user", "content": "route cache check"}]
+        }))
+        .unwrap();
+        for attempt in 0..3 {
+            let (code, _) = proxy.handle(HttpRequest {
+                method: "POST".to_string(),
+                path: "/context/ingest".to_string(),
+                body: body.clone(),
+            });
+            assert_eq!(code, 200, "context ingest {attempt} should succeed");
+        }
+
+        let report = proxy.preflight_report();
+        // One resolve for the first request; the other two come from the cache. Before this
+        // the count would have been three lookups and an empty cache, because the context
+        // path never went through the client that owns the cache.
+        assert_eq!(
+            report.client.route_refreshes, 1,
+            "three context requests should resolve the shard once, saw {} refreshes",
+            report.client.route_refreshes
+        );
+        assert!(
+            report.client.route_cache_hits >= 2,
+            "the last two requests should be cache hits, saw {}",
+            report.client.route_cache_hits
+        );
+        assert_eq!(
+            report.client.route_cache_size, 1,
+            "the context lookup should populate the shared route cache"
+        );
+    }
+
+    #[test]
+    fn context_route_cache_is_invalidated_when_the_shard_moves() {
+        // Caching the context route is only safe if something notices the shard moving. A
+        // proxy fronting the context gateway serves these three routes and nothing else --
+        // it never calls execute -- so if the context path did not check topology itself,
+        // nothing on that proxy ever would, and it would keep sending the gateway to the old
+        // datanode for the whole of route_cache_ttl_ms.
+        let dir_a = tempfile::tempdir().unwrap();
+        let engine_a = TemporalEngine::with_local_dirs(
+            1024,
+            dir_a.path().join("cache"),
+            dir_a.path().join("pages"),
+            dir_a.path().join("indexes"),
+        );
+        engine_a.load_shard(1);
+        start_context_server(test_addr(18_374), engine_a.clone());
+
+        let dir_b = tempfile::tempdir().unwrap();
+        let engine_b = TemporalEngine::with_local_dirs(
+            1024,
+            dir_b.path().join("cache"),
+            dir_b.path().join("pages"),
+            dir_b.path().join("indexes"),
+        );
+        engine_b.load_shard(1);
+        start_context_server(test_addr(18_375), engine_b.clone());
+
+        let meta = crate::meta::SingleNodeMeta::default();
+        meta.register_server(crate::meta::RegisterServerRequest {
+            server_addr: test_addr(18_374),
+            node_id: 1,
+            location: "zone-a".to_string(),
+            binary_version: "v-a".to_string(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: test_addr(18_374),
+        });
+        start_meta_service(test_addr(18_376), meta.clone());
+        wait_for_http(&test_addr(18_374));
+        wait_for_http(&test_addr(18_375));
+        wait_for_http(&test_addr(18_376));
+
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_376),
+            route_cache_ttl_ms: 60_000,
+            context_first_shard_id: 1,
+            context_shard_count: 1,
+            ..ProxyOptions::default()
+        });
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "scope": {"tenant_id": "team-alpha", "account_id": "acct_42"},
+            "messages": [{"role": "user", "content": "before the move"}]
+        }))
+        .unwrap();
+        let ingest = |body: Vec<u8>| {
+            proxy.handle(HttpRequest {
+                method: "POST".to_string(),
+                path: "/context/ingest".to_string(),
+                body,
+            })
+        };
+
+        let (code, _) = ingest(body.clone());
+        assert_eq!(code, 200);
+        let before = proxy.preflight_report();
+        assert_eq!(before.client.route_refreshes, 1, "first request resolves once");
+
+        // The shard moves to the second datanode.
+        meta.register_server(crate::meta::RegisterServerRequest {
+            server_addr: test_addr(18_375),
+            node_id: 2,
+            location: "zone-b".to_string(),
+            binary_version: "v-b".to_string(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: test_addr(18_375),
+        });
+
+        let moved_body = serde_json::to_vec(&serde_json::json!({
+            "scope": {"tenant_id": "team-alpha", "account_id": "acct_42"},
+            "messages": [{"role": "user", "content": "after the move"}]
+        }))
+        .unwrap();
+        let (code, _) = ingest(moved_body);
+        assert_eq!(code, 200);
+
+        let after = proxy.preflight_report();
+        assert!(
+            after.client.route_refreshes > before.client.route_refreshes,
+            "the context path must re-resolve after the shard moves, refreshes stayed at {}",
+            after.client.route_refreshes
+        );
+    }
+
+    #[test]
     fn proxy_routes_high_level_context_ingest_and_retrieve_by_tenant() {
         use crate::context_workflow::{ContextIngestExtractReport, ContextRetrieveReport};
 

--- a/crates/temporalstore-rust/src/proxy/context.rs
+++ b/crates/temporalstore-rust/src/proxy/context.rs
@@ -185,21 +185,35 @@ impl ProxyService {
         }
     }
 
-    /// Resolve the datanode that owns `shard_id` via the metaserver topology, or
+    /// Resolve the datanode that owns `shard_id` through the client's route cache, or
     /// an HTTP error response ready to return.
     fn context_shard_addr(&self, shard_id: ShardId) -> Result<String, (u16, Vec<u8>)> {
-        match self.get_shard(shard_id, true) {
-            Ok(response) => match response.location {
-                Some(location) => Ok(location.server_addr),
-                None => Err(crate::http::json_response(
+        // Drop routes the metaserver has moved, then resolve through the proxy's shared
+        // client: the same route cache, topology invalidation and continuous-failure check
+        // that every command entry point uses.
+        //
+        // This used to be a direct `/shards/{id}` GET, which is the one routing path in the
+        // proxy that was written by hand, and so the one that had none of the above. The
+        // invalidation is not optional here: a proxy fronting the context gateway serves
+        // only these three routes and never calls `execute`, so nothing else on it would
+        // ever notice a shard had moved.
+        self.invalidate_cached_routes_if_meta_changed();
+        match self.client().shard_primary_addr(shard_id, false) {
+            Ok(server_addr) => Ok(server_addr),
+            Err(err) => {
+                self.inner
+                    .stats
+                    .write()
+                    .expect("proxy stats lock poisoned")
+                    .metaserver_errors += 1;
+                Err(crate::http::json_response(
                     502,
                     &Status::error(
                         "metaserver_error",
-                        format!("shard {shard_id} has no registered datanode"),
+                        format!("shard {shard_id} route lookup failed: {err}"),
                     ),
-                )),
-            },
-            Err(status) => Err(crate::http::json_response(502, &status)),
+                ))
+            }
         }
     }
 
@@ -219,6 +233,11 @@ impl ProxyService {
                     .write()
                     .expect("proxy stats lock poisoned")
                     .backend_errors += 1;
+                // Report the failure against the address so a datanode that keeps failing
+                // stops being served from the route cache. Forwarding by hand means this
+                // accounting has to be done by hand too -- without it the continuous-failure
+                // check only ever saw command traffic, and never the gateway's.
+                self.client().note_backend_failure(server_addr);
                 crate::http::json_response(
                     502,
                     &Status::error(


### PR DESCRIPTION
The three context routes -- ingest, extract, retrieve -- resolved their shard with a
hand-written /shards/{id} GET. Every other way into the proxy goes through its
client. So this one path, which is the whole of what the context gateway calls, was
the only one without any of what that client does:

- No route cache. Every request re-fetched the shard location.
- No topology invalidation.
- No continuous-failure accounting. A failed forward was counted, but never
  reported against the address it failed to reach, so the check that stops serving
  a backend which keeps failing only ever saw command traffic.

All three now come from the shared client.

The invalidation is the part that matters most, and it is not optional. A proxy put
in front of the context gateway serves these three routes and nothing else -- it
never calls execute -- so without the context path checking topology itself,
nothing on that proxy would ever notice a shard had moved, and it would keep
sending the gateway to the old datanode until the cache entry aged out. Caching the
route without that check would have been worse than the uncached lookup it
replaced. There is a test for it, and it fails with "refreshes stayed at 1" if the
invalidation call is removed -- checked, not assumed.

Deliberately NOT changed: the target. Resolution still pins the primary, which is
the node the old lookup returned. This changes how the address is found, not which
node gets the request.

One thing this does NOT do, which is worth being straight about: it does not take
the metaserver out of the per-request path. The topology check is itself a
synchronous POST to /meta/topology_version, and the command entry points already do
one on every single request, unthrottled. So the metaserver sits in the request
path of essentially all proxy traffic, and this change makes context consistent
with that rather than escaping it. Throttling that check would remove a round-trip
from every request on both paths, but it changes when a topology change is noticed
on the command path too, so it belongs in its own change rather than smuggled into
this one.

Tests: three context ingests resolve once and hit the cache twice, leaving the
shared cache populated; and a shard that moves mid-flight forces the context path
to re-resolve.