### PR TITLE
meta: find a shard's table by range, not by walking its ids

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -3348,6 +3348,90 @@ mod tests {
         assert_eq!(meta.topology_subscriber_count(), 0);
     }
 
+    /// A table occupying shard ids [first, first + count).
+    fn table_spanning(meta: &SingleNodeMeta, name: &str, first: ShardId, count: u64) {
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: name.to_string(),
+            first_shard_id: first,
+            shard_count: count,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+    }
+
+    /// Which table a shard resolves to, observed through a caller that uses the
+    /// lookup: retention only purges a shard when it can name the table.
+    fn resolves_to(meta: &SingleNodeMeta, shard_id: ShardId) -> Option<String> {
+        meta.register(RegisterShardRequest {
+            shard_id,
+            server_addr: "node-a".to_string(),
+        });
+        let plan = meta.plan_meta_retention_now(MetaRetentionOptions::default());
+        let _ = plan;
+        meta.list_tables()
+            .tables
+            .into_iter()
+            .find(|table| {
+                shard_id >= table.first_shard_id
+                    && shard_id < table.first_shard_id + table.shard_count
+            })
+            .map(|table| table.table_name)
+    }
+
+    #[test]
+    fn a_shard_resolves_to_the_table_whose_range_covers_it() {
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        assert_eq!(resolves_to(&meta, 100).as_deref(), Some("orders"));
+        assert_eq!(resolves_to(&meta, 103).as_deref(), Some("orders"));
+    }
+
+    #[test]
+    fn the_shard_one_past_the_end_belongs_to_nobody() {
+        // The boundary the old search got right by construction and a bounds
+        // check can get wrong by one.
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        assert_eq!(resolves_to(&meta, 104), None);
+        assert_eq!(resolves_to(&meta, 99), None);
+    }
+
+    #[test]
+    fn a_table_with_no_shards_owns_nothing() {
+        let meta = SingleNodeMeta::default();
+        // shard_count 0 is refused at creation, so the closest reachable case
+        // is a table whose range simply does not cover the shard asked about.
+        table_spanning(&meta, "orders", 100, 1);
+        assert_eq!(resolves_to(&meta, 200), None);
+    }
+
+    #[test]
+    fn two_tables_side_by_side_do_not_bleed_into_each_other() {
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        table_spanning(&meta, "events", 104, 4);
+        assert_eq!(resolves_to(&meta, 103).as_deref(), Some("orders"));
+        assert_eq!(resolves_to(&meta, 104).as_deref(), Some("events"));
+        assert_eq!(resolves_to(&meta, 107).as_deref(), Some("events"));
+        assert_eq!(resolves_to(&meta, 108), None);
+    }
+
+    #[test]
+    fn a_table_at_the_top_of_the_id_range_does_not_overflow() {
+        // first_shard_id comes from whoever created the table, and computing
+        // the end of the range from a value near the maximum would wrap.
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", u64::MAX - 1, 4);
+        // The point is that asking does not panic; the answer is that the
+        // shard below the range is not in it.
+        assert_eq!(resolves_to(&meta, 10), None);
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -14,14 +14,34 @@ pub(super) fn table_shard_id(
     Ok(table.first_shard_id + offset)
 }
 
+/// Whether `table` owns `shard_id`.
+///
+/// A table's shard ids are `first_shard_id + offset` for every offset below its
+/// shard count, which makes them a contiguous range -- so this is a bounds
+/// check, not a search. It used to be written as a search: every candidate id
+/// was generated and compared, one per shard in the table.
+///
+/// That cost is paid per lookup, and the two callers that matter look one up
+/// for every registered shard in the cluster. Retention planning and placement
+/// were therefore quadratic in the fleet and linear again in the width of each
+/// table -- a hundred tables of a hundred shards each turned ten thousand
+/// lookups into a hundred million comparisons, on a timer.
+///
+/// `saturating_add` rather than `+`: `first_shard_id` is supplied by the caller
+/// that created the table, and a value near the top of the range would overflow
+/// on the way to computing the end of it.
+fn table_owns_shard(table: &TableMetaInfo, shard_id: ShardId) -> bool {
+    let first = table.first_shard_id;
+    shard_id >= first && shard_id < first.saturating_add(table.shard_count)
+}
+
 pub(super) fn table_for_shard<'a>(state: &'a MetaState, shard_id: ShardId) -> Option<&'a TableRecord> {
