### PR TITLE
meta: let something subscribe to metadata change

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -30,6 +30,7 @@ mod shard_check;
 mod retention;
 mod proxy_groups;
 mod subsystem_metrics;
+mod event_bus;
 use self::partitioning::*;
 use self::topology_helpers::*;
 pub use self::auto_rebalance::{
@@ -54,6 +55,7 @@ pub use self::proxy_groups::{
     ProxyGroupShortfall, PutProxyGroupRequest,
 };
 pub use self::subsystem_metrics::{SubsystemMetrics, TIER_PROXY, TIER_SERVER};
+pub use self::event_bus::{TopologyNotice, TopologySubscription, SUBSCRIBER_QUEUE_DEPTH};
 pub use self::retention::{
     plan_freeze_aging, plan_meta_retention, FreezeAgingOptions, FreezeAgingPlan,
     FreezeAgingReport, MetaRetentionOptions, MetaRetentionPlan, MetaRetentionReport,
@@ -1039,6 +1041,10 @@ pub struct SingleNodeMeta {
     /// can report it. Shared by clone, so every handle to this meta writes to
     /// and reads from the same recorder.
     metrics: SubsystemMetrics,
+    /// Fan-out for metadata change, deliberately outside `inner` so a
+    /// subscriber's cost never lands inside the metadata lock. Shared by clone,
+    /// like the metadata itself.
+    events: Arc<event_bus::MetaEventBus>,
 }
 
 impl Default for SingleNodeMeta {
@@ -1052,6 +1058,7 @@ impl Default for SingleNodeMeta {
             mutation_log: None,
             forbid_self_clearing_conviction: false,
             metrics: SubsystemMetrics::new(),
+            events: Arc::new(event_bus::MetaEventBus::default()),
         }
     }
 }
@@ -3117,6 +3124,228 @@ mod tests {
             .filter(|addr| addr != "node-2")
             .collect::<Vec<_>>();
         assert_eq!(eastern, baseline, "the tie-break stopped being stable");
+    }
+
+    fn bus_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        // Setting the fixture up is itself a metadata change. Pump it through
+        // before anyone subscribes, so these tests observe what they cause
+        // rather than the registration that built the fixture.
+        meta.pump_topology_events();
+        meta
+    }
+
+    fn freeze(meta: &SingleNodeMeta) {
+        meta.freeze_server(StateChangeRequest {
+            endpoint: "node-a".to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        });
+    }
+
+    fn unfreeze(meta: &SingleNodeMeta) {
+        meta.unfreeze_server(StateChangeRequest {
+            endpoint: "node-a".to_string(),
+            freeze_cooldown_ms: 0,
+            reason: FreezeReason::Unspecified,
+        });
+    }
+
+    #[test]
+    fn a_subscriber_is_told_about_a_change_instead_of_polling_for_it() {
+        let meta = bus_meta();
+        let subscription = meta.subscribe_topology();
+        meta.pump_topology_events();
+
+        freeze(&meta);
+        assert_eq!(meta.pump_topology_events(), 1);
+
+        let notice = subscription.try_next().expect("a notice");
+        assert_eq!(notice.event.kind, "server_state");
+        assert_eq!(notice.event.resource, "server:node-a");
+        assert_eq!(notice.missed, 0);
+    }
+
+    #[test]
+    fn a_subscriber_can_ask_for_only_the_kinds_it_cares_about() {
+        let meta = bus_meta();
+        let subscription = meta.subscribe_topology_kinds(["add_table"]);
+        meta.pump_topology_events();
+
+        freeze(&meta);
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        meta.pump_topology_events();
+
+        let kinds = subscription
+            .drain()
+            .into_iter()
+            .map(|notice| notice.event.kind)
+            .collect::<Vec<_>>();
+        assert_eq!(kinds, vec!["add_table".to_string()]);
+    }
+
+    #[test]
+    fn every_subscriber_sees_the_same_change() {
+        let meta = bus_meta();
+        let first = meta.subscribe_topology();
+        let second = meta.subscribe_topology();
+        meta.pump_topology_events();
+
+        freeze(&meta);
+        meta.pump_topology_events();
+
+        assert_eq!(first.drain().len(), 1);
+        assert_eq!(second.drain().len(), 1);
+    }
+
+    #[test]
+    fn a_subscriber_that_stops_reading_cannot_hold_up_the_others() {
+        // The failure this design exists to survive. A subscriber that stops
+        // draining must not grow the metaserver's memory, block the pump, or
+        // cost anyone else a single event.
+        let meta = bus_meta();
+        let asleep = meta.subscribe_topology();
+        let awake = meta.subscribe_topology();
+        meta.pump_topology_events();
+
+        let rounds = SUBSCRIBER_QUEUE_DEPTH + 40;
+        for round in 0..rounds {
+            if round % 2 == 0 {
+                freeze(&meta);
+            } else {
+                unfreeze(&meta);
+            }
+            meta.pump_topology_events();
+            // The attentive one keeps up; the sleeping one never reads.
+            assert_eq!(awake.drain().len(), 1, "attentive subscriber missed round {round}");
+        }
+
+        // The sleeper banked at most its queue depth, not one per round.
+        let banked = asleep.drain();
+        assert!(
+            banked.len() <= SUBSCRIBER_QUEUE_DEPTH,
+            "queue grew past its bound: {}",
+            banked.len()
+        );
+        assert!(rounds > SUBSCRIBER_QUEUE_DEPTH);
+    }
+
+    #[test]
+    fn falling_behind_is_reported_rather_than_hidden() {
+        // Having missed a freeze is survivable; not knowing you missed it is
+        // not, so the count rides along on the next notice that gets through.
+        let meta = bus_meta();
+        let subscription = meta.subscribe_topology();
+        meta.pump_topology_events();
+
+        for round in 0..(SUBSCRIBER_QUEUE_DEPTH + 10) {
+            if round % 2 == 0 {
+                freeze(&meta);
+            } else {
+                unfreeze(&meta);
+            }
+            meta.pump_topology_events();
+        }
+        // Empty the backlog, then take one more notice: it must carry the count.
+        let banked = subscription.drain();
+        assert!(!banked.is_empty());
+        freeze(&meta);
+        unfreeze(&meta);
+        meta.pump_topology_events();
+        let after = subscription.try_next().expect("a notice after the backlog");
+        assert!(
+            after.missed > 0,
+            "the subscriber was never told it had fallen behind"
+        );
+    }
+
+    #[test]
+    fn events_the_ring_recycled_are_counted_as_missed() {
+        // The ring holds a bounded history. If more changes land between pumps
+        // than it retains, the pump never sees them -- and versions increase by
+        // exactly one per event, so exactly how many is knowable.
+        let meta = bus_meta();
+        let subscription = meta.subscribe_topology();
+        meta.pump_topology_events();
+
+        for round in 0..(TOPOLOGY_EVENT_HISTORY_LIMIT + 50) {
+            if round % 2 == 0 {
+                freeze(&meta);
+            } else {
+                unfreeze(&meta);
+            }
+        }
+        meta.pump_topology_events();
+
+        let notices = subscription.drain();
+        assert!(!notices.is_empty());
+        assert!(
+            notices.iter().any(|notice| notice.missed > 0),
+            "the pump did not notice the ring had recycled events"
+        );
+    }
+
+    #[test]
+    fn unsubscribing_stops_delivery() {
+        let meta = bus_meta();
+        let subscription = meta.subscribe_topology();
+        meta.pump_topology_events();
+        assert_eq!(meta.topology_subscriber_count(), 1);
+
+        meta.unsubscribe_topology(subscription.id);
+        assert_eq!(meta.topology_subscriber_count(), 0);
+
+        freeze(&meta);
+        meta.pump_topology_events();
+        assert!(subscription.try_next().is_none());
+    }
+
+    #[test]
+    fn a_subscriber_arriving_later_starts_from_now() {
+        // The cursor advances even with nobody listening, so subscribing does
+        // not replay the whole retained history at you.
+        let meta = bus_meta();
+        freeze(&meta);
+        unfreeze(&meta);
+        meta.pump_topology_events();
+
+        let subscription = meta.subscribe_topology();
+        meta.pump_topology_events();
+        assert!(subscription.try_next().is_none(), "history was replayed");
+
+        freeze(&meta);
+        meta.pump_topology_events();
+        assert!(subscription.try_next().is_some());
+    }
+
+    #[test]
+    fn a_dropped_subscription_is_forgotten() {
+        let meta = bus_meta();
+        {
+            let _subscription = meta.subscribe_topology();
+            assert_eq!(meta.topology_subscriber_count(), 1);
+        }
+        // The receiver is gone; the next fan-out reaps it.
+        freeze(&meta);
+        meta.pump_topology_events();
+        assert_eq!(meta.topology_subscriber_count(), 0);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/event_bus.rs
+++ b/crates/temporalstore-rust/src/meta/event_bus.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Subscribing to metadata change, rather than polling for it.
+//!
+//! Every metadata change already funnels through `record_topology_event`, which
+//! stamps a version and appends to a bounded ring. Reading it meant polling that
+//! ring and diffing, so anything that wanted to *react* to a change -- a proxy
+//! refreshing a route, an operator tool watching a drain -- had to ask
+//! repeatedly and work out for itself what was new.
+//!
+//! This turns that ring into something you can subscribe to. It deliberately
+//! does not publish from inside `record_topology_event`: that runs while the
+//! metadata write lock is held, and fanning out to subscribers there would put
+//! their cost, and any one of them misbehaving, inside the lock. A pump reads
+//! the ring on its own and fans out afterwards, so publishing stays exactly as
+//! cheap as it was.
+
+use super::*;
+use std::collections::BTreeSet;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
+use std::sync::Mutex;
+
+/// How many undelivered events one subscriber may bank up before the oldest are
+/// dropped. A subscriber that stops reading must not be able to grow the
+/// metaserver's memory, and must not be able to slow anyone else down.
+pub const SUBSCRIBER_QUEUE_DEPTH: usize = 128;
+
+/// One metadata change, plus what the subscriber missed before it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopologyNotice {
+    pub event: TopologyChangeEvent,
+    /// Events this subscriber did not receive between the previous notice and
+    /// this one, either because it was not reading fast enough or because the
+    /// ring recycled them before the pump got there.
+    ///
+    /// Reported rather than hidden: a subscriber that silently misses a drain
+    /// or a freeze is worse than one that knows it has fallen behind.
+    pub missed: u64,
+}
+
+/// A handle on the stream. Dropping it unsubscribes on the next fan-out.
+#[derive(Debug)]
+pub struct TopologySubscription {
+    pub id: u64,
+    receiver: Receiver<TopologyNotice>,
+}
+
+impl TopologySubscription {
+    /// Take the next notice, or `None` if nothing is waiting.
+    pub fn try_next(&self) -> Option<TopologyNotice> {
+        self.receiver.try_recv().ok()
+    }
+
+    /// Wait up to `timeout` for the next notice.
+    pub fn next_before(&self, timeout: Duration) -> Option<TopologyNotice> {
+        self.receiver.recv_timeout(timeout).ok()
+    }
+
+    /// Everything currently waiting, oldest first.
+    pub fn drain(&self) -> Vec<TopologyNotice> {
+        let mut out = Vec::new();
+        while let Ok(notice) = self.receiver.try_recv() {
+            out.push(notice);
+        }
+        out
+    }
+}
+
+struct Subscriber {
+    id: u64,
+    /// Kinds this subscriber cares about. Empty means every kind.
+    kinds: BTreeSet<String>,
+    sender: SyncSender<TopologyNotice>,
+    missed: u64,
+}
+
+#[derive(Default)]
+struct BusState {
+    next_id: u64,
+    subscribers: Vec<Subscriber>,
+    /// Highest `topology_version` already fanned out. Versions increase by
+    /// exactly one per event, which is what makes a dropped event detectable
+    /// rather than merely suspected.
+    cursor: u64,
+}
+
+/// Fan-out for metadata change, held outside the metadata lock.
+#[derive(Default)]
+pub(crate) struct MetaEventBus {
+    state: Mutex<BusState>,
+}
+
+impl std::fmt::Debug for MetaEventBus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetaEventBus").finish_non_exhaustive()
+    }
+}
+
+impl MetaEventBus {
+    fn subscribe(&self, kinds: BTreeSet<String>) -> TopologySubscription {
+        let (sender, receiver) = sync_channel(SUBSCRIBER_QUEUE_DEPTH);
+        let mut state = self.state.lock().expect("event bus lock poisoned");
+        state.next_id += 1;
+        let id = state.next_id;
+        state.subscribers.push(Subscriber {
+            id,
+            kinds,
+            sender,
+            missed: 0,
+        });
+        TopologySubscription { id, receiver }
+    }
+
+    fn unsubscribe(&self, id: u64) {
+        let mut state = self.state.lock().expect("event bus lock poisoned");
+        state.subscribers.retain(|subscriber| subscriber.id != id);
+    }
+
+    fn subscriber_count(&self) -> usize {
+        self.state
+            .lock()
+            .expect("event bus lock poisoned")
+            .subscribers
+            .len()
+    }
+
+    /// Fan `events` out, and account for anything the ring recycled first.
+    ///
+    /// `oldest_retained` is the lowest version still in the ring; anything
+    /// between the cursor and it was dropped before the pump saw it.
+    fn deliver(&self, events: Vec<TopologyChangeEvent>, oldest_retained: Option<u64>, newest: u64) {
+        let mut state = self.state.lock().expect("event bus lock poisoned");
+        let lost = match oldest_retained {
+            Some(oldest) if state.cursor > 0 && oldest > state.cursor + 1 => {
+                oldest - state.cursor - 1
+            }
+            _ => 0,
+        };
+        if newest > state.cursor {
+            state.cursor = newest;
+        }
+        if state.subscribers.is_empty() {
+            // Nothing listening: the cursor still moves, so a subscriber
+            // arriving later starts from now rather than replaying history.
+            return;
+        }
+        if lost > 0 {
+            for subscriber in state.subscribers.iter_mut() {
+                subscriber.missed = subscriber.missed.saturating_add(lost);
+            }
+        }
+        let mut dropped = Vec::new();
+        for event in events {
+            for subscriber in state.subscribers.iter_mut() {
+                if !subscriber.kinds.is_empty() && !subscriber.kinds.contains(&event.kind) {
+                    continue;
+                }
+                let notice = TopologyNotice {
+                    event: event.clone(),
+                    missed: subscriber.missed,
+                };
+                match subscriber.sender.try_send(notice) {
+                    Ok(()) => subscriber.missed = 0,
+                    Err(TrySendError::Full(_)) => {
+                        // Not reading fast enough. Drop this one and say so on
+                        // the next notice that does get through, rather than
+                        // blocking the pump on the slowest subscriber.
+                        subscriber.missed = subscriber.missed.saturating_add(1);
+                    }
+                    Err(TrySendError::Disconnected(_)) => dropped.push(subscriber.id),
+                }
+            }
+        }
+        if !dropped.is_empty() {
+            state
+                .subscribers
+                .retain(|subscriber| !dropped.contains(&subscriber.id));
+        }
+    }
+}
+
+impl SingleNodeMeta {
+    /// Subscribe to every metadata change.
+    pub fn subscribe_topology(&self) -> TopologySubscription {
+        self.events.subscribe(BTreeSet::new())
+    }
+
+    /// Subscribe to the given event kinds only -- `"server_state"`,
+    /// `"shard_state"`, `"add_table"` and so on, as recorded on the event.
+    pub fn subscribe_topology_kinds<I, S>(&self, kinds: I) -> TopologySubscription
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.events
+            .subscribe(kinds.into_iter().map(Into::into).collect())
+    }
+
+    pub fn unsubscribe_topology(&self, id: u64) {
+        self.events.unsubscribe(id);
+    }
+
+    pub fn topology_subscriber_count(&self) -> usize {
+        self.events.subscriber_count()
+    }
+
+    /// Fan out everything recorded since the last call. Returns how many events
+    /// were delivered to at least one subscriber.
+    pub fn pump_topology_events(&self) -> usize {
+        let cursor = {
+            let state = self.events.state.lock().expect("event bus lock poisoned");
+            state.cursor
+        };
+        let (events, oldest_retained, newest) = {
+            let state = self.inner.read().expect("meta lock poisoned");
+            let oldest = state
+                .topology_events
+                .front()
+                .map(|event| event.topology_version);
+            let newest = state
+                .topology_events
+                .back()
+                .map(|event| event.topology_version)
+                .unwrap_or(cursor);
+            let fresh = state
+                .topology_events
+                .iter()
+                .filter(|event| event.topology_version > cursor)
+                .cloned()
+                .collect::<Vec<_>>();
+            (fresh, oldest, newest)
+        };
+        let count = events.len();
+        self.events.deliver(events, oldest_retained, newest);
+        count
+    }
+
+    /// Background loop pumping on an interval.
+    pub fn start_topology_event_pump(&self, interval_ms: u64) -> thread::JoinHandle<()> {
+        let meta = self.clone();
+        let interval = Duration::from_millis(interval_ms.max(1));
+        thread::spawn(move || loop {
+            meta.pump_topology_events();
+            thread::sleep(interval);
+        })
+    }
+}

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -133,7 +133,7 @@ pub(super) fn stats_from_state(state: &MetaState) -> MetaStats {
     }
 }
 
