### PR TITLE
meta: serve a shard's replicas nearest-first to the caller that asked

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
@@ -413,6 +413,7 @@ fn handle_master_service_route(
                     meta,
                     get_table_topology,
                     GetTableTopologyRequest {
+                        client_location: String::new(),
                         namespace: req.namespace,
                         table_name: req.table_name,
                         old_topology_version: 0,
@@ -434,6 +435,7 @@ fn handle_master_service_route(
                     meta,
                     get_table_topology,
                     GetTableTopologyRequest {
+                        client_location: String::new(),
                         namespace: req.namespace,
                         table_name: req.table_name,
                         old_topology_version: 0,
@@ -450,6 +452,9 @@ fn handle_master_service_route(
                     meta,
                     get_table_topology,
                     GetTableTopologyRequest {
+                        // The caller has been sending this on every topology
+                        // request all along; it was being dropped here.
+                        client_location: req.idc,
                         namespace: req.namespace,
                         table_name: req.table_name,
                         old_topology_version: req.old_topology_version.max(req.old_topo_version),

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -2384,6 +2384,7 @@ fn validate_node_topology_from_meta(
             meta_addr,
             "/tables/topology",
             &GetTableTopologyRequest {
+                client_location: String::new(),
                 namespace: request.namespace.clone(),
                 table_name: table_name.clone(),
                 old_topology_version: 0,

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -28,6 +28,7 @@ impl TemporalStoreClient {
             meta_addr,
             "/tables/topology",
             &GetTableTopologyRequest {
+                client_location: String::new(),
                 namespace: namespace.clone(),
                 table_name: table_name.clone(),
                 old_topology_version: 0,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -562,6 +562,11 @@ pub struct GetTableTopologyRequest {
     pub table_name: String,
     #[serde(default)]
     pub old_topology_version: u64,
+    /// Where the caller is, in the same hierarchical form as a server's
+    /// location. Used only to order each shard's replicas nearest-first; an
+    /// empty value leaves the order exactly as it was.
+    #[serde(default)]
+    pub client_location: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1891,6 +1896,7 @@ mod tests {
             .ok);
 
         let topology = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "orders".to_string(),
             old_topology_version: 0,
@@ -2033,6 +2039,7 @@ mod tests {
 
         let units = |meta: &SingleNodeMeta| {
             let topology = meta.get_table_topology(GetTableTopologyRequest {
+                client_location: String::new(),
                 namespace: "ns".to_string(),
                 table_name: "orders".to_string(),
                 old_topology_version: 0,
@@ -2500,6 +2507,7 @@ mod tests {
 
     fn routed_shard(meta: &SingleNodeMeta) -> TableShard {
         meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "orders".to_string(),
             old_topology_version: 0,
@@ -2602,6 +2610,144 @@ mod tests {
             server_addr: "node-ghost".to_string(),
         });
         assert_eq!(routed_shard(&meta).primary, Some("node-ghost".to_string()));
+    }
+
+    /// One shard replicated across three zones, owned in zone-a. The servers are
+    /// registered a-b-c so the load-ordered scan produces that order, which is
+    /// what a caller sees today no matter where it is.
+    fn three_zone_shard() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        for (index, (addr, zone)) in [
+            ("node-a", "east/zone-a"),
+            ("node-b", "east/zone-b"),
+            ("node-c", "west/zone-c"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            meta.register_server(RegisterServerRequest {
+                server_addr: addr.to_string(),
+                node_id: index as u64 + 1,
+                location: zone.to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 3,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: "node-a".to_string(),
+        });
+        meta
+    }
+
+    fn topology_for(meta: &SingleNodeMeta, client_location: &str) -> TableShard {
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: client_location.to_string(),
+        })
+        .shards
+        .into_iter()
+        .next()
+        .expect("one shard")
+    }
+
+    #[test]
+    fn a_caller_is_offered_the_replica_in_its_own_zone_first() {
+        // Replicas are deliberately spread as far apart as the topology allows,
+        // so most of a shard's replicas are far from any given caller by
+        // construction. Without this the caller reads from whichever server
+        // sorted first on load, which is a coin flip against crossing zones.
+        let meta = three_zone_shard();
+        // The order without a caller location is not accidental: the placement
+        // scan spreads replicas as widely as the topology allows, so the *far*
+        // replica is offered second. That is exactly the behaviour that makes a
+        // location-blind read expensive.
+        assert_eq!(
+            topology_for(&meta, "").replicas,
+            vec![
+                "node-a".to_string(),
+                "node-c".to_string(),
+                "node-b".to_string()
+            ]
+        );
+        assert_eq!(
+            topology_for(&meta, "east/zone-b").replicas.first(),
+            Some(&"node-b".to_string())
+        );
+        assert_eq!(
+            topology_for(&meta, "west/zone-c").replicas.first(),
+            Some(&"node-c".to_string())
+        );
+    }
+
+    #[test]
+    fn a_caller_with_no_replica_in_its_zone_still_prefers_the_nearer_half() {
+        // Locations are hierarchical, so "no replica here" is not the end of the
+        // question: a caller in east/zone-d shares `east` with two of the three.
+        let meta = three_zone_shard();
+        let replicas = topology_for(&meta, "east/zone-d").replicas;
+        assert_eq!(replicas.len(), 3);
+        assert_eq!(replicas[2], "node-c", "the far replica should sort last");
+    }
+
+    #[test]
+    fn ordering_replicas_never_moves_the_primary() {
+        // The primary is where the shard is actually owned. Reordering is about
+        // which copy to read, and must not change who owns it.
+        let meta = three_zone_shard();
+        for caller in ["", "east/zone-b", "west/zone-c"] {
+            assert_eq!(
+                topology_for(&meta, caller).primary,
+                Some("node-a".to_string()),
+                "caller {caller:?} was given a different primary"
+            );
+        }
+    }
+
+    #[test]
+    fn the_endpoints_stay_lined_up_with_the_replicas() {
+        // The two lists are positional. Reordering one without the other would
+        // hand every caller the wrong address for every replica.
+        let meta = three_zone_shard();
+        let shard = topology_for(&meta, "west/zone-c");
+        let addrs = shard
+            .replica_endpoints
+            .iter()
+            .map(|endpoint| endpoint.server_addr.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(shard.replicas, addrs);
+    }
+
+    #[test]
+    fn a_caller_that_says_nothing_sees_exactly_what_it_saw_before() {
+        // The whole change is opt-in on a field the caller may not send.
+        let meta = three_zone_shard();
+        let quiet = topology_for(&meta, "");
+        let unknown = topology_for(&meta, "somewhere/else");
+        assert_eq!(quiet.replicas, unknown.replicas);
+        assert_eq!(quiet.primary, unknown.primary);
+    }
+
+    #[test]
+    fn callers_equally_close_keep_the_order_the_load_scan_chose() {
+        // The sort is stable on purpose: among servers the caller cannot tell
+        // apart, the placement scan's load ordering is still the better answer.
+        let meta = three_zone_shard();
+        let replicas = topology_for(&meta, "east/zone-d").replicas;
+        assert_eq!(&replicas[..2], &["node-a".to_string(), "node-b".to_string()]);
     }
 
     #[test]
@@ -2753,6 +2899,7 @@ mod tests {
         );
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -2796,6 +2943,7 @@ mod tests {
         assert!(unchanged_report.events.is_empty());
 
         let unchanged = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: topology_version,
@@ -2837,6 +2985,7 @@ mod tests {
         assert_eq!(meta.list_namespaces().namespaces[0].table_count, 0);
 
         let topology = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -2883,6 +3032,7 @@ mod tests {
         assert_eq!(meta.list_tables().tables[0].state, MetaEntityState::Frozen);
 
         let topology = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -2919,6 +3069,7 @@ mod tests {
         assert_eq!(meta.list_tables().tables[0].state, MetaEntityState::Normal);
 
         let topology = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -2966,6 +3117,7 @@ mod tests {
         assert!(table.topology_version > created.topology_version);
 
         let topology = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: created.topology_version,
@@ -3056,6 +3208,7 @@ mod tests {
         );
         assert_eq!(
             meta.get_table_topology(GetTableTopologyRequest {
+                client_location: String::new(),
                 namespace: "ns".to_string(),
                 table_name: "opts".to_string(),
                 old_topology_version: 0,
@@ -3154,6 +3307,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -3211,6 +3365,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "runtime_load".to_string(),
             old_topology_version: 0,
@@ -3265,6 +3420,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "serving_state".to_string(),
             old_topology_version: 0,
@@ -3314,6 +3470,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -3364,6 +3521,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -3412,6 +3570,7 @@ mod tests {
         });
 
         let topo = meta.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -3927,6 +4086,7 @@ mod tests {
         );
         assert_eq!(recovered.list_namespaces().namespaces[0].table_count, 1);
         let recovered_topology = recovered.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,
@@ -4074,6 +4234,7 @@ mod tests {
             MetaEntityState::Frozen
         );
         let topology = recovered.get_table_topology(GetTableTopologyRequest {
+            client_location: String::new(),
             namespace: "ns".to_string(),
             table_name: "tbl".to_string(),
             old_topology_version: 0,

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -44,7 +44,7 @@ impl SingleNodeMeta {
                 unchanged: true,
             };
         }
-        let shards = build_shards(&state, &table.info);
+        let shards = build_shards(&state, &table.info, &request.client_location);
         TableTopologyResponse {
             status: Status::ok(),
             table: Some(table.info.clone()),

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -19,7 +19,11 @@ fn owner_is_serving(state: &MetaState, server_addr: &str) -> bool {
         .unwrap_or(true)
 }
 
-pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<TableShard> {
+pub(super) fn build_shards(
+    state: &MetaState,
+    table: &TableMetaInfo,
+    client_location: &str,
+) -> Vec<TableShard> {
     #[derive(Debug)]
     struct PlacementCandidate {
         server_addr: String,
@@ -102,6 +106,7 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
         .iter()
         .map(|candidate| Location::parse(&candidate.location))
         .collect::<Vec<_>>();
+    let caller = Location::parse(client_location);
     let bucket_count = 1_u64 << 30;
     let mut shards = Vec::new();
     for offset in 0..table.shard_count {
@@ -196,6 +201,26 @@ pub(super) fn build_shards(state: &MetaState, table: &TableMetaInfo) -> Vec<Tabl
             // table gets one before anything registers.
             None => replicas.first().cloned(),
         };
+        // Replicas are deliberately spread as far apart as the topology
+        // allows, so most of a shard's replicas are far from any given caller
+        // by construction. Ordering them nearest-first is what lets a caller
+        // that has a replica in its own location read from it rather than
+        // crossing the fabric to whichever server happened to sort first on
+        // load. Only the order changes: the same servers are returned, and the
+        // primary -- which is where the shard is actually owned -- is untouched.
+        if !caller.is_empty() {
+            // Stable, so servers equally close to the caller keep the
+            // load-ordered sequence the scan above produced.
+            replicas.sort_by_key(|server_addr| {
+                std::cmp::Reverse(
+                    state
+                        .servers
+                        .get(server_addr)
+                        .map(|server| caller.shared_prefix_len(&Location::parse(&server.location)))
+                        .unwrap_or(0),
+                )
+            });
+        }
         let primary_endpoint = primary
             .as_ref()
             .map(|server_addr| server_endpoint(state, server_addr));

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -526,6 +526,7 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
     }
 
     let topology = meta.get_table_topology(GetTableTopologyRequest {
+        client_location: String::new(),
         namespace: "feature".to_string(),
         table_name: "user_seq".to_string(),
         old_topology_version: 0,
@@ -549,6 +550,7 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
         assert_eq!(meta.commit_index(node_id).unwrap(), 5);
     }
     let updated_topology = meta.get_table_topology(GetTableTopologyRequest {
+        client_location: String::new(),
         namespace: "feature".to_string(),
         table_name: "user_seq".to_string(),
         old_topology_version: 0,
@@ -580,6 +582,7 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
         assert_eq!(meta.commit_index(node_id).unwrap(), 7);
     }
     let dropped_topology = meta.get_table_topology(GetTableTopologyRequest {
+        client_location: String::new(),
         namespace: "feature".to_string(),
         table_name: "user_seq".to_string(),
         old_topology_version: 0,

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -2748,6 +2748,7 @@ fn verify_metaserver_scheduler_control_plane() {
     );
 
     let topology = meta.get_table_topology(GetTableTopologyRequest {
+        client_location: String::new(),
         namespace: "ns".to_string(),
         table_name: "meta_parts".to_string(),
         old_topology_version: 0,


### PR DESCRIPTION
## The caller already tells us where it is, and we throw it away

`MasterGetTableTopoRequest` — the wire type behind `POST /MasterService/GetTableTopo` — has carried an `idc` field all along:

```rust
#[allow(dead_code)]
struct MasterGetTableTopoRequest {
    namespace: String,
    table_name: String,
    old_topo_version: u64,
    old_topology_version: u64,
    idc: String,      // <- never read
    host: String,
    compress: bool,
}
```

The route forwards `namespace`, `table_name` and the version, and drops the rest. So every caller announces its location on every topology request, and every caller gets back the same answer.

That answer is ordered by *placement* preference, not by proximity. And placement deliberately spreads replicas **as far apart as the topology allows** — that is the whole point of the separation ladder in `meta/location.rs`. Which means most of a shard's replicas are far from any given caller *by construction*.

The test makes this concrete. Three replicas — `east/zone-a`, `east/zone-b`, `west/zone-c` — and the order every caller currently receives:

```
["node-a", "node-c", "node-b"]
```

The replica on the other side of the country is offered **second**, ahead of the one in the neighbouring zone, to a caller that may well be sitting in `east/zone-b`.

## What this changes

`GetTableTopologyRequest` gains an optional `client_location`, the route stops dropping `idc`, and each shard's replicas are ordered nearest-first using the `shared_prefix_len` that `meta/location.rs` already provides for placement.

Three properties hold it in place:

- **The primary never moves.** Reordering is about which copy to *read*. Who owns the shard is a different question, and it is not being answered here.
- **`replica_endpoints` is reordered with `replicas`.** The two lists are positional; reordering one alone would hand every caller the wrong address for every replica.
- **The sort is stable.** Among servers a caller cannot tell apart — same shared prefix — the placement scan's load ordering is still the better answer, so it survives.

Locations are hierarchical, so "no replica in my zone" is not the end of the question: a caller in `east/zone-d` shares `east` with two of the three replicas and gets both of them ahead of the western one.

## Compatibility

The field is `#[serde(default)]`, and an empty or unrecognised location leaves the order byte-identical to today. A caller that says nothing sees exactly what it saw before — there is a test for precisely that.

## Tests

6 new, covering: the caller's own zone coming first, the hierarchical fallback, the primary staying put, endpoints staying aligned, silence changing nothing, and the stable-sort tie-break.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — 267 passed, 2 failed.
- `cargo check -p temporalstore-rust --all-targets` — clean.

**Correction.** I originally wrote that these two fail on clean `main`. That was wrong. Re-running `proxy::tests` on its own gives **54 passed, 0 failed** both on `main` and on this branch. The failures I saw were port collisions — the proxy tests bind fixed ports, and another suite was running against the same ports in a second worktree at the time; one of them reported `AddrInUse` outright, which I should have read as the signal it was. `main` was not red, and this change does not affect these tests.

---

**Correction to the note above about the two proxy tests.**

I wrote that they fail on clean `main`. That was wrong, and I am striking it. Running `proxy::tests` on its own gives **54 passed, 0 failed** — on `main` and on this branch alike.

What I actually hit was a port collision: the proxy tests bind fixed ports, and a second worktree was running its own suite against the same ports at the time. One of the failures said `AddrInUse` outright, which I should have read as the signal it was instead of treating the set as a baseline. `main` was not red, and this change does not touch these tests.
