### PR TITLE
Start recovery at the watermark instead of reading the whole log

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -387,7 +387,16 @@ impl TemporalEngine {
         // the committed WAL tail and defeating the caller's refuse-load-on-DataLoss guard. An
         // absent WAL file is the only "nothing to replay" case, and `scan` already returns an
         // empty vec for it (never an error), so any Err here is a genuine failure -> abort.
-        let records = match self.wal_store.scan(shard_id, 0, u64::MAX, u64::MAX) {
+        // Start reading past the pieces that hold nothing after the watermark. Reading from the
+        // beginning made a restart cost the size of the LOG rather than the size of what was left
+        // to replay: every record was read and integrity-checked, and then nearly all of them were
+        // dropped by the sequence test below. The answer is conservative -- it never skips a record
+        // after the watermark -- so that test still decides what is replayed.
+        let start_at = self
+            .wal_store
+            .log_id_after_sequence(shard_id, watermark)
+            .unwrap_or(0);
+        let records = match self.wal_store.scan(shard_id, start_at, u64::MAX, u64::MAX) {
             Ok(records) => records,
             Err(err) => {
                 return Err(Status::error(

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -891,6 +891,14 @@ impl LocalWriteAheadLogStore {
             // one file would mean nothing to a caller once there is more than one, and would not
             // survive reclaim.
             let (base, header_len) = read_wal_base(&path)?;
+            // A piece that ends before the window starts holds nothing the caller asked for. Its
+            // start plus its length says where it ends, so skipping it costs a stat rather than a
+            // read of every line in it. This is what makes a windowed scan cost the window: without
+            // it the loop below still reads the whole log and merely declines to return most of it.
+            let piece_len = path.metadata().map(|meta| meta.len()).unwrap_or(0);
+            if base.saturating_add(piece_len.saturating_sub(header_len)) <= start_offset {
+                continue;
+            }
             let mut file = File::open(&path)?;
             file.seek(SeekFrom::Start(header_len))?;
             let mut reader = BufReader::new(file);
@@ -925,6 +933,38 @@ impl LocalWriteAheadLogStore {
         inner.stats.scans += 1;
         inner.stats.bytes_read += total;
         Ok(records)
+    }
+
+    /// Where reading can start, to see every record after `sequence` and no whole piece before it.
+    ///
+    /// Recovery knows a sequence -- the one its durable index already covers -- and needs a
+    /// position to read from. Sequences ascend through the log, so a piece whose last sequence is
+    /// at or below the watermark holds nothing left to replay, and reading can begin at the first
+    /// piece that is not. The answer is conservative: it never skips a record after the watermark,
+    /// and it may include some before it, which the caller already filters.
+    ///
+    /// A log in one piece answers zero, which is what it did before any of this existed.
+    pub fn log_id_after_sequence(
+        &self,
+        shard_id: ShardId,
+        sequence: u64,
+    ) -> Result<u64, WriteAheadLogError> {
+        let inner = self.inner.lock().expect("write-ahead log lock poisoned");
+        let mut start = 0u64;
+        for path in wal_segment_paths(&inner.root, shard_id) {
+            if !path.exists() {
+                continue;
+            }
+            let last = last_wal_sequence_in(&path)?;
+            // An empty piece holds nothing either way; keep looking past it.
+            if last > 0 && last > sequence {
+                return Ok(start);
+            }
+            let (base, header_len) = read_wal_base(&path)?;
+            let piece_len = path.metadata().map(|meta| meta.len()).unwrap_or(0);
+            start = base.saturating_add(piece_len.saturating_sub(header_len));
+        }
+        Ok(start)
     }
 
     pub fn flush(&self, shard_id: ShardId) -> Result<WriteAheadLogFlushReport, WriteAheadLogError> {
@@ -4061,6 +4101,97 @@ mod tests {
                 report.dropped_segments,
                 report.dropped_segment_bytes
             );
+        }
+        set_wal_segment_bytes_for_test(None);
+    }
+
+    /// Reading from a watermark never skips a record after it.
+    ///
+    /// This is the property recovery depends on. The strict sequence-continuity check downstream
+    /// turns a wrongly-skipped record into a refused load, so the answer must be conservative at
+    /// every watermark, not just convenient ones.
+    #[test]
+    fn reading_from_a_watermark_never_skips_a_record_after_it() {
+        set_wal_segment_bytes_for_test(Some(4 * 1024));
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        let records = 400u64;
+        for index in 0..records {
+            store
+                .append_with_sync(
+                    1,
+                    Command::StringSet {
+                        key: format!("k{index:06}"),
+                        value: vec![118u8; 64],
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+
+        for watermark in 0..=records {
+            let start = store.log_id_after_sequence(1, watermark).unwrap();
+            let seen = store.scan(1, start, u64::MAX, u64::MAX).unwrap();
+            let sequences: Vec<u64> = seen
+                .iter()
+                .map(|(_, line)| decode_wal_line(line).unwrap().sequence)
+                .collect();
+            for expected in (watermark + 1)..=records {
+                assert!(
+                    sequences.contains(&expected),
+                    "watermark {watermark} skipped sequence {expected}, which still had to be replayed"
+                );
+            }
+            // And the first thing read is never past the hole the caller would notice.
+            if let Some(first) = sequences.first() {
+                assert!(
+                    *first <= watermark + 1,
+                    "watermark {watermark} started at sequence {first}, leaving a hole"
+                );
+            }
+        }
+        set_wal_segment_bytes_for_test(None);
+    }
+
+    /// What a restart reads: from the beginning of the log, against from the watermark.
+    #[test]
+    fn what_a_restart_reads_from_zero_against_from_the_watermark() {
+        for segment_bytes in [0u64, 64 * 1024] {
+            set_wal_segment_bytes_for_test(Some(segment_bytes));
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let records = 20_000u64;
+            for index in 0..records {
+                store
+                    .append_with_sync(
+                        1,
+                        Command::StringSet {
+                            key: format!("k{index:06}"),
+                            value: vec![118u8; 128],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+            // The durable index already covers all but the last hundred records.
+            let watermark = records - 100;
+
+            let before = std::time::Instant::now();
+            let all = store.scan(1, 0, u64::MAX, u64::MAX).unwrap();
+            let from_zero = before.elapsed().as_secs_f64() * 1e6;
+
+            let before = std::time::Instant::now();
+            let start = store.log_id_after_sequence(1, watermark).unwrap();
+            let windowed = store.scan(1, start, u64::MAX, u64::MAX).unwrap();
+            let from_watermark = before.elapsed().as_secs_f64() * 1e6;
+
+            println!(
+                "  piece size {:>6}: from zero {from_zero:>9.0} us ({} records read) -> from the watermark {from_watermark:>8.0} us ({} read)",
+                if segment_bytes == 0 { "one".to_string() } else { format!("{segment_bytes}") },
+                all.len(),
+                windowed.len()
+            );
+            assert!(windowed.len() >= 100, "the tail must be there to replay");
         }
         set_wal_segment_bytes_for_test(None);
     }

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1,6 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
+//! The write-ahead log.
+//!
+//! A shard's log is a sequence of pieces. `shard-{id}.wal.jsonl` is the one being written;
+//! sealed ones are `shard-{id}.wal.{start_log_id:020}.jsonl`, named so they sort into log order.
+//! `TS_WAL_SEGMENT_BYTES` sets when a piece is sealed; zero, the default, never seals one, and
+//! then the log is a single file and behaves exactly as it did before pieces existed.
+//!
+//! Positions are **log ids**: a byte position in the log's whole history, not in whichever file
+//! happens to hold it. Each piece records in its first bytes the log id its contents start at, so
+//! a log id says which piece holds a record and where inside it, by arithmetic. A log id keeps
+//! meaning across pieces, and survives reclaim.
+//!
+//! Reclaim unlinks whole pieces that hold nothing above the retain floor, and copies only within
+//! the piece being written.
+//!
+//! # Two things deliberately absent
+//!
+//! **There is no per-piece index from record number to byte offset.** A segmented log usually
+//! carries one, as a sidecar file, so that "read entries N through M" is a seek rather than a walk
+//! from the start of the piece. Here it would have no reader. Random access is by log id, which is
+//! already arithmetic and needs no index; and the only component that reads the log sequentially is
+//! recovery (`engine::lifecycle::replay_wal_into_shard`), which starts at a watermark and reads
+//! forward to the end, so a seek into the middle buys it nothing. Replication does not read this
+//! log at all -- the raft log is a separate structure under `raft::local_wal`. Adding the sidecar
+//! would mean another file to write, checksum, recover and keep consistent with the piece beside
+//! it, in exchange for nothing, and it would have to be correct across reclaim and a torn tail.
+//!
+//! Should something ever need to find a record by sequence without reading forward to it, this is
+//! the thing to build, and the reason it was not built is only that nothing needed it.
+//!
+//! **Pieces are not preallocated.** Writing into a file that is already its full size avoids
+//! persisting a new size on every barrier, which measured 42.7% cheaper per record at eight
+//! records per barrier. It is not done because the file's length is what tells the log where its
+//! records end -- used to pick the next write offset, find the tail, repair a torn tail, seal a
+//! piece, and bound every reader -- so preallocating means threading a separate logical end
+//! through all of them. Reserving blocks without changing the size (`FALLOC_FL_KEEP_SIZE`), which
+//! would need none of that, was measured and made no difference: the cost is persisting the size,
+//! not allocating the blocks.
+
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};


### PR DESCRIPTION
Stacked on #183 — the piece-skipping below needs a log that has pieces.

`replay_wal_into_shard` is handed a watermark: the sequence the durable index already covers. It
then calls `scan(shard_id, 0, u64::MAX, u64::MAX)`, reads and integrity-checks **every record in
the log**, and discards everything at or below the watermark. So a restart costs the size of the
log, not the size of what is left to replay.

Same shape as WAL reclaim, the index collector, the expiry sweep and the band manifest: cost that
tracks what is **kept** rather than what **changed**. This is the one on the restart path.

20,000 records, durable index covering all but the last hundred:

| log | read from zero | read from the watermark | records read |
| --- | --- | --- | --- |
| one piece | 300–379 ms | 285–405 ms | 20,000 → 20,000 |
| 64 KiB pieces | 256–295 ms | **9.5–10.5 ms** | 20,000 → **159** |

Four runs each. **The one-piece row is unchanged, and that is the honest result**: with rolling off
a log has one piece, the window starts at zero, and the scan does exactly what it did before. The
two columns there are the same work and the spread is the box. The win arrives only once the log
has pieces to skip — which is what makes rolling worth turning on.

## Two parts

**`scan` skips a piece it can see ends before the window.** A piece's start plus its length says
where it ends, so the decision costs a stat rather than a read of every line in it. Without this
the loop still read the whole log and merely declined to return most of it.

**Recovery turns its sequence watermark into that window,** via `log_id_after_sequence`. Sequences
ascend through the log, so a piece whose last sequence is at or below the watermark holds nothing
left to replay.

## Why the conversion is conservative

Downstream, replay enforces strict sequence continuity: a hole is treated as data loss and the load
is refused. So a wrongly-skipped record does not produce a wrong answer, it produces a shard that
will not load — and it would do so only on the restart path, with the log already reclaimed behind
it.

The answer is therefore allowed to include records *before* the watermark, and never to omit one
after it. It holds because pieces partition the sequence space in order: the first piece whose last
sequence exceeds the watermark begins at watermark+1 or earlier, since the piece before it ended at
or below the watermark. The existing filter then decides what is actually replayed, exactly as
before.

`reading_from_a_watermark_never_skips_a_record_after_it` sweeps **every** watermark from 0 to N over
a rolled log and asserts both halves: nothing after the watermark is ever missing, and the first
record read is never past watermark+1. Testing a few convenient watermarks would not have covered
the piece boundaries, which is where the property is actually at risk.

`what_a_restart_reads_from_zero_against_from_the_watermark` is the table above.

`cargo check --all-targets` clean.
