### PR TITLE
Read the side index in one batched call, not one round trip per entry

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -901,6 +901,31 @@ class _TemporalDirectBackendMixin:
         versions.update(str(value) for value in new_versions if str(value))
         return sorted(versions)
 
+    def _read_hash_values_best_effort(
+        self, pairs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], str]:
+        """Read many (key, field) values in ONE call, when the client can.
+
+        Returns only the pairs it actually resolved. The caller falls back to the per-entry read
+        for anything missing, so a partial answer is never mistaken for an empty value -- an empty
+        value here would silently drop the existing refs a merge is supposed to preserve.
+        """
+        if bool(getattr(self, "_native_side_index_assume_fresh", False)):
+            return {}
+        reader = getattr(self._client, "batch_hget", None)
+        if not callable(reader) or not pairs:
+            return {}
+        try:
+            rows = reader([{"key": key, "field": field} for key, field in pairs])
+        except Exception:  # noqa: BLE001 - fall back to the per-entry reads.
+            return {}
+        out: dict[tuple[str, str], str] = {}
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            out[(str(row.get("key") or ""), str(row.get("field") or ""))] = str(row.get("value") or "")
+        return out
+
     def _read_hash_value_best_effort(self, key: str, field: str) -> str:
         if bool(getattr(self, "_native_side_index_assume_fresh", False)):
             return ""
@@ -969,11 +994,24 @@ class _TemporalDirectBackendMixin:
                     if route:
                         route_by_hash_field.setdefault(lookup_key, route)
 
+        # Every existing value below is addressed by a (key, field) pair that is already known,
+        # so they are fetched in ONE call rather than one round trip per merge.
+        prefetch_locator_key = self._context_ref_locator_key()
+        wanted: list[tuple[str, str]] = list(lookup_updates.keys())
+        wanted.extend((prefetch_locator_key, str(ref_hash)) for ref_hash in locator_updates)
+        wanted.extend(placement_updates.keys())
+        prefetched = self._read_hash_values_best_effort(wanted) if wanted else {}
+
+        def existing_for(key: str, field: str) -> str:
+            """The stored value: from the batch when it covered this pair, per-entry otherwise."""
+            hit = prefetched.get((key, field))
+            return hit if hit is not None else self._read_hash_value_best_effort(key, field)
+
         entries: list[Json] = []
         for (key, field), update in lookup_updates.items():
             new_refs = update.get("ref_hashes", []) if isinstance(update, dict) else []
             new_buckets = update.get("posting_buckets", set()) if isinstance(update, dict) else set()
-            existing_value = self._read_hash_value_best_effort(key, field)
+            existing_value = existing_for(key, field)
             merged_refs = self._merge_ref_hashes(existing_value, new_refs)
             existing_buckets: set[int] = set()
             if existing_value:
@@ -1011,7 +1049,7 @@ class _TemporalDirectBackendMixin:
         locator_key = self._context_ref_locator_key()
         for ref_hash, new_locations in locator_updates.items():
             field = str(ref_hash)
