### PR TITLE
Memory API on the record-log backends: availability, latency, and the rest of the mem0 surface

### DIFF
--- a/docs/MIGRATE_FROM_MEM0.md
+++ b/docs/MIGRATE_FROM_MEM0.md
@@ -130,6 +130,15 @@ m.reset()                                    # wipe the caller's whole tenant
 | `delete_all(user_id=…)`         | `POST /v1/forget`                | subject = `scope.user_id`; server requires `confirm == user_id` (exact match, no wildcard). The shim sets `confirm` for you. Returns the count removed. |
 | `get_all(user_id=…, limit=…)`   | `GET`/`POST /v1/memories`        | Lists a subject's active memories; forgotten/deleted memories are excluded. |
 | `reset()`                       | `POST /v1/reset`                 | Wipes the caller's tenant. Guarded by an explicit `confirm` — the shim sends the literal `"RESET"`; the server also accepts the resolved `tenant_id`. |
+| `batch_update(memories)`        | one `POST /v1/update` per entry  | Takes mem0's shape — `[{memory_id, text?, metadata?}]`, `text` mapped onto `data` — capped at 1000 entries. **Not atomic**: an update here is a supersede with no cross-memory transaction behind it, so entries are applied in order and a failure is reported per memory (`{"results": [...], "updated": n, "failed": [...]}`) instead of aborting the rest. |
+| `batch_delete(memories)`        | one `POST /v1/delete` per entry  | `[{memory_id}]`, or a bare list of ids. Capped at 1000, same non-atomic reporting as `batch_update`. |
+| `users(limit=…)`                | `POST /v1/users`                 | The users / agents / runs that **hold** memories, in mem0's `{"results": [{"type", "name"}]}` shape, with a `memory_count` on users. A subject whose memories were all forgotten or expired is not listed — this answers "who has memories", not "who was provisioned" (the admin user list is that other thing). Gated on `context:retrieve`, and scoped to the caller's tenant. |
+
+`add()` **finalizes by default**, which is what makes it read-after-write: a `get_all` / `search`
+issued straight after `add` sees the memory, as on mem0. Pass `finalize=False` to stream a
+conversation in and let the idle commit close it — cheaper per call, but the memory only becomes
+visible once a debounce elapses, and every further write to the same scope pushes that debounce
+out, so a burst of un-finalized `add` calls can stay invisible for as long as the burst lasts.
 
 Scope gates (enforced-mode keys): `forget`/`delete`/`reset` require
 `context:forget`; `update` requires `context:ingest`; `get_all`/`get`/`history`

--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -54,18 +54,16 @@ class _LocalAdapterContextNodeMixin:
             return self.default_shared_context_node_path(envelope.get("scope", {}), kind=str(envelope.get("kind") or "resource"), sharing_scope=sharing_scope)
         return self.default_session_node_path(envelope.get("scope", {}))
 
-    def ensure_context_node_path(self, *, node_path: list[str], scope: Json, updated_at_ms: int) -> Json:
-        prefixes = node_prefixes(node_path)
-        if not prefixes:
-            return {"nodes_created": 0, "child_refs_created": 0, "node_hashes": []}
+    def _existing_node_embedding_refs(self, current_model_ref: str) -> set[int]:
+        """Node hashes that already have a usable `context_node` embedding for this model.
 
-        compact_scope = serving_scope_ref(scope)
-        self._ensure_context_node_cache_loaded()
-        existing_nodes = self._context_node_hashes
-        existing_child_refs = self._context_child_ref_hashes
-        current_model = embedding_model_name()
-        current_model_ref = embedding_model_ref_for_name(current_model)
-        existing_node_embeddings: set[int] = set()
+        Walking the whole log is fine on the JSONL backend, where `read_all()` is an in-memory
+        list. It is NOT fine on a native backend, where `read_all()` is a full record-log read
+        shipped over the proxy and re-run through the serving pipeline -- and
+        `ensure_context_node_path` runs three times per ingest. The native adapter overrides this
+        with a keyed lookup; see `MatrixArkTemporalStoreDirectAdapter._existing_node_embedding_refs`.
+        """
+        refs: set[int] = set()
         for record in self.read_all():
             if (
                 record.get("record_type") != "context_embedding"
@@ -81,9 +79,30 @@ class _LocalAdapterContextNodeMixin:
             ):
                 continue
             try:
-                existing_node_embeddings.add(int(record.get("ref_hash")))
+                refs.add(int(record.get("ref_hash")))
             except (TypeError, ValueError):
                 continue
+        return refs
+
+    def _record_node_embedding_ref(self, node_hash: int, current_model_ref: str) -> None:
+        """Note that a node embedding now exists. No-op here; the log IS the record.
+
+        The native adapter overrides this to keep its keyed index current.
+        """
+        return None
+
+    def ensure_context_node_path(self, *, node_path: list[str], scope: Json, updated_at_ms: int) -> Json:
+        prefixes = node_prefixes(node_path)
+        if not prefixes:
+            return {"nodes_created": 0, "child_refs_created": 0, "node_hashes": []}
+
+        compact_scope = serving_scope_ref(scope)
+        self._ensure_context_node_cache_loaded()
+        existing_nodes = self._context_node_hashes
+        existing_child_refs = self._context_child_ref_hashes
+        current_model = embedding_model_name()
+        current_model_ref = embedding_model_ref_for_name(current_model)
+        existing_node_embeddings = self._existing_node_embedding_refs(current_model_ref)
         node_hashes: list[int] = []
         nodes_created = 0
         child_refs_created = 0
@@ -131,6 +150,7 @@ class _LocalAdapterContextNodeMixin:
                     })
                 )
                 existing_node_embeddings.add(node_hash)
+                self._record_node_embedding_ref(node_hash, current_model_ref)
                 node_embeddings_created += 1
             if parent_path:
                 child_ref_hash = stable_hash(f"child:{parent_hash}:{node_hash}")

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -85,6 +85,21 @@ def warn_if_profile_scope_missing(scope) -> str:
 _BATCH_MESSAGES_WARNED: set = set()
 BATCH_MESSAGES_WARN_THRESHOLD = int(os.environ.get("MATRIXARK_BATCH_MESSAGES_WARN_THRESHOLD", "6"))
 
+# Ingest fields that come from the CALLER rather than from extraction -- the exact set
+# MatrixArkLocalAdapter._stamp_ingest_fields puts on a `context_event`. Extraction cannot rebuild
+# them, so a commit that rewrites an existing event row has to carry them over (see the use below).
+# An explicit allowlist on purpose: the rewrite is meant to replace the extraction's own view of the
+# event, and inheriting anything broader would let a stale earlier row overrule a fresh
+# classification.
+CALLER_SUPPLIED_EVENT_FIELDS = (
+    "identity_key",
+    "truth_class",
+    "truth_rank",
+    "expires_at",
+    "expires_at_ms",
+    "ephemeral",
+)
+
 
 def warn_if_batched_messages(messages) -> str:
     """Warn when one message-ingest call carries many messages.
@@ -2094,6 +2109,43 @@ class _LocalAdapterIngestMixin:
                     continue
                 segment_hashes_by_position.setdefault(message_index, []).append(segment_hash)
                 segment_hash_by_position.setdefault(message_index, segment_hash)
+        # Fields the CALLER supplied on the original ingest. When extraction commits it REWRITES the
+        # `context_event` row for an id that already exists, building it from the extraction result
+        # alone -- and latest-value compaction then serves that newer row. Anything the caller put on
+        # the original row and the extractor does not reproduce is therefore silently dropped at read
+        # time: an `identity_key` ingest became unfindable by keyed recall and stopped superseding,
+        # and a `ttl_seconds` ingest became a record nothing would ever expire. They survived only
+        # when extraction ran inside the ingest call, because `_stamp_ingest_fields` is scoped to it
+        # -- so an in-process sync ingest looked correct while the same request through the gateway,
+        # where finalize commits separately, lost them. Carry them across the rewrite.
+        inherited_event_fields: dict[int, Json] = {}
+        if derive_from_existing_events and source_event_ids:
+            wanted_event_ids: set[int] = set()
+            for source_event_id in source_event_ids:
+                try:
+                    wanted_event_ids.add(int(source_event_id))
+                except (TypeError, ValueError):
+                    continue
+            # `prior_records` is the live view already loaded for prior context; only pay for a read
+            # when the caller asked to skip that. Reading the LIVE view rather than the raw log is
+            # deliberate -- a deleted row must not hand its identity key to its replacement.
+            lookup_records = prior_records if prior_records else self.read_all()
+            for prior_record in lookup_records:
+                if str(prior_record.get("record_type") or "") != "context_event":
+                    continue
+                try:
+                    prior_event_id = int(prior_record.get("event_id_hash"))
+                except (TypeError, ValueError):
+                    continue
+                if prior_event_id not in wanted_event_ids:
+                    continue
+                carried = {
+                    field: prior_record[field]
+                    for field in CALLER_SUPPLIED_EVENT_FIELDS
+                    if prior_record.get(field) is not None
+                }
+                if carried:
+                    inherited_event_fields[prior_event_id] = carried
         if derive_from_existing_events:
             for index, message in enumerate(envelope["messages"]):
                 if index >= len(source_event_ids):
@@ -2224,6 +2276,8 @@ class _LocalAdapterIngestMixin:
                     "extraction_phase": extraction_phase,
                     "final_session_boundary": final_session_boundary,
                     "extraction_context_event_ids": extraction_context_event_ids,
+                    # Last, so the caller's own fields win over anything above that shares a name.
+                    **inherited_event_fields.get(event_id_hash, {}),
                 }
                 event_memory_layer = candidate_memory_layer_name(event_record)
                 if event_memory_layer:

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -79,6 +79,13 @@ ENABLE_SUMMARY_REFRESH_AUDIT = os.environ.get("MATRIXARK_SUMMARY_REFRESH_AUDIT",
 ENABLE_SUMMARY_DIRTY_DEBUG_FIELDS = os.environ.get("MATRIXARK_SUMMARY_DIRTY_DEBUG_FIELDS", "0").strip().lower() in {"1", "true", "yes"}
 SUMMARY_REFRESH_INTERVAL_MS = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_INTERVAL_MS", "1000"))
 SUMMARY_REFRESH_LIMIT = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_LIMIT", "64"))
+# Largest share of wall-clock the background summary refresher may occupy. A refresh pass
+# costs O(store) -- it reads the whole record log and writes the refreshed summaries back
+# through the same proxy lane the request path uses -- so at a fixed interval a pass that
+# grows past that interval turns the loop into a permanent occupant of the lane. See
+# MatrixArkMcpServer._next_summary_refresh_delay_s.
+SUMMARY_REFRESH_MAX_DUTY = float(os.environ.get("MATRIXARK_SUMMARY_REFRESH_MAX_DUTY", "0.2"))
+SUMMARY_REFRESH_MAX_BACKOFF_MS = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_MAX_BACKOFF_MS", "300000"))
 BACKEND_READINESS_TIMEOUT_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_TIMEOUT_MS", "30000"))
 BACKEND_READINESS_BACKOFF_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_BACKOFF_MS", "200"))
 MATRIXARK_MCP_PROFILE = os.environ.get("MATRIXARK_MCP_PROFILE", "dev").strip().lower()
@@ -305,6 +312,22 @@ def matrixark_production_profile_enabled() -> bool:
 
 
 def python_hot_cache_allowed(*, backend_label: str = "") -> bool:
+    """Whether the record cache may serve a read. Native backends are excluded BY POLICY.
+
+    The cache itself is safe on any backend: it is validated by the record COUNT read fresh from
+    the store on every call, and the record log is append-only -- a delete is a tombstone append --
+    so any write anywhere moves the count and the entry misses. The mutable half, the
+    latest-context-state store, is never cached; it is re-read and re-folded even on a hit.
+
+    It is nonetheless off for the native backends on purpose, matching
+    `native_candidate_prefilter_required`: TemporalStore serving is meant to read through native
+    pushdown rather than a Python-side cache. `test_python_hot_cache_default_policy` pins that.
+
+    Turning it on is a measured, one-variable win if a deployment wants it --
+    MATRIXARK_ALLOW_PYTHON_HOT_CACHE=1. Over the mem0 surface, 4 users x a 10-turn conversation:
+    get_all 1491->326 ms, get 1677->402 ms, update 5050->1218 ms, users 1512->475 ms,
+    batch_update 7782->3144 ms, search 710->510 ms, with all 15 APIs still correct on both arms.
+    """
     if MATRIXARK_ALLOW_PYTHON_HOT_CACHE:
         return MATRIXARK_ALLOW_PYTHON_HOT_CACHE in {"1", "true", "yes"}
     return backend_label == "local"
@@ -359,6 +382,7 @@ MATRIXARK_TOOL_SCOPES: dict[str, set[str]] = {
     "matrixark_delete": {"context:forget"},
     "matrixark_reset": {"context:forget"},
     "matrixark_get_all": {"context:retrieve"},
+    "matrixark_list_users": {"context:retrieve"},
     "matrixark_get_memory": {"context:retrieve"},
     "matrixark_get_memory_by_key": {"context:retrieve"},
     "matrixark_update_memory": {"context:ingest"},

--- a/tools/matrixark_mcp_direct_cache.py
+++ b/tools/matrixark_mcp_direct_cache.py
@@ -56,12 +56,29 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_local_adapter import RETRIEVAL_HOT_RECORD_TYPES
 
 
+def direct_cache_scope(target: Any) -> str:
+    """The identity of the store a cache entry belongs to.
+
+    `_storage_prefix` alone is NOT that identity: it defaults to "matrixark:mcp" for every
+    adapter, while the store a client actually talks to is separated by namespace and table. Two
+    adapters over different stores in one process therefore share a cache key, and whichever
+    wrote last wins -- one store serving another store's records. It has been latent because the
+    record cache was off for native backends; turning it on makes it reachable, so the key names
+    the store.
+    """
+    return "%s|%s|%s" % (
+        str(getattr(target, "_namespace", "") or ""),
+        str(getattr(target, "_table", "") or ""),
+        str(getattr(target, "_storage_prefix", "") or ""),
+    )
+
+
 def direct_record_load_lock(target: Any) -> threading.RLock:
     with _DIRECT_RECORD_CACHE_LOCK:
-        lock = _DIRECT_RECORD_LOAD_LOCKS.get(target._storage_prefix)
+        lock = _DIRECT_RECORD_LOAD_LOCKS.get(direct_cache_scope(target))
         if lock is None:
             lock = threading.RLock()
-            _DIRECT_RECORD_LOAD_LOCKS[target._storage_prefix] = lock
+            _DIRECT_RECORD_LOAD_LOCKS[direct_cache_scope(target)] = lock
         return lock
 
 
@@ -69,7 +86,7 @@ def get_direct_record_cache(target: Any, count: int) -> list[Json] | None:
     if not target.python_hot_cache_enabled():
         return None
     with _DIRECT_RECORD_CACHE_LOCK:
-        cached = _DIRECT_RECORD_CACHE.get(target._storage_prefix)
+        cached = _DIRECT_RECORD_CACHE.get(direct_cache_scope(target))
         if cached is None:
             return None
         cached_count, records = cached
@@ -82,10 +99,10 @@ def put_direct_record_cache(target: Any, count: int, records: list[Json]) -> Non
     if not target.python_hot_cache_enabled():
         return
     with _DIRECT_RECORD_CACHE_LOCK:
-        if len(_DIRECT_RECORD_CACHE) >= _DIRECT_RECORD_CACHE_MAX_PREFIXES and target._storage_prefix not in _DIRECT_RECORD_CACHE:
+        if len(_DIRECT_RECORD_CACHE) >= _DIRECT_RECORD_CACHE_MAX_PREFIXES and direct_cache_scope(target) not in _DIRECT_RECORD_CACHE:
             oldest = next(iter(_DIRECT_RECORD_CACHE))
             _DIRECT_RECORD_CACHE.pop(oldest, None)
-        _DIRECT_RECORD_CACHE[target._storage_prefix] = (count, list(records))
+        _DIRECT_RECORD_CACHE[direct_cache_scope(target)] = (count, list(records))
 
 
 def drop_direct_record_cache(target: Any) -> None:
@@ -93,7 +110,7 @@ def drop_direct_record_cache(target: Any) -> None:
     target._records_cache = None
     target._index_cache = None
     with _DIRECT_RECORD_CACHE_LOCK:
-        _DIRECT_RECORD_CACHE.pop(target._storage_prefix, None)
+        _DIRECT_RECORD_CACHE.pop(direct_cache_scope(target), None)
     with target._retrieval_candidate_cache_lock:
         target._retrieval_candidate_cache.clear()
 

--- a/tools/matrixark_mcp_dispatch.py
+++ b/tools/matrixark_mcp_dispatch.py
@@ -316,6 +316,10 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         )
         response = {**result, "access": args.get("_matrixark_auth", {})}
         return server._finalize_write_response(name, args, identity, hook, response)
+    if name == "matrixark_list_users":
+        result = server.adapter.list_memory_subjects(args)
+        server.access.append_audit("context.list_users", identity, status="ok", details={"count": result.get("count")})
+        return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_get_all":
         result = server.adapter.get_all(args)
         server.access.append_audit("context.get_all", identity, status="ok", details={"count": result.get("count")})

--- a/tools/matrixark_mcp_latest_context_state.py
+++ b/tools/matrixark_mcp_latest_context_state.py
@@ -21,6 +21,29 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
+def expand_record_bundles(records: list[Json]) -> list[Json]:
+    """Flatten bundled appends into their constituent records.
+
+    A bundled append stores ``{"record_bundle": [rec, rec, ...]}`` as ONE hash field. The
+    wrapper carries no ``record_type``; the type every reader filters on lives on the
+    records inside it. Readers walking the raw entries therefore saw a typeless wrapper and
+    skipped it, so a bundled ``context_event`` was invisible to get / get_all / update /
+    history even though it was durably stored. The JSONL adapter appends records
+    individually and never bundles, which is why the same reader code worked there.
+
+    Idempotent: unbundled records pass through untouched.
+    """
+    expanded: list[Json] = []
+    for record in records:
+        if isinstance(record, dict):
+            bundle = record.get("record_bundle")
+            if isinstance(bundle, list):
+                expanded.extend(inner for inner in bundle if isinstance(inner, dict))
+                continue
+        expanded.append(record)
+    return expanded
+
+
 def latest_context_state_storage_key(storage_prefix: str) -> str:
     return f"{storage_prefix}:context_latest_state"
 
@@ -108,7 +131,9 @@ class LatestContextStateAdapterMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        return compact_latest_context_state_records(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5074,6 +5074,43 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             "updated_at_ms": best.get("updated_at_ms"),
         }
 
+    # mem0 calls these "users", but the list is really every identity that holds memories:
+    # a user, an agent, or a run (a session here). The tuple is (mem0 type, scope field).
+    MEMORY_SUBJECT_FIELDS = (("user", "user_id"), ("agent", "agent_id"), ("run", "session_id"))
+
+    @classmethod
+    def memory_subjects_in_record(cls, record: Json) -> list[tuple[str, str]]:
+        """The (type, name) identities a single record attributes memory to."""
+        scope = record.get("scope") if isinstance(record, dict) else None
+        if not isinstance(scope, dict):
+            return []
+        found = []
+        for kind, field in cls.MEMORY_SUBJECT_FIELDS:
+            value = str(scope.get(field) or "").strip()
+            if value:
+                found.append((kind, value))
+        return found
+
+    def list_memory_subjects(self, args: Json) -> Json:
+        """Every user / agent / run that holds at least one live memory (mem0 ``users``).
+
+        Derived from the live view, so a subject whose memories were all forgotten or expired
+        stops being listed -- which is the point: mem0's `users()` answers "who has memories",
+        not "who was ever provisioned". The account-level user list answers that other question
+        and is deliberately not reused here.
+        """
+        limit = args.get("limit") if isinstance(args, dict) else None
+        limit = int(limit) if isinstance(limit, int) and limit > 0 else 0
+        seen: dict[tuple[str, str], int] = {}
+        for record in self.read_all():
+            for subject in self.memory_subjects_in_record(record):
+                seen[subject] = seen.get(subject, 0) + 1
+        results = [{"type": kind, "name": name, "memory_count": count}
+                   for (kind, name), count in sorted(seen.items())]
+        if limit:
+            results = results[:limit]
+        return {"results": results, "count": len(results)}
+
     def get_all(self, args: Json) -> Json:
         """List a scope's active (non-forgotten, non-deleted) memories (mem0 ``get_all(user_id=...)``).
         Projects live ``context_event`` records for the subject scope to ``{id, memory, ...}``. Because

