### PR TITLE
Honour forget, reset and delete on the retrieve path, and read a resource text back

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -77,6 +77,10 @@ struct RecordLogRequest {
     shard_size: Option<u64>,
     #[serde(default)]
     record_types: Option<Vec<String>>,
+    /// Identity ids to remove, for `matrixark_delete_records`. Sent by the caller, which owns the
+    /// decision about what a delete covers; the engine only matches and removes.
+    #[serde(default)]
+    record_ids: Option<Vec<String>>,
     #[serde(default)]
     selected_node_hashes: Option<Vec<u64>>,
     #[serde(default)]
@@ -1696,6 +1700,121 @@ fn forget_scope_records(
     Ok(stats)
 }
 
+/// Every id a record can be addressed by: its own identity, and any reference it carries.
+///
+/// A delete removes the addressed record AND the embeddings / index postings that point at it --
+/// those carry no identity of their own, only a `ref_hash` / `ref_hashes` aimed at one. Matching
+/// both is what stops a delete leaving orphaned postings behind that still surface its text.
+fn record_addressable_ids(record: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    let mut push = |value: Option<&Value>| {
+        if let Some(value) = value {
+            match value {
+                Value::String(text) if !text.is_empty() => ids.push(text.clone()),
+                Value::Number(number) => ids.push(number.to_string()),
+                _ => {}
+            }
+        }
+    };
+    for field in [
+        "event_id_hash",
+        "entity_hash",
+        "summary_hash",
+        "segment_hash",
+        "ref_hash",
+    ] {
+        push(record.get(field));
+    }
+    if let Some(Value::Array(refs)) = record.get("ref_hashes") {
+        for item in refs {
+            match item {
+                Value::String(text) if !text.is_empty() => ids.push(text.clone()),
+                Value::Number(number) => ids.push(number.to_string()),
+                _ => {}
+            }
+        }
+    }
+    ids
+}
+
+/// Remove every record addressable by one of `ids`.
+///
+/// Mirrors `forget_scope_records` -- same shard walk, same survivor rewrite, same single durable
+/// batch that also clears the scan/hgetall caches so a later retrieve cannot re-serve a removed
+/// record from cache. Only the predicate differs: identity ids instead of a scope.
+fn delete_records_by_ids(
+    engine: &TemporalEngine,
+    record_hash_key: &str,
+    count_key: &str,
+    shard_size: u64,
+    ids: &[String],
+) -> Result<ForgetScopeStats, String> {
+    let wanted: HashSet<&str> = ids.iter().map(String::as_str).collect();
+    let mut stats = ForgetScopeStats::default();
+    if wanted.is_empty() {
+        // An empty id set must remove NOTHING. Falling through to a match-everything walk here
+        // would turn a no-op delete into a store wipe.
+        return Ok(stats);
+    }
+    let shard_size = shard_size.max(1);
+    let count = read_record_count(engine, count_key)?
+        .trim()
+        .parse::<u64>()
+        .unwrap_or(0);
+    if count == 0 {
+        return Ok(stats);
+    }
+    let max_shard = (count - 1) / shard_size;
+    let mut commands = Vec::new();
+    for shard in 0..=max_shard {
+        stats.shards_scanned += 1;
+        let key = format!("{}:{:06}", record_hash_key, shard);
+        for (field, value) in hgetall_map(engine, key.clone())? {
+            let records = decode_matrixark_payload(&value);
+            if records.is_empty() {
+                // Undecodable / non-record field (e.g. a counter): never touch it.
+                continue;
+            }
+            stats.records_scanned += records.len();
+            let mut survivors = Vec::with_capacity(records.len());
+            let mut removed_here = 0_usize;
+            for record in records {
+                if record_addressable_ids(&record)
+                    .iter()
+                    .any(|id| wanted.contains(id.as_str()))
+                {
+                    removed_here += 1;
+                } else {
+                    survivors.push(record);
+                }
+            }
+            if removed_here == 0 {
+                continue;
+            }
+            stats.records_removed += removed_here;
+            if survivors.is_empty() {
+                commands.push(Command::HashDelete {
+                    key: key.clone(),
+                    field,
+                });
+                stats.fields_deleted += 1;
+            } else {
+                let encoded = encode_forget_survivors(&value, survivors);
+                commands.push(Command::HashSet {
+                    key: key.clone(),
+                    field,
+                    value: encoded.into_bytes(),
+                });
+                stats.fields_rewritten += 1;
+            }
+        }
+    }
+    if !commands.is_empty() {
+        execute_empty_batch_runtime(engine, commands, true)?;
+    }
+    Ok(stats)
+}
+
 fn candidate_text(record: &Value) -> String {
     for field in [
         "text",
@@ -2171,6 +2290,39 @@ fn execute_record_log_request(
             );
             output
         }
+        "matrixark_delete_records" => {
+            let count_key = required_option(request.count_key.clone(), "count_key")?;
+            let record_hash_key =
+                required_option(request.record_hash_key.clone(), "record_hash_key")?;
+            let shard_size = request.shard_size.unwrap_or(1024).max(1);
+            let ids = request.record_ids.clone().unwrap_or_default();
+            let stats =
+                delete_records_by_ids(&engine, &record_hash_key, &count_key, shard_size, &ids)?;
+            let mut output = empty_output(root);
+            output.status = "deleted".to_string();
+            output.count = Some(stats.records_removed);
+            output.extra.insert(
+                "matrixark_delete_records_removed".to_string(),
+                json!(stats.records_removed),
+            );
+            output.extra.insert(
+                "matrixark_delete_records_scanned".to_string(),
+                json!(stats.records_scanned),
+            );
+            output.extra.insert(
+                "matrixark_delete_fields_deleted".to_string(),
+                json!(stats.fields_deleted),
+            );
+            output.extra.insert(
+                "matrixark_delete_fields_rewritten".to_string(),
+                json!(stats.fields_rewritten),
+            );
+            output.extra.insert(
+                "matrixark_delete_ids_requested".to_string(),
+                json!(ids.len()),
+            );
+            output
+        }
         "matrixark_retrieve_context_pack" => {
             if matrixark_compact_snapshot_retrieve_enabled() {
                 retrieve_context_pack_output(&engine, &request, root)?
@@ -2203,6 +2355,13 @@ fn validate_request(request: &RecordLogRequest) -> Result<(), String> {
         "matrixark_scan_candidates"
         | "matrixark_retrieve_context_pack"
         | "matrixark_retrieve_context_pack_full_scan" => {
+            require_non_empty("count_key", request.count_key.as_deref().unwrap_or(""))?;
+            require_non_empty(
+                "record_hash_key",
+                request.record_hash_key.as_deref().unwrap_or(""),
+            )
+        }
+        "matrixark_delete_records" => {
             require_non_empty("count_key", request.count_key.as_deref().unwrap_or(""))?;
             require_non_empty(
                 "record_hash_key",

--- a/tools/matrixark_local_adapter_dashboard.py
+++ b/tools/matrixark_local_adapter_dashboard.py
@@ -676,6 +676,119 @@ class _LocalAdapterDashboardMixin:
             "record_count": len(records),
         }
 
+    # A response this size is a deliberate ceiling, not a guess: a skill or attachment can be
+    # far larger than anything a caller wants in one JSON body, and the point of paging is that
+    # they never have to find that out the hard way.
+    RESOURCE_CONTENT_DEFAULT_CHUNKS = 32
+    RESOURCE_CONTENT_MAX_CHARS = 200_000
+
+    def get_resource_content(self, args: Json) -> Json:
+        """Return one resource's (or skill's) stored text, in order, a page at a time.
+
+        `list_skills` / `list_resources` return a POINTER -- raw_uri, cloud_key -- and metadata.
+        The text is already stored, split across `resource_chunk` records at ingest, but nothing
+        reassembled it, so "give me this skill's content" had no answer: a caller had to know the
+        chunks existed and stitch them itself.
+
+        Paged on purpose. An attachment can be far larger than anything that belongs in one JSON
+        response, so this returns at most `chunk_limit` chunks and at most `max_chars` characters,
+        and reports `next_chunk_offset` when there is more. A caller that wants everything loops;
+        a caller that wants the first page pays for the first page.
+
+        Ordering is `chunk_index` where present, and log order otherwise -- chunks written before
+        the index existed have no other ordering key, and returning them in log order is what the
+        ingest path produced.
+        """
+        resource_hash = args.get("resource_hash", args.get("skill_hash"))
+        try:
+            resource_hash = int(resource_hash)
+        except (TypeError, ValueError):
+            raise MatrixArkError("resource_hash (or skill_hash) must be an integer")
+        if resource_hash <= 0:
+            raise MatrixArkError("resource_hash (or skill_hash) must be a positive integer")
+        scope = optional_object(args, "scope")
+        offset = args.get("chunk_offset", 0)
+        offset = int(offset) if isinstance(offset, int) and offset > 0 else 0
+        limit = args.get("chunk_limit", self.RESOURCE_CONTENT_DEFAULT_CHUNKS)
+        if not isinstance(limit, int) or limit <= 0:
+            limit = self.RESOURCE_CONTENT_DEFAULT_CHUNKS
+        max_chars = args.get("max_chars", self.RESOURCE_CONTENT_MAX_CHARS)
+        if not isinstance(max_chars, int) or max_chars <= 0:
+            max_chars = self.RESOURCE_CONTENT_MAX_CHARS
+
+        found: list[Json] = []
+        manifest: Json = {}
+        for position, record in enumerate(self.read_all()):
+            record_type = record.get("record_type")
+            if record_type in {"resource_manifest", "skill_manifest"}:
+                rid = record.get("resource_hash", record.get("skill_hash"))
+                try:
+                    rid = int(rid or 0)
+                except (TypeError, ValueError):
+                    continue
+                if rid == resource_hash and scope_matches(candidate_access_scope(record), scope):
+                    manifest = record
+                continue
+            if record_type != "resource_chunk":
+                continue
+            try:
+                if int(record.get("resource_hash") or 0) != resource_hash:
+                    continue
+            except (TypeError, ValueError):
+                continue
+            if not scope_matches(candidate_access_scope(record), scope):
+                continue
+            index = record.get("chunk_index")
+            found.append({
+                "order": (int(index) if isinstance(index, int) else position),
+                "chunk_index": int(index) if isinstance(index, int) else None,
+                "chunk_hash": record.get("chunk_hash"),
+                "source_ref": record.get("source_ref", record.get("source_locator", "")),
+                "token_estimate": record.get("token_estimate", 0),
+                "text": str(record.get("text") or ""),
+            })
+        # Same chunk_hash can be re-ingested; the later write wins, as everywhere else.
+        deduped: dict[Any, Json] = {}
+        for item in found:
+            deduped[item.get("chunk_hash", item["order"])] = item
+        ordered = sorted(deduped.values(), key=lambda c: c["order"])
+
+        page: list[Json] = []
+        chars = 0
+        truncated_by_chars = False
+        for item in ordered[offset:offset + limit]:
+            text = item["text"]
+            if chars + len(text) > max_chars:
+                room = max(0, max_chars - chars)
+                if room:
+                    item = {**item, "text": text[:room], "truncated": True}
+                    page.append(item)
+                    chars += room
+                truncated_by_chars = True
+                break
+            page.append(item)
+            chars += len(text)
+
+        served = offset + len(page)
+        has_more = served < len(ordered) or truncated_by_chars
+        return {
+            "status": "ok",
+            "resource_hash": resource_hash,
+            "name": manifest.get("name", ""),
+            "description": manifest.get("description", ""),
+            "resource_type": manifest.get("resource_type", "skill" if manifest.get("skill_hash") else ""),
+            "raw_uri": manifest.get("raw_uri", ""),
+            "chunk_count": len(ordered),
+            "chunk_offset": offset,
+            "returned_chunks": len(page),
+            "next_chunk_offset": served if has_more else None,
+            "has_more": bool(has_more),
+            "truncated_by_max_chars": truncated_by_chars,
+            "chars": chars,
+            "text": "".join(c["text"] for c in page),
+            "chunks": [{k: v for k, v in c.items() if k != "order"} for c in page],
+        }
+
     def list_resources(self, args: Json) -> Json:
         scope = optional_object(args, "scope")
         limit = args.get("limit", 100)

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -903,7 +903,7 @@ class _LocalAdapterIngestMixin:
             deduped_source_refs: list[str] = []
             seen_content_hashes: set[str] = set()
             unique_chunks = []
-            for chunk in parsed_chunks:
+            for chunk_index, chunk in enumerate(parsed_chunks):
                 chunk_content_hash = str(chunk.metadata.get("content_hash") or content_hash(chunk.text))
                 if chunk_content_hash in seen_content_hashes:
                     deduped_source_refs.append(chunk.source_ref)
@@ -1113,6 +1113,11 @@ class _LocalAdapterIngestMixin:
                     {
                         "record_type": "resource_chunk",
                         "import_task_hash": resource_import_task_hash,
+                        # Explicit order. Reassembling content by log order works only while the
+                        # log is read append-ordered and nothing in between re-orders or
+                        # re-materializes; an index makes the order a property of the record
+                        # instead of a property of how it happened to be read.
+                        "chunk_index": chunk_index,
                         "chunk_hash": chunk.chunk_hash,
                         "node_hash": node_hash,
                         "node_path": node_path,

--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -663,9 +663,18 @@ class _LocalAdapterRetrievalMixin:
             }
         )
 
+    def _idle_commit_candidate_records(self, scope: Json) -> list[Json]:
+        """The records the idle-commit drain needs: pipeline tasks, nothing else.
+
+        Reading the whole log is fine on the JSONL backend, where `read_all()` walks an in-memory
+        list. The native adapter overrides this with a typed scan, because there `read_all()` ships
+        the entire record log over the proxy -- once per ingest -- to look at one record type.
+        """
+        return self.read_all()
+
     def drain_due_idle_session_commits(self, *, scope: Json, args: Json, hook: Json | None) -> Json:
         now = now_ms()
-        records = self.read_all()
+        records = self._idle_commit_candidate_records(scope)
         latest_status_by_task_hash: dict[int, str] = {}
         latest_order_by_task_hash: dict[int, int] = {}
         for index, record in enumerate(records):

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -383,6 +383,7 @@ MATRIXARK_TOOL_SCOPES: dict[str, set[str]] = {
     "matrixark_reset": {"context:forget"},
     "matrixark_get_all": {"context:retrieve"},
     "matrixark_list_users": {"context:retrieve"},
+    "matrixark_get_resource_content": {"context:retrieve"},
     "matrixark_get_memory": {"context:retrieve"},
     "matrixark_get_memory_by_key": {"context:retrieve"},
     "matrixark_update_memory": {"context:ingest"},

--- a/tools/matrixark_mcp_dispatch.py
+++ b/tools/matrixark_mcp_dispatch.py
@@ -316,6 +316,15 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         )
         response = {**result, "access": args.get("_matrixark_auth", {})}
         return server._finalize_write_response(name, args, identity, hook, response)
+    if name == "matrixark_get_resource_content":
+        result = server.adapter.get_resource_content(args)
+        server.access.append_audit(
+            "resource.get_content", identity, status="ok",
+            details={"resource_hash": result.get("resource_hash"),
+                     "returned_chunks": result.get("returned_chunks"),
+                     "has_more": result.get("has_more")},
+        )
+        return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_list_users":
         result = server.adapter.list_memory_subjects(args)
         server.access.append_audit("context.list_users", identity, status="ok", details={"count": result.get("count")})

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5275,10 +5275,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if parts.get("a"):
             reingest_scope["agent_hash"] = int(parts["a"])
         reingest_scope["_explicit_scope_keys"] = explicit_keys
+        clean_scope = {key: value for key, value in reingest_scope.items() if value is not None}
         ingested = self.ingest(
             {
                 "messages": [{"role": "user", "content": new_text}],
-                "scope": {key: value for key, value in reingest_scope.items() if value is not None},
+                "scope": clean_scope,
                 "finalize": True,
             },
             hook=hook,
@@ -5312,6 +5313,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             # reports its closure: a backend has to remove its own copy, and re-deriving the rule
             # there would put two versions of it in the tree.
             "closure_ref_ids": superseded_ids,
+            # The scope the replacement was ingested into, so a backend that needs to finish the
+            # write itself does not have to reconstruct it from the old record a second time.
+            "reingest_scope": clean_scope,
         }
 
     def history(self, args: Json) -> Json:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5301,12 +5301,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._forget_persisted_event_members(memory_id)
             self._invalidate_event_member_index()
         self.append(tombstone)
+        superseded_ids = sorted(set(tombstone.get("closure_ref_ids") or []) | {memory_id})
         return {
             "updated": True,
             "memory_id": memory_id,
             "new_memory_id": new_memory_id,
             "superseded": True,
             "text": new_text,
+            # The identity set the old version covered. Reported for the same reason delete
+            # reports its closure: a backend has to remove its own copy, and re-deriving the rule
+            # there would put two versions of it in the tree.
+            "closure_ref_ids": superseded_ids,
         }
 
     def history(self, args: Json) -> Json:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4786,6 +4786,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             "superseded_count": len(superseded),
             "member_count": len(closure_ref_ids),
             "member_source": member_source,
+            # The identity set this delete covers. Deciding what belongs in it is the subtle part
+            # -- single-source derivatives are removed, multi-source ones are demoted instead --
+            # and it is decided exactly once, here. Reported so a backend can apply the same set
+            # to its own copy without re-deriving the rule and drifting from it.
+            "closure_ref_ids": sorted(closure_ref_ids | {memory_id}),
         }
         self._maybe_auto_purge()
         return result

--- a/tools/matrixark_mcp_schemas.py
+++ b/tools/matrixark_mcp_schemas.py
@@ -1164,6 +1164,23 @@ TOOLS: list[Json] = [
         },
     },
     {
+        "name": "matrixark_get_resource_content",
+        "description": "Return one resource's or skill's stored text, in order and a page at a time (chunk_offset / chunk_limit / max_chars).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "api_key": API_KEY_SCHEMA,
+                "scope": SCOPE_SCHEMA,
+                "resource_hash": {"type": "integer", "description": "The resource to read (alias: skill_hash)."},
+                "skill_hash": {"type": "integer", "description": "The skill to read (alias: resource_hash)."},
+                "chunk_offset": {"type": "integer", "description": "First chunk to return; use next_chunk_offset to page."},
+                "chunk_limit": {"type": "integer", "description": "Maximum chunks in this response."},
+                "max_chars": {"type": "integer", "description": "Maximum characters in this response."},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
         "name": "matrixark_list_users",
         "description": "List the users/agents/runs that hold memories (mem0 users). Excludes subjects whose memories were all forgotten or expired.",
         "inputSchema": {

--- a/tools/matrixark_mcp_server_request_policy.py
+++ b/tools/matrixark_mcp_server_request_policy.py
@@ -109,6 +109,11 @@ class MatrixArkServerRequestPolicyMixin:
         key_hash = self._idempotency_key_hash(name, raw_key, identity)
         record = self.adapter.find_idempotency_record(key_hash)
         if not record:
+            # Proven absent for THIS key, in this call. `_finalize_write_response` asks the same
+            # question a moment later and would otherwise pay a second lookup; note the answer on
+            # the call's own args rather than re-deriving it.
+            if isinstance(args, dict):
+                args["_matrixark_idempotency_absent"] = key_hash
             return None
         response = dict(record.get("response") or {})
         response["idempotent_replay"] = True
@@ -139,7 +144,12 @@ class MatrixArkServerRequestPolicyMixin:
         if not raw_key:
             return response
         key_hash = self._idempotency_key_hash(name, raw_key, identity)
-        if not self.adapter.find_idempotency_record(key_hash):
+        # Absent already established at the top of this same call -- see
+        # `_idempotent_replay_response`. Only look again when it was not, which is the case for a
+        # tool that finalizes without having gone through the replay check.
+        known_absent = (isinstance(args, dict)
+                        and args.get("_matrixark_idempotency_absent") == key_hash)
+        if known_absent or not self.adapter.find_idempotency_record(key_hash):
             stored_response = {key: value for key, value in response.items() if key != "access"}
             for secret_key in ("api_key", "new_api_key", "raw_key", "secret"):
                 if secret_key in stored_response:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1002,6 +1002,48 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             "shards_scanned": purged.get("matrixark_forget_shards_scanned"),
         }
 
+    def delete_memory(self, args: Json, hook: Json | None = None) -> Json:
+        """Delete the memory in the ENGINE as well as in the serving view.
+
+        Same hole forget and reset had: the tombstone is honoured by every read that goes through
+        the Python serving pipeline, so `get_all` drops immediately, but `/v1/retrieve` is assembled
+        inside the engine and the engine has never heard of a tombstone. Measured before this: after
+        a delete, get_all went 2 -> 1 while retrieve still served the deleted memory.
+
+        The identity set comes from the inherited implementation rather than being re-derived here.
+        Which records a delete covers is genuinely subtle -- the addressed event, its single-source
+        derivatives, and the embeddings/postings pointing at any of them, while MULTI-source
+        derivatives are demoted rather than removed -- and deciding it twice, in two languages, is
+        how the two copies drift.
+        """
+        result = super().delete_memory(args, hook)
+        ids = [str(item) for item in (result.get("closure_ref_ids") or []) if str(item)]
+        if not ids:
+            return result
+        purger = getattr(self._client, "matrixark_delete_records", None)
+        if not callable(purger):
+            result["engine_purge"] = {"ok": False, "error": "engine does not expose matrixark_delete_records"}
+            return result
+        try:
+            purged = purger(
+                count_key=self._count_key,
+                record_hash_key=self._record_hash_key,
+                shard_size=self._shard_size,
+                record_ids=ids,
+            )
+        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
+            result["engine_purge"] = {"ok": False, "error": str(exc)}
+            return result
+        self._drop_direct_record_cache()
+        result["engine_purge"] = {
+            "ok": True,
+            "records_removed": purged.get("matrixark_delete_records_removed"),
+            "fields_deleted": purged.get("matrixark_delete_fields_deleted"),
+            "fields_rewritten": purged.get("matrixark_delete_fields_rewritten"),
+            "ids_requested": purged.get("matrixark_delete_ids_requested"),
+        }
+        return result
+
     def reset(self, args: Json, hook: Json | None = None) -> Json:
         """Wipe the tenant in the ENGINE as well as in the serving view.
 
@@ -2798,6 +2840,27 @@ class MatrixArkRustProxyClient:
 
     def scan_hash(self, key: str) -> Json:
         return self._call_json("scan_hash", key=key)
+
+    def matrixark_delete_records(
+        self,
+        *,
+        count_key: str,
+        record_hash_key: str,
+        shard_size: int,
+        record_ids: list[str],
+    ) -> Json:
+        """Remove the named records in the engine.
+
+        A deliberately dumb primitive: the caller decides what a delete covers, the engine removes
+        what matches. An empty id list removes nothing.
+        """
+        return self._call_json(
+            "matrixark_delete_records",
+            count_key=count_key,
+            record_hash_key=record_hash_key,
+            shard_size=shard_size,
+            record_ids=[str(item) for item in record_ids],
+        )
 
     def matrixark_forget_scope(
         self,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -755,6 +755,22 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         self._store_summary_pass_state(token, refreshed)
         return result
 
+    def _invalidate_summary_pass_state(self) -> None:
+        """Force the next background refresh pass to actually run.
+
+        The skip in `refresh_summaries` rests on the record COUNT: dirty state only changes when
+        records are appended, so an unchanged count after a pass that found nothing means the next
+        pass would reach the same conclusion. A purge breaks that -- it removes and rewrites
+        records in place without moving the count -- and the node whose summary and index postings
+        it just removed is exactly the node that now needs rebuilding. Left alone, an updated
+        memory stayed in `get_all` and never became retrievable again.
+        """
+        self._summary_pass_state = (None, None)
+        try:
+            self._client.put_string(self._summary_pass_state_key(), "")
+        except Exception:  # noqa: BLE001 - the in-process copy already forces a pass here.
+            pass
+
     def _summary_pass_state_key(self) -> str:
         return f"{self._storage_prefix}:summary_pass_state"
 
@@ -993,6 +1009,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             )
         except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
             return {"ok": False, "error": str(exc)}
+        self._invalidate_summary_pass_state()
         self._drop_direct_record_cache()
         return {
             "ok": True,
@@ -1001,6 +1018,113 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             "fields_rewritten": purged.get("matrixark_forget_fields_rewritten"),
             "shards_scanned": purged.get("matrixark_forget_shards_scanned"),
         }
+
+    def _purge_record_ids_in_engine(self, ids: list[str]) -> Json | None:
+        """Remove the named records in the engine. Returns None when there is nothing to remove.
+
+        Shared by delete and update. Both address a set of records the caller has already decided
+        on -- an empty set means remove nothing, never "remove everything".
+        """
+        ids = [str(item) for item in (ids or []) if str(item)]
+        if not ids:
+            return None
+        purger = getattr(self._client, "matrixark_delete_records", None)
+        if not callable(purger):
+            return {"ok": False, "error": "engine does not expose matrixark_delete_records"}
+        try:
+            purged = purger(
+                count_key=self._count_key,
+                record_hash_key=self._record_hash_key,
+                shard_size=self._shard_size,
+                record_ids=ids,
+            )
+        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
+            return {"ok": False, "error": str(exc)}
+        self._invalidate_summary_pass_state()
+        self._drop_direct_record_cache()
+        return {
+            "ok": True,
+            "records_removed": purged.get("matrixark_delete_records_removed"),
+            "fields_deleted": purged.get("matrixark_delete_fields_deleted"),
+            "fields_rewritten": purged.get("matrixark_delete_fields_rewritten"),
+            "ids_requested": purged.get("matrixark_delete_ids_requested"),
+        }
+
+    def update_memory(self, args: Json, hook: Json | None = None) -> Json:
+        """Remove the superseded version from the ENGINE as well as from the serving view.
+
+        An update is a supersede: the new text is ingested and the old id tombstoned. `get_all`
+        honours that immediately. `/v1/retrieve` is assembled inside the engine, which has never
+        heard of a tombstone, so the OLD text kept being served -- and because it outranked the new
+        one, a search after a successful update returned the stale value and not the new value at
+        all:
+
+            after update:  get_all = the new text
+                           retrieve = the OLD text, and the new text nowhere in the results
+
+        That is worse than a failed update, because the caller is told it succeeded. The inherited
+        implementation already computes exactly which records the old version covered, and its own
+        comment says the sweep exists "so the old text can't leak via retrieval after the update" --
+        the engine simply never learned about it.
+        """
+        result = super().update_memory(args, hook)
+        purged = self._purge_record_ids_in_engine(result.get("closure_ref_ids") or [])
+        if purged is not None:
+            result["engine_purge"] = purged
+        return result
+
+    def _purge_record_ids_in_engine(self, ids: list[str]) -> Json | None:
+        """Remove the named records in the engine. Returns None when there is nothing to remove.
+
+        Shared by delete and update. Both address a set of records the caller has already decided
+        on -- an empty set means remove nothing, never "remove everything".
+        """
+        ids = [str(item) for item in (ids or []) if str(item)]
+        if not ids:
+            return None
+        purger = getattr(self._client, "matrixark_delete_records", None)
+        if not callable(purger):
+            return {"ok": False, "error": "engine does not expose matrixark_delete_records"}
+        try:
+            purged = purger(
+                count_key=self._count_key,
+                record_hash_key=self._record_hash_key,
+                shard_size=self._shard_size,
+                record_ids=ids,
+            )
+        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
+            return {"ok": False, "error": str(exc)}
+        self._drop_direct_record_cache()
+        return {
+            "ok": True,
+            "records_removed": purged.get("matrixark_delete_records_removed"),
+            "fields_deleted": purged.get("matrixark_delete_fields_deleted"),
+            "fields_rewritten": purged.get("matrixark_delete_fields_rewritten"),
+            "ids_requested": purged.get("matrixark_delete_ids_requested"),
+        }
+
+    def update_memory(self, args: Json, hook: Json | None = None) -> Json:
+        """Remove the superseded version from the ENGINE as well as from the serving view.
+
+        An update is a supersede: the new text is ingested and the old id tombstoned. `get_all`
+        honours that immediately. `/v1/retrieve` is assembled inside the engine, which has never
+        heard of a tombstone, so the OLD text kept being served -- and because it outranked the new
+        one, a search after a successful update returned the stale value and not the new value at
+        all:
+
+            after update:  get_all = the new text
+                           retrieve = the OLD text, and the new text nowhere in the results
+
+        That is worse than a failed update, because the caller is told it succeeded. The inherited
+        implementation already computes exactly which records the old version covered, and its own
+        comment says the sweep exists "so the old text can't leak via retrieval after the update" --
+        the engine simply never learned about it.
+        """
+        result = super().update_memory(args, hook)
+        purged = self._purge_record_ids_in_engine(result.get("closure_ref_ids") or [])
+        if purged is not None:
+            result["engine_purge"] = purged
+        return result
 
     def delete_memory(self, args: Json, hook: Json | None = None) -> Json:
         """Delete the memory in the ENGINE as well as in the serving view.
@@ -1017,31 +1141,9 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         how the two copies drift.
         """
         result = super().delete_memory(args, hook)
-        ids = [str(item) for item in (result.get("closure_ref_ids") or []) if str(item)]
-        if not ids:
-            return result
-        purger = getattr(self._client, "matrixark_delete_records", None)
-        if not callable(purger):
-            result["engine_purge"] = {"ok": False, "error": "engine does not expose matrixark_delete_records"}
-            return result
-        try:
-            purged = purger(
-                count_key=self._count_key,
-                record_hash_key=self._record_hash_key,
-                shard_size=self._shard_size,
-                record_ids=ids,
-            )
-        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
-            result["engine_purge"] = {"ok": False, "error": str(exc)}
-            return result
-        self._drop_direct_record_cache()
-        result["engine_purge"] = {
-            "ok": True,
-            "records_removed": purged.get("matrixark_delete_records_removed"),
-            "fields_deleted": purged.get("matrixark_delete_fields_deleted"),
-            "fields_rewritten": purged.get("matrixark_delete_fields_rewritten"),
-            "ids_requested": purged.get("matrixark_delete_ids_requested"),
-        }
+        purged = self._purge_record_ids_in_engine(result.get("closure_ref_ids") or [])
+        if purged is not None:
+            result["engine_purge"] = purged
         return result
 
     def reset(self, args: Json, hook: Json | None = None) -> Json:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -974,6 +974,100 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 break
         return {"results": results, "count": len(results)}
 
+    def _purge_scope_in_engine(self, scope: Json) -> Json:
+        """Ask the engine to physically remove every record matching `scope`.
+
+        Shared by forget (one subject) and reset (the whole tenant). The engine refuses an
+        under-specified scope -- it requires a non-zero tenant_hash or an explicit subject
+        dimension -- so an empty scope cannot be turned into "delete everything" by accident.
+        """
+        purger = getattr(self._client, "matrixark_forget_scope", None)
+        if not callable(purger):
+            return {"ok": False, "error": "engine does not expose matrixark_forget_scope"}
+        try:
+            purged = purger(
+                count_key=self._count_key,
+                record_hash_key=self._record_hash_key,
+                shard_size=self._shard_size,
+                scope=scope,
+            )
+        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
+            return {"ok": False, "error": str(exc)}
+        self._drop_direct_record_cache()
+        return {
+            "ok": True,
+            "records_removed": purged.get("matrixark_forget_records_removed"),
+            "fields_deleted": purged.get("matrixark_forget_fields_deleted"),
+            "fields_rewritten": purged.get("matrixark_forget_fields_rewritten"),
+            "shards_scanned": purged.get("matrixark_forget_shards_scanned"),
+        }
+
+    def reset(self, args: Json, hook: Json | None = None) -> Json:
+        """Wipe the tenant in the ENGINE as well as in the serving view.
+
+        Same defect as forget, same cause: the inherited implementation writes a tombstone that
+        only the Python serving pipeline honours, so `get_all` returned 0 while `/v1/retrieve` --
+        assembled inside the engine -- went on serving the tenant's memories verbatim. Measured
+        before this: get_all=0 and the reset canary still retrievable.
+
+        Scoped to the caller's tenant, never wider. The engine's own guard would refuse an
+        under-specified scope anyway, but the tenant hash is resolved here rather than trusting
+        whatever the request carried.
+        """
+        result = super().reset(args, hook)
+        scope = dict(optional_object(args, "scope"))
+        tenant_hash, _ = self._resolve_subject_hashes(scope)
+        if not tenant_hash:
+            return result
+        # Tenant-wide on purpose: drop the user/session dimensions so this matches every record in
+        # the tenant, which is what reset means -- and keep the tenant hash, which is what stops it
+        # matching anything else.
+        engine_scope = {k: v for k, v in scope.items()
+                        if k not in ("user_id", "session_id", "agent_id", "user_hash",
+                                     "session_hash", "scope_key", "_explicit_scope_keys")}
+        engine_scope["tenant_hash"] = tenant_hash
+        result["engine_purge"] = self._purge_scope_in_engine(engine_scope)
+        return result
+
+    def forget(self, args: Json, hook: Json | None = None) -> Json:
+        """Forget the subject in the ENGINE as well as in the serving view.
+
+        The inherited implementation writes a durable tombstone, and every read that goes through
+        the Python serving pipeline honours it -- `get_all` returns 0 immediately. `/v1/retrieve`
+        does not go through that pipeline: on a native backend the engine assembles the context
+        pack itself, and the engine has no idea the tombstone exists. So a forgotten memory kept
+        coming back from retrieve, verbatim, while every check that asked `/v1/memories` reported
+        a clean wipe:
+
+            before forget:  get_all=2, retrieve contains the subject's secret = True
+            forget:         http 200, removed_count 54
+            after forget:   get_all=0, retrieve contains the secret = STILL True
+
+        Deleting data has to mean deleting it on every read path. The engine has had
+        `matrixark_forget_scope` all along -- it removes the subject's records, refuses an
+        under-specified scope that would match everything, commits one durable batch, and clears
+        its scan caches so a later retrieve cannot re-serve from cache -- and nothing called it.
+
+        The tombstone is still written first, and deliberately: it is the durable, auditable record
+        of the forget, it makes the serving view correct even if the engine call fails, and its
+        order-aware semantics are what let a subject be re-ingested afterwards. The engine purge is
+        what makes the deletion real.
+        """
+        result = super().forget(args, hook)
+        try:
+            from tools.matrixark_mcp_core_identity import identity_hashes
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_core_identity import identity_hashes
+        scope = dict(optional_object(args, "scope"))
+        # The engine matches records by scope, so it needs the SUBJECT's own hashes rather than
+        # whatever the caller's request happened to carry.
+        user_id = str(scope.get("user_id") or "")
+        if user_id:
+            scope.update(identity_hashes(str(scope.get("account_id") or ""),
+                                         str(scope.get("tenant_id") or ""), user_id=user_id))
+        result["engine_purge"] = self._purge_scope_in_engine(scope)
+        return result
+
     def append(self, record: Json) -> None:
         self.append_many([record])
 
@@ -2704,6 +2798,28 @@ class MatrixArkRustProxyClient:
 
     def scan_hash(self, key: str) -> Json:
         return self._call_json("scan_hash", key=key)
+
+    def matrixark_forget_scope(
+        self,
+        *,
+        count_key: str,
+        record_hash_key: str,
+        shard_size: int,
+        scope: Json,
+    ) -> Json:
+        """Physically remove a subject's records in the engine.
+
+        The engine refuses an under-specified scope, so this cannot be used to wipe a store by
+        accident; it rewrites each hash field to its survivors, commits one durable batch, and
+        clears the engine's scan/hgetall caches.
+        """
+        return self._call_json(
+            "matrixark_forget_scope",
+            count_key=count_key,
+            record_hash_key=record_hash_key,
+            shard_size=shard_size,
+            scope=scope,
+        )
 
     def matrixark_scan_candidates(
         self,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1040,7 +1040,6 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             )
         except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
             return {"ok": False, "error": str(exc)}
-        self._invalidate_summary_pass_state()
         self._drop_direct_record_cache()
         return {
             "ok": True,
@@ -1068,59 +1067,24 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         the engine simply never learned about it.
         """
         result = super().update_memory(args, hook)
-        purged = self._purge_record_ids_in_engine(result.get("closure_ref_ids") or [])
-        if purged is not None:
-            result["engine_purge"] = purged
-        return result
-
-    def _purge_record_ids_in_engine(self, ids: list[str]) -> Json | None:
-        """Remove the named records in the engine. Returns None when there is nothing to remove.
-
-        Shared by delete and update. Both address a set of records the caller has already decided
-        on -- an empty set means remove nothing, never "remove everything".
-        """
-        ids = [str(item) for item in (ids or []) if str(item)]
-        if not ids:
-            return None
-        purger = getattr(self._client, "matrixark_delete_records", None)
-        if not callable(purger):
-            return {"ok": False, "error": "engine does not expose matrixark_delete_records"}
-        try:
-            purged = purger(
-                count_key=self._count_key,
-                record_hash_key=self._record_hash_key,
-                shard_size=self._shard_size,
-                record_ids=ids,
-            )
-        except Exception as exc:  # noqa: BLE001 - the tombstone stands; report the engine half.
-            return {"ok": False, "error": str(exc)}
-        self._drop_direct_record_cache()
-        return {
-            "ok": True,
-            "records_removed": purged.get("matrixark_delete_records_removed"),
-            "fields_deleted": purged.get("matrixark_delete_fields_deleted"),
-            "fields_rewritten": purged.get("matrixark_delete_fields_rewritten"),
-            "ids_requested": purged.get("matrixark_delete_ids_requested"),
-        }
-
-    def update_memory(self, args: Json, hook: Json | None = None) -> Json:
-        """Remove the superseded version from the ENGINE as well as from the serving view.
-
-        An update is a supersede: the new text is ingested and the old id tombstoned. `get_all`
-        honours that immediately. `/v1/retrieve` is assembled inside the engine, which has never
-        heard of a tombstone, so the OLD text kept being served -- and because it outranked the new
-        one, a search after a successful update returned the stale value and not the new value at
-        all:
-
-            after update:  get_all = the new text
-                           retrieve = the OLD text, and the new text nowhere in the results
-
-        That is worse than a failed update, because the caller is told it succeeded. The inherited
-        implementation already computes exactly which records the old version covered, and its own
-        comment says the sweep exists "so the old text can't leak via retrieval after the update" --
-        the engine simply never learned about it.
-        """
-        result = super().update_memory(args, hook)
+        # `finalize` is honoured by the DISPATCH layer, which runs session_commit as a second tool
+        # call; `adapter.ingest()` ignores it. update re-ingests through the adapter directly, so
+        # on a native backend the replacement stayed at `extraction_phase: hot_path` /
+        # `status: observed` forever -- read straight out of the engine it had no node_path, while
+        # an ordinary ingest in the same scope reached final/extraction_committed. Retrieval there
+        # serves committed content, so the updated memory was in `get_all` and in no search, while
+        # the value it replaced had been committed and was still being served.
+        #
+        # Only the native path needs this. On the JSONL backend the re-ingest is already
+        # retrievable and committing there BREAKS it -- doing this in the shared implementation
+        # turned `test_update_supersede_retrieve_returns_new` into an empty context pack.
+        reingest_scope = result.get("reingest_scope")
+        if isinstance(reingest_scope, dict) and reingest_scope:
+            try:
+                self.session_commit({"scope": reingest_scope, "force": True,
+                                     "commit_reason": "update_supersede"}, hook=hook)
+            except Exception as exc:  # noqa: BLE001 - durably stored; the idle commit still closes it.
+                result["commit_error"] = str(exc)
         purged = self._purge_record_ids_in_engine(result.get("closure_ref_ids") or [])
         if purged is not None:
             result["engine_purge"] = purged

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1176,6 +1176,31 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         result["engine_purge"] = self._purge_scope_in_engine(scope)
         return result
 
+    def _idle_commit_candidate_records(self, scope: Json) -> list[Json]:
+        """Ask the engine for the pipeline tasks instead of reading the whole log.
+
+        Safe to narrow because the drain uses these records for nothing else: both of its loops
+        skip anything that is not a `matrixark_async_pipeline_task`.
+
+        Order is what makes it equivalent, and it survives. The drain decides last-write-wins from
+        list position, and the scan's `compact_latest_context_state_records` keys only
+        `context_summary`, `context_model_registry` and some `context_embedding` rows -- a pipeline
+        task gets no key, so it passes through untouched -- and the function re-sorts by the
+        original index, so append order is preserved either way.
+
+        A scope is required. `idle_commit_task_records({})` degenerates to a cross-scope full-store
+        scan, which is the cost this exists to avoid; without one, fall back to the inherited read.
+        """
+        if not scope:
+            return super()._idle_commit_candidate_records(scope)
+        scanner = getattr(self, "idle_commit_task_records", None)
+        if not callable(scanner):
+            return super()._idle_commit_candidate_records(scope)
+        try:
+            return scanner(scope)
+        except Exception:  # noqa: BLE001 - a scan failure must not stop the drain.
+            return super()._idle_commit_candidate_records(scope)
+
     def append(self, record: Json) -> None:
         self.append_many([record])
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -167,6 +167,8 @@ _DATA_ROUTES: dict[str, Tuple[str, str]] = {
     "/v1/memories": ("matrixark_get_all", "retrieve"),
     # mem0 users(): which users/agents/runs hold memories. A read, gated like get_all.
     "/v1/users": ("matrixark_list_users", "retrieve"),
+    # One resource/skill's stored text, paged. A read, gated like the other listings.
+    "/v1/resource/content": ("matrixark_get_resource_content", "retrieve"),
     # update = supersede (ingest an amended version + tombstone the old id): gates on context:ingest.
     "/v1/update": ("matrixark_update_memory", "ingest"),
     # get (GET /v1/memory/<id>) and history (GET /v1/memory/<id>/history) are handled by dedicated

--- a/tools/test_engine_purge_on_delete.py
+++ b/tools/test_engine_purge_on_delete.py
@@ -135,5 +135,72 @@ class ResetReachesEngineTest(ForgetReachesEngineTest):
         self.assertNotIn("engine_purge", out)
 
 
+class _DeleteClient:
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def matrixark_delete_records(self, *, count_key, record_hash_key, shard_size, record_ids):
+        self.calls.append({"record_ids": record_ids, "shard_size": shard_size})
+        if self.fail:
+            raise RuntimeError("engine unavailable")
+        return {"matrixark_delete_records_removed": 4, "matrixark_delete_fields_deleted": 1,
+                "matrixark_delete_fields_rewritten": 2, "matrixark_delete_ids_requested": len(record_ids)}
+
+
+class DeleteReachesEngineTest(unittest.TestCase):
+    """`delete` had the same hole as forget: get_all dropped while retrieve still served it.
+
+    The identity set is NOT re-derived here. Which records a delete covers is subtle -- the
+    addressed event, its single-source derivatives, and the embeddings/postings pointing at any of
+    them, while MULTI-source derivatives are demoted rather than removed -- so the inherited
+    implementation decides it once and this passes that set through.
+    """
+
+    def setUp(self) -> None:
+        self._orig = adapters.MatrixArkLocalAdapter.delete_memory
+        self.addCleanup(lambda: setattr(adapters.MatrixArkLocalAdapter, "delete_memory", self._orig))
+
+    def _with_result(self, result):
+        adapters.MatrixArkLocalAdapter.delete_memory = lambda s, a, h=None: dict(result)
+
+    def test_passes_the_closure_through_to_the_engine(self) -> None:
+        self._with_result({"deleted": True, "closure_ref_ids": ["11", "22", "33"]})
+        client = _DeleteClient()
+        out = _adapter(client).delete_memory({"memory_id": "11"})
+        self.assertEqual(["11", "22", "33"], client.calls[0]["record_ids"])
+        self.assertTrue(out["engine_purge"]["ok"])
+        self.assertEqual(4, out["engine_purge"]["records_removed"])
+
+    def test_does_not_re_derive_the_closure(self) -> None:
+        """Whatever the inherited implementation decided is what the engine is told -- two copies
+        of that rule in two languages is how they drift apart."""
+        self._with_result({"deleted": True, "closure_ref_ids": ["only-this-one"]})
+        client = _DeleteClient()
+        _adapter(client).delete_memory({"memory_id": "something-else"})
+        self.assertEqual(["only-this-one"], client.calls[0]["record_ids"])
+
+    def test_an_empty_closure_purges_nothing(self) -> None:
+        """A delete that matched nothing must not turn into a wildcard removal."""
+        self._with_result({"deleted": False, "closure_ref_ids": []})
+        client = _DeleteClient()
+        out = _adapter(client).delete_memory({"memory_id": "nope"})
+        self.assertEqual([], client.calls)
+        self.assertNotIn("engine_purge", out)
+
+    def test_an_engine_failure_is_reported_not_swallowed(self) -> None:
+        self._with_result({"deleted": True, "closure_ref_ids": ["11"]})
+        out = _adapter(_DeleteClient(fail=True)).delete_memory({"memory_id": "11"})
+        self.assertFalse(out["engine_purge"]["ok"])
+        self.assertIn("engine unavailable", out["engine_purge"]["error"])
+
+    def test_a_client_without_the_op_degrades_rather_than_raising(self) -> None:
+        class _Old:
+            pass
+        self._with_result({"deleted": True, "closure_ref_ids": ["11"]})
+        out = _adapter(_Old()).delete_memory({"memory_id": "11"})
+        self.assertFalse(out["engine_purge"]["ok"])
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tools/test_engine_purge_on_delete.py
+++ b/tools/test_engine_purge_on_delete.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""forget and reset must reach the ENGINE, not only the serving view.
+
+On a native backend `/v1/retrieve` does not go through the Python serving pipeline at all: the
+engine assembles the context pack itself, and it has no idea a memory tombstone exists. So a
+tombstone-only forget left `get_all` reporting a clean wipe while retrieve went on serving the
+subject's memories verbatim:
+
+    before forget:  get_all=2, retrieve contains the subject's secret = True
+    forget:         http 200, removed_count 54
+    after forget:   get_all=0, retrieve contains the secret = STILL True
+
+Deleting data has to mean deleting it on every read path. The engine has had
+`matrixark_forget_scope` all along -- it removes the subject's records, refuses an
+under-specified scope, and clears its own scan caches -- and nothing called it.
+
+These pin the wiring and, more importantly, the scope handed to it: too wide and a forget wipes
+somebody else.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools.matrixark_mcp_core_identity import identity_hashes
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    from matrixark_mcp_core_identity import identity_hashes
+
+
+class _Client:
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def matrixark_forget_scope(self, *, count_key, record_hash_key, shard_size, scope):
+        self.calls.append({"count_key": count_key, "record_hash_key": record_hash_key,
+                           "shard_size": shard_size, "scope": scope})
+        if self.fail:
+            raise RuntimeError("engine unavailable")
+        return {"matrixark_forget_records_removed": 7, "matrixark_forget_fields_deleted": 2,
+                "matrixark_forget_fields_rewritten": 1, "matrixark_forget_shards_scanned": 3}
+
+
+def _adapter(client, base_result=None):
+    a = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+    a._client = client
+    a._count_key = "matrixark:mcp:record_count"
+    a._record_hash_key = "matrixark:mcp:records"
+    a._shard_size = 1024
+    a._drop_direct_record_cache = lambda: None  # type: ignore[assignment]
+    a._resolve_subject_hashes = lambda scope: (
+        int(scope.get("tenant_hash") or 0), int(scope.get("user_hash") or 0))
+    return a
+
+
+SCOPE = {"account_id": "acct", "tenant_id": "t1", "user_id": "alice",
+         **identity_hashes("acct", "t1", user_id="alice")}
+
+
+class ForgetReachesEngineTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._forget = adapters.MatrixArkLocalAdapter.forget
+        self._reset = adapters.MatrixArkLocalAdapter.reset
+        adapters.MatrixArkLocalAdapter.forget = lambda s, a, h=None: {"status": "ok", "removed_count": 2}
+        adapters.MatrixArkLocalAdapter.reset = lambda s, a, h=None: {"status": "ok", "removed_count": 5}
+        self.addCleanup(lambda: setattr(adapters.MatrixArkLocalAdapter, "forget", self._forget))
+        self.addCleanup(lambda: setattr(adapters.MatrixArkLocalAdapter, "reset", self._reset))
+
+    def test_forget_purges_the_subject_in_the_engine(self) -> None:
+        client = _Client()
+        out = _adapter(client).forget({"scope": dict(SCOPE), "confirm": "alice"})
+        self.assertEqual(1, len(client.calls), "the engine purge must be issued")
+        self.assertTrue(out["engine_purge"]["ok"])
+        self.assertEqual(7, out["engine_purge"]["records_removed"])
+
+    def test_forget_hands_the_engine_the_subjects_own_hashes(self) -> None:
+        """A scope carrying the CALLER's user_hash would purge the wrong subject."""
+        caller = dict(SCOPE)
+        caller.update(identity_hashes("acct", "t1", user_id="someone_else"))
+        caller["user_id"] = "alice"
+        client = _Client()
+        _adapter(client).forget({"scope": caller, "confirm": "alice"})
+        sent = client.calls[0]["scope"]
+        self.assertEqual(identity_hashes("acct", "t1", user_id="alice")["user_hash"],
+                         sent["user_hash"])
+
+    def test_forget_keeps_the_subject_dimension(self) -> None:
+        """Dropping user_id would widen a forget into a tenant wipe."""
+        client = _Client()
+        _adapter(client).forget({"scope": dict(SCOPE), "confirm": "alice"})
+        self.assertEqual("alice", client.calls[0]["scope"]["user_id"])
+
+    def test_an_engine_failure_is_reported_not_swallowed(self) -> None:
+        """The tombstone still stands, so the serving view is right -- but the caller must not be
+        told the data is gone from the engine when it is not."""
+        client = _Client(fail=True)
+        out = _adapter(client).forget({"scope": dict(SCOPE), "confirm": "alice"})
+        self.assertFalse(out["engine_purge"]["ok"])
+        self.assertIn("engine unavailable", out["engine_purge"]["error"])
+
+    def test_a_client_without_the_op_degrades_rather_than_raising(self) -> None:
+        class _Old:
+            pass
+        out = _adapter(_Old()).forget({"scope": dict(SCOPE), "confirm": "alice"})
+        self.assertFalse(out["engine_purge"]["ok"])
+
+
+class ResetReachesEngineTest(ForgetReachesEngineTest):
+    def test_reset_purges_the_whole_tenant(self) -> None:
+        client = _Client()
+        out = _adapter(client).reset({"scope": dict(SCOPE), "confirm": "RESET"})
+        self.assertEqual(1, len(client.calls))
+        self.assertTrue(out["engine_purge"]["ok"])
+
+    def test_reset_drops_the_user_dimension_but_keeps_the_tenant(self) -> None:
+        """Tenant-wide is the point; still carrying user_id would reset only one user, and
+        dropping the tenant hash would match everything."""
+        client = _Client()
+        _adapter(client).reset({"scope": dict(SCOPE), "confirm": "RESET"})
+        sent = client.calls[0]["scope"]
+        self.assertNotIn("user_id", sent)
+        self.assertNotIn("user_hash", sent)
+        self.assertEqual(SCOPE["tenant_hash"], sent["tenant_hash"])
+
+    def test_reset_without_a_resolvable_tenant_does_not_purge(self) -> None:
+        """No tenant hash means no safe scope to hand the engine -- purging anyway could match
+        every record in the store."""
+        client = _Client()
+        out = _adapter(client).reset({"scope": {"user_id": "alice"}, "confirm": "RESET"})
+        self.assertEqual([], client.calls)
+        self.assertNotIn("engine_purge", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_idempotency_lookup_once.py
+++ b/tools/test_idempotency_lookup_once.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One idempotency lookup per dispatch, not two.
+
+`_idempotent_replay_response` looks the key up at the start of a dispatch; if it finds a record the
+call ends there with a replay. So by the time `_finalize_write_response` runs, that same key has
+already been proven absent -- and it used to look it up again. An ingest that finalizes is two
+dispatches, so that was two redundant lookups per ingest on the request thread.
+
+The risk in skipping a check is skipping it when it was never actually made, so that is what most
+of these cover: the note is per key and per call, and anything that did not go through the replay
+path still looks.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_server_request_policy as policy
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_server_request_policy as policy
+
+
+class _Adapter:
+    def __init__(self, record=None):
+        self.record = record
+        self.lookups = 0
+        self.appended = []
+
+    def find_idempotency_record(self, key_hash):
+        self.lookups += 1
+        return self.record
+
+    def append_idempotency_record(self, **kw):
+        self.appended.append(kw)
+
+
+class _Access:
+    def append_audit(self, *a, **kw):
+        pass
+
+
+class _Policy(policy.MatrixArkServerRequestPolicyMixin):
+    IDEMPOTENT_WRITE_TOOLS = {"matrixark_ingest"}
+
+    def _raw_idempotency_key(self, args, hook):
+        return str(args.get("key") or "")
+
+    def _idempotency_key_hash(self, name, raw_key, identity):
+        return hash((name, raw_key))
+
+
+def _policy(record=None):
+    p = object.__new__(_Policy)
+    p.adapter = _Adapter(record)
+    p.access = _Access()
+    return p
+
+
+IDENT = {"tenant_id": "t"}
+
+
+class IdempotencyLookedUpOncePerCallTest(unittest.TestCase):
+    def test_finalize_does_not_look_up_again_after_replay_found_nothing(self) -> None:
+        p = _policy(record=None)
+        args = {"key": "k1"}
+        self.assertIsNone(p._idempotent_replay_response("matrixark_ingest", args, IDENT, None))
+        self.assertEqual(1, p.adapter.lookups)
+        p._finalize_write_response("matrixark_ingest", args, IDENT, None, {"ok": True})
+        self.assertEqual(1, p.adapter.lookups, "the same key must not be looked up twice in a call")
+        self.assertEqual(1, len(p.adapter.appended), "and the record must still be stored")
+
+    def test_finalize_still_looks_when_replay_never_ran(self) -> None:
+        """A tool that finalizes without going through the replay path has proven nothing."""
+        p = _policy(record=None)
+        p._finalize_write_response("matrixark_ingest", {"key": "k1"}, IDENT, None, {"ok": True})
+        self.assertEqual(1, p.adapter.lookups)
+
+    def test_the_note_is_per_key(self) -> None:
+        """Proving key A absent says nothing about key B."""
+        p = _policy(record=None)
+        args = {"key": "k1"}
+        p._idempotent_replay_response("matrixark_ingest", args, IDENT, None)
+        self.assertEqual(1, p.adapter.lookups)
+        args["key"] = "k2"          # same call object, different key
+        p._finalize_write_response("matrixark_ingest", args, IDENT, None, {"ok": True})
+        self.assertEqual(2, p.adapter.lookups, "a different key must be looked up")
+
+    def test_a_replay_hit_short_circuits_and_never_reaches_finalize(self) -> None:
+        p = _policy(record={"response": {"replayed": True}})
+        out = p._idempotent_replay_response("matrixark_ingest", {"key": "k1"}, IDENT, None)
+        self.assertIsNotNone(out)
+        self.assertTrue(out.get("idempotent_replay"))
+        self.assertEqual([], p.adapter.appended)
+
+    def test_a_call_without_a_key_is_untouched(self) -> None:
+        p = _policy(record=None)
+        args = {}
+        self.assertIsNone(p._idempotent_replay_response("matrixark_ingest", args, IDENT, None))
+        self.assertEqual(0, p.adapter.lookups)
+        self.assertNotIn("_matrixark_idempotency_absent", args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_idle_commit_candidates.py
+++ b/tools/test_idle_commit_candidates.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The idle-commit drain reads only pipeline tasks, not the whole record log.
+
+`drain_due_idle_session_commits` runs once per ingest and opened with `read_all()` -- on a native
+backend, the entire record log shipped over the proxy -- while using the result for nothing but
+`matrixark_async_pipeline_task` records.
+
+Two things make the narrower read equivalent, and both are pinned here.
+
+ORDER. The drain decides last-write-wins from list position. The native scan ends in
+`compact_latest_context_state_records`, which keys only `context_summary`,
+`context_model_registry` and some `context_embedding` rows -- a pipeline task gets no key, so it
+passes through untouched -- and that function re-sorts by the original index, so append order
+survives regardless.
+
+SCOPE. `idle_commit_task_records({})` degenerates to a cross-scope full-store scan, which is the
+very cost this avoids, so an empty scope must fall back rather than "optimise" into the worst case.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools.matrixark_mcp_core_compact import (
+        compact_latest_context_state_records,
+        latest_context_state_key,
+    )
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    from matrixark_mcp_core_compact import (
+        compact_latest_context_state_records,
+        latest_context_state_key,
+    )
+
+TASK = "matrixark_async_pipeline_task"
+
+
+def _task(task_hash, status, order):
+    return {"record_type": TASK, "task_hash": task_hash, "status": status, "n": order}
+
+
+class OrderSurvivesCompactionTest(unittest.TestCase):
+    """The equivalence argument, checked against the real compaction rather than assumed."""
+
+    def test_a_pipeline_task_gets_no_latest_state_key(self) -> None:
+        self.assertIsNone(latest_context_state_key(_task(1, "scheduled", 0)))
+
+    def test_compaction_keeps_every_task_in_append_order(self) -> None:
+        records = [_task(1, "scheduled", 0), _task(2, "scheduled", 1),
+                   _task(1, "idle_commit_scheduled", 2), _task(1, "completed", 3)]
+        out = compact_latest_context_state_records(list(records))
+        self.assertEqual([0, 1, 2, 3], [r["n"] for r in out],
+                         "the drain reads last-write-wins from position; order must survive")
+        self.assertEqual(4, len([r for r in out if r.get("record_type") == TASK]))
+
+
+class _Stub(adapters.MatrixArkTemporalStoreDirectAdapter):
+    """A real subclass, so the override's `super()` fallback resolves through the actual MRO.
+
+    Built with `object.__new__` -- the real __init__ would dial a metaserver and spawn a CLI.
+    """
+
+    def read_all(self):
+        self.read_all_calls += 1
+        return [{"record_type": "context_event"}, _task(9, "scheduled", 0)]
+
+    def idle_commit_task_records(self, scope):
+        self.scan_calls.append(scope)
+        if self.raises:
+            raise RuntimeError("scan unavailable")
+        return self.tasks
+
+
+def _Adapter(tasks=None, raises=False):
+    a = object.__new__(_Stub)
+    a.tasks = tasks or []
+    a.raises = raises
+    a.read_all_calls = 0
+    a.scan_calls = []
+    return a
+
+
+def _bind(adapter):
+    """Call the native override, bound so `super()` works."""
+    return adapters.MatrixArkTemporalStoreDirectAdapter._idle_commit_candidate_records
+
+
+class IdleCommitCandidateRecordsTest(unittest.TestCase):
+    def test_a_real_scope_uses_the_typed_scan(self) -> None:
+        a = _Adapter(tasks=[_task(1, "scheduled", 0)])
+        out = _bind(a)(a, {"user_id": "alice", "tenant_hash": 7})
+        self.assertEqual(1, len(out))
+        self.assertEqual(0, a.read_all_calls, "the whole log must not be read")
+        self.assertEqual([{"user_id": "alice", "tenant_hash": 7}], a.scan_calls)
+
+    def test_an_empty_scope_falls_back_instead_of_scanning_everything(self) -> None:
+        """A cross-scope task scan IS a full-store scan -- the exact cost this avoids."""
+        a = _Adapter()
+        out = _bind(a)(a, {})
+        self.assertEqual([], a.scan_calls, "must not issue a cross-scope scan")
+        self.assertEqual(1, a.read_all_calls)
+        self.assertEqual(2, len(out))
+
+    def test_a_failing_scan_falls_back_rather_than_stopping_the_drain(self) -> None:
+        a = _Adapter(raises=True)
+        out = _bind(a)(a, {"user_id": "alice"})
+        self.assertEqual(1, a.read_all_calls)
+        self.assertEqual(2, len(out))
+
+    def test_the_default_reads_the_log(self) -> None:
+        """The JSONL backend keeps the old behaviour; read_all there is an in-memory walk."""
+        try:
+            from tools.matrixark_local_adapter_retrieval import _LocalAdapterRetrievalMixin as M
+        except ImportError:
+            from matrixark_local_adapter_retrieval import _LocalAdapterRetrievalMixin as M
+        a = _Adapter()
+        out = M._idle_commit_candidate_records(a, {"user_id": "alice"})
+        self.assertEqual(1, a.read_all_calls)
+        self.assertEqual([], a.scan_calls)
+        self.assertEqual(2, len(out))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tools/test_resource_content.py
+++ b/tools/test_resource_content.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Reading one resource's / skill's stored text back, in order and a page at a time.
+
+`list_skills` and `list_resources` return a POINTER — raw_uri, cloud_key — and metadata. The text
+is already stored, split across `resource_chunk` records at ingest, but nothing reassembled it, so
+"give me this skill's content" had no answer.
+
+Two things are worth pinning. Ordering: content stitched in the wrong order is worse than no
+content, and it is silent. And paging: an attachment can be far larger than belongs in one JSON
+response, so a caller must be able to take it a page at a time and be told there is more.
+"""
+from __future__ import annotations
+
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as local_mod
+
+SKILL = 4242
+
+
+def _chunk(text, index=None, chunk_hash=None, resource_hash=SKILL):
+    record = {
+        "record_type": "resource_chunk",
+        "resource_hash": resource_hash,
+        "chunk_hash": chunk_hash if chunk_hash is not None else abs(hash(text)) % 10**9,
+        "source_ref": "doc#%s" % (index if index is not None else "?"),
+        "token_estimate": len(text) // 4,
+        "text": text,
+    }
+    if index is not None:
+        record["chunk_index"] = index
+    return record
+
+
+def _manifest(name="Cold start runbook"):
+    return {
+        "record_type": "skill_manifest",
+        "skill_hash": SKILL,
+        "name": name,
+        "description": "How to bring payments up from cold.",
+        "raw_uri": "file:///skills/cold_start.md",
+    }
+
+
+def _adapter(records):
+    adapter = object.__new__(local_mod.MatrixArkLocalAdapter)
+    adapter.read_all = lambda: list(records)  # type: ignore[assignment]
+    return adapter
+
+
+class ResourceContentTest(unittest.TestCase):
+    def test_reassembles_in_chunk_index_order_not_log_order(self) -> None:
+        """The whole point of the index: log order must not decide the content."""
+        records = [_manifest(),
+                   _chunk("third. ", index=2),
+                   _chunk("first. ", index=0),
+                   _chunk("second. ", index=1)]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL})
+        self.assertEqual("first. second. third. ", out["text"])
+        self.assertEqual([0, 1, 2], [c["chunk_index"] for c in out["chunks"]])
+
+    def test_falls_back_to_log_order_for_chunks_written_before_the_index(self) -> None:
+        records = [_manifest(), _chunk("alpha "), _chunk("beta "), _chunk("gamma ")]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL})
+        self.assertEqual("alpha beta gamma ", out["text"])
+
+    def test_carries_the_manifest_metadata(self) -> None:
+        out = _adapter([_manifest(), _chunk("x", index=0)]).get_resource_content({"skill_hash": SKILL})
+        self.assertEqual("Cold start runbook", out["name"])
+        self.assertEqual("file:///skills/cold_start.md", out["raw_uri"])
+
+    def test_ignores_other_resources(self) -> None:
+        records = [_manifest(),
+                   _chunk("mine ", index=0),
+                   _chunk("theirs ", index=0, resource_hash=999)]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL})
+        self.assertEqual("mine ", out["text"])
+        self.assertEqual(1, out["chunk_count"])
+
+    def test_a_reingested_chunk_takes_the_later_text(self) -> None:
+        records = [_manifest(),
+                   _chunk("stale", index=0, chunk_hash=7),
+                   _chunk("fresh", index=0, chunk_hash=7)]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL})
+        self.assertEqual("fresh", out["text"])
+        self.assertEqual(1, out["chunk_count"])
+
+    # ---- paging -------------------------------------------------------------------------
+
+    def test_pages_by_chunk_limit_and_reports_more(self) -> None:
+        records = [_manifest()] + [_chunk("c%d " % i, index=i) for i in range(10)]
+        adapter = _adapter(records)
+        first = adapter.get_resource_content({"skill_hash": SKILL, "chunk_limit": 4})
+        self.assertEqual(4, first["returned_chunks"])
+        self.assertEqual(10, first["chunk_count"])
+        self.assertTrue(first["has_more"])
+        self.assertEqual(4, first["next_chunk_offset"])
+        self.assertEqual("c0 c1 c2 c3 ", first["text"])
+
+    def test_a_caller_can_walk_every_page_and_rebuild_the_whole_thing(self) -> None:
+        records = [_manifest()] + [_chunk("c%d " % i, index=i) for i in range(10)]
+        adapter = _adapter(records)
+        text, offset, pages = "", 0, 0
+        while offset is not None and pages < 20:
+            page = adapter.get_resource_content(
+                {"skill_hash": SKILL, "chunk_limit": 3, "chunk_offset": offset})
+            text += page["text"]
+            offset = page["next_chunk_offset"]
+            pages += 1
+        self.assertEqual("".join("c%d " % i for i in range(10)), text)
+        self.assertEqual(4, pages)
+
+    def test_the_last_page_says_there_is_no_more(self) -> None:
+        records = [_manifest()] + [_chunk("c%d " % i, index=i) for i in range(4)]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL, "chunk_limit": 4})
+        self.assertFalse(out["has_more"])
+        self.assertIsNone(out["next_chunk_offset"])
+
+    def test_max_chars_truncates_and_says_so(self) -> None:
+        """A caller asking for a bounded response must not get an unbounded one.
+
+        Distinct chunk_hash per chunk on purpose: identical text would share a hash and be
+        de-duplicated down to one chunk, which is correct behaviour but tests nothing here.
+        """
+        records = [_manifest()] + [_chunk("x" * 100, index=i, chunk_hash=i) for i in range(5)]
+        out = _adapter(records).get_resource_content({"skill_hash": SKILL, "max_chars": 250})
+        self.assertLessEqual(out["chars"], 250)
+        self.assertTrue(out["truncated_by_max_chars"])
+        self.assertTrue(out["has_more"])
+
+    # ---- input ---------------------------------------------------------------------------
+
+    def test_resource_hash_and_skill_hash_are_aliases(self) -> None:
+        records = [_manifest(), _chunk("v", index=0)]
+        a = _adapter(records).get_resource_content({"skill_hash": SKILL})
+        b = _adapter(records).get_resource_content({"resource_hash": SKILL})
+        self.assertEqual(a["text"], b["text"])
+
+    def test_a_missing_or_bad_id_is_rejected(self) -> None:
+        adapter = _adapter([_manifest()])
+        for bad in ({}, {"skill_hash": 0}, {"skill_hash": -1}, {"resource_hash": "abc"}):
+            with self.assertRaises(local_mod.MatrixArkError):
+                adapter.get_resource_content(bad)
+
+    def test_an_unknown_resource_returns_empty_rather_than_failing(self) -> None:
+        out = _adapter([_manifest(), _chunk("x", index=0)]).get_resource_content({"skill_hash": 5555})
+        self.assertEqual(0, out["chunk_count"])
+        self.assertEqual("", out["text"])
+        self.assertFalse(out["has_more"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Two follow-ups to the memory-API work merged in #133.

## forget and reset were not honoured by `/v1/retrieve`

Both wrote a durable tombstone, and every read that goes through the Python serving pipeline
honoured it — `get_all` returned 0 immediately. `/v1/retrieve` does not go through that pipeline:
on a native backend the engine assembles the context pack itself, and it has never heard of a
memory tombstone (`matrixark_memory_tombstone` appears nowhere in the engine). So a forgotten
memory kept coming back from retrieve, verbatim, as `type=event` items:

    before forget:  get_all=2, retrieve contains the subject's secret = True
    forget:         http 200, removed_count 54
    after forget:   get_all=0, retrieve contains the secret = STILL True

That is a deletion defect, not a ranking nuance, and it is invisible to any check that asks only
`/v1/memories`.

**The engine could already do this and nothing called it.** `matrixark_forget_scope` physically
removes a scope's records: it refuses an under-specified scope that would match everything,
rewrites each hash field down to its survivors, commits one durable batch, and clears the scan and
hgetall caches — its own comment says that last part exists *"so a subsequent retrieve/get_all
never re-serves a forgotten record"*. The only mention of it anywhere in Python was an unrelated
test name. So this needed no engine change and no rebuild, just the wiring.

The tombstone is still written first, deliberately: it is the durable, auditable record of the
forget, it keeps the serving view correct even if the engine call fails, and its order-aware
semantics are what let a subject be re-ingested afterwards. If the engine call fails, the result
says so (`engine_purge.ok = false`) rather than reporting a clean forget over data that is still
there.

Scope handling is what the tests mostly cover, because getting it wrong is the dangerous part:

- **forget** recomputes the *subject's* identity hashes with `identity_hashes`. A request scope
  carries hashes derived from the **caller**, and purging with those removes the wrong subject. It
  keeps `user_id`, since dropping it would widen a forget into a tenant wipe.
- **reset** does the opposite: drops the user/session dimensions, keeps the tenant hash, and
  declines to purge at all when no tenant hash resolves — there is then no safe scope to hand the
  engine.

Verified live on the same store, before and after:

| | before | after |
|---|---|---|
| forget | retrieve serves the secret | `get_all=0` **and** retrieve clean |
| reset | retrieve serves the canary | `get_all=0` **and** retrieve clean |

## delete, and a record-removal op in the engine

`delete` had the same hole, and could not be fixed by wiring: `matrixark_forget_scope` matches by
**scope**, and a delete addresses one memory. So this adds `matrixark_delete_records`.

It is deliberately a **dumb primitive**. Deciding what a delete covers is the subtle part — the
addressed event, its single-source derivatives, and the embeddings and index postings pointing at
any of them, while *multi*-source derivatives are demoted (rewritten with the source trimmed)
rather than removed. That rule already exists, once, in `delete_memory`. Re-deriving it in Rust
would put two copies of it in the tree in two languages, which is exactly the kind of drift these
fixes have been chasing. So the engine takes a list of ids and removes what matches; the caller
decides the list, and `delete_memory` now reports the set it decided instead of keeping it private.

The engine side mirrors `forget_scope_records` — same shard walk, same survivor rewrite, same
single durable batch that also clears the scan and hgetall caches. Only the predicate differs: a
record matches on any id it is addressable by, its own identity or a pointer it carries
(`ref_hash`, `ref_hashes`). Matching those pointers is what stops a delete leaving orphaned
postings behind that still surface the text.

An empty id list removes **nothing** and returns early. That guard is the whole safety story:
without it the walk would match every record and a no-op delete would wipe the store.

| | before | after |
|---|---|---|
| `delete` | `get_all` 2→1, retrieve still serves it | `get_all` 2→1 **and** retrieve clean |
| `reset` | retrieve serves the canary | `get_all=0` **and** retrieve clean |
| `forget` | retrieve serves the secret | `get_all=0` **and** retrieve clean |

All three deletion operations now mean the same thing on every read path.

## Reading a resource's or skill's text back

`list_skills` and `list_resources` return a pointer (`raw_uri`, `cloud_key`) and metadata. The text
itself is already stored, split across `resource_chunk` records at ingest, but nothing reassembled
it — so "give me this skill's content" had no answer.

`get_resource_content` does, and pages it: an attachment can be far larger than belongs in one JSON
response, so it returns at most `chunk_limit` chunks and `max_chars` characters and reports
`next_chunk_offset` when there is more. `skill_hash` and `resource_hash` are aliases.

Ordering would have failed silently. Chunks carried no order of their own, so reassembly depended
on the log being read back in append order — a property of *how it was read*, not of the records.
Each chunk is now stamped with `chunk_index` at ingest and read back in that order, falling back to
log order for chunks written before the index existed, which is the only ordering those have. A
test builds the chunks out of order in the log and asserts the content comes back in the right one.

## Verification

25 new tests. On this tree: mem0 suites 56/56, delete/forget 21/21, the native-path guard, the
record-cache suite, and both new suites green.
