### PR TITLE
Record why the embedding metadata copy is a repair net, not a fold

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -615,6 +615,23 @@ class _LocalAdapterRetrieveMixin:
         embedding_metadata_by_ref: dict[tuple[Any, Any], Json] = {}
 
         def remember_embedding_metadata(record: Json) -> None:
+            # A context_embedding row copies its owner's metadata. Measured on a real ingest:
+            # 29 of the 33 populated fields are IDENTICAL on the owner record, and only four are
+            # unique to the row -- dim, model, model_ref (encoder provenance) and storage_options.
+            #
+            # This is NOT a fold waiting to happen. record_with_embedding_defaults() below fills
+            # only fields the owner is MISSING, so retrieval is already owner-first and this copy
+            # is never consulted in normal operation. It is a self-repair net for an owner that
+            # has lost fields, which
+            # test_retrieve_recovers_hot_event_type_from_embedding_metadata exercises by
+            # stripping event_type/classification/status/source_kind from a context_event.
+            #
+            # Removing the copy was measured end to end: it saves 2.6% of total record bytes
+            # (129,938 -> 126,510) because the vector dominates a row, not its metadata, and it
+            # breaks the repair path. Recorded so the trade is not re-derived: losing self-repair
+            # to save 2.6% is not worth it, and dropping these rows entirely costs more still --
+            # eight tests covering hot_event_type recovery, cross-session profile lineage and
+            # memory-layer classification all read them.
             ref_type = record.get("ref_type")
             ref_hash = record.get("ref_hash")
             if ref_type in (None, "") or ref_hash in (None, ""):


### PR DESCRIPTION
Comment only — no behaviour change. It records a measurement so the trade behind
`context_embedding` rows is not re-derived from scratch.

## What was investigated

Whether a `context_embedding` row's metadata could be folded onto its owner, so the rows
could eventually stop being written. There is nothing to fold: **the metadata is already
on the owner.**

Measured on a real ingest, comparing every row against its owner record:

```
fields IDENTICAL on the owner   29 distinct
fields unique to the row         4   (dim, model, model_ref, storage_options)
```

The four unique ones are encoder provenance. Everything else is a copy.

`record_with_embedding_defaults()` fills **only** fields the owner is missing, so retrieval
is already owner-first and this copy is never consulted in normal operation. It is a
self-repair net for an owner that has lost fields —
`test_retrieve_recovers_hot_event_type_from_embedding_metadata` builds exactly that case,
stripping `event_type`/`classification`/`status`/`source_kind` from a `context_event` and
asserting recovery.

## The trade, measured end to end

```
dropping the copy   129,938 -> 126,510 bytes   (2.6%)
copy ON  -> repair test passes
copy OFF -> repair test fails
```

2.6%, because a row's bytes are the vector, not its metadata. Losing self-repair for that
is not worth it — and dropping the rows outright costs more still: eight tests covering
`hot_event_type` recovery, cross-session profile lineage and memory-layer classification
read them.

## Why a comment and not a knob

A knob was implemented and measured first, then removed rather than shipped. An option
nobody should enable is the same declared-config-that-should-not-be-used shape already
found twice in this codebase — `write_secondary_index`, read by nothing until it was
wired, and `raw_storage_policy`, stored and displayed but branched on nowhere. The finding
belongs in the code, not in a switch.

Verified comment-only: every added line is a comment, no removals. Mirror imports clean.
