### PR TITLE
Write and read a node embedding by naming the node

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -91,6 +91,7 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ContextUpsertChildRef { .. }
         | Command::ContextQueryChildren { .. }
         | Command::ContextUpsertEmbedding { .. }
+        | Command::ContextSetNodeEmbedding { .. }
         | Command::ContextQueryEmbeddings { .. }
         | Command::ContextTraverseTree { .. }
         | Command::ContextUpsertSummary { .. }
@@ -227,6 +228,12 @@ pub(super) fn context_command_key(command: &Command) -> Option<String> {
             tenant_hash,
             embedding,
         } => Some(context_embedding_key(*tenant_hash, embedding.ref_hash)),
+        // Keyed by the NODE, not by an embedding key -- the vector now lives on the node record.
+        Command::ContextSetNodeEmbedding {
+            tenant_hash,
+            node_hash,
+            ..
+        } => Some(context_node_key(*tenant_hash, *node_hash)),
         Command::ContextQueryEmbeddings {
             tenant_hash,
             ref_hashes,

--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -93,6 +93,7 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ContextUpsertEmbedding { .. }
         | Command::ContextSetNodeEmbedding { .. }
         | Command::ContextQueryEmbeddings { .. }
+        | Command::ContextQueryNodeEmbeddings { .. }
         | Command::ContextTraverseTree { .. }
         | Command::ContextUpsertSummary { .. }
         | Command::ContextQuerySummaries { .. }

--- a/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
+++ b/crates/temporalstore-rust/src/context_workflow/embed_drainer.rs
@@ -279,25 +279,51 @@ pub fn drain_embedding_dirty_once(
                 continue;
             }
         };
+        // Two commands per item: the separate record, and the same vector on the node itself.
+        // Both are written while readers are still on the separate record, so the inline copy
+        // is populated and can be verified before anything depends on it.
         let commands: Vec<Command> = chunk
             .iter()
             .zip(vectors.into_iter())