-const TOPOLOGY_EVENT_HISTORY_LIMIT: usize = 256;
+pub(super) const TOPOLOGY_EVENT_HISTORY_LIMIT: usize = 256;
 
 pub(super) fn topology_version_report_from_state(
     state: &MetaState,


### PR DESCRIPTION
## Metadata change could only be discovered by asking again

Every metadata change already funnels through one place — `record_topology_event` stamps a version and appends to a bounded ring. But the only way to read that ring was to fetch it and work out what was new since last time. Anything wanting to *react* to a change — a proxy refreshing a route, a tool watching a drain finish — had to poll and diff.

This makes it something you subscribe to:

```rust
let changes = meta.subscribe_topology_kinds(["server_state", "shard_state"]);
while let Some(notice) = changes.next_before(Duration::from_secs(5)) {
    // notice.event  — kind, resource, detail, version, timestamp
    // notice.missed — how many it did not see before this one
}
```

Subscribe to everything, or to named kinds. Ordered, versioned, and per subscriber.

## The design decisions, and why

**Publishing does not happen inside the metadata lock.** `record_topology_event` runs while the write lock is held, so fanning out from there would put every subscriber's cost — and any one of them misbehaving — inside the lock the whole metaserver serialises on. Instead a pump reads the ring on its own and fans out afterwards. Publishing stays exactly as cheap as it was: an append, unchanged.

**A slow subscriber cannot hurt anyone.** Each subscriber gets a bounded queue. When it fills, the pump drops rather than blocks — it never waits on the slowest reader, and a subscriber that stops reading entirely cannot grow the metaserver's memory. There is a test that runs past the queue depth with one subscriber asleep and asserts the attentive one misses nothing while the sleeper's backlog stays bounded.

**Falling behind is reported, not hidden.** Every notice carries `missed`: how many events that subscriber did not get since the last one it did. Missing a freeze is survivable; *not knowing* you missed it is not — a route cache that silently skipped a drain is worse than one that knows to resynchronise.

**Recycled events are counted exactly, not estimated.** The ring keeps 256 events. If more land between pumps, the pump never sees them — but `topology_version` increases by exactly one per event, so comparing the oldest retained version against the cursor gives the precise number lost, not a guess. That property is what makes `missed` trustworthy, and it has its own test.

**A subscriber arriving later starts from now.** The cursor advances even with nobody listening, so subscribing does not replay the retained history at you. A dropped subscription is reaped on the next fan-out.

## Scope

In-process, like the thing it mirrors: subscribers are objects in the metaserver, not HTTP clients. There is no streaming endpoint here — that is a separate surface with its own questions (framing, backpressure over a socket, auth), and bolting it on would have made this change about the transport instead of the mechanism.

The pump can be driven directly (`pump_topology_events`) or run on an interval (`start_topology_event_pump`), matching how the other background subsystems are started.

## Tests

9 new: a change reaching a subscriber; filtering by kind; two subscribers both seeing the same change; a sleeping subscriber not holding up an attentive one; falling behind being reported; the ring recycling being counted; unsubscribing stopping delivery; a late subscriber not being replayed history; and a dropped subscription being reaped.

Verification:

- `cargo test -p temporalstore-rust --lib meta -- --test-threads=1` — **278 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

Four of those tests failed on the first run, all for the same reason: registering the fixture's server is itself a metadata change, so the subscriber's first notice was the fixture building itself rather than what the test caused. The fixture now pumps past its own setup.
