### PR TITLE
meta: record what a server is made of

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2278,6 +2278,7 @@ mod tests {
     fn metaserver_metrics_expose_inventory_state_and_scheduler() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "metrics-server-a".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -2354,6 +2355,7 @@ mod tests {
         let snapshot_path = dir.path().join("meta-route-snapshot.json");
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "server-route-a".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -2487,6 +2489,7 @@ mod tests {
     fn metaserver_safe_mode_route_reports_frozen_cooldown_resources() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "safe-server".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -2580,6 +2583,7 @@ mod tests {
                 method: "POST".to_string(),
                 path: "/servers/register".to_string(),
                 body: serde_json::to_vec(&RegisterServerRequest {
+                    numa_nodes: Vec::new(),
                     server_addr: "raft-server-a".to_string(),
                     node_id: 11,
                     location: "zone-a".to_string(),
@@ -3026,6 +3030,7 @@ mod tests {
                 method: "POST".to_string(),
                 path: "/servers/register".to_string(),
                 body: serde_json::to_vec(&RegisterServerRequest {
+                    numa_nodes: Vec::new(),
                     server_addr: node_addr.clone(),
                     node_id: 9,
                     location: "zone-a".to_string(),

--- a/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
@@ -73,6 +73,7 @@ fn handle_manage_service_route(
                     meta,
                     register_server,
                     RegisterServerRequest {
+                        numa_nodes: Vec::new(),
                         server_addr: heartbeat_server_addr(&req),
                         node_id: 0,
                         location: req.location,
@@ -469,6 +470,7 @@ fn handle_master_service_route(
                     meta,
                     register_server,
                     RegisterServerRequest {
+                        numa_nodes: Vec::new(),
                         server_addr,
                         node_id: req.node_id,
                         location: req.location,

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -322,6 +322,7 @@ fn main() {
         );
     } else {
         let server_registration = RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: advertised_addr.clone(),
             node_id,
             location,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2904,6 +2904,7 @@ mod tests {
                 node_id: index as u64 + 1,
                 location: "rack-1".to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             });
         }
         meta.add_namespace(AddNamespaceRequest {
@@ -3120,6 +3121,7 @@ mod tests {
                 node_id: index + 1,
                 location: format!("region-{}/zone-{}", index % 3, index),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             });
         }
         meta.add_namespace(AddNamespaceRequest {
@@ -3173,6 +3175,7 @@ mod tests {
                 node_id: index as u64 + 1,
                 location: location.to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             });
         }
         meta.add_namespace(AddNamespaceRequest {
@@ -3224,6 +3227,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         // Setting the fixture up is itself a metadata change. Pump it through
         // before anyone subscribes, so these tests observe what they cause
@@ -3530,6 +3534,7 @@ mod tests {
             node_id: 1,
             location: "rack-1".to_string(),
             binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
         });
         meta.add_namespace(AddNamespaceRequest {
             namespace: "ns".to_string(),

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -179,6 +179,29 @@ pub struct AckResponse {
     pub status: Status,
 }
 
+/// One memory/CPU domain of a datanode's hardware.
+///
+/// A server is not uniform: it is some number of domains, each with its own
+/// cores and its own memory. The metaserver had no way to know that, so it
+/// could not tell a machine that is one large domain from a machine that is
+/// four smaller ones -- which is the difference between one big placement
+/// target and four that fail independently for memory pressure.
+///
+/// Recorded here, reported by `/servers`, and carried in snapshots. Placement
+/// still treats a server as one target; this is what a placement that wanted to
+/// be finer-grained would have to read.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NumaNode {
+    /// Index within the reporting server, as the server numbers them.
+    pub id: u64,
+    /// The cores in this domain, in the form the server reports them
+    /// (comma or space separated).
+    #[serde(default)]
+    pub cpu_list: String,
+    #[serde(default)]
+    pub memory_size_mb: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RegisterServerRequest {
     pub server_addr: String,
@@ -188,6 +211,10 @@ pub struct RegisterServerRequest {
     pub location: String,
     #[serde(default)]
     pub binary_version: String,
+    /// The memory/CPU domains this server is made of. Empty from a server that
+    /// does not report them, which is every server built before this existed.
+    #[serde(default)]
+    pub numa_nodes: Vec<NumaNode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -292,6 +319,9 @@ pub struct ServerMetaInfo {
     pub server_addr: String,
     pub node_id: u64,
     pub location: String,
+    /// The hardware shape this server declared when it registered.
+    #[serde(default)]
+    pub numa_nodes: Vec<NumaNode>,
     pub state: MetaEntityState,
     pub last_heartbeat_ms: u64,
     #[serde(default)]
@@ -1441,6 +1471,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         assert!(
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "127.0.0.1:18001".to_string(),
                 node_id: 1,
                 location: "zone-a".to_string(),
@@ -1554,6 +1585,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         assert!(
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "server-a".to_string(),
                 node_id: 7,
                 location: "zone-a".to_string(),
@@ -1623,6 +1655,7 @@ mod tests {
     fn metaserver_freezes_stale_servers_from_heartbeat_age() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "stale".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -1642,6 +1675,7 @@ mod tests {
     fn metaserver_failure_detector_loop_freezes_stale_servers_and_proxies() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "stale-server".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -1676,6 +1710,7 @@ mod tests {
         // still believes it serves, and reads routed there will all miss.
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -1718,6 +1753,7 @@ mod tests {
         // Re-registering is how a datanode says it is ready to be trusted again.
         assert!(meta
             .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -1738,6 +1774,7 @@ mod tests {
         // convict the entire fleet on upgrade.
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -1768,6 +1805,7 @@ mod tests {
 
     fn register(meta: &SingleNodeMeta, addr: &str) -> AckResponse {
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: addr.to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -1962,6 +2000,7 @@ mod tests {
         ] {
             assert!(meta
                 .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
                     server_addr: addr.to_string(),
                     node_id: 1,
                     location: location.to_string(),
@@ -2021,6 +2060,7 @@ mod tests {
         for (addr, location) in servers {
             assert!(meta
                 .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
                     server_addr: addr.to_string(),
                     node_id: 1,
                     location: location.to_string(),
@@ -2208,6 +2248,7 @@ mod tests {
         {
             let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -2228,6 +2269,7 @@ mod tests {
     fn stop_meta() -> SingleNodeMeta {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -2286,6 +2328,7 @@ mod tests {
 
         let meta = SingleNodeMeta::default().with_conviction_lock(true);
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -2296,6 +2339,7 @@ mod tests {
         // It restarts and registers again; the lock does not stand in its way.
         assert!(meta
             .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -2364,6 +2408,7 @@ mod tests {
         assert!(stopped_server(&meta).freeze_cooldown_until_ms <= now_ms());
         assert!(meta
             .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -2380,6 +2425,7 @@ mod tests {
         {
             let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -2401,6 +2447,7 @@ mod tests {
     fn muted_meta_with_a_server() -> SingleNodeMeta {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -2444,6 +2491,7 @@ mod tests {
             (
                 "register_server",
                 meta.register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
                     server_addr: "node-b".to_string(),
                     node_id: 2,
                     location: "rack-1".to_string(),
@@ -2499,6 +2547,7 @@ mod tests {
         // restarts cannot rejoin until an operator resumes.
         let meta = muted_meta_with_a_server();
         let rejoin = meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -2538,6 +2587,7 @@ mod tests {
         {
             let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -2571,6 +2621,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         for (addr, node_id, location) in [("node-a", 1, "rack-1"), ("node-b", 2, "rack-2")] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: addr.to_string(),
                 node_id,
                 location: location.to_string(),
@@ -2670,6 +2721,7 @@ mod tests {
         // against must still be told where its shards should go.
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -2717,6 +2769,7 @@ mod tests {
         .enumerate()
         {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: addr.to_string(),
                 node_id: index as u64 + 1,
                 location: zone.to_string(),
@@ -3610,12 +3663,126 @@ mod tests {
         assert_eq!(peer.stats().topology_query_total, 5);
     }
 
+    fn domains(count: u64) -> Vec<NumaNode> {
+        (0..count)
+            .map(|id| NumaNode {
+                id,
+                cpu_list: format!("{}-{}", id * 16, id * 16 + 15),
+                memory_size_mb: 65_536,
+            })
+            .collect()
+    }
+
+    fn register_with(meta: &SingleNodeMeta, addr: &str, numa_nodes: Vec<NumaNode>) {
+        meta.register_server(RegisterServerRequest {
+            server_addr: addr.to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes,
+        });
+    }
+
+    fn listed_server(meta: &SingleNodeMeta, addr: &str) -> ServerMetaInfo {
+        meta.list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == addr)
+            .expect("registered")
+    }
+
+    #[test]
+    fn a_server_can_say_what_it_is_made_of() {
+        // The metaserver could not tell one large memory domain from four
+        // smaller ones, because there was nowhere to say.
+        let meta = SingleNodeMeta::default();
+        register_with(&meta, "node-a", domains(4));
+        let server = listed_server(&meta, "node-a");
+        assert_eq!(server.numa_nodes.len(), 4);
+        assert_eq!(server.numa_nodes[0].cpu_list, "0-15");
+        assert_eq!(server.numa_nodes[3].memory_size_mb, 65_536);
+    }
+
+    #[test]
+    fn a_server_that_says_nothing_is_recorded_as_saying_nothing() {
+        // Every server built before this reports no domains, and that has to be
+        // an empty list rather than a guess.
+        let meta = SingleNodeMeta::default();
+        register_with(&meta, "node-a", Vec::new());
+        assert!(listed_server(&meta, "node-a").numa_nodes.is_empty());
+    }
+
+    #[test]
+    fn re_registering_replaces_the_shape_rather_than_adding_to_it() {
+        // A machine that came back with different hardware is describing itself
+        // now, not amending what it said before.
+        let meta = SingleNodeMeta::default();
+        register_with(&meta, "node-a", domains(4));
+        register_with(&meta, "node-a", domains(2));
+        assert_eq!(listed_server(&meta, "node-a").numa_nodes.len(), 2);
+    }
+
+    #[test]
+    fn the_hardware_shape_survives_snapshot_and_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("numa-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            register_with(&meta, "node-a", domains(3));
+
+            let snapshot = meta.export_snapshot();
+            let peer = SingleNodeMeta::default();
+            assert!(peer.install_snapshot(snapshot).status.ok);
+            assert_eq!(listed_server(&peer, "node-a").numa_nodes.len(), 3);
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert_eq!(listed_server(&recovered, "node-a").numa_nodes.len(), 3);
+    }
+
+    #[test]
+    fn knowing_the_shape_does_not_change_where_a_shard_goes() {
+        // Placement still treats a server as one target. Recording the shape is
+        // what a finer-grained placement would read; it is not that placement,
+        // and this pins that it did not quietly become it.
+        let meta = SingleNodeMeta::default();
+        register_with(&meta, "node-a", domains(8));
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-b".to_string(),
+            node_id: 2,
+            location: "rack-2".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 2,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        let topology = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        // Two servers, two replicas: the eight domains on one of them do not
+        // turn it into eight candidates.
+        assert_eq!(topology.shards[0].replicas.len(), 2);
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");
         let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "cooldown-server".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -3653,6 +3820,7 @@ mod tests {
         );
         assert_eq!(
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "cooldown-server".to_string(),
                 node_id: 1,
                 location: "z".to_string(),
@@ -3726,12 +3894,14 @@ mod tests {
     fn metaserver_serves_table_topology_and_version_not_modified() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "z1".to_string(),
             binary_version: String::new(),
         });
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s2".to_string(),
             node_id: 2,
             location: "z2".to_string(),
@@ -3865,6 +4035,7 @@ mod tests {
     fn metaserver_freeze_table_blocks_topology_update_and_finish_load_until_unfrozen() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -4137,6 +4308,7 @@ mod tests {
             ("warm", 100, 100),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: "z".to_string(),
@@ -4187,6 +4359,7 @@ mod tests {
             ("degraded", 0, 0, true),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: "z".to_string(),
@@ -4245,6 +4418,7 @@ mod tests {
             ("serving", "serving"),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: "z".to_string(),
@@ -4300,6 +4474,7 @@ mod tests {
             ("zone-b-hot", "zone-b", 10_000, 10_000),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: location.to_string(),
@@ -4351,6 +4526,7 @@ mod tests {
             ("10.0.0.2:18001", "zone-c", 10_000, 10_000),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: location.to_string(),
@@ -4400,6 +4576,7 @@ mod tests {
             ("10.0.0.1:18002", "zone-b", 20, 20),
         ] {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: server_addr.to_string(),
                 node_id: 0,
                 location: location.to_string(),
@@ -4533,6 +4710,7 @@ mod tests {
     fn metaserver_finish_load_updates_shard_route() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -4559,6 +4737,7 @@ mod tests {
         let snapshot_path = dir.path().join("scheduler-finish-load-snapshot.json");
         let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -4699,6 +4878,7 @@ mod tests {
         let log_path = dir.path().join("control-plane-parity.jsonl");
         let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -4791,6 +4971,7 @@ mod tests {
         assert_eq!(missing.status.code, "server_not_found");
 
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "s1".to_string(),
             node_id: 1,
             location: "z".to_string(),
@@ -4843,6 +5024,7 @@ mod tests {
         let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
         assert!(meta.info().durable_mutation_log);
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "server-a".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -5017,12 +5199,14 @@ mod tests {
         let snapshot_path = dir.path().join("meta-snapshot.json");
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "server-a".to_string(),
             node_id: 1,
             location: "zone-a".to_string(),
             binary_version: "v1".to_string(),
         });
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "server-b".to_string(),
             node_id: 2,
             location: "zone-b".to_string(),

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -934,6 +934,7 @@ mod tests {
 
     fn server(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ServerMetaInfo {
         ServerMetaInfo {
+            numa_nodes: Vec::new(),
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 0,

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -96,6 +96,7 @@ mod tests {
 
     fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
         ServerMetaInfo {
+            numa_nodes: Vec::new(),
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -54,6 +54,10 @@ impl SingleNodeMeta {
                 server_addr: request.server_addr,
                 node_id: request.node_id,
                 location: request.location,
+                // Re-declared on every registration rather than merged: a
+                // machine that came back with different hardware is describing
+                // itself now, not amending what it said before.
+                numa_nodes: request.numa_nodes,
                 state: MetaEntityState::Normal,
                 last_heartbeat_ms: now,
                 frozen_since_ms: 0,

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -619,6 +619,7 @@ mod tests {
         use crate::meta::*;
         let meta = SingleNodeMeta::with_mutation_log(log_path).unwrap();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -928,6 +929,7 @@ mod tests {
         // stay in the meta state -- and in every exported snapshot -- forever.
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -980,6 +982,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         let register = || {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -1277,6 +1280,7 @@ mod tests {
     fn purging_removes_the_resources_from_meta_state_and_from_snapshots() {
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),
@@ -1338,6 +1342,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         let register = || {
             meta.register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,
                 location: "rack-1".to_string(),
@@ -1367,6 +1372,7 @@ mod tests {
         // inherits rather than restarting every one of their clocks.
         let meta = SingleNodeMeta::default();
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "node-a".to_string(),
             node_id: 1,
             location: "rack-1".to_string(),

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -467,6 +467,7 @@ mod tests {
     /// A healthy, reporting server that boots long before any test clock.
     fn server(addr: &str, serving: &[(ShardId, &str)]) -> ServerMetaInfo {
         ServerMetaInfo {
+            numa_nodes: Vec::new(),
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 1,

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -113,6 +113,7 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         .servers
         .entry(server_addr.to_string())
         .or_insert_with(|| ServerMetaInfo {
+            numa_nodes: Vec::new(),
             freeze_reason: FreezeReason::Unspecified,
             server_addr: server_addr.to_string(),
             node_id: 0,

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1966,6 +1966,7 @@ mod tests {
 
         let meta = crate::meta::SingleNodeMeta::default();
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_328),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -2003,6 +2004,7 @@ mod tests {
         assert_eq!(proxy.info().route_cache_size, 1);
 
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_329),
             node_id: 2,
             location: "zone-b".to_string(),
@@ -2078,6 +2080,7 @@ mod tests {
 
         let meta = crate::meta::SingleNodeMeta::default();
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_340),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -2127,6 +2130,7 @@ mod tests {
         }
 
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_341),
             node_id: 2,
             location: "zone-b".to_string(),
@@ -4729,6 +4733,7 @@ mod tests {
 
         let meta = crate::meta::SingleNodeMeta::default();
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_384),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -4834,6 +4839,7 @@ mod tests {
 
         let meta = crate::meta::SingleNodeMeta::default();
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_380),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -5096,6 +5102,7 @@ mod tests {
 
         let meta = crate::meta::SingleNodeMeta::default();
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_374),
             node_id: 1,
             location: "zone-a".to_string(),
@@ -5138,6 +5145,7 @@ mod tests {
 
         // The shard moves to the second datanode.
         meta.register_server(crate::meta::RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: test_addr(18_375),
             node_id: 2,
             location: "zone-b".to_string(),

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -310,6 +310,7 @@ pub(super) fn topology_for_shard(
 
 pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
     ServerMetaInfo {
+        numa_nodes: Vec::new(),
         freeze_reason: crate::meta::FreezeReason::Unspecified,
         server_addr: addr.to_string(),
         node_id,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -484,6 +484,7 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
 
     assert!(
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: "server-a".to_string(),
             node_id: 1,
             location: "az-a".to_string(),
@@ -598,6 +599,7 @@ fn metaserver_raft_replicates_full_metadata_mutation_api() {
 fn metaserver_raft_freeze_stale_server_is_replicated_mutation() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.register_server(RegisterServerRequest {
+        numa_nodes: Vec::new(),
         server_addr: "server-stale".to_string(),
         node_id: 1,
         location: "az-a".to_string(),
@@ -649,6 +651,7 @@ fn production_meta_raft_runtime_ticks_failover_and_failure_detection() {
         runtime
             .cluster()
             .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
                 server_addr: "server-stale".to_string(),
                 node_id: 1,
                 location: "az-a".to_string(),

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -1823,6 +1823,7 @@ fn verify_proxy_route_quarantine_recovery() {
     let meta = SingleNodeMeta::default();
     let bad_server = "127.0.0.1:1".to_string();
     meta.register_server(RegisterServerRequest {
+        numa_nodes: Vec::new(),
         server_addr: bad_server.clone(),
         node_id: 1,
         location: "proxy-quarantine-zone".to_string(),
@@ -1861,6 +1862,7 @@ fn verify_proxy_route_quarantine_recovery() {
     std::thread::sleep(Duration::from_millis(10));
 
     meta.register_server(RegisterServerRequest {
+        numa_nodes: Vec::new(),
         server_addr: server_addr.clone(),
         node_id: 2,
         location: "proxy-quarantine-zone".to_string(),
@@ -1981,6 +1983,7 @@ fn verify_proxy_topology_churn_convergence() {
 
     let meta = SingleNodeMeta::default();
     meta.register_server(RegisterServerRequest {
+        numa_nodes: Vec::new(),
         server_addr: server_a.clone(),
         node_id: 1,
         location: "zone-a".to_string(),
@@ -2032,6 +2035,7 @@ fn verify_proxy_topology_churn_convergence() {
     }
 
     meta.register_server(RegisterServerRequest {
+        numa_nodes: Vec::new(),
         server_addr: server_b.clone(),
         node_id: 2,
         location: "zone-b".to_string(),
@@ -2709,6 +2713,7 @@ fn verify_metaserver_scheduler_control_plane() {
         (3, "127.0.0.1:27113", "zone-c"),
     ] {
         meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
             server_addr: addr.to_string(),
             node_id,
             location: location.to_string(),


### PR DESCRIPTION
## The metaserver did not know what a server is made of

A datanode is not a uniform box. It is some number of memory/CPU domains, each with its own cores and its own memory, and they fail independently for memory pressure. `RegisterServerRequest` carried an address, a node id, a location and a binary version — nothing about the shape of the machine underneath.

So the metaserver could not tell a host that is one large domain from a host that is four smaller ones.

## What this adds

`RegisterServerRequest` gains an optional list of domains — `id`, `cpu_list`, `memory_size_mb` — recorded on the server, reported by `GET /servers`, and carried in snapshots and the mutation log.

Re-registering **replaces** the list rather than merging into it: a machine that came back with different hardware is describing itself now, not amending what it said before.

The field is `#[serde(default)]`, so a server that reports nothing is recorded as reporting nothing. That is every server built before this, and an empty list is the honest record rather than a guess.

## What this deliberately does not do

**Placement still treats a server as one target.** A host with eight domains does not become eight candidates. There is a test pinning that, because it is exactly the kind of thing that could drift in later without anyone deciding to.

That restraint is the whole judgement call here, so it is worth being explicit about what the larger change would be. Making placement domain-aware is not a matter of reading a new field — it changes what a shard is placed *on*. `ShardLocation.server_addr` would stop being the unit of placement, host and location de-duplication would need to understand that two candidates on one machine are not independent, and the identity a client resolves to would change shape. That is a redesign of the placement core with wire-format consequences, and it is a product decision rather than something to infer from a field being available.

This change is the part that is closable on its own: the metaserver now *knows* the shape, which is the prerequisite for anyone deciding to act on it.

## Tests

5 new: a server declaring four domains and them coming back on `/servers`; a server declaring none being recorded as none; re-registration replacing rather than accumulating; the shape surviving both a snapshot install and mutation-log replay; and — the important one — eight domains on a host **not** turning it into eight placement candidates.

Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **222 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.
- `cargo test -p temporalstore-rust --lib proxy::tests` — 54 passed, 0 failed, unchanged from `main`.

Adding the field touched 77 struct literals across the tree. Two of those the filler got wrong and the compiler caught: it matched `RegisterServerRequest {` inside the *declaration* of a longer type whose name ends the same way, and it separated a `derive` from the struct it belonged to. Both are why the all-targets check runs before the push rather than after.