-            .map(|(item, vector)| Command::ContextUpsertEmbedding {
-                tenant_hash: item.tenant_hash,
-                embedding: ContextEmbedding {
-                    ref_hash: context_embedding_ref_hash(item.tenant_hash, item.node_hash, "node_l0"),
-                    level: 1,
-                    model_hash,
-                    vector,
-                    updated_at_ms,
-                },
+            .flat_map(|(item, vector)| {
+                [
+                    Command::ContextUpsertEmbedding {
+                        tenant_hash: item.tenant_hash,
+                        embedding: ContextEmbedding {
+                            ref_hash: context_embedding_ref_hash(
+                                item.tenant_hash,
+                                item.node_hash,
+                                "node_l0",
+                            ),
+                            level: 1,
+                            model_hash,
+                            vector: vector.clone(),
+                            updated_at_ms,
+                        },
+                    },
+                    Command::ContextSetNodeEmbedding {
+                        tenant_hash: item.tenant_hash,
+                        node_hash: item.node_hash,
+                        model_hash,
+                        vector,
+                        updated_at_ms,
+                    },
+                ]
             })
             .collect();
         let response = engine.batch_execute(BatchExecuteRequest {
             shard_id: config.shard_id,
             commands,
         });
-        for (item, entry) in chunk.iter().zip(response.responses.iter()) {
+        // Responses come back paired with the commands, so step in pairs -- zipping items
+        // against a flat response list would credit one item with another outcome. The pair is
+        // judged by its FIRST entry so this reports exactly what it reported before the inline
+        // write existed; the inline copy is not yet load-bearing.
+        for (item, pair) in chunk.iter().zip(response.responses.chunks(2)) {
+            let Some(entry) = pair.first() else {
+                report.failed += 1;
+                continue;
+            };
             if entry.status.ok {
                 report.embedded += 1;
                 if clear_marker(
@@ -445,6 +471,44 @@ mod tests {
         }
     }
 
+    /// The vector as carried by the separate record.
+    fn embedding_vector(engine: &TemporalEngine, tenant_hash: u64, node_hash: u64) -> Vec<f32> {
+        let ref_hash = context_embedding_ref_hash(tenant_hash, node_hash, "node_l0");
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddings {
+                tenant_hash,
+                ref_hashes: vec![ref_hash],
+                limit: Some(1),
+            },
+        });
+        match response.response {
+            CommandResponse::ContextEmbeddings { embeddings } => embeddings
+                .into_iter()
+                .next()
+                .map(|e| e.vector)
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// The vector as carried by the node itself, rather than by the separate record.
+    fn inline_vector(engine: &TemporalEngine, tenant_hash: u64, node_hash: u64) -> Vec<f32> {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextGetNode {
+                tenant_hash,
+                node_hash,
+            },
+        });
+        match response.response {
+            CommandResponse::ContextNode { node, .. } => {
+                node.map(|node| node.vector).unwrap_or_default()
+            }
+            _ => Vec::new(),
+        }
+    }
+
     fn has_embedding(engine: &TemporalEngine, tenant_hash: u64, node_hash: u64) -> bool {
         let ref_hash = context_embedding_ref_hash(tenant_hash, node_hash, "node_l0");
         let response = engine.execute(ExecuteRequest {
@@ -586,6 +650,20 @@ mod tests {
         // Every node now has an embedding and no marker remains.
         for (tenant, node, _) in nodes {
             assert!(has_embedding(&engine, tenant, node), "node {node} not embedded");
+        }
+
+        // ...and the same vector is on the node itself. Written together on purpose: while the
+        // separate record is still what readers use, this is the only thing proving the inline
+        // copy is actually being populated and agrees with it -- checking it later, after
+        // readers have switched, would be checking it too late to matter.
+        for (tenant, node, _) in nodes {
+            let inline = inline_vector(&engine, tenant, node);
+            assert!(!inline.is_empty(), "node {node} has no vector of its own");
+            let separate = embedding_vector(&engine, tenant, node);
+            assert_eq!(
+                separate, inline,
+                "node {node}: the record and the node disagree about its vector"
+            );
         }
         assert_eq!(count_pending(&engine), 0);
 

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -179,6 +179,13 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
             node_hash,
             ..
         } => vec![context_node_key(*tenant_hash, *node_hash)],
+        Command::ContextQueryNodeEmbeddings {
+            tenant_hash,
+            node_hashes,
+        } => node_hashes
+            .iter()
+            .map(|node_hash| context_node_key(*tenant_hash, *node_hash))
+            .collect(),
         Command::ContextUpsertSummary {
             tenant_hash,
             summary,

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -174,6 +174,11 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
             tenant_hash,
             embedding,
         } => vec![context_embedding_key(*tenant_hash, embedding.ref_hash)],
+        Command::ContextSetNodeEmbedding {
+            tenant_hash,
+            node_hash,
+            ..
+        } => vec![context_node_key(*tenant_hash, *node_hash)],
         Command::ContextUpsertSummary {
             tenant_hash,
             summary,
@@ -288,6 +293,7 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ContextUpsertEntity { .. }
             | Command::ContextUpsertChildRef { .. }
             | Command::ContextUpsertEmbedding { .. }
+            | Command::ContextSetNodeEmbedding { .. }
             | Command::ContextUpsertSummary { .. }
             | Command::ContextWriteCompressionEvent { .. }
             | Command::ContextCompressEvents { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1502,6 +1502,65 @@ pub(crate) fn execute_on_shard(
             }
             CommandResponse::HashEntries { entries }
         }
+        Command::ContextSetNodeEmbedding {
+            tenant_hash,
+            node_hash,
+            model_hash,
+            vector,
+            updated_at_ms,
+        } => {
+            // Read-modify-write of the node record. The vector rides along with the node from
+            // here on, so a reader that has fetched the node has already paid for the vector --
+            // no second key, no second block, and no hash to invert.
+            let object_key = context_node_key(tenant_hash, node_hash);
+            let existing = shard
+                .hashes
+                .get(&object_key)
+                .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
+                .or_else(|| shard.context_nodes.get(&object_key))
+                .and_then(|address| {
+                    read_page_bytes(cache, page_store, shard_id, address)
+                        .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
+                });
+            match existing {
+                // No node to attach to. Writing a placeholder here would invent a node that
+                // ingest never created, so report it rather than fabricate one.
+                None => CommandResponse::ContextObjectKey {
+                    object_key: String::new(),
+                },
+                Some(mut node) => {
+                    node.vector = vector;
+                    node.embedding_model_hash = model_hash;
+                    node.embedding_updated_at_ms = updated_at_ms;
+                    let object_id = stable_page_object_id(
+                        shard_id,
+                        "hash",
+                        &object_key,
+                        Some(CONTEXT_NODE_FIELD),
+                    );
+                    let routing_bucket =
+                        page_routing_bucket(&object_key, start_routing_bucket, end_routing_bucket);
+                    if let Ok(address) = append_value(
+                        cache,
+                        page_store,
+                        shard_id,
+                        &context_bytes(&node),
+                        Some(object_id),
+                        Some(routing_bucket),
+                        async_storage,
+                    ) {
+                        shard
+                            .hashes
+                            .entry(object_key.clone())
+                            .or_default()
+                            .insert(CONTEXT_NODE_FIELD.to_string(), address);
+                        mutated = true;
+                    }
+                    invalidate_record_all(cache, shard_id, &object_key);
+                    CommandResponse::ContextObjectKey { object_key }
+                }
+            }
+        }
         Command::ContextUpsertNode { tenant_hash, node } => {
             let object_key = context_node_key(tenant_hash, node.node_hash);
             let object_id =

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1502,6 +1502,35 @@ pub(crate) fn execute_on_shard(
             }
             CommandResponse::HashEntries { entries }
         }
+        Command::ContextQueryNodeEmbeddings {
+            tenant_hash,
+            node_hashes,
+        } => {
+            // One node read per hash, and the vector comes back with it -- where the separate
+            // record meant a second lookup per node on top of the node read retrieval does
+            // anyway.
+            let embeddings = dedupe_nonzero_u64_preserve_order(node_hashes)
+                .into_iter()
+                .take(context_limit(None))
+                .filter_map(|node_hash| {
+                    let object_key = context_node_key(tenant_hash, node_hash);
+                    let node = shard
+                        .hashes
+                        .get(&object_key)
+                        .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
+                        .or_else(|| shard.context_nodes.get(&object_key))
+                        .and_then(|address| {
+                            read_page_bytes(cache, page_store, shard_id, address)
+                                .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
+                        })?;
+                    if node.vector.is_empty() {
+                        return None;
+                    }
+                    Some((node_hash, node.vector))
+                })
+                .collect();
+            CommandResponse::ContextNodeEmbeddings { embeddings }
+        }
         Command::ContextSetNodeEmbedding {
             tenant_hash,
             node_hash,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -2575,3 +2575,181 @@ fn string_get_uses_memory_cache() {
     assert!(stats.memory_hits >= 1);
     assert!(stats.puts >= 2);
 }
+
+// shared-corpus: context_node_inline_embedding
+#[test]
+fn a_node_embedding_lands_on_the_node_itself() {
+    // Addressing the write by the node is the whole point: the old ref hash of
+    // (tenant, owner, level) is one-way, so a vector written under it could only ever be
+    // found again by recomputing that hash from an owner someone already had in hand.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 4242;
+    const NODE: u64 = 77;
+
+    let node = ContextNode {
+        node_hash: NODE,
+        parent_hash: 0,
+        kind: 1,
+        canonical_name: "session/with-a-vector".to_string(),
+        l0: "the text this node is about".to_string(),
+        status: 0,
+        last_event_time_ms: 0,
+        summary_dirty: false,
+        l1_ref: String::new(),
+        raw_metadata_ref: String::new(),
+        vector: Vec::new(),
+        embedding_model_hash: 0,
+        embedding_updated_at_ms: 0,
+    };
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertNode {
+            tenant_hash: TENANT,
+            node,
+        },
+    });
+
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextSetNodeEmbedding {
+            tenant_hash: TENANT,
+            node_hash: NODE,
+            model_hash: 909,
+            vector: vec![0.25, 0.5, -0.75],
+            updated_at_ms: 1_781_000_000_000,
+        },
+    });
+
+    let fetched = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextGetNode {
+            tenant_hash: TENANT,
+            node_hash: NODE,
+        },
+    });
+    let CommandResponse::ContextNode { node, .. } = fetched.response else {
+        panic!("expected ContextNode");
+    };
+    let node = node.expect("the node must still be there");
+    assert_eq!(vec![0.25, 0.5, -0.75], node.vector, "vector did not reach the node");
+    assert_eq!(909, node.embedding_model_hash);
+    assert_eq!(1_781_000_000_000, node.embedding_updated_at_ms);
+    // The rest of the node must survive a write that only meant to attach a vector.
+    assert_eq!("session/with-a-vector", node.canonical_name);
+    assert_eq!("the text this node is about", node.l0);
+    assert_eq!(1, node.kind);
+}
+
+// shared-corpus: context_node_inline_embedding_replaces
+#[test]
+fn re_embedding_a_node_replaces_the_vector_rather_than_accumulating() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 4243;
+    const NODE: u64 = 78;
+
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertNode {
+            tenant_hash: TENANT,
+            node: ContextNode {
+                node_hash: NODE,
+                parent_hash: 0,
+                kind: 1,
+                canonical_name: "n".to_string(),
+                l0: "text".to_string(),
+                status: 0,
+                last_event_time_ms: 0,
+                summary_dirty: false,
+                l1_ref: String::new(),
+                raw_metadata_ref: String::new(),
+                vector: Vec::new(),
+                embedding_model_hash: 0,
+                embedding_updated_at_ms: 0,
+            },
+        },
+    });
+    for (model, vector, at) in [
+        (1_u64, vec![1.0_f32, 0.0], 1_781_000_000_000_u64),
+        (2, vec![0.0, 1.0], 1_781_000_000_500),
+    ] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: TENANT,
+                node_hash: NODE,
+                model_hash: model,
+                vector,
+                updated_at_ms: at,
+            },
+        });
+    }
+    let fetched = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextGetNode {
+            tenant_hash: TENANT,
+            node_hash: NODE,
+        },
+    });
+    let CommandResponse::ContextNode { node, .. } = fetched.response else {
+        panic!("expected ContextNode");
+    };
+    let node = node.expect("node must exist");
+    assert_eq!(vec![0.0, 1.0], node.vector, "the newer vector must win outright");
+    assert_eq!(2, node.embedding_model_hash);
+    assert_eq!(1_781_000_000_500, node.embedding_updated_at_ms);
+}
+
+// shared-corpus: context_node_inline_embedding_no_node
+#[test]
+fn an_embedding_for_a_node_that_does_not_exist_is_refused_not_invented() {
+    // Writing a placeholder node here would put a node into the tree that ingest never
+    // created -- a node with a vector, no name and no text, which retrieval would then score.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextSetNodeEmbedding {
+            tenant_hash: 4244,
+            node_hash: 999,
+            model_hash: 1,
+            vector: vec![1.0],
+            updated_at_ms: 1_781_000_000_000,
+        },
+    });
+    let CommandResponse::ContextObjectKey { object_key } = response.response else {
+        panic!("expected ContextObjectKey");
+    };
+    assert!(object_key.is_empty(), "no node means nothing was written");
+
+    let fetched = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextGetNode {
+            tenant_hash: 4244,
+            node_hash: 999,
+        },
+    });
+    let CommandResponse::ContextNode { node, .. } = fetched.response else {
+        panic!("expected ContextNode");
+    };
+    assert!(node.is_none(), "a node must not be conjured by embedding it");
+}

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -2753,3 +2753,184 @@ fn an_embedding_for_a_node_that_does_not_exist_is_refused_not_invented() {
     };
     assert!(node.is_none(), "a node must not be conjured by embedding it");
 }
