### PR TITLE
Hearing from the leader proves it is alive, even when its entries are refused

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -387,6 +387,21 @@ impl RaftCluster {
         let leader_id = request.leader_id;
         let term = request.term;
         let leader_commit = request.leader_commit;
+        // Contact from the leader proves it is alive, whatever we go on to decide about its
+        // entries. A follower marks its leader down when its election timer expires, and until
+        // now only an ACCEPTED append marked it back up -- so a follower that is merely behind,
+        // which rejects appends while it catches up, held a healthy leader as down and refused
+        // every operation that needs one.
+        let heard_from_the_leader = inner
+            .nodes
+            .get(&target_id)
+            .map(|node| term >= node.current_term)
+            .unwrap_or(false);
+        if heard_from_the_leader && leader_id != target_id {
+            if let Some(leader) = inner.nodes.get_mut(&leader_id) {
+                leader.alive = true;
+            }
+        }
         let received_entries = entries.len() as u64;
         let received_bytes = entries
             .iter()

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -3337,3 +3337,56 @@ fn preparing_a_pre_vote_does_not_raise_the_term() {
         "asking twenty-five times must leave every term where it was"
     );
 }
+
+/// A follower that REFUSES an append still learns its leader is alive.
+///
+/// A follower marks its leader down when its election timer expires, and only an accepted append
+/// used to mark it back up. A follower that is merely behind rejects appends while it catches up,
+/// so it held a healthy leader as down indefinitely -- and every operation needing a leader, a
+/// membership change among them, was refused with "leader is not available" while the leader was
+/// leading a healthy majority.
+#[test]
+fn a_rejected_append_still_proves_the_leader_is_alive() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster
+        .propose(Command::StringSet {
+            key: "committed".to_string(),
+            value: b"v".to_vec(),
+        })
+        .unwrap();
+
+    // Node 3 timed out waiting and wrote its leader off, the way the election timer does.
+    cluster.set_alive(1, false).unwrap();
+
+    // The leader speaks to it, but from a point their logs do not agree on, so it is refused.
+    let response = cluster
+        .receive_append_entries(AppendEntriesRequest {
+            rpc: None,
+            shard_id: 1,
+            term: cluster.status().current_term,
+            leader_id: 1,
+            target_id: 3,
+            prev_log_index: 9,
+            prev_log_term: 9,
+            entries: Vec::new(),
+            leader_commit: 1,
+        })
+        .unwrap();
+    assert!(
+        !response.success,
+        "this append should be refused, or the test proves nothing: {response:?}"
+    );
+
+    let leader_alive = cluster
+        .status()
+        .nodes
+        .iter()
+        .any(|node| node.node_id == 1 && node.alive);
+    assert!(
+        leader_alive,
+        "being spoken to by the leader is proof it is alive, even when we refuse what it sent"
+    );
+}


### PR DESCRIPTION
A follower marks its leader down when its election timer expires. Only an **accepted** AppendEntries marked it back up — every rejection path returns before that line.

So a follower that is merely behind, which rejects appends while it catches up, held a perfectly healthy leader as down, and refused every operation that needs one. Seen as a membership change refused for a full thirty seconds with `leader is not available`, while the named leader was leading a healthy majority the whole time.

Liveness is about contact, not about agreeing on the log. Hearing from the current leader now marks it alive before the log-consistency checks that may reject what it sent.

## Test

`a_rejected_append_still_proves_the_leader_is_alive` — the follower writes its leader off, the leader speaks to it from a point their logs disagree on, the append is refused, and the leader must still be alive in the follower's view. Verified to fail before the change and pass after; I removed the fix and re-ran rather than assuming.

## Testing

Library suite: **997 passed, 11 failed**. Three names differ from the `main` comparison run, and all three pass **5/5 isolated** — `manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted`, `context_route_cache_is_invalidated_when_the_shard_moves`, `s2_state_image_snapshot_travels_through_chunk_stream`.

## What I could not measure

I cannot show what this does to `raft_secondary_replication_harness`. Interleaved on one machine with both binaries prebuilt, it was 1/6 both ways — but the load average hit 42 on 16 cores during that run, so that is noise rather than a result. An earlier standalone run was 2/6 against a 3/5 baseline, which is also within this harness's spread.

The argument for this change is the defect itself and the test, not a pass-rate delta. The harness on this machine has swung 0/5 to 5/5 on identical code depending on what else was running, so I would rather state that plainly than attach a number to it.
