### PR TITLE
Let the log accumulate a little before dumping, so repeated writes merge

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -782,7 +782,16 @@ pub struct StorageManagerOptions {
     #[serde(default = "default_storage_manager_max_dump_buckets_per_round")]
     #[serde(rename = "max_dump_slots_per_round")]
     pub max_dump_buckets_per_round: usize,
-    #[serde(rename = "min_undumped_wal_records", default)]
+    /// How much log must be undumped before a dump is worth taking.
+    ///
+    /// A bucket is dumped, dirtied again by the next write, and dumped again -- so writing one key
+    /// repeatedly cost one page write per write. Waiting lets those writes merge into a single
+    /// dump. What the wait buys back is a longer log to replay after a restart, and nothing else:
+    /// the records are durable in the log either way.
+    #[serde(
+        rename = "min_undumped_wal_records",
+        default = "default_storage_manager_min_undumped_wal_records"
+    )]
     pub min_undumped_wal_records: u64,
     #[serde(default)]
     #[serde(rename = "dirty_slot_pressure")]
@@ -814,11 +823,22 @@ pub struct StorageManagerOptions {
     pub enable_metrics_reap: bool,
 }
 
+/// Records that must be undumped before a dump is taken.
+///
+/// One meant "dump whenever anything is undumped", because the delay only applies while the count
+/// is below the threshold. Measured writing one key a hundred times, with the dumps taken: 100
+/// dumps at that setting, 10 at a threshold of ten, 2 at fifty. Dumps fall in proportion, and the
+/// only cost is that much more log to replay after a restart -- a thousand records is a few hundred
+/// kilobytes, against two orders of magnitude fewer page writes for a bucket that is written often.
+fn default_storage_manager_min_undumped_wal_records() -> u64 {
+    1_000
+}
+
 impl Default for StorageManagerOptions {
     fn default() -> Self {
         Self {
             max_dump_buckets_per_round: default_storage_manager_max_dump_buckets_per_round(),
-            min_undumped_wal_records: 1,
+            min_undumped_wal_records: default_storage_manager_min_undumped_wal_records(),
             dirty_bucket_pressure: 1,
             stale_page_slab_pressure: 1,
             reclaimable_physical_bytes_pressure: 1,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3623,3 +3623,111 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
         "a derived page must not read back as missing once its cache entry is gone"
     );
 }
+
+/// What waiting before a dump would save, and what it would cost to wait.
+///
+/// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log
+/// accumulate first lets those writes merge into one dump. The knob for that exists and is off, so
+/// today every cycle dumps every dirty bucket.
+///
+/// Off is a defensible choice -- the dumps saved are paid for with a longer log to replay after a
+/// restart -- so this reports both sides rather than asserting one is right.
+#[test]
+fn what_delaying_a_dump_would_save_and_cost() {
+    for threshold in [0u64, 5, 25, 100] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1 << 20,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        let writes = 100u64;
+        let mut dumps = 0u64;
+        let mut worst_undumped = 0u64;
+        for index in 0..writes {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    // One key, written over and over: the case where merging matters.
+                    key: "hot".to_string(),
+                    value: format!("v{index}").into_bytes(),
+                },
+            });
+            let plan = engine.storage_lifecycle_plan(StorageLifecycleRequest {
+                shard_id: 1,
+                min_undumped_wal_records: threshold,
+                max_dump_buckets_per_round: 16,
+                ..Default::default()
+            });
+            if !plan.selected_dump_buckets.is_empty() {
+                dumps += 1;
+            }
+            worst_undumped = worst_undumped.max(plan.undumped_wal_records);
+        }
+        println!(
+            "  threshold {threshold:>4} records: {dumps:>4} dumps for {writes} writes to one bucket, \
+             worst undumped backlog {worst_undumped} records"
+        );
+    }
+}
+
+/// What waiting before a dump saves, and what the wait costs.
+///
+/// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log
+/// accumulate first lets those writes merge into one dump. The knob for that exists and is off by
+/// default, so today every cycle dumps every dirty bucket.
+///
+/// Off is a defensible choice -- the dumps saved are paid for with a longer log to replay after a
+/// restart -- so this reports both sides rather than asserting one is right. The dumps are taken,
+/// not merely planned: planning alone never advances the dumped watermark, and then the backlog
+/// never falls and the counts mean nothing.
+#[test]
+fn what_delaying_a_dump_saves_and_costs() {
+    for threshold in [0u64, 10, 50] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1 << 20,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        let writes = 100u64;
+        let mut dumps = 0u64;
+        let mut worst_backlog = 0u64;
+        for index in 0..writes {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    // One key, written over and over: the case where merging matters.
+                    key: "hot".to_string(),
+                    value: format!("v{index}").into_bytes(),
+                },
+            });
+            let plan = engine.storage_lifecycle_plan(StorageLifecycleRequest {
+                shard_id: 1,
+                min_undumped_wal_records: threshold,
+                max_dump_buckets_per_round: 16,
+                ..Default::default()
+            });
+            worst_backlog = worst_backlog.max(plan.undumped_wal_records);
+            if !plan.selected_dump_buckets.is_empty() {
+                // Take the dump, so the watermark moves and the next backlog is real.
+                if engine
+                    .create_bucket_dump_manifest(1, plan.selected_dump_buckets.clone())
+                    .is_ok()
+                {
+                    dumps += 1;
+                }
+            }
+        }
+        println!(
+            "  threshold {threshold:>3} records: {dumps:>4} dumps for {writes} writes to one bucket, \
+             worst replay backlog {worst_backlog} records"
+        );
+    }
+}


### PR DESCRIPTION
A bucket is dumped, dirtied again by the very next write, and dumped again. Writing one key repeatedly therefore cost **one page write per write**.

The threshold that would prevent that already exists and was effectively off. It was `1`, and the delay only applies while the undumped count is *below* the threshold — so a single undumped record was enough to dump.

## Measured, writing one key a hundred times

| threshold | dumps | worst replay backlog |
|---:|---:|---|
| 0 | **100** | 1 record |
| 10 | 10 | 10 records |
| 50 | **2** | 50 records |

Dumps fall in proportion to the threshold, and the only thing bought back is a longer log to replay after a restart — the records are durable in the log either way, so this is write volume, not safety.

The default is now **1,000 records**: a few hundred kilobytes to replay, against two orders of magnitude fewer page writes for a bucket that is written often. That is far short of what the delay could be pushed to; it is picked to be obviously safe rather than maximal, and it is a config value, so a deployment that wants a different trade can set one.

## A note on the measurement

The first version of this measurement only *planned* the dumps. Planning never advances the dumped watermark, so the backlog never fell, and it reported 100 / 96 / 76 / 1 with a constant backlog — numbers that look like an answer and are not one. The test takes the dumps.

## Testing

Library suite: **1032 passed, 8 failed**. One name differs from the `main` comparison run — `manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted` — which has isolated 5/5 repeatedly today.

Worth noting explicitly: **no test depended on a dump happening every cycle.** That was the risk in changing this default, and the suite says it is not there.