+
+// shared-corpus: context_node_inline_embedding_query
+#[test]
+fn node_vectors_can_be_asked_for_by_owner() {
+    // The read that the separate record could never offer. ContextQueryEmbeddings is keyed by a
+    // hash of (tenant, owner, level), so a caller must already hold every owner just to build
+    // the keys, and the reply cannot say which owner each vector came from -- the caller has to
+    // rebuild that mapping itself. Asking by node returns the pairing directly.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 5150;
+
+    for (node_hash, vector) in [(1_u64, vec![1.0_f32, 0.0]), (2, vec![0.0, 1.0]), (3, vec![])] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: format!("n{node_hash}"),
+                    l0: format!("text {node_hash}"),
+                    status: 0,
+                    last_event_time_ms: 0,
+                    summary_dirty: false,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+        if !vector.is_empty() {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextSetNodeEmbedding {
+                    tenant_hash: TENANT,
+                    node_hash,
+                    model_hash: 5,
+                    vector,
+                    updated_at_ms: 1_781_000_000_000,
+                },
+            });
+        }
+    }
+
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextQueryNodeEmbeddings {
+            tenant_hash: TENANT,
+            node_hashes: vec![1, 2, 3, 4],
+        },
+    });
+    let CommandResponse::ContextNodeEmbeddings { embeddings } = response.response else {
+        panic!("expected ContextNodeEmbeddings");
+    };
+
+    // Node 3 exists but was never embedded, and node 4 does not exist at all. Both are omitted
+    // rather than returned as an empty vector, so "not embedded yet" stays distinguishable from
+    // "embedded to zeros" -- a caller that cannot tell them apart scores an un-embedded node as
+    // maximally dissimilar instead of falling back to lexical matching.
+    assert_eq!(2, embeddings.len(), "only embedded nodes may come back");
+    let by_node: std::collections::BTreeMap<u64, Vec<f32>> = embeddings.into_iter().collect();
+    assert_eq!(Some(&vec![1.0, 0.0]), by_node.get(&1));
+    assert_eq!(Some(&vec![0.0, 1.0]), by_node.get(&2));
+    assert!(!by_node.contains_key(&3), "an un-embedded node must not appear");
+    assert!(!by_node.contains_key(&4), "a missing node must not appear");
+}
+
+// shared-corpus: context_node_inline_embedding_query_agrees
+#[test]
+fn asking_by_owner_and_by_ref_hash_give_the_same_vector() {
+    // While both paths exist, they must not disagree -- otherwise switching readers over would
+    // silently change what gets scored.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 5151;
+    const NODE: u64 = 9;
+    let vector = vec![0.5_f32, 0.25, -0.125];
+
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertNode {
+            tenant_hash: TENANT,
+            node: ContextNode {
+                node_hash: NODE,
+                parent_hash: 0,
+                kind: 1,
+                canonical_name: "n".to_string(),
+                l0: "text".to_string(),
+                status: 0,
+                last_event_time_ms: 0,
+                summary_dirty: false,
+                l1_ref: String::new(),
+                raw_metadata_ref: String::new(),
+                vector: Vec::new(),
+                embedding_model_hash: 0,
+                embedding_updated_at_ms: 0,
+            },
+        },
+    });
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertEmbedding {
+            tenant_hash: TENANT,
+            embedding: ContextEmbedding {
+                ref_hash: crate::context_workflow::context_embedding_ref_hash(
+                    TENANT, NODE, "node_l0",
+                ),
+                level: 1,
+                model_hash: 5,
+                vector: vector.clone(),
+                updated_at_ms: 1_781_000_000_000,
+            },
+        },
+    });
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextSetNodeEmbedding {
+            tenant_hash: TENANT,
+            node_hash: NODE,
+            model_hash: 5,
+            vector: vector.clone(),
+            updated_at_ms: 1_781_000_000_000,
+        },
+    });
+
+    let by_owner = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryNodeEmbeddings {
+                tenant_hash: TENANT,
+                node_hashes: vec![NODE],
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextNodeEmbeddings { embeddings } => embeddings
+            .into_iter()
+            .next()
+            .map(|(_, vector)| vector)
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let by_ref_hash = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQueryEmbeddings {
+                tenant_hash: TENANT,
+                ref_hashes: vec![crate::context_workflow::context_embedding_ref_hash(
+                    TENANT, NODE, "node_l0",
+                )],
+                limit: Some(1),
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextEmbeddings { embeddings } => embeddings
+            .into_iter()
+            .next()
+            .map(|embedding| embedding.vector)
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    assert_eq!(vector, by_owner);
+    assert_eq!(by_ref_hash, by_owner, "the two read paths disagree");
+}

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -116,6 +116,7 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ContextUpsertEmbedding { .. }
         | Command::ContextSetNodeEmbedding { .. }
         | Command::ContextQueryEmbeddings { .. }
+        | Command::ContextQueryNodeEmbeddings { .. }
         | Command::ContextTraverseTree { .. }
         | Command::ContextUpsertSummary { .. }
         | Command::ContextQuerySummaries { .. }

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -40,6 +40,7 @@ pub(super) fn proxy_command_is_write(command: &Command) -> bool {
             | Command::ContextUpsertEntity { .. }
             | Command::ContextUpsertChildRef { .. }
             | Command::ContextUpsertEmbedding { .. }
+            | Command::ContextSetNodeEmbedding { .. }
             | Command::ContextUpsertSummary { .. }
             | Command::ContextWriteCompressionEvent { .. }
             | Command::ContextCompressEvents { .. }
@@ -113,6 +114,7 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ContextUpsertChildRef { .. }
         | Command::ContextQueryChildren { .. }
         | Command::ContextUpsertEmbedding { .. }
+        | Command::ContextSetNodeEmbedding { .. }
         | Command::ContextQueryEmbeddings { .. }
         | Command::ContextTraverseTree { .. }
         | Command::ContextUpsertSummary { .. }

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1476,6 +1476,20 @@ pub enum Command {
         start_ms: u64,
         end_ms: u64,
     },
+    /// Attach an embedding to the node it describes.
+    ///
+    /// Addressed by the node itself rather than by a hash of (tenant, owner, level). That hash
+    /// is one-way: a writer holding a node can compute it, but nothing holding the result can
+    /// get back to the node, so the vector and the record it describes could only ever be
+    /// re-associated by recomputing the hash from the owner. Naming the owner here is what lets
+    /// the vector live on the record it belongs to.
+    ContextSetNodeEmbedding {
+        tenant_hash: u64,
+        node_hash: u64,
+        model_hash: u64,
+        vector: Vec<f32>,
+        updated_at_ms: u64,
+    },
     ContextUpsertNode {
         tenant_hash: u64,
         node: ContextNode,

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1483,6 +1483,16 @@ pub enum Command {
     /// get back to the node, so the vector and the record it describes could only ever be
     /// re-associated by recomputing the hash from the owner. Naming the owner here is what lets
     /// the vector live on the record it belongs to.
+    /// Vectors for these nodes, read from the nodes themselves.
+    ///
+    /// The counterpart of ContextSetNodeEmbedding: asking by owner is only possible because the
+    /// vector lives on the owner now. ContextQueryEmbeddings cannot answer this -- it is keyed
+    /// by a hash of (tenant, owner, level), so the caller must already know each owner in order
+    /// to rebuild the key, and the reply cannot say which owner it came from.
+    ContextQueryNodeEmbeddings {
+        tenant_hash: u64,
+        node_hashes: Vec<u64>,
+    },
     ContextSetNodeEmbedding {
         tenant_hash: u64,
         node_hash: u64,
@@ -1934,6 +1944,11 @@ pub enum CommandResponse {
         refs: Vec<ContextChildRef>,
         #[serde(default)]
         created: Option<bool>,
+    },
+    /// (node_hash, vector) pairs -- nodes with no vector of their own are omitted, so a caller
+    /// can tell "not embedded yet" from "embedded to the zero vector".
+    ContextNodeEmbeddings {
+        embeddings: Vec<(u64, Vec<f32>)>,
     },
     ContextEmbeddings {
         embeddings: Vec<ContextEmbedding>,


### PR DESCRIPTION
Follow-on to #190, which gave `ContextNode` a place to keep its L0 vector. This wires the write and the read.

### The problem both halves solve

The separate embedding record is addressed by `context_embedding_ref_hash(tenant, owner, level)` -- a hash of those three. It is **one-way**. A writer holding a node can compute it; nothing holding the result can get back to the node. So:

- the engine receiving `ContextUpsertEmbedding` has no idea which record the vector belongs to, and could not attach it even if it wanted to;
- a reader must already hold every owner just to rebuild the keys, and the reply cannot say which owner each vector came from -- which is why retrieval carries a side table from ref hash back to node.

### What lands

**`ContextSetNodeEmbedding`** names the owner. The engine reads the node, sets the vector plus the model that produced it and when, and writes the node back. A reader that has fetched the node has already paid for the vector: no second key, no second block, no hash to invert.

An embedding for a node that does not exist is **refused rather than written** -- a placeholder would put a node into the tree that ingest never made, with a vector, no name and no text, which retrieval would then score.

**`ContextQueryNodeEmbeddings`** asks by owner and answers in pairs. Nodes with no vector of their own are omitted rather than returned empty, so a caller can tell "not embedded yet" from "embedded to zeros" -- one scores as maximally dissimilar, the other should fall back to lexical matching.

**The drainer now dual-writes**: the separate record and the node, in one batch. Responses come back paired with commands, so the per-item accounting steps in pairs -- zipping items against a flat response list would credit one item with another's outcome.

### Classification

Both commands are registered at every site that sorts commands (client keying, validation keying, validated writes, proxy routing), keyed by the node rather than by an embedding key. A command handled only in the engine and missed by those lists takes a different route than the write it replaces -- a failure that shows up as lost writes, not as a compile error. The exhaustive matches are what surfaced all four sites.

### Tests

- the dual-write assertion was **rehearsed against a neutralised dual-write** and failed with "node 1 has no vector of its own", so it observes the behaviour rather than passing vacuously
- the two read paths are asserted to return the same vector for the same node -- while readers are still on the ref-hash path, that is what would catch them drifting before anything is switched over
- 9 related tests pass

Readers are not switched over yet, and nothing is retired. That is the next change.