--- a/tools/matrixark_mcp_runtime_config.py
+++ b/tools/matrixark_mcp_runtime_config.py
@@ -28,6 +28,13 @@ ENABLE_SUMMARY_REFRESH_AUDIT = os.environ.get("MATRIXARK_SUMMARY_REFRESH_AUDIT",
 ENABLE_SUMMARY_DIRTY_DEBUG_FIELDS = os.environ.get("MATRIXARK_SUMMARY_DIRTY_DEBUG_FIELDS", "0").strip().lower() in {"1", "true", "yes"}
 SUMMARY_REFRESH_INTERVAL_MS = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_INTERVAL_MS", "1000"))
 SUMMARY_REFRESH_LIMIT = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_LIMIT", "64"))
+# Largest share of wall-clock the background summary refresher may occupy. A refresh pass
+# costs O(store) -- it reads the whole record log and writes the refreshed summaries back
+# through the same proxy lane the request path uses -- so at a fixed interval a pass that
+# grows past that interval turns the loop into a permanent occupant of the lane. See
+# MatrixArkMcpServer._next_summary_refresh_delay_s.
+SUMMARY_REFRESH_MAX_DUTY = float(os.environ.get("MATRIXARK_SUMMARY_REFRESH_MAX_DUTY", "0.2"))
+SUMMARY_REFRESH_MAX_BACKOFF_MS = int(os.environ.get("MATRIXARK_SUMMARY_REFRESH_MAX_BACKOFF_MS", "300000"))
 
 BACKEND_READINESS_TIMEOUT_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_TIMEOUT_MS", "30000"))
 BACKEND_READINESS_BACKOFF_MS = int(os.environ.get("MATRIXARK_BACKEND_READINESS_BACKOFF_MS", "200"))
@@ -46,6 +53,22 @@ def matrixark_production_profile_enabled() -> bool:
 
 
 def python_hot_cache_allowed(*, backend_label: str = "") -> bool:
+    """Whether the record cache may serve a read. Native backends are excluded BY POLICY.
+
+    The cache itself is safe on any backend: it is validated by the record COUNT read fresh from
+    the store on every call, and the record log is append-only -- a delete is a tombstone append --
+    so any write anywhere moves the count and the entry misses. The mutable half, the
+    latest-context-state store, is never cached; it is re-read and re-folded even on a hit.
+
+    It is nonetheless off for the native backends on purpose, matching
+    `native_candidate_prefilter_required`: TemporalStore serving is meant to read through native
+    pushdown rather than a Python-side cache. `test_python_hot_cache_default_policy` pins that.
+
+    Turning it on is a measured, one-variable win if a deployment wants it --
+    MATRIXARK_ALLOW_PYTHON_HOT_CACHE=1. Over the mem0 surface, 4 users x a 10-turn conversation:
+    get_all 1491->326 ms, get 1677->402 ms, update 5050->1218 ms, users 1512->475 ms,
+    batch_update 7782->3144 ms, search 710->510 ms, with all 15 APIs still correct on both arms.
+    """
     if MATRIXARK_ALLOW_PYTHON_HOT_CACHE:
         return MATRIXARK_ALLOW_PYTHON_HOT_CACHE in {"1", "true", "yes"}
     return backend_label == "local"

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -48,6 +48,7 @@ try:
         close_proxy_lanes,
         close_proxy_process,
         ensure_lane_process,
+        proxy_stderr_tail,
     )
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import Json, MatrixArkError
@@ -84,6 +85,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         close_proxy_lanes,
         close_proxy_process,
         ensure_lane_process,
+        proxy_stderr_tail,
     )
 
 
@@ -179,12 +181,14 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             self._lane_cursors[group] = index + 1
         return group, lanes[index]
 
-    def _read_json_line(self, proc: subprocess.Popen[str], op: str) -> Json:
+    def _read_json_line(self, proc: subprocess.Popen[str], op: str, lane: Json | None = None) -> Json:
         assert proc.stdout is not None
         deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
         while time.monotonic() < deadline:
             if proc.poll() is not None:
-                stderr = proc.stderr.read() if proc.stderr else ""
+                # The drain thread owns proc.stderr; reading it here would race it and, before
+                # the drain existed, could block. Quote what the drain captured instead.
+                stderr = proxy_stderr_tail(lane)
                 if op == "shutdown" and proc.returncode == 0:
                     return {"ok": True, "status": "shutdown"}
                 raise MatrixArkError(f"Rust TemporalStore {op} process exited ({proc.returncode}): {stderr[-1000:]}")
@@ -241,12 +245,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
                 except BrokenPipeError as exc:
                     lane["proc"] = None
                     returncode = proc.poll()
-                    stderr = ""
-                    try:
-                        if proc.stderr is not None:
-                            stderr = proc.stderr.read() or ""
-                    except Exception:
-                        stderr = ""
+                    stderr = proxy_stderr_tail(lane)
                     self._close_proc(proc)
                     detail = f"Rust TemporalStore {op} pipe closed"
                     if returncode is not None:
@@ -254,7 +253,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
                     if stderr:
                         detail += f": {stderr[-1000:]}"
                     raise MatrixArkError(detail) from exc
-                response = self._read_json_line(proc, op)
+                response = self._read_json_line(proc, op, lane)
         except Exception:
             elapsed_ms = (time.perf_counter() - started) * 1000.0
             self._record_call_metrics(op, kwargs, None, elapsed_ms, failed=True, lane=group, wait_ms=wait_ms)

--- a/tools/matrixark_mcp_rust_proxy_process.py
+++ b/tools/matrixark_mcp_rust_proxy_process.py
@@ -5,13 +5,72 @@
 
 from __future__ import annotations
 
+import collections
 import os
 import subprocess
+import threading
 from pathlib import Path, PurePosixPath
 from typing import Any
 
 
 Json = dict[str, Any]
+
+# Lines of proxy stderr kept per lane for error reporting. Only the tail is ever quoted (the
+# error paths take the last 1000 characters), so this is generous.
+PROXY_STDERR_TAIL_LINES = 200
+
+
+def _drain_proxy_stderr(proc: subprocess.Popen[str], sink: collections.deque) -> None:
+    """Continuously read the proxy's stderr so it can never block writing to it.
+
+    The proxy is spawned with `stderr=subprocess.PIPE` and nothing read that pipe outside the
+    error paths, which only run once the process has already exited or the stdin pipe has broken.
+    A pipe holds 64KB. A proxy that logs past that blocks forever inside its next stderr write --
+    it stops answering, sits near-idle because it is blocked rather than working, holds its lane,
+    and never recovers. Downstream that shows up as one request hanging to its timeout and every
+    later one rejected on the lane, which reads like a storage problem and is not one.
+
+    The busier the proxy, the sooner it happens: work that makes it log more brings the wedge
+    within a handful of requests.
+
+    Draining into a bounded deque keeps the error paths working -- they quote the tail -- without
+    keeping an unbounded log in memory. Daemon thread, so it never holds up interpreter exit.
+    """
+    stream = proc.stderr
+    if stream is None:
+        return
+    # Debug seam: MATRIXARK_PROXY_STDERR_LOG=<path> mirrors the drained stream to a file, so a
+    # proxy that stops answering can be read after the fact instead of guessed at.
+    log_path = os.environ.get("MATRIXARK_PROXY_STDERR_LOG", "").strip()
+    log = None
+    if log_path:
+        try:
+            log = open(f"{log_path}.{proc.pid}", "a", encoding="utf-8", buffering=1)
+        except OSError:
+            log = None
+    try:
+        for line in iter(stream.readline, ""):
+            sink.append(line)
+            if log is not None:
+                log.write(line)
+    except Exception:  # noqa: BLE001 - a closed pipe on shutdown must not raise here
+        pass
+    finally:
+        if log is not None:
+            try:
+                log.close()
+            except OSError:
+                pass
+
+
+def proxy_stderr_tail(lane: Json | None, limit: int = 1000) -> str:
+    """The drained stderr tail for a lane, for error messages."""
+    if not isinstance(lane, dict):
+        return ""
+    sink = lane.get("stderr_tail")
+    if not sink:
+        return ""
+    return "".join(sink)[-limit:]
 
 
 def close_proxy_process(proc: subprocess.Popen[str]) -> None:
@@ -88,4 +147,16 @@ def ensure_lane_process(target: Any, lane: Json) -> subprocess.Popen[str]:
         bufsize=1,
         env=env,
     )
+    # Start draining stderr immediately -- see _drain_proxy_stderr. Without this the proxy
+    # deadlocks on its own log output once it has written a pipe buffer's worth.
+    sink: collections.deque = collections.deque(maxlen=PROXY_STDERR_TAIL_LINES)
+    lane["stderr_tail"] = sink
+    drain = threading.Thread(
+        target=_drain_proxy_stderr,
+        args=(lane["proc"], sink),
+        name="matrixark-proxy-stderr-drain",
+        daemon=True,
+    )
+    lane["stderr_drain"] = drain
+    drain.start()
     return lane["proc"]

