### PR TITLE
Agreeing on a leader should mean agreeing it is live

### DIFF
--- a/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
+++ b/crates/temporalstore-rust/src/bin/raft_secondary_replication_harness.rs
@@ -19,7 +19,7 @@ use temporalstore_rust::raft::{
 use temporalstore_rust::{
     Command, CommandResponse, DistributedRaftCommandResponse, DistributedRaftProposeRequest,
     DistributedRaftReadRequest, ProductionRaftNode, RaftApplyHealth, RaftClusterStatus,
-    RaftFailoverReport, RaftMembershipChangeReport, RaftNodeId, Status,
+    RaftFailoverReport, RaftMembershipChangeReport, RaftNodeId, RaftRole, Status,
     TemporalRaftDataNodeProcessRolloutReport, TemporalRaftProcessNodeEvidence,
     TemporalRaftProcessOperationalSemanticsEvidence, VoteRequest, VoteResponse,
 };
@@ -1234,17 +1234,27 @@ fn establish_leader(nodes: &[ProductionRaftNode], preferred: RaftNodeId) -> Raft
     let _ = try_elect_leader(node_by_id(nodes, preferred), preferred);
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
+        // Every node must name the same leader AND consider it live and leading -- that is what
+        // an operation needing a leader checks, so anything less leaves the wait satisfied while
+        // the next call still fails.
         let observed: Vec<Option<RaftNodeId>> = nodes
             .iter()
             .map(|node| {
-                get_json_with_options::<RaftClusterStatus>(
+                let status = get_json_with_options::<RaftClusterStatus>(
                     &node.addr,
                     "/raft/status",
                     request_options(),
                 )
-                .ok()
-                .filter(|status| status.leader_id != 0)
-                .map(|status| status.leader_id)
+                .ok()?;
+                if status.leader_id == 0 {
+                    return None;
+                }
+                let leader_is_live = status.nodes.iter().any(|peer| {
+                    peer.node_id == status.leader_id
+                        && peer.alive
+                        && peer.role == RaftRole::Leader
+                });
+                leader_is_live.then_some(status.leader_id)
             })
             .collect();
         if let Some(Some(first)) = observed.first().copied() {


### PR DESCRIPTION
Test-only.

An operation that needs a leader checks this node's **own view** for one that is alive and actually leading. Naming the right node is not enough: a view that still has it marked down, or not yet marked leader, refuses the operation while the real leader is healthy — which is exactly the failure this harness hits.

The wait now requires what the operation requires, and when it expires it reports every node's view rather than only saying no leader was found.

## Honest about the evidence

This does not measurably change the pass rate: 3/5 before, 4/6 after, which is inside this harness's spread. I am proposing it because the wait was checking something weaker than what the next call needs — a wait that can be satisfied while the operation still fails is not much of a wait — not because I can show it fixes anything.

The companion product fix is in the contact-proves-liveness change, which addresses why a follower's view has the leader marked down in the first place.