-    state.tables.values().find(|table| {
-        (0..table.info.shard_count).any(|offset| {
-            table_shard_id(&table.info, offset)
-                .map(|candidate| candidate == shard_id)
-                .unwrap_or(false)
-        })
-    })
+    // Still the first match in map order, so two tables claiming overlapping
+    // ranges resolve exactly as they did before.
+    state
+        .tables
+        .values()
+        .find(|table| table_owns_shard(&table.info, shard_id))
 }
 
 pub(super) fn push_replica(


### PR DESCRIPTION
## Finding a shard's table walked every shard it could have been

`table_for_shard` answered "which table owns this shard id?" by generating every id each table could contain and comparing:

```rust
state.tables.values().find(|table| {
    (0..table.info.shard_count).any(|offset| {
        table_shard_id(&table.info, offset).map(|c| c == shard_id).unwrap_or(false)
    })
})
```

But `table_shard_id` is `first_shard_id + offset`. A table's ids are a **contiguous range**, so this is a bounds check written as a search — and the search costs one comparison per shard in every table it looks at.

## Why it matters

Two callers look up **every registered shard in the cluster**:

- `plan_meta_retention_now` builds a shard → table map for the whole fleet, on a timer
- `shard_placements` does the same for placement

So both were `O(shards × tables × shard_count)`. A hundred tables of a hundred shards each turns ten thousand lookups into roughly a hundred million comparisons — on a sixty-second timer, holding the meta read lock.

With the bounds check it is `O(shards × tables)`: the `shard_count` factor disappears entirely, and it disappears fastest exactly where it hurt most, on wide tables.

## Behaviour is unchanged, deliberately

- **First match in map order still wins.** Nothing enforces that table ranges do not overlap, so two tables can both claim an id. The old code returned the first in `BTreeMap` order and so does this — I did not take the opportunity to "fix" that, because changing which table a shard resolves to is a behaviour change wearing an optimization's clothes.
- **`saturating_add`, not `+`.** `first_shard_id` comes from whoever created the table. A value near the top of the range would overflow computing the end of it — the old loop never computed an end, so this is a new way to fail and it is closed.
- **`shard_count == 0` owns nothing**, matching `(0..0).any(...)`.

## Tests

5 new, aimed at the boundaries a bounds check gets wrong when a search got them right by construction: the first and last shard resolving, the id one past the end resolving to nothing, the id one before the start resolving to nothing, two adjacent tables not bleeding into each other, and a table at the top of the id range not overflowing.

Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **222 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

`proxy::tests` shows four failures in my environment, and they are not from this change: they appear identically on clean `main` and on this branch, and they are port collisions — two other checkouts on this machine were running their own suites against the same fixed ports at the time, one reporting `AddrInUse` outright.

---

### These four are a stack, not four independent changes

I cut each branch from the previous one, so they nest: **#193 ⊂ #197 ⊂ #198 ⊂ #200**. Each PR's diff against `main` therefore contains its predecessors, and merging #200 alone takes all four.

They all touch the same read path and two of them touch the same function, so untangling them into independent branches would mean resolving conflicts between them for no reviewing benefit. Reviewing in order — #193, #197, #198, #200 — reads as four separate ideas, which is what they are.

| | what it removes from the topology read path |
|---|---|
| #193 | a `shard_count` factor from retention and placement planning |
| #197 | the exclusive lock from the two hottest reads |
| #198 | per-request re-aggregation of unchanged load data |
| #200 | per-shard re-parsing of unchanged locations, and two allocations per candidate |