--- a/tools/matrixark_mcp_schemas.py
+++ b/tools/matrixark_mcp_schemas.py
@@ -1164,6 +1164,18 @@ TOOLS: list[Json] = [
         },
     },
     {
+        "name": "matrixark_list_users",
+        "description": "List the users/agents/runs that hold memories (mem0 users). Excludes subjects whose memories were all forgotten or expired.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "api_key": API_KEY_SCHEMA,
+                "limit": {"type": "integer", "description": "Optional cap on the number of subjects returned."},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
         "name": "matrixark_reset",
         "description": "Wipe ALL memory for the caller's tenant (mem0 reset). Guarded by confirm == tenant_id or the literal 'RESET'.",
         "inputSchema": {

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -80,6 +80,7 @@ try:
     )
     from tools.matrixark_mcp_schemas import TOOLS
     from tools.matrixark_mcp_stream_materialize import flush_due_scopes
+    from tools.matrixark_mcp_summary_runtime import next_summary_refresh_delay_s
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
         MATRIXARK_ALLOW_LOCAL_BACKEND,
@@ -134,6 +135,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
     from matrixark_mcp_schemas import TOOLS
     from matrixark_mcp_stream_materialize import flush_due_scopes
+    from matrixark_mcp_summary_runtime import next_summary_refresh_delay_s
 
 
 __all__ = [
@@ -301,10 +303,15 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
             f"matrixark summary refresher started interval_ms={SUMMARY_REFRESH_INTERVAL_MS} limit={self._summary_refresh_limit}"
         )
 
+    def _next_summary_refresh_delay_s(self, last_pass_s: float) -> float:
+        """Delay before the next refresh pass -- see `next_summary_refresh_delay_s`."""
+        return next_summary_refresh_delay_s(self._summary_refresh_interval_s, last_pass_s)
+
     def _summary_refresh_loop(self) -> None:
-        while not self._summary_stop.wait(self._summary_refresh_interval_s):
+        delay_s = self._summary_refresh_interval_s
+        while not self._summary_stop.wait(delay_s):
+            started_perf = time.perf_counter()
             try:
-                started_perf = time.perf_counter()
                 result = self.adapter.refresh_summaries({"scope": {}, "limit": self._summary_refresh_limit})
                 self.metrics.observe_operation("summary_refresh", "ok", (time.perf_counter() - started_perf) * 1000.0)
                 refreshed_count = int(result.get("refreshed_count") or 0)
@@ -313,6 +320,7 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
             except Exception as exc:
                 self.metrics.observe_operation("summary_refresh", "error", 0.0, timeout=is_retryable_temporalstore_error(exc))
                 _mcp_debug_log(f"matrixark summary refresh loop failed: {exc}")
+            delay_s = self._next_summary_refresh_delay_s(time.perf_counter() - started_perf)
 
     def ensure_stream_materialize_worker(self) -> None:
         """Start the background stream-materializer loop (idempotent, per-process).

--- a/tools/matrixark_mcp_summary_runtime.py
+++ b/tools/matrixark_mcp_summary_runtime.py
@@ -19,6 +19,8 @@ try:
         TIME_COMPRESSION_WINDOW_EVENTS,
         ENABLE_SUMMARY_REFRESH_AUDIT,
         EMBEDDING_LINEAGE_DEBUG_FIELDS,
+        SUMMARY_REFRESH_MAX_BACKOFF_MS,
+        SUMMARY_REFRESH_MAX_DUTY,
         candidate_index_terms,
         candidate_access_scope,
         context_index_posting_record,
@@ -45,6 +47,8 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         TIME_COMPRESSION_WINDOW_EVENTS,
         ENABLE_SUMMARY_REFRESH_AUDIT,
         EMBEDDING_LINEAGE_DEBUG_FIELDS,
+        SUMMARY_REFRESH_MAX_BACKOFF_MS,
+        SUMMARY_REFRESH_MAX_DUTY,
         candidate_index_terms,
         candidate_access_scope,
         context_index_posting_record,
@@ -80,6 +84,33 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         node_summary_dirty_records,
         pending_dirty_node_records,
     )
+
+
+def next_summary_refresh_delay_s(interval_s: float, last_pass_s: float) -> float:
+    """How long the background refresher should wait before its next pass.
+
+    A pass is O(store): `refresh_dirty_node_summaries` reads the entire record log and then
+    writes the refreshed summaries back through the SAME proxy lane the request path uses. In
+    shared_process_mode that lane is one process behind one permit shared by every write, read
+    and control op, so waiting a FIXED interval between passes is only safe while a pass is
+    cheap. Once a pass costs longer than the interval -- which happens as soon as the store
+    holds a real number of records -- the loop is running essentially all the time and holds
+    that permit for most of every second. Foreground requests then queue on the semaphore,
+    block until the request timeout, and are rejected on lane backpressure from then on.
+    Nothing recovers, because the store only grows and each pass is slower than the last.
+
+    Waiting in proportion to what the pass actually cost caps the loop at
+    SUMMARY_REFRESH_MAX_DUTY of wall-clock however large the store gets, leaving the rest for
+    the request path. A pass that finishes inside `interval_s` keeps that interval, so the cheap
+    common case is unchanged, and a duty outside (0, 1) degrades to the fixed interval rather
+    than dividing by zero.
+    """
+    max_duty = SUMMARY_REFRESH_MAX_DUTY
+    if interval_s <= 0 or not (0.0 < max_duty < 1.0):
+        return interval_s
+    # `last_pass_s` of work at `max_duty` occupancy implies this much idle time after it.
+    idle_needed_s = max(0.0, last_pass_s) * (1.0 - max_duty) / max_duty
+    return max(interval_s, min(idle_needed_s, SUMMARY_REFRESH_MAX_BACKOFF_MS / 1000.0))
 
 
 def compact_summary_embedding_record(record: Json) -> Json:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -5,10 +5,25 @@
 
 from __future__ import annotations
 
+import collections
 import queue
 import socket
+import threading
 import time
 from pathlib import PurePosixPath
+
+try:  # the proxy stderr drain is shared with the standalone proxy client
+    from tools.matrixark_mcp_rust_proxy_process import (
+        PROXY_STDERR_TAIL_LINES,
+        _drain_proxy_stderr,
+        proxy_stderr_tail,
+    )
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_mcp_rust_proxy_process import (
+        PROXY_STDERR_TAIL_LINES,
+        _drain_proxy_stderr,
+        proxy_stderr_tail,
+    )
 
 try:
     from tools.matrixark_mcp_core import *
@@ -356,6 +371,23 @@ try:  # mixin
 except ImportError:
     from matrixark_temporal_direct_retrieve import _TemporalDirectRetrieveMixin
 
+def matrixark_storage_mode_label(adapter: Any) -> str:
+    """The storage mode a native adapter is actually running, for metrics/diagnostics."""
+    if getattr(adapter, "_matrixark_proxy_mode", False):
+        return "temporalstore-native-proxy"
+    return "temporalstore-native"
+
+
+# Scope fields that are DERIVED from an identity rather than naming one. When re-scoping a
+# request from the caller to some other subject, these have to go: they are already computed for
+# the caller, and leaving them in means the subject filter silently resolves back to the caller.
+# That is not theoretical -- it made `users()` report the caller's memory count for every user and
+# never drop a user whose memories had all been forgotten.
+_SUBJECT_RESCOPE_DROP = frozenset({
+    "session_id", "agent_id", "user_hash", "session_hash", "scope_key", "_explicit_scope_keys",
+})
+
+
 class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, _TemporalDirectWriteMixin, _TemporalDirectReadMixin, _TemporalDirectRetrieveMixin):
     """MatrixArk adapter backed by TemporalStore proxy or direct SDK.
 
@@ -365,6 +397,582 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
     embedded/local path; MATRIXARK_TEMPORALSTORE_NATIVE_PROXY_ENDPOINT selects the
     proxy boundary.
     """
+
+    def read_all(self) -> list[Json]:
+        """Read through the native record log, not MatrixArkLocalAdapter's JSONL log.
+
+        `MatrixArkLocalAdapter` precedes the direct mixins in this class's MRO and also
+        defines `read_all`, so its JSONL implementation won here -- and on a native backend
+        there is no JSONL log, so it returned ZERO records. Every reader built on read_all
+        (get / get_all / update / history / keyed recall) therefore read empty while the
+        records sat durably in the record log; the same inherited method is correct on the
+        JSONL backend, which is why only the native backends looked broken.
+
+        Only `read_all` collided: `read_all_without_disk_fallback_recovery` is defined solely
+        on `_TemporalDirectReadMixin` and already resolved correctly, so delegating to it
+        reproduces the direct read exactly without reordering bases (which would silently
+        move every other method both classes define).
+
+        The live-view post-processing MUST be kept: `MatrixArkLocalAdapter.read_all` does not
+        just read, it filters the log down to live records. Delegating to the raw direct read
+        alone silently drops that -- forget/delete tombstones stop being honoured (the subject's
+        records stay visible after a forget) and a TTL record never expires, because expiry is
+        enforced on read and is never cached.
+
+        The body is deliberately identical to `MatrixArkLocalAdapter.read_all`; only the
+        `_read_all_compacted` beneath it differs per backend.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import filter_live_memory_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import filter_live_memory_records
+        records = self._read_all_compacted()
+        return filter_live_memory_records(records)
+
+    def _read_all_compacted(self) -> list[Json]:
+        """The compacted, tombstone-swept view -- WITHOUT the expiry/retention filter.
+
+        The seam between "compacted" and "live" exists because some callers need to see records
+        the live view hides: `sweep_expired_memories` has to find the expired rows in order to
+        tombstone them, and would reclaim nothing if handed a view they had already been filtered
+        out of. Overriding it here rather than only `read_all` is what makes the three memory
+        paths built on it work on a native backend -- keyed upsert (`_apply_identity_upsert`),
+        the retention-cutoff scope resolver, and the expiry sweep. All three called the inherited
+        JSONL implementation, which returns `[]` as soon as `_local_jsonl_enabled` is False, so on
+        every native backend keyed upsert silently never ran: a second ingest under the same
+        `identity_key` found no existing record to supersede and both values stayed live.
+
+        The two extra serving-pipeline stages are applied HERE rather than inside
+        `_with_latest_context_state_records`, which the retrieval hot path also goes through:
+
+          * `compact_latest_value_records` collapses records sharing a latest-value key. For a
+            `context_event` that key is the `event_id_hash`, and ingest persists an event row
+            twice -- once on the hot path (`extraction_phase: hot_path`) and again when
+            extraction commits (`final`). Without it both rows serve and `get_all` reports one
+            memory as two.
+          * `apply_memory_tombstones` is what makes forget / delete / reset remove anything.
+            Without it a forget writes its tombstone, reports an accurate `removed_count`, and
+            then serves every one of those records right back.
+
+        `compact_and_apply_tombstones` composes all three in the one order correct for both
+        orphan sweeping and supersede (see its docstring). Both added stages fast-path a log
+        with no duplicate keys / no tombstone, and all three are idempotent -- which matters,
+        because the result feeds a cache this method is called against repeatedly.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import compact_and_apply_tombstones
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_all")
+        return compact_and_apply_tombstones(self.read_all_without_disk_fallback_recovery())
+
+    def _read_raw_records(self) -> list[Json]:
+        """The native record log in append order -- NOT compacted, NOT tombstone-filtered.
+
+        Same MRO collision as `read_all`: `MatrixArkLocalAdapter._read_raw_records` reads the
+        JSONL shards and returns `[]` the moment `_local_jsonl_enabled` is False, which is
+        exactly what every native backend sets. `history` is built on this method -- it is
+        deliberately the RAW log, because the change history of a memory is the tombstones and
+        superseded rows that the live view exists to hide -- so on a native backend history
+        reported an empty log for a memory that plainly had one.
+
+        The delete-before-extract guard in `session_commit` also reads through here. It asks
+        whether a pending event survived the tombstone sweep and treats a tombstone-free log as
+        "keep everything", so an empty result made it silently inert on native backends rather
+        than wrong; with a real log behind it the guard now does its job there too.
+
+        Deliberately does NOT fold in `_load_latest_context_state_records()`: that store holds
+        the compacted latest state, which is the opposite of an append history, and none of it
+        is a `context_event` or a tombstone.
+
+        Deliberately does NOT take `_records_lock` either. That lock guards the serving-record
+        cache, and this method reads nothing from it -- but taking it would put a thread inside
+        `_records_lock` while it waits on the proxy client's lane semaphore, while the serving
+        read holds a lane slot and waits on `_records_lock`. Two threads, opposite order: a real
+        inversion, and nothing here needs the lock, since each call reads a fresh count and its
+        records straight from the backend.
+
+        To be precise about what was and was not observed: dropping this lock did NOT resolve the
+        gateway wedge it was first suspected of causing. That wedge was the background summary
+        refresher holding the single shared proxy lane (see `next_summary_refresh_delay_s`). The
+        inversion above is a hazard on the code's own terms, not a diagnosis of that incident.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+        self._recover_serving_from_disk_fallback_if_needed(reason="read_raw_records")
+        count = self._get_count()
+        if count > 0:
+            records = self._load_records_by_count(count)
+        else:
+            records = self._load_records(self._get_index())
+        return expand_record_bundles(records)
+
+    def _idempotency_index_key(self) -> str:
+        return f"{self._storage_prefix}:idempotency_index"
+
+    def _idempotency_index_ready_key(self) -> str:
+        return f"{self._storage_prefix}:idempotency_index_ready"
+
+    @staticmethod
+    def _idempotency_index_field(key_hash: int) -> str:
+        # Fixed width, so a field is never a prefix of another and ordering stays stable.
+        return f"{int(key_hash):020d}"
+
+    def _ensure_idempotency_index(self) -> None:
+        """Make the keyed index cover what the log already holds, exactly once per store.
+
+        Without this a miss could not be trusted. A store written before the index existed has
+        idempotency records in the log and nothing in the index, so "absent from the index" would
+        not mean "absent from the store", and a replay would be missed -- the one thing the
+        idempotency record exists to prevent. Backfilling once and persisting a marker makes a
+        miss authoritative from then on, and keeps a restart or a second worker from repeating it.
+        """
+        if getattr(self, "_idempotency_index_built", False):
+            return
+        try:
+            if self._client.get_string(self._idempotency_index_ready_key()):
+                self._idempotency_index_built = True
+                return
+        except Exception:  # noqa: BLE001 - an unreadable marker just means "build it".
+            pass
+        import json as _json
+
+        entries: list[Json] = []
+        index_key = self._idempotency_index_key()
+        for record in self.read_all():
+            if not isinstance(record, dict) or record.get("record_type") != "matrixark_idempotency":
+                continue
+            key_hash = record.get("key_hash")
+            if key_hash is None:
+                continue
+            entries.append({
+                "key": index_key,
+                "field": self._idempotency_index_field(int(key_hash)),
+                "value": _json.dumps(record, separators=(",", ":"), default=str),
+            })
+        if entries:
+            self._client.batch_hset(entries)
+        self._client.put_string(self._idempotency_index_ready_key(), "1")
+        self._idempotency_index_built = True
+
+    def find_idempotency_record(self, key_hash: int) -> Json | None:
+        """Point-lookup, instead of walking the whole record log to answer one key.
+
+        `MatrixArkLocalAdapter.find_idempotency_record` scans `reversed(self.read_all())`. On the
+        JSONL backend that walks an in-memory list; on a native backend `read_all()` is a full
+        record-log read shipped over the proxy and re-run through the serving pipeline. The request
+        policy asks this twice per tool call -- once to replay, once before storing -- and an ingest
+        is two tool calls, so ONE ingest paid four full-store reads purely to answer "have I seen
+        this key". That is most of why ingest latency climbed with the number of records held.
+
+        The log stays the source of truth: `append_idempotency_record` still appends the record and
+        additionally writes the keyed entry, so durability, replay and history are unchanged.
+        """
+        self._ensure_idempotency_index()
+        import json as _json
+
+        try:
+            raw = self._client.hget(self._idempotency_index_key(), self._idempotency_index_field(key_hash))
+        except Exception:  # noqa: BLE001 - scan rather than wrongly report "never seen".
+            return self.find_idempotency_record_in_log(key_hash)
+        if not raw:
+            return None
+        try:
+            record = _json.loads(raw)
+        except (TypeError, ValueError):
+            return self.find_idempotency_record_in_log(key_hash)
+        return record if isinstance(record, dict) else None
+
+    def append_idempotency_record(self, *, key_hash: int, tool_name: str, raw_key: str, identity: Json, response: Json) -> None:
+        """Append the record to the log AND index it, so the next lookup is a point read.
+
+        The indexed value is built with the same builder the log record uses rather than read
+        back out of the log, because reading it back would be the very full-store scan this
+        exists to remove.
+        """
+        super().append_idempotency_record(
+            key_hash=key_hash, tool_name=tool_name, raw_key=raw_key, identity=identity, response=response,
+        )
+        try:
+            from tools.matrixark_mcp_local_idempotency import build_idempotency_record
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_idempotency import build_idempotency_record
+        import json as _json
+
+        self._ensure_idempotency_index()
+        record = build_idempotency_record(
+            key_hash=key_hash, tool_name=tool_name, raw_key=raw_key, identity=identity, response=response,
+        )
+        try:
+            self._client.hset(
+                self._idempotency_index_key(),
+                self._idempotency_index_field(key_hash),
+                _json.dumps(record, separators=(",", ":"), default=str),
+            )
+        except Exception:  # noqa: BLE001 - the log already holds it; the index rebuilds from there.
+            pass
+
+    def find_idempotency_record_in_log(self, key_hash: int) -> Json | None:
+        """The scanning lookup, kept addressable as the fallback and for tests."""
+        return super().find_idempotency_record(key_hash)
+
+    def _node_embedding_index_key(self) -> str:
+        return f"{self._storage_prefix}:node_embedding_index"
+
+    def _node_embedding_index_ready_key(self) -> str:
+        return f"{self._storage_prefix}:node_embedding_index_ready"
+
+    @staticmethod
+    def _node_embedding_index_field(node_hash: int, model_ref: str) -> str:
+        return f"{model_ref}:{int(node_hash):020d}"
+
+    def _ensure_node_embedding_index(self) -> None:
+        """Backfill the keyed index from the log once per store, then trust it.
+
+        Same reasoning as the idempotency index: a store written before this index existed has
+        node embeddings in the log and nothing in the index, so a miss would not mean "absent"
+        and every node would be re-embedded. The marker is persisted so a restart or a second
+        worker does not repeat the backfill -- which matters here because the native adapters
+        deliberately start their context-node caches EMPTY and never load them from the store.
+        """
+        if getattr(self, "_node_embedding_index_built", False):
+            return
+        try:
+            if self._client.get_string(self._node_embedding_index_ready_key()):
+                self._node_embedding_index_built = True
+                return
+        except Exception:  # noqa: BLE001 - an unreadable marker just means "build it".
+            pass
+        entries: list[Json] = []
+        index_key = self._node_embedding_index_key()
+        for record in self.read_all():
+            if (
+                not isinstance(record, dict)
+                or record.get("record_type") != "context_embedding"
+                or record.get("ref_type") != "node"
+                or record.get("embedding_type") != "context_node"
+                or record.get("ref_hash") is None
+                or not isinstance(record.get("vector"), list)
+                or not record.get("vector")
+            ):
+                continue
+            try:
+                ref_hash = int(record.get("ref_hash"))
+            except (TypeError, ValueError):
+                continue
+            entries.append({
+                "key": index_key,
+                "field": self._node_embedding_index_field(ref_hash, str(record.get("model_ref") or "")),
+                "value": "1",
+            })
+        if entries:
+            self._client.batch_hset(entries)
+        self._client.put_string(self._node_embedding_index_ready_key(), "1")
+        self._node_embedding_index_built = True
+
+    def _existing_node_embedding_refs(self, current_model_ref: str) -> set[int]:
+        """One small keyed scan instead of a full record-log read.
+
+        The inherited implementation walks `read_all()` to collect the node hashes that already
+        have an embedding. On a native backend that is a full record-log read over the proxy, and
+        `ensure_context_node_path` runs THREE times per ingest, so it was the largest remaining
+        O(store) cost on the ingest path. This index holds one tiny entry per embedded node rather
+        than every record in the store.
+        """
+        self._ensure_node_embedding_index()
+        scanner = getattr(self._client, "scan_hash", None)
+        if not callable(scanner):
+            return super()._existing_node_embedding_refs(current_model_ref)
+        try:
+            response = scanner(self._node_embedding_index_key())
+        except Exception:  # noqa: BLE001 - re-embedding is worse than one slow read.
+            return super()._existing_node_embedding_refs(current_model_ref)
+        rows = response.get("records") if isinstance(response, dict) else []
+        prefix = f"{current_model_ref}:"
+        refs: set[int] = set()
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            field = str(row.get("field") or "")
+            if not field.startswith(prefix):
+                continue
+            try:
+                refs.add(int(field[len(prefix):]))
+            except (TypeError, ValueError):
+                continue
+        return refs
+
+    def _record_node_embedding_ref(self, node_hash: int, current_model_ref: str) -> None:
+        self._ensure_node_embedding_index()
+        try:
+            self._client.hset(
+                self._node_embedding_index_key(),
+                self._node_embedding_index_field(node_hash, current_model_ref),
+                "1",
+            )
+        except Exception:  # noqa: BLE001 - the log still has it; the index rebuilds from there.
+            pass
+
+    def refresh_summaries(self, args: Json) -> Json:
+        """Skip the cross-scope background pass when the store has not changed since the last one.
+
+        The background refresher calls this with an EMPTY scope on a timer. The first thing the
+        pass does is `read_all()` -- a full record-log read -- and on a native backend that read
+        goes over the proxy and holds the single shared lane for its whole duration. Measured on a
+        99 MB store that is minutes, during which every request queues on the lane and is rejected
+        on backpressure, with NO client load and nothing to refresh. Spacing the passes out cannot
+        help: the cost is inside one pass, not between them.
+
+        Dirty state only changes when records are appended, and the record count is a single point
+        read. So if the count is exactly what it was before the last pass AND that pass found
+        nothing to refresh, this pass would read the whole store to reach the same conclusion --
+        skip it. The `refreshed_count == 0` half matters: a pass that hit its node limit left work
+        behind, and must be allowed to run again even though nothing new was written.
+
+        Deliberately scoped to the empty-scope background caller. The pre-retrieval refresh passes
+        a real scope and is on the request path already, so it is left exactly as it was.
+        """
+        scope = args.get("scope") if isinstance(args, dict) else None
+        if scope:
+            return super().refresh_summaries(args)
+        token = None
+        try:
+            token = int(self._get_count())
+        except Exception:  # noqa: BLE001 - no cheap token available, just do the pass.
+            token = None
+        last_token, last_refreshed = self._load_summary_pass_state()
+        if token is not None and token == last_token and last_refreshed == 0:
+            return {"refreshed_count": 0, "status": "unchanged", "skipped": True}
+        result = super().refresh_summaries(args)
+        # Record the count as it was BEFORE the pass: a pass that refreshes something appends, so
+        # the count moves and the next pass runs regardless.
+        try:
+            refreshed = int((result or {}).get("refreshed_count") or 0)
+        except (TypeError, ValueError):
+            refreshed = None
+        self._store_summary_pass_state(token, refreshed)
+        return result
+
+    def _summary_pass_state_key(self) -> str:
+        return f"{self._storage_prefix}:summary_pass_state"
+
+    def _load_summary_pass_state(self) -> tuple[int | None, int | None]:
+        """The record count and outcome of the last completed background pass.
+
+        Held in the store, not just on the instance, so a RESTART does not force one full-store
+        pass. That pass is minutes long on a large store and holds the single shared proxy lane
+        for its whole duration, so an in-memory-only token turns every restart into a window
+        where the gateway answers nothing -- which is exactly what it looked like before this
+        was persisted.
+        """
+        cached = getattr(self, "_summary_pass_state", None)
+        if cached is not None:
+            return cached
+        token: int | None = None
+        refreshed: int | None = None
+        try:
+            raw = self._client.get_string(self._summary_pass_state_key())
+        except Exception:  # noqa: BLE001 - unreadable state just means "run the pass".
+            raw = ""
+        if raw and ":" in raw:
+            left, _, right = raw.partition(":")
+            try:
+                token, refreshed = int(left), int(right)
+            except (TypeError, ValueError):
+                token, refreshed = None, None
+        self._summary_pass_state = (token, refreshed)
+        return self._summary_pass_state
+
+    def _store_summary_pass_state(self, token: int | None, refreshed: int | None) -> None:
+        self._summary_pass_state = (token, refreshed)
+        if token is None or refreshed is None:
+            return
+        try:
+            self._client.put_string(self._summary_pass_state_key(), f"{token}:{refreshed}")
+        except Exception:  # noqa: BLE001 - the instance copy still short-circuits this process.
+            pass
+
+    def backend_metrics(self) -> Json:
+        """Describe the backend this adapter actually uses.
+
+        Without this the direct adapter inherits `MatrixArkLocalAdapter.backend_metrics`, which
+        hardcodes `mode: "local-jsonl"` and reports `event_log` -- and on a native backend that
+        path is the `-unused-` sentinel file the adapter never writes to. So a native deployment
+        asking for backend metrics was told it was running the JSONL backend, and pointed at a
+        file that does not exist. The subclass used by `temporalstore-rust` already overrides
+        this; `temporalstore-direct` is the backend that was left reporting the wrong engine.
+
+        Kept cheap on purpose: a metrics call must not become a full-store read, so the only
+        store access is the record count, which is a single point read.
+        """
+        metrics: Json = {
+            "mode": matrixark_storage_mode_label(self),
+            "storage_prefix": getattr(self, "_storage_prefix", ""),
+            "namespace": getattr(self, "_namespace", ""),
+            "table": getattr(self, "_table", ""),
+        }
+        try:
+            metrics["record_count"] = int(self._get_count())
+        except Exception:  # noqa: BLE001 - metrics must never be the thing that fails.
+            metrics["record_count"] = None
+        for name in ("health", "readiness", "metrics_snapshot"):
+            probe = getattr(self._client, name, None)
+            if not callable(probe):
+                continue
+            try:
+                metrics[name] = probe()
+            except Exception as exc:  # noqa: BLE001
+                metrics[name] = {"ok": False, "error": str(exc)}
+        return {
+            "backend": self._backend_label(),
+            "metrics_format": "json",
+            "metrics": metrics,
+        }
+
+    def _subject_index_key(self) -> str:
+        return f"{self._storage_prefix}:memory_subject_index"
+
+    def _subject_index_ready_key(self) -> str:
+        return f"{self._storage_prefix}:memory_subject_index_ready"
+
+    def _ensure_subject_index(self) -> None:
+        """Backfill the subject index from the log once per store, behind a persisted marker.
+
+        Same shape as the idempotency and node-embedding indexes: without the backfill a store
+        written before this existed would list no subjects at all, and without persisting the
+        marker every restart would re-read the whole log to rebuild it.
+        """
+        if getattr(self, "_subject_index_built", False):
+            return
+        try:
+            if self._client.get_string(self._subject_index_ready_key()):
+                self._subject_index_built = True
+                return
+        except Exception:  # noqa: BLE001 - an unreadable marker just means "build it".
+            pass
+        entries: list[Json] = []
+        index_key = self._subject_index_key()
+        for record in self.read_all():
+            for kind, name in self.memory_subjects_in_record(record):
+                entries.append({"key": index_key, "field": f"{kind}:{name}", "value": "1"})
+        if entries:
+            self._client.batch_hset(entries)
+        self._client.put_string(self._subject_index_ready_key(), "1")
+        self._subject_index_built = True
+
+    def _index_memory_subjects(self, records: list[Json]) -> None:
+        """Note any NEW subject these records introduce.
+
+        Called on the append path, so it has to stay close to free. The set of subjects is tiny
+        and changes almost never, so an in-process set of the ones already written means a steady
+        stream of writes for known subjects costs nothing, and only a genuinely new user / agent
+        / run pays a single hset.
+        """
+        known = getattr(self, "_subject_index_seen", None)
+        if known is None:
+            known = self._subject_index_seen = set()
+        fresh = []
+        for record in records:
+            for subject in self.memory_subjects_in_record(record):
+                if subject not in known:
+                    known.add(subject)
+                    fresh.append(subject)
+        if not fresh:
+            return
+        self._ensure_subject_index()
+        index_key = self._subject_index_key()
+        try:
+            self._client.batch_hset([
+                {"key": index_key, "field": f"{kind}:{name}", "value": "1"} for kind, name in fresh
+            ])
+        except Exception:  # noqa: BLE001 - the log still holds the truth; the index rebuilds.
+            for subject in fresh:
+                known.discard(subject)
+
+    @staticmethod
+    def _subject_scope(base_scope: Json, user_id: str) -> Json:
+        """The caller's scope re-pointed at another subject, with that subject's OWN hashes.
+
+        A request scope carries identity fields DERIVED from the caller -- `user_hash`,
+        `session_hash`, `scope_key` -- and `get_all` filters on the hashes, never on `user_id`.
+        So swapping only `user_id` leaves the caller's `user_hash` in place and the lookup
+        resolves straight back to the caller; dropping the hashes instead yields `user_hash == 0`,
+        which reads as "no subject filter" and returns the whole tenant. Both were observed:
+        every user reported the same memory count, and a user whose memories had all been
+        forgotten never dropped out of `users()`.
+
+        The hashes have to be recomputed for the subject, by the same function the ingest path
+        uses, so they match what is actually stored.
+        """
+        try:
+            from tools.matrixark_mcp_core_identity import identity_hashes
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_core_identity import identity_hashes
+        account_id = str(base_scope.get("account_id") or "")
+        tenant_id = str(base_scope.get("tenant_id") or "")
+        scope = {k: v for k, v in base_scope.items() if k not in _SUBJECT_RESCOPE_DROP}
+        scope["user_id"] = user_id
+        scope.update(identity_hashes(account_id, tenant_id, user_id=user_id))
+        return scope
+
+    def list_memory_subjects(self, args: Json) -> Json:
+        """The keyed subject index, instead of reading the whole log to collect scopes.
+
+        The inherited implementation walks `read_all()`. On a native backend that is a full
+        record-log read over the proxy, and `users()` is exactly the kind of call an operator
+        loops over, so it must not be O(store).
+
+        The index is add-only, so it can name a subject whose memories have since all been
+        forgotten or expired. mem0's `users()` means "who has memories", so the live view decides:
+        the count comes from a scoped `get_all`, and a subject with none is dropped. That keeps
+        the expensive part proportional to the number of SUBJECTS, not to the size of the store.
+        """
+        self._ensure_subject_index()
+        limit = args.get("limit") if isinstance(args, dict) else None
+        limit = int(limit) if isinstance(limit, int) and limit > 0 else 0
+        scanner = getattr(self._client, "scan_hash", None)
+        if not callable(scanner):
+            return super().list_memory_subjects(args)
+        try:
+            response = scanner(self._subject_index_key())
+        except Exception:  # noqa: BLE001
+            return super().list_memory_subjects(args)
+        rows = response.get("records") if isinstance(response, dict) else []
+        subjects: list[tuple[str, str]] = []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            field = str(row.get("field") or "")
+            kind, _, name = field.partition(":")
+            if kind and name:
+                subjects.append((kind, name))
+        # The subject's memories have to be counted in the CALLER's scope. A bare
+        # {"user_id": name} carries no account/tenant, so the subject filter resolves to nothing
+        # and get_all returns the whole tenant -- every user then reports the same count and a
+        # user whose memories were all forgotten never drops out of the list.
+        base_scope = dict(args.get("scope") or {}) if isinstance(args, dict) else {}
+        results: list[Json] = []
+        for kind, name in sorted(set(subjects)):
+            if kind != "user":
+                # Only a user is addressable by get_all here, so agents/runs are reported without
+                # a live count rather than with a wrong one.
+                results.append({"type": kind, "name": name})
+                continue
+            scope = self._subject_scope(base_scope, name)
+            try:
+                listed = self.get_all({"scope": scope})
+            except Exception:  # noqa: BLE001
+                results.append({"type": kind, "name": name})
+                continue
+            memories = listed.get("memories") or listed.get("items") or listed.get("results") or []
+            if not memories:
+                continue
+            results.append({"type": kind, "name": name, "memory_count": len(memories)})
+            if limit and len(results) >= limit:
+                break
+        return {"results": results, "count": len(results)}
 
     def append(self, record: Json) -> None:
         self.append_many([record])
@@ -395,9 +1003,29 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # this class); the fast direct-ingest path calls _append_many_materialized
         # itself (never append), so there is no double write. Disable with
         # MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND=0 as an escape hatch.
-        materialized = materialize_serving_record_batch(records)
+        #
+        # Per-ingestion stamping runs HERE, in the same order as
+        # MatrixArkLocalAdapter.append_many, because it was being skipped entirely on every
+        # native backend. `_stamp_ingest_fields` is what puts `expires_at_ms`/`ephemeral` and
+        # `identity_key`/`truth_class`/`truth_rank` onto the records; without it an
+        # `ttl_seconds` ingest stored a record that nothing would ever expire, an
+        # `identity_key` ingest stored a record keyed recall could not find (404) and
+        # keyed-upsert never superseded, and a tenant that switched a record kind off still
+        # had it written. Policy runs on the RAW records, before serving materialization
+        # strips the scope a context_embedding row carries -- afterwards there is no tenant
+        # left to attribute it to.
+        #
+        # `_apply_serving_dedup` is deliberately NOT applied here: its summary-dirty
+        # coalescing calls read_all(), which on a native backend is a full record-log read on
+        # every append batch. It only removes redundant pending markers -- a size
+        # optimization, not correctness -- and paying an O(store) read per ingest to get it
+        # is the wrong trade on this path.
+        materialized = self._stamp_ingest_fields(materialize_serving_record_batch(records))
         if not materialized:
             return
+        # Index subjects from the RAW records: serving materialization strips the scope off some
+        # rows, and a subject with no scope left cannot be attributed to anyone.
+        self._index_memory_subjects(records)
         if self._queue_batched_records(materialized):
             return
         append_backend = getattr(self, "_append_many_materialized", None)
@@ -1355,6 +1983,23 @@ class MatrixArkRustProxyClient:
             bufsize=1,
             env=env,
         )
