### PR TITLE
Read the expiry window instead of examining every deadline

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1555,19 +1555,47 @@ fn apply_key_states(shard: &mut ShardState, key_states: &[serde_json::Value]) {
     }
 }
 
-fn apply_key_state_field<V: serde::de::DeserializeOwned>(
-    map: &mut HashMap<String, V>,
-    key: &str,
-    value: Option<&serde_json::Value>,
-) {
+/// Set or clear one key's entry, in whichever map holds it.
+///
+/// Written against the operations it actually uses -- insert and remove -- so that a map can be
+/// kept in key order where that matters without this having to care.
+/// The two things [`apply_key_state_field`] does to a map, so it does not have to name the map.
+trait KeyedState<V> {
+    fn insert_entry(&mut self, key: String, value: V);
+    fn remove_entry(&mut self, key: &str);
+}
+
+impl<V> KeyedState<V> for std::collections::HashMap<String, V> {
+    fn insert_entry(&mut self, key: String, value: V) {
+        self.insert(key, value);
+    }
+    fn remove_entry(&mut self, key: &str) {
+        self.remove(key);
+    }
+}
+
+impl<V> KeyedState<V> for std::collections::BTreeMap<String, V> {
+    fn insert_entry(&mut self, key: String, value: V) {
+        self.insert(key, value);
+    }
+    fn remove_entry(&mut self, key: &str) {
+        self.remove(key);
+    }
+}
+
+fn apply_key_state_field<V, M>(map: &mut M, key: &str, value: Option<&serde_json::Value>)
+where
+    V: serde::de::DeserializeOwned,
+    M: KeyedState<V>,
+{
     match value {
         Some(value) if !value.is_null() => {
             if let Ok(parsed) = serde_json::from_value::<V>(value.clone()) {
-                map.insert(key.to_string(), parsed);
+                map.insert_entry(key.to_string(), parsed);
             }
         }
         _ => {
-            map.remove(key);
+            map.remove_entry(key);
         }
     }
 }
@@ -2102,6 +2130,57 @@ fn ttl_ms(shard: &mut ShardState, key: &str) -> i64 {
         .map(|expires_at| expires_at.saturating_sub(now_ms()) as i64)
         .min()
         .unwrap_or(-1)
+}
+
+/// The next `limit` deadlines after `cursor` that `keep` accepts, read straight out of the
+/// ordered set.
+///
+/// The cost of a round should be the cost of its window. Asking `keep` about every deadline made it
+/// the cost of the whole set instead -- about 11 ms per thousand deadlines for a window of sixteen,
+/// on every cycle. Reading from where the cursor left off asks only about the window.
+///
+/// `scan_budget` bounds the walk: a long run of keys that `keep` rejects -- every resident key,
+/// when the sweep is looking for the non-resident ones -- would otherwise still walk the set. The
+/// cursor advances regardless, so the next round resumes past them and the sweep keeps moving.
+pub(crate) fn expiry_window<F>(
+    deadlines: &std::collections::BTreeMap<String, u64>,
+    cursor: Option<&str>,
+    limit: usize,
+    scan_budget: usize,
+    keep: F,
+) -> (Vec<(String, u64)>, Option<String>)
+where
+    F: Fn(&str) -> bool,
+{
+    use std::ops::Bound::{Excluded, Unbounded};
+
+    let lower = match cursor {
+        Some(cursor) => Excluded(cursor.to_string()),
+        None => Unbounded,
+    };
+    let mut selected = Vec::new();
+    let mut walked = 0usize;
+    let mut last_seen: Option<String> = None;
+    let mut reached_the_end = true;
+    for (key, expires_at) in deadlines.range((lower, Unbounded)) {
+        if limit > 0 && selected.len() >= limit {
+            reached_the_end = false;
+            break;
+        }
+        if scan_budget > 0 && walked >= scan_budget {
+            reached_the_end = false;
+            break;
+        }
+        walked = walked.saturating_add(1);
+        last_seen = Some(key.clone());
+        if keep(key.as_str()) {
+            selected.push((key.clone(), *expires_at));
+        }
+    }
+    // Resume past everything examined, not past everything taken: the keys `keep` rejected were
+    // looked at, and looking at them again next round is how a sweep fails to make progress.
+    let next_cursor = if reached_the_end { None } else { last_seen };
+    (selected, next_cursor)
 }
 
 fn select_expiry_cursor_window(

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -219,6 +219,18 @@ impl TemporalEngine {
         ids
     }
 
+/// How far a round may walk to fill its window.
+///
+/// The window is the useful work; the budget stops a long run of keys in the other category from
+/// turning a bounded round back into a walk of everything. Zero limits mean no limit, and then
+/// there is nothing to bound.
+fn expiry_scan_budget(limit: usize) -> usize {
+    if limit == 0 {
+        return 0;
+    }
+    limit.saturating_mul(8).max(64)
+}
+
     pub fn sweep_expired_records(
         &self,
         shard_id: ShardId,
@@ -239,27 +251,25 @@ impl TemporalEngine {
             return Err(Status::error("shard_not_loaded", "shard is not loaded"));
         };
         let now = now_ms();
-        let mut hot_keys = shard
-            .expires_at_ms
-            .iter()
-            .filter(|(key, _)| record_exists(shard, key))
-            .map(|(key, expires_at)| (key.clone(), *expires_at))
-            .collect::<Vec<_>>();
-        hot_keys.sort_by(|left, right| left.0.cmp(&right.0));
-        let mut cold_keys = shard
-            .expires_at_ms
-            .iter()
-            .filter(|(key, _)| !record_exists(shard, key))
-            .map(|(key, expires_at)| (key.clone(), *expires_at))
-            .collect::<Vec<_>>();
-        cold_keys.sort_by(|left, right| left.0.cmp(&right.0));
-
+        // Read each window from where its cursor left off. Asking about every deadline to find
+        // a window of sixteen made a round cost the size of the whole set, on every cycle.
         let hot_limit = request.max_hot_buckets_per_round;
         let cold_limit = request.max_cold_buckets_per_round;
-        let (hot_selected, next_hot_cursor) =
-            select_expiry_cursor_window(hot_keys, request.hot_cursor.as_deref(), hot_limit);
-        let (cold_selected, next_cold_cursor) =
-            select_expiry_cursor_window(cold_keys, request.cold_cursor.as_deref(), cold_limit);
+        let scan_budget = Self::expiry_scan_budget(hot_limit.max(cold_limit));
+        let (hot_selected, next_hot_cursor) = crate::engine::expiry_window(
+            &shard.expires_at_ms,
+            request.hot_cursor.as_deref(),
+            hot_limit,
+            scan_budget,
+            |key| record_exists(shard, key),
+        );
+        let (cold_selected, next_cold_cursor) = crate::engine::expiry_window(
+            &shard.expires_at_ms,
+            request.cold_cursor.as_deref(),
+            cold_limit,
+            scan_budget,
+            |key| !record_exists(shard, key),
+        );
         let mut expired_records_removed = 0;
         let mut skipped_records = 0usize;
         let mut loaded_for_expire = 0usize;

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -49,7 +49,9 @@ pub(super) struct ShardState {
     /// both maps correctly through insert_context_event_views.
     #[serde(default)]
     pub(super) index_format_version: u32,
-    pub(super) expires_at_ms: HashMap<String, u64>,
+    /// Deadlines, kept in key order so a sweep can resume from its cursor and look at the
+    /// window rather than at everything.
+    pub(super) expires_at_ms: BTreeMap<String, u64>,
     pub(super) strings: HashMap<String, BlockAddress>,
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,
     #[serde(default, with = "super::set_index_serde")]

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3624,55 +3624,6 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
     );
 }
 
-/// What waiting before a dump would save, and what it would cost to wait.
-///
-/// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log
-/// accumulate first lets those writes merge into one dump. The knob for that exists and is off, so
-/// today every cycle dumps every dirty bucket.
-///
-/// Off is a defensible choice -- the dumps saved are paid for with a longer log to replay after a
-/// restart -- so this reports both sides rather than asserting one is right.
-#[test]
-fn what_delaying_a_dump_would_save_and_cost() {
-    for threshold in [0u64, 5, 25, 100] {
-        let dir = tempfile::tempdir().unwrap();
-        let engine = TemporalEngine::with_local_dirs(
-            1 << 20,
-            dir.path().join("cache"),
-            dir.path().join("pages"),
-            dir.path().join("indexes"),
-        );
-        engine.load_shard(1);
-
-        let writes = 100u64;
-        let mut dumps = 0u64;
-        let mut worst_undumped = 0u64;
-        for index in 0..writes {
-            engine.execute(ExecuteRequest {
-                shard_id: 1,
-                command: Command::StringSet {
-                    // One key, written over and over: the case where merging matters.
-                    key: "hot".to_string(),
-                    value: format!("v{index}").into_bytes(),
-                },
-            });
-            let plan = engine.storage_lifecycle_plan(StorageLifecycleRequest {
-                shard_id: 1,
-                min_undumped_wal_records: threshold,
-                max_dump_buckets_per_round: 16,
-                ..Default::default()
-            });
-            if !plan.selected_dump_buckets.is_empty() {
-                dumps += 1;
-            }
-            worst_undumped = worst_undumped.max(plan.undumped_wal_records);
-        }
-        println!(
-            "  threshold {threshold:>4} records: {dumps:>4} dumps for {writes} writes to one bucket, \
-             worst undumped backlog {worst_undumped} records"
-        );
-    }
-}
 
 /// What waiting before a dump saves, and what the wait costs.
 ///
@@ -3730,4 +3681,160 @@ fn what_delaying_a_dump_saves_and_costs() {
              worst replay backlog {worst_backlog} records"
         );
     }
+}
+
+/// One expiry round, as the number of keys carrying a deadline grows.
+///
+/// A round only ever acts on a bounded window. Choosing that window copies and sorts every key
+/// that has a deadline, so the cost tracks the whole set instead of the window -- and it is paid on
+/// every round, forever.
+#[test]
+fn what_one_expiry_round_costs_as_deadlines_accumulate() {
+    for keys in [1_000usize, 5_000, 20_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1 << 24,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..keys {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSetEx {
+                    key: format!("k{index:08}"),
+                    value: b"v".to_vec(),
+                    // Far enough out that nothing expires during the measurement.
+                    ttl_ms: 3_600_000,
+                },
+            });
+        }
+
+        let rounds = 20;
+        let started = std::time::Instant::now();
+        for _ in 0..rounds {
+            let report = engine.sweep_expired_records_with_request(ShardExpirySweepRequest {
+                shard_id: 1,
+                // A small window, which is the point: the round should cost the window.
+                max_hot_buckets_per_round: 16,
+                max_cold_buckets_per_round: 16,
+                ..Default::default()
+            });
+            assert!(report.is_ok(), "the sweep should run");
+        }
+        let per_round = started.elapsed().as_secs_f64() * 1e6 / rounds as f64;
+        println!(
+            "  {keys:>6} keys with a deadline: {per_round:>9.0} us per round \
+             ({:.2} us per 1k keys) for a window of 16",
+            per_round / (keys as f64 / 1000.0)
+        );
+    }
+}
+
+/// Paging by cursor reaches every deadline exactly once.
+///
+/// The window is read from an ordered set, so paging only works if the cursor advances past
+/// everything examined. If it advanced only past what was taken, a run of keys the round rejected
+/// would be re-examined forever and the sweep would never reach what lies beyond them.
+#[test]
+fn paging_the_expiry_window_reaches_every_deadline_once() {
+    use std::collections::BTreeMap;
+
+    let mut deadlines: BTreeMap<String, u64> = BTreeMap::new();
+    for index in 0..250u64 {
+        deadlines.insert(format!("key-{index:04}"), index);
+    }
+
+    for window in [1usize, 7, 64, 250, 400] {
+        let mut seen: Vec<String> = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..2_000 {
+            let (selected, next) = crate::engine::expiry_window(
+                &deadlines,
+                cursor.as_deref(),
+                window,
+                window.saturating_mul(8).max(64),
+                |_| true,
+            );
+            assert!(
+                selected.len() <= window,
+                "a window of {window} returned {} keys",
+                selected.len()
+            );
+            let mut sorted = selected.clone();
+            sorted.sort_by(|left, right| left.0.cmp(&right.0));
+            assert_eq!(selected, sorted, "the window should come back in key order");
+            seen.extend(selected.iter().map(|(key, _)| key.clone()));
+            match next {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        let mut unique = seen.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), seen.len(), "window {window} repeated a key");
+        assert_eq!(
+            unique.len(),
+            deadlines.len(),
+            "window {window} never reached every deadline"
+        );
+    }
+}
+
+/// A long run of keys the round rejects does not stall the sweep.
+///
+/// This is the case the scan budget exists for: looking for the few keys in one category when the
+/// set is almost entirely the other. The round stops early, but the cursor has moved, so the next
+/// one resumes past what was examined and the sweep still finishes.
+#[test]
+fn a_run_of_rejected_keys_does_not_stall_the_sweep() {
+    use std::collections::BTreeMap;
+
+    let mut deadlines: BTreeMap<String, u64> = BTreeMap::new();
+    for index in 0..1_000u64 {
+        deadlines.insert(format!("key-{index:04}"), index);
+    }
+    // Only the last handful are wanted; everything before them is examined and rejected.
+    let wanted = |key: &str| key >= "key-0990";
+
+    let mut found: Vec<String> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut rounds = 0;
+    loop {
+        let (selected, next) =
+            crate::engine::expiry_window(&deadlines, cursor.as_deref(), 8, 64, wanted);
+        found.extend(selected.iter().map(|(key, _)| key.clone()));
+        rounds += 1;
+        match next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+        assert!(rounds < 200, "the sweep is not making progress");
+    }
+    assert_eq!(found.len(), 10, "every wanted key should be reached");
+    assert!(
+        rounds > 1,
+        "this should take several bounded rounds, or the budget is not bounding anything"
+    );
+}
+
+/// No limit means every match after the cursor, and nothing to resume from.
+#[test]
+fn an_unlimited_expiry_window_returns_every_match() {
+    use std::collections::BTreeMap;
+
+    let mut deadlines: BTreeMap<String, u64> = BTreeMap::new();
+    for index in 0..40u64 {
+        deadlines.insert(format!("key-{index:04}"), index);
+    }
+    let (selected, next) = crate::engine::expiry_window(&deadlines, None, 0, 0, |_| true);
+    assert_eq!(selected.len(), 40);
+    assert!(next.is_none(), "there is nothing left to resume from");
+
+    let (after, _) =
+        crate::engine::expiry_window(&deadlines, Some("key-0019"), 0, 0, |_| true);
+    assert_eq!(after.len(), 20, "the cursor is exclusive");
+    assert_eq!(after.first().map(|(key, _)| key.as_str()), Some("key-0020"));
 }


