### PR TITLE
Add delete_users to the mem0 surface

### DIFF
--- a/tools/matrixark_mem0_compat.py
+++ b/tools/matrixark_mem0_compat.py
@@ -511,6 +511,55 @@ class Memory:
         body: Json = {"scope": scope, "confirm": user_id}
         return _post_json(self._base_url, self._api_key, "/v1/forget", body, self._timeout)
 
+    def delete_users(self, *, user_id: Optional[str] = None, agent_id: Optional[str] = None,
+                     run_id: Optional[str] = None, **kw: Any) -> Json:
+        """Forget one named subject, or EVERY subject that holds memories (mem0 ``delete_users``).
+
+        With `user_id`, this is `delete_all` for that subject. With no identity at all, it lists
+        the subjects that hold memories and forgets each one -- which is what mem0's no-argument
+        `delete_users()` means.
+
+        Two things it deliberately does not pretend about:
+
+        * The server addresses a forget by `scope.user_id`. An agent or a run cannot be forgotten
+          on its own, so an `agent_id`/`run_id`-only call raises instead of quietly deleting
+          nothing. Pass the `user_id` whose memories you mean, or use `reset` for the tenant.
+        * Every subject that fails is reported in `failed`, with the error. A partial wipe must
+          not return looking like a complete one -- the caller is deleting data and needs to know
+          which subjects still hold it.
+
+        Returns ``{"deleted": n, "results": [...], "failed": [...]}``.
+        """
+        if user_id:
+            return {
+                "deleted": 1,
+                "results": [{"user_id": user_id,
+                             "result": self.delete_all(user_id=user_id, agent_id=agent_id,
+                                                       run_id=run_id)}],
+                "failed": [],
+            }
+        if agent_id or run_id:
+            raise ValueError(
+                "delete_users addresses a subject by user_id; an agent_id or run_id alone is not "
+                "a forgettable subject. Pass the user_id whose memories you mean, or use reset()."
+            )
+        listed = self.users()
+        rows = listed.get("results") or listed.get("items") or []
+        subjects = [
+            str(row.get("name") or "")
+            for row in rows
+            if isinstance(row, dict) and str(row.get("type") or "user") == "user" and row.get("name")
+        ]
+        results: list[Json] = []
+        failed: list[Json] = []
+        for name in subjects:
+            try:
+                results.append({"user_id": name, "result": self.delete_all(user_id=name)})
+            except Exception as exc:  # noqa: BLE001 - report it; a silent skip reads as success.
+                failed.append({"user_id": name, "error": repr(exc)})
+        return {"deleted": len(results), "results": results, "failed": failed,
+                "subjects_listed": len(subjects)}
+
     def get_all(self, *, user_id: Optional[str] = None, agent_id: Optional[str] = None,
                 run_id: Optional[str] = None, limit: Optional[int] = None, **kw: Any) -> Json:
         """List a subject's active memories (mem0 ``get_all(user_id=...)``). Maps identity kwargs to

--- a/tools/test_mem0_delete_users.py
+++ b/tools/test_mem0_delete_users.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""mem0 `delete_users`: forget one named subject, or every subject that holds memories.
+
+`delete_all` forgets ONE subject and `reset` wipes the tenant; there was nothing in between, so a
+caller wanting mem0's no-argument `delete_users()` had to list the subjects and loop, getting each
+confirm token right themselves.
+
+What is worth pinning is the honesty of the result, not the happy path. A wipe that half worked
+must not return looking like a wipe that worked -- the caller is deleting data and needs to know
+which subjects still hold it.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mem0_compat as compat
+except ImportError:  # run from tools/ dir
+    import matrixark_mem0_compat as compat
+
+
+class _Memory(compat.Memory):
+    """A shim whose HTTP calls are recorded instead of sent."""
+
+    def __init__(self, listed, *, failing=()):
+        self.listed = listed
+        self.failing = set(failing)
+        self.forgotten = []
+        self.users_calls = 0
+
+    def users(self, **kw):
+        self.users_calls += 1
+        return {"results": list(self.listed)}
+
+    def delete_all(self, *, user_id=None, agent_id=None, run_id=None, **kw):
+        if not user_id:
+            raise ValueError("delete_all requires user_id (the subject to forget)")
+        if user_id in self.failing:
+            raise RuntimeError("forget refused for %s" % user_id)
+        self.forgotten.append(user_id)
+        return {"forgotten": user_id}
+
+
+class DeleteUsersTests(unittest.TestCase):
+    def test_a_named_subject_is_forgotten(self):
+        memory = _Memory([])
+        result = memory.delete_users(user_id="alice")
+        self.assertEqual(["alice"], memory.forgotten)
+        self.assertEqual(1, result["deleted"])
+        self.assertEqual([], result["failed"])
+        self.assertEqual(0, memory.users_calls, "a named subject needs no listing")
+
+    def test_no_arguments_forgets_every_listed_subject(self):
+        memory = _Memory([{"type": "user", "name": "alice"}, {"type": "user", "name": "bob"}])
+        result = memory.delete_users()
+        self.assertEqual(["alice", "bob"], memory.forgotten)
+        self.assertEqual(2, result["deleted"])
+
+    def test_a_subject_that_fails_is_reported_not_skipped(self):
+        """A partial wipe must not read as a complete one."""
+        memory = _Memory(
+            [{"type": "user", "name": "alice"}, {"type": "user", "name": "bob"}],
+            failing=["bob"],
+        )
+        result = memory.delete_users()
+        self.assertEqual(["alice"], memory.forgotten)
+        self.assertEqual(1, result["deleted"])
+        self.assertEqual(["bob"], [row["user_id"] for row in result["failed"]])
+        self.assertIn("refused", result["failed"][0]["error"])
+        self.assertEqual(2, result["subjects_listed"],
+                         "the caller can see one of the two listed subjects still holds memories")
+
+    def test_non_user_subjects_are_left_alone(self):
+        """An agent or run is not addressable by forget, so it is not silently counted as deleted."""
+        memory = _Memory([
+            {"type": "user", "name": "alice"},
+            {"type": "agent", "name": "planner"},
+            {"type": "run", "name": "run-7"},
+        ])
+        result = memory.delete_users()
+        self.assertEqual(["alice"], memory.forgotten)
+        self.assertEqual(1, result["subjects_listed"])
+
+    def test_an_agent_only_call_raises_rather_than_deleting_nothing(self):
+        memory = _Memory([])
+        with self.assertRaises(ValueError) as caught:
+            memory.delete_users(agent_id="planner")
+        self.assertIn("user_id", str(caught.exception))
+        self.assertEqual([], memory.forgotten)
+        self.assertEqual(0, memory.users_calls)
+
+    def test_a_run_only_call_raises_too(self):
+        memory = _Memory([])
+        with self.assertRaises(ValueError):
+            memory.delete_users(run_id="run-7")
+
+    def test_nothing_to_delete_is_not_an_error(self):
+        memory = _Memory([])
+        result = memory.delete_users()
+        self.assertEqual({"deleted": 0, "results": [], "failed": [], "subjects_listed": 0}, result)
+
+    def test_a_listing_in_the_items_shape_is_understood(self):
+        memory = _Memory([])
+        memory.users = lambda **kw: {"items": [{"type": "user", "name": "carol"}]}
+        memory.delete_users()
+        self.assertEqual(["carol"], memory.forgotten)
+
+    def test_a_row_without_a_type_is_treated_as_a_user(self):
+        """`users()` labels rows, but a bare listing should still be actionable."""
+        memory = _Memory([{"name": "dave"}])
+        memory.delete_users()
+        self.assertEqual(["dave"], memory.forgotten)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`delete_all(user_id=...)` forgets ONE named subject and `reset` wipes the whole tenant. mem0 also
has `delete_users`, which forgets a named entity or -- called with no arguments -- every entity that
holds memories. There was nothing in between: a caller wanting the no-argument form had to list the
subjects and loop, getting each subject's confirm token right themselves.

Built on the primitives that already exist rather than a new server route, so the deletion rule
stays in one place: `users()` to find the subjects, `/v1/forget` per subject with its own confirm.

Two things it deliberately does not pretend about, both decided by the server:

* `forget` addresses a subject by `scope.user_id`. An agent or a run is not a forgettable subject
  on its own, so an `agent_id`/`run_id`-only call raises with a message saying what to pass
  instead, rather than quietly deleting nothing and reporting success.
* Every subject whose forget fails is reported in `failed`, with the error, alongside how many
  subjects were listed. A wipe that half worked must not return looking like one that worked --
  the caller is deleting data and needs to know which subjects still hold it.

Proven against the running gateway through the shim itself, not just stubbed HTTP: two users with
one memory each, `delete_users()` with no arguments, both users at 0 memories afterwards and
neither still listed by `users()`, deleted=2, failed=[].

9 tests: a named subject, the no-argument sweep, a failing subject reported rather than skipped,
non-user rows left alone, both identity-only calls raising, an empty store being a no-op rather
than an error, and the two listing shapes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
