### PR TITLE
Reword the prose that still framed this work as trailing something else

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -73,7 +73,7 @@ page_store_compression_level = 3       # TS_PAGE_STORE_COMPRESSION_LEVEL    comp
 page_store_compression_min_bytes = 4096  # TS_PAGE_STORE_COMPRESSION_MIN_BYTES  skip compressing pages smaller than this
 cross_shard_reclaim_guard = 1          # TS_CROSS_SHARD_RECLAIM_GUARD  1 = retain slabs referenced by ANY loaded shard during GC (safe default; 0 = legacy per-shard, unsafe under multi-shard hosting)
 index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped index-log gap (bytes, 1 MiB) that triggers a background catalog/index dump under the manifest-parity catalog fold (TS_INDEX_CATALOG_FOLD); 0 disables the threshold cadence
-# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference parity) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.
+# index_catalog_fold = 1               # TS_INDEX_CATALOG_FOLD  1 = fold the band/zone catalog into the index-log MetaItem (reference conformance) and drive it via the threshold dump above, instead of the per-write band-manifest file. Ships OFF (byte-identical); uncomment to enable.
 
 
 # -----------------------------------------------------------------------------

--- a/crates/temporalstore-rust/README.md
+++ b/crates/temporalstore-rust/README.md
@@ -50,7 +50,7 @@ passing report must prove:
 - per-peer progress, WAL first/last index, snapshot state, and admin metrics.
 
 If those fields are missing, readiness reports should keep the service blocked
-with concrete missing evidence rather than claiming parity from local fixtures.
+with concrete missing evidence rather than claiming conformance from local fixtures.
 
 ## Quick Validation
 
