### PR TITLE
meta: let the task scheduler's pacing be configured

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -367,6 +367,13 @@ struct MetaTaskScheduler {
     inner: Arc<Mutex<DeterministicTaskScheduler>>,
     executions: Arc<Mutex<Vec<MetaSchedulerExecutionRecord>>>,
     snapshot_path: Option<PathBuf>,
+    /// How the scheduler paces itself when a caller does not say.
+    ///
+    /// Every other background subsystem here takes its pacing from the
+    /// environment; this one alone had its retry backoff and its concurrency
+    /// compiled in, so changing how hard the metaserver drives tasks meant
+    /// changing the code.
+    default_options: TaskSchedulerOptions,
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -2183,6 +2190,88 @@ mod tests {
             code >= 400 || parsed["status"]["ok"] == serde_json::Value::Bool(false),
             "an empty body was accepted: {code} {parsed}"
         );
+    }
+
+    /// The scheduler knobs, set for the duration of one test.
+    ///
+    /// Serialised because the environment is process-wide, and two of these
+    /// running at once would read each other's values.
+    fn with_scheduler_env<T>(pairs: &[(&str, &str)], body: impl FnOnce() -> T) -> T {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner());
+        for (key, value) in pairs {
+            std::env::set_var(key, value);
+        }
+        let out = body();
+        for (key, _) in pairs {
+            std::env::remove_var(key);
+        }
+        out
+    }
+
+    #[test]
+    fn the_scheduler_takes_its_pacing_from_the_environment() {
+        // Every other background subsystem here is configurable; this one had
+        // its backoff and its concurrency compiled in.
+        let scheduler = with_scheduler_env(
+            &[
+                ("TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS", "250"),
+                ("TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS", "300000"),
+                ("TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES", "3"),
+                ("TS_META_TASK_SCHEDULER_MAX_INFLIGHT", "10"),
+            ],
+            || MetaTaskScheduler::from_env().expect("scheduler"),
+        );
+        assert_eq!(scheduler.default_options.base_postpone_ms, 250);
+        assert_eq!(scheduler.default_options.max_postpone_ms, 300_000);
+        assert_eq!(scheduler.default_options.max_retry_times, 3);
+        assert_eq!(scheduler.default_options.max_inflight, 10);
+    }
+
+    #[test]
+    fn an_unconfigured_scheduler_paces_exactly_as_before() {
+        // The knobs must change nothing until someone sets them.
+        let scheduler = with_scheduler_env(&[], || {
+            MetaTaskScheduler::from_env().expect("scheduler")
+        });
+        assert_eq!(scheduler.default_options, TaskSchedulerOptions::default());
+    }
+
+    #[test]
+    fn a_request_that_names_its_own_pacing_still_wins() {
+        // The per-request options were the only way to set these, and callers
+        // that use them must keep overriding the configured default.
+        let scheduler = with_scheduler_env(
+            &[("TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS", "9999")],
+            || MetaTaskScheduler::from_env().expect("scheduler"),
+        );
+        assert_eq!(scheduler.default_options.base_postpone_ms, 9999);
+
+        let (code, body) = handle(
+            &MetaBackend::Single(SingleNodeMeta::default()),
+            &scheduler,
+            HttpRequest {
+                method: "POST".to_string(),
+                path: "/meta/scheduler/run_next".to_string(),
+                body: serde_json::to_vec(&serde_json::json!({
+                    "now_ms": 100,
+                    "result": "RetryLater",
+                    "options": {
+                        "base_postpone_ms": 5,
+                        "max_postpone_ms": 50,
+                        "max_retry_times": 2,
+                        "max_inflight": 1
+                    }
+                }))
+                .unwrap(),
+            },
+        );
+        assert_eq!(code, 200);
+        // An empty queue answers with no report either way; what matters is
+        // that supplying options is still accepted rather than rejected.
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(parsed.get("status").is_some());
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/bin/metaserver/task_scheduler.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/task_scheduler.rs
@@ -6,11 +6,46 @@
 
 impl MetaTaskScheduler {
     fn from_env() -> io::Result<Self> {
-        std::env::var("TS_META_SCHEDULER_SNAPSHOT")
+        let scheduler = std::env::var("TS_META_SCHEDULER_SNAPSHOT")
             .ok()
             .map(|path| Self::with_snapshot_path(PathBuf::from(path)))
             .transpose()
-            .map(|scheduler| scheduler.unwrap_or_default())
+            .map(|scheduler| scheduler.unwrap_or_default())?;
+        // Applied here as well as in `with_snapshot_path`: without a snapshot
+        // path that branch is never taken, and the pacing would silently only
+        // work for deployments that happen to persist their queue.
+        Ok(Self {
+            default_options: Self::options_from_env(),
+            ..scheduler
+        })
+    }
+
+    /// Pacing from the environment, falling back to the compiled defaults so an
+    /// unconfigured metaserver behaves exactly as it did.
+    fn options_from_env() -> TaskSchedulerOptions {
+        let defaults = TaskSchedulerOptions::default();
+        TaskSchedulerOptions {
+            base_postpone_ms: env_u64(
+                "TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS",
+                defaults.base_postpone_ms,
+            ),
+            max_postpone_ms: env_u64(
+                "TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS",
+                defaults.max_postpone_ms,
+            ),
+            max_retry_times: env_u64(
+                "TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES",
+                defaults.max_retry_times,
+            ),
+            // How many tasks the metaserver will have in flight at once. The
+            // compiled default is 1, which drives one shard move or load at a
+            // time; a large fleet will want more, and now can have it without
+            // a rebuild.
+            max_inflight: env_u64(
+                "TS_META_TASK_SCHEDULER_MAX_INFLIGHT",
+                defaults.max_inflight as u64,
+            ) as usize,
+        }
     }
 
     fn with_snapshot_path(path: PathBuf) -> io::Result<Self> {
@@ -24,6 +59,7 @@ impl MetaTaskScheduler {
             inner: Arc::new(Mutex::new(scheduler)),
             executions: Arc::new(Mutex::new(executions)),
             snapshot_path: Some(path),
+            default_options: Self::options_from_env(),
         })
     }
 
@@ -57,7 +93,7 @@ impl MetaTaskScheduler {
         match scheduler.run_next(
             request.now_ms,
             request.result,
-            request.options.unwrap_or_default(),
+            request.options.unwrap_or(self.default_options),
         ) {
             Ok(report) => MetaSchedulerRunResponse {
                 status: if report.is_some() {


### PR DESCRIPTION
## The scheduler was the one subsystem you could not tune

Every background subsystem in the metaserver takes its pacing from the environment — the failure detector, rebalance, proxy calibration, retention, freeze aging, the divergence check. The task scheduler does not. Its retry backoff and its concurrency were compiled in, so changing how hard the metaserver drives shard loads and moves meant changing the code and rebuilding.

The values it was compiled with:

| | compiled default |
|---|---|
| `base_postpone_ms` | 1 000 |
| `max_postpone_ms` | 60 000 |
| `max_retry_times` | 10 |
| `max_inflight` | **1** |

`max_inflight: 1` is the one worth looking at. It means the metaserver drives **one task at a time** — one shard load, or one move, and nothing else until it finishes. On a small cluster that is invisible. On a large one it is the difference between a rebalance finishing this afternoon and finishing this week.

## What this changes

Four knobs, read at startup:

```
TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS
TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS
TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES
TS_META_TASK_SCHEDULER_MAX_INFLIGHT
```

**The defaults are unchanged.** An unconfigured metaserver paces exactly as it did, including `max_inflight: 1`. Raising it is a real behaviour change on a live cluster and belongs to whoever runs it, not to this change — but until now it was not theirs to make.

Per-request options still win where a caller supplies them, which is how the existing tests drive the scheduler.

## A hole I put in and took back out

My first version read the environment only inside `with_snapshot_path`. That branch is taken only when `TS_META_SCHEDULER_SNAPSHOT` is set, so the knobs would have worked exclusively for deployments that happen to persist their queue and silently done nothing for everyone else — the sort of thing that looks configured and is not. Both construction paths now read it.

## Tests

3 new: the knobs being read; an unconfigured scheduler matching the compiled defaults exactly; and a request that names its own pacing still overriding the configured default. The environment is process-wide, so they take a lock rather than racing each other.

Verification:

- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — **21 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.
