### PR TITLE
Proxy: publish the one counter that never reached /metrics, and stop it happening again

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -2498,6 +2498,74 @@ mod tests {
     }
 
     #[test]
+    fn every_proxy_counter_is_exposed_on_the_metrics_endpoint() {
+        // A counter nobody can read is a counter nobody acts on. topology_checks_skipped was
+        // added and never exposed, so the round-trips it was counting stayed invisible.
+        //
+        // The destructuring below has NO `..` rest pattern on purpose: adding a field to
+        // ProxyStats stops this test compiling until whoever added it says where it surfaces.
+        // That is the only guard that survives someone forgetting -- a hand-kept list of
+        // metric names would drift exactly the way this one already did.
+        let ProxyStats {
+            execute_requests,
+            batch_execute_requests,
+            bad_requests,
+            context_ingest_requests,
+            context_extract_requests,
+            context_retrieve_requests,
+            admission_rejections,
+            account_rejections,
+            inflight_rejections,
+            heartbeat_total,
+            heartbeat_slow_total,
+            auto_register_total,
+            route_cache_hits,
+            route_cache_misses,
+            route_refreshes,
+            topology_checks_skipped,
+            backend_errors,
+            continuous_backend_failures,
+            metaserver_errors,
+        } = ProxyStats::default();
+
+        // Field -> the label it is published under. Values are only here so the destructured
+        // bindings are used; what is asserted is that each label reaches the endpoint.
+        let published: [(&str, u64); 19] = [
+            ("kind=\"execute\"", execute_requests),
+            ("kind=\"batch_execute\"", batch_execute_requests),
+            ("kind=\"bad_request\"", bad_requests),
+            ("kind=\"context_ingest\"", context_ingest_requests),
+            ("kind=\"context_extract\"", context_extract_requests),
+            ("kind=\"context_retrieve\"", context_retrieve_requests),
+            ("kind=\"admission_rejection\"", admission_rejections),
+            ("kind=\"account_rejection\"", account_rejections),
+            ("kind=\"inflight_rejection\"", inflight_rejections),
+            ("kind=\"heartbeat\"", heartbeat_total),
+            ("kind=\"heartbeat_slow\"", heartbeat_slow_total),
+            ("kind=\"auto_register\"", auto_register_total),
+            ("kind=\"hit\"", route_cache_hits),
+            ("kind=\"miss\"", route_cache_misses),
+            ("kind=\"refresh\"", route_refreshes),
+            ("kind=\"topology_check_skipped\"", topology_checks_skipped),
+            ("kind=\"backend_error\"", backend_errors),
+            ("kind=\"continuous_backend_failure\"", continuous_backend_failures),
+            ("kind=\"metaserver_error\"", metaserver_errors),
+        ];
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let metrics = proxy.prometheus_metrics();
+        let missing: Vec<&str> = published
+            .iter()
+            .map(|(label, _)| *label)
+            .filter(|label| !metrics.contains(label))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these counters never reach /metrics: {missing:?}"
+        );
+    }
+
+    #[test]
     fn a_partial_config_push_keeps_every_field_it_does_not_mention() {
         let proxy = scoped_proxy(ProxyOptions {
             serving_mode: ProxyServingMode::NotServing,

--- a/crates/temporalstore-rust/src/proxy/prometheus.rs
+++ b/crates/temporalstore-rust/src/proxy/prometheus.rs
@@ -52,6 +52,10 @@ impl ProxyService {
             ("hit", stats.route_cache_hits),
             ("miss", stats.route_cache_misses),
             ("refresh", stats.route_refreshes),
+            // Metaserver topology checks skipped because one was made within the interval.
+            // This is the count of round-trips kept off the request path, so it belongs
+            // where the rest of the route-cache maintenance is reported.
+            ("topology_check_skipped", stats.topology_checks_skipped),
         ] {
             push_proxy_metric(
                 &mut out,


### PR DESCRIPTION
topology_checks_skipped counts the metaserver round-trips kept off the request path
by the topology check interval. It was incremented and never published, so the thing
it exists to demonstrate was invisible to anyone running the proxy. Eighteen of the
nineteen proxy counters were on /metrics. That one was not.

It is now published as
temporalstore_proxy_route_cache_events_total{kind="topology_check_skipped"},
alongside hit / miss / refresh, which is where the rest of the route-cache
maintenance is already reported.

The more useful half of this change is the test, which makes the omission
structurally impossible rather than merely fixed once:

- It destructures ProxyStats with NO `..` rest pattern. Adding a counter stops the
  test COMPILING, with "pattern does not mention field <name>", until whoever added
  it says where it surfaces.
- It then asserts each field's label actually appears in the rendered endpoint, so
  answering that question with a label that is never emitted fails too.

Both halves are checked rather than asserted. Delete the new metric line and the test
names it: "these counters never reach /metrics: [kind=\"topology_check_skipped\"]".
Add a field to ProxyStats and the test stops compiling with E0027.

A hand-kept list of metric names would have drifted the same way the counter did --
which is exactly how this one got missed, since I added the counter and did not come
back here.