### PR TITLE
Count every subject in one pass, instead of reading the whole log once per subject

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -969,12 +969,24 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # and get_all returns the whole tenant -- every user then reports the same count and a
         # user whose memories were all forgotten never drops out of the list.
         base_scope = dict(args.get("scope") or {}) if isinstance(args, dict) else {}
+        ordered = sorted(set(subjects))
+        counts = self._subject_counts_in_one_pass(
+            base_scope, [name for kind, name in ordered if kind == "user"]
+        )
         results: list[Json] = []
-        for kind, name in sorted(set(subjects)):
+        for kind, name in ordered:
             if kind != "user":
                 # Only a user is addressable by get_all here, so agents/runs are reported without
                 # a live count rather than with a wrong one.
                 results.append({"type": kind, "name": name})
+                continue
+            if counts is not None:
+                live = counts.get(name, 0)
+                if not live:
+                    continue
+                results.append({"type": kind, "name": name, "memory_count": live})
+                if limit and len(results) >= limit:
+                    break
                 continue
             scope = self._subject_scope(base_scope, name)
             try:
@@ -989,6 +1001,59 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             if limit and len(results) >= limit:
                 break
         return {"results": results, "count": len(results)}
+
+    def _subject_counts_in_one_pass(self, base_scope: Json, names: list[str]) -> dict[str, int] | None:
+        """Live `context_event` count per named user, from ONE read of the record log.
+
+        Replaces one scoped `get_all` per subject. `get_all` filters in Python after reading the
+        whole log, so per-subject reads cost O(subjects x store): 21 full reads of ~450ms for a
+        single `users()` call over 20 subjects, measured.
+
+        The predicate is `get_all`'s, unchanged -- a record belongs to a subject when the tenant
+        and user hashes on its own access scope match the ones the same resolver derives for that
+        subject's scope -- so this is a cheaper way to compute the same answer, not a different
+        answer.
+
+        Returns None, never an empty map, when the subjects cannot be resolved to distinct user
+        hashes. The caller then falls back to the per-subject reads: being slow is recoverable,
+        reporting that nobody has memories is not.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import _record_scope_hashes
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import _record_scope_hashes
+        try:
+            tenant_by_user: dict[int, int] = {}
+            name_by_user: dict[int, str] = {}
+            for name in names:
+                tenant_hash, user_hash = self._resolve_subject_hashes(
+                    self._subject_scope(base_scope, name)
+                )
+                if not user_hash or user_hash in name_by_user:
+                    # Unresolvable, or two names landing on one hash: neither can be counted
+                    # apart here, and guessing would attribute one subject's memories to another.
+                    return None
+                name_by_user[user_hash] = name
+                tenant_by_user[user_hash] = tenant_hash
+            if not name_by_user:
+                return {}
+            counts: dict[str, int] = {name: 0 for name in names}
+            for record in self.read_all():
+                if not isinstance(record, dict):
+                    continue
+                if str(record.get("record_type") or "") != "context_event":
+                    continue
+                record_tenant, record_user = _record_scope_hashes(record)
+                name = name_by_user.get(record_user)
+                if name is None:
+                    continue
+                subject_tenant = tenant_by_user.get(record_user) or 0
+                if subject_tenant and record_tenant != subject_tenant:
+                    continue
+                counts[name] += 1
+            return counts
+        except Exception:  # noqa: BLE001 - fall back to the per-subject reads rather than answer wrong.
+            return None
 
     def _purge_scope_in_engine(self, scope: Json) -> Json:
         """Ask the engine to physically remove every record matching `scope`.