@@ -65,7 +65,7 @@ python3 tools/validate_rust_product_test_guard.py
 python3 tools/validate_no_duplicate_tests.py
 ```
 
-## Storage Tuning Parity
+## Storage Tuning Conformance
 
 Rust exposes the same public production tuning surface used by benchmark and
 deployment profiles. `StorageTuningConfig::from_env()` reads:

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1970,7 +1970,7 @@ fn wire_matrixobject_networked_durability(
     };
     let replicator = Arc::new(SharedStoreReplicator::new(cluster_id, Arc::new(store)));
 
-    // Fresh node: rebuild from the networked store via parity lazy
+    // Fresh node: rebuild from the networked store via conformance lazy
     // data-follow (index + address map, then WAL tail; old pages fetched on demand).
     if !local_state_present {
         let after_wal_index = match rt.block_on(replicator.restore_index_and_page_addresses(

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -134,7 +134,7 @@ pub struct BlockStoreStats {
     /// existed. Counted rather than timed, because a count says the same thing on a busy machine.
     #[serde(default)]
     pub band_manifest_writes: u64,
-    /// Slabs fetched on-demand from a shared-storage read-through source (parity
+    /// Slabs fetched on-demand from a shared-storage read-through source (conformance
     /// lazy recovery). Each shared slab is fetched at most once, only when a read
     /// misses it locally; a nonzero count proves recovery did not install every slab
     /// up front.
@@ -1358,7 +1358,7 @@ mod tests {
 
     #[test]
     fn per_append_does_not_reserialize_the_band_manifest_on_the_default_path() {
-        // MANIFEST-PARITY FOLD no-O(n) proof: on the default single-barrier path the per-append
+        // MANIFEST-CONFORMANCE FOLD no-O(n) proof: on the default single-barrier path the per-append
         // band-manifest full re-serialize (the measured O(n) aging driver -- ~961 B rewritten per
         // write, growing with the band count) is OFF the write path. Appending many records must
         // NOT rewrite `page_extent_manifest.json` each time; the catalog is deferred and made
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[test]
     fn zone_catalog_folds_bands_and_install_reconstructs_lifecycle() {
-        // MANIFEST-PARITY FOLD round-trip at the block-store layer: project the band catalog into
+        // MANIFEST-CONFORMANCE FOLD round-trip at the block-store layer: project the band catalog into
         // the durable ZoneInfo subset, then reconstruct the band lifecycle from that projection
         // with the band-manifest file deleted -- proving the folded catalog is a lossless source
         // of the durable band state (diagnostics are recomputed from the slab separately).
@@ -2783,7 +2783,7 @@ mod tests {
 
     #[test]
     fn band_garbage_floor_gates_reclaim_by_garbage_ratio() {
-        // garbage-ratio GC parity: reclaim is gated on a minimum band garbage ratio
+        // garbage-ratio GC conformance: reclaim is gated on a minimum band garbage ratio
         // (garbage = 10_000 - band live-fraction). Floor 0 (the default) reclaims every
         // eligible band as before; a floor above a band's garbage ratio excludes it.
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/block_store/band_reports.rs
+++ b/crates/temporalstore-rust/src/block_store/band_reports.rs
@@ -6,7 +6,7 @@
 use super::*;
 
 /// Map a band descriptor's lifecycle state to the index-log `ZoneState` (1:1). Kept a free fn
-/// so both directions of the MANIFEST-PARITY FOLD conversion share one mapping.
+/// so both directions of the MANIFEST-CONFORMANCE FOLD conversion share one mapping.
 fn band_state_to_zone_state(state: BlockStoreBandState) -> crate::index_log::ZoneState {
     match state {
         BlockStoreBandState::Active => crate::index_log::ZoneState::Active,
@@ -36,7 +36,7 @@ impl LocalBlockStore {
             .collect()
     }
 
-    /// MANIFEST-PARITY FOLD: project the in-memory band catalog into the DURABLE `ZoneInfo`
+    /// MANIFEST-CONFORMANCE FOLD: project the in-memory band catalog into the DURABLE `ZoneInfo`
     /// subset kept in the index-log band catalog. Only the durable fields ride in
     /// the fold; the band descriptor's diagnostic fields (readable_prefix / corruption / errors)
     /// are deliberately dropped -- they are recomputed on load by scanning the slab, exactly as
@@ -62,7 +62,7 @@ impl LocalBlockStore {
             .collect()
     }
 
-    /// MANIFEST-PARITY FOLD recovery: seed the band catalog from a folded `ZoneInfo` snapshot
+    /// MANIFEST-CONFORMANCE FOLD recovery: seed the band catalog from a folded `ZoneInfo` snapshot
     /// recovered from the index-log MetaItem. Applied on load AFTER the block store has already
     /// reconciled from durable pages (reconcile stays authoritative for on-disk physical bytes
     /// and diagnostics), so this only RESTORES the catalog fields a pure disk scan cannot infer:

--- a/crates/temporalstore-rust/src/client/table_control_state.rs
+++ b/crates/temporalstore-rust/src/client/table_control_state.rs
@@ -193,7 +193,7 @@ impl TemporalStoreTable {
         }
     }
 
-    /// Full-parity control-state atomic increment-then-read (`HSETANDGET`
+    /// Full-conformance control-state atomic increment-then-read (`HSETANDGET`
     /// analog) with precision bucketing, per-key TTL, and UUID idempotency.
     /// A repeated `uuid` within the dedup window is a no-op write that still
     /// returns the current windowed aggregate, so at-least-once queue replays do

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -220,7 +220,7 @@ impl TemporalEngine {
             };
             (loaded, replay_watermark)
         };
-        // MANIFEST-PARITY FOLD recovery (gate on only): seed the band catalog from the folded
+        // MANIFEST-CONFORMANCE FOLD recovery (gate on only): seed the band catalog from the folded
         // band-catalog anchor recovered from the index-log. This is applied AFTER the block
         // store already reconciled its catalog from the durable pages on open, so it only
         // RESTORES the catalog fields a pure disk scan cannot infer (exact lifecycle state,

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -372,7 +372,7 @@ impl TemporalEngine {
         let _ = atomic_write_bytes(&self.index_path(shard_id), &index_bytes);
     }
 
-    /// MANIFEST-PARITY FOLD threshold check: dump the index catalog when the undumped index-log
+    /// MANIFEST-CONFORMANCE FOLD threshold check: dump the index catalog when the undumped index-log
     /// gap has crossed `index_dump_wal_gap_bytes` (the index-meta dump gap
     /// cadence). No-op with the `TS_INDEX_CATALOG_FOLD` gate off, so the background cycle is
     /// byte-identical when the fold is not enabled. Returns whether a dump fired.
@@ -407,8 +407,8 @@ impl TemporalEngine {
         self.dump_index_catalog(shard_id)
     }
 
-    /// MANIFEST-PARITY FOLD dump: materialize the durable base index, fold the band/zone catalog
-    /// into an index-log anchor (the durable band catalog, parity), and
+    /// MANIFEST-CONFORMANCE FOLD dump: materialize the durable base index, fold the band/zone catalog
+    /// into an index-log anchor (the durable band catalog, conformance), and
     /// advance the dumped watermark -- the batched, threshold-driven replacement for the per-write
     /// band-manifest persist. No-op with the gate off. Ordering is single-barrier safe: pages +
     /// WAL are fsynced, then the base index is written durably, then the folded anchor is fsync'd,

--- a/crates/temporalstore-rust/src/engine/product_model.rs
+++ b/crates/temporalstore-rust/src/engine/product_model.rs
@@ -169,7 +169,7 @@ pub(super) fn control_state_family_name(family: ControlStateFamily) -> &'static 
     }
 }
 
-/// `MANAGER` op-code parity. Accepts the numeric code or its symbolic name.
+/// `MANAGER` op-code conformance. Accepts the numeric code or its symbolic name.
 /// `None` / unknown -> the family summary (the historical default).
 pub(super) fn control_state_manager_op_code(op_type: Option<&str>) -> Option<i64> {
     let value = op_type?.trim();

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -947,7 +947,7 @@ impl TemporalEngine {
                 + pressure_signals.raft_snapshot_retention_blockers,
         );
 
-        // MANIFEST-PARITY FOLD threshold dump (gate on only, never on a dry run): if the undumped
+        // MANIFEST-CONFORMANCE FOLD threshold dump (gate on only, never on a dry run): if the undumped
         // index-log gap has crossed `index_dump_wal_gap_bytes`, materialize the base index +
         // fold the band/zone catalog into an index-log anchor here, in the background cycle --
         // mirroring this design's background `StorageManager` dump-on-WAL-gap cadence, never

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1164,7 +1164,7 @@ fn durable_index_survives_restart_and_points_to_page_file() {
 
 #[test]
 fn async_write_survives_restart_via_wal_replay_like_native() {
-    // parity: an async_storage write records a WAL entry but defers page/
+    // conformance: an async_storage write records a WAL entry but defers page/
     // index materialization to the background dump. If the crash beats the dump,
     // Startup load replays the wal and recovers the write. Rust must replay
     // its WAL on shard load the same way, or the async write is silently lost.
@@ -1386,7 +1386,7 @@ fn control_state_coalesced_write_survives_restart_via_wal_replay() {
 
 #[test]
 fn async_storage_batch_write_records_wal_without_sync_or_index() {
-    // Batch analog of the single-command async parity: the batch path (used by
+    // Batch analog of the single-command async conformance: the batch path (used by
     // ingestion) must also record a WAL entry per async write, unfsynced, with page/
     // index materialization deferred.
     let dir = tempfile::tempdir().unwrap();
@@ -2095,7 +2095,7 @@ fn read_string(engine: &TemporalEngine, key: &str) -> Option<Vec<u8>> {
 
 #[test]
 fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() {
-    // MANIFEST-PARITY FOLD cadence: with a tiny WAL gap, a threshold dump fires once the
+    // MANIFEST-CONFORMANCE FOLD cadence: with a tiny WAL gap, a threshold dump fires once the
     // undumped index-log has grown past it, folding the band/zone catalog into an index-log
     // MetaItem anchor; below the gap nothing is dumped. Matches
     // index-meta dump background cadence -- never a per-write dump.
@@ -2139,7 +2139,7 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
 
 #[test]
 fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
-    // MANIFEST-PARITY FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
+    // MANIFEST-CONFORMANCE FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
     // file, reload -- every acked key must survive AND the band lifecycle must reconstruct from
     // the folded index-log MetaItem, proving the fold is a lossless catalog source.
     let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
@@ -3840,7 +3840,7 @@ fn feature_agg_rollup_matches_raw_scan() {
 }
 
 // The gated control-state rollup ladder must return exactly the same sum-family window
-// aggregates as the ungated raw scan, through the real execute() path. Functional-parity
+// aggregates as the ungated raw scan, through the real execute() path. Functional-conformance
 // gate for the O(levels) long-window control-state path (frequency caps / counts).
 #[test]
 fn control_state_rollup_matches_raw_scan_through_engine() {
@@ -3932,7 +3932,7 @@ fn control_state_rollup_matches_raw_scan_through_engine() {
     assert!(raw.iter().any(|value| *value != 0), "test series should be non-trivial");
 }
 
-// MANAGER op-code parity: QUERY(2) / FIELD_LIST(5) / FIELD_COUNT(6) / ALL_DATA_VALUE(7)
+// MANAGER op-code conformance: QUERY(2) / FIELD_LIST(5) / FIELD_COUNT(6) / ALL_DATA_VALUE(7)
 // over the H family series, plus the default summary path.
 #[test]
 fn control_state_manager_op_codes_match_hash_manager() {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2445,7 +2445,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
 
 #[test]
 fn control_state_set_and_get_with_options_buckets_by_precision() {
-    // HSETANDGET parity: precision floors the write into a single bucket, and
+    // HSETANDGET conformance: precision floors the write into a single bucket, and
     // the atomic increment-then-read returns the post-increment windowed aggregate.
     let engine = TemporalEngine::default();
     engine.load_shard(1);

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -677,7 +677,7 @@ fn partial_compaction_failure_durably_persists_the_consistent_partial_index() {
 
 #[test]
 fn sync_write_surfaces_wal_commit_failure_instead_of_acking_ok() {
-    // Durability parity: a synchronous write whose durable WAL commit fails must NOT be acked ok.
+    // Durability conformance: a synchronous write whose durable WAL commit fails must NOT be acked ok.
     // The WAL is the recovery source of truth, so a swallowed append error would tell the client a
     // write that is gone after a crash succeeded. surfaces the wal Commit failure
     // We inject the failure by replacing the WAL file with a

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -255,7 +255,7 @@ struct IndexLogInner {
     root: PathBuf,
     stats: IndexLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
-    /// MANIFEST-PARITY FOLD: the index-log byte length recorded at the last catalog dump, per
+    /// MANIFEST-CONFORMANCE FOLD: the index-log byte length recorded at the last catalog dump, per
     /// shard. `undumped_len_since_dump` subtracts this from the current on-disk length to get the
     /// undumped gap that drives the threshold-dump cadence. Reset to 0
     /// on process restart, so the first post-restart cycle may dump once -- harmless (a dump only
@@ -297,7 +297,7 @@ fn indexlog_wal_only_sync() -> bool {
     )
 }
 
-/// MANIFEST-PARITY FOLD gate (default OFF, byte-identical when off). When on, the band/zone
+/// MANIFEST-CONFORMANCE FOLD gate (default OFF, byte-identical when off). When on, the band/zone
 /// catalog is folded into the index-log anchor at a threshold dump
 /// and the per-write band-manifest file stops being the
 /// catalog's source of truth (it is reconstructed on load from the durable pages + the folded

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -950,7 +950,7 @@ fn monotonic_record_count_enabled() -> bool {
         .unwrap_or(true)
 }
 
-// TemporalStore parity with the native storage engine: the storage engine's
+// TemporalStore conformance with the native storage engine: the storage engine's
 // record/serving SEQUENCE is an engine-owned MONOTONIC log id, taken from the append
 // log's own iterator id and exposed read-only. It is advanced only by the append log /
 // commit and is never a client
@@ -2688,7 +2688,7 @@ fn env_i32_any(names: &[&str], default: i32) -> i32 {
 }
 
 fn execute_empty(engine: &TemporalEngine, command: Command) -> Result<(), String> {
-    // parity monotonic serving sequence: never let a record_count write regress.
+    // conformance monotonic serving sequence: never let a record_count write regress.
     let command = clamp_record_count_command(engine, command);
     let retrieve_cache_keys = match &command {
         Command::HashSet { key, .. }
@@ -2759,7 +2759,7 @@ fn execute_empty_batch_runtime(
     if commands.is_empty() {
         return Ok(());
     }
-    // parity monotonic serving sequence: never let a record_count write regress
+    // conformance monotonic serving sequence: never let a record_count write regress
     // (mirrors the append-log's advance-only log id). Applies to the serving append
     // batch that carries the {prefix}:record_count StringSet.
     let commands: Vec<Command> = commands

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
-//! SingleNodeMeta reporting methods (parity/info/stats/preflight/topology_version), extracted from meta.rs.
+//! SingleNodeMeta reporting methods (conformance/info/stats/preflight/topology_version), extracted from meta.rs.
 
 use super::*;
 

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -1379,7 +1379,7 @@ pub fn execute_redis_command_with_state(
             end_offset: String::new(),
             is_distinct: false,
         })),
-        // MANAGER op parity: CONTROLSTATEMANAGER key op_type is_distinct [start_offset end_offset | field...]
+        // MANAGER op conformance: CONTROLSTATEMANAGER key op_type is_distinct [start_offset end_offset | field...]
         // op_type: QUERY(2)|FIELD_LIST(5)|FIELD_COUNT(6)|ALL_DATA_VALUE(7). is_distinct: 0/1.
         "CONTROLSTATEMANAGER" if args.len() >= 4 => {
             let op_type = string_arg(&args[2]);

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -1646,7 +1646,7 @@ struct SharedSlabAddress {
     sha256: String,
 }
 
-/// Lazy read-through source backing parity recovery on the shared-filesystem
+/// Lazy read-through source backing conformance recovery on the shared-filesystem
 /// (`FileObjectStore`) backend. Holds the checkpoint's slab address map (slab id ->
 /// shared object key) with no slab bytes, and resolves each slab on demand to a
 /// synchronous filesystem read of the shared store, verifying the checkpoint
@@ -1686,7 +1686,7 @@ impl SharedSlabSource for SharedPathSlabSource {
             ))
         })?;
         let bytes = std::fs::read(&path)?;
-        // Parity with restore_checkpoint: reject a corrupt shared slab before caching it.
+        // Conformance with restore_checkpoint: reject a corrupt shared slab before caching it.
         let actual = sha256_hex(&bytes);
         if bytes.len() as u64 != address.byte_size || actual != address.sha256 {
             return Err(BlockStoreError::ChecksumMismatch {
@@ -1701,7 +1701,7 @@ impl SharedSlabSource for SharedPathSlabSource {
     }
 }
 
-/// Lazy read-through source backing parity recovery on the *networked*
+/// Lazy read-through source backing conformance recovery on the *networked*
 /// matrixobject (`MatrixObjectHttpStore`) backend. Same contract as
 /// [`SharedPathSlabSource`], but resolves each slab to a synchronous networked
 /// GET ([`MatrixObjectHttpStore::get_blocking`]) of the shared object instead of a
@@ -1745,7 +1745,7 @@ impl SharedSlabSource for MatrixObjectSlabSource {
                 ))
             })?
             .to_vec();
-        // Parity with restore_checkpoint: reject a corrupt shared slab before caching it.
+        // Conformance with restore_checkpoint: reject a corrupt shared slab before caching it.
         let actual = sha256_hex(&bytes);
         if bytes.len() as u64 != address.byte_size || actual != address.sha256 {
             return Err(BlockStoreError::ChecksumMismatch {
@@ -1764,7 +1764,7 @@ impl<O> SharedStoreReplicator<O>
 where
     O: ObjectStore + 'static,
 {
-    /// Shared body of the parity LAZY restore, parameterized over the
+    /// Shared body of the conformance LAZY restore, parameterized over the
     /// slab-source constructor so every shared-storage backend reuses the identical
     /// index-install + address-map + lazy-range-reserve logic; only the per-slab
     /// fetch transport differs (a local filesystem read vs a networked GET). Install
@@ -1842,7 +1842,7 @@ where
 }
 
 impl SharedStoreReplicator<FileObjectStore> {
-    /// Parity LAZY restore for the shared-filesystem backend: install the served
+    /// Conformance LAZY restore for the shared-filesystem backend: install the served
     /// INDEX and a per-slab shared address map WITHOUT downloading any slab bytes.
     /// Old (pre-checkpoint) pages are then read lazily through [`SharedPathSlabSource`]
     /// on the first read that needs them. See
@@ -1862,7 +1862,7 @@ impl SharedStoreReplicator<FileObjectStore> {
 }
 
 impl SharedStoreReplicator<MatrixObjectHttpStore> {
-    /// Parity LAZY restore for the *networked* matrixobject backend: install
+    /// Conformance LAZY restore for the *networked* matrixobject backend: install
     /// the served INDEX and a per-slab shared address map WITHOUT downloading any slab
     /// bytes. Old (pre-checkpoint) pages are then fetched lazily over the network
     /// through [`MatrixObjectSlabSource`] on the first read that needs them, so shard
@@ -3509,7 +3509,7 @@ mod tests {
 
     #[tokio::test]
     async fn matrixobject_networked_lazy_restore_reads_old_page_on_demand() {
-        // Parity lazy data-follow over the NETWORK: a fresh node with only
+        // Conformance lazy data-follow over the NETWORK: a fresh node with only
         // the networked matrixobject store restores the served index + a slab ADDRESS
         // map (no slab bytes), replays the WAL tail, and fetches an old (pre-checkpoint)
         // slab ON DEMAND over the socket the first time a read needs it.

--- a/crates/temporalstore-rust/src/storage_config.rs
+++ b/crates/temporalstore-rust/src/storage_config.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_COLD_SCAN_NO_CACHE_FILL: bool = true;
 pub const DEFAULT_PAGE_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 pub const DEFAULT_BLOCK_INDEX_CACHE_BYTES: u64 = 64 * 1024 * 1024;
 // Undumped index-log-gap threshold that triggers a background catalog/index dump under the
-// MANIFEST-PARITY FOLD (TS_INDEX_CATALOG_FOLD). Matches the
+// MANIFEST-CONFORMANCE FOLD (TS_INDEX_CATALOG_FOLD). Matches the
 // default of 1 MiB.
 pub const DEFAULT_INDEX_DUMP_WAL_GAP_BYTES: u64 = 1024 * 1024;
 
@@ -150,7 +150,7 @@ pub fn storage_zone_size_bytes() -> u64 {
 }
 
 /// Undumped index-log-gap threshold (bytes) that triggers a background catalog/index dump under
-/// the MANIFEST-PARITY FOLD. Reads the `TS_INDEX_DUMP_WAL_GAP_BYTES` env override -- or the
+/// the MANIFEST-CONFORMANCE FOLD. Reads the `TS_INDEX_DUMP_WAL_GAP_BYTES` env override -- or the
 /// previous name for it, so existing deployments keep working -- falling back to the 1 MiB
 /// default. Only consulted when `index_catalog_fold_enabled()`.
 pub fn index_dump_wal_gap_bytes() -> u64 {

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1410,7 +1410,7 @@ pub enum Command {
         end_ms: u64,
         aggregator: String,
     },
-    /// Full-parity analog of the control_state `HSETANDGET` operator: an
+    /// Full-conformance analog of the control_state `HSETANDGET` operator: an
     /// atomic increment-then-read that additionally supports precision bucketing,
     /// per-key TTL, and UUID idempotency (dedup within a bounded window so
     /// at-least-once queue replays do not double-count). `aggregator` accepts the
@@ -1453,7 +1453,7 @@ pub enum Command {
     },
     ControlStateManager {
         key: String,
-        /// Optional manager op-code for `MANAGER` parity: QUERY(2), FIELD_LIST(5),
+        /// Optional manager op-code for `MANAGER` conformance: QUERY(2), FIELD_LIST(5),
         /// FIELD_COUNT(6), ALL_DATA_VALUE(7). `None` / unknown returns the family summary.
         #[serde(default)]
         op_type: Option<String>,

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -510,7 +510,7 @@ struct WriteAheadLogInner {
     root: PathBuf,
     stats: WriteAheadLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
-    // MANIFEST-PARITY / phase-1 flat-append cache (TS_PHASE1_FLAT). The WAL file byte length as
+    // MANIFEST-CONFORMANCE / phase-1 flat-append cache (TS_PHASE1_FLAT). The WAL file byte length as
     // this process last left it after its own append (or after a full reconcile scan), per shard.
     // On the next append the fast path stats the file: if the on-disk length still equals this,
     // no other writer touched the file since we wrote it (the append lock is cross-process) and --

--- a/docs/CONTEXT_DIRTY_INMEMORY.md
+++ b/docs/CONTEXT_DIRTY_INMEMORY.md
@@ -80,7 +80,7 @@ inmemory_dirty_check: OK (coalescing, latest-ts, max-depth, window-filter, bound
 
 `MarkSummaryDirty` / `QuerySummaryDirty` use a process-local, mutex-guarded
 coalescing map (`InMemoryDirtyEntry`) instead of the `ContextDirtyModel` `OrSet`
-timeline — parity with the Rust behavior. Existing context reference-test expectations
+timeline — conformance with the Rust behavior. Existing context reference-test expectations
 (mark once → one marker, `propagate_depth == 1`) are preserved. Compile-verified
 against the project's `compile_commands.json` flags.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ python3 tools/run_temporalstore_unified_tests.py --validate-only
   `compat/unified_temporalstore_cases.json`.
 - New Rust product tests must include `shared-corpus: <case_id>`.
 - Rust-only implementation tests must include `rust-internal: <reason>`.
-- Keep parity claims tied to shared corpus cases, harness output, or docs
+- Keep conformance claims tied to shared corpus cases, harness output, or docs
   that describe the remaining blocker.
 
 ## Scope Boundaries

--- a/docs/LLM_CONTEXT_TEMPORALSTORE_DEEP_DIVE.md
+++ b/docs/LLM_CONTEXT_TEMPORALSTORE_DEEP_DIVE.md
@@ -1,7 +1,7 @@
 # TemporalStore LLM Context Deep Dive
 
 This document consolidates the MatrixArk / TemporalStore context design, serving
-schemas, ingestion/query workflows, parity gates, and local validation steps.
+schemas, ingestion/query workflows, conformance gates, and local validation steps.
 
 ## Goal
 
@@ -531,9 +531,9 @@ why older context was compressed.
 ## Monitoring UI Readiness
 
 The monitoring UI under `tools/temporalstore-monitoring-ui/` now exposes two
-operator-facing parity sections.
+operator-facing conformance sections.
 
-### End-to-End Parity
+### End-to-End Conformance
 
 This table repeats the runtime story across nine complete paths:
 
@@ -550,7 +550,7 @@ module parity
 ```
 
 Every row must show the evidence command or corpus case, the expected output, and
