### PR TITLE
Proxy: the report of published metric families had fallen eight behind

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1463,18 +1463,22 @@ fn proxy_operational_surface_entry(
     }
 }
 
-fn proxy_metrics_families() -> Vec<&'static str> {
-    vec![
-        "temporalstore_proxy_requests_total",
-        "temporalstore_proxy_route_cache_entries",
-        "temporalstore_proxy_route_cache_events_total",
-        "temporalstore_proxy_backend_events_total",
-        "temporalstore_proxy_serving_mode",
-        "temporalstore_proxy_drop_percent",
-        "temporalstore_proxy_metric_family_parity",
-        "temporalstore_proxy_service_registry_state",
-        "temporalstore_proxy_service_registry_events_total",
-    ]
+/// The metric families this proxy actually publishes, read back off the rendered endpoint.
+///
+/// This used to be a hand-written list, and it had fallen eight families behind what the
+/// proxy emits -- every admission metric among them, so anyone building a dashboard from the
+/// report got no in-flight quota, no account enforcement and no read pinning. Reading the
+/// rendered output back means the list cannot be behind by construction.
+pub(super) fn proxy_metric_families_from(rendered: &str) -> Vec<String> {
+    let mut families: Vec<String> = rendered
+        .lines()
+        .filter_map(|line| line.strip_prefix("# TYPE "))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(str::to_string)
+        .collect();
+    families.sort();
+    families.dedup();
+    families
 }
 
 fn proxy_metrics_parity_mappings() -> Vec<ProxyMetricFamilyMapping> {
@@ -2495,6 +2499,50 @@ mod tests {
         let body = String::from_utf8_lossy(&body).to_string();
         assert!(!body.contains("proxy_write_disabled"), "{body}");
         assert!(!body.contains("proxy_not_serving"), "{body}");
+    }
+
+    #[test]
+    fn the_metrics_report_lists_exactly_what_the_endpoint_emits() {
+        // The list in this report was written by hand and had fallen eight families behind
+        // the endpoint -- including every admission metric, so a dashboard built from the
+        // report showed no in-flight quota, no account enforcement and no read pinning. It is
+        // now read back off the rendered output, and this pins that it stays that way.
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let emitted = proxy_metric_families_from(&proxy.prometheus_metrics());
+        let report = proxy.metrics_parity_report();
+
+        assert_eq!(
+            report.rust_prometheus_families, emitted,
+            "the report must list what the endpoint actually publishes"
+        );
+        assert!(
+            emitted.len() >= 17,
+            "expected the full family set, saw {}: {emitted:?}",
+            emitted.len()
+        );
+        for family in [
+            "temporalstore_proxy_inflight_requests",
+            "temporalstore_proxy_inflight_limit",
+            "temporalstore_proxy_account_enforcement",
+            "temporalstore_proxy_pin_primary_reads",
+        ] {
+            assert!(
+                report.rust_prometheus_families.iter().any(|f| f == family),
+                "{family} is published but was missing from the report"
+            );
+        }
+
+        // The other half: a mapping that names a family nothing emits is a dashboard wired to
+        // a metric that will never arrive. Derived lists cannot catch that -- mappings carry
+        // external panel names and stay hand-written -- so check them against reality here.
+        for mapping in &report.mappings {
+            assert!(
+                emitted.contains(&mapping.rust_prometheus_family),
+                "mapping for panel {:?} names {:?}, which the endpoint does not emit",
+                mapping.grafana_panel,
+                mapping.rust_prometheus_family
+            );
+        }
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/proxy/reports.rs
+++ b/crates/temporalstore-rust/src/proxy/reports.rs
@@ -167,10 +167,7 @@ impl ProxyService {
                 "<repo>/crates/temporalstore-rust/src/proxy/handle.rs".to_string(),
                 "<repo>/crates/temporalstore-rust/src/proxy/config.rs".to_string(),
             ],
-            rust_prometheus_families: proxy_metrics_families()
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
+            rust_prometheus_families: proxy_metric_families_from(&self.prometheus_metrics()),
             mappings: proxy_metrics_parity_mappings(),
             grafana_panels_ready: true,
             alerts_ready: true,


### PR DESCRIPTION
The proxy serves a report listing the metric families it publishes. That list was
written by hand and had drifted: the endpoint emits seventeen families, the report
named nine.

The eight it left out were not incidental. They were the in-flight quota, the
in-flight limit, account enforcement, read pinning, and the four production
readiness families -- so anyone building a dashboard from that report got no
admission telemetry at all, which is most of what a saturated proxy has to say
about itself.

Nothing was falsely advertised, which is the only reason this stayed quiet: every
family the report named does exist. It simply stopped mentioning half of them as
the endpoint grew.

The list is now read back off the rendered output, so it cannot be behind by
construction. Nine hand-written names became one derivation.

The mappings alongside it stay hand-written, because they carry external dashboard
panel names that cannot be derived from anything in this repo. What can be checked
is the direction that matters: the test asserts every mapping names a family the
endpoint actually emits, so a mapping pointing at a metric that no longer exists --
a dashboard wired to a value that will never arrive -- fails here rather than in
someone's console.

Checked rather than asserted: restore the hand-written list and the test fails with
"the report must list what the endpoint actually publishes".

This is the second hand-maintained list in this area to be caught drifting, after
the counter that was incremented but never published. The pattern is the same one
that limited the config carry-forward to five fields of twenty-five: a list someone
has to remember to update is a list that will be wrong.