### PR TITLE
meta: let shard placement be listed

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -19,7 +19,7 @@ use temporalstore_rust::meta::{
     MetaSnapshot, MetaSnapshotFileRequest, MetaSnapshotFileResponse, MetaSnapshotResponse,
     ProxyHeartbeatRequest, PublishShardSnapshotRequest, RegisterProxyRequest,
     RegisterServerRequest, RegisterShardRequest, SafeModePolicy, ServerHeartbeatRequest,
-    ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason,
+    ListShardsRequest, ShardCheckOptions, ShardChecker, ShardReassignment, ShardReassignmentReason,
     DropProxyGroupRequest, NotifyStopRequest, ProxyCalibrationOptions, PutProxyGroupRequest, SingleNodeMeta, StateChangeRequest, TopologyVersionRequest, UpdateServerRequest,
     UpdateTableRequest,
 };
@@ -1540,6 +1540,13 @@ fn handle(
         }),
         ("POST", "/tables/unfreeze") => parse_or(&request.body, |req: DeleteTableRequest| {
             backend_call!(meta, unfreeze_table, req)
+        }),
+        ("GET", "/shards") => json_response(
+            200,
+            &backend_call!(meta, list_shards, ListShardsRequest::default()),
+        ),
+        ("POST", "/shards/list") => parse_or(&request.body, |req: ListShardsRequest| {
+            json_response(200, &backend_call!(meta, list_shards, req))
         }),
         ("GET", "/tables") => json_response(200, &backend_call!(meta, list_tables)),
         ("POST", "/tables/topology") | ("POST", "/table_topology") => {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -669,6 +669,51 @@ pub struct ListTablesResponse {
     pub tables: Vec<TableMetaInfo>,
 }
 
+/// Which shards to list, and how many.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListShardsRequest {
+    /// Only shards owned by this server. Empty lists every server's.
+    #[serde(default)]
+    pub server_addr: String,
+    /// Resume after this shard id, exclusive. Zero starts from the beginning.
+    #[serde(default)]
+    pub after_shard_id: ShardId,
+    /// Most shards to return. Zero means the default cap.
+    #[serde(default)]
+    pub limit: usize,
+}
+
+/// One shard's placement, as the metaserver has it recorded.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShardListEntry {
+    pub shard_id: ShardId,
+    pub server_addr: String,
+    /// The table this shard's id falls inside, when one claims it. A registered
+    /// shard whose table was dropped, or that was registered before its table
+    /// existed, belongs to nothing and reports empty here -- which is worth
+    /// seeing rather than hiding.
+    pub namespace: String,
+    pub table_name: String,
+    pub latest_snapshot: Option<ShardSnapshotRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListShardsResponse {
+    pub status: Status,
+    pub shards: Vec<ShardListEntry>,
+    /// Set only when the cap cut the page short. Pass it back as
+    /// `after_shard_id` to continue; absent means this was the last page.
+    pub next_after_shard_id: Option<ShardId>,
+}
+
+/// Default and hard cap on one page of shards.
+///
+/// Every other list endpoint returns everything, which is fine for servers,
+/// proxies and tables -- there are tens of those. Shards are the one entity
+/// there can be hundreds of thousands of, so this one paginates rather than
+/// handing back the whole placement table in a single response.
+pub const LIST_SHARDS_DEFAULT_LIMIT: usize = 1_000;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListServersResponse {
     pub status: Status,
@@ -2748,6 +2793,219 @@ mod tests {
         let meta = three_zone_shard();
         let replicas = topology_for(&meta, "east/zone-d").replicas;
         assert_eq!(&replicas[..2], &["node-a".to_string(), "node-b".to_string()]);
+    }
+
+    /// One table of four shards spread over two servers, plus one shard that no
+    /// table claims.
+    fn placed_shards() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        for (index, addr) in ["node-a", "node-b"].into_iter().enumerate() {
+            meta.register_server(RegisterServerRequest {
+                server_addr: addr.to_string(),
+                node_id: index as u64 + 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 4,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        for shard_id in 1..=4 {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: if shard_id % 2 == 1 { "node-a" } else { "node-b" }.to_string(),
+            });
+        }
+        // Registered, but inside no table's id range.
+        meta.register(RegisterShardRequest {
+            shard_id: 99,
+            server_addr: "node-a".to_string(),
+        });
+        meta
+    }
+
+    fn listed(meta: &SingleNodeMeta, request: ListShardsRequest) -> ListShardsResponse {
+        let response = meta.list_shards(request);
+        assert!(response.status.ok, "{response:?}");
+        response
+    }
+
+    #[test]
+    fn shard_placement_can_be_listed_at_all() {
+        // Servers, proxies, proxy groups, namespaces and tables were all
+        // listable. Shards -- the thing the metaserver exists to place -- could
+        // only be fetched one id at a time.
+        let meta = placed_shards();
+        let response = listed(&meta, ListShardsRequest::default());
+        assert_eq!(
+            response
+                .shards
+                .iter()
+                .map(|entry| entry.shard_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 99],
+            "shards should come back in id order"
+        );
+        assert_eq!(response.next_after_shard_id, None);
+    }
+
+    #[test]
+    fn a_listed_shard_names_the_table_that_claims_it() {
+        let meta = placed_shards();
+        let response = listed(&meta, ListShardsRequest::default());
+        let first = &response.shards[0];
+        assert_eq!(first.namespace, "ns");
+        assert_eq!(first.table_name, "orders");
+        assert_eq!(first.server_addr, "node-a");
+    }
+
+    #[test]
+    fn a_shard_no_table_claims_is_listed_rather_than_hidden() {
+        // Answering "which shards is nothing serving?" is most of the reason to
+        // want this listing, so an unclaimed shard must appear, with empty table
+        // fields rather than being dropped from the page.
+        let meta = placed_shards();
+        let response = listed(&meta, ListShardsRequest::default());
+        let orphan = response
+            .shards
+            .iter()
+            .find(|entry| entry.shard_id == 99)
+            .expect("the unclaimed shard should be listed");
+        assert_eq!(orphan.namespace, "");
+        assert_eq!(orphan.table_name, "");
+        assert_eq!(orphan.server_addr, "node-a");
+    }
+
+    #[test]
+    fn shards_can_be_listed_for_one_server() {
+        // The operational question is usually "what is on this node?".
+        let meta = placed_shards();
+        let response = listed(
+            &meta,
+            ListShardsRequest {
+                server_addr: "node-b".to_string(),
+                ..ListShardsRequest::default()
+            },
+        );
+        assert_eq!(
+            response
+                .shards
+                .iter()
+                .map(|entry| entry.shard_id)
+                .collect::<Vec<_>>(),
+            vec![2, 4]
+        );
+        assert!(response
+            .shards
+            .iter()
+            .all(|entry| entry.server_addr == "node-b"));
+    }
+
+    #[test]
+    fn a_full_page_says_where_to_resume() {
+        // A cap that truncates silently reads as "that is all of them", which is
+        // the wrong answer to give an operator counting shards.
+        let meta = placed_shards();
+        let first = listed(
+            &meta,
+            ListShardsRequest {
+                limit: 2,
+                ..ListShardsRequest::default()
+            },
+        );
+        assert_eq!(
+            first
+                .shards
+                .iter()
+                .map(|entry| entry.shard_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(first.next_after_shard_id, Some(2));
+
+        let second = listed(
+            &meta,
+            ListShardsRequest {
+                limit: 2,
+                after_shard_id: first.next_after_shard_id.unwrap(),
+                ..ListShardsRequest::default()
+            },
+        );
+        assert_eq!(
+            second
+                .shards
+                .iter()
+                .map(|entry| entry.shard_id)
+                .collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+    }
+
+    #[test]
+    fn the_last_page_does_not_offer_a_cursor() {
+        // Otherwise a caller loops forever on an empty page.
+        let meta = placed_shards();
+        let page = listed(
+            &meta,
+            ListShardsRequest {
+                limit: 2,
+                after_shard_id: 4,
+                ..ListShardsRequest::default()
+            },
+        );
+        assert_eq!(
+            page.shards
+                .iter()
+                .map(|entry| entry.shard_id)
+                .collect::<Vec<_>>(),
+            vec![99]
+        );
+        assert_eq!(page.next_after_shard_id, None);
+    }
+
+    #[test]
+    fn a_listing_cannot_be_asked_for_more_than_the_cap() {
+        // The cap is what stops one request returning the whole placement table.
+        let meta = placed_shards();
+        let response = listed(
+            &meta,
+            ListShardsRequest {
+                limit: usize::MAX,
+                ..ListShardsRequest::default()
+            },
+        );
+        assert!(response.shards.len() <= LIST_SHARDS_DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn a_listed_shard_carries_its_latest_snapshot() {
+        let meta = placed_shards();
+        let snapshot = ShardSnapshotRef {
+            uri: "s3://cluster/shards/1/manifest.json".to_string(),
+            checksum: "sha256:abc".to_string(),
+            byte_size: 2048,
+            last_log_index: 77,
+            created_at_ms: 1_000,
+        };
+        assert!(
+            meta.publish_shard_snapshot(PublishShardSnapshotRequest {
+                shard_id: 1,
+                snapshot: snapshot.clone(),
+            })
+            .status
+            .ok
+        );
+        let response = listed(&meta, ListShardsRequest::default());
+        assert_eq!(response.shards[0].latest_snapshot, Some(snapshot));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -89,6 +89,75 @@ impl SingleNodeMeta {
         }
     }
 
+    /// List shard placement, ordered by shard id and returned a page at a time.
+    ///
+    /// Servers, proxies, proxy groups, namespaces and tables could all be
+    /// listed; shards -- the thing the metaserver exists to place -- could only
+    /// be fetched one id at a time, so answering "what is on this node?" or
+    /// "which shards has nothing claimed?" meant knowing every id up front.
+    pub fn list_shards(&self, request: ListShardsRequest) -> ListShardsResponse {
+        let state = self.inner.read().expect("meta lock poisoned");
+        let limit = if request.limit == 0 {
+            LIST_SHARDS_DEFAULT_LIMIT
+        } else {
+            request.limit.min(LIST_SHARDS_DEFAULT_LIMIT)
+        };
+
+        // One pass over the tables to build shard id -> owning table, rather
+        // than asking per shard: the per-shard lookup scans every table, so
+        // doing it inside the loop would be quadratic in a large deployment.
+        let mut shard_tables = BTreeMap::new();
+        for table in state.tables.values() {
+            for offset in 0..table.info.shard_count {
+                if let Ok(shard_id) = table_shard_id(&table.info, offset) {
+                    shard_tables.insert(
+                        shard_id,
+                        (table.info.namespace.clone(), table.info.table_name.clone()),
+                    );
+                }
+            }
+        }
+
+        let mut ids = state
+            .shards
+            .keys()
+            .copied()
+            .filter(|shard_id| *shard_id > request.after_shard_id)
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+
+        let mut shards = Vec::new();
+        let mut next_after_shard_id = None;
+        for shard_id in ids {
+            let Some(location) = state.shards.get(&shard_id) else {
+                continue;
+            };
+            if !request.server_addr.is_empty() && location.server_addr != request.server_addr {
+                continue;
+            }
+            if shards.len() == limit {
+                // A full page and at least one more match: hand back where to
+                // resume rather than silently truncating.
+                next_after_shard_id = shards.last().map(|entry: &ShardListEntry| entry.shard_id);
+                break;
+            }
+            let (namespace, table_name) = shard_tables.get(&shard_id).cloned().unwrap_or_default();
+            shards.push(ShardListEntry {
+                shard_id,
+                server_addr: location.server_addr.clone(),
+                namespace,
+                table_name,
+                latest_snapshot: location.latest_snapshot.clone(),
+            });
+        }
+
+        ListShardsResponse {
+            status: Status::ok(),
+            shards,
+            next_after_shard_id,
+        }
+    }
+
     pub fn list_servers(&self) -> ListServersResponse {
         let state = self.inner.read().expect("meta lock poisoned");
         ListServersResponse {

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -24,6 +24,7 @@ use crate::http::{
 use crate::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, DeleteTableRequest, GetShardResponse,
     GetTableTopologyRequest, ListNamespacesResponse, ListProxiesResponse, ListServersResponse,
+    ListShardsResponse,
     ListTablesResponse, LoadFinishRequest, MetaEntityState, MetaInfo, MetaMutation,
     MetaPreflightReport, MetaSnapshot, MetaStats, ProxyHeartbeatRequest, ProxyHeartbeatResponse,
     PublishShardSnapshotRequest, RegisterProxyRequest, RegisterServerRequest, RegisterShardRequest,

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -361,6 +361,17 @@ impl MetaRaftCluster {
         )
     }
 
+    pub fn list_shards(&self, request: crate::meta::ListShardsRequest) -> ListShardsResponse {
+        self.read_meta().map_or_else(
+            |status| ListShardsResponse {
+                status,
+                shards: Vec::new(),
+                next_after_shard_id: None,
+            },
+            |meta| meta.list_shards(request),
+        )
+    }
+
     pub fn list_servers(&self) -> ListServersResponse {
         self.read_meta().map_or_else(
             |status| ListServersResponse {


### PR DESCRIPTION
## Shards are the one thing you cannot list

`GET /servers`, `GET /proxies`, `GET /proxy_groups`, `GET /namespaces`, `GET /tables` — every entity the metaserver tracks can be enumerated. Except shards, which are the thing it exists to place. The only way to read placement was `GET /shards/<id>`, one id at a time, which means you already had to know every id.

So none of these had an answer:

- *What is on this node?* — the question you ask before draining it.
- *Which shards is nothing serving?* — a shard can outlive the table that claimed it, and nothing surfaced that.
- *Where is this table actually served from, and does each shard have a recent snapshot?*

## What this adds

`GET /shards` for the default listing, and `POST /shards/list` taking a filter and a cursor:

```json
{ "server_addr": "node-b", "after_shard_id": 0, "limit": 500 }
```

Each entry carries the shard id, its owner, the table whose id range claims it, and the snapshot it most recently published — the same one the single-shard read already returns, so the listing is the batched form of a call that exists rather than a new shape to learn.

## Three decisions worth checking

**It paginates, and the other list endpoints do not.** That asymmetry is deliberate. There are tens of servers, proxies and tables; there can be hundreds of thousands of shards. Returning the whole placement table in one response is the kind of thing that is fine in a test and painful in a real cluster. Default and hard cap are both `LIST_SHARDS_DEFAULT_LIMIT` (1000), and a caller asking for more gets the cap rather than an error.

**A full page hands back where to resume.** `next_after_shard_id` is set *only* when the cap actually cut the page short, and is absent on the last page. A cursor that truncates silently reads as "that is all of them", which is the wrong answer to give someone counting shards; a cursor that is always present makes callers loop forever on an empty page. Both directions have a test.

**A shard no table claims is listed, not hidden.** It comes back with empty `namespace` and `table_name`. Filtering it out would have removed exactly the rows you go looking for.

The owning table is resolved with one pass over the tables to build a shard-id index, rather than the existing per-shard lookup — that lookup scans every table, so calling it inside the loop would have been quadratic in a large deployment.

## Tests

8 new: that placement can be listed at all and comes back in id order, that an entry names its table, that an unclaimed shard still appears, filtering to one server, the cursor round trip across two pages, the last page offering no cursor, the cap holding against `usize::MAX`, and the published snapshot coming through.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **277 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

The raft backend gets the same operation through `read_meta`, like its neighbouring listings, so it refuses rather than serving from a replica that has not caught up.