-the pass/fail status. This makes parity visible without reading the JSON corpus.
+the pass/fail status. This makes conformance visible without reading the JSON corpus.
 
 ### UI Production Readiness
 

--- a/docs/MIGRATE_FROM_MEM0.md
+++ b/docs/MIGRATE_FROM_MEM0.md
@@ -156,7 +156,7 @@ hashed-subject audit record (`sha256(user_id)` + count).
 `memory_history(memory_id)`, `forget(user_id=…)`, `delete_memory(memory_id)`,
 `get_all(user_id=…)`, `reset_memory()`.
 
-### `search()` return shape (mem0 parity)
+### `search()` return shape (mem0 conformance)
 
 `m.search(...)` returns mem0's shape so existing mem0 code that reads
 `res["results"][i]["memory"]` works unchanged:

--- a/docs/benchmark_threshold_policy.md
+++ b/docs/benchmark_threshold_policy.md
@@ -10,9 +10,9 @@ that can support production readiness claims.
 Benchmark result docs must stay strict:
 
 - Fixture scores are wiring evidence only; they must not be called paper-equivalent scores or
-  production-parity evidence.
+  production-conformance evidence.
 - Deterministic-reader full-dataset scores can claim retrieval/reader gate readiness for that
-  configured runner, but not live OSS-reader parity.
+  configured runner, but not live OSS-reader conformance.
 - OSS/open-model claims require at least one successful real local reader call and
   `require_open_source_reader=true`.
 - MatrixArk vs OpenViking/VikingMem OSS comparisons must pass the shared OSS model contract:
@@ -20,7 +20,7 @@ Benchmark result docs must stay strict:
   context budget, same reader prompt policy, and declared provider identities for both sides.
   Mismatched model, budget, or reader-policy runs are diagnostic-only even when their individual
   scores look good.
-- Production parity, production-ready, or paper-comparable benchmark claims require all evidence in
+- Production conformance, production-ready, or paper-comparable benchmark claims require all evidence in
   the same result doc: real dataset artifact, live OSS reader calls, full Rust TemporalStore replay,
   all-pipeline Rust evidence, and passing threshold output with zero threshold violations.
 - The archive gate must also show `reader_mode_effective=open-source`,
@@ -158,7 +158,7 @@ with the Python ranker and requires Rust case count, Hit@K, mean reciprocal rank
 query count to match the Python scorer within `--rust-temporalstore-score-tolerance` before marking
 the backend ready. Reports also emit `all_pipelines_use_rust_temporalstore`; production benchmark
 evidence requires that field to be `true`. A fixed `1e-6` numerical epsilon is always allowed so
-Rust f32 report output does not fail exact source-rank parity. Use `--skip-rust-temporalstore`
+Rust f32 report output does not fail exact source-rank conformance. Use `--skip-rust-temporalstore`
 only with `--allow-python-only-diagnostic` for explicit diagnostic Python-only runs; those reports
 are not Rust-backed evidence. Use
 `--rust-temporalstore-max-cases 0 --rust-temporalstore-source-limit 0` only when a full Rust
@@ -220,6 +220,6 @@ and report path.
 The Docker/open-model runner for `oss_reader_full` is documented in
 [context_benchmarks_docker_open_model.md](context_benchmarks_docker_open_model.md).
 Use `tools/run_context_benchmarks_oss_reader_endpoint.sh` when validating the
-VikingMem parity reader profile against an existing OpenAI-compatible endpoint.
+VikingMem conformance reader profile against an existing OpenAI-compatible endpoint.
 That path defaults to `vikingmem-gpt-4o-mini-reader` and `gpt-4o-mini`, and must
 report `reader_open_source_calls > 0`.

--- a/docs/client_sdk_contract.md
+++ b/docs/client_sdk_contract.md
@@ -103,7 +103,7 @@ tests or validators:
 - MetaSyncer production behavior is covered by deadline-limited topology calls, exponential backoff with deterministic jitter, metaserver outage survival, and topology-version route churn refresh tests.
 - retry budgets are covered by separate read/write retry-budget tests, including the no-duplicate
   unsafe write retry path.
