### PR TITLE
Ask whether a tombstone exists, instead of reading the whole log to find out

### DIFF
--- a/tools/matrixark_local_adapter_session_commit.py
+++ b/tools/matrixark_local_adapter_session_commit.py
@@ -106,7 +106,16 @@ class _LocalAdapterSessionCommitMixin:
         # TODO(engine): the Rust engine-side batch-extraction/commit path (crates/**) needs the same
         # forward guard against delete-before-extract resurrection; this fix wires only the Python local
         # adapter. Not edited here per scope (crates are out of scope for this change).
-        _surviving_event_ids = surviving_source_event_ids(self._read_raw_records())
+        # Ask first whether there is anything to guard against. `surviving_source_event_ids`
+        # returns None -- i.e. keep every pending event -- whenever the log carries no tombstone,
+        # so on a log with none the raw read below is pure cost, once per commit, over the whole
+        # store. A backend that can answer the question cheaply says so; the default answers it
+        # by doing the read, exactly as before.
+        _surviving_event_ids = (
+            surviving_source_event_ids(self._read_raw_records())
+            if self.memory_tombstones_may_exist()
+            else None
+        )
         if _surviving_event_ids is not None:
             pending_all_unfiltered = [
                 record

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4534,6 +4534,16 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     # (the purged log replays to the same logical state). DEFERRED (separate parallel workstream):
     # rust-datanode-native StringDelete/CommonDelete/FeatureDelete wiring, and true re-derivation
     # (re-extraction) of a demoted multi-source entity/summary -- we trim evidence, not re-summarize.
+    def memory_tombstones_may_exist(self) -> bool:
+        """Could the durable log hold a memory tombstone? Conservative: True means "look properly".
+
+        The delete-before-extract guard reads the whole raw log on every commit, and on a log with
+        no tombstone that read changes nothing -- `surviving_source_event_ids` returns None. This
+        gives a backend a chance to answer the question without the read. Here, on the JSONL log,
+        the read IS the answer, so this is exactly what the guard used to do.
+        """
+        return _records_contain_memory_tombstone(self._read_raw_records())
+
     def _resolve_subject_hashes(self, scope: Json) -> tuple[int, int]:
         """Return ``(tenant_hash, user_hash)`` for an already-identity-enriched request scope,
         resolving each from an explicit hash field or by parsing the scope_key."""

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1055,6 +1055,52 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         except Exception:  # noqa: BLE001 - fall back to the per-subject reads rather than answer wrong.
             return None
 
+    def memory_tombstones_may_exist(self) -> bool:
+        """Answer from a type-filtered scan, so the guard does not read the whole log to find out.
+
+        The inherited implementation reads every raw record. On a native backend that is a full
+        record-log read on EVERY commit -- measured at up to 2392 records per commit -- and its
+        entire output is one boolean, almost always False. The engine can filter by record type
+        during its own walk, so only tombstone rows cross the boundary: normally none at all.
+
+        Deliberately scope-free: the guard is store-wide, and a tombstone in any scope is a reason
+        to do the full read. Bundled appends are handled engine-side, which matters because a
+        tombstone can be stored inside a bundle whose wrapper carries no record_type.
+
+        Returns True on ANY failure or missing support. A false negative here would skip the guard
+        and let a deleted event be re-materialised by extraction; a false positive only costs the
+        read the guard used to do unconditionally.
+        """
+        scanner = getattr(self._client, "matrixark_scan_candidates", None)
+        if not callable(scanner):
+            return super().memory_tombstones_may_exist()
+        try:
+            from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        try:
+            response = scanner(
+                count_key=self._count_key,
+                record_hash_key=self._record_hash_key,
+                shard_size=self._shard_size,
+                scope={},
+                record_types=[MEMORY_TOMBSTONE_RECORD_TYPE],
+                secondary_index_groups=[],
+                selected_node_hashes=[],
+            )
+        except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
+            return True
+        if not isinstance(response, dict):
+            return True
+        records = response.get("records")
+        if not isinstance(records, list):
+            return True
+        return any(
+            isinstance(record, dict)
+            and str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE
+            for record in records
+        )
+
     def _purge_scope_in_engine(self, scope: Json) -> Json:
         """Ask the engine to physically remove every record matching `scope`.
 

--- a/tools/test_tombstone_probe.py
+++ b/tools/test_tombstone_probe.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The delete-before-extract guard asks whether a tombstone exists before reading the whole log.
+
+The guard has to run on every commit, but on a log with no tombstone it changes nothing --
+`surviving_source_event_ids` returns None and every pending event is kept. Establishing that cost
+a full raw record-log read per commit on a native backend, up to 2392 records, for one boolean.
+
+These tests pin both halves: the probe answers from a type-filtered scan, and it answers
+CONSERVATIVELY -- anything it cannot determine is reported as "a tombstone may exist", because a
+false negative skips the guard and lets extraction re-materialise deleted content, while a false
+positive only costs the read the guard used to do unconditionally.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    import matrixark_mcp_local_adapter as local_mod
+
+TOMBSTONE = local_mod.MEMORY_TOMBSTONE_RECORD_TYPE
+
+
+class _Client:
+    """A native client whose candidate scan returns whatever the test wants."""
+
+    def __init__(self, response, *, raises=False):
+        self.response = response
+        self.raises = raises
+        self.calls = []
+
+    def matrixark_scan_candidates(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises:
+            raise RuntimeError("engine unreachable")
+        return self.response
+
+
+def _adapter(client, *, raw_records=None):
+    adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+    adapter._storage_prefix = "matrixark:mcp"
+    adapter._local_jsonl_enabled = False
+    adapter._count_key = "matrixark:mcp:record_count"
+    adapter._record_hash_key = "matrixark:mcp:records"
+    adapter._shard_size = 1024
+    adapter._client = client
+    adapter.raw_reads = 0
+
+    def _read_raw_records():
+        adapter.raw_reads += 1
+        return list(raw_records or [])
+
+    adapter._read_raw_records = _read_raw_records
+    return adapter
+
+
+class TombstoneProbeTests(unittest.TestCase):
+    def test_no_tombstone_rows_means_no_tombstone(self):
+        adapter = _adapter(_Client({"records": []}))
+        self.assertFalse(adapter.memory_tombstones_may_exist())
+
+    def test_the_probe_does_not_read_the_raw_log(self):
+        """The whole point: the answer arrives without the full record-log read."""
+        adapter = _adapter(_Client({"records": []}), raw_records=[{"record_type": "context_event"}])
+        adapter.memory_tombstones_may_exist()
+        self.assertEqual(0, adapter.raw_reads)
+
+    def test_it_asks_the_engine_for_tombstones_only(self):
+        client = _Client({"records": []})
+        _adapter(client).memory_tombstones_may_exist()
+        self.assertEqual(1, len(client.calls))
+        self.assertEqual([TOMBSTONE], client.calls[0]["record_types"])
+        self.assertEqual({}, client.calls[0]["scope"],
+                         "the guard is store-wide: a tombstone in any scope counts")
+
+    def test_a_tombstone_row_is_reported(self):
+        adapter = _adapter(_Client({"records": [{"record_type": TOMBSTONE, "tombstone_kind": "delete"}]}))
+        self.assertTrue(adapter.memory_tombstones_may_exist())
+
+    def test_rows_of_another_type_do_not_count_as_a_tombstone(self):
+        """The filter is the engine's; this is the check that a wrong answer cannot sneak through."""
+        adapter = _adapter(_Client({"records": [{"record_type": "context_event"}]}))
+        self.assertFalse(adapter.memory_tombstones_may_exist())
+
+    def test_a_scan_failure_reports_that_a_tombstone_may_exist(self):
+        adapter = _adapter(_Client(None, raises=True))
+        self.assertTrue(adapter.memory_tombstones_may_exist(),
+                        "an unanswered question must not skip the guard")
+
+    def test_an_unexpected_response_shape_reports_that_one_may_exist(self):
+        for response in ({"records": "not a list"}, {}, None, []):
+            with self.subTest(response=response):
+                self.assertTrue(_adapter(_Client(response)).memory_tombstones_may_exist())
+
+    def test_a_client_without_the_scan_falls_back_to_reading_the_log(self):
+        class _Bare:
+            pass
+
+        adapter = _adapter(_Bare(), raw_records=[{"record_type": TOMBSTONE}])
+        self.assertTrue(adapter.memory_tombstones_may_exist())
+        self.assertEqual(1, adapter.raw_reads, "the fallback is the old behaviour, not a guess")
+
+    def test_the_fallback_reads_the_log_and_reports_no_tombstone_when_there_is_none(self):
+        class _Bare:
+            pass
+
+        adapter = _adapter(_Bare(), raw_records=[{"record_type": "context_event"}])
+        self.assertFalse(adapter.memory_tombstones_may_exist())
+        self.assertEqual(1, adapter.raw_reads)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every commit runs the delete-before-extract guard, and the guard reads the ENTIRE raw record log so
`surviving_source_event_ids` can look for a memory tombstone. On a log with no tombstone that
function returns None and nothing changes -- which is the normal case, and it was the single most
expensive thing a commit did.

Instrumented at the native read choke points, 20 subjects / 40 ingests:

    _read_raw_records   n=40   up to 2527 records per read   one per commit

The question is answerable with a type-filtered scan the engine already supports, so only tombstone
rows cross the boundary -- normally none. The full raw read still happens when a tombstone IS
present, because that is exactly when the guard has work to do. Behaviour is therefore unchanged in
every case where the guard changes anything.

Same three ingests, before and after:

    before   3 raw reads (one per commit)
    after    1 (a one-time cold-path read; the per-commit one is gone)

The seam lives on the shared adapter and its default implementation IS the old code -- read the raw
log and look -- so the JSONL backend behaves exactly as it did. Only the native backend overrides
it. On any doubt the answer is "a tombstone may exist": an unreachable engine, an unsupported
client, an unexpected response shape, or a raised exception all make the guard do the expensive,
correct thing. A false negative here would let extraction re-materialise deleted content; a false
positive costs one read that used to happen unconditionally.

9 tests for the probe -- that no tombstone rows means no tombstone, that it asks for tombstones only
and store-wide, that a tombstone row is reported, that rows of another type are not, that it does
not touch the raw log, and all four conservative paths (raised, wrong shape, missing records list,
client without the scan). The existing 10-test delete-before-extract suite is green unchanged, and
live conformance is 22/22 including delete, forget and reset.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
