### PR TITLE
Http: a request that timed out on a pooled socket is not sent again

### DIFF
--- a/crates/temporalstore-rust/src/http.rs
+++ b/crates/temporalstore-rust/src/http.rs
@@ -568,6 +568,16 @@ fn request_raw_with_options(
     Err(last_error.unwrap_or_else(|| HttpError::BadResponse("request failed".to_string())))
 }
 
+/// Whether the exchange failed because the peer stopped answering, rather than because the
+/// connection was already dead. The distinction decides whether the request may be sent
+/// again: a dead socket carried nothing, a timeout may have carried everything.
+fn timed_out(err: &HttpError) -> bool {
+    matches!(
+        err,
+        HttpError::Io(err) if matches!(err.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock)
+    )
+}
+
 fn is_retryable_request_error(err: &HttpError) -> bool {
     match err {
         HttpError::Io(err) => matches!(
@@ -685,6 +695,17 @@ fn request_raw_once(
                 pool_put(addr, stream);
                 return Ok(response);
             }
+            // A pooled socket the server reaped fails immediately -- a reset, a broken pipe,
+            // or an EOF that parses as a missing response header. Nothing was served on it,
+            // so reconnecting and sending again is transparent, and that is what this
+            // fallback is for.
+            //
+            // A timeout is not that. It means the peer accepted the request and did not
+            // answer in time, so the request may well have been processed. Silently sending
+            // it again on a fresh socket would apply a write twice, which is exactly the
+            // thing the routing layer above refuses to do -- and doing it here would undo
+            // that decision from underneath.
+            Err(err) if timed_out(&err) => return Err(err),
             Err(_) => { /* stale/broken pooled connection: drop it, reconnect */ }
         }
     }

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3931,6 +3931,66 @@ mod tests {
     }
 
     #[test]
+    fn a_timed_out_request_on_a_pooled_socket_is_not_resent() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // The keep-alive pool reconnects and sends again when a pooled socket fails, which is
+        // right when the server had reaped that socket -- nothing was served on it. It was
+        // also doing it when the peer simply stopped answering, which sends the request a
+        // second time even though the first may have been processed. One layer below the
+        // routing guard, and it would undo that guard from underneath.
+        let hits = std::sync::Arc::new(AtomicUsize::new(0));
+        let addr = test_addr(18_392);
+        let h = hits.clone();
+        let addr_for_thread = addr.clone();
+        std::thread::spawn(move || {
+            serve(&addr_for_thread, move |_request| {
+                // First exchange answers immediately, so the socket lands in the pool.
+                // Everything after that accepts the request and goes quiet.
+                if h.fetch_add(1, Ordering::SeqCst) > 0 {
+                    std::thread::sleep(Duration::from_millis(700));
+                }
+                crate::http::json_response(200, &Status::ok())
+            })
+            .unwrap();
+        });
+        wait_for_http(&addr);
+
+        let options = HttpRequestOptions {
+            connect_timeout_ms: 200,
+            io_timeout_ms: 120,
+            max_retries: 0,
+        };
+        // Warm the pool: this must succeed and leave a keep-alive socket for this thread.
+        crate::http::request_bytes_with_options(
+            &addr,
+            "POST",
+            "/warm",
+            b"{}",
+            "application/json",
+            options,
+        )
+        .expect("first exchange should succeed and pool its socket");
+
+        let before = hits.load(Ordering::SeqCst);
+        let _ = crate::http::request_bytes_with_options(
+            &addr,
+            "POST",
+            "/slow",
+            b"{}",
+            "application/json",
+            options,
+        );
+        // Leave room for a second attempt to arrive, so this fails loudly rather than racing.
+        std::thread::sleep(Duration::from_millis(500));
+        assert_eq!(
+            hits.load(Ordering::SeqCst) - before,
+            1,
+            "a request that timed out on a pooled socket must not be sent again on a fresh one"
+        );
+    }
+
+    #[test]
     fn a_write_whose_outcome_is_unknown_is_not_sent_twice() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 


### PR DESCRIPTION
The keep-alive pool reconnects and sends the request again whenever a pooled socket
fails. For the case it was written for that is exactly right: the server reaps idle
sockets, the next exchange on one fails immediately with a reset or a broken pipe or
an EOF, nothing was ever served on it, and reconnecting is transparent.

It was doing the same thing after a timeout, and a timeout is not that. The peer
accepted the request and did not answer in time. It may have processed it. Sending
it again on a fresh socket applies a write twice.

This sits one layer below the routing guard that just stopped re-sending writes of
unknown outcome, and it would have undone that guard from underneath: the routing
layer can decline to retry all it likes while the transport quietly retries for it.

Now a pooled exchange that fails with a timeout returns the error. Every other
failure still reconnects and re-sends, so the reaped-socket path -- the reason the
fallback exists -- is untouched.

Deliberately applied to all requests rather than only writes. The transport does not
know a write from a read, and threading that through every caller would put the
decision in more places than can be kept honest. Reads lose nothing that matters:
the routing layer above already refreshes and retries a read on any backend failure,
so the recovery is still there, one layer up, where it can see what it is retrying.

Measured by counting what the server received: the request arrived twice before this
change and arrives once after. The test fails with "left: 2, right: 1" if the guard
is removed.