-            merged_locations = self._merge_ref_locations(self._read_hash_value_best_effort(locator_key, field), new_locations)
+            merged_locations = self._merge_ref_locations(existing_for(locator_key, field), new_locations)
             entries.append(
                 {
                     "key": locator_key,
@@ -1023,7 +1061,7 @@ class _TemporalDirectBackendMixin:
         for (key, field), update in placement_updates.items():
             new_locations = update.get("locations", []) if isinstance(update, dict) else []
             new_versions = update.get("resource_versions", set()) if isinstance(update, dict) else set()
-            existing_value = self._read_hash_value_best_effort(key, field)
+            existing_value = existing_for(key, field)
             merged_locations = self._merge_ref_locations(existing_value, new_locations)
             merged_versions = self._merge_resource_versions(existing_value, new_versions if isinstance(new_versions, set) else set())
             entries.append(

--- a/tools/test_side_index_batch_read.py
+++ b/tools/test_side_index_batch_read.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The side index reads its existing values in one batched call, and never mistakes a miss for one.
+
+Rebuilding the three side-index maps used to read each existing value with its own `hget`: 47 of
+them for a single steady-state ingest, the majority of that ingest's engine traffic, each a round
+trip holding the shared proxy lane.
+
+The dangerous failure mode is not slowness, it is silence. These merges fold NEW refs into the
+EXISTING value, so a batch that quietly returns "" for a pair it did not resolve does not error --
+it drops every posting already stored under that key, and retrieval simply stops finding older
+memories. So the batch is only ever allowed to supply pairs it actually returned; anything else
+falls back to the per-entry read.
+"""
+import unittest
+
+try:
+    from tools import matrixark_temporal_direct_backend as backend
+except ImportError:  # run from tools/ dir
+    import matrixark_temporal_direct_backend as backend
+
+
+class _Client:
+    _NO_OVERRIDE = object()
+
+    def __init__(self, stored, *, batch=True, raises=False, returns=_NO_OVERRIDE):
+        self.stored = stored
+        self.raises = raises
+        self.returns = returns
+        self.hget_calls = []
+        self.batch_calls = []
+        if not batch:
+            self.batch_hget = None
+
+    def hget(self, key, field):
+        self.hget_calls.append((key, field))
+        return self.stored.get((key, field), "")
+
+    def batch_hget(self, entries):
+        self.batch_calls.append(list(entries))
+        if self.raises:
+            raise RuntimeError("engine unreachable")
+        # A sentinel, not None: a None response is itself a case worth testing, and a None
+        # default would make it indistinguishable from "no override".
+        if self.returns is not _Client._NO_OVERRIDE:
+            return self.returns
+        return [
+            {"key": e["key"], "field": e["field"],
+             "value": self.stored.get((e["key"], e["field"]), "")}
+            for e in entries
+        ]
+
+
+def _adapter(client):
+    obj = object.__new__(backend._TemporalDirectBackendMixin)
+    obj._client = client
+    return obj
+
+
+class BatchReadTests(unittest.TestCase):
+    def test_many_pairs_cost_one_call(self):
+        client = _Client({("k", "a"): "1", ("k", "b"): "2", ("j", "c"): "3"})
+        out = _adapter(client)._read_hash_values_best_effort([("k", "a"), ("k", "b"), ("j", "c")])
+        self.assertEqual({("k", "a"): "1", ("k", "b"): "2", ("j", "c"): "3"}, out)
+        self.assertEqual(1, len(client.batch_calls))
+        self.assertEqual([], client.hget_calls)
+
+    def test_a_client_without_the_batch_read_returns_nothing_to_use(self):
+        """Empty map, not empty values: the caller then reads each pair the old way."""
+        client = _Client({("k", "a"): "1"}, batch=False)
+        self.assertEqual({}, _adapter(client)._read_hash_values_best_effort([("k", "a")]))
+
+    def test_a_failing_batch_returns_nothing_to_use(self):
+        client = _Client({("k", "a"): "1"}, raises=True)
+        self.assertEqual({}, _adapter(client)._read_hash_values_best_effort([("k", "a")]))
+
+    def test_pairs_the_batch_did_not_return_are_absent_rather_than_empty(self):
+        """The pair must fall through to a real read, not be merged against ''."""
+        client = _Client({("k", "a"): "1", ("k", "b"): "2"},
+                         returns=[{"key": "k", "field": "a", "value": "1"}])
+        out = _adapter(client)._read_hash_values_best_effort([("k", "a"), ("k", "b")])
+        self.assertIn(("k", "a"), out)
+        self.assertNotIn(("k", "b"), out,
+                         "an unreturned pair must not appear as an empty value")
+
+    def test_a_junk_response_yields_nothing_to_use(self):
+        for junk in ("not a list", None, [None, 7, "x"]):
+            with self.subTest(junk=junk):
+                client = _Client({}, returns=junk)
+                self.assertEqual({}, _adapter(client)._read_hash_values_best_effort([("k", "a")]))
+
+    def test_no_pairs_means_no_call(self):
+        client = _Client({})
+        self.assertEqual({}, _adapter(client)._read_hash_values_best_effort([]))
+        self.assertEqual([], client.batch_calls)
+
+    def test_assume_fresh_skips_the_read_entirely(self):
+        """The existing fast path: when the index is known fresh, nothing needs reading."""
+        client = _Client({("k", "a"): "1"})
+        adapter = _adapter(client)
+        adapter._native_side_index_assume_fresh = True
+        self.assertEqual({}, adapter._read_hash_values_best_effort([("k", "a")]))
+        self.assertEqual([], client.batch_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_side_index_merge.py
+++ b/tools/test_side_index_merge.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The side index ACCUMULATES: a new write must not erase what earlier writes stored there.
+
+The batched read exists to stop an ingest costing one round trip per side-index entry. Its danger
+is silent: these rows are built by merging new refs into the EXISTING value, so a read that returns
+"" where a value exists does not fail -- it drops every posting already under that key.
+
+A retrieval check cannot catch that. It was tried: with the bug deliberately injected, five facts
+were still all recalled, because retrieval does not depend on these rows for that workload. So the
+rows themselves are asserted here, against a client that HAS the earlier value stored.
+"""
+import json
+import unittest
+
+try:
+    from tools import matrixark_temporal_direct_backend as backend
+except ImportError:  # run from tools/ dir
+    import matrixark_temporal_direct_backend as backend
+
+PREFIX = "matrixark:mcp"
+SCOPE_KEY = "t=11|u=22|s=33|"
+
+
+class _Client:
+    """A client whose hash already holds the side-index rows an earlier ingest wrote."""
+
+    def __init__(self, stored, *, batch=True):
+        self.stored = dict(stored)
+        self.batch_calls = 0
+        self.hget_calls = 0
+        if not batch:
+            self.batch_hget = None
+
+    def hget(self, key, field):
+        self.hget_calls += 1
+        return self.stored.get((key, field), "")
+
+    def batch_hget(self, entries):
+        self.batch_calls += 1
+        return [
+            {"key": e["key"], "field": e["field"],
+             "value": self.stored.get((e["key"], e["field"]), "")}
+            for e in entries
+        ]
+
+
+def _adapter(client):
+    obj = object.__new__(backend._TemporalDirectBackendMixin)
+    obj._client = client
+    obj._storage_prefix = PREFIX
+    return obj
+
+
+def _index_record(ref_hash):
+    return {
+        "record_type": "context_index",
+        "index_name": "text",
+        "scope_key": SCOPE_KEY,
+        "ref_hash": ref_hash,
+        "ref_hashes": [ref_hash],
+        "node_hash": 909,
+        "posting_bucket": 1,
+    }
+
+
+def _entries_by_key(entries):
+    return {(row["key"], row["field"]): row for row in entries}
+
+
+class SideIndexMergeTests(unittest.TestCase):
+    def setUp(self):
+        self.locator_key = f"{PREFIX}:context_ref_locator"
+        self.existing_locator = json.dumps(
+            {"locations": [{"key": "recs:000000", "field": "00000000000000000001"}]})
+
+    def _run(self, client, ref_hash=777):
+        bundle = [_index_record(ref_hash)]
+        return _adapter(client)._native_side_index_entries_for_bundles(
+            [(bundle, "recs:000000", "00000000000000000002")])
+
+    def test_an_earlier_location_survives_a_later_write(self):
+        """The regression the batched read could cause: the stored location must still be there."""
+        client = _Client({(self.locator_key, "777"): self.existing_locator})
+        rows = _entries_by_key(self._run(client))
+        locations = json.loads(rows[(self.locator_key, "777")]["value"])["locations"]
+        fields = {loc.get("field") for loc in locations}
+        self.assertIn("00000000000000000001", fields, "the earlier location was dropped")
+        self.assertIn("00000000000000000002", fields, "the new location was not added")
+
+    def test_the_existing_value_is_read_through_the_batch(self):
+        client = _Client({(self.locator_key, "777"): self.existing_locator})
+        self._run(client)
+        self.assertEqual(1, client.batch_calls)
+        self.assertEqual(0, client.hget_calls, "the batch should have covered every pair")
+
+    def test_a_client_without_the_batch_read_still_accumulates(self):
+        """The fallback path has to preserve the earlier location too."""
+        client = _Client({(self.locator_key, "777"): self.existing_locator}, batch=False)
+        rows = _entries_by_key(self._run(client))
+        locations = json.loads(rows[(self.locator_key, "777")]["value"])["locations"]
+        self.assertIn("00000000000000000001", {loc.get("field") for loc in locations})
+        self.assertGreater(client.hget_calls, 0)
+
+    def test_an_index_lookup_row_keeps_the_refs_already_stored(self):
+        lookup_key = f"{PREFIX}:context_index_lookup:{backend.stable_hash(SCOPE_KEY)}"
+        client = _Client({
+            (lookup_key, "text"): json.dumps({"ref_hashes": [111], "posting_buckets": [1]}),
+        })
+        rows = _entries_by_key(self._run(client, ref_hash=222))
+        stored = json.loads(rows[(lookup_key, "text")]["value"])
+        self.assertIn(111, stored["ref_hashes"], "an earlier ref was dropped from the lookup row")
+        self.assertIn(222, stored["ref_hashes"], "the new ref was not added")
+
+    def test_nothing_stored_yet_is_not_treated_as_a_failure(self):
+        client = _Client({})
+        rows = _entries_by_key(self._run(client))
+        locations = json.loads(rows[(self.locator_key, "777")]["value"])["locations"]
+        self.assertEqual(["00000000000000000002"], [loc.get("field") for loc in locations])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every ingest rebuilds three side-index maps -- the index lookup, the ref locator and the placement
lookup -- and each merge read its existing value with its own `hget`. Instrumented at the client's
single call funnel, ONE steady-state ingest cost:

    47 hget                             nearly all from the side-index rebuild
    17 matrixark_batch_append_records
     7 hset
     6 scan_hash
     ...                                82 engine round trips in total

The reads alone were most of an ingest's engine traffic, and each one holds the single shared proxy
lane while it runs.

The client already exposes `batch_hget`; this builder never used it. Every value it needs is
addressed by a (key, field) pair known before any of them is read, so they are collected first,
fetched in one call, and the merges read from that map.

    47 hget  ->  4 hget + 9 batch_hget
    82 engine round trips per ingest  ->  48

Deliberately NOT `hgetall` per key: the ref locator is one store-wide hash keyed by every ref hash
ever written, so fetching all of it to answer a dozen fields would trade a bounded cost for an
unbounded one.

A pair the batch does not return is treated as ABSENT, not as an empty value, and falls through to
the per-entry read. That distinction is the whole safety story: these rows are built by merging new
refs into the existing value, so a read that yields "" where a value exists does not fail -- it
silently drops every posting already stored under that key.

Which is exactly why the obvious test is not enough. A retrieval check -- write five facts, ask for
the first -- was tried with that bug deliberately injected and still passed all five, because
retrieval does not depend on these rows for that workload. The rows themselves are asserted
instead: with an earlier location already stored, the rebuilt row must contain BOTH it and the new
one. With the bug injected those tests fail; without it they pass.

12 tests: the merge accumulating on both the batched and the fallback path, the index-lookup row
keeping refs it already held, an empty store not being treated as a failure, and the batch reader's
own edges -- no batch client, a raising batch, a partial response, junk responses, no pairs, and
the assume-fresh fast path.

Note this changes matrixark_temporal_direct_backend.py, the copy the live adapter uses. There is a
second, unreferenced implementation of the same function in matrixark_mcp_native_side_index.py;
patching that one changes nothing at runtime.

The five memory suites are green and live conformance is 22/22.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
