### PR TITLE
Set the new identity list in the request the tests build

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3619,6 +3619,8 @@ mod tests {
 
     fn request(op: &str) -> RecordLogRequest {
         RecordLogRequest {
+            // This request names no identities: the field is only read by the delete op.
+            record_ids: None,
             op: op.to_string(),
             metaserver: "127.0.0.1:18000".to_string(),
             namespace: "codex_ns".to_string(),


### PR DESCRIPTION
`cargo check --all-targets` does not compile on `main`.

A request type gained `record_ids` — the identities a delete should remove — and the helper the tests build requests with was not updated. `matrixark_rust_proxy` and `matrixark_rust_direct_sdk` fail to build, along with their test targets.

It gets `None`: a request that names no identities, which is what every op except the delete sends.

## This is the fourth today

Same shape every time — a field added in one change, a caller left behind in another, each passing CI on its own because the library builds either way and only `--all-targets` sees the combination:

| | field added | caller left behind |
|---|---|---|
| #84 | `StateChangeRequest.reason` | corpus builder |
| #103 | `ContextEvent.vector` | 7 constructors |
| #109 | `ProductionRaftRuntimeOptions.snapshot_check_interval_ms` | 5 initializers |
| this | `RecordLogRequest.record_ids` | the tests' request helper |

A PR's green check reflects the merge base it was tested against, not the one it lands on. Requiring branches to be up to date before merging would turn every one of these into a pre-merge re-run instead of a broken `main`. I have raised it twice in passing; four occurrences in a day seems worth acting on.

## Verified

`cargo check --all-targets` exits 0.
