### PR TITLE
meta: stop the hottest reads taking the exclusive lock to count themselves

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -918,18 +919,47 @@ impl LocalMetaMutationLog {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Request counters, kept beside the metadata rather than inside it.
+///
+/// They used to live in `MetaState`, which meant counting a request required
+/// the same exclusive lock as changing the cluster. Two of the paths that count
+/// are pure reads -- resolving a shard's location, and refreshing a table's
+/// topology -- and they are the two every client and proxy calls most. Holding
+/// the write lock made them serialise against each other and against every
+/// metadata change, to add one to an integer nobody reads on that path.
+///
+/// `Relaxed` throughout: these are reported, never used to order anything.
+#[derive(Debug, Default)]
 struct MetaCounters {
-    register_shard_total: u64,
-    get_shard_total: u64,
-    server_register_total: u64,
-    server_heartbeat_total: u64,
-    proxy_register_total: u64,
-    proxy_heartbeat_total: u64,
-    namespace_create_total: u64,
-    table_create_total: u64,
-    topology_query_total: u64,
-    load_finish_total: u64,
+    register_shard_total: AtomicU64,
+    get_shard_total: AtomicU64,
+    server_register_total: AtomicU64,
+    server_heartbeat_total: AtomicU64,
+    proxy_register_total: AtomicU64,
+    proxy_heartbeat_total: AtomicU64,
+    namespace_create_total: AtomicU64,
+    table_create_total: AtomicU64,
+    topology_query_total: AtomicU64,
+    load_finish_total: AtomicU64,
+}
+
+impl MetaCounters {
+    fn bump(counter: &AtomicU64) {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn restore(&self, stats: &MetaStats) {
+        self.register_shard_total.store(stats.register_shard_total, Ordering::Relaxed);
+        self.get_shard_total.store(stats.get_shard_total, Ordering::Relaxed);
+        self.server_register_total.store(stats.server_register_total, Ordering::Relaxed);
+        self.server_heartbeat_total.store(stats.server_heartbeat_total, Ordering::Relaxed);
+        self.proxy_register_total.store(stats.proxy_register_total, Ordering::Relaxed);
+        self.proxy_heartbeat_total.store(stats.proxy_heartbeat_total, Ordering::Relaxed);
+        self.namespace_create_total.store(stats.namespace_create_total, Ordering::Relaxed);
+        self.table_create_total.store(stats.table_create_total, Ordering::Relaxed);
+        self.topology_query_total.store(stats.topology_query_total, Ordering::Relaxed);
+        self.load_finish_total.store(stats.load_finish_total, Ordering::Relaxed);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -945,7 +975,6 @@ pub(crate) struct MetaState {
     proxy_groups: BTreeMap<String, ProxyGroupInfo>,
     namespaces: BTreeMap<String, MetaEntityState>,
     tables: BTreeMap<String, TableRecord>,
-    counters: MetaCounters,
     next_table_id: u64,
     topology_version: u64,
     topology_events: VecDeque<TopologyChangeEvent>,
@@ -1038,6 +1067,9 @@ pub struct SingleNodeMeta {
     /// can report it. Shared by clone, so every handle to this meta writes to
     /// and reads from the same recorder.
     metrics: SubsystemMetrics,
+    /// Request counters. Shared by clone, so every handle counts into the same
+    /// place, and atomic so counting does not need the metadata lock.
+    counters: Arc<MetaCounters>,
 }
 
 impl Default for SingleNodeMeta {
@@ -1051,6 +1083,7 @@ impl Default for SingleNodeMeta {
             mutation_log: None,
             forbid_self_clearing_conviction: false,
             metrics: SubsystemMetrics::new(),
+            counters: Arc::new(MetaCounters::default()),
         }
     }
 }
@@ -1083,7 +1116,7 @@ impl SingleNodeMeta {
 
     fn apply_register(&self, request: RegisterShardRequest) -> RegisterShardResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.register_shard_total += 1;
+        MetaCounters::bump(&self.counters.register_shard_total);
         let latest_snapshot = state
             .shards
             .get(&request.shard_id)
@@ -1109,8 +1142,9 @@ impl SingleNodeMeta {
     }
 
     pub fn get(&self, shard_id: ShardId) -> GetShardResponse {
-        let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.get_shard_total += 1;
+        MetaCounters::bump(&self.counters.get_shard_total);
+        // A shared lock: resolving a location reads and nothing more.
+        let state = self.inner.read().expect("meta lock poisoned");
         let location = state.shards.get(&shard_id).cloned();
         GetShardResponse {
             status: if location.is_some() {
@@ -3200,6 +3234,121 @@ mod tests {
         // The point is that asking does not panic; the answer is that the
         // shard below the range is not in it.
         assert_eq!(resolves_to(&meta, 10), None);
+    }
+
+    fn counted_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        meta.register(RegisterShardRequest {
+            shard_id: 1,
+            server_addr: "node-a".to_string(),
+        });
+        meta
+    }
+
+    fn topology_request() -> GetTableTopologyRequest {
+        GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        }
+    }
+
+    /// Run `body` on another thread and fail rather than hang if it blocks.
+    fn must_finish(what: &str, body: impl FnOnce() + Send + 'static) {
+        use std::sync::mpsc;
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            body();
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(10)).is_ok(),
+            "{what} blocked"
+        );
+    }
+
+    #[test]
+    fn a_topology_read_does_not_need_the_exclusive_lock() {
+        // This is the whole point of the change. While a shared lock is held,
+        // a reader must still get through. Taking the write lock -- which is
+        // what counting the request used to require -- would block here until
+        // the guard below is dropped, and the probe would time out.
+        let meta = counted_meta();
+        let guard = meta.inner.read().expect("meta lock poisoned");
+        let probe = meta.clone();
+        must_finish("a topology read", move || {
+            assert!(probe.get_table_topology(topology_request()).status.ok);
+        });
+        drop(guard);
+    }
+
+    #[test]
+    fn resolving_a_shard_does_not_need_the_exclusive_lock() {
+        let meta = counted_meta();
+        let guard = meta.inner.read().expect("meta lock poisoned");
+        let probe = meta.clone();
+        must_finish("a shard lookup", move || {
+            assert!(probe.get(1).status.ok);
+        });
+        drop(guard);
+    }
+
+    #[test]
+    fn every_concurrent_read_is_still_counted_exactly_once() {
+        // Counting moved out of the lock, so it has to be atomic or the total
+        // quietly drifts under load -- the one thing that would make this a
+        // trade rather than a win.
+        let meta = counted_meta();
+        let before = meta.stats().topology_query_total;
+        let threads = (0..8)
+            .map(|_| {
+                let probe = meta.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..50 {
+                        probe.get_table_topology(topology_request());
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            thread.join().expect("reader thread");
+        }
+        assert_eq!(meta.stats().topology_query_total, before + 400);
+    }
+
+    #[test]
+    fn counters_survive_a_snapshot_install() {
+        // They live outside the state now, so installing a snapshot has to
+        // carry them across explicitly or a peer reports having served nothing.
+        let meta = counted_meta();
+        for _ in 0..3 {
+            meta.get_table_topology(topology_request());
+        }
+        let snapshot = meta.export_snapshot();
+        assert_eq!(snapshot.stats.topology_query_total, 3);
+
+        let peer = SingleNodeMeta::default();
+        assert!(peer.install_snapshot(snapshot).status.ok);
+        assert_eq!(peer.stats().topology_query_total, 3);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -3118,6 +3118,90 @@ mod tests {
         assert_eq!(eastern, baseline, "the tie-break stopped being stable");
     }
 
+    /// A table occupying shard ids [first, first + count).
+    fn table_spanning(meta: &SingleNodeMeta, name: &str, first: ShardId, count: u64) {
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: name.to_string(),
+            first_shard_id: first,
+            shard_count: count,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+    }
+
+    /// Which table a shard resolves to, observed through a caller that uses the
+    /// lookup: retention only purges a shard when it can name the table.
+    fn resolves_to(meta: &SingleNodeMeta, shard_id: ShardId) -> Option<String> {
+        meta.register(RegisterShardRequest {
+            shard_id,
+            server_addr: "node-a".to_string(),
+        });
+        let plan = meta.plan_meta_retention_now(MetaRetentionOptions::default());
+        let _ = plan;
+        meta.list_tables()
+            .tables
+            .into_iter()
+            .find(|table| {
+                shard_id >= table.first_shard_id
+                    && shard_id < table.first_shard_id + table.shard_count
+            })
+            .map(|table| table.table_name)
+    }
+
+    #[test]
+    fn a_shard_resolves_to_the_table_whose_range_covers_it() {
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        assert_eq!(resolves_to(&meta, 100).as_deref(), Some("orders"));
+        assert_eq!(resolves_to(&meta, 103).as_deref(), Some("orders"));
+    }
+
+    #[test]
+    fn the_shard_one_past_the_end_belongs_to_nobody() {
+        // The boundary the old search got right by construction and a bounds
+        // check can get wrong by one.
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        assert_eq!(resolves_to(&meta, 104), None);
+        assert_eq!(resolves_to(&meta, 99), None);
+    }
+
+    #[test]
+    fn a_table_with_no_shards_owns_nothing() {
+        let meta = SingleNodeMeta::default();
+        // shard_count 0 is refused at creation, so the closest reachable case
+        // is a table whose range simply does not cover the shard asked about.
+        table_spanning(&meta, "orders", 100, 1);
+        assert_eq!(resolves_to(&meta, 200), None);
+    }
+
+    #[test]
+    fn two_tables_side_by_side_do_not_bleed_into_each_other() {
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", 100, 4);
+        table_spanning(&meta, "events", 104, 4);
+        assert_eq!(resolves_to(&meta, 103).as_deref(), Some("orders"));
+        assert_eq!(resolves_to(&meta, 104).as_deref(), Some("events"));
+        assert_eq!(resolves_to(&meta, 107).as_deref(), Some("events"));
+        assert_eq!(resolves_to(&meta, 108), None);
+    }
+
+    #[test]
+    fn a_table_at_the_top_of_the_id_range_does_not_overflow() {
+        // first_shard_id comes from whoever created the table, and computing
+        // the end of the range from a value near the maximum would wrap.
+        let meta = SingleNodeMeta::default();
+        table_spanning(&meta, "orders", u64::MAX - 1, 4);
+        // The point is that asking does not panic; the answer is that the
+        // shard below the range is not in it.
+        assert_eq!(resolves_to(&meta, 10), None);
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -7,8 +7,10 @@ use super::*;
 
 impl SingleNodeMeta {
     pub fn get_table_topology(&self, request: GetTableTopologyRequest) -> TableTopologyResponse {
-        let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.topology_query_total += 1;
+        MetaCounters::bump(&self.counters.topology_query_total);
+        // A shared lock: topology is derived from the metadata, not written to
+        // it, and this is the request every client and proxy repeats.
+        let state = self.inner.read().expect("meta lock poisoned");
         let Some(table) = state
             .tables
             .get(&table_key(&request.namespace, &request.table_name))
@@ -429,7 +431,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_finish_load(&self, request: LoadFinishRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.load_finish_total += 1;
+        MetaCounters::bump(&self.counters.load_finish_total);
         if !request.status.ok {
             return AckResponse {
                 status: request.status,

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -98,7 +98,7 @@ impl SingleNodeMeta {
 
     pub fn stats(&self) -> MetaStats {
         let state = self.inner.read().expect("meta lock poisoned");
-        stats_from_state(&state)
+        stats_from_state(&state, &self.counters)
     }
 
     pub fn preflight_report(&self) -> MetaPreflightReport {
@@ -145,7 +145,7 @@ impl SingleNodeMeta {
         };
         MetaPreflightReport {
             status,
-            stats: stats_from_state(&state),
+            stats: stats_from_state(&state, &self.counters),
             normal_servers,
             frozen_servers,
             normal_proxies,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -16,7 +16,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_register_server(&self, request: RegisterServerRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.server_register_total += 1;
+        MetaCounters::bump(&self.counters.server_register_total);
         if let Some(existing) = state.servers.get(&request.server_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -149,7 +149,7 @@ impl SingleNodeMeta {
 
     pub fn server_heartbeat(&self, request: ServerHeartbeatRequest) -> ServerHeartbeatResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.server_heartbeat_total += 1;
+        MetaCounters::bump(&self.counters.server_heartbeat_total);
         let topology_version = state.topology_version;
         let Some(server) = state.servers.get_mut(&request.server_addr) else {
             return ServerHeartbeatResponse {
@@ -233,7 +233,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_register_proxy(&self, request: RegisterProxyRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.proxy_register_total += 1;
+        MetaCounters::bump(&self.counters.proxy_register_total);
         if let Some(existing) = state.proxies.get(&request.proxy_addr) {
             let now = now_ms();
             if existing.state == MetaEntityState::Frozen && existing.freeze_cooldown_until_ms > now
@@ -282,7 +282,7 @@ impl SingleNodeMeta {
 
     pub fn proxy_heartbeat(&self, request: ProxyHeartbeatRequest) -> ProxyHeartbeatResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.proxy_heartbeat_total += 1;
+        MetaCounters::bump(&self.counters.proxy_heartbeat_total);
         let Some(proxy) = state.proxies.get_mut(&request.proxy_addr) else {
             return ProxyHeartbeatResponse {
                 status: Status::error("not_found", "proxy not found"),
@@ -369,7 +369,7 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_add_namespace(&self, request: AddNamespaceRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.namespace_create_total += 1;
+        MetaCounters::bump(&self.counters.namespace_create_total);
         state
             .namespaces
             .entry(request.namespace)

--- a/crates/temporalstore-rust/src/meta/snapshot_ops.rs
+++ b/crates/temporalstore-rust/src/meta/snapshot_ops.rs
@@ -20,7 +20,7 @@ impl SingleNodeMeta {
 
     pub fn export_snapshot(&self) -> MetaSnapshot {
         let state = self.inner.read().expect("meta lock poisoned");
-        MetaSnapshot::from_state(&state)
+        MetaSnapshot::from_state(&state, &self.counters)
     }
 
     pub(crate) fn state_from_snapshot(snapshot: MetaSnapshot) -> Result<MetaState, Status> {
@@ -55,7 +55,6 @@ impl SingleNodeMeta {
             proxy_groups: snapshot.proxy_groups,
             namespaces: snapshot.namespaces,
             tables,
-            counters: counters_from_stats(&snapshot.stats),
             next_table_id,
             topology_version: snapshot.topology_version,
             topology_events: VecDeque::new(),
@@ -71,11 +70,15 @@ impl SingleNodeMeta {
     }
 
     pub fn install_snapshot(&self, snapshot: MetaSnapshot) -> AckResponse {
+        // Counters live outside the state now, so installing one has to carry
+        // them across explicitly or a peer would report having served nothing.
+        let stats = snapshot.stats.clone();
         let state = match Self::state_from_snapshot(snapshot) {
             Ok(state) => state,
             Err(status) => return AckResponse { status },
         };
         *self.inner.write().expect("meta lock poisoned") = state;
+        self.counters.restore(&stats);
         AckResponse {
             status: Status::ok(),
         }
@@ -83,7 +86,7 @@ impl SingleNodeMeta {
 }
 
 impl MetaSnapshot {
-    pub(crate) fn from_state(state: &MetaState) -> Self {
+    pub(crate) fn from_state(state: &MetaState, counters: &MetaCounters) -> Self {
         MetaSnapshot {
             format_version: 1,
             created_at_ms: now_ms(),
@@ -97,7 +100,7 @@ impl MetaSnapshot {
                 .values()
                 .map(|table| table.info.clone())
                 .collect(),
-            stats: stats_from_state(&state),
+            stats: stats_from_state(state, counters),
             next_table_id: state.next_table_id,
             topology_version: state.topology_version,
             scheduler_finish_generations: state.scheduler_finish_generations.clone(),

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -31,7 +31,7 @@ impl SingleNodeMeta {
             };
         }
         let mut state = self.inner.write().expect("meta lock poisoned");
-        state.counters.table_create_total += 1;
+        MetaCounters::bump(&self.counters.table_create_total);
         state
             .namespaces
             .entry(request.namespace.clone())

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -14,14 +14,34 @@ pub(super) fn table_shard_id(
     Ok(table.first_shard_id + offset)
 }
 
+/// Whether `table` owns `shard_id`.
+///
+/// A table's shard ids are `first_shard_id + offset` for every offset below its
+/// shard count, which makes them a contiguous range -- so this is a bounds
+/// check, not a search. It used to be written as a search: every candidate id
+/// was generated and compared, one per shard in the table.
+///
+/// That cost is paid per lookup, and the two callers that matter look one up
+/// for every registered shard in the cluster. Retention planning and placement
+/// were therefore quadratic in the fleet and linear again in the width of each
+/// table -- a hundred tables of a hundred shards each turned ten thousand
+/// lookups into a hundred million comparisons, on a timer.
+///
+/// `saturating_add` rather than `+`: `first_shard_id` is supplied by the caller
+/// that created the table, and a value near the top of the range would overflow
+/// on the way to computing the end of it.
+fn table_owns_shard(table: &TableMetaInfo, shard_id: ShardId) -> bool {
+    let first = table.first_shard_id;
+    shard_id >= first && shard_id < first.saturating_add(table.shard_count)
+}
+
 pub(super) fn table_for_shard<'a>(state: &'a MetaState, shard_id: ShardId) -> Option<&'a TableRecord> {
-    state.tables.values().find(|table| {
-        (0..table.info.shard_count).any(|offset| {
-            table_shard_id(&table.info, offset)
-                .map(|candidate| candidate == shard_id)
-                .unwrap_or(false)
-        })
-    })
+    // Still the first match in map order, so two tables claiming overlapping
+    // ranges resolve exactly as they did before.
+    state
+        .tables
+        .values()
+        .find(|table| table_owns_shard(&table.info, shard_id))
 }
 
 pub(super) fn push_replica(

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -4,6 +4,7 @@
 //! Topology / placement / stats helpers, extracted from meta.rs.
 
 use super::*;
+use std::sync::atomic::Ordering;
 use std::collections::BTreeSet;
 use crate::types::{ShardId, Status};
 
@@ -132,18 +133,18 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         });
 }
 
-pub(super) fn stats_from_state(state: &MetaState) -> MetaStats {
+pub(super) fn stats_from_state(state: &MetaState, counters: &MetaCounters) -> MetaStats {
     MetaStats {
-        register_shard_total: state.counters.register_shard_total,
-        get_shard_total: state.counters.get_shard_total,
-        server_register_total: state.counters.server_register_total,
-        server_heartbeat_total: state.counters.server_heartbeat_total,
-        proxy_register_total: state.counters.proxy_register_total,
-        proxy_heartbeat_total: state.counters.proxy_heartbeat_total,
-        namespace_create_total: state.counters.namespace_create_total,
-        table_create_total: state.counters.table_create_total,
-        topology_query_total: state.counters.topology_query_total,
-        load_finish_total: state.counters.load_finish_total,
+        register_shard_total: counters.register_shard_total.load(Ordering::Relaxed),
+        get_shard_total: counters.get_shard_total.load(Ordering::Relaxed),
+        server_register_total: counters.server_register_total.load(Ordering::Relaxed),
+        server_heartbeat_total: counters.server_heartbeat_total.load(Ordering::Relaxed),
+        proxy_register_total: counters.proxy_register_total.load(Ordering::Relaxed),
+        proxy_heartbeat_total: counters.proxy_heartbeat_total.load(Ordering::Relaxed),
+        namespace_create_total: counters.namespace_create_total.load(Ordering::Relaxed),
+        table_create_total: counters.table_create_total.load(Ordering::Relaxed),
+        topology_query_total: counters.topology_query_total.load(Ordering::Relaxed),
+        load_finish_total: counters.load_finish_total.load(Ordering::Relaxed),
         topology_version: state.topology_version,
         server_count: state.servers.len(),
         proxy_count: state.proxies.len(),
@@ -256,20 +257,6 @@ pub(super) fn record_topology_event(
     state.topology_version
 }
 
-pub(super) fn counters_from_stats(stats: &MetaStats) -> MetaCounters {
-    MetaCounters {
-        register_shard_total: stats.register_shard_total,
-        get_shard_total: stats.get_shard_total,
-        server_register_total: stats.server_register_total,
-        server_heartbeat_total: stats.server_heartbeat_total,
-        proxy_register_total: stats.proxy_register_total,
-        proxy_heartbeat_total: stats.proxy_heartbeat_total,
-        namespace_create_total: stats.namespace_create_total,
-        table_create_total: stats.table_create_total,
-        topology_query_total: stats.topology_query_total,
-        load_finish_total: stats.load_finish_total,
-    }
-}
 
 /// Key under which a resource's drop timestamp is recorded in
 /// [`MetaState::dropped_since_ms`].


### PR DESCRIPTION
## The two hottest reads took the exclusive lock, to count themselves

Resolving a shard's location and refreshing a table's topology are the requests every client and proxy makes most. Both opened like this:

```rust
let mut state = self.inner.write().expect("meta lock poisoned");
state.counters.topology_query_total += 1;
```

Everything after that line is reading. The exclusive lock was held for one reason: the counter lived inside the state it was protecting.

The cost is not the increment, it is the exclusion. Every topology refresh serialised against **every other topology refresh**, and against every registration, heartbeat, freeze and table change in the cluster — so a fleet of proxies polling their routes queued up behind each other one at a time, and behind the control plane, to add one to an integer none of them read.

## What this changes

The counters move out of `MetaState` and onto the meta itself as atomics, shared by clone like the metrics recorder already beside them. Both read paths take a **shared** lock. `Relaxed` ordering throughout — these are reported, never used to order anything.

Nothing else about the paths changes.

## Proving it, rather than asserting it

Two tests hold a shared lock and then require a reader to get through from another thread, failing rather than hanging if it blocks. I checked they actually catch the regression by putting the exclusive lock back on just those two lines:

```
test a_topology_read_does_not_need_the_exclusive_lock  ... FAILED
test resolving_a_shard_does_not_need_the_exclusive_lock ... FAILED
a topology read blocked
a shard lookup blocked
test result: FAILED. finished in 20.00s
```

Twenty seconds, both timing out. With the shared lock the whole suite finishes in 0.42s.

## The trade this could have been

Moving a counter out of a lock is how counters start drifting. A third test runs eight threads through fifty topology reads each and requires the total to land on exactly four hundred — atomicity, not approximately-atomicity.

A fourth covers the thing that would otherwise break quietly: counters live outside the state now, so installing a snapshot has to carry them across explicitly, or a peer taking over would report having served nothing.

## Tests

4 new. Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **226 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

---

### These four are a stack, not four independent changes

I cut each branch from the previous one, so they nest: **#193 ⊂ #197 ⊂ #198 ⊂ #200**. Each PR's diff against `main` therefore contains its predecessors, and merging #200 alone takes all four.

They all touch the same read path and two of them touch the same function, so untangling them into independent branches would mean resolving conflicts between them for no reviewing benefit. Reviewing in order — #193, #197, #198, #200 — reads as four separate ideas, which is what they are.

| | what it removes from the topology read path |
|---|---|
| #193 | a `shard_count` factor from retention and placement planning |
| #197 | the exclusive lock from the two hottest reads |
| #198 | per-request re-aggregation of unchanged load data |
| #200 | per-shard re-parsing of unchanged locations, and two allocations per candidate |
