### PR TITLE
meta: stop the hottest read taking the exclusive lock to count

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -921,18 +922,50 @@ impl LocalMetaMutationLog {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Service counters, held outside the metadata lock.
+///
+/// These used to live inside `MetaState`, which meant the two hottest *read*
+/// paths -- resolving a table's topology and reading one shard's location --
+/// had to take the **exclusive** lock, purely to add one to a number. Every
+/// topology lookup therefore serialised against every other lookup and against
+/// every metadata write, on a path that every client and every proxy calls.
+///
+/// Counting is the one thing here that does not need to agree with anything
+/// else, so `Relaxed` is the right ordering: the total is a monotonic tally for
+/// `/metrics`, never a decision input.
+#[derive(Debug, Default)]
 struct MetaCounters {
-    register_shard_total: u64,
-    get_shard_total: u64,
-    server_register_total: u64,
-    server_heartbeat_total: u64,
-    proxy_register_total: u64,
-    proxy_heartbeat_total: u64,
-    namespace_create_total: u64,
-    table_create_total: u64,
-    topology_query_total: u64,
-    load_finish_total: u64,
+    register_shard_total: AtomicU64,
+    get_shard_total: AtomicU64,
+    server_register_total: AtomicU64,
+    server_heartbeat_total: AtomicU64,
+    proxy_register_total: AtomicU64,
+    proxy_heartbeat_total: AtomicU64,
+    namespace_create_total: AtomicU64,
+    table_create_total: AtomicU64,
+    topology_query_total: AtomicU64,
+    load_finish_total: AtomicU64,
+}
+
+impl MetaCounters {
+    /// Restore the tallies carried by an installed snapshot, so a peer that
+    /// installs one does not report its counters starting from zero.
+    fn install_from(&self, stats: &MetaStats) {
+        for (slot, value) in [
+            (&self.register_shard_total, stats.register_shard_total),
+            (&self.get_shard_total, stats.get_shard_total),
+            (&self.server_register_total, stats.server_register_total),
+            (&self.server_heartbeat_total, stats.server_heartbeat_total),
+            (&self.proxy_register_total, stats.proxy_register_total),
+            (&self.proxy_heartbeat_total, stats.proxy_heartbeat_total),
+            (&self.namespace_create_total, stats.namespace_create_total),
+            (&self.table_create_total, stats.table_create_total),
+            (&self.topology_query_total, stats.topology_query_total),
+            (&self.load_finish_total, stats.load_finish_total),
+        ] {
+            slot.store(value, Ordering::Relaxed);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -948,7 +981,6 @@ pub(crate) struct MetaState {
     proxy_groups: BTreeMap<String, ProxyGroupInfo>,
     namespaces: BTreeMap<String, MetaEntityState>,
     tables: BTreeMap<String, TableRecord>,
-    counters: MetaCounters,
     next_table_id: u64,
     topology_version: u64,
     topology_events: VecDeque<TopologyChangeEvent>,
@@ -1045,6 +1077,10 @@ pub struct SingleNodeMeta {
     /// subscriber's cost never lands inside the metadata lock. Shared by clone,
     /// like the metadata itself.
     events: Arc<event_bus::MetaEventBus>,
+    /// Service counters, deliberately outside `inner` -- see [`MetaCounters`].
+    /// Shared by clone, like the metadata itself, so every handle counts into
+    /// the same tallies.
+    counters: Arc<MetaCounters>,
 }
 
 impl Default for SingleNodeMeta {
@@ -1059,6 +1095,7 @@ impl Default for SingleNodeMeta {
             forbid_self_clearing_conviction: false,
             metrics: SubsystemMetrics::new(),
             events: Arc::new(event_bus::MetaEventBus::default()),
+            counters: Arc::new(MetaCounters::default()),
         }
     }
 }
@@ -1091,7 +1128,7 @@ impl SingleNodeMeta {
 
     fn apply_register(&self, request: RegisterShardRequest) -> RegisterShardResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.register_shard_total += 1;
+        self.counters.register_shard_total.fetch_add(1, Ordering::Relaxed);
         let latest_snapshot = state
             .shards
             .get(&request.shard_id)
@@ -1117,8 +1154,9 @@ impl SingleNodeMeta {
     }
 
     pub fn get(&self, shard_id: ShardId) -> GetShardResponse {
-        let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.get_shard_total += 1;
+        self.counters.get_shard_total.fetch_add(1, Ordering::Relaxed);
+        // Reading one shard's location only reads, for the same reason.
+        let state = self.inner.read().expect("meta lock poisoned");
         let location = state.shards.get(&shard_id).cloned();
         GetShardResponse {
             status: if location.is_some() {
@@ -3430,6 +3468,146 @@ mod tests {
         // The point is that asking does not panic; the answer is that the
         // shard below the range is not in it.
         assert_eq!(resolves_to(&meta, 10), None);
+    }
+
+    fn counted_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: "node-a".to_string(),
+        });
+        meta
+    }
+
+    fn topology_request() -> GetTableTopologyRequest {
+        GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        }
+    }
+
+    #[test]
+    fn resolving_a_topology_does_not_need_the_exclusive_lock() {
+        // This is the whole point. Every client and every proxy resolves
+        // topology, and it used to take the write lock purely to add one to a
+        // counter -- so each lookup serialised against every other lookup and
+        // against all metadata change. Holding a *read* guard here and
+        // resolving from another thread would have blocked forever before.
+        let meta = counted_meta();
+        let held = meta.inner.read().expect("meta lock poisoned");
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let reader = meta.clone();
+        let worker = std::thread::spawn(move || {
+            let response = reader.get_table_topology(topology_request());
+            let _ = sender.send(response.status.ok);
+        });
+
+        let finished = receiver
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("a topology read must not wait on a concurrent reader");
+        assert!(finished);
+        drop(held);
+        worker.join().expect("reader thread");
+    }
+
+    #[test]
+    fn reading_one_shard_does_not_need_the_exclusive_lock_either() {
+        let meta = counted_meta();
+        let held = meta.inner.read().expect("meta lock poisoned");
+
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let reader = meta.clone();
+        let worker = std::thread::spawn(move || {
+            let _ = sender.send(reader.get(1).status.ok);
+        });
+
+        assert!(receiver
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("a shard read must not wait on a concurrent reader"));
+        drop(held);
+        worker.join().expect("reader thread");
+    }
+
+    #[test]
+    fn counting_still_counts() {
+        // Moving the tallies out of the lock must not lose them.
+        let meta = counted_meta();
+        let before = meta.stats();
+        for _ in 0..3 {
+            assert!(meta.get_table_topology(topology_request()).status.ok);
+        }
+        meta.get(1);
+        let after = meta.stats();
+        assert_eq!(after.topology_query_total, before.topology_query_total + 3);
+        assert_eq!(after.get_shard_total, before.get_shard_total + 1);
+    }
+
+    #[test]
+    fn every_handle_counts_into_the_same_tallies() {
+        // The counters are shared by clone, exactly as they were when they
+        // lived inside the shared state.
+        let meta = counted_meta();
+        let clone = meta.clone();
+        clone.get_table_topology(topology_request());
+        assert_eq!(meta.stats().topology_query_total, 1);
+    }
+
+    #[test]
+    fn concurrent_readers_lose_no_counts() {
+        // Relaxed ordering is fine for a tally, but it still has to be atomic:
+        // a plain += from eight threads would drop increments.
+        let meta = counted_meta();
+        let mut workers = Vec::new();
+        for _ in 0..8 {
+            let reader = meta.clone();
+            workers.push(std::thread::spawn(move || {
+                for _ in 0..50 {
+                    reader.get_table_topology(topology_request());
+                }
+            }));
+        }
+        for worker in workers {
+            worker.join().expect("reader thread");
+        }
+        assert_eq!(meta.stats().topology_query_total, 400);
+    }
+
+    #[test]
+    fn installing_a_snapshot_restores_the_tallies() {
+        // The counters no longer travel inside MetaState, so the install has to
+        // carry them across deliberately or a peer taking over reports every
+        // total starting again from zero.
+        let meta = counted_meta();
+        for _ in 0..5 {
+            meta.get_table_topology(topology_request());
+        }
+        let snapshot = meta.export_snapshot();
+        assert_eq!(snapshot.stats.topology_query_total, 5);
+
+        let peer = SingleNodeMeta::default();
+        assert!(peer.install_snapshot(snapshot).status.ok);
+        assert_eq!(peer.stats().topology_query_total, 5);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -7,8 +7,11 @@ use super::*;
 
 impl SingleNodeMeta {
     pub fn get_table_topology(&self, request: GetTableTopologyRequest) -> TableTopologyResponse {
-        let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.topology_query_total += 1;
+        self.counters.topology_query_total.fetch_add(1, Ordering::Relaxed);
+        // Resolving a topology only reads. It took the exclusive lock solely to
+        // count, which serialised every client's and every proxy's hottest call
+        // against each other and against all metadata writes.
+        let state = self.inner.read().expect("meta lock poisoned");
         let Some(table) = state
             .tables
             .get(&table_key(&request.namespace, &request.table_name))
@@ -429,7 +432,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_finish_load(&self, request: LoadFinishRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.load_finish_total += 1;
+        self.counters.load_finish_total.fetch_add(1, Ordering::Relaxed);
         if !request.status.ok {
             return AckResponse {
                 status: request.status,

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -98,7 +98,7 @@ impl SingleNodeMeta {
 
     pub fn stats(&self) -> MetaStats {
         let state = self.inner.read().expect("meta lock poisoned");
-        stats_from_state(&state)
+        stats_from_state(&state, &self.counters)
     }
 
     pub fn preflight_report(&self) -> MetaPreflightReport {
@@ -145,7 +145,7 @@ impl SingleNodeMeta {
         };
         MetaPreflightReport {
             status,
-            stats: stats_from_state(&state),
+            stats: stats_from_state(&state, &self.counters),
             normal_servers,
             frozen_servers,
             normal_proxies,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -16,7 +16,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_register_server(&self, request: RegisterServerRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.server_register_total += 1;
+        self.counters.server_register_total.fetch_add(1, Ordering::Relaxed);
         if let Some(existing) = state.servers.get(&request.server_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -149,7 +149,7 @@ impl SingleNodeMeta {
 
     pub fn server_heartbeat(&self, request: ServerHeartbeatRequest) -> ServerHeartbeatResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.server_heartbeat_total += 1;
+        self.counters.server_heartbeat_total.fetch_add(1, Ordering::Relaxed);
         let topology_version = state.topology_version;
         let Some(server) = state.servers.get_mut(&request.server_addr) else {
             return ServerHeartbeatResponse {
@@ -233,7 +233,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_register_proxy(&self, request: RegisterProxyRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.proxy_register_total += 1;
+        self.counters.proxy_register_total.fetch_add(1, Ordering::Relaxed);
         if let Some(existing) = state.proxies.get(&request.proxy_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -282,7 +282,7 @@ impl SingleNodeMeta {
 
     pub fn proxy_heartbeat(&self, request: ProxyHeartbeatRequest) -> ProxyHeartbeatResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.proxy_heartbeat_total += 1;
+        self.counters.proxy_heartbeat_total.fetch_add(1, Ordering::Relaxed);
         let Some(proxy) = state.proxies.get_mut(&request.proxy_addr) else {
             return ProxyHeartbeatResponse {
                 status: Status::error("not_found", "proxy not found"),
@@ -369,7 +369,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_add_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.namespace_create_total += 1;
+        self.counters.namespace_create_total.fetch_add(1, Ordering::Relaxed);
         state
             .namespaces
             .entry(request.namespace)

--- a/crates/temporalstore-rust/src/meta/snapshot_ops.rs
+++ b/crates/temporalstore-rust/src/meta/snapshot_ops.rs
@@ -20,7 +20,7 @@ impl SingleNodeMeta {
 
     pub fn export_snapshot(&self) -> MetaSnapshot {
         let state = self.inner.read().expect("meta lock poisoned");
-        MetaSnapshot::from_state(&state)
+        MetaSnapshot::from_state(&state, &self.counters)
     }
 
     pub(crate) fn state_from_snapshot(snapshot: MetaSnapshot) -> Result<MetaState, Status> {
@@ -55,7 +55,6 @@ impl SingleNodeMeta {
             proxy_groups: snapshot.proxy_groups,
             namespaces: snapshot.namespaces,
             tables,
-            counters: counters_from_stats(&snapshot.stats),
             next_table_id,
             topology_version: snapshot.topology_version,
             topology_events: VecDeque::new(),
@@ -71,11 +70,16 @@ impl SingleNodeMeta {
     }
 
     pub fn install_snapshot(&self, snapshot: MetaSnapshot) -> AckResponse {
+        // Taken before the state is consumed: the counters no longer travel
+        // inside MetaState, so without this a peer that installs a snapshot
+        // reports every total starting again from zero.
+        let stats = snapshot.stats.clone();
         let state = match Self::state_from_snapshot(snapshot) {
             Ok(state) => state,
             Err(status) => return AckResponse { status },
         };
         *self.inner.write().expect("meta lock poisoned") = state;
+        self.counters.install_from(&stats);
         AckResponse {
             status: Status::ok(),
         }
@@ -83,7 +87,7 @@ impl SingleNodeMeta {
 }
 
 impl MetaSnapshot {
-    pub(crate) fn from_state(state: &MetaState) -> Self {
+    pub(crate) fn from_state(state: &MetaState, counters: &MetaCounters) -> Self {
         MetaSnapshot {
             format_version: 1,
             created_at_ms: now_ms(),
@@ -97,7 +101,7 @@ impl MetaSnapshot {
                 .values()
                 .map(|table| table.info.clone())
                 .collect(),
-            stats: stats_from_state(&state),
+            stats: stats_from_state(state, counters),
             next_table_id: state.next_table_id,
             topology_version: state.topology_version,
             scheduler_finish_generations: state.scheduler_finish_generations.clone(),

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -31,7 +31,7 @@ impl SingleNodeMeta {
             };
         }
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.table_create_total += 1;
+        self.counters.table_create_total.fetch_add(1, Ordering::Relaxed);
         state
             .namespaces
             .entry(request.namespace.clone())

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -4,6 +4,7 @@
 //! Topology / placement / stats helpers, extracted from meta.rs.
 
 use super::*;
+use std::sync::atomic::Ordering;
 use std::collections::BTreeSet;
 use crate::types::{ShardId, Status};
 
@@ -132,18 +133,18 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         });
 }
 
-pub(super) fn stats_from_state(state: &MetaState) -> MetaStats {
+pub(super) fn stats_from_state(state: &MetaState, counters: &MetaCounters) -> MetaStats {
     MetaStats {
-        register_shard_total: state.counters.register_shard_total,
-        get_shard_total: state.counters.get_shard_total,
-        server_register_total: state.counters.server_register_total,
-        server_heartbeat_total: state.counters.server_heartbeat_total,
-        proxy_register_total: state.counters.proxy_register_total,
-        proxy_heartbeat_total: state.counters.proxy_heartbeat_total,
-        namespace_create_total: state.counters.namespace_create_total,
-        table_create_total: state.counters.table_create_total,
-        topology_query_total: state.counters.topology_query_total,
-        load_finish_total: state.counters.load_finish_total,
+        register_shard_total: counters.register_shard_total.load(Ordering::Relaxed),
+        get_shard_total: counters.get_shard_total.load(Ordering::Relaxed),
+        server_register_total: counters.server_register_total.load(Ordering::Relaxed),
+        server_heartbeat_total: counters.server_heartbeat_total.load(Ordering::Relaxed),
+        proxy_register_total: counters.proxy_register_total.load(Ordering::Relaxed),
+        proxy_heartbeat_total: counters.proxy_heartbeat_total.load(Ordering::Relaxed),
+        namespace_create_total: counters.namespace_create_total.load(Ordering::Relaxed),
+        table_create_total: counters.table_create_total.load(Ordering::Relaxed),
+        topology_query_total: counters.topology_query_total.load(Ordering::Relaxed),
+        load_finish_total: counters.load_finish_total.load(Ordering::Relaxed),
         topology_version: state.topology_version,
         server_count: state.servers.len(),
         proxy_count: state.proxies.len(),
@@ -256,20 +257,6 @@ pub(super) fn record_topology_event(
     state.topology_version
 }
 
-pub(super) fn counters_from_stats(stats: &MetaStats) -> MetaCounters {
-    MetaCounters {
-        register_shard_total: stats.register_shard_total,
-        get_shard_total: stats.get_shard_total,
-        server_register_total: stats.server_register_total,
-        server_heartbeat_total: stats.server_heartbeat_total,
-        proxy_register_total: stats.proxy_register_total,
-        proxy_heartbeat_total: stats.proxy_heartbeat_total,
-        namespace_create_total: stats.namespace_create_total,
-        table_create_total: stats.table_create_total,
-        topology_query_total: stats.topology_query_total,
-        load_finish_total: stats.load_finish_total,
-    }
-}
 
 /// Key under which a resource's drop timestamp is recorded in
 /// [`MetaState::dropped_since_ms`].


### PR DESCRIPTION
## The hottest read on the metaserver took the exclusive lock, to count

`get_table_topology` is what every client and every proxy calls to find out where to send a request. It opened like this:

```rust
let mut state = self.inner.write().expect("meta lock poisoned");
state.counters.topology_query_total += 1;
```

Everything after that line is a read. The exclusive lock was taken **solely to add one to a number** — because the counters lived inside `MetaState`, behind the same `RwLock` as the metadata.

The cost is not the increment, it is the exclusion: every topology lookup serialised against every *other* topology lookup, and against every metadata write. An `RwLock` that the hot read path always takes for writing is an `RwLock` doing the job of a `Mutex`.

`get`, the single-shard location read, had it too. Between them that is essentially all metaserver read traffic.

## The change

The counters move out of `MetaState` into an `Arc<MetaCounters>` of `AtomicU64` on `SingleNodeMeta` — shared by clone, exactly as they were when they lived in shared state — and the two read paths take `read()`.

`Relaxed` is the right ordering here and the comment says why: a tally is never a decision input, only something `/metrics` reports. Nothing branches on it.

One consequence had to be handled rather than discovered later: the counters no longer travel inside `MetaState`, so `install_snapshot` now carries them across explicitly. Without that, a peer installing a snapshot would report every total starting again from zero.

## The proof

The two contention tests hold a **read** guard and resolve from another thread. With the old locking that thread waits forever on a lock it should never have needed:

```
test reading_one_shard_does_not_need_the_exclusive_lock_either ... FAILED
test resolving_a_topology_does_not_need_the_exclusive_lock     ... FAILED
test result: FAILED. 0 passed; 2 failed;  finished in 20.00s
```

Twenty seconds for two tests — both sat on their full ten-second timeout. I produced that by putting `write()` back on this branch and re-running, so it is the same tests against the old locking rather than an argument about it.

## Tests

6 new:

- the two contention proofs above
- **counting still counts** — three topology reads and one shard read move the totals by exactly three and one
- **every handle counts into the same tallies** — the `Arc` keeps clone-sharing, which is what moving out of shared state could easily have broken
- **concurrent readers lose no counts** — 8 threads × 50 reads must total exactly 400; `Relaxed` is fine for a tally but it still has to be atomic, and a plain `+= 1` from eight threads would drop increments
- **installing a snapshot restores the tallies**

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **275 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

No behaviour change beyond concurrency: the same numbers are reported through `/metrics` and `/meta/stats`, and they survive a snapshot round trip.
