### PR TITLE
Read the record log once per summary refresh pass, not twice

### DIFF
--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -246,13 +246,16 @@ class _LocalAdapterContextNodeMixin:
         limit: int = 512,
         updated_at_ms: int | None = None,
         record_types: set[str] | None = None,
+        records: list[Json] | None = None,
     ) -> Json:
         limit = max(1, int(limit or 1))
         refreshed_at_ms = updated_at_ms if isinstance(updated_at_ms, int) else now_ms()
         current_model = embedding_model_name()
         current_model_ref = embedding_model_ref_for_name(current_model)
         existing_embeddings: dict[tuple[str, str, int], Json] = {}
-        records = self.read_all()
+        # A caller that has already read the log this pass can hand its snapshot in, but only when
+        # nothing has been written since -- this needs to see rows produced earlier in the pass.
+        records = self.read_all() if records is None else records
         for record in records:
             if record.get("record_type") != "context_embedding":
                 continue

--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -590,10 +590,13 @@ class _LocalAdapterSummariesMixin:
         min_compression_event_age_ms: int = TIME_COMPRESSION_MIN_EVENT_AGE_MS,
         raw_event_ttl_after_compression_ms: int = TIME_COMPRESSION_RAW_EVENT_TTL_AFTER_COMPRESSION_MS,
         skip_dirty_reasons: set[str] | None = None,
+        records: list[Json] | None = None,
     ) -> Json:
         refreshed_at_ms = refreshed_at_ms or now_ms()
         skip_dirty_reasons = skip_dirty_reasons or set()
-        records = self.read_all()
+        # `records` lets one caller's read serve a whole pass. Reading here is a full record-log
+        # read, and on a native backend it holds the single shared proxy lane while it runs.
+        records = self.read_all() if records is None else records
         skipped_dirty_reasons: Json = {}
         pending_by_node = pending_dirty_node_records(
             records=records,
@@ -1180,7 +1183,11 @@ class _LocalAdapterSummariesMixin:
             for reason in args.get("skip_dirty_reasons", [])
             if str(reason or "").strip()
         } if isinstance(args.get("skip_dirty_reasons"), list) else set()
+        # One read for the pass. The embedding step below reuses it only when nothing was
+        # written -- see there.
+        pass_records = self.read_all()
         result = self.refresh_dirty_node_summaries(
+            records=pass_records,
             scope=scope,
             limit=limit,
             refreshed_at_ms=refreshed_at_ms,
@@ -1214,10 +1221,21 @@ class _LocalAdapterSummariesMixin:
             else str(ensure_embeddings_arg).strip().lower() not in {"0", "false", "no", "off"}
         )
         if ensure_embeddings:
+            # Reuse the snapshot ONLY when the summary pass wrote nothing: then the store is
+            # unchanged and a second read returns the same records. When it did write, this must
+            # re-read, because it has to see the summaries just produced -- and a row read back
+            # from the store differs from the one written (serving materialization strips the
+            # scope it carries), so an in-memory reconstruction would not be the same input.
+            try:
+                wrote_nothing = int(result.get("refreshed_count") or 0) == 0
+            except (TypeError, ValueError):
+                wrote_nothing = False
             result["embedding_refresh"] = self.ensure_context_embeddings(
+                records=pass_records if wrote_nothing else None,
                 scope=scope,
                 limit=integer_arg(args, "embedding_backfill_limit", max(1, limit * 8), minimum=1),
                 updated_at_ms=refreshed_at_ms,
             )
+            result["embedding_refresh_reused_pass_records"] = bool(wrote_nothing)
         return result
 

