### PR TITLE
Client: a write whose outcome is unknown is no longer sent twice

### DIFF
--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -48,6 +48,10 @@ impl TemporalStoreClient {
                     if !self.inner.options.refresh_route_on_backend_error {
                         return Err(err.into());
                     }
+                    if !Self::may_send_again(&request.commands, &err) {
+                        let _ = self.resolve_route(request.shard_id, true, None);
+                        return Err(err.into());
+                    }
                     let refreshed = self.resolve_route(request.shard_id, true, None)?;
                     Ok(post_json_with_options(
                         &refreshed,
@@ -106,6 +110,22 @@ impl TemporalStoreClient {
         )
     }
 
+    /// Whether a request that just failed may simply be sent again.
+    ///
+    /// A read always may -- repeating it cannot change anything. A write may only if the
+    /// error proves it never arrived: a refused connection sent no bytes, so nothing was
+    /// applied and re-sending is the recovery the caller wants. A read timeout proves
+    /// nothing of the sort -- the datanode stopped answering, which is not the same as never
+    /// having received the write -- and re-sending there counts `ControlStateIncrement`
+    /// twice with nothing downstream able to tell.
+    ///
+    /// The command layer above already drew this line: it retries a write only when the
+    /// backend REFUSED it (`safe_budget_free_write_retry` requires a topology retry), a
+    /// definite "not applied". This layer had no such reasoning and re-sent regardless.
+    fn may_send_again(commands: &[Command], err: &HttpError) -> bool {
+        !commands.iter().any(super::commands::is_write) || err.request_never_reached_the_server()
+    }
+
     pub(super) fn execute_routed_with_http_and_policy(
         &self,
         request: ExecuteRequest,
@@ -141,6 +161,19 @@ impl TemporalStoreClient {
                         .expect("client stats lock poisoned")
                         .record_backend_error(became_continuous);
                     if !self.inner.options.refresh_route_on_backend_error {
+                        return Err(err.into());
+                    }
+                    if !Self::may_send_again(std::slice::from_ref(&request.command), &err) {
+                        // Drop the stale route so the NEXT request re-resolves, but do not
+                        // send this write a second time -- its outcome is unknown, not known
+                        // to be "never happened".
+                        let _ = self.resolve_route_with_policy(
+                            request.shard_id,
+                            true,
+                            continuous_failed_time_ms,
+                            policy,
+                            preferred_location,
+                        );
                         return Err(err.into());
                     }
                     let refreshed = self.resolve_route_with_policy(
@@ -193,6 +226,11 @@ impl TemporalStoreClient {
                         .expect("client stats lock poisoned")
                         .record_backend_error(became_continuous);
                     if !self.inner.options.refresh_route_on_backend_error {
+                        return Err(err.into());
+                    }
+                    if !Self::may_send_again(&request.commands, &err) {
+                        let _ =
+                            self.resolve_route(request.shard_id, true, continuous_failed_time_ms);
                         return Err(err.into());
                     }
                     let refreshed =

--- a/crates/temporalstore-rust/src/http.rs
+++ b/crates/temporalstore-rust/src/http.rs
@@ -30,6 +30,22 @@ pub enum HttpError {
     BadResponse(String),
 }
 
+impl HttpError {
+    /// Whether this error proves the request never reached the server.
+    ///
+    /// Only a refused connection proves it: the peer rejected the TCP handshake, so not one
+    /// byte of the request was sent. Everything else -- a read timeout above all -- means
+    /// the server stopped answering, which is not the same as never having heard the
+    /// request. That distinction is what decides whether a write may be sent again.
+    ///
+    /// Deliberately conservative. A connect timeout is indistinguishable from a read
+    /// timeout here (both surface as `TimedOut`), so it is treated as "unknown" and a write
+    /// is not repeated after one.
+    pub fn request_never_reached_the_server(&self) -> bool {
+        matches!(self, HttpError::Io(err) if err.kind() == ErrorKind::ConnectionRefused)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HttpRequestOptions {
     pub connect_timeout_ms: u64,

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3931,6 +3931,69 @@ mod tests {
     }
 
     #[test]
+    fn a_write_whose_outcome_is_unknown_is_not_sent_twice() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // A datanode that accepts the request and then stops answering. That is the case
+        // that matters: the connection succeeded, the request was delivered, and the client
+        // is left not knowing whether it was applied.
+        let hits = std::sync::Arc::new(AtomicUsize::new(0));
+        let slow = test_addr(18_390);
+        let h = hits.clone();
+        let slow_for_thread = slow.clone();
+        std::thread::spawn(move || {
+            serve(&slow_for_thread, move |_request| {
+                h.fetch_add(1, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(500));
+                json_response(200, &Status::ok())
+            })
+            .unwrap();
+        });
+        start_meta(test_addr(18_391), slow.clone());
+        wait_for_http(&test_addr(18_391));
+
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_391),
+            route_cache_ttl_ms: 60_000,
+            connect_timeout_ms: 200,
+            io_timeout_ms: 120,
+            ..ProxyOptions::default()
+        });
+
+        hits.store(0, Ordering::SeqCst);
+        let _ = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "counted".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        // Leave time for a second attempt to land, so this fails loudly rather than racing.
+        std::thread::sleep(Duration::from_millis(400));
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "a write that timed out must not be sent again -- the timeout says the datanode              stopped answering, not that it never received the write"
+        );
+
+        // A read is a different matter: repeating it cannot change anything, so the
+        // refresh-and-retry still applies. Pinned so the guard cannot quietly widen.
+        hits.store(0, Ordering::SeqCst);
+        let _ = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: "counted".to_string(),
+            },
+        });
+        std::thread::sleep(Duration::from_millis(400));
+        assert!(
+            hits.load(Ordering::SeqCst) >= 2,
+            "a read should still be retried after a backend failure, saw {}",
+            hits.load(Ordering::SeqCst)
+        );
+    }
+
+    #[test]
     fn topology_check_stays_off_the_request_path() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let topo_posts = std::sync::Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
When a request to a datanode failed, the client refreshed the route and sent the
same request again. For a read that is free. For a write it depends entirely on
what the failure was, and the code did not look.

A refused connection is fine to repeat: the peer rejected the handshake, not one
byte was sent, nothing was applied. That is the case the existing tests cover and
it still works exactly as before.

A read timeout is a different thing. It does not mean the datanode never got the
request -- it means it stopped answering. The write may well have been applied.
Sending it again applies it twice, and nothing downstream can tell: an increment
counted twice, an append appended twice. That case was being re-sent too.

This was not behind an off-by-default knob. refresh_route_on_backend_error defaults
to true, so a timed-out write was re-sent in the default configuration, at all
three places that route a request -- execute and both batch_execute paths.

Measured by counting what the datanode actually received: a write that times out
arrived twice before this change and arrives once after.

So the rule is now about what the error proves, not about the verb alone:

- read, any failure                  -> send again, unchanged
- write, connection refused          -> send again; it provably never arrived
- write, anything else               -> refresh the route, return the error

The route is still refreshed in every case, so the next request re-resolves and
recovers. What is dropped is only the second copy of a write whose fate is unknown.

The classifier is deliberately conservative in one place worth naming: a connect
timeout and a read timeout are indistinguishable at this layer -- both surface as
TimedOut -- so a connect timeout counts as "unknown" and the write is not repeated.
Wrong in the safe direction.

Worth saying: the command layer above already drew this exact line. It retries a
write only when the backend REFUSED it (safe_budget_free_write_retry requires a
topology retry, a definite "not applied"). The routing layer underneath had no such
reasoning and re-sent regardless, quietly undoing the guarantee the layer above was
maintaining. The write classifier used here is the engine's own is_write, the same
one that gates WAL persistence, rather than a second hand-maintained list -- a
hand-maintained one had already drifted once.

The new test fails with "left: 2, right: 1" if the guard is removed. Checked, not
assumed. My first cut of the guard was too broad -- it blocked the refused case too
-- and the two pre-existing route-refresh tests caught it.

Not addressed here, and worth its own look: the connection pool falls back to a
fresh socket when a pooled one fails, and that fallback cannot currently tell a
socket the server reaped from one that carried a request the server processed.