### PR TITLE
Client: tell the caller when a write's outcome is unknown

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -53,6 +53,15 @@ pub enum ClientError {
     Status(String),
     #[error("invalid request: {0}")]
     InvalidRequest(String),
+    /// A write failed in a way that does not say whether it was applied.
+    ///
+    /// The datanode stopped answering; it may have processed the write, or not. The write was
+    /// deliberately not sent again, because repeating it could apply it twice. That leaves the
+    /// caller with a decision only the caller can make -- reconcile, or accept the risk -- and
+    /// it can only make it if it is told this is what happened, rather than being handed the
+    /// same generic failure as a write that provably never arrived.
+    #[error("write outcome unknown: {0}")]
+    WriteOutcomeUnknown(String),
     #[error("unexpected response for {operation}: {response:?}")]
     UnexpectedResponse {
         operation: &'static str,

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -55,7 +55,7 @@ impl TemporalStoreClient {
                             .expect("client stats lock poisoned")
                             .record_write_of_unknown_outcome();
                         let _ = self.resolve_route(request.shard_id, true, None);
-                        return Err(err.into());
+                        return Err(ClientError::WriteOutcomeUnknown(err.to_string()));
                     }
                     let refreshed = self.resolve_route(request.shard_id, true, None)?;
                     Ok(post_json_with_options(
@@ -184,7 +184,7 @@ impl TemporalStoreClient {
                             policy,
                             preferred_location,
                         );
-                        return Err(err.into());
+                        return Err(ClientError::WriteOutcomeUnknown(err.to_string()));
                     }
                     let refreshed = self.resolve_route_with_policy(
                         request.shard_id,
@@ -246,7 +246,7 @@ impl TemporalStoreClient {
                             .record_write_of_unknown_outcome();
                         let _ =
                             self.resolve_route(request.shard_id, true, continuous_failed_time_ms);
-                        return Err(err.into());
+                        return Err(ClientError::WriteOutcomeUnknown(err.to_string()));
                     }
                     let refreshed =
                         self.resolve_route(request.shard_id, true, continuous_failed_time_ms)?;

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -901,7 +901,7 @@ impl ProxyService {
         let response = self
             .client()
             .execute_with_options(request, RequestOptions::default())
-            .unwrap_or_else(|err| execute_error("server_error", err.to_string()));
+            .unwrap_or_else(|err| execute_error(proxy_client_error_code(&err), err.to_string()));
         self.sync_client_stats();
         response
     }
@@ -926,7 +926,7 @@ impl ProxyService {
             .client()
             .batch_execute_with_options(request, RequestOptions::default())
             .unwrap_or_else(|err| BatchExecuteResponse {
-                status: Status::error("server_error", err.to_string()),
+                status: Status::error(proxy_client_error_code(&err), err.to_string()),
                 responses: Vec::new(),
             });
         self.sync_client_stats();
@@ -1008,7 +1008,7 @@ impl ProxyService {
         let response = self
             .table_for_request(request.namespace, request.table_name)
             .and_then(|table| table.execute(request.command))
-            .unwrap_or_else(|err| execute_error("server_error", err.to_string()));
+            .unwrap_or_else(|err| execute_error(proxy_client_error_code(&err), err.to_string()));
         self.sync_client_stats();
         response
     }
@@ -1036,7 +1036,7 @@ impl ProxyService {
             .table_for_request(request.namespace, request.table_name)
             .and_then(|table| table.batch_execute(request.commands))
             .unwrap_or_else(|err| BatchExecuteResponse {
-                status: Status::error("server_error", err.to_string()),
+                status: Status::error(proxy_client_error_code(&err), err.to_string()),
                 responses: Vec::new(),
             });
         self.sync_client_stats();
@@ -1506,6 +1506,20 @@ fn context_drop_key(scope: &context::ProxyContextScope) -> String {
 /// HTTP status for an admission rejection on the `/context/*` routes, which
 /// return the transport code rather than embedding it in a body the gateway
 /// would have to parse to notice it was shed.
+/// The status code a client error should reach the caller as.
+///
+/// Everything used to arrive as `server_error`, which told an application only that something
+/// went wrong -- not whether its write had landed. Those are different situations with
+/// different correct responses: a failure that provably did not apply can simply be retried,
+/// while one that may have applied has to be reconciled, and retrying it is how a write gets
+/// counted twice. The proxy knows which it was; the caller could not find out.
+fn proxy_client_error_code(err: &crate::client::ClientError) -> &'static str {
+    match err {
+        crate::client::ClientError::WriteOutcomeUnknown(_) => "write_outcome_unknown",
+        _ => "server_error",
+    }
+}
+
 fn proxy_rejection_http_status(code: &str) -> u16 {
     match code {
         "proxy_account_denied" => 403,
@@ -4502,6 +4516,61 @@ mod tests {
             hits.load(Ordering::SeqCst) - before,
             1,
             "a request that timed out on a pooled socket must not be sent again on a fresh one"
+        );
+    }
+
+    #[test]
+    fn a_caller_can_tell_an_unknown_write_from_a_failed_one() {
+        // The counter added alongside this tells an OPERATOR how many writes are unaccounted
+        // for. It does not help the application holding the error, and that application has
+        // the same decision the client had: retry, or not. Retrying a write that already
+        // applied is how it gets applied twice -- the exact thing the client stopped doing
+        // internally. Handing back the same "server_error" for both cases pushes that bug one
+        // layer out.
+        let slow = test_addr(18_402);
+        let slow_for_thread = slow.clone();
+        std::thread::spawn(move || {
+            serve(&slow_for_thread, move |_request| {
+                std::thread::sleep(Duration::from_millis(500));
+                crate::http::json_response(200, &Status::ok())
+            })
+            .unwrap();
+        });
+        start_meta(test_addr(18_403), slow.clone());
+        wait_for_http(&test_addr(18_403));
+
+        let proxy = ProxyService::new(ProxyOptions {
+            meta_addr: test_addr(18_403),
+            route_cache_ttl_ms: 60_000,
+            connect_timeout_ms: 200,
+            io_timeout_ms: 120,
+            ..ProxyOptions::default()
+        });
+        let response = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        assert!(!response.status.ok);
+        assert_eq!(
+            response.status.code, "write_outcome_unknown",
+            "a caller must be able to see that retrying this write is not free"
+        );
+
+        // A read that fails the same way is NOT unknown -- repeating a read cannot change
+        // anything, so it keeps the ordinary code and callers keep retrying it freely.
+        let response = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: "k".to_string(),
+            },
+        });
+        assert!(!response.status.ok);
+        assert_ne!(
+            response.status.code, "write_outcome_unknown",
+            "a read is always safe to repeat and must not be labelled unknown"
         );
     }
 

--- a/crates/temporalstore-rust/src/sdk.rs
+++ b/crates/temporalstore-rust/src/sdk.rs
@@ -621,6 +621,10 @@ fn client_error_code(err: &ClientError) -> &'static str {
         ClientError::Status(_) => "status_error",
         ClientError::InvalidRequest(_) => "invalid_request",
         ClientError::UnexpectedResponse { .. } => "unexpected_response",
+        // Distinct on purpose: the caller has to be able to tell a write that provably did not
+        // apply from one that may have. Retrying the first is free; retrying the second is how
+        // a write gets applied twice.
+        ClientError::WriteOutcomeUnknown(_) => "write_outcome_unknown",
     }
 }
 


### PR DESCRIPTION
A write that times out is no longer sent again, because repeating it could apply it
twice. That was the right call inside the client, and the counter added alongside it
tells an operator how many writes are unaccounted for.

It does nothing for the application holding the error. That application faces the
same decision the client just made -- retry, or not -- and it was handed
"server_error" either way. So a write that provably never arrived and a write that
may already have been applied were indistinguishable at the point where someone was
about to decide whether to send it again. Retrying the second is exactly how a write
gets applied twice, which means the bug was not removed so much as moved one layer
out, to the layer least equipped to reason about it.

Those two cases now arrive as different status codes. The unknown one is
write_outcome_unknown, on the proxy surface and on the SDK surface both.

A read is deliberately never labelled that way. Repeating a read cannot change
anything, so callers should keep retrying reads freely and the test asserts they
still can -- the distinction is only meaningful for writes.

This does not decide anything on the caller's behalf. Reconciling, retrying anyway,
or failing the request are all reasonable, and which is right depends on what the
write meant. The point is that the choice now exists: it was previously being made
by default, in the dark, by whichever retry loop happened to be wrapping the call.

Checked rather than asserted: map the case back to server_error and the test fails
with left "server_error", right "write_outcome_unknown".

One note on how this landed. Adding the error variant did not compile, because a
match in the SDK surface enumerated every case -- which is the compiler pointing out
that the gRPC callers needed telling too, not just the HTTP ones. I had checked for
exhaustive matches first and concluded there were none; I was wrong, and the build
was right.