### PR TITLE
Ask whether an election could be won before starting one

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
+++ b/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
@@ -816,6 +816,7 @@ fn run_network_vote_phase(
         &target.addr,
         "/raft/request_vote",
         &VoteRequest {
+            pre_vote: false,
             rpc: Some(raft_rpc("wrong-token", "unauthorized-vote")),
             shard_id,
             term: target_node_status.current_term + 1,
@@ -837,6 +838,7 @@ fn run_network_vote_phase(
         &target.addr,
         "/raft/request_vote",
         &VoteRequest {
+            pre_vote: false,
             rpc: Some(raft_rpc(auth_token, "stale-vote")),
             shard_id,
             term: target_node_status.current_term + 1,
@@ -871,6 +873,7 @@ fn run_network_vote_phase(
         &target.addr,
         "/raft/request_vote",
         &VoteRequest {
+            pre_vote: false,
             rpc: Some(raft_rpc(auth_token, "valid-vote")),
             shard_id,
             term: refreshed_target.current_term + 1,

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -1435,6 +1435,14 @@ pub struct VoteRequest {
     pub target_id: RaftNodeId,
     pub last_log_index: u64,
     pub last_log_term: u64,
+    /// Asks whether the vote WOULD be granted, without anyone acting on the question.
+    ///
+    /// A node that cannot reach the cluster would otherwise campaign on a timer and raise its term
+    /// every time, and a leader that later hears that term must step down -- so one unreachable
+    /// node drags a healthy cluster through repeated elections. Answering a pre-vote changes no
+    /// state, so an unreachable node never moves its term.
+    #[serde(default)]
+    pub pre_vote: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/raft/cluster_election.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_election.rs
@@ -63,6 +63,48 @@ impl RaftCluster {
     /// Step one of a networked election: bump this node's term, record its self-vote,
     /// and get both durable BEFORE any vote is requested. Returns the RequestVote to
     /// send to each peer (`target_id` is filled in per peer by the caller).
+    /// Build the question: would you vote for me, at the term I would use?
+    ///
+    /// Read-only on purpose. The term is not raised and no vote is recorded, so asking costs
+    /// nothing and losing costs nothing. Only [`Self::prepare_campaign`] commits to an election.
+    pub fn prepare_pre_vote(&self, candidate_id: RaftNodeId) -> Result<VoteRequest, RaftError> {
+        let inner = self.inner.read().expect("raft cluster lock poisoned");
+        if inner.config.prohibits_election {
+            return Err(RaftError::ElectionProhibited);
+        }
+        if !inner
+            .nodes
+            .get(&candidate_id)
+            .map(|node| node.alive && node.replica_role.can_be_leader())
+            .unwrap_or(false)
+        {
+            return Err(RaftError::NodeNotFound(candidate_id));
+        }
+        let candidate = inner
+            .nodes
+            .get(&candidate_id)
+            .ok_or(RaftError::NodeNotFound(candidate_id))?;
+        let last_log_index = node_last_log_or_snapshot_index(candidate);
+        let last_log_term =
+            node_term_at_log_or_snapshot_index(candidate, last_log_index).unwrap_or_default();
+        Ok(VoteRequest {
+            rpc: None,
+            shard_id: inner.shard_id,
+            term: inner
+                .nodes
+                .values()
+                .map(|node| node.current_term)
+                .max()
+                .unwrap_or_default()
+                .saturating_add(1),
+            candidate_id,
+            target_id: candidate_id,
+            last_log_index,
+            last_log_term,
+            pre_vote: true,
+        })
+    }
+
     pub fn prepare_campaign(&self, candidate_id: RaftNodeId) -> Result<VoteRequest, RaftError> {
         let mut inner = self.inner.write().expect("raft cluster lock poisoned");
         if inner.config.prohibits_election {
@@ -107,6 +149,7 @@ impl RaftCluster {
         inner.election_elapsed_tick = 0;
         inner.persist_configured_wal()?;
         Ok(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id,
             term,

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -679,6 +679,7 @@ impl RaftCluster {
         };
         inner.persist_configured_wal()?;
         Ok(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id,
             term: election_term,
@@ -721,6 +722,26 @@ impl RaftCluster {
                 term: node.current_term,
                 vote_granted: false,
                 reject_reason: Some("target_not_voter".to_string()),
+            });
+        }
+        if request.pre_vote {
+            // Answer, and change nothing: no term adopted, no vote recorded, nothing persisted.
+            // That is what makes a pre-vote safe to lose, and what stops a node that cannot reach
+            // anyone from walking its term up on a timer.
+            let local_last_index = node_last_log_or_snapshot_index(node);
+            let local_last_term =
+                node_term_at_log_or_snapshot_index(node, local_last_index).unwrap_or_default();
+            let would_grant = request.term > node.current_term
+                && (request.last_log_term, request.last_log_index)
+                    >= (local_last_term, local_last_index);
+            if !would_grant {
+                node.pipeline_state.pre_vote_rejections =
+                    node.pipeline_state.pre_vote_rejections.saturating_add(1);
+            }
+            return Ok(VoteResponse {
+                term: node.current_term,
+                vote_granted: would_grant,
+                reject_reason: (!would_grant).then(|| "pre_vote_declined".to_string()),
             });
         }
         if request.term < node.current_term {

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -515,15 +515,40 @@ impl ProductionRaftRuntime {
                         if stale_leader != local_node_id && stale_leader != 0 {
                             let _ = cluster.set_alive(stale_leader, false);
                         }
+                        let transport = RaftRpcRuntime::with_auth_token(
+                            AuthenticatedRaftTransport::new(
+                                HttpRaftTransport::with_options(peer_map.clone(), http_options),
+                                auth_token.clone(),
+                            ),
+                            rpc_options,
+                            Some(auth_token.clone()),
+                        );
+                        // Ask before committing to an election. Raising the term is what forces a
+                        // healthy leader to stand down, so a node that cannot reach a majority
+                        // must never do it: otherwise one unreachable node walks its term up on a
+                        // timer and disrupts the cluster every time it is heard from again.
+                        let could_win = match cluster.prepare_pre_vote(local_node_id) {
+                            Ok(probe) => {
+                                let mut would_grant = 1usize; // itself
+                                for target_id in &peer_ids {
+                                    let mut request = probe.clone();
+                                    request.target_id = *target_id;
+                                    if let Ok(response) = transport.request_vote(request) {
+                                        if response.vote_granted {
+                                            would_grant += 1;
+                                        }
+                                    }
+                                }
+                                would_grant >= majority_size
+                            }
+                            Err(_) => false,
+                        };
+                        if !could_win {
+                            let _ = cluster.tick_election();
+                            thread::sleep(election_tick);
+                            continue;
+                        }
                         if let Ok(template) = cluster.prepare_campaign(local_node_id) {
-                            let transport = RaftRpcRuntime::with_auth_token(
-                                AuthenticatedRaftTransport::new(
-                                    HttpRaftTransport::with_options(peer_map.clone(), http_options),
-                                    auth_token.clone(),
-                                ),
-                                rpc_options,
-                                Some(auth_token.clone()),
-                            );
                             // The self-vote was made durable by prepare_campaign.
                             let mut grants = 1usize;
                             let mut highest_term = template.term;

--- a/crates/temporalstore-rust/src/raft/tests/part1.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part1.rs
@@ -974,6 +974,7 @@ fn raft_transport_rejects_stale_append_entries_and_behind_vote() {
 
     let vote_response = cluster
         .request_vote(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: cluster.hard_state(2).unwrap().current_term + 1,
@@ -1119,6 +1120,7 @@ fn append_entries_higher_term_clears_stale_vote() {
     // Node 3 grants its term-5 vote to candidate 1.
     let granted = cluster
         .receive_vote_request(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 5,
@@ -1150,6 +1152,7 @@ fn append_entries_higher_term_clears_stale_vote() {
     // carried-over voted_for=1 rejected this as "already_voted".
     let regrant = cluster
         .receive_vote_request(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 6,
@@ -1178,6 +1181,7 @@ fn install_snapshot_clears_stale_vote_on_term_raise() {
     // Node 3 grants a term-3 vote to candidate 1.
     let granted = cluster
         .receive_vote_request(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 3,
@@ -1224,6 +1228,7 @@ fn install_snapshot_clears_stale_vote_on_term_raise() {
     // A DIFFERENT candidate can now win node 3's vote in term 5.
     let regrant = cluster
         .receive_vote_request(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 5,
@@ -1712,6 +1717,7 @@ fn request_vote_higher_term_resets_prior_vote_before_decision() {
 
     let first_vote = cluster
         .request_vote(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 3,
@@ -1726,6 +1732,7 @@ fn request_vote_higher_term_resets_prior_vote_before_decision() {
 
     let higher_term_vote = cluster
         .request_vote(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 4,
@@ -1752,6 +1759,7 @@ fn request_vote_higher_term_updates_term_even_when_candidate_log_is_behind() {
         .unwrap();
     let response = cluster
         .request_vote(VoteRequest {
+            pre_vote: false,
             rpc: None,
             shard_id: 1,
             term: 5,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -3192,3 +3192,148 @@ fn a_reply_from_a_newer_term_makes_the_leader_step_down() {
         "the leader must step down rather than keep sending requests that can only be refused"
     );
 }
+
+/// Answering a pre-vote changes nothing about the node that answers.
+///
+/// That is the whole property. A node that cannot reach the cluster campaigns on a timer, and if
+/// asking raised terms or recorded votes, one unreachable node would drag a healthy cluster
+/// through an election every time it tried.
+#[test]
+fn a_pre_vote_does_not_move_the_term_or_spend_the_vote() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    let term_before = cluster.status().current_term;
+
+    let answer = cluster
+        .receive_vote_request(VoteRequest {
+            rpc: None,
+            shard_id: 1,
+            term: term_before + 40,
+            candidate_id: 3,
+            target_id: 2,
+            last_log_index: 0,
+            last_log_term: 0,
+            pre_vote: true,
+        })
+        .unwrap();
+    assert!(
+        answer.vote_granted,
+        "an up-to-date candidate at a newer term should be told yes: {answer:?}"
+    );
+
+    let term_after = cluster
+        .status()
+        .nodes
+        .iter()
+        .find(|node| node.node_id == 2)
+        .map(|node| node.current_term)
+        .unwrap();
+    assert_eq!(
+        term_after, term_before,
+        "answering a pre-vote must not adopt the term it asks about"
+    );
+
+    // And no vote was spent: a different candidate can still win that term for real.
+    let real = cluster
+        .receive_vote_request(VoteRequest {
+            rpc: None,
+            shard_id: 1,
+            term: term_before + 40,
+            candidate_id: 1,
+            target_id: 2,
+            last_log_index: 0,
+            last_log_term: 0,
+            pre_vote: false,
+        })
+        .unwrap();
+    assert!(
+        real.vote_granted,
+        "the pre-vote must not have recorded a vote, so this real one should be granted: {real:?}"
+    );
+}
+
+/// A candidate whose log is behind is told no, and still nothing moves.
+#[test]
+fn a_pre_vote_from_a_behind_candidate_is_declined() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    for index in 0..3 {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("committed-{index}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+    let term_before = cluster
+        .status()
+        .nodes
+        .iter()
+        .find(|node| node.node_id == 2)
+        .map(|node| node.current_term)
+        .unwrap();
+
+    let answer = cluster
+        .receive_vote_request(VoteRequest {
+            rpc: None,
+            shard_id: 1,
+            term: term_before + 40,
+            candidate_id: 3,
+            target_id: 2,
+            last_log_index: 0,
+            last_log_term: 0,
+            pre_vote: true,
+        })
+        .unwrap();
+    assert!(
+        !answer.vote_granted,
+        "a candidate missing committed entries must be told no: {answer:?}"
+    );
+    let term_after = cluster
+        .status()
+        .nodes
+        .iter()
+        .find(|node| node.node_id == 2)
+        .map(|node| node.current_term)
+        .unwrap();
+    assert_eq!(
+        term_after, term_before,
+        "a declined pre-vote must not move the term either"
+    );
+}
+
+/// Preparing the question does not raise the asker's own term.
+///
+/// A node that never gets a majority of yes answers repeats this forever, so if preparing it cost
+/// a term, an isolated node would still walk its term upward exactly as before.
+#[test]
+fn preparing_a_pre_vote_does_not_raise_the_term() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    let before = cluster.status().current_term;
+    for _ in 0..25 {
+        let probe = cluster.prepare_pre_vote(2).expect("a voter can ask");
+        assert!(probe.pre_vote, "the request must be marked as a question");
+        assert!(
+            probe.term > before,
+            "it should ask about the term it would use"
+        );
+    }
+    let after = cluster
+        .status()
+        .nodes
+        .iter()
+        .map(|node| node.current_term)
+        .max()
+        .unwrap();
+    assert_eq!(
+        after, before,
+        "asking twenty-five times must leave every term where it was"
+    );
+}


### PR DESCRIPTION
A node that cannot reach the cluster campaigns on a timer, and every campaign raises its term. When that node is heard from again the leader sees the higher term and steps down — correctly, that is the rule — so **one unreachable node drags a healthy cluster through election after election**.

Seen directly while chasing something else: a partitioned node had driven the group to **term 52**, and the leader had become a follower with an invalid lease while a majority was up and in contact with each other.

## What changes

A candidate asks first, at the term it *would* use. Answering that question changes nothing: no term adopted, no vote recorded, nothing persisted — so a node with no reachable peers gets no answers, never campaigns, and never moves its term. Only a candidate that would actually win goes on to raise its term and ask for real.

The pieces for this already existed (`enable_pre_vote`, `pre_vote_would_win`, a `pre_vote_rejections` counter) but nothing on the campaigning path used them, and the config that gated them defaults to off. This wires the check into the path that actually campaigns, so it does not depend on the gate.

`VoteRequest` gains a `pre_vote` flag, defaulted, so an older node reading a newer one's request sees exactly what it sees today.

## Tests

Three, and deliberately deterministic — the behaviour this fixes is timing-driven, but the contract is not:

- answering a pre-vote moves neither the term nor the recorded vote — checked by then winning a *real* vote at the same term, which would be impossible if the pre-vote had spent it
- a candidate whose log is behind is told no, and still nothing moves
- preparing the question twenty-five times leaves every term where it was

## Testing

Library suite: **995 passed, 11 failed**, and **no name fails here that does not also fail on `main`** — the set difference is empty. That includes the failover tests added with the campaigning path.

An earlier run of the same code showed 19 failures and 8 apparent regressions. That run was on a box at load average 28 (16 cores) and took 472s against a 295s baseline; every one of the 8 was a timeout-sensitive client or context test, and all 8 are gone on a quieter box. I mention it because the numbers below are only worth reading with the machine state attached.

## What this does not fix

`raft_secondary_replication_harness` is red on `main` at the moment, and it is **still red with this change — 0/5 both ways, interleaved on the same machine**, failing identically: a membership apply on a follower whose *local* view has no live leader, while the real leader is healthy and leading. That is a different problem, and it is the same shape as the two before it — the harness drives per-process admin APIs against each node's own view, and those views are only as fresh as the last AppendEntries that reached them. Worth addressing properly rather than one call at a time.