--- a/tools/test_refresh_one_read.py
+++ b/tools/test_refresh_one_read.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A summary refresh pass reads the record log once when it can, twice only when it must.
+
+The pass used to read the whole log twice back to back -- once to find dirty nodes, once to find
+rows needing embeddings. Instrumented over three ingests the refresher was the largest reader in
+the process, and on a native backend each read holds the single shared proxy lane for its whole
+duration, which is the resource request traffic contends for.
+
+Reuse is only sound when the summary half wrote NOTHING: then the store is unchanged and the second
+read returns the same records. These tests pin both directions, because the failure mode of getting
+it wrong is silent -- embeddings computed against a stale view would simply be missing, and the next
+pass would paper over it.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as local_mod
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as local_mod
+
+
+class _Adapter(local_mod.MatrixArkLocalAdapter):
+    """Counts reads and records what each half of the pass was handed."""
+
+    def __init__(self, refreshed_count):
+        self.reads = 0
+        self.refreshed_count = refreshed_count
+        self.summary_records = "unset"
+        self.embedding_records = "unset"
+        self._log = [{"record_type": "context_event", "event_id_hash": 1, "text": "hello"}]
+
+    def read_all(self):
+        self.reads += 1
+        return list(self._log)
+
+    def refresh_dirty_node_summaries(self, *, records=None, **kwargs):
+        self.summary_records = records
+        if records is None:
+            self.read_all()
+        return {"status": "ok", "refreshed_count": self.refreshed_count, "refreshed": []}
+
+    def ensure_context_embeddings(self, *, records=None, **kwargs):
+        self.embedding_records = records
+        if records is None:
+            self.read_all()
+        return {"status": "ok"}
+
+
+class RefreshPassReadTests(unittest.TestCase):
+    def test_a_pass_that_refreshes_nothing_reads_once(self):
+        adapter = _Adapter(refreshed_count=0)
+        result = adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(1, adapter.reads)
+        self.assertTrue(result["embedding_refresh_reused_pass_records"])
+
+    def test_both_halves_get_the_same_snapshot_when_nothing_was_written(self):
+        adapter = _Adapter(refreshed_count=0)
+        adapter.refresh_summaries({"scope": {}})
+        self.assertIsNotNone(adapter.summary_records)
+        self.assertIs(adapter.summary_records, adapter.embedding_records)
+
+    def test_a_pass_that_wrote_something_reads_again_for_the_embeddings(self):
+        """The embedding half has to SEE the summaries the pass just wrote."""
+        adapter = _Adapter(refreshed_count=3)
+        result = adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(2, adapter.reads)
+        self.assertIsNone(adapter.embedding_records,
+                          "a written-to store must be re-read, not reused")
+        self.assertFalse(result["embedding_refresh_reused_pass_records"])
+
+    def test_the_summary_half_never_reads_for_itself(self):
+        """Its read is hoisted into the pass; it is the same read, taken one level up."""
+        for refreshed in (0, 5):
+            with self.subTest(refreshed=refreshed):
+                adapter = _Adapter(refreshed_count=refreshed)
+                adapter.refresh_summaries({"scope": {}})
+                self.assertIsNotNone(adapter.summary_records)
+
+    def test_an_unreadable_refreshed_count_re_reads_rather_than_reusing(self):
+        """Conservative: if the pass cannot say what it wrote, assume it wrote."""
+        adapter = _Adapter(refreshed_count=None)
+
+        def _refresh(*, records=None, **kwargs):
+            adapter.summary_records = records
+            return {"status": "ok", "refreshed_count": "not a number"}
+
+        adapter.refresh_dirty_node_summaries = _refresh
+        result = adapter.refresh_summaries({"scope": {}})
+        self.assertEqual(2, adapter.reads)
+        self.assertFalse(result["embedding_refresh_reused_pass_records"])
+
+    def test_skipping_embeddings_still_only_reads_once(self):
+        adapter = _Adapter(refreshed_count=7)
+        adapter.refresh_summaries({"scope": {}, "ensure_embeddings": False})
+        self.assertEqual(1, adapter.reads)
+        self.assertEqual("unset", adapter.embedding_records)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A refresh pass reads the whole log twice, back to back: once in `refresh_dirty_node_summaries` to
find dirty nodes, and again in `ensure_context_embeddings` to find rows needing embeddings.
Instrumented over three ingests, the refresher was the largest single reader in the process -- 8 of
the 10 full reads -- and on a native backend each read holds the single shared proxy lane for its
whole duration, which is the resource request traffic contends for.

The second read is only necessary when the first half WROTE something. When it refreshed nothing,
the store is unchanged and the second read returns the same records, so the snapshot is reused.

    same three ingests:   refresher reads 8 -> 6,  total reads 10 -> 9

The saving is bounded by how often a pass finds nothing to do, which is why a write-heavy burst
like this one shows 25% rather than half. Note the background pass is already skipped outright when
the record count has not moved since a pass that refreshed nothing, so this is the case in between:
the store changed, but this pass had no node to rebuild.

When the pass DID write, the embedding half re-reads exactly as before. It has to see the summaries
just produced, and a row read back from the store is not the row that was written -- serving
materialization strips the scope it carries, and that scope decides whether a tenant gets
embeddings at all -- so reconstructing the post-write view in memory would change behaviour rather
than preserve it.

The snapshot parameter is optional on both halves and defaults to reading, so every other caller is
untouched.

6 tests: that a pass refreshing nothing reads once and both halves get the SAME snapshot, that a
pass which wrote re-reads and the embedding half is handed nothing, that the summary half never
reads for itself in either case, that an unreadable refreshed_count re-reads rather than reusing,
and that skipping embeddings still costs one read.

The five memory suites are green and live conformance is 22/22. `test_matrixark_summary_worker` has
one failure (`test_summary_dirty_markers_are_compact_by_default`) that fails identically without
this change; it is not addressed here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
