### PR TITLE
meta: parse each server location once per topology query

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2751,6 +2751,116 @@ mod tests {
     }
 
     #[test]
+    fn spread_still_holds_across_a_fleet_big_enough_to_misalign() {
+        // The scan now indexes into the locations parsed once up front instead
+        // of re-parsing each candidate. That is only correct while the two
+        // vectors stay in step, so this uses a fleet large enough that an
+        // off-by-one would hand a shard two replicas in the same domain.
+        let meta = SingleNodeMeta::default();
+        for index in 0..12u64 {
+            meta.register_server(RegisterServerRequest {
+                server_addr: format!("node-{index:02}"),
+                node_id: index + 1,
+                location: format!("region-{}/zone-{}", index % 3, index),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 8,
+            replica_count: 3,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+
+        let topology = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert_eq!(topology.shards.len(), 8);
+        for shard in &topology.shards {
+            assert_eq!(shard.replicas.len(), 3, "shard {} short", shard.shard_id);
+            let regions = shard
+                .replicas
+                .iter()
+                .map(|addr| {
+                    let index: u64 = addr.trim_start_matches("node-").parse().unwrap();
+                    index % 3
+                })
+                .collect::<std::collections::BTreeSet<_>>();
+            assert_eq!(
+                regions.len(),
+                3,
+                "shard {} put two replicas in one region: {:?}",
+                shard.shard_id,
+                shard.replicas
+            );
+        }
+    }
+
+    #[test]
+    fn the_caller_ordering_is_unchanged_by_computing_distance_once() {
+        // The nearest-first sort now works the distance out per replica instead
+        // of inside the comparator. Same order, including the stable tie-break.
+        let meta = SingleNodeMeta::default();
+        for (index, location) in ["east/a", "east/b", "west/c", "east/d"].into_iter().enumerate() {
+            meta.register_server(RegisterServerRequest {
+                server_addr: format!("node-{index}"),
+                node_id: index as u64 + 1,
+                location: location.to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 4,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        let ask = |client_location: &str| {
+            meta.get_table_topology(GetTableTopologyRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+                old_topology_version: 0,
+                client_location: client_location.to_string(),
+            })
+            .shards[0]
+                .replicas
+                .clone()
+        };
+
+        let far = ask("west/c");
+        assert_eq!(far.first().map(String::as_str), Some("node-2"));
+
+        // Three servers share `east`; among them the order the scan produced
+        // must survive the sort rather than being reshuffled.
+        let near = ask("east/z");
+        let eastern = near
+            .iter()
+            .filter(|addr| addr.as_str() != "node-2")
+            .cloned()
+            .collect::<Vec<_>>();
+        let baseline = ask("")
+            .into_iter()
+            .filter(|addr| addr != "node-2")
+            .collect::<Vec<_>>();
+        assert_eq!(eastern, baseline, "the tie-break stopped being stable");
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -148,15 +148,19 @@ pub(super) fn build_shards(
             if replicas.len() >= table.replica_count as usize {
                 break;
             }
-            for candidate in &normal_servers {
+            for (index, candidate) in normal_servers.iter().enumerate() {
                 if replicas.len() >= table.replica_count as usize {
                     break;
                 }
                 if seen_replicas.contains(&candidate.server_addr) {
                     continue;
                 }
-                let candidate_location = Location::parse(&candidate.location);
-                if !separated_from(&placed_locations, &candidate_location, separation) {
+                // Parsed once, above, into candidate_locations. This scan runs
+                // per shard and per rung of the separation ladder, so re-parsing
+                // here cost one parse and allocation per server per shard per
+                // rung on a call every client and proxy makes.
+                let candidate_location = &candidate_locations[index];
+                if !separated_from(&placed_locations, candidate_location, separation) {
                     continue;
                 }
                 let host = server_host(&candidate.server_addr);
@@ -164,7 +168,7 @@ pub(super) fn build_shards(
                     continue;
                 }
                 if !candidate_location.is_empty() {
-                    placed_locations.push(candidate_location);
+                    placed_locations.push(candidate_location.clone());
                 }
                 push_replica(
                     state,
@@ -209,17 +213,33 @@ pub(super) fn build_shards(
         // load. Only the order changes: the same servers are returned, and the
         // primary -- which is where the shard is actually owned -- is untouched.
         if !caller.is_empty() {
-            // Stable, so servers equally close to the caller keep the
-            // load-ordered sequence the scan above produced.
-            replicas.sort_by_key(|server_addr| {
-                std::cmp::Reverse(
-                    state
+            // Each replica's distance is worked out once. `sort_by_key` calls
+            // its key function O(n log n) times, and this one parsed a location
+            // on every call, so the distance is computed up front and the sort
+            // then only compares integers.
+            //
+            // Still stable: ties fall back to the position the scan above
+            // produced, so servers equally close to the caller keep their
+            // load-ordered sequence.
+            let mut ranked = replicas
+                .iter()
+                .enumerate()
+                .map(|(position, server_addr)| {
+                    let distance = state
                         .servers
                         .get(server_addr)
                         .map(|server| caller.shared_prefix_len(&Location::parse(&server.location)))
-                        .unwrap_or(0),
-                )
+                        .unwrap_or(0);
+                    (distance, position, server_addr.clone())
+                })
+                .collect::<Vec<_>>();
+            ranked.sort_by(|left, right| {
+                right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1))
             });
+            replicas = ranked
+                .into_iter()
+                .map(|(_, _, server_addr)| server_addr)
+                .collect();
         }
         let primary_endpoint = primary
             .as_ref()


### PR DESCRIPTION
## Every topology query re-parsed the same location strings, thousands of times

`build_shards` runs on every topology query — the call every client and every proxy makes. It parses each live server's location into a `Location` up front, into `candidate_locations`. Then the replica scan throws that away and parses again:

```rust
for candidate in &normal_servers {
    …
    let candidate_location = Location::parse(&candidate.location);
```

That scan runs **per shard, and per rung of the separation ladder**. So the number of parses — each one splitting a string and allocating a `Vec` — is roughly `shards × rungs × servers`, when the answers were already sitting in a vector built for exactly this purpose. A 64-shard table on a 100-server fleet with a three-rung ladder is on the order of 19,000 parses per query, to produce 100 distinct values.

The nearest-first ordering had the same shape in miniature: it parsed inside a `sort_by_key` comparator, and `sort_by_key` calls its key function O(n log n) times.

## The change

The scan indexes into the locations already parsed; the ordering computes each replica's distance once and then sorts integers. Per query the parse count goes from `shards × rungs × servers` to `servers`.

Nothing about the output changes. This is a refactor, and the argument that it is safe is not "the tests pass" but that the two vectors are aligned **by construction**: `candidate_locations` is built from `normal_servers` after it is sorted, and `normal_servers` is never mutated afterwards — only iterated. I checked that specifically, because an off-by-one here would silently hand a shard two replicas in the same failure domain, which is the one thing the separation ladder exists to prevent.

The ordering keeps its stable tie-break explicitly (`then_with` on the original position) rather than relying on `sort_by_key`'s stability, since the decorate-and-sort form no longer gets it for free.

## Tests

2 new, aimed at the two ways this could go wrong quietly:

- **a fleet big enough to misalign** — 12 servers across 3 regions, 8 shards, 3 replicas each, asserting every shard's replicas land in 3 distinct regions. An off-by-one in the indexing shows up here and not on a three-server fixture.
- **the caller ordering is unchanged** — the nearest replica still comes first, and among servers the caller cannot tell apart, the scan's original order survives. That is the property the decorate-and-sort rewrite could have dropped.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — 267 passed, 2 failed.
- `cargo check -p temporalstore-rust --all-targets` — clean.

**Correction.** I originally wrote that these two fail on clean `main`. That was wrong. Re-running `proxy::tests` on its own gives **54 passed, 0 failed** both on `main` and on this branch. The failures I saw were port collisions — the proxy tests bind fixed ports, and another suite was running against the same ports in a second worktree at the time; one of them reported `AddrInUse` outright, which I should have read as the signal it was. `main` was not red, and this change does not affect these tests.

## Why this rather than caching the response

Caching the whole topology response is the larger prize, and I did not take it: `build_shards` orders candidates by reported server load, which changes on every heartbeat *without* bumping the topology version. A cache keyed on that version would freeze the ordering, and a cache keyed on the load would never hit. Making it cacheable means deciding that served topology no longer tracks load — a change in what the metaserver promises, not an optimization. This one is strictly a matter of not doing the same work twice.

---

**Correction to the note above about the two proxy tests.**

I wrote that they fail on clean `main`. That was wrong, and I am striking it. Running `proxy::tests` on its own gives **54 passed, 0 failed** — on `main` and on this branch alike.

What I actually hit was a port collision: the proxy tests bind fixed ports, and a second worktree was running its own suite against the same ports at the time. One of the failures said `AddrInUse` outright, which I should have read as the signal it was instead of treating the set as a baseline. `main` was not red, and this change does not touch these tests.
