### PR TITLE
Client: the route cache never returned a hit

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -608,6 +608,14 @@ struct ClientInner {
     tables: Mutex<HashMap<String, TableOptions>>,
     meta_sync_tables: Mutex<HashMap<String, ClientMetaSyncTableState>>,
     stats: Mutex<ClientStats>,
+    /// Topology version this client last heard from the metaserver.
+    ///
+    /// Routes resolved by direct shard lookup carry no version of their own, and a route
+    /// stamped 0 reads as "unknown", which the staleness check treats as stale. Every such
+    /// route was stamped 0, so every check found the cache stale and dropped it, and the
+    /// next request resolved again -- a cache that could never converge. Recording what the
+    /// topology was when the route was resolved is what lets "unchanged" mean anything.
+    known_topology_version: AtomicU64,
 }
 
 #[derive(Debug, Clone)]
@@ -712,6 +720,7 @@ impl TemporalStoreClient {
                 tables: Mutex::default(),
                 meta_sync_tables: Mutex::default(),
                 stats: Mutex::default(),
+                known_topology_version: AtomicU64::new(0),
             }),
         }
     }

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -328,6 +328,11 @@ impl TemporalStoreClient {
         if !topology.status.ok {
             return Err(ClientError::Status(topology.status.message));
         }
+        // Remember what the metaserver just said, so routes resolved from here on are
+        // stamped with it and a later "unchanged" reply can actually keep the cache.
+        self.inner
+            .known_topology_version
+            .store(topology.current_topology_version, std::sync::atomic::Ordering::Relaxed);
 
         let stale_before_invalidation = old_topology_version < topology.current_topology_version
             || (before.unknown_topology_version_routes > 0 && !topology.unchanged);

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -299,14 +299,19 @@ impl TemporalStoreClient {
             .location
             .ok_or_else(|| ClientError::Status("route missing".to_string()))?
             .server_addr;
+        // Stamp the topology this route was resolved against. Without it the route is
+        // version 0 = unknown, the staleness check treats unknown as stale, and the entry is
+        // dropped on the very next request -- which is why the cache never returned a hit.
+        let mut cached = CachedRoute::for_shard(shard_id, server_addr.clone(), "shard_lookup");
+        cached.topology_version = self
+            .inner
+            .known_topology_version
+            .load(std::sync::atomic::Ordering::Relaxed);
         self.inner
             .routes
             .lock()
             .expect("client route cache lock poisoned")
-            .insert(
-                shard_id,
-                CachedRoute::for_shard(shard_id, server_addr.clone(), "shard_lookup"),
-            );
+            .insert(shard_id, cached);
         self.inner
             .stats
             .lock()

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3865,6 +3865,103 @@ mod tests {
         });
     }
 
