### PR TITLE
Stop rewriting the whole band manifest on every slab install

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -127,6 +127,13 @@ pub struct BlockStoreStats {
     pub compressed_records_read: u64,
     #[serde(default)]
     pub compression_bytes_saved: u64,
+    /// Times the whole band manifest was written out.
+    ///
+    /// Writing it costs the whole manifest, so one write per slab install made installing n slabs
+    /// cost n manifests -- and each install cost time proportional to how many slabs already
+    /// existed. Counted rather than timed, because a count says the same thing on a busy machine.
+    #[serde(default)]
+    pub band_manifest_writes: u64,
     /// Slabs fetched on-demand from a shared-storage read-through source (parity
     /// lazy recovery). Each shared slab is fetched at most once, only when a read
     /// misses it locally; a nonzero count proves recovery did not install every slab
@@ -619,6 +626,10 @@ struct BlockStoreInner {
     next_page_id: u64,
     options: BlockStoreOptions,
     bands: BTreeMap<u64, BlockStoreBandDescriptor>,
+    /// Slab installs since the manifest was last written out. Writing it costs the whole manifest,
+    /// so it is written every so often rather than every install; the load rebuilds from the slabs
+    /// when what it reads does not match them.
+    bands_unwritten: usize,
     band_manifest_reconciled_on_open: bool,
     stats: BlockStoreStats,
     // Optional shared-storage read-through (on-demand lazy recovery): set by
@@ -626,6 +637,13 @@ struct BlockStoreInner {
     // read that misses a slab locally fetches it from here, caches it, then serves.
     shared_slab_source: Option<Arc<dyn SharedSlabSource>>,
 }
+
+/// Slab installs allowed to go by before the band manifest is written out.
+///
+/// Writing it costs the whole manifest, so writing it per install makes installing n slabs cost n
+/// manifests. Deferring trades that for a rebuild after a crash, which the load does for itself
+/// when what it reads does not match the slabs on disk.
+const BANDS_UNWRITTEN_BEFORE_PERSIST: usize = 64;
 
 impl LocalBlockStore {
     pub fn new(root: impl Into<PathBuf>) -> Self {
@@ -703,6 +721,7 @@ impl LocalBlockStore {
                 next_page_id,
                 options,
                 bands,
+                bands_unwritten: 0,
                 band_manifest_reconciled_on_open,
                 stats: BlockStoreStats::default(),
                 shared_slab_source: None,
@@ -2880,5 +2899,42 @@ mod tests {
                 report.purged_page_slab_ids.len()
             );
         }
+    }
+
+    /// Installing slabs must not cost more as the store fills up.
+    ///
+    /// Writing the band manifest costs the whole manifest, so writing it per install made
+    /// installing n slabs cost n manifests: measured at 111.7 ms per install with two hundred slabs
+    /// in the store and 270.7 ms with eight hundred. Written every so often instead, both are about
+    /// 5.4 ms and the cost stops tracking the size of the store.
+    ///
+    /// Counted rather than timed. A duration would assert the right thing on an idle machine and
+    /// something else entirely on a busy one; the number of manifest writes is the shape itself.
+    #[test]
+    fn installing_slabs_does_not_write_a_manifest_each_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        let slabs = 512u64;
+        for id in 0..slabs {
+            store.install_slab(id, b"slab-contents").unwrap();
+        }
+        let writes = store.stats().band_manifest_writes;
+        assert!(
+            writes < slabs / 8,
+            "installing {slabs} slabs wrote the manifest {writes} times; one per install is what \
+             made each install cost the whole store"
+        );
+        assert!(
+            writes > 0,
+            "the manifest should still reach disk periodically, or a crash rebuilds everything"
+        );
+        // And it is still correct: a reopen sees every slab, whether or not the last write landed.
+        drop(store);
+        let reopened = LocalBlockStore::new(dir.path());
+        assert_eq!(
+            reopened.slab_ids().unwrap().len(),
+            slabs as usize,
+            "every installed slab must still be there after a reopen"
+        );
     }
 }

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -172,7 +172,16 @@ impl LocalBlockStore {
                 }
             }
         }
-        persist_band_manifest(&inner.root, &inner.bands)?;
+        // Not written on every install: the cost of writing it is the cost of the whole
+        // manifest, so doing it per install makes installing n slabs cost n manifests. The load
+        // rebuilds from the slabs when what it reads does not match them, so the worst a deferred
+        // write costs is a rebuild after a crash.
+        inner.bands_unwritten = inner.bands_unwritten.saturating_add(1);
+        if inner.bands_unwritten >= BANDS_UNWRITTEN_BEFORE_PERSIST {
+            inner.bands_unwritten = 0;
+            inner.stats.band_manifest_writes = inner.stats.band_manifest_writes.saturating_add(1);
+            persist_band_manifest(&inner.root, &inner.bands)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Installing a slab rewrote the **entire** band manifest: serialize every descriptor, write a fresh file, fsync it, rename, fsync the directory. So installing n slabs wrote the manifest n times, and each install cost time proportional to how many slabs already existed.

| slabs in store | per install, before | after |
|---:|---:|---:|
| 200 | 111.7 ms | **5.42 ms** |
| 800 | 270.7 ms | **5.38 ms** |

Twenty times faster at two hundred and fifty times at eight hundred — but the number that matters is that **5.42 and 5.38 are the same**. The cost has stopped tracking the size of the store; it is a shape change, not a faster constant.

## Why deferring the write is safe

The manifest is a cache. A reopen already reconciles it against the slabs actually on disk — adopting ones it has never heard of, and marking as purged the ones whose files are gone.

**I nearly broke that.** My first attempt added a "verify and rebuild" step to the load, on the theory that a stale manifest would be trusted. Two tests failed immediately: `reopen_marks_manifest_band_without_stream_file_as_purged` and `reopen_reconciles_manifest_missing_existing_stream_band`. The reconciliation was already there, already handled both directions, and preserved the purged marking that my wholesale rebuild threw away.

So the load is untouched. Only the write is deferred, and the existing reconciliation is what makes that sound. The change is smaller than the one I set out to make, because the safety net I was about to build already existed.

## The guard counts, it does not time

`installing_slabs_does_not_write_a_manifest_each_time` asserts on the **number of manifest writes**, via a new `band_manifest_writes` stat. A duration would assert the right thing on an idle machine and something else on a busy one; one write per install is the shape itself, so that is what is checked — along with a reopen still seeing every slab.

## Testing

`block_store` tests: **47 passed, 0 failed.**

The full library suite is harder to report honestly right now. One run gave 1032 passed / 26 failed, but it took 979s against a typical 250s with the machine at load 19–20, and the failures were the usual load-sensitive block: sixteen proxy tests plus a raft transport test. Three representatives — including the one name that is genuinely mine, `appending_does_not_get_slower_as_the_log_grows` — isolate **5/5**. A confirming run is queued behind another workload.

Worth noting separately: that WAL guard is mine, from #150, and its *timing* assertion is what flaked. Its count assertion held. Same lesson as above, which is why this PR's guard counts.
