### PR TITLE
meta: summarise a server's load when it reports it, not on every read

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4797,6 +4797,7 @@ mod tests {
                 node_id: 1,
                 location: location.to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             });
         }
         meta

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -368,6 +368,22 @@ pub struct ServerMetaInfo {
     /// does not send them, so the shard-divergence check declines to judge it.
     #[serde(default)]
     pub reports_shard_states: bool,
+    /// What `shard_loads` and `shard_states` add up to, summarised when the
+    /// server reports them.
+    ///
+    /// Placement needs three numbers out of those two lists: the total keys,
+    /// the total memory, and the worst serving state. It used to add them up
+    /// from scratch inside every topology request -- walking every shard of
+    /// every live server, twice for the loads and once for the states, to
+    /// re-derive figures that only change when a heartbeat arrives. A hundred
+    /// servers of fifty shards is fifteen thousand iterations per request, for
+    /// an answer identical to the last request's.
+    #[serde(default)]
+    pub load_key_count: u64,
+    #[serde(default)]
+    pub load_memory_bytes: u64,
+    #[serde(default)]
+    pub worst_shard_state_penalty: u8,
     pub binary_version: String,
     pub shard_loads: Vec<ShardLoad>,
     #[serde(default)]
@@ -4741,6 +4757,123 @@ mod tests {
             recovered.reserved_names().reserved,
             reserving(&["system"], &["audit"])
         );
+    }
+
+    fn beat(meta: &SingleNodeMeta, addr: &str, loads: &[(u64, u64)]) {
+        meta.server_heartbeat(ServerHeartbeatRequest {
+            server_addr: addr.to_string(),
+            boot_time_ms: 1,
+            binary_version: "v1".to_string(),
+            shard_loads: loads
+                .iter()
+                .enumerate()
+                .map(|(index, (keys, bytes))| ShardLoad {
+                    shard_id: index as ShardId + 1,
+                    key_count: *keys,
+                    memory_bytes: *bytes,
+                })
+                .collect(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: ServerRuntimeLoad::default(),
+            shard_states: Vec::new(),
+        });
+    }
+
+    fn server_summary(meta: &SingleNodeMeta, addr: &str) -> (u64, u64) {
+        let server = meta
+            .list_servers()
+            .servers
+            .into_iter()
+            .find(|server| server.server_addr == addr)
+            .expect("registered");
+        (server.load_key_count, server.load_memory_bytes)
+    }
+
+    fn loaded_meta() -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        for (addr, location) in [("node-a", "rack-1"), ("node-b", "rack-2")] {
+            meta.register_server(RegisterServerRequest {
+                server_addr: addr.to_string(),
+                node_id: 1,
+                location: location.to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta
+    }
+
+    #[test]
+    fn a_heartbeat_summarises_the_load_it_reports() {
+        let meta = loaded_meta();
+        beat(&meta, "node-a", &[(10, 100), (20, 200), (30, 300)]);
+        assert_eq!(server_summary(&meta, "node-a"), (60, 600));
+    }
+
+    #[test]
+    fn a_lighter_heartbeat_lowers_the_summary_rather_than_adding_to_it() {
+        // The summary describes the latest report, not the history of them.
+        // Accumulating would make a server look permanently loaded once it had
+        // ever been busy, and placement would stop sending it anything.
+        let meta = loaded_meta();
+        beat(&meta, "node-a", &[(10, 100), (20, 200)]);
+        assert_eq!(server_summary(&meta, "node-a"), (30, 300));
+        beat(&meta, "node-a", &[(5, 50)]);
+        assert_eq!(server_summary(&meta, "node-a"), (5, 50));
+    }
+
+    #[test]
+    fn a_server_that_reports_nothing_summarises_to_nothing() {
+        let meta = loaded_meta();
+        beat(&meta, "node-a", &[]);
+        assert_eq!(server_summary(&meta, "node-a"), (0, 0));
+    }
+
+    #[test]
+    fn placement_still_prefers_the_lighter_server() {
+        // The behaviour the summary exists to serve, unchanged. This is the
+        // regression guard: if the summary ever stops tracking the report,
+        // placement silently starts choosing on stale numbers and only a test
+        // like this notices.
+        let meta = loaded_meta();
+        beat(&meta, "node-a", &[(1_000, 10_000)]);
+        beat(&meta, "node-b", &[(1, 10)]);
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 1,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+        let shard = meta
+            .get_table_topology(GetTableTopologyRequest {
+                namespace: "ns".to_string(),
+                table_name: "orders".to_string(),
+                old_topology_version: 0,
+                client_location: String::new(),
+            })
+            .shards
+            .into_iter()
+            .next()
+            .expect("one shard");
+        assert_eq!(
+            shard.primary,
+            Some("node-b".to_string()),
+            "the heavier server was proposed"
+        );
+    }
+
+    #[test]
+    fn the_summary_survives_a_snapshot_round_trip() {
+        let meta = loaded_meta();
+        beat(&meta, "node-a", &[(10, 100), (20, 200)]);
+        let peer = SingleNodeMeta::default();
+        assert!(peer.install_snapshot(meta.export_snapshot()).status.ok);
+        assert_eq!(server_summary(&peer, "node-a"), (30, 300));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -935,6 +935,9 @@ mod tests {
     fn server(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ServerMetaInfo {
         ServerMetaInfo {
             numa_nodes: Vec::new(),
+            load_key_count: 0,
+            load_memory_bytes: 0,
+            worst_shard_state_penalty: 0,
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 0,

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -44,22 +44,6 @@ pub(super) fn build_shards(
         .values()
         .filter(|server| server.state == MetaEntityState::Normal)
         .map(|server| {
-            let key_count = server
-                .shard_loads
-                .iter()
-                .map(|load| load.key_count)
-                .sum::<u64>();
-            let memory_bytes = server
-                .shard_loads
-                .iter()
-                .map(|load| load.memory_bytes)
-                .sum::<u64>();
-            let shard_state_penalty = server
-                .shard_states
-                .iter()
-                .map(|state| placement_shard_state_penalty(&state.serving_state))
-                .max()
-                .unwrap_or_default();
             PlacementCandidate {
                 server_addr: server.server_addr.clone(),
                 location: server.location.clone(),
@@ -69,9 +53,9 @@ pub(super) fn build_shards(
                 running_shard_count: server.runtime_load.running_shard_count,
                 dirty_object_count: server.runtime_load.dirty_object_count,
                 dirty_shard_count: server.runtime_load.dirty_shard_count,
-                shard_state_penalty,
-                key_count,
-                memory_bytes,
+                shard_state_penalty: server.worst_shard_state_penalty,
+                key_count: server.load_key_count,
+                memory_bytes: server.load_memory_bytes,
             }
         })
         .collect::<Vec<_>>();

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -97,6 +97,9 @@ mod tests {
     fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
         ServerMetaInfo {
             numa_nodes: Vec::new(),
+            load_key_count: 0,
+            load_memory_bytes: 0,
+            worst_shard_state_penalty: 0,
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -50,6 +50,9 @@ impl SingleNodeMeta {
         state.servers.insert(
             server_addr.clone(),
             ServerMetaInfo {
+                load_key_count: 0,
+                load_memory_bytes: 0,
+                worst_shard_state_penalty: 0,
                 freeze_reason: FreezeReason::Unspecified,
                 server_addr: request.server_addr,
                 node_id: request.node_id,
@@ -218,6 +221,20 @@ impl SingleNodeMeta {
         server.reports_shard_states =
             server.reports_shard_states || !request.shard_states.is_empty();
         server.shard_states = request.shard_states;
+        // Summarised here, where the lists change, so that the read path does
+        // not have to walk them.
+        server.load_key_count = server.shard_loads.iter().map(|load| load.key_count).sum();
+        server.load_memory_bytes = server
+            .shard_loads
+            .iter()
+            .map(|load| load.memory_bytes)
+            .sum();
+        server.worst_shard_state_penalty = server
+            .shard_states
+            .iter()
+            .map(|state| placement_shard_state_penalty(&state.serving_state))
+            .max()
+            .unwrap_or_default();
         let server_state = server.state.as_str().to_string();
         let anchored = server.reported_boot_time_ms;
         if rebooted {

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -466,6 +466,9 @@ mod tests {
     fn server(addr: &str, serving: &[(ShardId, &str)]) -> ServerMetaInfo {
         ServerMetaInfo {
             numa_nodes: Vec::new(),
+            load_key_count: 0,
+            load_memory_bytes: 0,
+            worst_shard_state_penalty: 0,
             freeze_reason: FreezeReason::Unspecified,
             server_addr: addr.to_string(),
             node_id: 1,

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -114,6 +114,9 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         .entry(server_addr.to_string())
         .or_insert_with(|| ServerMetaInfo {
             numa_nodes: Vec::new(),
+            load_key_count: 0,
+            load_memory_bytes: 0,
+            worst_shard_state_penalty: 0,
             freeze_reason: FreezeReason::Unspecified,
             server_addr: server_addr.to_string(),
             node_id: 0,

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -311,6 +311,9 @@ pub(super) fn topology_for_shard(
 pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
     ServerMetaInfo {
         numa_nodes: Vec::new(),
+        load_key_count: 0,
+        load_memory_bytes: 0,
+        worst_shard_state_penalty: 0,
         freeze_reason: crate::meta::FreezeReason::Unspecified,
         server_addr: addr.to_string(),
         node_id,


### PR DESCRIPTION
## Every topology request re-added up numbers that had not changed

Placement ranks candidate servers on three figures derived from what each server last reported: total keys, total memory, and the worst serving state among its shards. `build_shards` computed all three from scratch, inside the request:

```rust
let key_count    = server.shard_loads.iter().map(|l| l.key_count).sum();
let memory_bytes = server.shard_loads.iter().map(|l| l.memory_bytes).sum();
let shard_state_penalty = server.shard_states.iter().map(...).max();
```

That is every shard of every live server walked three times — twice for the loads, once for the states — on **every topology request**. A hundred servers holding fifty shards each is fifteen thousand iterations per request, producing an answer identical to the previous request's, because the inputs only change when a heartbeat arrives.

## What this changes

The three figures are summarised in `server_heartbeat`, where the lists are written, and stored on the server. The read path reads three numbers.

The work does not get cheaper, it moves: from the path every client and proxy hits, to the path that already had the data in hand and was already touching it.

## The hazard this introduces, and the test for it

Derived state goes stale. If the summary ever stops tracking the report, placement quietly starts choosing servers on old numbers — and nothing looks broken, it just packs badly.

`server_heartbeat` is the only place in the crate that writes `shard_loads` or `shard_states` outside tests, which is what makes summarising there sufficient. Four tests hold it down: a heartbeat summarising what it reported; a **lighter** heartbeat lowering the summary rather than accumulating (otherwise a server that was once busy looks permanently loaded and placement stops sending it anything); an empty report summarising to zero; and the summary surviving a snapshot round trip.

The fifth is the one that matters — placement still preferring the lighter of two servers, end to end through `get_table_topology`. That is the behaviour the summary exists to serve, and the guard that notices if it ever drifts.

## On upgrade

The fields are `#[serde(default)]`, so a server loaded from an older snapshot summarises to zero until its next heartbeat, which is seconds away. During that window it looks unloaded to placement. Worth knowing; not worth a migration.

## Tests

5 new. Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **231 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

---

### These four are a stack, not four independent changes

I cut each branch from the previous one, so they nest: **#193 ⊂ #197 ⊂ #198 ⊂ #200**. Each PR's diff against `main` therefore contains its predecessors, and merging #200 alone takes all four.

They all touch the same read path and two of them touch the same function, so untangling them into independent branches would mean resolving conflicts between them for no reviewing benefit. Reviewing in order — #193, #197, #198, #200 — reads as four separate ideas, which is what they are.

| | what it removes from the topology read path |
|---|---|
| #193 | a `shard_count` factor from retention and placement planning |
| #197 | the exclusive lock from the two hottest reads |
| #198 | per-request re-aggregation of unchanged load data |
| #200 | per-shard re-parsing of unchanged locations, and two allocations per candidate |
