### PR TITLE
Show where a record's bytes actually are before changing its format

### DIFF
--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -401,4 +401,49 @@ mod tests {
             }
         }
     }
+
+    /// Where a record's bytes are now, and what carrying the value raw would leave.
+    ///
+    /// A JSON document cannot hold bytes, so the value is base64 -- a flat third on top, whatever
+    /// it is. At four kilobytes that dwarfs everything else in the record, which is why the shape
+    /// of the remaining saving is not "the format" but "the payload".
+    #[test]
+    fn where_a_records_bytes_are_now() {
+        use crate::types::Command;
+        use crate::wal::{WriteAheadLogRecord, WriteAheadLogRecordMetadata};
+
+        for value_len in [64usize, 256, 1024, 4096, 16384] {
+            let record = WriteAheadLogRecord {
+                shard_id: 1,
+                sequence: 1,
+                command: Command::StringSet {
+                    key: "scale-key-000000000".to_string(),
+                    value: vec![118u8; value_len],
+                },
+                metadata: Some(WriteAheadLogRecordMetadata {
+                    version: crate::wal::WRITE_AHEAD_LOG_FORMAT_VERSION,
+                    timestamp_ms: 1_787_270_070_192,
+                    items: Vec::new(),
+                    batch_id: None,
+                    batch_size: None,
+                    batch_index: None,
+                }),
+                staged_pages: Vec::new(),
+            };
+            let framed = crate::log_framing::encode_line(&serde_json::to_vec(&record).unwrap());
+            // base64 of n bytes is 4 characters per 3, rounded up to a multiple of 4.
+            let encoded_value = value_len.div_ceil(3) * 4;
+            let envelope = framed.len() - encoded_value;
+            let if_raw = envelope + value_len;
+            println!(
+                "  value {value_len:>6}B: record {:>7}B = envelope {:>4}B + payload {:>7}B ({:.2}x) \
+                 -> carrying it raw would be {if_raw:>7}B ({:.2}x)",
+                framed.len(),
+                envelope,
+                encoded_value,
+                framed.len() as f64 / value_len as f64,
+                if_raw as f64 / value_len as f64
+            );
+        }
+    }
 }


### PR DESCRIPTION
Answering "the log does not have to be JSON — how much more is there?" before building anything.

The remaining saving is **not spread across the record**. The envelope — shard, sequence, field names, framing, metadata — is a **constant 122 bytes at every size**. Everything else is the value, encoded as base64 because a JSON document cannot hold bytes, which costs a flat third.

| value | record | envelope | payload | today | if the value were carried raw |
|---:|---:|---:|---:|---|---|
| 64 B | 210 B | 122 | 88 | 3.28x | 186 B (2.91x) |
| 256 B | 466 B | 122 | 344 | 1.82x | 378 B (1.48x) |
| 1 KiB | 1,491 B | 123 | 1,368 | 1.46x | **1,147 B (1.12x)** |
| 4 KiB | 5,587 B | 123 | 5,464 | 1.36x | **4,219 B (1.03x)** |
| 16 KiB | 21,972 B | 124 | 21,848 | 1.34x | **16,508 B (1.01x)** |

## What this changes about the plan

The binary record measured 1,094 B at a kilobyte and 4,166 at four. Carrying the value raw gets 1,147 and 4,219. **From a kilobyte up, that is the entire difference** — and it does not require adopting a record that describes a *mutation* rather than a command, which is what would change the meaning of replay.

Below a kilobyte the constant envelope starts to dominate and the binary record keeps a real advantage: 131 B against 186 at 64 bytes. That is the honest case for it, and it is a much smaller case than the numbers used to suggest.

## What carrying the value raw would need

One prerequisite, and it is the same one for any binary content: **every reader currently splits the log on newlines**, and raw bytes contain newlines. The frame already carries an explicit length, so a length-aware reader is a contained change — and it is worth doing on its own merits regardless of what the payload ends up being.

## Testing

Test-only; it measures, it does not change the format.
