### PR TITLE
Answer 404 for a stale memory id, instead of 500

### DIFF
--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -85,6 +85,19 @@ class MatrixArkError(ValueError):
     pass
 
 
+class MatrixArkNotFoundError(MatrixArkError):
+    """The thing the request addressed does not exist.
+
+    A distinct type so the edge can answer 404 instead of 500. The difference matters to a caller:
+    a stale memory id is its own state to fix, while a 500 says the server failed and invites a
+    retry or a page.
+
+    Defined HERE, beside the  the adapters actually raise and catch. There is a
+    second, unrelated  in matrixark_mcp_errors.py; subclassing that one instead
+    would produce an exception that  on this path does not catch.
+    """
+
+
 def is_retryable_temporalstore_error(error: Any) -> bool:
     text = str(error).lower()
     retryable_fragments = (

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5266,7 +5266,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 old = record
                 break
         if old is None:
-            raise MatrixArkError("update target memory not found (already deleted, or not a memory id)")
+            raise MatrixArkNotFoundError("update target memory not found (already deleted, or not a memory id)")
         old_scope_key = str(old.get("scope_key") or "")
         parts = parse_scope_key(old_scope_key)
         # Tenant isolation: an authenticated request scope pins tenant_hash; refuse cross-tenant edits.

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -178,6 +178,9 @@ _DATA_ROUTES: dict[str, Tuple[str, str]] = {
 # Backend exception class names we translate to specific edge status codes (matched by name to avoid
 # a hard import dependency on the backend package).
 _BACKPRESSURE_ERRORS = {"MatrixArkBackpressureError"}
+# The addressed thing does not exist -- the caller's own state to fix, not a server fault. Matched
+# by class name, like the sets above, so a message that merely contains "not found" is unaffected.
+_NOT_FOUND_ERRORS = {"MatrixArkNotFoundError"}
 _STORAGE_QUOTA_ERRORS = {
     "MatrixArkStorageQuotaError",
     "StorageQuotaExceeded",
@@ -1048,6 +1051,8 @@ def _classify_backend_error(exc: Exception) -> int:
         return 507
     if name in _BACKPRESSURE_ERRORS:
         return 429
+    if name in _NOT_FOUND_ERRORS:
+        return 404
     return 500
 
 

--- a/tools/test_stale_id_status.py
+++ b/tools/test_stale_id_status.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A stale memory id is the caller's state to fix, so it answers 404 rather than 500.
+
+Updating a memory twice by its ORIGINAL id is the ordinary way to reach this: the first update
+supersedes that id and returns a new one, so the second call addresses something that no longer
+names a live memory. That raised a plain adapter error, which the edge classifies as 500 -- and a
+500 tells the caller the server failed, inviting a retry or a page, when nothing is wrong with it.
+
+The subtle part is WHICH error class. There are two unrelated `MatrixArkError` definitions in the
+tree; the not-found type has to subclass the one the adapters actually raise and catch, or
+`except MatrixArkError` on that path stops catching it and the raise site cannot even resolve the
+name. That is what these tests pin, alongside the status mapping itself.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as adapter_mod
+    from tools import matrixark_v1_gateway as gateway
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as adapter_mod
+    import matrixark_v1_gateway as gateway
+
+
+class NotFoundErrorTypeTests(unittest.TestCase):
+    def test_the_raise_site_can_resolve_it(self):
+        """It reaches the adapter through the same star import as MatrixArkError."""
+        self.assertTrue(hasattr(adapter_mod, "MatrixArkNotFoundError"))
+
+    def test_it_subclasses_the_error_the_adapters_use(self):
+        """Not the identically-named class in matrixark_mcp_errors -- that one is a different type,
+        and an `except MatrixArkError` on this path would let it through uncaught."""
+        self.assertTrue(issubclass(adapter_mod.MatrixArkNotFoundError, adapter_mod.MatrixArkError))
+
+    def test_existing_handlers_still_catch_it(self):
+        try:
+            raise adapter_mod.MatrixArkNotFoundError("gone")
+        except adapter_mod.MatrixArkError as exc:
+            self.assertEqual("gone", str(exc))
+        else:  # pragma: no cover - the assertion above either runs or the test fails
+            self.fail("MatrixArkError did not catch MatrixArkNotFoundError")
+
+
+class StatusClassificationTests(unittest.TestCase):
+    def test_a_not_found_error_maps_to_404(self):
+        self.assertEqual(404, gateway._classify_backend_error(
+            adapter_mod.MatrixArkNotFoundError("update target memory not found")))
+
+    def test_an_ordinary_backend_error_still_maps_to_500(self):
+        """The point is to distinguish the two, so a real fault must not become a 404."""
+        self.assertEqual(500, gateway._classify_backend_error(
+            adapter_mod.MatrixArkError("the backend fell over")))
+
+    def test_a_message_containing_not_found_is_not_enough(self):
+        """Classification is by type, not by words in the message."""
+        self.assertEqual(500, gateway._classify_backend_error(
+            adapter_mod.MatrixArkError("shard not found on the datanode")))
+
+    def test_backpressure_still_maps_to_429(self):
+        class MatrixArkBackpressureError(adapter_mod.MatrixArkError):
+            pass
+
+        self.assertEqual(429, gateway._classify_backend_error(
+            MatrixArkBackpressureError("busy")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Updating a memory twice by its ORIGINAL id is the ordinary way to reach this: the first update
supersedes that id and returns a new one, so the second call addresses something that no longer
names a live memory. That raised a plain adapter error, which the edge classifies as 500:

    batch_update on a superseded id
    -> HTTP 500 {"error": "backend_error",
                 "detail": "update target memory not found (already deleted, or not a memory id)"}

A 500 tells the caller the server failed, which invites a retry or a page, when nothing is wrong
with the server and the caller is holding a stale id. Now:

    live id      -> 200, updated
    stale id     -> 404, same detail
    unknown id   -> 404
    a real fault -> still 500

Classified by exception CLASS, the way backpressure and storage-quota already are. A substring rule
on "not found" would reclassify unrelated errors -- "shard not found on the datanode" is a server
fault and must stay a 500; there is a test for exactly that.

The subtle part is WHICH class. There are two unrelated `MatrixArkError` definitions in the tree,
and the new type has to subclass the one the adapters actually raise and catch. Subclassing the
other one first was wrong in two ways at once: the raise site could not resolve the name, and had
it resolved, `except MatrixArkError` on that path would no longer have caught it. It is defined
beside the class it extends, with a comment saying so.

Verified against the running gateway, not only in unit tests: live id 200, stale id 404, never-
existed id 404. Live conformance 22/22 and the five memory suites green.

7 tests: that the raise site can resolve the type, that it subclasses the adapter's error, that
existing handlers still catch it, and the four status mappings including the message-is-not-enough
case.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