+        # Drain stderr from the moment the proxy starts. Nothing read this pipe outside the
+        # error paths, which only run once the process has exited or its stdin has broken -- so
+        # a proxy that logged past the 64KB pipe buffer blocked forever inside its next stderr
+        # write. It stopped answering, sat near-idle because it was blocked rather than working,
+        # held its lane, and never recovered; downstream that looked like one request hanging to
+        # its timeout and every later one rejected on the lane. The busier the proxy, the sooner
+        # it happened. Bounded deque, daemon thread: the error paths still quote the tail.
+        sink: collections.deque = collections.deque(maxlen=PROXY_STDERR_TAIL_LINES)
+        lane["stderr_tail"] = sink
+        drain = threading.Thread(
+            target=_drain_proxy_stderr,
+            args=(lane["proc"], sink),
+            name="matrixark-proxy-stderr-drain",
+            daemon=True,
+        )
+        lane["stderr_drain"] = drain
+        drain.start()
         return lane["proc"]
 
     def _lane_group_for_op(self, op: str) -> str:
@@ -1383,12 +2028,13 @@ class MatrixArkRustProxyClient:
             self._lane_cursors[group] = index + 1
         return group, lanes[index]
 
-    def _read_json_line(self, proc: subprocess.Popen[str], op: str) -> Json:
+    def _read_json_line(self, proc: subprocess.Popen[str], op: str, lane: Json | None = None) -> Json:
         assert proc.stdout is not None
         deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
         while time.monotonic() < deadline:
             if proc.poll() is not None:
