### PR TITLE
meta: stop rebuilding per-request what does not change between requests

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4900,6 +4900,7 @@ mod tests {
                 node_id: index as u64 + 1,
                 location: location.to_string(),
                 binary_version: "v1".to_string(),
+                numa_nodes: Vec::new(),
             });
         }
         meta.add_namespace(AddNamespaceRequest {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4878,6 +4878,75 @@ mod tests {
     }
 
     #[test]
+    fn every_shard_of_a_table_is_spread_across_domains() {
+        // The parsed locations are now indexed rather than re-derived inside
+        // the placement loop, so they have to stay lined up with the candidate
+        // list they were built from. If an index slipped, the separation check
+        // would be reading some other server's location and replicas would
+        // start landing in the same domain -- which is precisely what the
+        // ladder exists to prevent, and it would fail silently.
+        let meta = SingleNodeMeta::default();
+        for (index, (addr, location)) in [
+            ("node-a", "east/zone-a"),
+            ("node-b", "east/zone-b"),
+            ("node-c", "west/zone-c"),
+            ("node-d", "west/zone-d"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            meta.register_server(RegisterServerRequest {
+                server_addr: addr.to_string(),
+                node_id: index as u64 + 1,
+                location: location.to_string(),
+                binary_version: "v1".to_string(),
+            });
+        }
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "ns".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            first_shard_id: 1,
+            shard_count: 4,
+            replica_count: 2,
+            partition_version: 0,
+            serving_options: TableServingOptions::default(),
+        });
+
+        let topology = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "orders".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert_eq!(topology.shards.len(), 4);
+        for shard in topology.shards {
+            assert_eq!(shard.replicas.len(), 2, "shard {} under-replicated", shard.shard_id);
+            let domains = shard
+                .replica_endpoints
+                .iter()
+                .map(|endpoint| {
+                    endpoint
+                        .location
+                        .split('/')
+                        .next()
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect::<std::collections::BTreeSet<_>>();
+            assert_eq!(
+                domains.len(),
+                2,
+                "shard {} put both replicas in one domain: {:?}",
+                shard.shard_id,
+                shard.replicas
+            );
+        }
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -24,10 +24,17 @@ pub(super) fn build_shards(
     table: &TableMetaInfo,
     client_location: &str,
 ) -> Vec<TableShard> {
+    /// A server being considered for a shard, borrowed from the metadata
+    /// rather than copied out of it.
+    ///
+    /// These used to own their two strings, which is two heap allocations per
+    /// live server on every topology request, for values dropped when the
+    /// request ends. The state is read-locked for the whole of this function,
+    /// so borrowing is sound and the copies bought nothing.
     #[derive(Debug)]
-    struct PlacementCandidate {
-        server_addr: String,
-        location: String,
+    struct PlacementCandidate<'a> {
+        server_addr: &'a str,
+        location: &'a str,
         degraded: bool,
         queue_depth: usize,
         background_queue_depth: usize,
@@ -45,8 +52,8 @@ pub(super) fn build_shards(
         .filter(|server| server.state == MetaEntityState::Normal)
         .map(|server| {
             PlacementCandidate {
-                server_addr: server.server_addr.clone(),
-                location: server.location.clone(),
+                server_addr: server.server_addr.as_str(),
+                location: server.location.as_str(),
                 degraded: !server.runtime_load.degraded_reasons.is_empty(),
                 queue_depth: server.runtime_load.queue_depth,
                 background_queue_depth: server.runtime_load.background_queue_depth,
@@ -70,7 +77,7 @@ pub(super) fn build_shards(
             left.dirty_shard_count,
             left.key_count,
             left.memory_bytes,
-            &left.server_addr,
+            left.server_addr,
         )
             .cmp(&(
                 right.degraded,
@@ -82,15 +89,18 @@ pub(super) fn build_shards(
                 right.dirty_shard_count,
                 right.key_count,
                 right.memory_bytes,
-                &right.server_addr,
+                right.server_addr,
             ))
     });
     // Every live server's parsed location, used to size the separation ladder.
     let candidate_locations = normal_servers
         .iter()
-        .map(|candidate| Location::parse(&candidate.location))
+        .map(|candidate| Location::parse(candidate.location))
         .collect::<Vec<_>>();
     let caller = Location::parse(client_location);
+    // Derived from the candidate locations alone, so it is the same for every
+    // shard of this table. It was being rebuilt per shard.
+    let ladder = separation_ladder(&candidate_locations);
     let bucket_count = 1_u64 << 30;
     let mut shards = Vec::new();
     for offset in 0..table.shard_count {
@@ -148,7 +158,7 @@ pub(super) fn build_shards(
         // nothing qualifies. Comparing whole location strings, as this used to,
         // treats two racks in one availability unit as "different locations" and
         // happily puts both replicas of a shard inside it.
-        for separation in separation_ladder(&candidate_locations) {
+        for &separation in &ladder {
             if replicas.len() >= table.replica_count as usize {
                 break;
             }
@@ -156,7 +166,7 @@ pub(super) fn build_shards(
                 if replicas.len() >= table.replica_count as usize {
                     break;
                 }
-                if seen_replicas.contains(&candidate.server_addr) {
+                if seen_replicas.contains(candidate.server_addr) {
                     continue;
                 }
                 // Parsed once, above, into candidate_locations. This scan runs
@@ -167,7 +177,7 @@ pub(super) fn build_shards(
                 if !separated_from(&placed_locations, candidate_location, separation) {
                     continue;
                 }
-                let host = server_host(&candidate.server_addr);
+                let host = server_host(candidate.server_addr);
                 if !host.is_empty() && used_hosts.contains(&host) {
                     continue;
                 }
@@ -180,7 +190,7 @@ pub(super) fn build_shards(
                     &mut seen_replicas,
                     &mut used_locations,
                     &mut used_hosts,
-                    &candidate.server_addr,
+                    candidate.server_addr,
                 );
             }
         }
@@ -194,7 +204,7 @@ pub(super) fn build_shards(
                 &mut seen_replicas,
                 &mut used_locations,
                 &mut used_hosts,
-                &candidate.server_addr,
+                candidate.server_addr,
             );
         }
         let primary = match state.shards.get(&shard_id) {


### PR DESCRIPTION
## The placement loop re-derived a value it had already computed

`build_shards` parses every live server's location once, up front, into `candidate_locations`. Then, inside the loop that actually places replicas, it parsed the same strings again:

```rust
for separation in separation_ladder(&candidate_locations) {
    for candidate in &normal_servers {
        ...
        let candidate_location = Location::parse(&candidate.location);
```

Parsing a location splits a string and allocates a `Vec<String>`. That was happening **once per candidate, per rung of the separation ladder, per shard in the table** — for a value that is identical every time, and that was already sitting in a vector built from the same list, in the same order.

A hundred-shard table across a hundred servers with a three-rung ladder is thirty thousand parses and thirty thousand vector allocations, to produce a hundred distinct answers.

The ladder itself was rebuilt per shard too, from the same unchanging input.

## What this changes

Both are computed once for the table. The loop indexes into the parsed locations instead of re-deriving them. No behaviour change — this is loop-invariant work being hoisted out of a loop.

## Why the existing tests are the evidence

There is nothing new to test here: if the output changed, the change would be wrong. The 231 tests that covered placement before cover it unchanged after.

What *is* worth a new test is the one way this can break. The parsed locations are now reached **by index**, so they have to stay lined up with the candidate list they were built from — and that list is sorted before they are derived. If an index ever slipped, the separation check would be reading some other server's location, replicas would start landing in the same failure domain, and nothing would look broken: the topology would still be well-formed, just quietly unsafe.

So: a four-shard table over four servers in two domains, requiring **every** shard to end up with its two replicas in different domains. That is what the ladder exists to guarantee, and it is what a misaligned index would silently take away.

## Tests

1 new. Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **232 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

---

### These four are a stack, not four independent changes

I cut each branch from the previous one, so they nest: **#193 ⊂ #197 ⊂ #198 ⊂ #200**. Each PR's diff against `main` therefore contains its predecessors, and merging #200 alone takes all four.

They all touch the same read path and two of them touch the same function, so untangling them into independent branches would mean resolving conflicts between them for no reviewing benefit. Reviewing in order — #193, #197, #198, #200 — reads as four separate ideas, which is what they are.

| | what it removes from the topology read path |
|---|---|
| #193 | a `shard_count` factor from retention and placement planning |
| #197 | the exclusive lock from the two hottest reads |
| #198 | per-request re-aggregation of unchanged load data |
| #200 | per-shard re-parsing of unchanged locations, and two allocations per candidate |
