### PR TITLE
Client: count the writes whose outcome nobody can determine

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -368,6 +368,16 @@ pub struct ClientStats {
     pub backend_error_streak: u64,
     pub continuous_backend_failures: u64,
     pub backend_successes_after_error: u64,
+    /// Writes that failed with an outcome nobody can determine, and so were deliberately not
+    /// sent again.
+    ///
+    /// A refused connection proves the write never arrived and it is simply retried. A
+    /// timeout does not: the datanode stopped answering, and the write may or may not have
+    /// been applied. Repeating it there would apply it twice, so it is not repeated -- which
+    /// means these are the writes whose fate is genuinely unknown. That is a number an
+    /// operator has to be able to see; it was previously indistinguishable from an ordinary
+    /// backend error.
+    pub writes_of_unknown_outcome: u64,
     pub meta_sync_total: u64,
     pub meta_sync_errors: u64,
 }
@@ -579,6 +589,10 @@ pub struct ClientRetryDecision {
 }
 
 impl ClientStats {
+    fn record_write_of_unknown_outcome(&mut self) {
+        self.writes_of_unknown_outcome += 1;
+    }
+
     fn record_backend_error(&mut self, became_continuous: bool) {
         self.backend_errors += 1;
         self.backend_error_streak += 1;

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -49,6 +49,11 @@ impl TemporalStoreClient {
                         return Err(err.into());
                     }
                     if !Self::may_send_again(&request.commands, &err) {
+                        self.inner
+                            .stats
+                            .lock()
+                            .expect("client stats lock poisoned")
+                            .record_write_of_unknown_outcome();
                         let _ = self.resolve_route(request.shard_id, true, None);
                         return Err(err.into());
                     }
@@ -164,6 +169,11 @@ impl TemporalStoreClient {
                         return Err(err.into());
                     }
                     if !Self::may_send_again(std::slice::from_ref(&request.command), &err) {
+                        self.inner
+                            .stats
+                            .lock()
+                            .expect("client stats lock poisoned")
+                            .record_write_of_unknown_outcome();
                         // Drop the stale route so the NEXT request re-resolves, but do not
                         // send this write a second time -- its outcome is unknown, not known
                         // to be "never happened".
@@ -229,6 +239,11 @@ impl TemporalStoreClient {
                         return Err(err.into());
                     }
                     if !Self::may_send_again(&request.commands, &err) {
+                        self.inner
+                            .stats
+                            .lock()
+                            .expect("client stats lock poisoned")
+                            .record_write_of_unknown_outcome();
                         let _ =
                             self.resolve_route(request.shard_id, true, continuous_failed_time_ms);
                         return Err(err.into());

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -268,6 +268,9 @@ pub struct ProxyStats {
     /// Registration attempts not made because one was made within
     /// `auto_register_min_interval_ms`.
     pub auto_register_throttled: u64,
+    /// Writes abandoned because the failure did not prove they never arrived, so replaying
+    /// them could have applied them twice. These are the writes whose fate is unknown.
+    pub writes_of_unknown_outcome: u64,
     pub auto_register_total: u64,
 }
 
@@ -1206,6 +1209,9 @@ impl ProxyService {
         stats.continuous_backend_failures += current
             .continuous_backend_failures
             .saturating_sub(last.continuous_backend_failures);
+        stats.writes_of_unknown_outcome += current
+            .writes_of_unknown_outcome
+            .saturating_sub(last.writes_of_unknown_outcome);
         *last = current;
     }
 
@@ -2741,6 +2747,7 @@ mod tests {
             heartbeat_slow_total,
             auto_register_total,
             auto_register_throttled,
+            writes_of_unknown_outcome,
             route_cache_hits,
             route_cache_misses,
             route_refreshes,
@@ -2752,7 +2759,7 @@ mod tests {
 
         // Field -> the label it is published under. Values are only here so the destructured
         // bindings are used; what is asserted is that each label reaches the endpoint.
-        let published: [(&str, u64); 20] = [
+        let published: [(&str, u64); 21] = [
             ("kind=\"execute\"", execute_requests),
             ("kind=\"batch_execute\"", batch_execute_requests),
             ("kind=\"bad_request\"", bad_requests),
@@ -2766,6 +2773,7 @@ mod tests {
             ("kind=\"heartbeat_slow\"", heartbeat_slow_total),
             ("kind=\"auto_register\"", auto_register_total),
             ("kind=\"auto_register_throttled\"", auto_register_throttled),
+            ("kind=\"write_of_unknown_outcome\"", writes_of_unknown_outcome),
             ("kind=\"hit\"", route_cache_hits),
             ("kind=\"miss\"", route_cache_misses),
             ("kind=\"refresh\"", route_refreshes),
@@ -4494,6 +4502,81 @@ mod tests {
             hits.load(Ordering::SeqCst) - before,
             1,
             "a request that timed out on a pooled socket must not be sent again on a fresh one"
+        );
+    }
+
+    #[test]
+    fn writes_of_unknown_outcome_are_counted_separately_from_ordinary_failures() {
+        // After a write stopped being replayed on timeout, "backend_errors" stopped being
+        // enough to reason about. A refused connection is harmless -- the write never landed
+        // and it was retried. A timeout is not: the write may have been applied and nothing
+        // retried it. Those two were indistinguishable in the counters, so nobody could
+        // answer the one question that matters after an incident: did any writes end up in a
+        // state we cannot determine?
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let slow = test_addr(18_396);
+        let slow_for_thread = slow.clone();
+        std::thread::spawn(move || {
+            serve(&slow_for_thread, move |_request| {
+                std::thread::sleep(Duration::from_millis(500));
+                crate::http::json_response(200, &Status::ok())
+            })
+            .unwrap();
+        });
+        start_meta(test_addr(18_397), slow.clone());
+        wait_for_http(&test_addr(18_397));
+
+        let timing_out = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_397),
+            route_cache_ttl_ms: 60_000,
+            connect_timeout_ms: 200,
+            io_timeout_ms: 120,
+            ..ProxyOptions::default()
+        });
+        let _ = timing_out.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        assert_eq!(
+            timing_out.info().stats.writes_of_unknown_outcome, 1,
+            "a write that timed out is a write nobody can account for"
+        );
+
+        // A refused connection is the opposite case and must NOT be counted: it proves the
+        // write never arrived, and it was replayed onto a healthy datanode.
+        start_server(test_addr(18_398), engine.clone());
+        start_meta(test_addr(18_399), test_addr(18_398));
+        wait_for_http(&test_addr(18_399));
+        wait_for_http(&test_addr(18_398));
+        let refused = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_399),
+            route_cache_ttl_ms: 60_000,
+            connect_timeout_ms: 50,
+            io_timeout_ms: 200,
+            ..ProxyOptions::default()
+        });
+        refused.client().insert_cached_route_for_test(1, "127.0.0.1:1");
+        let response = refused.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        assert!(response.status.ok, "a refused write is replayed and should succeed");
+        assert_eq!(
+            refused.info().stats.writes_of_unknown_outcome, 0,
+            "a refused write provably never arrived, so it is not unknown"
         );
     }
 

--- a/crates/temporalstore-rust/src/proxy/prometheus.rs
+++ b/crates/temporalstore-rust/src/proxy/prometheus.rs
@@ -74,6 +74,7 @@ impl ProxyService {
                 "continuous_backend_failure",
                 stats.continuous_backend_failures,
             ),
+            ("write_of_unknown_outcome", stats.writes_of_unknown_outcome),
             ("metaserver_error", stats.metaserver_errors),
             ("client_meta_sync_error", client.meta_sync_errors),
         ] {


### PR DESCRIPTION
Once a write stopped being replayed after a timeout, backend_errors stopped being
enough to reason about. Two very different things were landing in the same number:

- A refused connection. The write provably never arrived, it was replayed onto a
  healthy datanode, and nothing is outstanding. Harmless.
- A timeout. The datanode stopped answering, so the write may or may not have been
  applied, and it was deliberately not repeated -- repeating it could apply it
  twice. Nothing retried it and nothing recorded it.

The second is the only number that matters after an incident: did any writes end up
in a state we cannot determine? It was not answerable, because it was added to the
same counter as the harmless case.

Now counted separately, and published as
temporalstore_proxy_backend_events_total{kind="write_of_unknown_outcome"}.

The test asserts both directions, which is the whole point: a write that times out
increments it, and a write to a refused address does not -- that one provably never
arrived, so calling it unknown would be its own kind of wrong. Disable the counter
and the test fails with left: 0, right: 1.

Not changed here, and worth a decision separately: the data-path timeout defaults
are connect 200ms and io 200ms. Those are tight enough that an ordinary datanode
pause -- a compaction, a large batch, a read that touches disk -- can produce one of
these. Now that they are visible, the size of that number in a real deployment is
the evidence for whether the defaults are right, which is a better basis for
changing them than an argument from first principles.