### PR TITLE
meta: let the raft cluster be operated, not only watched

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -323,6 +323,34 @@ fn main() {
     }
 }
 
+/// Which node an operation is about.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct MetaRaftNodeRequest {
+    node_id: u64,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MetaRaftMembershipResponse {
+    status: Status,
+    leader_id: u64,
+    members: Vec<u64>,
+    term: u64,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MetaRaftScaleResponse {
+    status: Status,
+    /// Who the voters are once the change settled, and whether a majority of
+    /// them is live. Absent when the change was refused.
+    report: Option<temporalstore_rust::raft::RaftScaleChangeReport>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MetaRaftSnapshotTriggerResponse {
+    status: Status,
+    report: Option<temporalstore_rust::raft::RaftSnapshotTriggerReport>,
+}
+
 #[derive(Clone)]
 enum MetaBackend {
     Single(SingleNodeMeta),
@@ -1375,6 +1403,21 @@ fn handle(
             ),
         },
         ("GET", "/meta/raft/ready") => json_response(200, &meta.raft_ready()),
+        ("GET", "/meta/raft/membership") => json_response(200, &meta.raft_membership()),
+        ("POST", "/meta/raft/add_node") => parse_or(&request.body, |req: MetaRaftNodeRequest| {
+            meta.raft_add_node(req.node_id)
+        }),
+        ("POST", "/meta/raft/remove_node") => {
+            parse_or(&request.body, |req: MetaRaftNodeRequest| {
+                meta.raft_remove_node(req.node_id)
+            })
+        }
+        ("POST", "/meta/raft/transfer_leader") => {
+            parse_or(&request.body, |req: MetaRaftNodeRequest| {
+                meta.raft_transfer_leader(req.node_id)
+            })
+        }
+        ("POST", "/meta/raft/snapshot") => json_response(200, &meta.raft_trigger_snapshot()),
         ("GET", "/meta/snapshot") => json_response(200, &meta.export_snapshot()),
         ("POST", "/meta/snapshot") | ("POST", "/meta/snapshot/restore") => {
             parse_or(&request.body, |snapshot: MetaSnapshot| {
@@ -2049,6 +2092,91 @@ mod tests {
     use temporalstore_rust::meta::{MetaEntityState, ShardSnapshotRef, TableTopologyResponse};
     use temporalstore_rust::rebalance::RebalanceStep;
     use temporalstore_rust::ProductionReadinessReport;
+
+    /// Drive one route against a single-node backend.
+    fn call(method: &str, path: &str, body: Vec<u8>) -> (u16, Vec<u8>) {
+        let backend = MetaBackend::Single(SingleNodeMeta::default());
+        let scheduler = MetaTaskScheduler::default();
+        handle(
+            &backend,
+            &scheduler,
+            HttpRequest {
+                method: method.to_string(),
+                path: path.to_string(),
+                body,
+            },
+        )
+    }
+
+    fn node_body(node_id: u64) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({ "node_id": node_id })).unwrap()
+    }
+
+    #[test]
+    fn the_membership_routes_exist() {
+        // They did not: changing the shape of the meta raft cluster meant
+        // restarting it, because the only raft routes were read-only. A 404
+        // here means the operation is still unreachable.
+        for (method, path, body) in [
+            ("GET", "/meta/raft/membership", Vec::new()),
+            ("POST", "/meta/raft/add_node", node_body(7)),
+            ("POST", "/meta/raft/remove_node", node_body(7)),
+            ("POST", "/meta/raft/transfer_leader", node_body(7)),
+            ("POST", "/meta/raft/snapshot", Vec::new()),
+        ] {
+            let (code, _) = call(method, path, body);
+            assert_eq!(code, 200, "{method} {path} is not routed");
+        }
+    }
+
+    #[test]
+    fn a_single_node_metaserver_says_so_rather_than_pretending() {
+        // Every one of these is meaningless without a cluster. Refusing
+        // clearly beats a route that appears to have done something.
+        for (method, path, body) in [
+            ("POST", "/meta/raft/add_node", node_body(7)),
+            ("POST", "/meta/raft/remove_node", node_body(7)),
+            ("POST", "/meta/raft/transfer_leader", node_body(7)),
+            ("POST", "/meta/raft/snapshot", Vec::new()),
+        ] {
+            let (_, body) = call(method, path, body);
+            let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(
+                parsed["status"]["code"], "raft_disabled",
+                "{method} {path} did not refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn listing_membership_without_a_cluster_is_empty_and_says_why() {
+        let (code, body) = call("GET", "/meta/raft/membership", Vec::new());
+        assert_eq!(code, 200);
+        let parsed: MetaRaftMembershipResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.status.code, "raft_disabled");
+        assert!(parsed.members.is_empty());
+    }
+
+    #[test]
+    fn a_scale_change_that_was_refused_carries_no_report() {
+        // The report describes the membership a change settled into. Returning
+        // one for a change that did not happen would be a lie an operator
+        // could act on.
+        let (_, body) = call("POST", "/meta/raft/add_node", node_body(7));
+        let parsed: MetaRaftScaleResponse = serde_json::from_slice(&body).unwrap();
+        assert!(!parsed.status.ok);
+        assert!(parsed.report.is_none());
+    }
+
+    #[test]
+    fn a_membership_request_without_a_node_is_rejected_not_guessed() {
+        let (code, body) = call("POST", "/meta/raft/add_node", b"{}".to_vec());
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            code >= 400 || parsed["status"]["ok"] == serde_json::Value::Bool(false),
+            "an empty body was accepted: {code} {parsed}"
+        );
+    }
 
     #[test]
     fn metaserver_metrics_expose_inventory_state_and_scheduler() {

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -54,6 +54,110 @@ impl MetaBackend {
         }
     }
 
+    /// The refusal every membership operation gives on the single-node
+    /// backend. There is no cluster to change the shape of, and saying so is
+    /// better than a route that appears to work.
+    fn raft_only() -> Status {
+        Status::error("raft_disabled", "meta raft is disabled")
+    }
+
+    fn raft_membership(&self) -> MetaRaftMembershipResponse {
+        match self {
+            Self::Single(_) => MetaRaftMembershipResponse {
+                status: Self::raft_only(),
+                leader_id: 0,
+                members: Vec::new(),
+                term: 0,
+            },
+            Self::Raft(runtime) => {
+                let status = runtime.status();
+                MetaRaftMembershipResponse {
+                    status: Status::ok(),
+                    leader_id: status.leader_id,
+                    members: runtime.list_membership(),
+                    term: status.current_term,
+                }
+            }
+        }
+    }
+
+    /// Add a voter, refusing anything that would leave the cluster unable to
+    /// reach a majority. The unguarded variant exists but is not what an
+    /// operator should be able to reach over HTTP.
+    fn raft_add_node(&self, node_id: u64) -> MetaRaftScaleResponse {
+        match self {
+            Self::Single(_) => MetaRaftScaleResponse {
+                status: Self::raft_only(),
+                report: None,
+            },
+            Self::Raft(runtime) => match runtime.cluster().add_node_safely(node_id) {
+                Ok(report) => MetaRaftScaleResponse {
+                    status: Status::ok(),
+                    report: Some(report),
+                },
+                Err(err) => MetaRaftScaleResponse {
+                    status: Status::error("raft_scale_refused", err.to_string()),
+                    report: None,
+                },
+            },
+        }
+    }
+
+    fn raft_remove_node(&self, node_id: u64) -> MetaRaftScaleResponse {
+        match self {
+            Self::Single(_) => MetaRaftScaleResponse {
+                status: Self::raft_only(),
+                report: None,
+            },
+            Self::Raft(runtime) => match runtime.cluster().remove_node_safely(node_id) {
+                Ok(report) => MetaRaftScaleResponse {
+                    status: Status::ok(),
+                    report: Some(report),
+                },
+                Err(err) => MetaRaftScaleResponse {
+                    status: Status::error("raft_scale_refused", err.to_string()),
+                    report: None,
+                },
+            },
+        }
+    }
+
+    fn raft_transfer_leader(&self, node_id: u64) -> AckResponse {
+        match self {
+            Self::Single(_) => AckResponse {
+                status: Self::raft_only(),
+            },
+            Self::Raft(runtime) => AckResponse {
+                status: runtime
+                    .cluster()
+                    .transfer_leader(node_id)
+                    .map(|_| Status::ok())
+                    .unwrap_or_else(|err| {
+                        Status::error("raft_transfer_refused", err.to_string())
+                    }),
+            },
+        }
+    }
+
+    fn raft_trigger_snapshot(&self) -> MetaRaftSnapshotTriggerResponse {
+        match self {
+            Self::Single(_) => MetaRaftSnapshotTriggerResponse {
+                status: Self::raft_only(),
+                report: None,
+            },
+            Self::Raft(runtime) => match runtime.cluster().maybe_trigger_snapshot() {
+                Ok(report) => MetaRaftSnapshotTriggerResponse {
+                    status: Status::ok(),
+                    report: Some(report),
+                },
+                Err(err) => MetaRaftSnapshotTriggerResponse {
+                    status: Status::error("raft_snapshot_refused", err.to_string()),
+                    report: None,
+                },
+            },
+        }
+    }
+
     fn export_snapshot(&self) -> MetaSnapshotResponse {
         match self {
             Self::Single(meta) => MetaSnapshotResponse {


### PR DESCRIPTION
## The meta raft cluster could be watched but not operated

The metaserver served exactly two raft routes, both read-only: `GET /meta/raft/status` and `GET /meta/raft/ready`. Everything that *changes* the cluster — adding a voter, removing one, handing over leadership, forcing a snapshot — exists in the library, is covered by tests, and was reachable only from inside the process.

So growing or shrinking the metaserver cluster meant restarting it.

## What this exposes

- `GET  /meta/raft/membership` — who the members are, who leads, current term
- `POST /meta/raft/add_node` · `{"node_id": 4}`
- `POST /meta/raft/remove_node`
- `POST /meta/raft/transfer_leader`
- `POST /meta/raft/snapshot`

No new mechanism: these call the operations already there.

## Two decisions worth reviewing

**Scaling goes through the guarded variants.** `add_node` and `remove_node` both have an unguarded form and a `_safely` form that refuses a change leaving the cluster unable to reach a majority. The unguarded ones stay unreachable over HTTP — an operator who can destroy quorum with one unlucky call is not an operator interface, and the guarded refusal is the only sane default for something a human types under pressure.

**The single-node backend refuses instead of pretending.** Every one of these is meaningless without a cluster, so on `MetaBackend::Single` they answer `raft_disabled` rather than silently succeeding or panicking. That is what most of the tests check, because a route that looks like it worked is worse than one that says it cannot.

A refused scale change carries **no report**. The report describes the membership a change settled into; returning one for a change that did not happen is a lie an operator could act on.

## Tests

5 new, against the single-node backend:

- the routes exist at all — a 404 here means the operation is still unreachable
- each one refuses with `raft_disabled` rather than pretending
- listing membership comes back empty *and* says why
- a refused scale change carries no report
- a request with no `node_id` is rejected rather than guessed

Verification:

- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — **23 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

## Not included

No mute guard. Metadata change can be muted as an incident lever, but these operations are how you *respond* to an incident — being unable to replace a dead metaserver node because change is muted would be the wrong failure. Worth a second opinion, since the argument runs the other way for `remove_node`.
