### PR TITLE
Guard the barrier sharing that concurrent writes depend on

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2887,4 +2887,69 @@ mod tests {
         let decoded: WriteAheadLogRecord = serde_json::from_str(&encoded).unwrap();
         assert_eq!(decoded, record, "a record must survive its own encoding");
     }
+
+    /// Barriers taken per durable write, as concurrency rises.
+    ///
+    /// A durable write costs an fsync, and the fsync dominates it -- so the lever on throughput is
+    /// how many writes share one barrier. A ratio near 1.0 means every writer paid for its own; the
+    /// lower it goes, the better concurrent writers are being coalesced.
+    #[test]
+    fn durable_write_barriers_per_write_under_concurrency() {
+        use std::sync::Arc;
+
+        for writers in [1usize, 2, 4, 8, 16] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = Arc::new(LocalWriteAheadLogStore::new(dir.path()));
+            let per_writer = 40u64;
+            let started = std::time::Instant::now();
+            let mut handles = Vec::new();
+            for writer in 0..writers {
+                let store = Arc::clone(&store);
+                handles.push(std::thread::spawn(move || {
+                    for index in 0..per_writer {
+                        store
+                            .append_with_sync(
+                                1,
+                                Command::StringSet {
+                                    key: format!("w{writer}-{index:06}"),
+                                    value: vec![118u8; 128],
+                                },
+                                true,
+                            )
+                            .unwrap();
+                    }
+                }));
+            }
+            for handle in handles {
+                handle.join().unwrap();
+            }
+            let elapsed = started.elapsed();
+            let total = writers as u64 * per_writer;
+            let stats = store.raw_stats(1);
+            let per_write = stats.syncs as f64 / total as f64;
+            println!(
+                "  {writers:>2} writers: {total:>4} writes, {:>4} barriers = {per_write:.2} per write, {:>7.0} writes/s, {:>7.1} us/write",
+                stats.syncs,
+                total as f64 / elapsed.as_secs_f64(),
+                elapsed.as_secs_f64() * 1e6 / total as f64
+            );
+
+            // One barrier per write is the ceiling -- more than that would mean a durable write
+            // paid for someone else's fsync as well as its own.
+            assert!(
+                stats.syncs <= total,
+                "{writers} writers took {} barriers for {total} writes",
+                stats.syncs
+            );
+            if writers >= 8 {
+                // Measured at 0.20 and 0.17 on an idle machine; this only has to catch coalescing
+                // being switched off or broken, which shows up as 1.00 at every concurrency.
+                assert!(
+                    per_write < 0.9,
+                    "concurrent writers should share barriers, but {writers} writers took \
+                     {per_write:.2} per write -- that is one each, so nothing is being coalesced"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
A durable write is dominated by its fsync, not by its bytes. So the lever on write throughput is not making the record smaller — it is how many writes share one barrier.

That sharing works well. Nothing asserted it, so a change that quietly stopped it would cost most of the write throughput with every test still green.

## Measured, same idle machine, both ways

| | 1 writer | 16 writers |
|---|---|---|
| coalescing **on** | 1.00 barriers/write, 565 writes/s | **0.17** barriers/write, **2800 writes/s** |
| coalescing **off** | 1.00 barriers/write, 507 writes/s | 1.00 barriers/write, 558 writes/s |

With it off, throughput is flat no matter how many writers there are — every writer pays for its own fsync. With it on it scales five times, and the barrier count per write falls from 1.00 to 0.17.

## The guard

The test reports the table above and fails if eight or more concurrent writers each pay for their own barrier, which is exactly what switching the coalescing off looks like. Verified by switching it off — the assertion fires with `8 writers took 1.00 per write -- that is one each, so nothing is being coalesced`.

The threshold is 0.9 against a measured 0.17, so it has a wide margin: it is there to catch the behaviour disappearing, not to pin a number that depends on the disk. There is also a hard invariant that the log never takes more barriers than it accepted writes.

## Testing

Test-only. Library suite: **1016 passed, 9 failed**. One name differs from the `main` comparison run, `manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted`, which I isolated 5/5 twice today.

## Context

This closes out the latency side of the footprint work. Making records smaller (the encoding and field-name changes) cut the *asynchronous* write path substantially — up to 2.96x faster at 4 KiB — but a synchronous write is a barrier, and no amount of shrinking touches that. The barrier sharing is what does, and it is already in place; it just was not protected.