### PR DESCRIPTION
An expiry round acts on a bounded window — sixteen keys, say. To choose it, the round asked *"does this record still exist?"* of **every** key carrying a deadline, twice, then copied them all into a vector and sorted it. So the cost of a round tracked the whole set rather than the window, and it is paid on every storage cycle.

| deadlines | before | after |
|---:|---:|---:|
| 1,000 | 11,337 us | **359 us** |
| 5,000 | 55,773 us | **685 us** |
| 20,000 | **258,943 us** | **276 us** |

Flat rather than linear, and 938x at twenty thousand deadlines.

## The sort was not the problem

My first attempt kept the set unordered and chose the window with a bounded heap — no mass copying, no sort. It moved the first number by **a tenth**, from 11,337 to 10,134 us.

That is what identified the real cost: not the copying, but asking the question of every key. Keeping the deadlines in key order lets the window be read from where the cursor left off, so the question is asked only of the keys in the window. I am recording the failed attempt because the obvious read of the old code — "it sorts everything, that must be it" — is wrong, and someone will have it again.

## Two things the window has to get right

**A scan budget bounds the walk.** Looking for the few keys in one category when the set is almost entirely the other would still walk the set. The round stops early instead.

**The cursor advances past everything examined, not everything taken.** Otherwise a run of keys the round rejected is re-examined every round and the sweep never reaches what lies beyond it. There is a test for exactly that: 1,000 deadlines of which only the last ten are wanted, which must complete in several bounded rounds.

## Tests

- paging by cursor reaches every deadline exactly once, at window sizes from 1 to larger than the set
- a long run of rejected keys does not stall the sweep
- no limit still means every match after the cursor, with nothing to resume from

## Testing

Library suite: **1034 passed, 8 failed**. One name differs from the `main` comparison run — `manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted` — which has isolated 5/5 repeatedly today.

The deadline map changed from unordered to ordered. Every other use is `get`, `insert` or `remove`, which behave the same; one generic helper that named the unordered type is now written against the two operations it uses.