-- pipeline parity is covered by ordered batch execution, per-command partial-failure preservation,
+- pipeline conformance is covered by ordered batch execution, per-command partial-failure preservation,
   retry-safe versus unsafe write classification, and timeout-budget propagation tests.
 - admission policy is covered by readonly, write-disabled, not-serving, drop-percent, and degraded
   proxy/client preflight tests.
@@ -134,7 +134,7 @@ New production command families must update all of these in the same change:
 - `proto/temporalstore/v1/temporalstore.proto`
 - `compat/unified_temporalstore_cases.json` when behavior is externally observable
 - Rust client/proxy/server command handling
-- native corpus runner support, when the command is part of parity
+- native corpus runner support, when the command is part of conformance
 - `tools/validate_sdk_contract.py`
 
 ## Readiness Status

--- a/docs/context_benchmarks_docker_open_model.md
+++ b/docs/context_benchmarks_docker_open_model.md
@@ -11,7 +11,7 @@ The repo also includes a Hugging Face Transformers endpoint for the exact
 `tools/openai_compatible_hf_reader.py`, defaults to `google/flan-t5-small`, and
 is packaged by `docker/Dockerfile.context-oss-reader`.
 
-Claim level: packaged open-model benchmark path. This page does not present production parity or
+Claim level: packaged open-model benchmark path. This page does not present production conformance or
 VikingMem paper-comparable evidence by itself. Those labels require a mounted real dataset, a
 successful real reader call, no deterministic fallback, full Rust TemporalStore replay, and passing
 threshold output in the archived report.
@@ -149,7 +149,7 @@ LOCOMO/LongMemEval_s full gate commands also require it unless they are run in a
 marked local diagnostic mode. Accepted pipeline and benchmark evidence invokes the Rust
 `context_workflow_harness`, compare Rust case count, Hit@K, mean reciprocal rank,
 and zero-hit queries with the Python scorer on the exact converted subset, and
-fails closed unless the parity result is on par. Production benchmark evidence requires
+fails closed unless the conformance result is on par. Production benchmark evidence requires
 `all_pipelines_use_rust_temporalstore=true`,
 `rust_temporalstore_context_event_ingest_ready=true`, and
 `rust_temporalstore_direct_source_scoring=false`.

--- a/docs/context_extraction_injection_workflow.md
+++ b/docs/context_extraction_injection_workflow.md
@@ -9,7 +9,7 @@ TemporalStore keeps Context data in its existing `ContextNode`, `ContextEvent`, 
 
 The workflow is:
 
-1. `manage`: report supported routes, provider count, pipeline stages, and/the baseline memory system parity
+1. `manage`: report supported routes, provider count, pipeline stages, and/the baseline memory system conformance
    evidence before admitting a deployment as context-ready. The management report now includes
    per-stage readiness, provider names, and policy controls so operators can see which part of the
    pipeline owns a failure.
@@ -100,7 +100,7 @@ profiles through `GET /context/workflow/state`:
 - `baseline-internvl-vllm`: `OpenGVLab/InternVL2_5-8B` VLM,
   `Qwen/Qwen2.5-7B-Instruct` chat model, `BAAI/bge-m3` embedding model, OpenAI-compatible
   gateway at `127.0.0.1:8000/v1`
-- `baseline-gpt-4o-mini-reader`: `gpt-4o-mini` reader/chat model for the baseline memory system benchmark parity,
+- `baseline-gpt-4o-mini-reader`: `gpt-4o-mini` reader/chat model for the baseline memory system benchmark conformance,
   `sentence-transformers/all-MiniLM-L6-v2` embedding model, OpenAI-compatible gateway at
   `https://api.openai.com/v1`
 - `matrixark-native-oss-context`: `google/flan-t5-small` extraction model and
@@ -171,11 +171,11 @@ The harness verifies:
 - restart replay preserves the same `ContextNode` and `ContextEvent`
 - shared-store sync and async replay preserve the same Context pipeline writes
 - Raft replica reads can serve the same Context event after the write path is replicated
-- `context_pipeline_ready` is true only when the parity report covers Context models,
+- `context_pipeline_ready` is true only when the conformance report covers Context models,
   the baseline memory system L0/L1/L2 tiers, extraction, retrieval, injection, index refs, pack audit, dirty
   summary, restart replay, shared-store sync/async replay, Raft reads, and unified corpus evidence
 
-## Context Model Parity
+## Context Model Conformance
 
 The current TemporalStore context module registers first-class LLM context model names on top of
 existing hash/feature page primitives:
@@ -209,7 +209,7 @@ Covered:
 - Data-node HTTP routes expose management and batch ingest/extract pipeline handoff.
 - The local harness and Docker-packaged harness validate management, ingest/extract, retrieval,
   injection, and audit refs.
--/the baseline memory system parity evidence covers engine-local restart, shared-store sync/async replay,
+-/the baseline memory system conformance evidence covers engine-local restart, shared-store sync/async replay,
   Raft reads, and the shared conformance Context corpus.
 
 ## the baseline memory system-Style Benchmark
@@ -217,7 +217,7 @@ Covered:
 `context_workflow_harness` runs a deterministic local benchmark inspired by the baseline memory system paper's
 long-term memory evaluation themes: retrieval effectiveness, low interactive latency, hierarchical
 context loading, and reduced context tokens. The benchmark does not claim byte-for-byte the baseline memory system
-workload parity, published the baseline memory system scores, or a licensed copy of LOCOMO/LongMemEval_s. It
+workload conformance, published the baseline memory system scores, or a licensed copy of LOCOMO/LongMemEval_s. It
 includes LOCOMO-style conversational-memory and LongMemEval_s-style long-context synthetic profiles
 so local validation can exercise similar source/query scaling and hit-ranking behavior. It produces
 local TemporalStore evidence:
@@ -320,7 +320,7 @@ after the dinner update?" and "What risk score was recorded after the latest fra
 numeric memory updates. Alias cases such as "What is Emma's roommate's name after the move?" and
 "What is the dog's name in the latest pet update?" cover entity-disambiguation updates.
 
-The shared conformance corpus also has a dedicated reasoning/VLM parity case.
+The shared conformance corpus also has a dedicated reasoning/VLM conformance case.
 Rust executes a conformance check that requires explicit
 coverage for multi-hop reasoning, temporal reasoning, memory updates, stale-memory replacement,
 open-domain retrieval, and VLM image/content understanding. The VLM case is currently a

--- a/docs/context_ingestion_extraction_retrieval_manual.md
+++ b/docs/context_ingestion_extraction_retrieval_manual.md
@@ -103,7 +103,7 @@ Current local scale evidence:
   cases, 10,960 sources, Hit@K 1.0, reader hit 0.974, retrieval p95 28.978 ms, token reduction
   81.4017%, and the required Rust-backed fields all true. The passing replay used release-mode
   batches of 16 with source packing disabled, because LongMemEval_s native per-session sources
-  preserve exact per-query output and Rust/Python case parity.
+  preserve exact per-query output and Rust/Python case conformance.
 - LOCOMO full Rust replay now passes on the real `/tmp/locomo10.json` artifact with 1,542 cases,
   Hit@K 0.9533073930, reader hit 0.8839169909, retrieval p95 46.160 ms, and the required
   Rust-backed fields all true. The optimized replay uses source packing to preserve all source text
@@ -365,7 +365,7 @@ local gateway such as Ollama or vLLM:
 `Vision-CAIR/MiniGPT-4` profile. Use `mock_mode=true` with the same profile names for deterministic
 Docker validation when a live VLM server is not running.
 
-For the baseline memory system benchmark parity, use the GPT-4o-mini reader profile:
+For the baseline memory system benchmark conformance, use the GPT-4o-mini reader profile:
 
 ```json
 {

--- a/docs/distributed_raft_readiness.md
+++ b/docs/distributed_raft_readiness.md
@@ -181,10 +181,10 @@ closed because the local model is test-only. Local Raft fixtures remain availabl
 compatibility tests, and harness validation, but they are not an accepted runtime or deployment
 mode.
 
-The Rust production target is Rust-native behavior parity: keep TemporalRaft/raft-rs as the production
+The Rust production target is Rust-native behavior conformance: keep TemporalRaft/raft-rs as the production
 path and borrow RustRaft semantics, safety contracts, metrics, admin surfaces, and tests. The
 RustRaft-derived evidence is now paired with the Rust TemporalRaft process rollout evidence, and the
-process-path gate fails closed if that evidence is absent. This makes the runtime parity claim
+process-path gate fails closed if that evidence is absent. This makes the runtime conformance claim
 harder to fake, but it is still Rust-native TemporalRaft readiness evidence, not a claim that Rust is
 byte-for-byte or implementation-identical to RustRaft. Direct RustRaft FFI is not part of
 the readiness target.
@@ -225,8 +225,8 @@ The production runtime surface is:
   verifies post-failover reads
 - `run_raft_shared_cases.py` validates every shared conformance Raft corpus case has Rust process or
   harness evidence and required paths. Its Rust combined mode runs the data-node plus metaserver
-  parity gate once instead of treating individual corpus rows as production proof by name alone.
-- The combined Raft parity summary now promotes metaserver scheduler execution coverage,
+  conformance gate once instead of treating individual corpus rows as production proof by name alone.
+- The combined Raft conformance summary now promotes metaserver scheduler execution coverage,
   TemporalRaft metaserver process rollout, and metaserver-owned data-Raft membership into first-class
   evidence fields. Validation requires learner add, catch-up verification, promotion, leader
   transfer, voter removal, follower-lag/failover/scale-up/scale-down/secondary-replication flags,
@@ -260,7 +260,7 @@ The current unified corpus includes these Raft/replication cases:
 | `raft_metaserver_leader_snapshot_restart` | `tools/run_metaserver_raft_failover_ubuntu22.sh`, `tools/run_metaserver_raft_snapshot_restore_ubuntu22.sh` | `metaserver_raft_harness` names leader/failover, snapshot install, and restart recovery as a separate shared scenario |
 | `raft_metaserver_membership_add_promote_remove` | `tools/run_metaserver_raft_membership_ubuntu22.sh` | `metaserver_raft_harness` names learner add, catch-up, promote, leader transfer, voter remove, stale generation rejection, and scheduler generation/token coupling as a separate shared scenario |
 | `raft_temporal_raft_process_rollout_evidence` | `tools/run_raft_production_gate_ubuntu22.sh`, `tools/run_raft_stress_suite_ubuntu22.sh` | Rust unit/readiness evidence verifies local mode is rejected for deployment and production readiness depends on TemporalRaft data-node and metaserver process rollout plus log-store validation fields; `distributed_raft_harness` now emits `membership_role_process_evidence` and requires `rustraft_runtime_semantics.membership_role_process_validated=true` for witness quorum/no-data behavior, learner auto-promote, and pending joint-consensus WAL restore before final commit; local-status Prometheus now exports RustRaft-style peer progress, snapshot state, transfer target, pre-vote/election counters, and WAL first/last log index; the membership matrix also requires metaserver generation/token replay evidence |
-| `raft_production_gate` | `tools/run_raft_production_gate_ubuntu22.sh` | `tools/run_storage_raft_production_readiness.sh` is the Rust storage/Raft local gate, and `tools/run_raft_distributed_conformance.sh` is the Rust Raft-only parity gate for data-node plus metaserver multi-node behavior; strict production mode still fails until networked TemporalRaft rollout and real multi-process log-store validation are complete |
+| `raft_production_gate` | `tools/run_raft_production_gate_ubuntu22.sh` | `tools/run_storage_raft_production_readiness.sh` is the Rust storage/Raft local gate, and `tools/run_raft_distributed_conformance.sh` is the Rust Raft-only conformance gate for data-node plus metaserver multi-node behavior; strict production mode still fails until networked TemporalRaft rollout and real multi-process log-store validation are complete |
 
 Focused Raft-case-driven Rust validation:
 
@@ -271,7 +271,7 @@ python3 tools/run_raft_cases_on_rust.py \
 ```
 
 This command uses the unified Raft case names above to verify required paths, write a
