### PR TITLE
Carry a record's payloads as bytes, beside the document

### DIFF
--- a/crates/temporalstore-rust/src/bytes_serde.rs
+++ b/crates/temporalstore-rust/src/bytes_serde.rs
@@ -56,6 +56,89 @@ pub fn set_array_shape_for_measurement(array_shape: bool) {
     SHAPE.with(|shape| shape.set(if array_shape { 2 } else { 1 }));
 }
 
+thread_local! {
+    /// Payloads pulled out of the document being written, in the order they were met.
+    ///
+    /// Only the log sets this, and only while it is encoding one record. Everywhere else -- a
+    /// request on the wire, a response to a client -- the payload stays in the document, so nothing
+    /// outside the log sees a different shape.
+    static CARRIED: std::cell::RefCell<Option<Vec<Vec<u8>>>> = const { std::cell::RefCell::new(None) };
+    /// Payloads read out of a record, for the document to refer back to.
+    static AVAILABLE: std::cell::RefCell<Option<Vec<Vec<u8>>>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Marks a payload that lives beside the document. Base64 never produces a leading `~`, so a
+/// marker can never be mistaken for an encoded payload, in either direction.
+const CARRIED_PREFIX: char = '~';
+
+/// Collect the payloads of whatever `write` serializes, instead of encoding them into the document.
+///
+/// Returns them in the order they were met, which is the order a reader meets the markers.
+pub(crate) fn carrying_payloads<T>(write: impl FnOnce() -> T) -> (T, Vec<Vec<u8>>) {
+    CARRIED.with(|carried| *carried.borrow_mut() = Some(Vec::new()));
+    let outcome = write();
+    let payloads = CARRIED
+        .with(|carried| carried.borrow_mut().take())
+        .unwrap_or_default();
+    (outcome, payloads)
+}
+
+/// Resolve payload markers while `read` deserializes.
+pub(crate) fn with_payloads<T>(payloads: Vec<Vec<u8>>, read: impl FnOnce() -> T) -> T {
+    AVAILABLE.with(|available| *available.borrow_mut() = Some(payloads));
+    let outcome = read();
+    AVAILABLE.with(|available| *available.borrow_mut() = None);
+    outcome
+}
+
+/// What escaping this payload would cost, so the cheaper of the two can be chosen on the bytes
+/// rather than on a guess. Newline and the escape byte each become two.
+fn escaped_len(bytes: &[u8]) -> usize {
+    bytes
+        .iter()
+        .map(|byte| usize::from(*byte == b'\n' || *byte == ESCAPE) + 1)
+        .sum()
+}
+
+pub(crate) const ESCAPE: u8 = 0x1b;
+
+/// Remove newlines from a payload so it can sit in a newline-delimited log.
+pub(crate) fn escape_payload(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(escaped_len(bytes));
+    for byte in bytes {
+        match *byte {
+            b'\n' => out.extend_from_slice(&[ESCAPE, b'n']),
+            ESCAPE => out.extend_from_slice(&[ESCAPE, ESCAPE]),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Put back what [`escape_payload`] took out.
+pub(crate) fn unescape_payload(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut following_escape = false;
+    for byte in bytes {
+        if following_escape {
+            match *byte {
+                b'n' => out.push(b'\n'),
+                ESCAPE => out.push(ESCAPE),
+                other => return Err(format!("payload has an unknown escape: {other:#04x}")),
+            }
+            following_escape = false;
+        } else if *byte == ESCAPE {
+            following_escape = true;
+        } else {
+            out.push(*byte);
+        }
+    }
+    if following_escape {
+        return Err("payload ends inside an escape".to_string());
+    }
+    Ok(out)
+}
+
 pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
     if writes_the_array_shape() {
         let mut seq = serializer.serialize_seq(Some(bytes.len()))?;
@@ -64,7 +147,24 @@ pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S:
         }
         return seq.end();
     }
-    serializer.serialize_str(&STANDARD.encode(bytes))
+    // Carried beside the document when that is smaller. Escaping costs whatever newlines weigh in
+    // these particular bytes -- about 1% for most payloads -- against base64's flat third. A
+    // payload that is mostly newlines would grow, so it stays encoded.
+    let marker = CARRIED.with(|carried| {
+        let mut carried = carried.borrow_mut();
+        let Some(payloads) = carried.as_mut() else {
+            return None;
+        };
+        if escaped_len(bytes) >= bytes.len().div_ceil(3) * 4 {
+            return None;
+        }
+        payloads.push(bytes.to_vec());
+        Some(format!("{CARRIED_PREFIX}{}", payloads.len() - 1))
+    });
+    match marker {
+        Some(marker) => serializer.serialize_str(&marker),
+        None => serializer.serialize_str(&STANDARD.encode(bytes)),
+    }
 }
 
 pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
@@ -82,6 +182,27 @@ impl<'de> Visitor<'de> for EitherShape {
     }
 
     fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+        // A marker naming a payload carried beside the document. Base64 never starts with this,
+        // so there is no shape a payload could take that would be read as the wrong one.
+        if let Some(index) = value.strip_prefix(CARRIED_PREFIX) {
+            let index: usize = index
+                .parse()
+                .map_err(|_| E::custom(format!("payload marker is not a number: {value}")))?;
+            return AVAILABLE.with(|available| {
+                let available = available.borrow();
+                let payloads = available.as_ref().ok_or_else(|| {
+                    E::custom(format!(
+                        "record refers to a payload carried beside it, but none were read: {value}"
+                    ))
+                })?;
+                payloads.get(index).cloned().ok_or_else(|| {
+                    E::custom(format!(
+                        "record refers to payload {index}, and only {} were read",
+                        payloads.len()
+                    ))
+                })
+            });
+        }
         STANDARD
             .decode(value)
             .map_err(|err| E::custom(format!("bytes are not valid base64: {err}")))

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2183,23 +2183,6 @@ where
     (selected, next_cursor)
 }
 
-fn select_expiry_cursor_window(
-    keys: Vec<(String, u64)>,
-    cursor: Option<&str>,
-    limit: usize,
-) -> (Vec<(String, u64)>, Option<String>) {
-    let start = cursor
-        .and_then(|cursor| keys.iter().position(|(key, _)| key.as_str() > cursor))
-        .unwrap_or_default();
-    let remaining = keys.into_iter().skip(start).collect::<Vec<_>>();
-    if limit == 0 || remaining.len() <= limit {
-        return (remaining, None);
-    }
-    let mut selected = remaining.into_iter().take(limit).collect::<Vec<_>>();
-    let next_cursor = selected.last().map(|(key, _)| key.clone());
-    (std::mem::take(&mut selected), next_cursor)
-}
-
 fn remove_if_expired(shard: &mut ShardState, key: &str) -> bool {
     // Use the replay-aware clock: during WAL replay this resolves to the per-record leader
     // timestamp so lazy expiry reproduces the leader's original branch. Using the real

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -49,7 +49,96 @@ fn is_current_write_ahead_log_format_version(version: &u32) -> bool {
 /// committed record surfaces as `Corruption` instead of replaying as truth.
 pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
     let payload = crate::log_framing::decode_line(line)?;
-    Ok(serde_json::from_slice::<WriteAheadLogRecord>(payload)?)
+    let (document, carried) = split_carried_payloads(payload)?;
+    if carried.is_empty() {
+        return Ok(serde_json::from_slice::<WriteAheadLogRecord>(document)?);
+    }
+    crate::bytes_serde::with_payloads(carried, || {
+        serde_json::from_slice::<WriteAheadLogRecord>(document)
+    })
+    .map_err(WriteAheadLogError::from)
+}
+
+/// Separates the document from the payloads carried beside it.
+///
+/// A serde_json document never contains a literal 0x1f -- control bytes are escaped -- so this can
+/// only be the separator this writer put there. A record written without carried payloads has none
+/// and is returned whole.
+const CARRIED_SEPARATOR: u8 = 0x1f;
+
+fn split_carried_payloads(payload: &[u8]) -> Result<(&[u8], Vec<Vec<u8>>), WriteAheadLogError> {
+    let Some(document_end) = payload.iter().position(|byte| *byte == CARRIED_SEPARATOR) else {
+        return Ok((payload, Vec::new()));
+    };
+    let document = &payload[..document_end];
+    let rest = &payload[document_end + 1..];
+    let lengths_end = rest
+        .iter()
+        .position(|byte| *byte == CARRIED_SEPARATOR)
+        .ok_or_else(|| {
+            WriteAheadLogError::Corruption(
+                "record carries payloads but does not say how long they are".to_string(),
+            )
+        })?;
+    let lengths = std::str::from_utf8(&rest[..lengths_end])
+        .map_err(|_| {
+            WriteAheadLogError::Corruption("payload lengths are not readable".to_string())
+        })?
+        .split(',')
+        .map(|length| {
+            length.parse::<usize>().map_err(|_| {
+                WriteAheadLogError::Corruption(format!("payload length is not a number: {length}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut carried = Vec::with_capacity(lengths.len());
+    let mut at = lengths_end + 1;
+    for length in lengths {
+        let end = at.checked_add(length).filter(|end| *end <= rest.len()).ok_or_else(|| {
+            WriteAheadLogError::Corruption(
+                "record claims more carried payload than it holds".to_string(),
+            )
+        })?;
+        carried.push(
+            crate::bytes_serde::unescape_payload(&rest[at..end])
+                .map_err(WriteAheadLogError::Corruption)?,
+        );
+        at = end;
+    }
+    if at != rest.len() {
+        return Err(WriteAheadLogError::Corruption(
+            "record holds more carried payload than it claims".to_string(),
+        ));
+    }
+    Ok((document, carried))
+}
+
+/// Encode a record: the document, and the payloads worth carrying beside it.
+fn encode_wal_payload(record: &WriteAheadLogRecord) -> Result<Vec<u8>, WriteAheadLogError> {
+    let (document, carried) =
+        crate::bytes_serde::carrying_payloads(|| serde_json::to_vec(record));
+    let mut payload = document?;
+    if carried.is_empty() {
+        // Nothing worth carrying: written exactly as it always was.
+        return Ok(payload);
+    }
+    let escaped = carried
+        .iter()
+        .map(|bytes| crate::bytes_serde::escape_payload(bytes))
+        .collect::<Vec<_>>();
+    let lengths = escaped
+        .iter()
+        .map(|bytes| bytes.len().to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    payload.push(CARRIED_SEPARATOR);
+    payload.extend_from_slice(lengths.as_bytes());
+    payload.push(CARRIED_SEPARATOR);
+    for bytes in &escaped {
+        payload.extend_from_slice(bytes);
+    }
+    Ok(payload)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -90,55 +179,13 @@ pub struct WriteAheadLogRecord {
 pub struct StagedPage {
     /// The object the page belongs to, which is what a read has when it comes looking.
     pub object_id: u64,
-    /// The page contents, stored text-encoded.
+    /// The page contents.
     ///
-    /// A byte vector serializes as an array of numbers, about five bytes of log per byte of
-    /// page. For a field that exists to carry page contents that is the dominant cost of the
-    /// whole record, so it is encoded instead -- about a third of the size.
-    #[serde(with = "staged_page_bytes")]
+    /// Carried beside the document when that is smaller, and encoded into it otherwise -- the same
+    /// choice every other payload gets. A page is the whole point of this record, so it is the
+    /// field where the difference between carrying bytes and encoding them shows up most.
+    #[serde(with = "crate::bytes_serde")]
     pub bytes: Vec<u8>,
-}
-
-/// Text encoding for a staged page's contents.
-///
-/// Reading accepts the array form too, so a log written before this still loads.
-mod staged_page_bytes {
-    use base64::engine::general_purpose::STANDARD;
-    use base64::Engine;
-    use serde::de::{Deserializer, Error, SeqAccess, Visitor};
-    use serde::Serializer;
-
-    pub(super) fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&STANDARD.encode(bytes))
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Vec<u8>, D::Error> {
-        struct EitherShape;
-
-        impl<'de> Visitor<'de> for EitherShape {
-            type Value = Vec<u8>;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("an encoded page, or the array of bytes written before")
-            }
-
-            fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
-                STANDARD.decode(value).map_err(E::custom)
-            }
-
-            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(byte) = seq.next_element::<u8>()? {
-                    bytes.push(byte);
-                }
-                Ok(bytes)
-            }
-        }
-
-        deserializer.deserialize_any(EitherShape)
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1465,7 +1512,7 @@ fn append_record_locked(
     // Frame the record with a length + SHA-256 digest so a later value-preserving bit-flip in
     // this committed line is detected on read (see `crate::log_framing`). Offsets/stats below
     // use the real byte length, so framing is transparent to the append report and replication.
-    let bytes = crate::log_framing::encode_line(&serde_json::to_vec(record)?);
+    let bytes = crate::log_framing::encode_line(&encode_wal_payload(record)?);
     let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
     file.write_all(&bytes)?;
     if sync {
@@ -3257,6 +3304,184 @@ mod tests {
             stats.append_full_scans <= 2,
             "the append path walked the whole log {} times; it should learn the end once",
             stats.append_full_scans
+        );
+    }
+
+    /// Every byte value survives being carried beside the document.
+    #[test]
+    fn a_carried_payload_survives_every_byte_value() {
+        let all_bytes: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 9,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: all_bytes.clone(),
+            },
+            metadata: None,
+            staged_pages: Vec::new(),
+        };
+        let framed = crate::log_framing::encode_line(&encode_wal_payload(&record).unwrap());
+        assert!(
+            !framed[..framed.len() - 1].contains(&b'\n'),
+            "a record must not contain a newline, or every reader here loses the log"
+        );
+        let decoded = decode_wal_line(&framed).unwrap();
+        assert_eq!(decoded, record, "the payload changed on the way back");
+    }
+
+    /// Several payloads in one record come back in the right order, not swapped.
+    #[test]
+    fn several_carried_payloads_come_back_in_the_right_order() {
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 3,
+            command: Command::HashMultiSet {
+                key: "k".to_string(),
+                entries: vec![
+                    ("first".to_string(), vec![1u8; 600]),
+                    ("second".to_string(), vec![2u8; 600]),
+                    ("third".to_string(), vec![3u8; 600]),
+                ],
+            },
+            metadata: None,
+            staged_pages: Vec::new(),
+        };
+        let framed = crate::log_framing::encode_line(&encode_wal_payload(&record).unwrap());
+        assert_eq!(decode_wal_line(&framed).unwrap(), record);
+    }
+
+    /// A payload that escaping would grow stays encoded, so the record never gets bigger.
+    #[test]
+    fn a_payload_that_escaping_would_grow_stays_encoded() {
+        let newlines = vec![b'\n'; 2048];
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 4,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: newlines.clone(),
+            },
+            metadata: None,
+            staged_pages: Vec::new(),
+        };
+        let payload = encode_wal_payload(&record).unwrap();
+        assert!(
+            !payload.contains(&0x1f),
+            "a payload that would grow should have been left in the document"
+        );
+        let framed = crate::log_framing::encode_line(&payload);
+        assert_eq!(decode_wal_line(&framed).unwrap(), record);
+    }
+
+    /// A record with nothing worth carrying is written exactly as it was before.
+    #[test]
+    fn a_record_with_no_payload_is_unchanged_on_disk() {
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 5,
+            command: Command::StringGet {
+                key: "k".to_string(),
+            },
+            metadata: None,
+            staged_pages: Vec::new(),
+        };
+        let payload = encode_wal_payload(&record).unwrap();
+        assert_eq!(
+            payload,
+            serde_json::to_vec(&record).unwrap(),
+            "a record that carries nothing must be byte-identical to the document"
+        );
+    }
+
+    /// Records written before payloads were carried still load.
+    #[test]
+    fn a_record_written_before_payloads_were_carried_still_loads() {
+        let written_before = concat!(
+            r#"{"s":1,"q":7,"c":{"kind":"string_set","key":"k","value":"aGk="},"#,
+            r#""m":{"t":1787429651961}}"#
+        );
+        let framed = crate::log_framing::encode_line(written_before.as_bytes());
+        let decoded = decode_wal_line(&framed).unwrap();
+        assert_eq!(
+            decoded.command,
+            Command::StringSet {
+                key: "k".to_string(),
+                value: b"hi".to_vec(),
+            }
+        );
+    }
+
+    /// A truncated payload section is corruption, not a record with fewer bytes in it.
+    #[test]
+    fn a_truncated_carried_payload_is_refused() {
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 8,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: vec![7u8; 900],
+            },
+            metadata: None,
+            staged_pages: Vec::new(),
+        };
+        let mut payload = encode_wal_payload(&record).unwrap();
+        payload.truncate(payload.len() - 40);
+        let framed = crate::log_framing::encode_line(&payload);
+        assert!(
+            decode_wal_line(&framed).is_err(),
+            "a record holding less than it claims must be refused"
+        );
+    }
+
+    /// Through the real log: written, reopened, and read back.
+    #[test]
+    fn carried_payloads_survive_a_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        let payloads: Vec<Vec<u8>> = (0..8)
+            .map(|index| (0..=255u8).cycle().skip(index).take(1500).collect())
+            .collect();
+        for payload in &payloads {
+            store
+                .append_with_sync(
+                    1,
+                    Command::StringSet {
+                        key: "hot".to_string(),
+                        value: payload.clone(),
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+        drop(store);
+
+        let reopened = LocalWriteAheadLogStore::new(dir.path());
+        let scanned = reopened.scan(1, 0, u64::MAX, u64::MAX).unwrap();
+        assert_eq!(scanned.len(), payloads.len(), "every record should be there");
+        for (index, (_, line)) in scanned.iter().enumerate() {
+            let record = decode_wal_line(line).unwrap();
+            match record.command {
+                Command::StringSet { value, .. } => {
+                    assert_eq!(value, payloads[index], "record {index} came back changed")
+                }
+                other => panic!("unexpected command: {other:?}"),
+            }
+        }
+        // And the sequence still resolves, which is the backward walk over binary payloads.
+        assert_eq!(
+            reopened
+                .append_with_sync(
+                    1,
+                    Command::StringSet {
+                        key: "after".to_string(),
+                        value: b"v".to_vec(),
+                    },
+                    false,
+                )
+                .unwrap()
+                .sequence,
+            payloads.len() as u64 + 1
         );
     }
 }

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -348,4 +348,57 @@ mod tests {
             );
         }
     }
+
+    /// What it would cost to carry a payload as bytes rather than as base64.
+    ///
+    /// Base64 is a flat third whatever the bytes are. Escaping just the newline and the escape byte
+    /// costs whatever those two bytes weigh in the data -- near nothing for most payloads, and worse
+    /// than base64 only for data that is mostly newlines. Measured across shapes, including one
+    /// picked to be hostile.
+    #[test]
+    fn what_carrying_a_payload_as_bytes_would_cost() {
+        // Escape 0x0A so the payload can never contain a newline, and 0x1B so the escape is
+        // reversible. Everything else is carried as itself.
+        fn stuffed_len(bytes: &[u8]) -> usize {
+            bytes
+                .iter()
+                .map(|byte| if *byte == b'\n' || *byte == 0x1b { 2 } else { 1 })
+                .sum()
+        }
+        fn base64_len(len: usize) -> usize {
+            len.div_ceil(3) * 4
+        }
+
+        // A cheap deterministic spread of byte values, so the measurement does not depend on a
+        // random seed and does not flatter itself with a single repeated byte.
+        let spread = |len: usize| -> Vec<u8> {
+            (0..len)
+                .map(|index| ((index * 97 + index / 251 * 13) % 256) as u8)
+                .collect()
+        };
+        let text = |len: usize| -> Vec<u8> {
+            (0..len)
+                .map(|index| if index % 64 == 63 { b'\n' } else { b'a' + (index % 26) as u8 })
+                .collect()
+        };
+        let hostile = |len: usize| -> Vec<u8> { vec![b'\n'; len] };
+
+        for (name, make) in [
+            ("every byte value", &spread as &dyn Fn(usize) -> Vec<u8>),
+            ("text, a newline every 64", &text),
+            ("nothing but newlines", &hostile),
+        ] {
+            for len in [1024usize, 4096] {
+                let bytes = make(len);
+                let encoded = base64_len(len);
+                let stuffed = stuffed_len(&bytes);
+                println!(
+                    "  {name:<26} {len:>5}B: base64 {encoded:>6}B ({:.3}x)   as bytes {stuffed:>6}B ({:.3}x)   {:.2}x smaller",
+                    encoded as f64 / len as f64,
+                    stuffed as f64 / len as f64,
+                    encoded as f64 / stuffed as f64
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
A JSON document cannot hold bytes, so payloads were base64 — a flat third on top, whatever they are. At four kilobytes that was **5,464 bytes of a 5,587-byte record**: the envelope is a constant 122 bytes, so the payload *is* the record.

## Why the bytes could not simply be dropped in

Every reader here finds records by newline, and the walk that finds the log's end reads backward to the last one. A payload containing `0x0A` breaks both.

Escaping the newline — and the escape byte, so it reverses — keeps that property at a cost that depends on how often those bytes occur rather than a flat third:

| payload | escaped | base64 |
|---|---|---|
| every byte value | **1.008x** | 1.334x |
| text, a newline every 64 | **1.016x** | 1.334x |
| nothing but newlines | 2.000x | 1.334x |

That last row is why the choice is made **per payload, on the actual bytes**. A payload that escaping would grow stays encoded, so no record is ever made bigger.

## Result

| value | before | after |
|---:|---|---|
| 64 B | 3.29x (209 B) | **3.01x (191 B)** |
| 256 B | 1.82x | **1.51x** |
| 1 KiB | 1.46x | **1.13x** |
| 4 KiB | 1.36x | **1.03x** |

At 4 KiB that is 3.90x smaller and 3.82x faster than where this line of work started. It also matches what the fully binary record measured (1.02x at 4 KiB) — without adopting a record that describes a mutation rather than a command, and so without changing what replay means.

## The format

A record holds the document and, when there is anything worth carrying, the payloads after it:

```
<document> 0x1f <escaped lengths, comma separated> 0x1f <escaped payloads>
```

`serde_json` never emits a literal `0x1f` — control bytes are escaped — so the separator is unambiguous. Lengths are explicit, so the payload section is split by arithmetic rather than by scanning. The integrity envelope already covers the whole frame, so it covers the payloads.

**A record with nothing worth carrying is written exactly as before, byte for byte**, and records written earlier still load.

Staged pages take the same choice, since carrying page contents is what that record exists for. Their own encoder is gone, along with the window selection that the ordered expiry read replaced.

## Tests

The fidelity ones matter most here — a payload is user data, and an encoding that loses a byte is data loss, not a regression:

- every byte value survives, and the record contains no newline
- several payloads in one record come back in the right order, not swapped
- a payload escaping would grow stays encoded
- a record carrying nothing is byte-identical to the document
- a record written before this still loads
- a truncated payload section is refused rather than read short
- written, reopened and read back through the real log — which exercises the backward walk over binary payloads

## Testing

Library suite: **1046 passed, 9 failed**. One name differs from the `main` comparison run — `manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted` — which has isolated 5/5 repeatedly.