--- a/tools/test_users_subject_counts.py
+++ b/tools/test_users_subject_counts.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`users()` counts every subject in one pass over the record log.
+
+The listing used to ask a scoped `get_all` per subject, and `get_all` on a native backend reads the
+whole log into Python before filtering, so the call cost O(subjects x store) -- 21 full reads for
+one `users()` over 20 subjects, each around 450ms. These tests pin the cheaper shape AND the answer
+it has to keep producing: same counts, same liveness, one read.
+
+The read count is asserted directly, because that is the property that regresses silently -- a
+correct answer computed the expensive way looks identical from outside.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_mcp_local_adapter as local_mod
+
+
+class _CountingAdapter:
+    """A direct adapter whose record log is a list, counting how often it is read.
+
+    `object.__new__` skips __init__ (which would dial a metaserver and spawn a CLI); only what
+    these paths touch is stubbed.
+    """
+
+    @staticmethod
+    def build(records):
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._storage_prefix = "matrixark:mcp"
+        adapter._local_jsonl_enabled = False
+        adapter._native_log = list(records)
+        adapter.reads = 0
+
+        def _read_all():
+            adapter.reads += 1
+            return list(adapter._native_log)
+
+        adapter.read_all = _read_all
+        return adapter
+
+
+def _hashes_for(adapter, name):
+    """The tenant/user hashes the product itself derives for a subject name."""
+    return adapter._resolve_subject_hashes(adapter._subject_scope({}, name))
+
+
+def _event(adapter, name, event_id, text):
+    """A `context_event` row scoped to `name`, carrying the hashes the reader matches on."""
+    tenant_hash, user_hash = _hashes_for(adapter, name)
+    scope_key = f"t={tenant_hash}|u={user_hash}|s=1|"
+    return {
+        "record_type": "context_event",
+        "event_id_hash": event_id,
+        "text": text,
+        "scope_key": scope_key,
+        "access_scope": {"tenant_hash": tenant_hash, "user_hash": user_hash,
+                         "scope_key": scope_key},
+        "extraction_phase": "final",
+        "status": "extraction_committed",
+        "updated_at_ms": 1000 + event_id,
+        "timestamp_key_ms": 1000 + event_id,
+    }
+
+
+class SubjectCountsInOnePassTests(unittest.TestCase):
+    def _adapter_with(self, per_user):
+        adapter = _CountingAdapter.build([])
+        log = []
+        event_id = 1
+        for name, how_many in per_user.items():
+            for _ in range(how_many):
+                log.append(_event(adapter, name, event_id, f"{name} memory {event_id}"))
+                event_id += 1
+        adapter._native_log = log
+        return adapter
+
+    def test_counts_each_subject_from_the_records_own_scope(self):
+        adapter = self._adapter_with({"alice": 3, "bob": 1})
+        counts = adapter._subject_counts_in_one_pass({}, ["alice", "bob"])
+        self.assertEqual({"alice": 3, "bob": 1}, counts)
+
+    def test_the_log_is_read_once_regardless_of_how_many_subjects(self):
+        """The whole point: cost stops scaling with the number of subjects."""
+        adapter = self._adapter_with({"u%d" % i: 2 for i in range(12)})
+        adapter.reads = 0
+        counts = adapter._subject_counts_in_one_pass({}, ["u%d" % i for i in range(12)])
+        self.assertEqual(1, adapter.reads, "twelve subjects must still cost one read")
+        self.assertEqual({"u%d" % i: 2 for i in range(12)}, counts)
+
+    def test_a_subject_with_no_records_counts_zero_rather_than_being_missed(self):
+        adapter = self._adapter_with({"alice": 2})
+        counts = adapter._subject_counts_in_one_pass({}, ["alice", "never_ingested"])
+        self.assertEqual({"alice": 2, "never_ingested": 0}, counts)
+
+    def test_another_subjects_records_are_not_attributed_to_this_one(self):
+        adapter = self._adapter_with({"alice": 2, "bob": 5})
+        counts = adapter._subject_counts_in_one_pass({}, ["alice"])
+        self.assertEqual({"alice": 2}, counts, "bob's five must not land on alice")
+
+    def test_an_unresolvable_subject_returns_none_so_the_caller_falls_back(self):
+        """None, not {} -- an empty map would report that nobody has memories, and `users()`
+        would answer with an empty list instead of falling back to the per-subject reads."""
+        adapter = self._adapter_with({"alice": 2})
+        adapter._resolve_subject_hashes = lambda scope: (0, 0)
+        self.assertIsNone(adapter._subject_counts_in_one_pass({}, ["alice"]))
+
+    def test_two_names_on_one_hash_return_none_rather_than_a_wrong_split(self):
+        adapter = self._adapter_with({"alice": 2, "bob": 1})
+        adapter._resolve_subject_hashes = lambda scope: (7, 99)
+        self.assertIsNone(adapter._subject_counts_in_one_pass({}, ["alice", "bob"]))
+
+    def test_a_read_failure_returns_none_rather_than_zero_counts(self):
+        adapter = self._adapter_with({"alice": 2})
+
+        def _boom():
+            raise RuntimeError("record log unavailable")
+
+        adapter.read_all = _boom
+        self.assertIsNone(adapter._subject_counts_in_one_pass({}, ["alice"]))
+
+    def test_only_context_events_are_counted(self):
+        """`get_all` counts memories, not the summaries and postings derived from them."""
+        adapter = self._adapter_with({"alice": 1})
+        tenant_hash, user_hash = _hashes_for(adapter, "alice")
+        scope_key = f"t={tenant_hash}|u={user_hash}|s=1|"
+        for record_type in ("context_summary", "context_embedding", "context_index"):
+            adapter._native_log.append({
+                "record_type": record_type,
+                "scope_key": scope_key,
+                "access_scope": {"tenant_hash": tenant_hash, "user_hash": user_hash,
+                                 "scope_key": scope_key},
+            })
+        self.assertEqual({"alice": 1}, adapter._subject_counts_in_one_pass({}, ["alice"]))
+
+
+class ListMemorySubjectsTests(unittest.TestCase):
+    """End to end through `list_memory_subjects`, with the subject index stubbed."""
+
+    def _adapter(self, per_user, index_names):
+        adapter = _CountingAdapter.build([])
+        log, event_id = [], 1
+        for name, how_many in per_user.items():
+            for _ in range(how_many):
+                log.append(_event(adapter, name, event_id, f"{name} memory {event_id}"))
+                event_id += 1
+        adapter._native_log = log
+        adapter._ensure_subject_index = lambda: None
+        adapter._subject_index_key = lambda: "matrixark:mcp:subject_index"
+
+        class _Client:
+            @staticmethod
+            def scan_hash(_key):
+                return {"records": [{"field": "user:%s" % n} for n in index_names]}
+
+        adapter._client = _Client()
+        return adapter
+
+    def test_listing_costs_one_read_and_reports_each_subjects_count(self):
+        adapter = self._adapter({"alice": 3, "bob": 1}, ["alice", "bob"])
+        adapter.reads = 0
+        listed = adapter.list_memory_subjects({})
+        self.assertEqual(1, adapter.reads)
+        self.assertEqual(
+            [{"type": "user", "name": "alice", "memory_count": 3},
+             {"type": "user", "name": "bob", "memory_count": 1}],
+            listed["results"],
+        )
+
+    def test_a_subject_the_index_still_names_but_holds_nothing_is_dropped(self):
+        """The index is add-only, so it outlives the memories; `users()` answers who HAS memories."""
+        adapter = self._adapter({"alice": 2}, ["alice", "forgotten_user"])
+        listed = adapter.list_memory_subjects({})
+        self.assertEqual(["alice"], [row["name"] for row in listed["results"]])
+        self.assertEqual(1, listed["count"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`users()` already avoided walking the log to DISCOVER subjects -- it reads the keyed subject index
-- but it then asked a scoped `get_all` per subject to decide which ones still hold memories. On a
native backend `get_all` does not push the scope down: it reads the entire record log into Python
and filters there. So the listing cost O(subjects x store), and the subject index was saving the
cheap half.

Measured with the native read choke points instrumented, 20 subjects, one `users()` call:

    read_all         n=112   total 41.5s    up to 1517 records per read
    users() p50      9.6s    = 21 full reads, ~450ms each

and every one of those reads has the same trail: `list_memory_subjects -> get_all -> read_all`.

One pass answers all of them. A record is attributed the way `get_all` attributes it -- the tenant
and user hashes on the record's own access scope, against the hashes the same resolver derives for
each subject's scope -- so this computes the same answer a cheaper way rather than a different one.

Same harness, after:

    read_all         n=53    (the rest are the ingest path, not this call)
    users() p50      3.2s    = ONE read per call

and without instrumentation, 20 subjects on a comparably loaded box: 18.1s -> 9.2s p50, with both
arms listing all 21 subjects and reporting identical counts. What remains is one full store read,
which is the floor until the scan itself can be filtered in the engine.

A first attempt bucketed `memory_subjects_in_record`, which reads `record["scope"]`. Native records
do not carry that field, so every count came out zero, the safety fallback fired, and the result
was one EXTRA full read on top of the old cost -- 12 subjects unchanged, 40 subjects past the
gateway timeout. It looked plausible and was measurably worse, which is why the counts here come
from the hashes and why the probe asserts the LIST, not just the latency.

The fallback returns None, never an empty map. An empty map would say nobody has memories and
`users()` would answer with an empty list; None sends the caller back to the per-subject reads.
It fires when a subject cannot be resolved to a user hash, when two names collide on one hash, and
when the read itself fails -- being slow is recoverable, answering wrong is not.

10 tests: the counts, that twelve subjects still cost ONE read, that a subject with no records
counts zero rather than being skipped, that another subject's records are not attributed to this
one, that only `context_event` rows count, all three fallback paths, and two end to end through
`list_memory_subjects` including that an index entry whose memories are gone drops out of the list.

The five memory suites are green, and live conformance is 22/22.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