+    #[test]
+    fn route_cache_serves_repeat_requests_instead_of_re_resolving() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let shard_gets = std::sync::Arc::new(AtomicUsize::new(0));
+        let topo_posts = std::sync::Arc::new(AtomicUsize::new(0));
+
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        start_server(test_addr(18_380), engine.clone());
+
+        let meta = crate::meta::SingleNodeMeta::default();
+        meta.register_server(crate::meta::RegisterServerRequest {
+            server_addr: test_addr(18_380),
+            node_id: 1,
+            location: "zone-a".to_string(),
+            binary_version: "v-a".to_string(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: test_addr(18_380),
+        });
+
+        let addr = test_addr(18_381);
+        let sg = shard_gets.clone();
+        let tp = topo_posts.clone();
+        let m = meta.clone();
+        std::thread::spawn(move || {
+            serve(&addr, move |request| {
+                match (request.method.as_str(), request.path.as_str()) {
+                    ("GET", path) if path.starts_with("/shards/") => {
+                        sg.fetch_add(1, Ordering::SeqCst);
+                        let shard_id = path.trim_start_matches("/shards/").parse().unwrap_or_default();
+                        json_response(200, &m.get(shard_id))
+                    }
+                    ("POST", "/tables/topology") => {
+                        let req = parse_json::<GetTableTopologyRequest>(&request.body).unwrap();
+                        json_response(200, &m.get_table_topology(req))
+                    }
+                    ("POST", "/meta/topology_version") => {
+                        tp.fetch_add(1, Ordering::SeqCst);
+                        let req = parse_json::<TopologyVersionRequest>(&request.body).unwrap();
+                        json_response(200, &m.topology_version_report(req))
+                    }
+                    _ => json_response(404, &Status::error("not_found", "not found")),
+                }
+            })
+            .unwrap();
+        });
+        wait_for_http(&test_addr(18_380));
+        wait_for_http(&test_addr(18_381));
+
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_381),
+            route_cache_ttl_ms: 60_000,
+            ..ProxyOptions::default()
+        });
+
+        for i in 0..10 {
+            assert!(proxy.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet { key: format!("k{i}"), value: b"v".to_vec() },
+            }).status.ok);
+        }
+
+        let gets = shard_gets.load(Ordering::SeqCst);
+        let posts = topo_posts.load(Ordering::SeqCst);
+        let report = proxy.preflight_report();
+
+        // Ten identical requests behind a 60s TTL. This used to be 10 shard lookups and
+        // zero cache hits: routes resolved by shard lookup were stamped topology version 0,
+        // "unknown" counted as stale, so every request invalidated the entry it had just
+        // written and resolved again. The cache existed and never once returned a hit.
+        assert!(
+            gets <= 2,
+            "10 requests should resolve at most twice, took {gets} shard lookups              (hits={} misses={} refreshes={})",
+            report.client.route_cache_hits,
+            report.client.route_cache_misses,
+            report.client.route_refreshes
+        );
+        assert!(
+            report.client.route_cache_hits >= 7,
+            "the cache should serve the repeats, saw {} hits across 10 requests",
+            report.client.route_cache_hits
+        );
+
+        // NOT asserted low on purpose: the topology check itself is still one POST per
+        // request on every command entry point. That is a separate cost and a separate
+        // change; this test pins the route cache, not the topology check.
+        assert!(posts >= 1, "topology is still checked, saw {posts}");
+    }
+
     fn start_meta_service(addr: String, meta: crate::meta::SingleNodeMeta) {
         std::thread::spawn(move || {
             serve(&addr, move |request| {


### PR DESCRIPTION
Ten identical requests through the proxy, behind a sixty second route TTL, produced
ten shard lookups and zero cache hits. Measured, with a counting metaserver:

  before:  10 executes -> 10 shard GETs,  cache hits=0 misses=10 refreshes=10
  after:   10 executes ->  2 shard GETs,  cache hits=8 misses=2  refreshes=2

A route resolved by direct shard lookup was stamped topology version 0. Zero means
"unknown", and the staleness check counts unknown as stale, so every topology check
found the cache stale and dropped it -- including the entry the previous request had
just written. The next request then resolved again, and stamped 0 again. The cache
could not converge, by construction. It has presumably never returned a hit for
shard-routed traffic since the check was added.

So the proxy paid two metaserver round-trips per request, not one: the topology
check, and then the shard lookup that the check had just made necessary.

The fix is to record what the metaserver reports and stamp routes with it, so a
later "unchanged" reply means something. Convergence takes two requests: the first
has an empty cache and so skips the check entirely, learning nothing.

What did NOT change: routes are still dropped when topology actually changes. That
is the whole point of the check and it still fires -- the tests covering shard
movement, topology churn across several proxies, backend-failure refresh and the
continuous-failure skip all still pass, and the context route test that fails when
invalidation is removed still fails when it is removed.

Still one metaserver round-trip per request, and still worth removing: the topology
check itself runs on every request at every command entry point, unthrottled. That
is a behaviour change to when a topology change is noticed, so it is deliberately
not in this change. The new test pins the route cache and explicitly does not pin
the topology check, so whoever throttles it will not have to argue with this test.