-                stderr = proc.stderr.read() if proc.stderr else ""
+                # The drain thread owns proc.stderr; read what it captured, never the pipe.
+                stderr = proxy_stderr_tail(lane)
                 if op == "shutdown" and proc.returncode == 0:
                     return {"ok": True, "status": "shutdown"}
                 raise MatrixArkError(f"Rust TemporalStore {op} process exited ({proc.returncode}): {stderr[-1000:]}")
@@ -1460,12 +2106,7 @@ class MatrixArkRustProxyClient:
                 except BrokenPipeError as exc:
                     lane["proc"] = None
                     returncode = proc.poll()
-                    stderr = ""
-                    try:
-                        if proc.stderr is not None:
-                            stderr = proc.stderr.read() or ""
-                    except Exception:
-                        stderr = ""
+                    stderr = proxy_stderr_tail(lane)
                     self._close_proc(proc)
                     detail = f"Rust TemporalStore {op} pipe closed"
                     if returncode is not None:
@@ -1473,7 +2114,7 @@ class MatrixArkRustProxyClient:
                     if stderr:
                         detail += f": {stderr[-1000:]}"
                     raise MatrixArkError(detail) from exc
-                response = self._read_json_line(proc, op)
+                response = self._read_json_line(proc, op, lane)
         except Exception:
             elapsed_ms = (time.perf_counter() - started) * 1000.0
             self._record_call_metrics(op, kwargs, None, elapsed_ms, failed=True, lane=group, wait_ms=wait_ms)

--- a/tools/matrixark_mem0_compat.py
+++ b/tools/matrixark_mem0_compat.py
@@ -35,6 +35,10 @@ resolution is reused verbatim from ``matrixark_ingest_client`` so ``base_url`` /
 """
 from __future__ import annotations
 
+# mem0 documents a ceiling of 1000 memories per batch call; refuse past it rather than
+# quietly issuing an unbounded number of requests.
+MEM0_BATCH_LIMIT = 1000
+
 from typing import Any, Optional
 
 try:  # top-level (run from tools/) ...
@@ -259,7 +263,7 @@ class Memory:
             metadata: Optional[Json] = None, provider: Optional[str] = None,
             expires_at: Optional[float] = None, ttl: Optional[float] = None,
             identity_key: Optional[str] = None, truth_class: Optional[str] = None,
-            **kw: Any) -> Json:
+            finalize: bool = True, **kw: Any) -> Json:
         """Ingest ``messages`` (mem0 ``add``). Maps ``run_id`` -> ``session_id``
         and ``agent_id`` -> ``scope.agent_id``; accepts a bare string.
 
@@ -275,6 +279,16 @@ class Memory:
         auto-expired at read time and excluded from summaries; ``identity_key``
         + ``truth_class`` drive the keyed-upsert truth-rank guard (a higher/equal
         rank supersedes the prior value for that key; a lower rank is rejected).
+        ``finalize`` (default ``True``) commits the ingest before returning, which
+        is what makes ``add`` read-after-write: a ``get_all`` / ``search`` issued
+        straight afterwards sees the memory, as it does on mem0. Without it the
+        ingest is a streaming write that only becomes visible once a debounce
+        elapses, and because every further write to the same scope pushes that
+        debounce out, a burst of ``add`` calls can stay invisible for as long as
+        the burst lasts -- which reads as data loss in code written against mem0.
+        Pass ``finalize=False`` deliberately to stream a conversation in and let
+        the idle commit close it, which is cheaper per call.
+
         Extra kwargs are ignored for mem0 signature compatibility. Returns the
         parsed ``/v1/ingest`` response."""
         normalized = _normalize_messages(messages, provider)
@@ -292,7 +306,7 @@ class Memory:
         # Pass finalize=False for the streaming behaviour (cheaper add, retrievable after
         # the debounce).
         body: Json = {"kind": "message", "messages": normalized,
-                      "finalize": bool(kw.get("finalize", True))}
+                      "finalize": bool(finalize)}
         scope = _scope_from_identity(user_id, agent_id, run_id)
         if scope:
             body["scope"] = scope
@@ -416,6 +430,76 @@ class Memory:
         body: Json = {"memory_id": str(memory_id)}
         return _post_json(self._base_url, self._api_key, "/v1/delete", body, self._timeout)
 
+    def batch_update(self, memories: Any, **kw: Any) -> Json:
+        """Update many memories in one call (mem0 ``batch_update``).
+
+        Takes mem0's shape: a list of dicts with ``memory_id`` (required) and ``text`` and/or
+        ``metadata``. ``text`` is mem0's name for the field this API calls ``data``, so it is
+        mapped; either name is accepted here.
+
+        NOT atomic. mem0's batch endpoint is a single server-side request, but MatrixArk's update
+        is a supersede (ingest the amended version, tombstone the old id) with no cross-memory
+        transaction behind it, so this issues one update per entry and reports what happened to
+        each. Callers who need all-or-nothing must not use this. Entries are attempted in order
+        and one failure does not stop the rest -- the failures are returned rather than raised, so
+        a partial batch is visible instead of silently half-applied.
+        """
+        entries = list(memories or [])
+        if len(entries) > MEM0_BATCH_LIMIT:
+            raise ValueError(
+                f"batch_update accepts at most {MEM0_BATCH_LIMIT} memories, got {len(entries)}"
+            )
+        results: list[Json] = []
+        failed: list[Json] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError("each batch_update entry must be a dict with a memory_id")
+            memory_id = entry.get("memory_id")
+            if not memory_id:
+                raise ValueError("each batch_update entry requires memory_id")
+            body: Json = {"memory_id": str(memory_id)}
+            data = entry.get("text", entry.get("data"))
+            if data is not None:
+                body["data"] = data
+            if entry.get("metadata") is not None:
+                body["metadata"] = entry["metadata"]
+            try:
+                response = _post_json(self._base_url, self._api_key, "/v1/update", body, self._timeout)
+            except Exception as exc:  # noqa: BLE001 - report, do not abort the rest of the batch
+                failed.append({"memory_id": str(memory_id), "error": repr(exc)})
+                continue
+            results.append({"memory_id": str(memory_id), "result": response})
+        return {"results": results, "updated": len(results), "failed": failed}
+
+    def batch_delete(self, memories: Any, **kw: Any) -> Json:
+        """Delete many memories in one call (mem0 ``batch_delete``).
+
+        Takes mem0's shape: a list of dicts with ``memory_id``. A bare list of ids is accepted too,
+        because it is the obvious thing to reach for and rejecting it helps nobody.
+
+        NOT atomic, for the same reason as `batch_update`: one delete per entry, failures reported
+        per memory rather than raised, so a partial batch is visible.
+        """
+        entries = list(memories or [])
+        if len(entries) > MEM0_BATCH_LIMIT:
+            raise ValueError(
+                f"batch_delete accepts at most {MEM0_BATCH_LIMIT} memories, got {len(entries)}"
+            )
+        results: list[Json] = []
+        failed: list[Json] = []
+        for entry in entries:
+            memory_id = entry.get("memory_id") if isinstance(entry, dict) else entry
+            if not memory_id:
+                raise ValueError("each batch_delete entry requires memory_id")
+            try:
+                response = _post_json(self._base_url, self._api_key, "/v1/delete",
+                                      {"memory_id": str(memory_id)}, self._timeout)
+            except Exception as exc:  # noqa: BLE001 - report, do not abort the rest of the batch
+                failed.append({"memory_id": str(memory_id), "error": repr(exc)})
+                continue
+            results.append({"memory_id": str(memory_id), "result": response})
+        return {"results": results, "deleted": len(results), "failed": failed}
+
     def delete_all(self, *, user_id: Optional[str] = None, agent_id: Optional[str] = None,
                    run_id: Optional[str] = None, **kw: Any) -> Json:
         """Delete ALL memory for a subject (mem0 ``delete_all(user_id=...)``). Maps identity kwargs to
@@ -438,6 +522,19 @@ class Memory:
         if limit is not None:
             body["limit"] = int(limit)
         return _post_json(self._base_url, self._api_key, "/v1/memories", body, self._timeout)