-case-to-Rust-runner mapping report, and execute the Rust data-node plus metaserver Raft parity gate.
+case-to-Rust-runner mapping report, and execute the Rust data-node plus metaserver Raft conformance gate.
 
 ## June 17, 2026 Local Multi-Node Validation
 
@@ -417,7 +417,7 @@ cargo build -p temporalstore-rust --bins
 cargo run -p temporalstore-rust --bin external_chaos_gate -- --profile quick
 ```
 
-The executable Raft-only parity gate for both data-node and metaserver multi-node behavior is:
+The executable Raft-only conformance gate for both data-node and metaserver multi-node behavior is:
 
 ```bash
 tools/run_raft_distributed_conformance.sh
@@ -425,7 +425,7 @@ tools/run_raft_distributed_conformance.sh
 
 It runs `distributed_raft_harness`, `raft_secondary_replication_harness`, and
 `metaserver_raft_harness`, then uses `build_raft_distributed_conformance_summary.py` to validate a
-combined `raft-distributed-parity.json` report with data-node replica reads, follower-write
+combined `raft-distributed-conformance.json` report with data-node replica reads, follower-write
 rejection, membership scale down/up, external snapshot restore, secondary restart/partition/lag/
 failover, post-snapshot re-scale down/up, and metaserver
 membership/read-index/snapshot/lagging-voter catch-up/failover/replacement/scale-down/no-majority

--- a/docs/matrixark_claude_hook_integration.md
+++ b/docs/matrixark_claude_hook_integration.md
@@ -7,7 +7,7 @@ identity. It is the Claude Code counterpart to the Codex hook family
 
 Entry point: [`tools/matrixark_claude_hook.sh`](../tools/matrixark_claude_hook.sh).
 
