### PR TITLE
Time slab install, quarantine and purge apart

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -2845,4 +2845,40 @@ mod tests {
         assert_eq!(store.slab_ids().unwrap(), vec![1, 2, 3]);
         assert_eq!(store.delayed_destroy_slab_ids().unwrap(), vec![0]);
     }
+
+    /// Install, quarantine and purge, timed apart.
+    ///
+    /// A purge unlinks every quarantined slab in one round with the store's lock held, so the round
+    /// is unbounded in the amount of work it does. Whether that is the expensive part, or whether
+    /// getting there is, is what this separates -- an earlier attempt timed all three together at
+    /// twenty thousand slabs and did not finish in an hour.
+    #[test]
+    fn quarantine_and_purge_timed_by_phase() {
+        for slabs in [200u64, 800, 3_200] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalBlockStore::new(dir.path());
+
+            let started = std::time::Instant::now();
+            for id in 0..slabs {
+                store.install_slab(id, b"slab-contents").unwrap();
+            }
+            let install = started.elapsed().as_secs_f64() * 1e3;
+
+            let started = std::time::Instant::now();
+            store
+                .gc_slabs_before_with_live_refs_delayed_destroy(slabs - 1, [slabs - 1])
+                .unwrap();
+            let quarantine = started.elapsed().as_secs_f64() * 1e3;
+
+            let started = std::time::Instant::now();
+            let report = store.purge_delayed_destroy_slabs_with_report().unwrap();
+            let purge = started.elapsed().as_secs_f64() * 1e3;
+
+            println!(
+                "  {slabs:>5} slabs: install {install:>9.1} ms ({:>6.3} ms each)   quarantine {quarantine:>9.1} ms   purge {purge:>8.1} ms ({} destroyed)",
+                install / slabs as f64,
+                report.purged_page_slab_ids.len()
+            );
+        }
+    }
 }

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -91,6 +91,19 @@ impl LocalBlockStore {
         Ok(fs::read(slab_path(&root, page_slab_id))?)
     }
 
+    /// Install one slab, and rewrite the whole band manifest.
+    ///
+    /// The manifest rewrite is the expensive part and it grows with the store: every install
+    /// serializes every band descriptor, writes them to a fresh file, fsyncs it, renames it and
+    /// fsyncs the directory. Installing n slabs therefore writes the manifest n times. Timed by
+    /// phase on one machine: 111.7 ms per install at 200 slabs, 270.7 ms at 800 -- while purging
+    /// all of them afterwards costs about 0.65 ms each, so the collection is not what is dear here.
+    ///
+    /// Fixable, and not fixed: the manifest is a CACHE, rebuildable from the slabs themselves by
+    /// `rebuild_band_manifest_at`, so it does not have to be written on every install. Writing it
+    /// periodically needs the load path to notice a stale one -- comparing its set against the
+    /// slabs actually present -- because a stale manifest is trusted today, which is worse than a
+    /// missing one.
     pub fn install_slab(
         &self,
         page_slab_id: u64,


### PR DESCRIPTION
I set out to bound the purge round — it destroys every quarantined slab in one pass with the store's lock held, and nothing limits it, which matches the pattern of every other unbounded sweep here.

Timed by phase, **purge is the cheap part.**

| slabs | install | per install | quarantine | purge |
|---:|---:|---:|---:|---:|
| 200 | 22,332 ms | **111.7 ms** | 3,344 ms | 216 ms |
| 800 | 216,584 ms | **270.7 ms** | 13,853 ms | 516 ms |

Purging costs about 0.65 ms a slab and is roughly linear. **Installing one costs time proportional to how many already exist** — because every install rewrites the whole band manifest: serialize every descriptor, write a fresh file, fsync it, rename, fsync the directory. Installing n slabs writes the manifest n times.

That is the same shape as two other places in this codebase: the cost tracks what is *retained* rather than what *changed*. It is now three for three, which is starting to look like the thing to check first.

## Why this stops at a measurement

The manifest is a **cache** — `rebuild_band_manifest_at` reconstructs it from the slabs themselves — so it does not have to be written on every install. Writing it periodically instead needs the load path to notice a stale manifest, by comparing its set against the slabs actually present, because today a stale one is **trusted**. That is worse than a missing one, and it makes this a durability change rather than a tuning change.

I would rather land the measurement and the note than a half-verified change to when block state reaches disk. The note sits at `install_slab`, where someone would be standing when they wonder about this.

## On the measurement itself

The first version asked for twenty thousand slabs and timed all three phases together. It had not finished after an hour, and it could not have said which phase was slow even if it had. Small enough to finish, and separated, it answers the question.

## Testing

Measurement and comments only; no behaviour change. `cargo check --all-targets` exits 0.