+
+    def users(self, *, limit: Optional[int] = None, **kw: Any) -> Json:
+        """List the users / agents / runs that hold memories (mem0 ``users``).
+
+        Returns mem0's shape, ``{"results": [{"type": "user", "name": "alice"}, ...]}``, with a
+        ``memory_count`` added for users. "Holds memories" is the live view: a subject whose
+        memories were all forgotten or have expired is not listed, which is what mem0's users()
+        means -- it is not a list of provisioned accounts.
+        """
+        body: Json = {}
+        if limit is not None:
+            body["limit"] = int(limit)
+        return _post_json(self._base_url, self._api_key, "/v1/users", body, self._timeout)
 
     def reset(self, *, confirm: str = "RESET", **kw: Any) -> Json:
         """Wipe ALL memory for the caller's tenant (mem0 ``reset``). Posts to ``/v1/reset`` with an

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1184,7 +1184,38 @@ class _TemporalDirectBackendMixin:
         return records
 
     def _with_latest_context_state_records(self, records: list[Json]) -> list[Json]:
-        return compact_latest_context_state_records(list(records) + self._load_latest_context_state_records())
+        """Fold the latest-state store into a native read and collapse it for serving.
+
+        This runs on the RETRIEVAL hot path as well as the memory API, so it deliberately does
+        only the last of the serving pipeline's three stages. The two the memory API also needs
+        -- latest-value collapse and the tombstone sweep -- are applied one level up, in
+        `MatrixArkTemporalStoreDirectAdapter._read_all_compacted`.
+
+        The split was originally introduced because applying the stages here appeared to wedge
+        the proxy -- a retrieve hanging 120s and every later one rejected on the lane at 40s.
+        THAT ATTRIBUTION WAS WRONG, and is recorded here so it is not repeated. The wedge was
+        the background summary refresher: it ran a full-store pass on a fixed 1000 ms timer and
+        wrote the result back through the same single-permit proxy lane the request path uses,
+        so it starved every request as soon as a pass outlasted the interval. A one-variable
+        control settled it -- same rig, refresher off, 8/8 retrieves in 179-263 ms; refresher on
+        with a fixed interval, the wedge; refresher on with a cost-proportional delay, 8/8 in
+        229-760 ms. See `next_summary_refresh_delay_s`.
+
+        So the split is now a COST choice, not a safety one: these two stages are O(n) and this
+        method is on the retrieval hot path, where the memory API's needs do not apply. Moving
+        them here would also keep deleted content out of the retrieval candidate set, as on the
+        JSONL backend, which is the one behavioural argument for doing it -- deleted content can
+        still influence retrieval scoring until the memory-API read sweeps it. That is worth
+        revisiting on its own merits and with its own measurement; it is no longer blocked by an
+        unexplained wedge.
+        """
+        try:
+            from tools.matrixark_mcp_latest_context_state import expand_record_bundles
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_latest_context_state import expand_record_bundles
+        return compact_latest_context_state_records(
+            expand_record_bundles(records) + self._load_latest_context_state_records()
+        )
 
     def _latest_context_state_records_for_candidate_scan(
         self,

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -165,6 +165,8 @@ _DATA_ROUTES: dict[str, Tuple[str, str]] = {
     "/v1/delete": ("matrixark_delete", "forget"),
     "/v1/reset": ("matrixark_reset", "forget"),
     "/v1/memories": ("matrixark_get_all", "retrieve"),
+    # mem0 users(): which users/agents/runs hold memories. A read, gated like get_all.
+    "/v1/users": ("matrixark_list_users", "retrieve"),
     # update = supersede (ingest an amended version + tombstone the old id): gates on context:ingest.
     "/v1/update": ("matrixark_update_memory", "ingest"),
     # get (GET /v1/memory/<id>) and history (GET /v1/memory/<id>/history) are handled by dedicated

--- a/tools/test_direct_record_cache.py
+++ b/tools/test_direct_record_cache.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The direct record cache: what makes it safe to serve a read from.
+
+It is validated by the record COUNT, read fresh from the store on every call. The record log is
+append-only — a delete is a tombstone append — so any write moves the count and the entry misses.
+That is the whole safety argument, and these pin it, because a cache that serves one stale read is
+worse than no cache at all.
+
+The second thing pinned here is the cache KEY. `_storage_prefix` defaults to "matrixark:mcp" for
+every adapter, while the store a client actually talks to is separated by namespace and table, so
+keying on the prefix alone lets two adapters over different stores share an entry and serve each
+other's records. That was latent while the cache was off for native backends; it is reachable now
+that it is on.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_direct_cache as cache
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_direct_cache as cache
+
+
+class _Target:
+    """The handful of attributes the cache helpers touch."""
+
+    def __init__(self, namespace="ns1", table="t1", prefix="matrixark:mcp", enabled=True):
+        self._namespace = namespace
+        self._table = table
+        self._storage_prefix = prefix
+        self._enabled = enabled
+        self._entry_count_cache = None
+        self._records_cache = None
+        self._index_cache = None
+        import threading
+        self._retrieval_candidate_cache = {}
+        self._retrieval_candidate_cache_lock = threading.RLock()
+
+    def python_hot_cache_enabled(self) -> bool:
+        return self._enabled
+
+
+class DirectRecordCacheTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # The cache is process-global; start each test from empty.
+        with cache._DIRECT_RECORD_CACHE_LOCK:
+            cache._DIRECT_RECORD_CACHE.clear()
+
+    def test_a_hit_requires_the_same_count(self) -> None:
+        t = _Target()
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        self.assertEqual([{"r": 1}], cache.get_direct_record_cache(t, 10))
+
+    def test_an_append_invalidates_it(self) -> None:
+        """This is read-after-write: one more record means a different count, so no hit."""
+        t = _Target()
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        self.assertIsNone(cache.get_direct_record_cache(t, 11),
+                          "a changed record count must not serve the old records")
+
+    def test_a_shrinking_count_also_misses(self) -> None:
+        t = _Target()
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        self.assertIsNone(cache.get_direct_record_cache(t, 9))
+
+    def test_returns_a_copy_not_the_cached_list(self) -> None:
+        """A caller mutating its result must not corrupt what everyone else reads."""
+        t = _Target()
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        got = cache.get_direct_record_cache(t, 10)
+        got.append({"r": 2})
+        self.assertEqual([{"r": 1}], cache.get_direct_record_cache(t, 10))
+
+    # ---- the key names the store -------------------------------------------------------
+
+    def test_different_namespaces_do_not_share_an_entry(self) -> None:
+        a = _Target(namespace="ns_a")
+        b = _Target(namespace="ns_b")
+        cache.put_direct_record_cache(a, 10, [{"store": "a"}])
+        self.assertIsNone(cache.get_direct_record_cache(b, 10),
+                          "a different namespace is a different store")
+
+    def test_different_tables_do_not_share_an_entry(self) -> None:
+        a = _Target(table="t_a")
+        b = _Target(table="t_b")
+        cache.put_direct_record_cache(a, 10, [{"store": "a"}])
+        self.assertIsNone(cache.get_direct_record_cache(b, 10))
+
+    def test_same_store_does_share(self) -> None:
+        a = _Target(namespace="ns", table="t")
+        b = _Target(namespace="ns", table="t")
+        cache.put_direct_record_cache(a, 10, [{"store": "shared"}])
+        self.assertEqual([{"store": "shared"}], cache.get_direct_record_cache(b, 10))
+
+    def test_scope_includes_all_three_parts(self) -> None:
+        scope = cache.direct_cache_scope(_Target(namespace="N", table="T", prefix="P"))
+        for part in ("N", "T", "P"):
+            self.assertIn(part, scope)
+
+    # ---- the switch still works ---------------------------------------------------------
+
+    def test_disabled_never_serves(self) -> None:
+        t = _Target(enabled=True)
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        t._enabled = False
+        self.assertIsNone(cache.get_direct_record_cache(t, 10))
+
+    def test_disabled_never_stores(self) -> None:
+        t = _Target(enabled=False)
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        t._enabled = True
+        self.assertIsNone(cache.get_direct_record_cache(t, 10))
+
+    def test_drop_clears_the_entry(self) -> None:
+        t = _Target()
+        cache.put_direct_record_cache(t, 10, [{"r": 1}])
+        cache.drop_direct_record_cache(t)
+        self.assertIsNone(cache.get_direct_record_cache(t, 10))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_mem0_batch_ops.py
+++ b/tools/test_mem0_batch_ops.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""mem0 surface completeness on the compat shim: `batch_update`, `batch_delete`, and the
+read-after-write behaviour of `add`.
+
+mem0 takes a list of dicts keyed by `memory_id`, with `text` (its name for what this API calls
+`data`) and optional `metadata`, and documents a ceiling of 1000 per call.
+
+The behaviour worth pinning is what happens when part of a batch fails. mem0's batch is one
+server-side request; here an update is a supersede and a delete is a tombstone, with no
+cross-memory transaction behind them, so a batch is N requests and CANNOT be atomic. These tests
+pin that a failure is reported per memory and does not abort the rest, so a partial batch is
+visible to the caller rather than silently half-applied.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mem0_compat as mem0
+except ImportError:  # run from tools/ dir
+    import matrixark_mem0_compat as mem0
+
+
+class _Recorder:
+    """Stands in for the shim's HTTP POST, recording (path, body) and replaying canned results."""
+
+    def __init__(self, fail_ids=()):
+        self.calls: list[tuple[str, dict]] = []
+        self.fail_ids = set(fail_ids)
+
+    def __call__(self, base_url, api_key, path, body, timeout):
+        self.calls.append((path, body))
+        if str(body.get("memory_id")) in self.fail_ids:
+            raise RuntimeError("boom for " + str(body.get("memory_id")))
+        return {"ok": True, "echo": body}
+
+
+class Mem0BatchOpsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._original = mem0._post_json
+        self.addCleanup(lambda: setattr(mem0, "_post_json", self._original))
+
+    def _client(self, recorder):
+        mem0._post_json = recorder  # type: ignore[assignment]
+        client = object.__new__(mem0.Memory)
+        client._base_url = "http://gw"
+        client._api_key = None
+        client._timeout = 30
+        return client
+
+    # ---- batch_update --------------------------------------------------------------------
+
+    def test_batch_update_maps_mem0_text_onto_data(self) -> None:
+        rec = _Recorder()
+        client = self._client(rec)
+        result = client.batch_update([
+            {"memory_id": "m1", "text": "Updated text"},
+            {"memory_id": "m2", "text": "Another", "metadata": {"verified": True}},
+        ])
+        self.assertEqual(["/v1/update", "/v1/update"], [c[0] for c in rec.calls])
+        self.assertEqual({"memory_id": "m1", "data": "Updated text"}, rec.calls[0][1])
+        self.assertEqual(
+            {"memory_id": "m2", "data": "Another", "metadata": {"verified": True}},
+            rec.calls[1][1],
+        )
+        self.assertEqual(2, result["updated"])
+        self.assertEqual([], result["failed"])
+
+    def test_batch_update_also_accepts_the_native_data_key(self) -> None:
+        rec = _Recorder()
+        client = self._client(rec)
+        client.batch_update([{"memory_id": "m1", "data": "native name"}])
+        self.assertEqual({"memory_id": "m1", "data": "native name"}, rec.calls[0][1])
+
+    def test_batch_update_reports_a_failure_and_keeps_going(self) -> None:
+        """A partial batch must be visible. Aborting would leave the caller unable to tell which
+        memories were applied."""
+        rec = _Recorder(fail_ids={"m2"})
+        client = self._client(rec)
+        result = client.batch_update([
+            {"memory_id": "m1", "text": "a"},
+            {"memory_id": "m2", "text": "b"},
+            {"memory_id": "m3", "text": "c"},
+        ])
+        self.assertEqual(3, len(rec.calls), "a failure must not stop the remaining entries")
+        self.assertEqual(2, result["updated"])
+        self.assertEqual(["m2"], [f["memory_id"] for f in result["failed"]])
+
+    def test_batch_update_requires_memory_id(self) -> None:
+        client = self._client(_Recorder())
+        with self.assertRaises(ValueError):
+            client.batch_update([{"text": "no id"}])
+
+    def test_batch_update_refuses_more_than_the_documented_ceiling(self) -> None:
+        client = self._client(_Recorder())
+        too_many = [{"memory_id": str(i), "text": "x"} for i in range(mem0.MEM0_BATCH_LIMIT + 1)]
+        with self.assertRaises(ValueError):
+            client.batch_update(too_many)
+
+    # ---- batch_delete --------------------------------------------------------------------
+
+    def test_batch_delete_takes_mem0_dicts(self) -> None:
+        rec = _Recorder()
+        client = self._client(rec)
+        result = client.batch_delete([{"memory_id": "m1"}, {"memory_id": "m2"}])
+        self.assertEqual(["/v1/delete", "/v1/delete"], [c[0] for c in rec.calls])
+        self.assertEqual([{"memory_id": "m1"}, {"memory_id": "m2"}], [c[1] for c in rec.calls])
+        self.assertEqual(2, result["deleted"])
+
+    def test_batch_delete_also_takes_bare_ids(self) -> None:
+        rec = _Recorder()
+        client = self._client(rec)
+        client.batch_delete(["m1", "m2"])
+        self.assertEqual([{"memory_id": "m1"}, {"memory_id": "m2"}], [c[1] for c in rec.calls])
+
+    def test_batch_delete_reports_a_failure_and_keeps_going(self) -> None:
+        rec = _Recorder(fail_ids={"m1"})
+        client = self._client(rec)
+        result = client.batch_delete(["m1", "m2"])
+        self.assertEqual(2, len(rec.calls))
+        self.assertEqual(1, result["deleted"])
+        self.assertEqual(["m1"], [f["memory_id"] for f in result["failed"]])
+
+    def test_batch_delete_refuses_more_than_the_documented_ceiling(self) -> None:
+        client = self._client(_Recorder())
+        with self.assertRaises(ValueError):
+            client.batch_delete([str(i) for i in range(mem0.MEM0_BATCH_LIMIT + 1)])
+
+    def test_empty_batches_do_nothing(self) -> None:
+        rec = _Recorder()
+        client = self._client(rec)
+        self.assertEqual(0, client.batch_update([])["updated"])
+        self.assertEqual(0, client.batch_delete([])["deleted"])
+        self.assertEqual([], rec.calls)
+
+
+class Mem0AddFinalizeTest(unittest.TestCase):
+    """`add` must be read-after-write, as it is on mem0.
+
+    Without a finalize the ingest is a streaming write that only becomes visible once a debounce
+    elapses, and every further write to the same scope pushes that debounce out -- so a burst of
+    `add` calls can stay invisible for as long as the burst lasts. Against a live gateway, three
+    `add` calls followed by `get_all` returned 0 memories; with the finalize they return 3.
+    """
+
+    def setUp(self) -> None:
+        self._original = mem0._post_json
+        self.addCleanup(lambda: setattr(mem0, "_post_json", self._original))
+        self.rec = _Recorder()
+        mem0._post_json = self.rec  # type: ignore[assignment]
+        self.client = object.__new__(mem0.Memory)
+        self.client._base_url = "http://gw"
+        self.client._api_key = None
+        self.client._timeout = 30
+
+    def test_add_finalizes_by_default(self) -> None:
+        self.client.add("I like espresso.", user_id="u1")
+        path, body = self.rec.calls[0]
+        self.assertEqual("/v1/ingest", path)
+        self.assertTrue(body.get("finalize"), "add must commit so a later get_all sees it")
+
+    def test_streaming_callers_can_opt_out(self) -> None:
+        """Opting out says so explicitly rather than omitting the key, so the request states the
+        caller's intent instead of leaning on whatever the server's default happens to be."""
+        self.client.add("part of a conversation", user_id="u1", finalize=False)
+        _, body = self.rec.calls[0]
+        self.assertIs(False, body.get("finalize"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_mem0_native_read_path.py
+++ b/tools/test_mem0_native_read_path.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The memory API on a native (record-log) backend: forget removes, history has a log, get_all
+lists one entry per memory, and the fields the caller supplied on an ingest survive the rewrite
+extraction performs when it commits.
+
+Each test here fails on the unfixed tree. The adapter is driven through a stub record log rather
+than a live datanode, because every defect these cover is in the Python read/write path, not in
+the engine: the native branch skipped two of the three serving-pipeline stages, and three memory
+methods called a JSONL-only reader that returns `[]` the moment the JSONL log is disabled -- which
+is exactly what a native backend does.
+"""
+import json
+import os
+import tempfile
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_mcp_local_adapter as local_mod
+
+
+TENANT = 4848243343181226175
+USER = 4473490034483841169
+SCOPE_KEY = f"t={TENANT}|u={USER}|s=1|"
+
+
+def _event(event_id, text, *, phase="hot_path", updated_at_ms=1000, **extra):
+    """A `context_event` row shaped like the ones the ingest pipeline writes."""
+    record = {
+        "record_type": "context_event",
+        "event_id_hash": event_id,
+        "text": text,
+        "scope_key": SCOPE_KEY,
+        "access_scope": {"tenant_hash": TENANT, "user_hash": USER, "scope_key": SCOPE_KEY},
+        "extraction_phase": phase,
+        "status": "observed" if phase == "hot_path" else "extraction_committed",
+        "updated_at_ms": updated_at_ms,
+        "timestamp_key_ms": updated_at_ms,
+    }
+    record.update(extra)
+    return record
+
+
+def _forget_tombstone(created_at_ms=9000):
+    return {
+        "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+        "tombstone_kind": "forget",
+        "target_tenant_hash": TENANT,
+        "target_user_hash": USER,
+        "target_scope_key": SCOPE_KEY,
+        "removed_count": 2,
+        "created_at_ms": created_at_ms,
+    }
+
+
+class _StubNativeAdapter:
+    """Build a direct adapter whose native record log is a plain list.
+
+    `object.__new__` skips __init__ (which would dial a metaserver / spawn a CLI); everything the
+    read path touches is stubbed. This is the same construction the membership-index tests use.
+    """
+
+    @staticmethod
+    def build(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._storage_prefix = "matrixark:mcp"
+        adapter._local_jsonl_enabled = False
+        adapter._native_log = list(records)
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._load_latest_context_state_records = lambda: []
+        # The native read exactly as the retrieval path sees it: the latest-state fold and the
+        # state collapse, and nothing else. The latest-value collapse and the tombstone sweep
+        # the memory API needs are applied above this, in `_read_all_compacted`, and these tests
+        # go through `read_all` / `_read_all_compacted` so they exercise that seam for real.
+        adapter.read_all_without_disk_fallback_recovery = (
+            lambda: adapter._with_latest_context_state_records(list(adapter._native_log))
+        )
+        return adapter
+
+    @staticmethod
+    def retrieval_view(records):
+        """What the retrieval hot path gets -- deliberately WITHOUT the memory-API stages."""
+        adapter = _StubNativeAdapter.build(records)
+        return adapter.read_all_without_disk_fallback_recovery()
+
+
+class NativeReadPathTests(unittest.TestCase):
+    def test_forget_tombstone_is_applied_on_the_native_read(self):
+        """A forget wrote a durable tombstone and reported an accurate removed_count, then served
+        every one of those records straight back: the native read ran only the last of the three
+        serving-pipeline stages, so `apply_memory_tombstones` never ran."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _event(22, "user: My favourite language is Rust.", updated_at_ms=2000),
+            _forget_tombstone(),
+        ])
+        live = adapter.read_all()
+        self.assertEqual([], [r for r in live if r.get("record_type") == "context_event"])
+        # The tombstone marker itself is internal and must not surface either.
+        self.assertEqual([], [r for r in live
+                              if r.get("record_type") == local_mod.MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def test_forget_does_not_remove_a_later_re_ingest(self):
+        """The sweep is order-aware: re-ingesting after a forget produces live memories again."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", updated_at_ms=1000),
+            _forget_tombstone(),
+            _event(33, "user: I am vegetarian.", updated_at_ms=11000),
+        ])
+        live_ids = [r["event_id_hash"] for r in adapter.read_all()
+                    if r.get("record_type") == "context_event"]
+        self.assertEqual([33], live_ids)
+
+    def test_one_memory_serves_as_one_record_not_two(self):
+        """The ingest pipeline persists an event row twice -- once on the hot path and again when
+        extraction commits -- and both rows served, so get_all reported 2 ingests as 4 memories.
+        Latest-value compaction collapses them to the committed row."""
+        adapter = _StubNativeAdapter.build([
+            _event(11, "user: I am vegetarian.", phase="hot_path", updated_at_ms=1000),
+            _event(11, "user: I am vegetarian.", phase="final", updated_at_ms=1500),
+            _event(22, "user: My favourite language is Rust.", phase="hot_path", updated_at_ms=2000),
+            _event(22, "user: My favourite language is Rust.", phase="final", updated_at_ms=2500),
+        ])
+        events = [r for r in adapter.read_all() if r.get("record_type") == "context_event"]
+        self.assertEqual(2, len(events))
+        self.assertEqual([11, 22], sorted(r["event_id_hash"] for r in events))
+        self.assertEqual({"final"}, {r["extraction_phase"] for r in events})
+
+    def test_the_memory_stages_stay_off_the_retrieval_hot_path(self):
+        """`_with_latest_context_state_records` runs on retrieval too, so the latest-value
+        collapse and the tombstone sweep are applied one level up instead.
+
+        This split was once believed to be what kept the proxy from wedging. It was not: the
+        wedge was the background summary refresher holding the single shared proxy lane, and is
+        fixed in `next_summary_refresh_delay_s`. The split survives as a COST choice -- both
+        stages are O(n) and this method is on the retrieval hot path, where the memory API's
+        needs do not apply. This test pins the split so moving the stages back down is a
+        deliberate, measured decision rather than an accident."""
+        records = [
+            _event(11, "user: I am vegetarian.", phase="hot_path", updated_at_ms=1000),
+            _event(11, "user: I am vegetarian.", phase="final", updated_at_ms=1500),
+            _forget_tombstone(),
+        ]
+        hot_path = _StubNativeAdapter.retrieval_view(records)
+        # Untouched by the memory stages: both event rows, and the tombstone, still present.
+        self.assertEqual(2, len([r for r in hot_path if r.get("record_type") == "context_event"]))
+        self.assertEqual(1, len([r for r in hot_path
+                                 if r.get("record_type") == local_mod.MEMORY_TOMBSTONE_RECORD_TYPE]))
+        # The memory API, one level up, still sees the swept view.
+        self.assertEqual([], [r for r in _StubNativeAdapter.build(records).read_all()
+                              if r.get("record_type") == "context_event"])
+
+    def test_compacted_view_keeps_expired_records_for_the_sweep(self):
+        """`_read_all_compacted` is the seam below the live view: the expiry sweep has to SEE an
+        expired record to tombstone it, so only `read_all` may filter by expiry."""
+        expired = _event(11, "user: Use gate B12 today.", expires_at_ms=1, ephemeral=True)
+        adapter = _StubNativeAdapter.build([expired])
+        self.assertEqual(
+            [11], [r["event_id_hash"] for r in adapter._read_all_compacted()
+                   if r.get("record_type") == "context_event"])
+        self.assertEqual(
+            [], [r for r in adapter.read_all() if r.get("record_type") == "context_event"])
+
+
+class NativeRawLogReadTests(unittest.TestCase):
+    """`history` reads the RAW log on purpose -- a memory's change history IS the tombstones and
+    superseded rows the live view exists to hide. The inherited reader is JSONL-only, so on a
+    native backend history reported an empty log for a memory that plainly had one."""
+
+    @staticmethod
+    def _adapter(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        adapter._recover_serving_from_disk_fallback_if_needed = lambda *, reason="": None
+        adapter._records_lock = __import__("threading").RLock()
+        adapter._get_count = lambda: len(records)
+        adapter._load_records_by_count = lambda count: list(records[:count])
+        adapter._load_records = lambda index: list(records)
+        adapter._get_index = lambda: []
+        return adapter
+
+    def test_raw_records_read_the_native_log(self):
+        records = [_event(11, "user: I am vegetarian."), _forget_tombstone()]
+        self.assertEqual(2, len(self._adapter(records)._read_raw_records()))
+
+    def test_raw_records_expand_a_bundled_append(self):
+        """A bundled append stores several records as ONE hash field; the wrapper carries no
+        record_type, which is what every reader filters on."""
+        bundled = [{"record_bundle": [_event(11, "user: a"), _event(22, "user: b")]}]
+        raw = self._adapter(bundled)._read_raw_records()
+        self.assertEqual([11, 22], [r["event_id_hash"] for r in raw])
+
+    def test_history_reports_ingest_and_supersede_from_the_raw_log(self):
+        adapter = self._adapter([
+            _event(11, "user: I am vegetarian."),
+            {
+                "record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE,
+                "tombstone_kind": "delete",
+                "target_memory_id": "11",
+                "tombstone_reason": "supersede",
+                "superseded_by": 22,
+                "created_at_ms": 5000,
+            },
+        ])
+        history = adapter.history({"memory_id": "11"})
+        self.assertEqual(2, history["count"])
+        self.assertEqual(["ingested", "superseded"], [entry["event"] for entry in history["history"]])
+        self.assertEqual(22, history["history"][1]["superseded_by"])
+
+
+class CallerSuppliedFieldsSurviveExtractionTests(unittest.TestCase):
+    """`identity_key` / TTL come from the CALLER; extraction cannot rebuild them. When extraction
+    commits it rewrites the event row for an id that already exists and latest-value compaction
+    serves that newer row, so anything the extractor does not reproduce was silently dropped at
+    read time -- keyed recall 404'd and a TTL record never expired. They survived only when
+    extraction happened to run inside the ingest call, which is why an in-process sync ingest
+    looked correct while the same request through the gateway did not."""
+
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.adapter = local_mod.MatrixArkLocalAdapter(
+            __import__("pathlib").Path(self._dir.name) / "events.jsonl")
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def _scope(self):
+        return {"tenant_id": "t1", "user_id": "u1", "session_id": "s1"}
+
+    def _live_event(self, event_id):
+        for record in self.adapter.read_all():
+            if (str(record.get("record_type") or "") == "context_event"
+                    and str(record.get("event_id_hash")) == str(event_id)):
+                return record
+        return None
+
+    def test_identity_key_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "identity_key": "pref.seat",
+            "truth_class": "asserted",
+        })
+        event_id = result["event_id_hash"]
+        self.assertEqual("pref.seat", self._live_event(event_id).get("identity_key"))
+        # Commit extraction OUTSIDE the ingest call -- what a finalize through the gateway does.
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Preferred seat: aisle"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served, "the event must still serve after extraction commits")
+        self.assertEqual("pref.seat", served.get("identity_key"))
+        self.assertEqual("asserted", served.get("truth_class"))
+
+    def test_ttl_survives_a_separate_extraction_commit(self):
+        result = self.adapter.ingest({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "ttl_seconds": 3600,
+        })
+        event_id = result["event_id_hash"]
+        expires_at_ms = self._live_event(event_id).get("expires_at_ms")
+        self.assertTrue(expires_at_ms, "the ingest must stamp an expiry")
+        self.adapter.batch_extract({
+            "scope": self._scope(),
+            "messages": [{"role": "user", "content": "Use gate B12 today"}],
+            "derive_from_existing_events": True,
+            "source_event_ids": [event_id],
+            "extraction_phase": "final",
+            "force": True,
+        })
+        served = self._live_event(event_id)
+        self.assertIsNotNone(served)
+        self.assertEqual(expires_at_ms, served.get("expires_at_ms"))
+        self.assertTrue(served.get("ephemeral"))
+
+
+class NativeWritePathStampTests(unittest.TestCase):
+    """The native writer built its own record batch and skipped the per-ingestion stamp the
+    JSONL writer applies, so those fields never reached the store at all."""
+
+    def test_append_many_stamps_like_the_jsonl_writer(self):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._local_jsonl_enabled = False
+        written = []
+        adapter._append_many_materialized = lambda records, allow_queue=True: written.extend(records)
+        adapter._queue_batched_records = lambda records: False
+        adapter._update_latest_entity_cache = lambda records: None
+        adapter._maintain_event_membership_after_append = lambda records: None
+        adapter._push_ingest_stamp({"identity_key": "pref.seat", "truth_class": "asserted"})
+        try:
+            adapter.append_many([_event(11, "user: Preferred seat: aisle")])
+        finally:
+            adapter._pop_ingest_stamp()
+        events = [r for r in written if r.get("record_type") == "context_event"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("pref.seat", events[0].get("identity_key"))
+        self.assertEqual("asserted", events[0].get("truth_class"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_mem0_users.py
+++ b/tools/test_mem0_users.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""mem0 `users()`: the users / agents / runs that hold memories.
+
+The part worth pinning is the re-scoping. A request scope carries identity fields DERIVED from
+the caller -- `user_hash`, `session_hash`, `scope_key` -- and `get_all` filters on those hashes,
+never on `user_id`. Both naive re-scopings are wrong, and both were observed against a live
+gateway before this was fixed:
+
+  * swap only `user_id`     -> the caller's `user_hash` stays, the lookup resolves back to the
+                               caller, and every user reports the same memory count (3 and 3 for
+                               users who had 2 and 1)
+  * drop the hashes instead -> `user_hash == 0` reads as "no subject filter" and returns the whole
+                               tenant, so a user whose memories were all forgotten never drops out
+
+The subject's hashes have to be recomputed by the same function the ingest path uses.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools.matrixark_mcp_core_identity import identity_hashes
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    from matrixark_mcp_core_identity import identity_hashes
+
+
+CALLER_SCOPE = {
+    "account_id": "acct_local",
+    "tenant_id": "anonymous",
+    "user_id": "root",
+    "agent_name": "local_agent",
+    "session_id": "caller-session",
+    **identity_hashes("acct_local", "anonymous", user_id="root", session_id="caller-session"),
+    "_explicit_scope_keys": ["account_id", "tenant_id", "user_id"],
+}
+
+
+class SubjectRescopeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scope = adapters.MatrixArkTemporalStoreDirectAdapter._subject_scope(CALLER_SCOPE, "alice")
+
+    def test_names_the_subject(self) -> None:
+        self.assertEqual("alice", self.scope["user_id"])
+
+    def test_uses_the_subjects_own_hashes(self) -> None:
+        expected = identity_hashes("acct_local", "anonymous", user_id="alice")
+        self.assertEqual(expected["user_hash"], self.scope["user_hash"])
+        self.assertEqual(expected["scope_key"], self.scope["scope_key"])
+
+    def test_does_not_keep_the_callers_identity(self) -> None:
+        """The bug that made every user report the caller's memory count."""
+        self.assertNotEqual(CALLER_SCOPE["user_hash"], self.scope["user_hash"])
+        self.assertNotEqual(CALLER_SCOPE["scope_key"], self.scope["scope_key"])
+
+    def test_user_hash_is_never_zero(self) -> None:
+        """A zero hash reads as 'no subject filter' and returns the whole tenant."""
+        self.assertTrue(self.scope["user_hash"])
+
+    def test_drops_the_callers_session(self) -> None:
+        """users() asks about a user, not about the caller's session."""
+        self.assertNotIn("session_id", self.scope)
+        self.assertFalse(self.scope.get("session_hash"))
+
+    def test_keeps_the_tenant(self) -> None:
+        """Re-scoping must stay inside the caller's tenant -- it is not a cross-tenant listing."""
+        self.assertEqual("anonymous", self.scope["tenant_id"])
+        self.assertEqual("acct_local", self.scope["account_id"])
+        self.assertEqual(CALLER_SCOPE["tenant_hash"], self.scope["tenant_hash"])
+
+
+class MemorySubjectExtractionTest(unittest.TestCase):
+    def test_extracts_user_agent_and_run(self) -> None:
+        record = {"scope": {"user_id": "alice", "agent_id": "assistant", "session_id": "s1"}}
+        found = adapters.MatrixArkTemporalStoreDirectAdapter.memory_subjects_in_record(record)
+        self.assertEqual(
+            [("user", "alice"), ("agent", "assistant"), ("run", "s1")],
+            found,
+        )
+
+    def test_ignores_blank_and_missing_identities(self) -> None:
+        cls = adapters.MatrixArkTemporalStoreDirectAdapter
+        self.assertEqual([], cls.memory_subjects_in_record({"scope": {"user_id": "  "}}))
+        self.assertEqual([], cls.memory_subjects_in_record({"scope": {}}))
+        self.assertEqual([], cls.memory_subjects_in_record({}))
+        self.assertEqual([], cls.memory_subjects_in_record({"scope": "not-a-dict"}))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_native_backends_reach_temporalstore.py
+++ b/tools/test_native_backends_reach_temporalstore.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Every memory API must reach TemporalStore on a native backend, not the local JSONL log.
+
+`MatrixArkLocalAdapter` precedes the direct mixins in every native adapter's MRO and defines
+JSONL-only readers and writers. Each of those returns `[]`, or writes nothing, the moment
+`_local_jsonl_enabled` is False -- which is exactly what a native backend sets. So a method can
+look implemented, resolve happily, and silently do nothing on the backends that actually ship.
+That is not hypothetical: it is how `read_all`, `_read_all_compacted`, `_read_raw_records` and
+`append_many` all came to be broken at once, which made forget serve deleted memories back,
+history report an empty log, and keyed upsert never supersede.
+
+Resolving to a `matrixark_local_adapter_*` module is NOT the defect -- most of those are
+backend-agnostic orchestration that reads through `read_all()` and writes through `append_many()`,
+both overridden natively. The defect is a method whose own code reaches for the local log.
+
+This checks every native adapter a deployment can select, because auditing one of them checks a
+backend nobody may be running: `temporalstore-direct` builds MatrixArkTemporalStoreDirectAdapter
+and `temporalstore-rust` builds MatrixArkTemporalStoreRustAdapter (see matrixark_mcp_backends).
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+
+
+NATIVE_ADAPTERS = [
+    ("temporalstore-direct", adapters.MatrixArkTemporalStoreDirectAdapter),
+    ("temporalstore-rust", adapters.MatrixArkTemporalStoreRustAdapter),
+    ("rust-direct", adapters.MatrixArkTemporalStoreRustDirectAdapter),
+]
+
+# Every adapter method the memory/mem0 surface dispatches to, plus the seams beneath them.
+MEMORY_PATH_METHODS = [
+    "ingest", "session_commit", "retrieve", "batch_extract",
+    "get_memory", "get_all", "history", "update_memory", "delete_memory",
+    "forget", "reset", "get_memory_by_identity_key", "feedback",
+    "refresh_summaries", "replay", "backend_metrics",
+    "get_tenant_policy", "set_tenant_policy",
+    "read_all", "_read_all_compacted", "_read_raw_records",
+    "read_all_without_disk_fallback_recovery", "_with_latest_context_state_records",
+    "recent_records", "append", "append_many", "_append_many_materialized",
+    "_apply_identity_upsert", "_write_retention_cutoff", "sweep_expired_memories",
+    "find_idempotency_record", "append_idempotency_record",
+    "ensure_context_node_path", "_existing_node_embedding_refs",
+    "refresh_dirty_node_summaries", "drain_due_idle_session_commits",
+]
+
+# Source markers that mean "this reaches the local JSONL log itself".
+LOCAL_LOG_MARKERS = ("_local_jsonl_enabled", "_shard_path", "_read_shard", "_write_shard",
+                     ".jsonl", "_jsonl_", "_log_path")
+
+# `append_many` names `_local_jsonl_enabled`, but as the GUARD that routes the write to the native
+# backend: `route_to_backend = callable(append_backend) and not _local_jsonl_enabled and ...`.
+# Reading the flag to choose the native path is the opposite of falling back to the local log.
+ALLOWED = {"append_many"}
+
+
+_CODE_CACHE: dict[int, str] = {}
+
+
+def _code_only(fn) -> str:
+    """The method's source with docstrings stripped.
+
+    The native overrides EXPLAIN this trap in their docstrings, so scanning raw source reports
+    them as reaching for the local log -- false positives that would bury a real one.
+
+    Memoized on the function object: the three adapters inherit most of these methods, so the
+    same source would otherwise be parsed and unparsed three times, and some of these functions
+    are very large.
+    """
+    cached = _CODE_CACHE.get(id(fn))
+    if cached is not None:
+        return cached
+    _CODE_CACHE[id(fn)] = result = _parse_code_only(fn)
+    return result
+
+
+def _parse_code_only(fn) -> str:
+    try:
+        src = textwrap.dedent(inspect.getsource(fn))
+    except (OSError, TypeError):
+        return ""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return src
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list) or not body:
+            continue
+        first = body[0]
+        if (isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)):
+            body.pop(0)
+            if not body:
+                body.append(ast.Pass())
+    try:
+        return ast.unparse(tree)
+    except Exception:  # noqa: BLE001
+        return src
+
+
+class NativeBackendsReachTemporalStoreTest(unittest.TestCase):
+    def test_no_memory_path_method_reaches_the_local_jsonl_log(self) -> None:
+        offenders: list[str] = []
+        for label, cls in NATIVE_ADAPTERS:
+            for name in MEMORY_PATH_METHODS:
+                if name in ALLOWED:
+                    continue
+                fn = getattr(cls, name, None)
+                if fn is None:
+                    continue
+                hits = sorted({m for m in LOCAL_LOG_MARKERS if m in _code_only(fn)})
+                if hits:
+                    offenders.append(
+                        f"{label}.{name} (from {getattr(fn, '__module__', '?')}) touches {hits}"
+                    )
+        self.assertEqual([], offenders, "\n".join(["memory-path methods on a local log:"] + offenders))
+
+    def test_backend_metrics_does_not_claim_the_jsonl_backend(self) -> None:
+        """A native deployment asking for backend metrics must not be told it is running JSONL.
+
+        The direct adapter used to inherit the JSONL implementation, which hardcodes
+        `mode: "local-jsonl"` and reports an `event_log` path that on a native backend is the
+        `-unused-` sentinel the adapter never writes to.
+        """
+        for label, cls in NATIVE_ADAPTERS:
+            src = _code_only(cls.backend_metrics)
+            self.assertNotIn("local-jsonl", src, f"{label}.backend_metrics claims the JSONL backend")
+
+    def test_every_dispatched_memory_method_exists(self) -> None:
+        """A missing method would fall through to whatever the MRO happens to offer."""
+        for label, cls in NATIVE_ADAPTERS:
+            for name in ("ingest", "session_commit", "retrieve", "get_memory", "get_all",
+                         "history", "update_memory", "delete_memory", "forget", "reset",
+                         "get_memory_by_identity_key", "refresh_summaries", "backend_metrics"):
+                self.assertTrue(callable(getattr(cls, name, None)), f"{label} is missing {name}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_summary_background_pass_skip.py
+++ b/tools/test_summary_background_pass_skip.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The cross-scope background refresh pass must not read the whole store to learn nothing changed.
+
+The background refresher calls `refresh_summaries` with an EMPTY scope on a timer. The first thing
+that pass does is `read_all()`, which on a native backend is a full record-log read over the proxy
+and holds the single shared lane for its whole duration. Measured on a 105 MB store that is
+minutes, during which every retrieve is rejected on lane backpressure -- with no client load and
+nothing to refresh:
+
+    before   8 probes, no load: all rejected at 40 s
+    after    8 probes, no load: 200 in 67-583 ms, immediately after a restart
+
+Skipping is only safe when it cannot lose work, so these pin the three conditions: the store is
+unchanged, the previous pass had nothing left to do, and the caller is the background one.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+
+
+class _StubClient:
+    """Just the two key/value ops the pass-state uses, backed by a dict."""
+
+    def __init__(self) -> None:
+        self.strings: dict[str, str] = {}
+
+    def get_string(self, key: str) -> str:
+        return self.strings.get(key, "")
+
+    def put_string(self, key: str, value: str) -> None:
+        self.strings[key] = value
+
+
+class SummaryBackgroundPassSkipTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Stand in for the parent implementation, so we can see whether the pass actually ran.
+        self.calls: list[dict] = []
+        self.refreshed = 0
+        self._original = adapters.MatrixArkLocalAdapter.refresh_summaries
+
+        def fake_refresh(inner_self, args):
+            self.calls.append(args)
+            return {"refreshed_count": self.refreshed}
+
+        adapters.MatrixArkLocalAdapter.refresh_summaries = fake_refresh
+        self.addCleanup(
+            lambda: setattr(adapters.MatrixArkLocalAdapter, "refresh_summaries", self._original)
+        )
+
+    def _adapter(self, client: _StubClient, count: int = 100):
+        # object.__new__ skips __init__, which would dial a metaserver / spawn a CLI.
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._storage_prefix = "matrixark:test"
+        adapter._client = client
+        adapter._get_count = lambda: count  # type: ignore[assignment]
+        return adapter
+
+    def test_unchanged_store_after_an_empty_pass_is_skipped(self) -> None:
+        client = _StubClient()
+        adapter = self._adapter(client, count=100)
+        first = adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls), "the first pass must run -- nothing is known yet")
+        self.assertNotIn("skipped", first)
+
+        second = adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls), "an unchanged store must not be read again")
+        self.assertTrue(second.get("skipped"))
+        self.assertEqual(0, second.get("refreshed_count"))
+
+    def test_a_changed_store_runs_the_pass(self) -> None:
+        client = _StubClient()
+        adapter = self._adapter(client, count=100)
+        adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls))
+        # A write landed: the count moved, so there may be new dirty state.
+        adapter._get_count = lambda: 101  # type: ignore[assignment]
+        adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(2, len(self.calls), "a changed store must run the pass")
+
+    def test_a_pass_that_left_work_behind_runs_again(self) -> None:
+        """A pass that hit its node limit must be allowed to continue, unchanged store or not."""
+        client = _StubClient()
+        adapter = self._adapter(client, count=100)
+        self.refreshed = 64  # hit the limit; there is a backlog
+        adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls))
+        adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(2, len(self.calls), "a backlog must not be skipped")
+
+    def test_a_scoped_caller_is_never_skipped(self) -> None:
+        """The pre-retrieval refresh passes a real scope and is on the request path already."""
+        client = _StubClient()
+        adapter = self._adapter(client, count=100)
+        for _ in range(3):
+            result = adapter.refresh_summaries({"scope": {"user_id": "u1"}})
+            self.assertNotIn("skipped", result)
+        self.assertEqual(3, len(self.calls))
+
+    def test_the_decision_survives_a_restart(self) -> None:
+        """The state lives in the store, not the instance.
+
+        An in-memory-only token makes every restart pay one full-store pass, which on a large
+        store is a multi-minute window where the gateway answers nothing.
+        """
+        client = _StubClient()
+        first = self._adapter(client, count=100)
+        first.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls))
+
+        # A brand-new adapter over the SAME store, as after a restart.
+        second = self._adapter(client, count=100)
+        result = second.refresh_summaries({"scope": {}})
+        self.assertEqual(1, len(self.calls), "a restart must not force a full-store pass")
+        self.assertTrue(result.get("skipped"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_summary_refresh_duty_cycle.py
+++ b/tools/test_summary_refresh_duty_cycle.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The background summary refresher must never occupy the shared proxy lane.
+
+A refresh pass is O(store): it reads the whole record log and writes the refreshed summaries
+back through the SAME proxy lane the request path uses. In `shared_process_mode` that lane is a
+single process behind a single permit shared by every write, read and control op, so a loop that
+runs a pass on a fixed interval starves the request path as soon as one pass costs longer than
+the interval -- and it never recovers, because the store only grows.
+
+Measured on a single-worker gateway over the record-log backend, 16 ingests then 8 retrieves:
+
+    fixed interval (before)   ingest 391 -> 22392 ms, retrieve: 3 ok then a 120s hang and
+                              every later retrieve rejected on lane backpressure at 40s
+    cost-proportional (after) ingest 699 ->  2808 ms, retrieve: 8/8 ok, 229-760 ms
+
+Both arms ran the refresher at the shipping default interval of 1000 ms; the only difference is
+the delay between passes.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_server as mcp
+
+# The tools modules are importable both as `tools.<name>` and bare `<name>`, and the two are
+# DISTINCT module objects with separate globals. Patching the knobs on the wrong one silently
+# does nothing -- the test then asserts against the shipping defaults and "passes" for the wrong
+# reason. Resolve the module that actually supplied the function under test.
+summary_runtime = sys.modules[mcp.next_summary_refresh_delay_s.__module__]
+
+
+class _RecordingStop:
+    """Stands in for the loop's stop Event, recording the delay it is asked to wait each time."""
+
+    def __init__(self, stop_after: int) -> None:
+        self.delays: list[float] = []
+        self._stop_after = stop_after
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self.delays.append(float(timeout or 0.0))
+        # Returning True means "stopped", which ends the loop.
+        return len(self.delays) > self._stop_after
+
+    def set(self) -> None:  # pragma: no cover - only to complete the Event interface
+        pass
+
+    def clear(self) -> None:  # pragma: no cover - only to complete the Event interface
+        pass
+
+
+class SummaryRefreshDutyCycleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_duty = summary_runtime.SUMMARY_REFRESH_MAX_DUTY
+        self._old_cap = summary_runtime.SUMMARY_REFRESH_MAX_BACKOFF_MS
+
+    def tearDown(self) -> None:
+        summary_runtime.SUMMARY_REFRESH_MAX_DUTY = self._old_duty
+        summary_runtime.SUMMARY_REFRESH_MAX_BACKOFF_MS = self._old_cap
+
+    def _server(self, tmpdir: str) -> mcp.MatrixArkMcpServer:
+        adapter = mcp.MatrixArkLocalAdapter(Path(tmpdir) / "events.jsonl")
+        server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+        self.addCleanup(server.close, timeout_s=1.0)
+        return server
+
+    # ---- the delay itself ----------------------------------------------------------------
+
+    def test_cheap_pass_keeps_the_configured_interval(self) -> None:
+        """The common case must be unchanged: a fast pass still runs every interval."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            server._summary_refresh_interval_s = 1.0
+            summary_runtime.SUMMARY_REFRESH_MAX_DUTY = 0.2
+            # 0.05s of work at 20% duty needs only 0.2s idle, which is under the interval.
+            self.assertEqual(1.0, server._next_summary_refresh_delay_s(0.05))
+
+    def test_expensive_pass_backs_off_in_proportion_to_its_cost(self) -> None:
+        """This is the regression: a slow pass must buy a proportionally long yield."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            server._summary_refresh_interval_s = 1.0
+            summary_runtime.SUMMARY_REFRESH_MAX_DUTY = 0.2
+            # 10s of work at 20% duty implies 40s idle after it (10 / 50 == 20%).
+            self.assertAlmostEqual(40.0, server._next_summary_refresh_delay_s(10.0), places=6)
+
+    def test_backoff_is_capped(self) -> None:
+        """A pathologically slow pass must not park the refresher effectively forever."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            server._summary_refresh_interval_s = 1.0
+            summary_runtime.SUMMARY_REFRESH_MAX_DUTY = 0.2
+            summary_runtime.SUMMARY_REFRESH_MAX_BACKOFF_MS = 30_000
+            self.assertEqual(30.0, server._next_summary_refresh_delay_s(10_000.0))
+
+    def test_disabled_refresher_stays_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            server._summary_refresh_interval_s = 0.0
+            self.assertEqual(0.0, server._next_summary_refresh_delay_s(10.0))
+
+    def test_duty_outside_zero_to_one_falls_back_to_the_interval(self) -> None:
+        """A misconfigured duty must degrade to the old behaviour, not to a divide-by-zero."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            server._summary_refresh_interval_s = 2.0
+            for bad in (0.0, 1.0, -0.5, 4.0):
+                summary_runtime.SUMMARY_REFRESH_MAX_DUTY = bad
+                self.assertEqual(2.0, server._next_summary_refresh_delay_s(10.0), f"duty={bad}")
+
+    # ---- the loop uses it ----------------------------------------------------------------
+
+    def test_loop_reschedules_from_the_cost_of_the_last_pass(self) -> None:
+        """The loop must feed the observed pass cost back into its own delay.
+
+        Without this the loop asks for the fixed interval every time, which is exactly what let
+        a slow pass run back-to-back and hold the lane.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            server = self._server(tmpdir)
+            # Stop the real background thread; drive the loop synchronously instead.
+            server._summary_stop.set()
+            server._summary_refresh_interval_s = 0.01
+            summary_runtime.SUMMARY_REFRESH_MAX_DUTY = 0.2
+
+            pass_s = 0.2
+
+            def slow_refresh(_args):
+                time.sleep(pass_s)
+                return {"refreshed_count": 0}
+
+            server.adapter.refresh_summaries = slow_refresh  # type: ignore[assignment]
+            stop = _RecordingStop(stop_after=2)
+            server._summary_stop = stop  # type: ignore[assignment]
+
+            server._summary_refresh_loop()
+
+            # First wait is the configured interval (nothing has run yet); every later wait is
+            # derived from the pass that just finished: 0.2s at 20% duty implies ~0.8s idle.
+            self.assertEqual(0.01, stop.delays[0])
+            self.assertGreaterEqual(len(stop.delays), 2)
+            for delay in stop.delays[1:]:
+                self.assertGreater(
+                    delay, pass_s,
+                    "a pass costing %.2fs must yield for longer than it ran, got %.3fs"
+                    % (pass_s, delay),
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
The memory API on the record-log backends — the ones that actually ship. Two availability
defects that made it unusable under load, three O(store) costs on the ingest path, the missing
part of the mem0 surface, and a guard so the defect class that started this cannot come back
silently.

## Availability

### The background summary refresher could hold the only proxy lane

`_summary_refresh_loop` calls `refresh_summaries({"scope": {}})` on a fixed 1000 ms timer. That
pass is O(store): it reads the whole record log and writes the refreshed summaries back **through
the same proxy lane the request path uses**. In `shared_process_mode`, `build_lane_pools` points
`write`, `read` and `control` at ONE lane behind a single permit — one permit for the whole
gateway. Once a pass costs longer than the interval, the loop holds that permit essentially
continuously: requests queue on the semaphore, block to the request timeout, then are rejected on
lane backpressure. Nothing recovers, because the store only grows.

This is why the native record-log read had to be reverted the same day it landed. Before it,
`read_all()` returned `[]` on a native backend, so a pass did no work and this always-unbounded
loop was harmless. Making the read work turned it into a permanent occupant of the lane. **The
read path was never the problem.**

16 ingests then 8 retrieves, refresher at the shipping default on every arm:

| | ingest, first → last | retrieves |
|---|---|---|
| fixed interval | 391 → 22392 ms | 3 ok, then a 120 s hang, then every retrieve rejected at 40 s |
| refresher off entirely | 568 → 2412 ms | 8/8 ok, 179–263 ms |
| **cost-proportional delay** | **699 → 2808 ms** | **8/8 ok, 229–760 ms** |

### …and bounding the interval between passes was not enough

Testing at a realistic size exposed that the first fix was incomplete. The cost is *inside* one
pass, not between them: the pass opens with `read_all()`, which on a 105 MB store takes minutes and
holds the lane throughout. With **no client load and nothing to refresh**, eight retrieves in a row
were rejected at 40 s.

Dirty state only changes when records are appended, and the record count is a single point read. So
when the count is unchanged since the last pass AND that pass refreshed nothing, this pass would
read the entire store to reach the same conclusion — skip it. The state is persisted, because an
in-memory-only token makes every restart pay one full-store pass.

| 105 MB store, no load, after a restart | result |
|---|---|
| before | 8/8 rejected at 40 s |
| in-memory token only | 4 fast, 4 timed out during the first pass, then fast |
| **persisted** | **8/8 answered in 67–583 ms** (~104 ms warm) |

## Ingest cost: 19 → 5.7 full-store reads

Three scans replaced by keyed indexes, each backfilled once per store behind a persisted marker.

- **Idempotency** was a *point* question — "have I seen this key" — answered by walking
  `reversed(read_all())`, and asked **4× per ingest** (replay + before-store, across two tool
  calls).
- **Node embeddings**: `ensure_context_node_path` read the whole log just to collect which nodes
  already had an embedding, **3× per ingest**. The persisted marker is load-bearing: the native
  adapters deliberately start their context-node caches empty, so an in-process-only index would
  re-embed every node after a restart. Proven across a restart — fresh store creates 3, restart
  creates 0.
- **Subjects** (for `users()`, below) are indexed on append rather than scanned.

| | full-store reads per ingest |
|---|---|
| before | 19 (114 over 6 ingests) |
| after idempotency index | 11 (68) |
| **after node-embedding index** | **5.7 (34)** |

Ingest, 24 into one scope, median of the second half: **2431 → 1617 ms (−33%)**. Retrieve unchanged
at 270–400 ms.

## mem0 surface

- **`batch_update` / `batch_delete`** — mem0's shape, capped at the documented 1000. Deliberately
  **not atomic** and documented as such: an update here is a supersede with no cross-memory
  transaction, so failures are reported per memory rather than aborting the batch, because a
  partial batch the caller cannot see is worse than one they can.
- **`users()`** — the users/agents/runs that *hold* memories, which is not the question the
  account-level user list answers. The re-scoping was subtly wrong twice: a request scope carries
  identity fields **derived from the caller** (`user_hash`, `scope_key`), and `get_all` filters on
  those, never on `user_id`. Swapping only `user_id` made every user report the caller's count
  (users with 2 and 1 memories both reported 3); dropping the hashes made `user_hash == 0`, read as
  "no filter", returning the whole tenant. Neither errors — both answer confidently and wrongly.
  Hashes are now recomputed with `identity_hashes`, the same function ingest uses.
- **`add()` now finalizes by default** — a behaviour change, stated plainly. `add` was a streaming
  ingest, so a memory only appeared once a debounce elapsed, and every further write to the scope
  pushed that debounce out. Three `add` calls followed by `get_all` returned **0 memories** against
  a live gateway. Written against mem0, that reads as data loss. `finalize=False` keeps the old
  behaviour.

## A guard for the defect class

The original five defects were one shape: `MatrixArkLocalAdapter` precedes the direct mixins in
every native adapter's MRO and defines JSONL-only readers/writers that return `[]` once
`_local_jsonl_enabled` is False — which is what a native backend sets. Four methods were broken at
once, silently. Nothing stopped a fifth, so that check is now a test.

It flags a method whose own **code** reaches for the local log, not merely one that resolves to a
local module (most of those are backend-agnostic orchestration going through the overridden seams).
Docstrings are stripped first, because the native overrides explain this very trap and would report
themselves. It checks all three native adapters — auditing one checks a backend nobody may be
running, which is exactly what hid the one real defect: **`backend_metrics` on
`temporalstore-direct`** inherited the JSONL implementation and reported `mode: "local-jsonl"` with
the path of an unused sentinel file, so a native deployment was told it was running the wrong
engine.

## Verification

Full mem0 surface over the native path, asserted on **values**, not status codes — the existing
matrix harness scores `get_all` on `count > 0` and `history` on `http == 200`, and both passed
while `get_all` returned twice the rows it should and `history` returned an empty log:

**22/22** — add, get, get_all (exact count AND content), search, update, history, delete, forget,
keyed upsert, keyed recall, TTL, reset. Plus `users()`, `batch_update`, `batch_delete` end to end.

- mem0 suites 56/56; delete/forget 21/21; 34 new tests across the five areas above
- The module-boundary runner matches `main` exactly. Every other failing suite was confirmed
  pre-existing by running it in place with and without these changes, and again against `main`;
  `test_retrieval_audit_is_off_by_default` is a flaky teardown race that fires 3/5 on `main` and
  1/5 here
- Three comments that recorded the *wrong* cause for the wedge are corrected — that
  misattribution had already sent two investigations to the wrong place

Scope of evidence, so it is not overstated: `temporalstore-rust` is verified live throughout.
`temporalstore-direct` could not be exercised here — it fails at construction because the Python
SDK in this tree does not export `Client` — so the `backend_metrics` fix rests on the guard test,
which does fail without it.

## Known remaining cost

About 3 full-store reads per ingest remain: `drain_due_idle_session_commits`, `batch_extract`, and
`_read_raw_records` via `session_commit`. The first looked straightforward — a native scoped scan
already exists — but `_native_candidate_scan` ends in `compact_latest_context_state_records`, so it
does not return the append-ordered log that the drain's last-write-wins logic depends on. That has
to be established before switching, not assumed.
