### PR TITLE
Measure the record against the one the log writes, not the one it used to

### DIFF
--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -281,44 +281,43 @@ mod tests {
         assert_eq!(with_block.encode_to_vec(), vec![0x6a, 0x02, b'a', b'b']);
     }
 
-    /// What a write costs on disk, in the shape the log uses today versus the binary one.
+    /// What a write costs on disk in the shape the log writes today, against the binary one.
     ///
-    /// The value of a write is stored as an array of decimal numbers when the record is JSON,
-    /// so every byte of user data becomes three or four characters before framing, metadata and
-    /// key names are counted at all. This measures both on identical content so the cost is a
-    /// number rather than an impression.
+    /// This is the headroom still available from changing the record format, and it is much
+    /// smaller than it once was: encoding payloads compactly and shortening the log's own field
+    /// names already took most of it. Measured against the REAL record -- the type the log
+    /// serializes -- because measuring against the shape records used to have would overstate what
+    /// is left and is the kind of number that justifies a migration it should not.
     #[test]
-    fn record_encoding_cost_per_byte_written() {
+    fn what_is_left_to_gain_from_a_binary_record() {
         use crate::types::Command;
+        use crate::wal::{WriteAheadLogRecord, WriteAheadLogRecordMetadata};
 
         for value_len in [64usize, 128, 1024, 4096] {
-            let value = vec![b'v'; value_len];
+            let value = vec![118u8; value_len];
             let key = "scale-key-000000000";
 
-            // As written today: a JSON document, then the integrity frame around it.
-            let json_record = serde_json::json!({
-                "shard_id": 1,
-                "sequence": 1,
-                "command": { "kind": "string_set", "key": key, "value": value },
-                "metadata": {
-                    "version": 1,
-                    "timestamp_ms": 1_787_270_070_192u64,
-                    "items": [{
-                        "item_kind": "kv",
-                        "model": "string",
-                        "object_key": key,
-                        "slot_id": 8539,
-                        "deleted": false,
-                        "meta_log": false,
-                        "block_log": false
-                    }]
-                }
-            });
-            let json_bytes = serde_json::to_vec(&json_record).unwrap();
-            let json_framed = crate::log_framing::encode_line(&json_bytes);
+            // Exactly what the log writes: the real record, serialized and framed the same way.
+            let record = WriteAheadLogRecord {
+                shard_id: 1,
+                sequence: 1,
+                command: Command::StringSet {
+                    key: key.to_string(),
+                    value: value.clone(),
+                },
+                metadata: Some(WriteAheadLogRecordMetadata {
+                    version: crate::wal::WRITE_AHEAD_LOG_FORMAT_VERSION,
+                    timestamp_ms: 1_787_270_070_192,
+                    items: Vec::new(),
+                    batch_id: None,
+                    batch_size: None,
+                    batch_index: None,
+                }),
+                staged_pages: Vec::new(),
+            };
+            let today = crate::log_framing::encode_line(&serde_json::to_vec(&record).unwrap());
 
-            // The binary shape: one record carrying the same write, length-prefixed and
-            // checksummed by the shared framing.
+            // The binary shape, carrying the same write.
             let binary_record = WalRecord {
                 version: WAL_RECORD_VERSION,
                 sequence: 1,
@@ -332,36 +331,21 @@ mod tests {
                     ..Default::default()
                 }],
             };
-            let binary_framed = encode_framed(&binary_record);
+            let binary = encode_framed(&binary_record);
 
-            let json_ratio = json_framed.len() as f64 / value_len as f64;
-            let binary_ratio = binary_framed.len() as f64 / value_len as f64;
             println!(
-                "  value {value_len:>5}B -> json {:>7}B ({json_ratio:>5.2}x)   binary {:>6}B ({binary_ratio:>5.2}x)   {:>5.1}x smaller",
-                json_framed.len(),
-                binary_framed.len(),
-                json_framed.len() as f64 / binary_framed.len() as f64
+                "  value {value_len:>5}B -> today {:>6}B ({:>5.2}x)   binary {:>6}B ({:>5.2}x)   {:.2}x left to gain",
+                today.len(),
+                today.len() as f64 / value_len as f64,
+                binary.len(),
+                binary.len() as f64 / value_len as f64,
+                today.len() as f64 / binary.len() as f64
             );
 
-            // The binary record must never be the larger of the two.
             assert!(
-                binary_framed.len() < json_framed.len(),
-                "binary encoding should be smaller at {value_len}B"
+                binary.len() < today.len(),
+                "the binary form should still be the smaller of the two at {value_len}B"
             );
         }
-
-        // Guard the headline: a small write costs several times its own size as JSON.
-        let value = vec![b'v'; 128];
-        let json = serde_json::to_vec(&serde_json::json!({
-            "shard_id": 1, "sequence": 1,
-            "command": { "kind": "string_set", "key": "scale-key-000000000", "value": value },
-        }))
-        .unwrap();
-        assert!(
-            json.len() > value.len() * 3,
-            "a 128B value should cost more than 3x as JSON, got {}B",
-            json.len()
-        );
     }
-
 }


### PR DESCRIPTION
This compared a hand-built JSON document in the shape records had **before** their payload encoding and field names were changed. Against that, a binary record looked **four times smaller** — and that is precisely the number someone would reach for to justify a file-format migration.

The log does not write that shape any more.

## Measured against the real record type

| value | today | binary | left to gain |
|---:|---|---|---|
| 64 B | 210 B (3.28x) | 131 B (2.05x) | **1.60x** |
| 128 B | 294 B (2.30x) | 198 B (1.55x) | 1.48x |
| 1 KiB | 1,491 B (1.46x) | 1,094 B (1.07x) | 1.36x |
| 4 KiB | 5,587 B (1.36x) | 4,166 B (1.02x) | **1.34x** |

So the headroom is **1.34x to 1.60x, not 4x**. Encoding payloads compactly and shortening the log's own field names already took most of what was there.

## Why this matters beyond the test

A binary record is not a drop-in. The binary types in this module describe a *mutation* — key, value, model, deleted, ttl — rather than a command, so adopting them changes what replay does: install bytes instead of re-execute. It also needs per-file format detection, because a length-prefixed frame and a JSON line are ambiguous in one file.

That is a reasonable project to take on for 4x. It is a much weaker case for 1.34x at the sizes where records are large, and the gain is concentrated in small records where the remaining cost is the key and the frame as much as the encoding.

I am not arguing the change should never happen — only that the codebase should not carry a number that argues for it on false terms. Anyone who picks this up should start from the table above.

## Testing

Test-only; the module's other tests are unchanged.