-## Feature parity with the Codex hook
+## Feature conformance with the Codex hook
 
 The Claude hook and the Codex hook run the **same engine**, parametrized by agent.
 They differ only in agent identity and session scope (`claude:<id>` vs
@@ -19,7 +19,7 @@ They differ only in agent identity and session scope (`claude:<id>` vs
 | **Extraction** | `Stop`, `SubagentStop`, `PreCompact`, `SessionEnd`, idle/threshold | `matrixark_session_commit` batch extract (segments, entities, index, summary, embeddings) | same |
 | **Retrieval** | `UserPromptSubmit` (before LLM) | `matrixark_retrieve` → `hookSpecificOutput.additionalContext` | same |
 
-Parity is enforced by
+Conformance is enforced by
 `tools/test_matrixark_popular_agent_hooks.py::test_codex_and_claude_hooks_have_ingestion_extraction_retrieval_parity`,
 which drives both agents through all three stages and asserts equivalent
 behavior and identical result shapes.
@@ -28,7 +28,7 @@ behavior and identical result shapes.
 
 Selected with `MATRIXARK_CLAUDE_HOOK_BACKEND`:
 
-- **`auto`** (default) — the python parity pipeline when the rust proxy binary
+- **`auto`** (default) — the python conformance pipeline when the rust proxy binary
   (`target/release/matrixark_rust_proxy`) is present, otherwise the offline rust
   engine.
 - **`python`** — `tools/matrixark_agent_hook.py --agent claude`. Byte-for-byte the

--- a/docs/matrixark_codex_mcp_hook_installation_manual.md
+++ b/docs/matrixark_codex_mcp_hook_installation_manual.md
@@ -50,7 +50,7 @@ Set `startup_timeout_sec = 180` or `240` for local development.
 
 ### Rust backend MCP config
 
-Use this when validating Rust parity:
+Use this when validating Rust conformance:
 
 ```toml
 [mcp_servers.matrixark]
@@ -173,7 +173,7 @@ Codex hook availability depends on the Codex surface/version. If hooks are not v
 }
 ```
 
-Use the Rust hook launcher for Rust parity:
+Use the Rust hook launcher for Rust conformance:
 
 ```json
 {

--- a/docs/matrixark_installation_operations_monitoring.md
+++ b/docs/matrixark_installation_operations_monitoring.md
@@ -131,16 +131,16 @@ matrixark-server start --backend rust --local
 matrixark-server apply-key --agent codex
 ```
 
-## And Rust Store Parity
+## And Rust Store Conformance
 
 MatrixArk should operate against either TemporalStore implementation through the same product contract. The caller should not change API payloads, access scopes, ContextPack shape, monitoring views, or benchmark commands when switching backends.
 
-| Area | TemporalStore | Rust TemporalStore | Required parity |
+| Area | TemporalStore | Rust TemporalStore | Required conformance |
 | --- | --- | --- | --- |
 | Local developer mode | Native process, direct SDK, or proxy/gateway. | Long-lived Rust proxy or binding; CLI-per-operation is debug only. | Same `backend=native|rust` switch in config and Docker. |
 | Serving data | ContextNode, ContextSummary, ContextEmbedding, ContextEvent, ContextEntity, ContextIndex, ResourceChunk, SkillManifest, ContextPackAudit. | Same logical records and wire shape. | Same record keys, timestamps, ids, and replay output. |
 | Ingestion | API, MCP, hook, batch/session commit, streaming, resource, skill, feedback. | Same ingestion APIs. | Same idempotency behavior and audit refs. |
-| Retrieval | Tree-first traversal, secondary-index filtering, event/entity/resource/skill selection, token-budget packing. | Same retrieval semantics. | Same selected refs and dropped-ref reasons for parity tests. |
+| Retrieval | Tree-first traversal, secondary-index filtering, event/entity/resource/skill selection, token-budget packing. | Same retrieval semantics. | Same selected refs and dropped-ref reasons for conformance tests. |
 | Storage mode | Local single node, multi data node, async oplog, future Raft HA. | Local single node first, then gateway-backed async writes and future HA mode. | Same health state and metrics labels. |
 | Benchmarking | LOCOMO, LongMemEval, scale tests, resource/skill tests. | Same unified tests. | Same artifacts: result JSON, report JSON/MD, hypotheses JSONL, ContextPack JSONL, judge JSONL. |
 
@@ -154,9 +154,9 @@ export MATRIXARK_TEMPORALSTORE_BACKEND=rust
 python3 tools/matrixark_mcp_server.py --event-log "$MATRIXARK_MCP_EVENT_LOG"
 ```
 
-Production Rust must not spawn a Rust CLI once per storage operation. That path is useful for feature parity tests, but product runs need a long-lived process, gateway, or in-process binding so latency and concurrency are comparable with.
+Production Rust must not spawn a Rust CLI once per storage operation. That path is useful for feature conformance tests, but product runs need a long-lived process, gateway, or in-process binding so latency and concurrency are comparable with.
 
-Parity gates:
+Conformance gates:
 
 1. Same message/resource/skill input produces the same logical records.
 2. Same query produces equivalent ContextPack sections, selected refs, dropped refs, and audit reasons.
@@ -280,10 +280,10 @@ Common fixes:
 - Slow retrieval: check model encode latency, TemporalStore write/audit backlog, and tree traversal fallback.
 - Resource miss: inspect parser output, chunk hashes, L0 summary, chunk embeddings, and resource access scope.
 - Skill miss: inspect skill triggers, owner scope, status, precedence, and selected-skill audit.
-- Backend mismatch: run the same parity fixture with `backend=native` and `backend=rust`; compare ContextPack JSONL, selected refs, dropped refs, and audit rows.
+- Backend mismatch: run the same conformance fixture with `backend=native` and `backend=rust`; compare ContextPack JSONL, selected refs, dropped refs, and audit rows.
 - Rust slow path: verify the Rust backend is a Rust proxy/binding, not CLI-per-operation.
 - slow path: verify async oplog, batch append, audit buffering, and data-node count before raising retrieval worker concurrency.
 
-## Product Parity Target
+## Product Conformance Target
 
 baseline-style operation teaches the right expectation: context systems need an install path, a control surface, and diagnostics. MatrixArk should match that operator experience while keeping the serving architecture TemporalStore-native: local or distributed, or Rust backend, one context store first, and optional MatrixDB/MatrixKV for offline analysis or transactional metadata.

--- a/docs/matrixark_no_metaserver_local_mode.md
+++ b/docs/matrixark_no_metaserver_local_mode.md
@@ -79,24 +79,24 @@ The same MatrixArk logic is used:
 | --- | ---: | ---: | --- | --- |
 | `temporalstore-local` | no | no | local JSONL record log | local dev, Codex hook debugging, demos |
 | `temporalstore-direct` | yes | yes | TemporalStore SDK | production-like pipeline tests |
-| `temporalstore-rust` | yes | yes | Rust SDK process over TemporalStore | cross-format parity tests |
+| `temporalstore-rust` | yes | yes | Rust SDK process over TemporalStore | cross-format conformance tests |
 
 
 ## Validation Result On 2026-06-23
 
-The local deployment was stopped before validation, and `127.0.0.1:18000` refused connections. The no-metaserver backend still passed the MatrixArk parity flows:
+The local deployment was stopped before validation, and `127.0.0.1:18000` refused connections. The no-metaserver backend still passed the MatrixArk conformance flows:
 
 | Test | Backend | Result | Elapsed |
 | --- | --- | ---: | ---: |
-| backend parity | `local-nometa` | pass | 93.89 ms |
-| feature parity | `local-nometa` | pass | 161.81 ms |
+| backend conformance | `local-nometa` | pass | 93.89 ms |
+| feature conformance | `local-nometa` | pass | 161.81 ms |
 
-Feature parity covered online ingest, async summary refresh, retrieve, feedback confirmation, batch extraction, current-state retrieval, tree traversal with L0/L1 summary embeddings, and replay.
+Feature conformance covered online ingest, async summary refresh, retrieve, feedback confirmation, batch extraction, current-state retrieval, tree traversal with L0/L1 summary embeddings, and replay.
 
 Artifacts:
 
-- `/tmp/matrixark-mcp-backend-parity/matrixark_mcp_backend_parity_local-nometa-20260623-now2.json`
-- `/tmp/matrixark-mcp-feature-parity/matrixark_mcp_feature_parity_local-nometa-feature-20260623-now2.json`
+- `/tmp/matrixark-mcp-backend-conformance/matrixark_mcp_backend_parity_local-nometa-20260623-now2.json`
+- `/tmp/matrixark-mcp-feature-conformance/matrixark_mcp_feature_parity_local-nometa-feature-20260623-now2.json`
 
 ## Current Boundary
 
@@ -104,9 +104,9 @@ This change gives MatrixArk a no-metaserver local mode today. It does not yet tu
 
 The next native-storage step is a true embedded/single-node backend that bootstraps one local partition without metaserver table discovery. The public MatrixArk switch can stay the same: `MATRIXARK_LOCAL_MODE=no-metaserver`.
 
-## Parity Test
+## Conformance Test
 
-Run the no-metaserver backend through the same parity harness:
+Run the no-metaserver backend through the same conformance harness:
 
 ```bash
 cd <repo>

--- a/docs/matrixark_resource_skill_parsing_pipeline.md
+++ b/docs/matrixark_resource_skill_parsing_pipeline.md
@@ -324,7 +324,7 @@ Packing policy prefers answer-dense evidence:
 
 ## Injection Completeness Gate
 
-The resource/skill parity runner now fails unless the complete serving model is injected. A passing run proves all of these records exist and are replayable:
+The resource/skill conformance runner now fails unless the complete serving model is injected. A passing run proves all of these records exist and are replayable:
 
 | Area | Required records |
 | --- | --- |
@@ -342,21 +342,21 @@ Important product boundary:
 
 ## Test Commands
 
-Run local resource/skill parity:
+Run local resource/skill conformance:
 
 ```bash
 cd <repo>
 python3 third_party/TemporalStoreTestCorpus/tools/run_matrixark_resource_skill_backend_parity.py --backends local
 ```
 
-Run live parity after topology readiness:
+Run live conformance after topology readiness:
 
 ```bash
 cd <repo>
 python3 third_party/TemporalStoreTestCorpus/tools/run_matrixark_resource_skill_backend_parity.py --backends native
 ```
 
-Run Rust live parity:
+Run Rust live conformance:
 
 ```bash
 cd <repo>

--- a/docs/matrixark_resource_skill_tree_retrieval.html
+++ b/docs/matrixark_resource_skill_tree_retrieval.html
@@ -126,7 +126,7 @@ The query parser extracts general filters before vector scoring, for example:
 
 These filters prune candidates before embedding similarity. The layer scan then scores fewer child folders and fewer leaf records.
 
-## And Rust Parity Gate
+## And Rust Conformance Gate
 
 The shared parity runner validates both backends from ingestion through retrieval:
 

--- a/docs/matrixark_rust_metrics_grafana.md
+++ b/docs/matrixark_rust_metrics_grafana.md
@@ -57,5 +57,5 @@ errors, and every executed storage command.
 
 This is process-local bridge telemetry. It complements the native server
 metrics such as oplogger, page store, index, raft, and storage manager metrics.
-For production Rust parity, the next step is to expose the same metrics from a
+For production Rust conformance, the next step is to expose the same metrics from a
 Rust proxy instead of CLI-per-operation paths.

--- a/docs/matrixark_rust_production_backend.md
+++ b/docs/matrixark_rust_production_backend.md
@@ -102,7 +102,7 @@ python3 tools/matrixark_mcp_server.py \
   --storage-prefix matrixark:mcp
 ```
 
-For the Rust direct SDK parity path:
+For the Rust direct SDK conformance path:
 
 ```bash
 python3 tools/matrixark_mcp_server.py \
@@ -121,10 +121,10 @@ Operational probes:
 - `matrixark_backend_metrics`: returns health, readiness, Prometheus text, audit
   buffer stats, and backend config.
 
-## Parity Requirement
+## Conformance Requirement
 
-Full benchmark parity must use the Rust proxy or Rust direct SDK bridge. The
-shared corpus rejects Rust CLI-per-operation mode for full parity. The accepted
+Full benchmark conformance must use the Rust proxy or Rust direct SDK bridge. The
+shared corpus rejects Rust CLI-per-operation mode for full conformance. The accepted
 production-facing binaries are `matrixark_rust_proxy` and
 `matrixark_rust_direct_sdk`; `matrixark_record_log` is retained only as a
 compatibility/debug wrapper and should not appear in new production reports.

--- a/docs/open_source_readiness.md
+++ b/docs/open_source_readiness.md
@@ -34,7 +34,7 @@ evidence with independent WAL/snapshot stores.
 
 Current Rust compatibility positioning:
 
-- Reference implementation behavior parity is tracked through shared tests,
+- Reference implementation behavior conformance is tracked through shared tests,
   migration corpus, harness reports, and readiness docs.
 - Rust public surfaces are Rust APIs, HTTP/JSON, RESP, tonic/gRPC, Codex MCP,
   and harness contracts.

--- a/docs/ops/rolling-upgrade-rollback-runbook.md
+++ b/docs/ops/rolling-upgrade-rollback-runbook.md
@@ -1,7 +1,7 @@
 # TemporalStore Rust Rolling Upgrade And Rollback Runbook
 
 This runbook covers the open-source Rust deployment shape: metaserver, data nodes, proxy, clients,
-and optional local Raft/replica harnesses. It is not a claim of AWS multi-node performance parity or
+and optional local Raft/replica harnesses. It is not a claim of AWS multi-node performance conformance or
 legacy wire compatibility.
 
 ## Preflight Gate

--- a/docs/raft_replication_and_snapshots.md
+++ b/docs/raft_replication_and_snapshots.md
@@ -120,9 +120,9 @@ Covered locally:
 - chunked timestamped KV commands are covered across data-Raft command serialization,
   packed page storage layout, follower reads, and snapshot install
 
-## Missing For Production Raft Parity
+## Missing For Production Raft Conformance
 
-Before claiming production parity with RustRaft or a real OpenRaft/raft-rs based
+Before claiming production conformance with RustRaft or a real OpenRaft/raft-rs based
 system, the Rust code still needs:
 
 - HTTP transport for AppendEntries/Vote/InstallSnapshot exists; production still needs pooled/authenticated RPC with full observability

--- a/docs/rust_temporalstore_code_deep_dive.md
+++ b/docs/rust_temporalstore_code_deep_dive.md
@@ -5,7 +5,7 @@
 This document is a code-oriented map of the Rust TemporalStore implementation in
 `crates/temporalstore-rust`. It focuses on how the Rust code is organized, where
 major product behavior lives, how data flows through storage, Raft, context
-management, client/proxy paths, and what the current test and parity posture
+management, client/proxy paths, and what the current test and conformance posture
 looks like versus the shared conformance test corpus.
 
 Rust TemporalStore is intentionally Rust-native. The production surfaces are
@@ -122,9 +122,9 @@ of maintaining parallel product implementations.
 
 ## Storage And Cache
 
-Rust storage keeps a Rust-native page envelope and log format. parity is
-tracked as behavior and migration/replay parity, not byte-for-byte internal
-layout parity.
+Rust storage keeps a Rust-native page envelope and log format. conformance is
+tracked as behavior and migration/replay conformance, not byte-for-byte internal
+layout conformance.
 
 Important files:
 
@@ -247,7 +247,7 @@ data-node and metaserver paths, not on local in-process fixtures.
 - membership tokens and generation checks
 - topology history and operational reports
 
-The parity target here is behavior: scheduler-owned topology and membership
+The conformance target here is behavior: scheduler-owned topology and membership
 changes, durable replay, stale token rejection, and real data-node process
 coordination.
 
@@ -305,17 +305,17 @@ Current inventory snapshot from the repo tooling:
 
 Shared families currently include:
 
-- storage/cache parity
-- data Raft parity
-- context pipeline parity
-- context benchmark parity
-- ingestion parity
-- proxy/client/control-plane parity
-- data-node lifecycle parity
-- metaserver control-plane parity
-- ops/scale parity
-- Codex/MCP parity
-- Redis/admin product parity
+- storage/cache conformance
+- data Raft conformance
+- context pipeline conformance
+- context benchmark conformance
+- ingestion conformance
+- proxy/client/control-plane conformance
+- data-node lifecycle conformance
+- metaserver control-plane conformance
+- ops/scale conformance
+- Codex/MCP conformance
+- Redis/admin product conformance
 
 Adapter status is still mixed. Raft has native plus static gate coverage,
 benchmarks have a native adapter contract, and several families still depend on
@@ -386,7 +386,7 @@ should remain evidence based:
 - Context benchmark readiness requires Rust TemporalStore backend evidence;
   paper-comparable the baseline memory system claims additionally require real dataset, live
   reader, full replay, and archived report fields.
-- parity should be measured by shared executable product behavior, not by
+- conformance should be measured by shared executable product behavior, not by
   LOC matching or internal implementation shape.
 
 ## Recommended Next Deep-Dive Work

--- a/docs/rustraft_production_readiness.md
+++ b/docs/rustraft_production_readiness.md
@@ -23,7 +23,7 @@ The report also returns semantic `production_blockers`, for example:
 ```
 
 `rustraft_production_readiness_report` is the stricter production gate. It wraps
-the parity report and also requires runtime evidence for peer pipeline behavior,
+the conformance report and also requires runtime evidence for peer pipeline behavior,
 snapshot lifecycle, WAL lifecycle, data-node process rollout, and metaserver
 process rollout. Missing evidence fails closed with precise blockers such as:
 
@@ -141,6 +141,6 @@ Latest local proof on June 29, 2026:
 
 The focused RustRaft library tests and TemporalStore RustRaft consumer tests pass
 against the separate `RustRaft` checkout. Broader distributed/data-node Raft
-parity remains covered by `tools/run_raft_distributed_conformance.sh`, which runs
+conformance remains covered by `tools/run_raft_distributed_conformance.sh`, which runs
 data-node distributed Raft, secondary replication, metaserver Raft, and the
-combined parity summary.
+combined conformance summary.

--- a/docs/temporalstore_page_block_address_contract.md
+++ b/docs/temporalstore_page_block_address_contract.md
@@ -3,7 +3,7 @@
 This is the shared storage-address contract for and Rust TemporalStore. It defines
 the public report/API vocabulary for page addresses, block addresses, logical indexes,
 and GC metadata. and Rust may keep different private implementation details, but
-public reports, parity tests, metrics, and compatibility docs should use these names.
+public reports, conformance tests, metrics, and compatibility docs should use these names.
 
 ## Goals
 
@@ -11,7 +11,7 @@ public reports, parity tests, metrics, and compatibility docs should use these n
 - Make page/block index reports comparable across both engines.
 - Prevent public naming drift such as `page_store` in one backend and `block_store`
   in another when the concept is the same serving/durable page layer.
-- Provide a stable target for shared parity tests, recovery tests, compaction tests,
+- Provide a stable target for shared conformance tests, recovery tests, compaction tests,
   and storage lifecycle reports.
 
 ## Canonical Address Types
@@ -212,7 +212,7 @@ Required safety gates before physical reclaim:
   the page/block;
 - compaction generation is newer than the stale page generation.
 
-## Read/Write Behavior Parity
+## Read/Write Behavior Conformance
 
 and Rust must expose the same logical read/write behavior even if their
 private page-store or block-store internals differ.
@@ -262,7 +262,7 @@ Required write sequence step names:
 
 Required behavior per step:
 
-| step | required parity behavior |
+| step | required conformance behavior |
 |---|---|
 | append record | Accept a typed record with logical model/table/object key, optional field, optional timestamp, payload bytes, and write options. |
 | route shard | Derive the same shard/partition decision from the shared routing key. Context records should use the agreed placement key, not broad tenant scans. |
@@ -321,7 +321,7 @@ Required write-path metrics:
 - `block_writes`
 - `bytes_written`
 
-Parity rules:
+Conformance rules:
 
 - The write result must contain canonical `PageAddress`, `BlockAddress`, and
   `append_watermark` fields in public reports.
@@ -339,7 +339,7 @@ Parity rules:
 - Batch append must preserve per-record logical ordering within the same
   shard/object/timestamp range, publish a `batch_watermark`, and report
   `records_appended`.
-- `append_durability_failures` must be zero for parity acceptance.
+- `append_durability_failures` must be zero for conformance acceptance.
 
 ### Read Path
 
@@ -500,7 +500,7 @@ Required behavior:
   but raw source pages must not enter hot LRU/admission unless an explicit
   replay/query path reinforces them.
 
-## Public Config Parity
+## Public Config Conformance
 
 and Rust must expose the same public storage tuning knobs. The names below
 are the public contract; each backend may map them into private gflags, typed
@@ -534,7 +534,7 @@ Required report shape:
 }
 ```
 
-Parity rules:
+Conformance rules:
 
 - launchers must map `TS_STORAGE_ZONE_SIZE` to `--storage_zone_size` and
   `TS_STREAM_MAX_BLOB_SIZE` to `--stream_max_blob_size` until native gflags use
@@ -542,12 +542,12 @@ Parity rules:
 - Rust must read all eight names through its typed storage tuning config.
 - Benchmark and scale reports must include `effective_storage_tuning` at the
   top-level config and per backend.
-- A parity gate should fail if one backend reports a missing knob or a different
+- A conformance gate should fail if one backend reports a missing knob or a different
   effective value under the same run config.
 
 ## Normalize Naming
 
-Public APIs, reports, metrics, docs, parity tests, and externally visible JSON
+Public APIs, reports, metrics, docs, conformance tests, and externally visible JSON
 must use the canonical names below. Private implementation names may still exist
 inside or Rust, but they must be translated before data leaves the backend.
 
@@ -620,7 +620,7 @@ Compatibility aliases are allowed only when all three conditions are true:
 1. The canonical field is present in the same report.
 2. The alias is clearly marked as `legacy_alias` or appears only in a migration
    section.
-3. The parity gate ignores the alias and validates only the canonical field.
+3. The conformance gate ignores the alias and validates only the canonical field.
 
 New public report fields must not introduce backend-specific names such as:
 
@@ -654,7 +654,7 @@ Required Phase 1 outputs:
 
 Phase 1 rules:
 
-- Aliases may be read by tools and dashboards, but parity gates must validate
+- Aliases may be read by tools and dashboards, but conformance gates must validate
   the canonical fields.
 - New reports must include canonical fields even when old alias fields are still
   emitted for compatibility.
@@ -694,7 +694,7 @@ Required Phase 3 behavior:
 - Rust compatibility deserializers continue reading old report fields through
   `compatibility_aliases`.
 
-### Phase 4: Report Shape Parity
+### Phase 4: Report Shape Conformance
 
 Phase 4 updates public reports to emit the same canonical shape as Rust.
 
@@ -714,7 +714,7 @@ Phase 5 makes the shared tests the source of truth for both engines.
 Required Phase 5 coverage:
 
 - shared page-address compatibility corpus;
-- shared page/block metrics parity validator;
+- shared page/block metrics conformance validator;
 - old-report compatibility fixtures;
 - and Rust native tests for page split, compaction rewrite, tombstones,
   no-promote cold scans, crash/restart index rebuild, and watermark behavior;
@@ -732,13 +732,13 @@ Required Phase 6 gates:
 - fail if canonical fields are absent from new reports;
 - fail if alias fields appear outside `compatibility_aliases` after the
   compatibility window;
-- fail if broad legacy report paths are used in production-performance parity
+- fail if broad legacy report paths are used in production-performance conformance
   claims.
 
 Removal gate:
 
 - remove or hide alias output only after dashboards, benchmark reports, portal
-  pages, tests, Rust tests, replay/audit tooling, and parity gates all read
+  pages, tests, Rust tests, replay/audit tooling, and conformance gates all read
   the canonical schema directly.
 
 ## conformance Mapping
@@ -753,9 +753,9 @@ Removal gate:
 | `Tombstone` / `GcEligibility` | deleted/dirty page and delayed destroy state | tombstone/GC report state | `Tombstone` / `GcEligibility` |
 | `FollowerCursorSafety` | follower cursor and snapshot retention state | raft/shared-store cursor safety state | `FollowerCursorSafety` |
 
-## Required Parity Tests
+## Required Conformance Tests
 
-Shared conformance parity cases must cover:
+Shared conformance conformance cases must cover:
 
 - encode/decode `PageAddress`;
 - encode/decode `BlockAddress`;
@@ -790,7 +790,7 @@ PageAddress and BlockAddress subset that both and Rust must consume:
 - cold scan reads that do not warm the serving cache;
 - crash/restart rebuild of `PageIndex`, `BlockIndex`, and `ObjectIndexEntry`.
 
-Lifecycle parity reports must also include `storage_index_contract` with these
+Lifecycle conformance reports must also include `storage_index_contract` with these
 required fields:
 
 - `page_address_codec`
@@ -903,7 +903,7 @@ Canonical cache metrics:
 - `cache_writeback_queue_depth`
 - `cache_writeback_rejections`
 
-Lifecycle parity reports must also include `storage_cache_contract` with these
+Lifecycle conformance reports must also include `storage_cache_contract` with these
 required fields:
 
 - `layers`
@@ -929,7 +929,7 @@ Required cache contract behavior:
 - `compaction_watermark_invalidation` must be `true`.
 - `cold_scan_no_promote` must be `true`.
 - `writeback_backpressure_measured` must be `true`.
-- `hot_cache_promotions` must be `0` for cold scan no-promote parity.
+- `hot_cache_promotions` must be `0` for cold scan no-promote conformance.
 
 Canonical StorageManager/StoreManager lifecycle phases:
 
@@ -1109,14 +1109,14 @@ pair that proves `page_store`, `block_store`, stream/blob, and page-segment
 aliases are accepted only under `compatibility_aliases` and compared through the
 canonical public shape.
 
-Lifecycle parity is intentionally stricter than cache eviction parity:
+Lifecycle conformance is intentionally stricter than cache eviction conformance:
 
 - cache eviction only proves memory pressure relief;
 - tombstone metadata proves logical delete eligibility;
 - compaction and GC prove live-record rewrite and stale-generation exclusion;
 - physical reclaim is complete only when reclaimable bytes and reclaimed bytes
   are reported with zero physical reclaim errors;
-- cold scan parity requires no-cache/no-promote reads and no hot-cache admission.
+- cold scan conformance requires no-cache/no-promote reads and no hot-cache admission.
 
 Canonical reclaim semantics:
 
@@ -1197,11 +1197,11 @@ Shared proof requirements:
 - physical reclaim is only complete when stale pages/blocks are tombstoned,
   rewritten or skipped safely, and reclaimed bytes are reported.
 
-## Nine-Phase Parity Gate
+## Nine-Phase Conformance Gate
 
 `tools/validate_storage_engine_9_phase_conformance.py` is the umbrella gate for the
-storage-engine parity loop. It runs the focused validators in the same phase
-order used by the conformance parity plan:
+storage-engine conformance loop. It runs the focused validators in the same phase
+order used by the conformance conformance plan:
 
 1. canonical public contract;
 2. read/write/cold-scan sequences;
@@ -1209,8 +1209,8 @@ order used by the conformance parity plan:
 4. page/block/slot/index behavior;
 5. multi-layer cache behavior;
 6. eviction, GC, compaction, and reclaim;
-7. public config parity;
-8. metrics/report parity;
+7. public config conformance;
+8. metrics/report conformance;
 9. shared storage/proxy/Raft evidence.
 
 The gate should be used after every storage lifecycle change:
@@ -1235,7 +1235,7 @@ This contract is satisfied when and Rust:
 
 - emit the same public address/index field names;
 - can convert private storage metadata into the canonical report shape;
-- pass the shared page/block/index parity cases;
+- pass the shared page/block/index conformance cases;
 - expose the same storage lifecycle metrics;
 - reject public report changes that reintroduce backend-specific naming drift;
 - encode the same logical `PageAddress`;

--- a/integrations/agent-hooks/config/temporalstore-claude.example.env
+++ b/integrations/agent-hooks/config/temporalstore-claude.example.env
@@ -5,7 +5,7 @@
 # to its own agent/tenant, kept distinct from Codex.
 
 # Backend for the Claude hook:
-#   auto   (default) -> python parity pipeline when the rust proxy is built, else rust
+#   auto   (default) -> python conformance pipeline when the rust proxy is built, else rust
 #   python           -> matrixark_agent_hook.py --agent claude (same engine as Codex)
 #   rust             -> self-contained offline crate bin codex_context_hook
 MATRIXARK_CLAUDE_HOOK_BACKEND=auto
@@ -19,7 +19,7 @@ MATRIXARK_USER_ID=local_user
 MATRIXARK_TEAM=agent
 TEMPORALSTORE_AGENT_PROJECT=TemporalStore
 
-# Python (parity) backend: local rust proxy, no metaserver required.
+# Python (conformance) backend: local rust proxy, no metaserver required.
 MATRIXARK_MCP_BACKEND=temporalstore-rust
 MATRIXARK_LOCAL_MODE=no-metaserver
 MATRIXARK_TEMPORALSTORE_METASERVER=local

--- a/tools/matrixark_claude_hook.sh
+++ b/tools/matrixark_claude_hook.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 PYTHON="${TEMPORALSTORE_PYTHON:-python3}"
 # Backend selection:
-#   auto   (default) -> python parity pipeline when its runtime (rust proxy) is
+#   auto   (default) -> python conformance pipeline when its runtime (rust proxy) is
 #                       present, else the self-contained offline rust engine.
 #   python           -> tools/matrixark_agent_hook.py --agent claude (full MCP
 #                       pipeline; byte-for-byte the same code as the Codex hook).
@@ -150,7 +150,7 @@ if [[ "$BACKEND" == "auto" ]]; then
 fi
 
 if [[ "$BACKEND" == "python" ]]; then
-  # Parity pipeline: matrixark_agent_hook.py runs the identical ingest/extract/
+  # Conformance pipeline: matrixark_agent_hook.py runs the identical ingest/extract/
   # retrieve engine as the Codex hook and already emits the Claude Code contract
   # (hookSpecificOutput.additionalContext on UserPromptSubmit). Uses the local
   # rust proxy so it works without a running metaserver.

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4676,14 +4676,14 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return list(records)
 
     # ============================================================================================
-    # Memory management: forget (delete_all) / delete / get_all / reset  (mem0 parity)
+    # Memory management: forget (delete_all) / delete / get_all / reset  (mem0 conformance)
     # --------------------------------------------------------------------------------------------
     # These implement the mem0 memory-management surface against the local JSONL store via durable
     # tombstones (see `apply_memory_tombstones`). subject = `scope.user_id`. A tombstone is appended
     # to the same event log, so a "deleted"/"forgotten" memory never resurfaces from retrieve /
     # get_all / caches and the removal survives reload.
     #
-    # This pass ALSO adds: get/update(=supersede)/history (mem0 read/update parity), provenance-
+    # This pass ALSO adds: get/update(=supersede)/history (mem0 read/update conformance), provenance-
     # closure delete (a source-event delete cascades to its single-source derivatives, and demotes
     # multi-source derivatives by trimming the deleted source from their evidence), and a crash-safe
     # physical PURGE that rewrites the JSONL log without tombstoned records + markers to reclaim space

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -158,7 +158,7 @@ _DATA_ROUTES: dict[str, Tuple[str, str]] = {
     "/v1/session/commit": ("matrixark_session_commit", "ingest"),
     "/v1/retrieve": ("matrixark_retrieve", "retrieve"),
     "/v1/mcp": ("__mcp__", "retrieve"),
-    # Memory management (mem0 parity). forget/delete/reset gate on `context:forget` (see
+    # Memory management (mem0 conformance). forget/delete/reset gate on `context:forget` (see
     # _CATEGORY_SCOPE); get_all (POST /v1/memories) gates on `context:retrieve`. GET /v1/memories is
     # handled by a dedicated branch below (data routes are POST-only).
     "/v1/forget": ("matrixark_forget", "forget"),

--- a/tools/temporalstore-monitoring-ui/README.md
+++ b/tools/temporalstore-monitoring-ui/README.md
@@ -41,7 +41,7 @@ Expected optional fields in `health.json`:
 - `replication`: replay mode, source, secondary lag, visibility
 - `scale_tests`: workload, QPS, p50, p99, secondary lag
 - `module_tests`: module coverage for direct/proxy paths and latency
-- `context_ops`: status, KPIs, backend parity, pipeline stages, test cards, request builder entries,
+- `context_ops`: status, KPIs, backend conformance, pipeline stages, test cards, request builder entries,
   query workbench, config groups, tree nodes, context-pack events/chunks/filters,
   open-source model registry, operator rows, safeguards, alerts, audit rows, and runbook steps
 
@@ -70,12 +70,12 @@ matrixark-server start --backend rust --local
 matrixark-server apply-key --agent codex
 ```
 
-Backend parity expectations:
+Backend conformance expectations:
 
 - The same monitoring UI must work for `backend=native` and `backend=rust`.
 - Health payloads should expose `temporalstore.backend`, `mode`, `storage`, `raft`, and `gateway`.
 - and Rust runs should render the same ContextNode topology, summaries, embeddings, events, entities, resource chunks, skills, ContextPacks, and audit rows.
-- Rust CLI-per-operation is acceptable for debug parity only; production Rust should use the Rust proxy or Rust direct SDK.
+- Rust CLI-per-operation is acceptable for debug conformance only; production Rust should use the Rust proxy or Rust direct SDK.
 - and Rust benchmark runs should emit the same artifact set so LOCOMO, LongMemEval, resource, skill, and scale reports can be compared side by side.
 
 Today, the same pieces are available through the MCP server, Docker OSS scale

--- a/tools/test_matrixark_popular_agent_hooks.py
+++ b/tools/test_matrixark_popular_agent_hooks.py
@@ -177,19 +177,19 @@ class MatrixArkPopularAgentHooksTest(unittest.TestCase):
 
         for agent in agents:
             s = results[agent]
-            # Ingestion parity.
+            # Ingestion conformance.
             self.assertEqual("ok", s["ingest"]["status"], agent)
             self.assertTrue(s["ingest"]["ingested"], agent)
             self.assertEqual(agent, s["ingest"]["agent"], agent)
             self.assertEqual(f"{agent}:{agent}-parity", s["ingest"]["session_id"], agent)
-            # Retrieval parity.
+            # Retrieval conformance.
             self.assertEqual("ok", s["retrieve"]["status"], agent)
             self.assertGreaterEqual(s["retrieve"]["retrieved"]["selected_ref_count"], 0, agent)
-            # LLM-response ingestion parity (assistant message on Stop).
+            # LLM-response ingestion conformance (assistant message on Stop).
             self.assertEqual("ok", s["commit"]["status"], agent)
             self.assertTrue(s["commit"]["ingested"], agent)
 
-        # Structural parity: identical result shape per stage across the two agents.
+        # Structural conformance: identical result shape per stage across the two agents.
         for stage in ("ingest", "retrieve", "commit"):
             self.assertEqual(
                 set(results["codex"][stage].keys()),
@@ -197,9 +197,9 @@ class MatrixArkPopularAgentHooksTest(unittest.TestCase):
                 f"{stage} result-shape parity",
             )
 
-        # Decision parity: query/config-derived retrieval decisions are identical
+        # Decision conformance: query/config-derived retrieval decisions are identical
         # across agents (only identity/scope differ). This is substantive
-        # ingestion/extraction/retrieval parity beyond result-shape parity.
+        # ingestion/extraction/retrieval conformance beyond result-shape conformance.
         codex_ret = results["codex"]["retrieve"]["retrieved"]
         claude_ret = results["claude"]["retrieve"]["retrieved"]
         self.assertEqual(


### PR DESCRIPTION
#168 renamed the files. The same disallowed provenance word remained **651 times in file
content**. This takes the part that is safe to change on its own — prose in markdown and in
comments — leaving 472.

**179 lines across 51 files.** The diff is symmetric, 179 insertions and 179 deletions, because
nothing moved; only the word did.

## What was deliberately left alone

**Fenced code blocks in markdown are skipped.** A doc that quotes real code or a real artifact
has to keep quoting it, or the doc starts describing something that does not exist. Four such
lines were passed over.

The remaining 472 are not prose:

```
string literals   334   JSON artifact names, format ids, record types
field access etc   87   evidence-struct field reads on the harness path
identifiers        23   struct fields, functions, evidence types
docs code blocks    4
```

Of **197 distinct string values** carrying the word, **138 also appear in `.py`, `.rs` or `.sh`
files** — renaming those is a coordinated change across code and stored artifacts, not a reword.
The other 59 live only in data files, but they name artifacts consumers outside this repository
may read, so they are not free either. Both groups want their own change with their own
verification.

## Verified

- Rust builds
- every touched python file parses
- suite unchanged: **131 failing locally, identical to `main` locally**

The ratchet flags 9 differences on my machine — the browser-facing tests and
`test_ingest_envelope_schema`, which the baseline records as passing because CI has a newer node
than this box (v12). That is the environment split the script documents, and it is why CI's run
is the gate rather than a local one.
