### PR TITLE
Share durability barriers between writers, and stop replay and replication from rescanning the log

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -69,6 +69,10 @@ name = "matrixark_rust_metaserver"
 path = "src/bin/matrixark_rust_metaserver.rs"
 
 [[bin]]
+name = "raft_barrier_profile"
+path = "src/bin/raft_barrier_profile.rs"
+
+[[bin]]
 name = "matrixark_rust_datanode"
 path = "src/bin/matrixark_rust_datanode.rs"
 

--- a/crates/temporalstore-rust/src/bin/raft_barrier_profile.rs
+++ b/crates/temporalstore-rust/src/bin/raft_barrier_profile.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Reports where a raft write's durability barriers are actually taken.
+//!
+//! A write costs roughly `barriers x fsync`, and on a three-node cluster it has been measured at
+//! about 5.5 barriers against 2.3 for a single node -- so most of the latency is barriers, and the
+//! question worth answering is which call sites take them. Twice now that question has been
+//! answered by reading the code, a change made on the strength of it, and the change then measured
+//! at exactly zero. This prints the split instead of arguing it.
+//!
+//! Runs in its own process because the counters are process-wide: as a test it would race whatever
+//! else the harness scheduled alongside it.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::path::PathBuf;
+
+use temporalstore_rust::durability_metrics;
+use temporalstore_rust::raft::{AppendEntriesRequest, RaftCluster, RaftConfig, RaftLogEntry};
+use temporalstore_rust::Command;
+
+/// A private directory for one scenario. `tempfile` is a dev-dependency, so this bin makes its
+/// own; the process id keeps concurrent runs from colliding.
+fn scratch(scenario: &str) -> PathBuf {
+    let dir = std::env::temp_dir()
+        .join(format!("ts-barrier-profile-{}-{scenario}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    dir
+}
+
+fn writes() -> u64 {
+    std::env::var("TS_BARRIER_PROFILE_WRITES")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(50)
+}
+
+/// Print one scenario's barrier split, normalised per write. The per-write figure is what
+/// compares against the fdatasync/write numbers measured under strace on a real node.
+fn report(scenario: &str, per: u64, before: BTreeMap<&'static str, u64>) {
+    let after = durability_metrics::snapshot();
+    let mut rows: Vec<(&'static str, u64)> = after
+        .into_iter()
+        .map(|(site, count)| (site, count - before.get(site).copied().unwrap_or(0)))
+        .filter(|(_, count)| *count > 0)
+        .collect();
+    rows.sort_by(|left, right| right.1.cmp(&left.1).then(left.0.cmp(right.0)));
+    let total: u64 = rows.iter().map(|(_, count)| count).sum();
+    println!("\n== {scenario} ==  {per} writes, {total} barriers, {:.3} per write", total as f64 / per as f64);
+    for (site, count) in rows {
+        println!("   {:<34} {:>7}  {:>7.3}/write", site, count, count as f64 / per as f64);
+    }
+}
+
+/// Leader side: what one `propose` costs in barriers once it is durable.
+fn leader_propose(per: u64) {
+    let dir = scratch("leader");
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(&dir, 1, [1, 2, 3], RaftConfig::default())
+            .expect("cluster");
+    // A deployed process owns exactly one node while holding a view of the whole cluster, and
+    // persists only its own record. Left unset -- the in-process default -- it persists a record
+    // per peer instead, so this would report three barriers where a real node takes one, and
+    // every number here would describe a topology nobody runs.
+    cluster.set_local_node_id(1);
+    // Warm up first: the first append creates the file and syncs the parent directory, which is a
+    // one-off that would otherwise be smeared across the average.
+    cluster
+        .propose(Command::StringSet { key: "warmup".into(), value: b"warmup".to_vec() })
+        .expect("warmup propose");
+    let before = durability_metrics::snapshot();
+    for index in 0..per {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("profile-{index:06}"),
+                value: format!("value-{index:06}").into_bytes(),
+            })
+            .expect("propose");
+    }
+    report("leader propose", per, before);
+}
+
+/// Follower side: what accepting one AppendEntries carrying a real entry costs. Measured at about
+/// 74% of a three-node write, so this is the half that matters most.
+///
+/// It must carry entries and advance the indices. An empty heartbeat that repeats the indices
+/// changes nothing the node must persist, so the fingerprint skip correctly elides it and the
+/// scenario reports zero -- true, but not the number anyone came here for.
+fn follower_append(per: u64) {
+    let dir = scratch("follower");
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(&dir, 1, [1, 2, 3], RaftConfig::default())
+            .expect("cluster");
+    // This scenario plays node 2 -- the follower the requests below are addressed to.
+    cluster.set_local_node_id(2);
+    let request = |index: u64| AppendEntriesRequest {
+        rpc: None,
+        shard_id: 1,
+        term: 1,
+        leader_id: 1,
+        target_id: 2,
+        prev_log_index: index,
+        prev_log_term: if index == 0 { 0 } else { 1 },
+        entries: vec![RaftLogEntry {
+            term: 1,
+            index: index + 1,
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("follower-{index:06}"),
+                value: format!("value-{index:06}").into_bytes(),
+            },
+        }],
+        // Commit trails by one, as a real leader's does: it can only report an entry committed
+        // once a majority has already acknowledged it.
+        leader_commit: index,
+    };
+    cluster.receive_append_entries(request(0)).expect("warmup append");
+    let before = durability_metrics::snapshot();
+    for index in 1..=per {
+        cluster.receive_append_entries(request(index)).expect("append");
+    }
+    report("follower append (one entry)", per, before);
+}
+
+/// Many writers at once. This is the case that separates "each write pays its own barrier" from
+/// "writers that arrive while a flush is in flight ride the next one": barriers per write should
+/// FALL as concurrency rises if anything coalesces, and stay flat if nothing does.
+fn concurrent_propose(per: u64, threads: u64) {
+    let dir = scratch(&format!("concurrent-{threads}"));
+    let cluster = Arc::new(
+        RaftCluster::new_single_shard_with_wal(&dir, 1, [1, 2, 3], RaftConfig::default())
+            .expect("cluster"),
+    );
+    cluster.set_local_node_id(1);
+    cluster
+        .propose(Command::StringSet { key: "warmup".into(), value: b"warmup".to_vec() })
+        .expect("warmup propose");
+    let before = durability_metrics::snapshot();
+    let each = per / threads;
+    let handles: Vec<_> = (0..threads)
+        .map(|thread_index| {
+            let cluster = Arc::clone(&cluster);
+            std::thread::spawn(move || {
+                for index in 0..each {
+                    cluster
+                        .propose(Command::StringSet {
+                            key: format!("c-{thread_index:03}-{index:06}"),
+                            value: format!("value-{index:06}").into_bytes(),
+                        })
+                        .expect("propose");
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().expect("writer thread");
+    }
+    report(&format!("concurrent propose (threads={threads})"), each * threads, before);
+}
+
+/// How long replaying a node log takes as it gets longer.
+///
+/// Reported per record, so shape is obvious: flat means replay is linear in the number of
+/// records, doubling means it is quadratic and a long-lived node pays for its whole history every
+/// time it restarts.
+fn recovery_cost() {
+    for records in [2_000u64, 4_000] {
+        let dir = scratch(&format!("recovery-{records}"));
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(&dir, 1, [1, 2, 3], RaftConfig::default())
+                .expect("cluster");
+        cluster.set_local_node_id(1);
+        for index in 0..records {
+            cluster
+                .propose(Command::StringSet {
+                    key: format!("r-{index:07}"),
+                    value: b"v".to_vec(),
+                })
+                .expect("propose");
+        }
+        let wal = temporalstore_rust::raft::LocalRaftWal::new(&dir);
+        let started = std::time::Instant::now();
+        let recovered = wal.recover_node(1, 1).expect("recover");
+        let elapsed = started.elapsed();
+        println!(
+            "   replay {records:>5} records: {:>8.1} ms total, {:>7.3} ms/record  ({} valid)",
+            elapsed.as_secs_f64() * 1000.0,
+            elapsed.as_secs_f64() * 1000.0 / records as f64,
+            recovered.valid_records
+        );
+    }
+}
+
+/// What one write costs on disk, and how much of that is the encoding rather than the data.
+///
+/// Every byte here is paid twice over: once writing it, and again on every replay that has to
+/// parse it back. A text encoding spells out every field name on every record.
+fn wal_format_cost() {
+    let records = 2_000u64;
+    let dir = scratch("format");
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(&dir, 1, [1, 2, 3], RaftConfig::default())
+            .expect("cluster");
+    cluster.set_local_node_id(1);
+    for index in 0..records {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("fmt-{index:06}"),
+                value: b"0123456789".to_vec(),
+            })
+            .expect("propose");
+    }
+    fn dir_bytes(path: &std::path::Path) -> u64 {
+        let mut total = 0;
+        if let Ok(entries) = std::fs::read_dir(path) {
+            for entry in entries.flatten() {
+                let Ok(meta) = entry.metadata() else { continue };
+                if meta.is_dir() {
+                    total += dir_bytes(&entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+        }
+        total
+    }
+    let bytes = dir_bytes(&dir);
+    println!(
+        "   {records} writes produced {bytes} WAL bytes = {:.1} bytes/write",
+        bytes as f64 / records as f64
+    );
+    println!(
+        "   the payload actually written was {} bytes/write (key + value)",
+        "fmt-000000".len() + 10
+    );
+
+    // How much of a record is structure rather than content: strip everything that is a field
+    // name, quote, brace or comma from the encoded form and see what is left.
+    let sample = std::fs::read_dir(dir.join("raft-wal"))
+        .ok()
+        .and_then(|mut entries| entries.find_map(|entry| entry.ok()))
+        .map(|entry| entry.path());
+    if let Some(sample) = sample {
+        fn first_line(path: &std::path::Path) -> Option<Vec<u8>> {
+            if path.is_dir() {
+                let entries = std::fs::read_dir(path).ok()?;
+                for entry in entries.flatten() {
+                    if let Some(found) = first_line(&entry.path()) {
+                        return Some(found);
+                    }
+                }
+                return None;
+            }
+            let data = std::fs::read(path).ok()?;
+            data.split(|byte| *byte == b'\n')
+                .find(|line| !line.is_empty())
+                .map(|line| line.to_vec())
+        }
+        if let Some(line) = first_line(&sample) {
+            let structural = line
+                .iter()
+                .filter(|byte| matches!(byte, b'"' | b'{' | b'}' | b'[' | b']' | b',' | b':'))
+                .count();
+            println!(
+                "   one record is {} bytes, of which {} ({:.0}%) are quotes, braces and separators",
+                line.len(),
+                structural,
+                structural as f64 * 100.0 / line.len() as f64
+            );
+        }
+    }
+}
+
+fn main() {
+    let per = writes();
+    leader_propose(per);
+    follower_append(per);
+    for threads in [1u64, 4, 16] {
+        concurrent_propose(per, threads);
+    }
+    println!("\n== what one write costs on disk ==");
+    wal_format_cost();
+    println!("\n== replay cost as the log grows ==");
+    recovery_cost();
+    println!("\ntotal across scenarios: {}", durability_metrics::report_line());
+}

--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -694,6 +694,7 @@ impl LocalBlockStore {
                     .open(slab_path(&root, page_slab_id))
                 {
                     if file.set_len(readable_prefix).is_ok() {
+                        crate::durability_metrics::record_barrier("block_store_open");
                         let _ = file.sync_all();
                         if let Ok(dir) = File::open(&root) {
                             let _ = dir.sync_all();
@@ -776,6 +777,7 @@ impl LocalBlockStore {
             .saturating_add(1);
         let path = slab_path(&inner.root, new_slab_id);
         let file = File::create(&path)?;
+        crate::durability_metrics::record_barrier("block_store_checkpoint_reserve");
         file.sync_all()?;
         sync_parent_dir(&path)?;
         inner.page_slab_id = new_slab_id;
@@ -1163,6 +1165,7 @@ fn roll_slab_inner(
     {
         let prev_path = slab_path(&inner.root, previous_page_slab_id);
         if let Ok(prev) = OpenOptions::new().append(true).open(&prev_path) {
+            crate::durability_metrics::record_barrier("block_store_slab_roll_prev");
             let _ = prev.sync_data();
         }
     }
@@ -1176,6 +1179,7 @@ fn roll_slab_inner(
     inner.write_offset = 0;
     let path = slab_path(&inner.root, inner.page_slab_id);
     let file = File::create(&path)?;
+    crate::durability_metrics::record_barrier("block_store_slab_roll");
     file.sync_all()?;
     sync_parent_dir(&path)?;
     let transition_unix_ms = now_unix_ms();

--- a/crates/temporalstore-rust/src/durability_metrics.rs
+++ b/crates/temporalstore-rust/src/durability_metrics.rs
@@ -1,0 +1,93 @@
+//! Counts durability barriers by the call site that takes them.
+//!
+//! A write's latency is roughly `barriers x fsync`, so a total barrier count per write says how
+//! much there is to win but not where to go looking. Attributing them by reasoning about the code
+//! has produced confident wrong answers here more than once -- two changes aimed at a suspected
+//! site passed their tests and then moved nothing. Each site reports itself instead, so the split
+//! is measured rather than argued.
+//!
+//! The counters are process-wide and monotonic. A mutex per barrier is free next to an fsync
+//! (microseconds against milliseconds), so this stays on rather than hiding behind a build flag
+//! that would be off exactly when someone needs the numbers.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+fn counters() -> &'static Mutex<BTreeMap<&'static str, u64>> {
+    static COUNTERS: OnceLock<Mutex<BTreeMap<&'static str, u64>>> = OnceLock::new();
+    COUNTERS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Record one durability barrier taken at `site`.
+///
+/// Call this immediately before the `sync_data`/`sync_all` itself, not after: a barrier that
+/// fails still cost the wait, and a site that reports only its successes understates itself.
+pub fn record_barrier(site: &'static str) {
+    if let Ok(mut counts) = counters().lock() {
+        *counts.entry(site).or_insert(0) += 1;
+    }
+}
+
+/// Add `count` to a named tally of work done.
+///
+/// Separate from `record_barrier` only in what it counts: barriers are events, this is a
+/// quantity. Both share the map so a harness reads one place. Used where a cost must be asserted
+/// exactly rather than timed -- on a shared machine a stopwatch measures the other tenants.
+pub fn record_scan(name: &'static str, count: u64) {
+    if let Ok(mut counts) = counters().lock() {
+        *counts.entry(name).or_insert(0) += count;
+    }
+}
+
+/// Every site's total so far, ordered by site name.
+pub fn snapshot() -> BTreeMap<&'static str, u64> {
+    counters()
+        .lock()
+        .map(|counts| counts.clone())
+        .unwrap_or_default()
+}
+
+/// Drop every count. Used by a harness to bracket a measured span.
+pub fn reset() {
+    if let Ok(mut counts) = counters().lock() {
+        counts.clear();
+    }
+}
+
+/// Total barriers across all sites.
+pub fn total() -> u64 {
+    snapshot().values().sum()
+}
+
+/// The counts as `site=count` pairs, busiest first, for a one-line log or report.
+pub fn report_line() -> String {
+    let counts = snapshot();
+    let mut pairs: Vec<(&'static str, u64)> = counts.into_iter().collect();
+    pairs.sort_by(|left, right| right.1.cmp(&left.1).then(left.0.cmp(right.0)));
+    pairs
+        .iter()
+        .map(|(site, count)| format!("{site}={count}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_are_attributed_per_site_and_reset_clears_them() {
+        reset();
+        record_barrier("alpha");
+        record_barrier("alpha");
+        record_barrier("beta");
+        let counts = snapshot();
+        assert_eq!(counts.get("alpha"), Some(&2));
+        assert_eq!(counts.get("beta"), Some(&1));
+        assert_eq!(total(), 3);
+        // Busiest site leads the report so the dominant cost is the first thing read.
+        assert!(report_line().starts_with("alpha=2"));
+        reset();
+        assert_eq!(total(), 0);
+    }
+}

--- a/crates/temporalstore-rust/src/flush_gate.rs
+++ b/crates/temporalstore-rust/src/flush_gate.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Shares one durability barrier between everything that is waiting for one.
+//!
+//! Used by the raft node log and by the index log: both append and fsync per write, and both
+//! had every writer pay for a barrier that would have covered all of them.
+//!
+//! An `fsync` makes every byte already written to the file durable, not just the caller's own, so
+//! a barrier taken while other writers are queued behind it covers them too. Taking one barrier
+//! per writer therefore pays repeatedly for work a single barrier would have done: measured at 1,
+//! 4 and 16 concurrent writers, barriers-per-write stayed flat at exactly 1.0 --
+//! sixteen writers cost sixteen barriers where one would have sufficed.
+//!
+//! The rule here is that at most one barrier is ever in flight per file. A writer that arrives
+//! while one is running does not start a second: it waits, and the next barrier covers it.
+//! Barriers-per-write then falls roughly as 1/concurrency instead of staying flat, while a lone
+//! writer still takes exactly one barrier and waits no longer than it does today.
+//!
+//! Ordering is what makes this safe. A writer registers its ticket only after its `write_all` has
+//! returned, and a barrier claims a target of "every ticket registered so far", so a ticket a
+//! barrier counts is always already in the file. Sequence numbers only increase, so
+//! `durable >= mine` is a complete test for "my bytes are on disk".
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Instant;
+
+/// A writer's claim on a future barrier: "make everything up to here durable".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlushTicket(u64);
+
+#[derive(Debug, Default)]
+struct GateState {
+    /// Tickets handed out so far. Every one of these is already written to the file.
+    issued: u64,
+    /// The highest ticket a completed barrier has covered.
+    durable: u64,
+    /// Whether a barrier is running right now. At most one ever is.
+    in_flight: bool,
+}
+
+/// One file's barrier gate.
+#[derive(Debug, Default)]
+pub struct FlushGate {
+    state: Mutex<GateState>,
+    changed: Condvar,
+}
+
+impl FlushGate {
+    /// Claim a barrier for bytes that have ALREADY been written to the file.
+    ///
+    /// Call this after `write_all` returns and never before: a ticket a barrier can see must
+    /// correspond to bytes that barrier will actually flush.
+    pub fn register_write(&self) -> FlushTicket {
+        let mut state = self.state.lock().expect("wal flush gate poisoned");
+        state.issued += 1;
+        FlushTicket(state.issued)
+    }
+
+    /// Make `ticket` durable, either by taking the barrier or by riding one already in flight.
+    ///
+    /// Returns how long the caller waited in milliseconds -- the barrier's own duration for the
+    /// writer that took it, and the wait for one that rode along.
+    pub fn await_durable<F>(&self, ticket: FlushTicket, barrier: F) -> io::Result<u64>
+    where
+        F: FnOnce() -> io::Result<()>,
+    {
+        let started = Instant::now();
+        let target = {
+            let mut state = self.state.lock().expect("wal flush gate poisoned");
+            loop {
+                if state.durable >= ticket.0 {
+                    return Ok(started.elapsed().as_millis() as u64);
+                }
+                if !state.in_flight {
+                    // First to arrive since the last barrier finished: take this one, and cover
+                    // everyone who has queued up in the meantime.
+                    state.in_flight = true;
+                    break state.issued;
+                }
+                state = self.changed.wait(state).expect("wal flush gate poisoned");
+            }
+        };
+        // The barrier runs with the gate UNLOCKED, which is the whole point: writers keep arriving
+        // and registering while it is in flight, and the next barrier sweeps them up.
+        let outcome = barrier();
+        let mut state = self.state.lock().expect("wal flush gate poisoned");
+        state.in_flight = false;
+        match outcome {
+            Ok(()) => {
+                state.durable = state.durable.max(target);
+                self.changed.notify_all();
+                Ok(started.elapsed().as_millis() as u64)
+            }
+            Err(err) => {
+                // A failed barrier advances `durable` for nobody. Waking the waiters is enough:
+                // each re-checks, finds its ticket still not durable and no barrier in flight,
+                // and takes its own -- so a failure is retried honestly rather than reported to
+                // one thread and silently swallowed for the rest.
+                self.changed.notify_all();
+                Err(err)
+            }
+        }
+    }
+}
+
+/// The gates, one per file, keyed by whatever identifies that file to the caller.
+#[derive(Debug, Default)]
+pub struct FlushRegistry {
+    gates: Mutex<BTreeMap<(u64, u64), Arc<FlushGate>>>,
+}
+
+impl FlushRegistry {
+    /// The gate for one file, created on first use.
+    ///
+    /// Keyed per file rather than shared process-wide: one shared gate would let a barrier on one
+    /// file report another file's bytes durable, and a process here holds many.
+    pub fn gate(&self, key: (u64, u64)) -> Arc<FlushGate> {
+        let mut gates = self.gates.lock().expect("wal flush registry poisoned");
+        Arc::clone(gates.entry(key).or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Barrier;
+
+    #[test]
+    fn a_lone_writer_takes_exactly_one_barrier() {
+        let gate = FlushGate::default();
+        let barriers = AtomicU64::new(0);
+        for _ in 0..8 {
+            let ticket = gate.register_write();
+            gate.await_durable(ticket, || {
+                barriers.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .unwrap();
+        }
+        // No concurrency to amortise against, so nothing is saved -- and nothing is lost.
+        assert_eq!(barriers.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn writers_that_arrive_during_a_barrier_ride_the_next_one() {
+        let gate = Arc::new(FlushGate::default());
+        let barriers = Arc::new(AtomicU64::new(0));
+        let writers = 16usize;
+        // Every writer registers BEFORE any barrier starts, so one barrier could cover them all.
+        let tickets: Vec<FlushTicket> = (0..writers).map(|_| gate.register_write()).collect();
+        let start = Arc::new(Barrier::new(writers));
+        let handles: Vec<_> = tickets
+            .into_iter()
+            .map(|ticket| {
+                let gate = Arc::clone(&gate);
+                let barriers = Arc::clone(&barriers);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    gate.await_durable(ticket, || {
+                        barriers.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        let taken = barriers.load(Ordering::SeqCst);
+        // The point of the exercise: far fewer barriers than writers.
+        assert!(
+            taken < writers as u64,
+            "{taken} barriers for {writers} writers -- nothing coalesced"
+        );
+        assert!(taken >= 1);
+    }
+
+    #[test]
+    fn a_failed_barrier_is_reported_and_not_mistaken_for_durability() {
+        let gate = FlushGate::default();
+        let ticket = gate.register_write();
+        let err = gate
+            .await_durable(ticket, || Err(io::Error::other("disk gone")))
+            .unwrap_err();
+        assert!(err.to_string().contains("disk gone"));
+        // The ticket is still not durable, so a retry must actually take a barrier.
+        let retried = AtomicU64::new(0);
+        gate.await_durable(ticket, || {
+            retried.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(retried.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -248,6 +248,9 @@ pub struct IndexLogGcReport {
 #[derive(Debug, Clone)]
 pub struct LocalIndexLogStore {
     inner: Arc<Mutex<IndexLogInner>>,
+    /// One barrier gate per shard log, so appends that arrive while an fsync is in flight ride it
+    /// instead of queueing to take an identical one.
+    flush_gates: Arc<crate::flush_gate::FlushRegistry>,
 }
 
 #[derive(Debug)]
@@ -390,6 +393,7 @@ impl LocalIndexLogStore {
                 last_sequence_by_shard: HashMap::new(),
                 last_dumped_len_by_shard: HashMap::new(),
             })),
+            flush_gates: Arc::new(crate::flush_gate::FlushRegistry::default()),
         }
     }
 
@@ -548,13 +552,26 @@ impl LocalIndexLogStore {
             .open(index_log_path(&inner.root, shard_id))?;
         file.write_all(&bytes)?;
         file.flush()?;
-        if durable {
-            file.sync_data()?;
-        }
         inner.stats.writes += 1;
         inner.stats.bytes_written += bytes.len() as u64;
         inner.stats.last_sequence = next_sequence;
         inner.last_sequence_by_shard.insert(shard_id, next_sequence);
+        // The bytes are in the file and the bookkeeping is done, so claim a barrier and then let
+        // the lock go before taking it. Holding the lock across the fsync meant writers could
+        // never reach the barrier together, so each paid for one that would have covered all of
+        // them.
+        let barrier = durable.then(|| {
+            let gate = self.flush_gates.gate((shard_id as u64, 0));
+            let ticket = gate.register_write();
+            (gate, ticket)
+        });
+        drop(inner);
+        if let Some((gate, ticket)) = barrier {
+            gate.await_durable(ticket, || {
+                crate::durability_metrics::record_barrier("engine_index_log_append");
+                file.sync_data()
+            })?;
+        }
         Ok(next_sequence)
     }
 
@@ -751,6 +768,7 @@ impl LocalIndexLogStore {
                 temp.write_all(&crate::log_framing::encode_line(payload))?;
             }
             temp.flush()?;
+            crate::durability_metrics::record_barrier("engine_index_log_gc");
             temp.sync_all()?;
         }
         fs::rename(&temp_path, &path)?;
@@ -830,6 +848,7 @@ fn last_sequence_at(root: &Path, shard_id: ShardId) -> Result<u64, IndexLogError
     }
     if good_offset < offset || good_offset < file.metadata()?.len() {
         file.set_len(good_offset)?;
+        crate::durability_metrics::record_barrier("engine_index_log_seq_probe");
         file.sync_all()?;
         sync_parent_dir(&path)?;
     }
@@ -839,6 +858,7 @@ fn last_sequence_at(root: &Path, shard_id: ShardId) -> Result<u64, IndexLogError
 fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         if let Ok(dir) = File::open(parent) {
+            crate::durability_metrics::record_barrier("engine_index_log_dir");
             dir.sync_all()?;
         }
     }
@@ -1321,5 +1341,63 @@ mod tests {
              collector has stopped copying what it keeps, and a per-round bound may now be worth \
              having"
         );
+    }
+
+    /// Concurrent appends to one shard's index log must SHARE durability barriers.
+    ///
+    /// An fsync makes every byte already in the file durable, so a barrier taken while other
+    /// writers are queued behind it covers them too. This held the store lock across the fsync,
+    /// so writers could not reach the barrier together and each paid for one of its own -- the
+    /// same shape the raft node log had.
+    #[test]
+    fn concurrent_index_log_appends_share_barriers() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(LocalIndexLogStore::new(dir.path()));
+        let writers = 16usize;
+        let each = 8usize;
+        // Release the threads together, so they genuinely overlap rather than trickling through
+        // one at a time and each finding no barrier to ride.
+        let start = std::sync::Arc::new(std::sync::Barrier::new(writers));
+
+        crate::durability_metrics::reset();
+        let handles: Vec<_> = (0..writers)
+            .map(|writer| {
+                let store = std::sync::Arc::clone(&store);
+                let start = std::sync::Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    for index in 0..each {
+                        store
+                            .append_delta(
+                                4,
+                                vec![page_item(1, &format!("k-{writer}-{index}"), false)],
+                                Vec::new(),
+                                None,
+                                None,
+                                true,
+                            )
+                            .unwrap();
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let appends = (writers * each) as u64;
+        let barriers = crate::durability_metrics::snapshot()
+            .get("engine_index_log_append")
+            .copied()
+            .unwrap_or(0);
+        assert!(barriers >= 1, "some barrier must actually be taken");
+        assert!(
+            barriers < appends,
+            "{barriers} barriers for {appends} concurrent appends -- nothing coalesced"
+        );
+
+        // Sharing a barrier must cost nobody their record: every append is still readable.
+        let records = store.read_delta_records(4, 0).unwrap();
+        assert_eq!(records.len() as u64, appends, "every append must survive");
     }
 }

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -11,6 +11,8 @@ pub mod context_workflow;
 pub mod control;
 pub mod data_node;
 pub mod e2e;
+pub mod durability_metrics;
+pub mod flush_gate;
 pub mod engine;
 pub mod http;
 pub mod index_log;

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -847,6 +847,7 @@ impl LocalMetaMutationLog {
             .open(&self.path)?;
         serde_json::to_writer(&mut file, mutation).map_err(io::Error::other)?;
         file.write_all(b"\n")?;
+        crate::durability_metrics::record_barrier("meta_log_append");
         file.sync_data()?;
         Ok(())
     }

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -1070,19 +1070,42 @@ pub struct RaftMembershipRuntimeEvidence {
     pub pending_joint_consensus_restore_count: u64,
 }
 
+impl RaftReplicaRole {
+    /// Whether this is the value an absent field decodes to, so the encoder can leave it out.
+    fn is_default(&self) -> bool {
+        *self == RaftReplicaRole::default()
+    }
+}
+
+impl RaftApplySnapshotFence {
+    /// Whether this is the value an absent field decodes to, so the encoder can leave it out.
+    fn is_default(&self) -> bool {
+        *self == RaftApplySnapshotFence::default()
+    }
+}
+
+impl RaftMembershipRuntimeEvidence {
+    /// Whether this is the value an absent field decodes to, so the encoder can leave it out.
+    /// This block is a dozen counters that are zero on almost every record, and spelling them
+    /// out cost more than the entry the record exists to carry.
+    fn is_default(&self) -> bool {
+        *self == RaftMembershipRuntimeEvidence::default()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RaftWalRecord {
     pub hard_state: RaftHardState,
     pub membership: RaftMembership,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "RaftReplicaRole::is_default")]
     pub replica_role: RaftReplicaRole,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub joint_membership: Option<JointConsensusMembership>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_external_snapshot_ref: Option<RaftExternalSnapshotRef>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installed_snapshot: Option<RaftSnapshot>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "RaftApplySnapshotFence::is_default")]
     pub apply_snapshot_fence: RaftApplySnapshotFence,
     #[serde(default)]
     pub storage_apply_fence: RaftStorageApplyFence,
@@ -1093,7 +1116,7 @@ pub struct RaftWalRecord {
     pub pipeline_state: RaftPeerPipelineRuntimeState,
     #[serde(default, skip_serializing_if = "RaftReadSafetyRuntimeState::is_default")]
     pub read_safety_state: RaftReadSafetyRuntimeState,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "RaftMembershipRuntimeEvidence::is_default")]
     pub membership_evidence: RaftMembershipRuntimeEvidence,
     pub entries: Vec<RaftLogEntry>,
 }
@@ -1120,6 +1143,16 @@ pub struct RaftPeerPipelineRuntimeState {
     pub inflight_entries: u64,
     pub inflight_bytes: u64,
     pub append_queue_depth: u64,
+    /// Cluster clock reading when this node last ACCEPTED an append. Not when one last
+    /// arrived: a follower stuck rejecting every entry still receives them, and counting
+    /// arrivals is how a stalled follower comes to look healthy.
+    #[serde(default)]
+    pub last_accepted_append_ms: u64,
+    /// The commit index the leader last reported here. It comes from the leader itself rather
+    /// than from this process's shadow of it, which is what makes it trustworthy: a shadow does
+    /// not move when a peer rejects, so it cannot tell "caught up" from "stuck".
+    #[serde(default)]
+    pub leader_reported_commit_index: u64,
     #[serde(default)]
     pub apply_inflight_tasks: u64,
     #[serde(default)]
@@ -1400,6 +1433,10 @@ fn raft_wal_delta_entries_enabled() -> bool {
 pub struct LocalRaftWal {
     root: PathBuf,
     cursors: Arc<Mutex<BTreeMap<(ShardId, RaftNodeId), NodeWalCursor>>>,
+    /// One barrier gate per node log, so writers that arrive while an fsync is in flight ride it
+    /// instead of queueing to take an identical one. Shared by `clone`, like the cursors: two
+    /// handles to the same file must share a gate or each would take its own barrier again.
+    flush_gates: Arc<crate::flush_gate::FlushRegistry>,
 }
 
 
@@ -4094,6 +4131,33 @@ impl RaftCluster {
         })
     }
 
+    /// Take the barriers a set of staged appends owes, holding NO cluster lock.
+    ///
+    /// The lock is needed to decide WHAT to write and to keep those writes ordered, not to make
+    /// them durable: an fsync covers every byte already in the file whoever wrote it. Holding a
+    /// lock here would block the next proposer for the length of an fsync and serialise exactly
+    /// the writers this is meant to let share a barrier.
+    fn finish_staged_unlocked(
+        &self,
+        staged: Vec<local_wal::StagedWalAppend>,
+    ) -> Result<(), RaftError> {
+        if staged.is_empty() {
+            return Ok(());
+        }
+        let wal = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            inner.wal.clone()
+        };
+        let Some(wal) = wal else {
+            return Ok(());
+        };
+        for append in staged {
+            wal.finish_staged(append)
+                .map_err(|err| RaftError::Wal(err.to_string()))?;
+        }
+        Ok(())
+    }
+
     pub fn propose(&self, command: Command) -> Result<CommandResponse, RaftError> {
         let limit = self
             .inner
@@ -4109,11 +4173,60 @@ impl RaftCluster {
             }
             Err(err) => return Err(err),
         };
-        let mut last_response = CommandResponse::Empty;
+        // Defer the writes, then flush them with no lock held. `propose_one` takes the cluster
+        // write lock for its whole body, barrier included, so proposers could never reach the
+        // barrier together and each paid for one of its own -- measured flat at 1.0 barriers per
+        // write from 1 to 16 concurrent writers. Deferring does not reduce how many writes there
+        // are; it moves the barrier out from under the lock so writers can share one. A command
+        // split across chunks takes one barrier for the whole command: no chunk is acknowledged
+        // until every chunk is written and flushed.
+        //
+        // The deferral is a per-thread claim recorded in SHARED state, so the span from opening
+        // it to staging it must not interleave with another proposer's. Unserialised, two
+        // proposers race: A marks the state dirty, B opens its own deferral and clears that flag,
+        // and A then stages nothing and returns success for a write no barrier ever covered. The
+        // replicated path already holds this same lock for this same span. It costs no throughput
+        // here -- `propose_one` serialises on the cluster write lock anyway -- and it is released
+        // before the barrier, so the flushes still coalesce.
+        let local_propose_gate = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            inner.propose_serialize.clone()
+        };
+        let local_propose_guard = local_propose_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .begin_deferred_persist();
+        let mut outcome = Ok(CommandResponse::Empty);
         for chunk in chunks {
-            last_response = self.propose_one(chunk)?;
+            match self.propose_one(chunk) {
+                Ok(response) => outcome = Ok(response),
+                Err(err) => {
+                    outcome = Err(err);
+                    break;
+                }
+            }
         }
-        Ok(last_response)
+        let staged = self
+            .inner
+            .write()
+            .expect("raft cluster lock poisoned")
+            .stage_deferred_persist();
+        // The writes are done and ordered; the barrier needs no ordering, so release before it.
+        drop(local_propose_guard);
+        // Flush on the failure path too: a propose that failed part-way still owes a barrier for
+        // whatever it already wrote, and nothing is returned to the caller before it is taken.
+        let flushed = match staged {
+            Ok(staged) => self.finish_staged_unlocked(staged),
+            Err(err) => Err(err),
+        };
+        match (outcome, flushed) {
+            (Ok(response), Ok(())) => Ok(response),
+            (Ok(_), Err(err)) => Err(err),
+            (Err(err), _) => Err(err),
+        }
     }
 
     fn propose_one(&self, command: Command) -> Result<CommandResponse, RaftError> {
@@ -4318,11 +4431,25 @@ impl RaftCluster {
         if !deferring {
             return outcome;
         }
-        let flushed = self
+        // Write what the deferral owes while the propose lock still orders it. Records carry the
+        // log, so an older record landing after a newer one would regress the log on recovery --
+        // the write must stay ordered.
+        let staged = self
             .inner
             .write()
             .expect("raft cluster lock poisoned")
-            .flush_deferred_persist();
+            .stage_deferred_persist();
+        // The barrier needs no such ordering: an fsync makes every byte already in the file
+        // durable whoever wrote it. Releasing the lock here is what finally gives group commit a
+        // queue to coalesce -- while the barrier was taken under this lock only one writer ever
+        // reached it, and barriers per write stayed flat however many writers there were.
+        // Nothing is acknowledged before its barrier: the flush still happens below, on the
+        // failure path as well as the success path.
+        drop(_propose_guard);
+        let flushed = match staged {
+            Ok(staged) => self.finish_staged_unlocked(staged),
+            Err(err) => Err(err),
+        };
         // Never ack a write whose barrier failed: a flush error wins over a successful propose.
         match (outcome, flushed) {
             (Ok(response), Ok(())) => Ok(response),

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -648,18 +648,42 @@ impl RaftClusterInner {
     }
 
     pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
+        let staged = self.stage_configured_wal()?;
+        self.finish_staged_wal(staged)
+    }
+
+    /// Take the barriers a set of staged appends owes.
+    ///
+    /// Safe to call with the propose lock released: the writes are already ordered, and a barrier
+    /// makes every byte already in the file durable regardless of who wrote it.
+    pub(super) fn finish_staged_wal(
+        &self,
+        staged: Vec<local_wal::StagedWalAppend>,
+    ) -> Result<(), RaftError> {
+        let Some(wal) = &self.wal else {
+            return Ok(());
+        };
+        for append in staged {
+            wal.finish_staged(append)
+                .map_err(|err| RaftError::Wal(err.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Write what this node must persist, WITHOUT taking the barrier for it.
+    fn stage_configured_wal(&mut self) -> Result<Vec<local_wal::StagedWalAppend>, RaftError> {
         // P4: this thread owes a barrier rather than skipping one -- `flush_deferred_persist`
         // takes it before the propose acks. Only the thread that opened the deferral defers, so
         // a vote grant or heartbeat racing this propose still fsyncs before it answers.
         if self.persist_deferred_owner == Some(std::thread::current().id()) {
             self.persist_dirty = true;
-            return Ok(());
+            return Ok(Vec::new());
         }
         // Clone the WAL handle (cheap -- it shares the cursor cache via an Arc) so `self` is free
         // to be borrowed mutably below for the coalescing fingerprint map.
         let wal = match &self.wal {
             Some(wal) => wal.clone(),
-            None => return Ok(()),
+            None => return Ok(Vec::new()),
         };
         let shard_id = self.shard_id;
         let max_segment_bytes = self.config.max_segment_bytes;
@@ -678,6 +702,7 @@ impl RaftClusterInner {
             Some(local) => self.wal_record_for(local).into_iter().collect::<Vec<_>>(),
             None => self.wal_records(),
         };
+        let mut staged = Vec::new();
         for (node_id, record) in records {
             // P1: when coalescing is enabled, skip the fdatasync for a node whose durability-
             // relevant state is byte-identical to what we last persisted. A false "changed" only
@@ -688,27 +713,31 @@ impl RaftClusterInner {
                 if self.last_durable_fingerprint.get(&node_id) == Some(&fingerprint) {
                     continue;
                 }
-                wal.persist_node_segmented(
-                    shard_id,
-                    node_id,
-                    &record,
-                    max_segment_bytes,
-                    min_keep_segment_num,
-                )
-                .map_err(|err| RaftError::Wal(err.to_string()))?;
+                staged.push(
+                    wal.stage_node_segmented(
+                        shard_id,
+                        node_id,
+                        &record,
+                        max_segment_bytes,
+                        min_keep_segment_num,
+                    )
+                    .map_err(|err| RaftError::Wal(err.to_string()))?,
+                );
                 self.last_durable_fingerprint.insert(node_id, fingerprint);
             } else {
-                wal.persist_node_segmented(
-                    shard_id,
-                    node_id,
-                    &record,
-                    max_segment_bytes,
-                    min_keep_segment_num,
-                )
-                .map_err(|err| RaftError::Wal(err.to_string()))?;
+                staged.push(
+                    wal.stage_node_segmented(
+                        shard_id,
+                        node_id,
+                        &record,
+                        max_segment_bytes,
+                        min_keep_segment_num,
+                    )
+                    .map_err(|err| RaftError::Wal(err.to_string()))?,
+                );
             }
         }
-        Ok(())
+        Ok(staged)
     }
 
     /// P4: start owing barriers on THIS thread instead of taking them. The caller must hold the
@@ -721,12 +750,24 @@ impl RaftClusterInner {
     /// P4: take the one real barrier covering everything deferred since `begin_deferred_persist`.
     /// Called before the propose acks, on the success and the failure path alike.
     pub(super) fn flush_deferred_persist(&mut self) -> Result<(), RaftError> {
+        let staged = self.stage_deferred_persist()?;
+        self.finish_staged_wal(staged)
+    }
+
+    /// End the deferral by WRITING what is owed, leaving the barrier to the caller.
+    ///
+    /// This is what lets the propose path drop its lock before flushing: the write happens while
+    /// the lock still orders it, and the barrier -- which every concurrent proposer can share --
+    /// happens after.
+    pub(super) fn stage_deferred_persist(
+        &mut self,
+    ) -> Result<Vec<local_wal::StagedWalAppend>, RaftError> {
         self.persist_deferred_owner = None;
         if !self.persist_dirty {
-            return Ok(());
+            return Ok(Vec::new());
         }
         self.persist_dirty = false;
-        self.persist_configured_wal()
+        self.stage_configured_wal()
     }
 
     pub(super) fn wal_records(&self) -> Vec<(RaftNodeId, RaftWalRecord)> {

--- a/crates/temporalstore-rust/src/raft/cluster_read_status.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_read_status.rs
@@ -91,6 +91,31 @@ impl RaftCluster {
         let _ = inner.persist_configured_wal();
     }
 
+    /// How long this node has been behind the leader without accepting anything, in
+    /// milliseconds of cluster clock. Zero when it is not behind.
+    ///
+    /// Staleness used to be derivable only by comparing log indices against this process's own
+    /// shadow of the peer. That shadow does not move when the peer rejects, so a follower that
+    /// had stopped converging reported a lag of ZERO while falling further behind -- the failure
+    /// mode reporting itself as health. This cannot: the comparison is against the commit index
+    /// the LEADER sent, and the clock advances whether or not appends are landing.
+    pub fn replication_stall_ms(&self, node_id: RaftNodeId) -> u64 {
+        let inner = self.inner.read().expect("raft cluster lock poisoned");
+        let Some(node) = inner.nodes.get(&node_id) else {
+            return 0;
+        };
+        let behind = node.pipeline_state.leader_reported_commit_index
+            > node_last_log_or_snapshot_index(node);
+        if !behind {
+            // Caught up with everything the leader has admitted to committing. An idle cluster
+            // must not look stalled.
+            return 0;
+        }
+        inner
+            .logical_time_ms
+            .saturating_sub(node.pipeline_state.last_accepted_append_ms)
+    }
+
     pub fn shard_id(&self) -> ShardId {
         self.inner
             .read()

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -201,11 +201,18 @@ impl RaftCluster {
             node_term_at_log_or_snapshot_index(leader, prev_log_index).unwrap_or_default();
         let mut entries = Vec::new();
         let mut inflight_bytes = 0u64;
-        for entry in leader
+        // A raft log is in ascending index order, so everything this peer still needs is a
+        // SUFFIX of it. Scanning from the front and filtering costs the whole log on every
+        // AppendEntries to every peer, which makes a write more expensive the more history sits
+        // in front of it -- appending one entry should cost the same at index 10 and 10,000.
+        let first_unsent = leader
             .log
-            .iter()
-            .filter(|entry| entry.index > prev_log_index)
-        {
+            .partition_point(|entry| entry.index <= prev_log_index);
+        crate::durability_metrics::record_scan(
+            "replication_entries_examined",
+            (leader.log.len() - first_unsent) as u64,
+        );
+        for entry in leader.log[first_unsent..].iter() {
             if entries.len() as u64 >= available_entries {
                 break;
             }
@@ -387,6 +394,21 @@ impl RaftCluster {
         let leader_id = request.leader_id;
         let term = request.term;
         let leader_commit = request.leader_commit;
+        // Record what the LEADER says its commit index is, on every request -- including the ones
+        // this node is about to reject. That is the whole point: a rejecting follower keeps
+        // hearing from the leader, so this stays fresh while the node's own log does not move,
+        // and the two together say "behind, and not catching up".
+        {
+            let logical_now = inner.logical_time_ms;
+            if let Some(node) = inner.nodes.get_mut(&target_id) {
+                node.pipeline_state.leader_reported_commit_index = leader_commit;
+                if node.pipeline_state.last_accepted_append_ms == 0 {
+                    // Never accepted anything yet: start the clock here rather than at zero, so a
+                    // node that just joined does not report the age of the process as a stall.
+                    node.pipeline_state.last_accepted_append_ms = logical_now;
+                }
+            }
+        }
         // Contact from the leader proves it is alive, whatever we go on to decide about its
         // entries. A follower marks its leader down when its election timer expires, and until
         // now only an ACCEPTED append marked it back up -- so a follower that is merely behind,
@@ -654,6 +676,11 @@ impl RaftCluster {
         }
         let config = inner.config.clone();
         let local_node_id_for_refresh = inner.local_node_id;
+        // This append was accepted, so progress happened: stamp it before anything can fail.
+        let accepted_at = inner.logical_time_ms;
+        if let Some(node) = inner.nodes.get_mut(&target_id) {
+            node.pipeline_state.last_accepted_append_ms = accepted_at;
+        }
         refresh_all_pipeline_states(&mut inner.nodes, leader_id, local_node_id_for_refresh, &config);
         inner.renew_leader_lease();
         inner.persist_configured_wal()?;

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -4,11 +4,29 @@
 //! LocalRaftWal WAL persistence/recovery methods, split from raft.rs.
 use super::*;
 
+/// An append whose bytes are in the file but whose durability barrier has not been taken.
+///
+/// Writing and flushing are separated so a caller can hold a lock across the write -- record
+/// order matters, since each record carries the log and an older one landing after a newer one
+/// would regress it on recovery -- and then release that lock before the barrier, which is both
+/// the expensive part and the part that concurrent writers can share.
+#[must_use = "a staged append is not durable until finish_staged takes its barrier"]
+pub struct StagedWalAppend {
+    gate: Arc<crate::flush_gate::FlushGate>,
+    ticket: crate::flush_gate::FlushTicket,
+    file: fs::File,
+    shard_id: ShardId,
+    node_id: RaftNodeId,
+    min_keep_segments: usize,
+    slow_fsync_threshold_ms: u64,
+}
+
 impl LocalRaftWal {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self {
             root: root.into(),
             cursors: Arc::new(Mutex::new(BTreeMap::new())),
+            flush_gates: Arc::new(crate::flush_gate::FlushRegistry::default()),
         }
     }
 
@@ -42,6 +60,7 @@ impl LocalRaftWal {
         let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
         serde_json::to_writer(&mut file, &envelope).map_err(io::Error::other)?;
         file.write_all(b"\n")?;
+        crate::durability_metrics::record_barrier("raft_wal_append_unsegmented");
         file.sync_data()?;
         Ok(())
     }
@@ -75,6 +94,26 @@ impl LocalRaftWal {
         )
     }
 
+    /// Write a record's bytes without taking its barrier. See `finish_staged`.
+    pub fn stage_node_segmented(
+        &self,
+        shard_id: ShardId,
+        node_id: RaftNodeId,
+        record: &RaftWalRecord,
+        max_segment_bytes: u64,
+        min_keep_segments: usize,
+    ) -> io::Result<StagedWalAppend> {
+        self.stage_node_segmented_with_fsync_threshold(
+            shard_id,
+            node_id,
+            record,
+            max_segment_bytes,
+            min_keep_segments,
+            u64::MAX,
+        )
+    }
+
+    /// Append a record and make it durable before returning.
     pub fn persist_node_segmented_with_fsync_threshold(
         &self,
         shard_id: ShardId,
@@ -84,6 +123,32 @@ impl LocalRaftWal {
         min_keep_segments: usize,
         slow_fsync_threshold_ms: u64,
     ) -> io::Result<RaftWalSegmentReport> {
+        let staged = self.stage_node_segmented_with_fsync_threshold(
+            shard_id,
+            node_id,
+            record,
+            max_segment_bytes,
+            min_keep_segments,
+            slow_fsync_threshold_ms,
+        )?;
+        self.finish_staged(staged)
+    }
+
+    /// Write a record's bytes WITHOUT taking its durability barrier.
+    ///
+    /// The returned handle owes a barrier: nothing here is durable until `finish_staged` takes
+    /// it. Callers that must order their writes against each other hold their lock across this
+    /// call and release it before finishing, so the barriers coalesce while the writes stay in
+    /// order.
+    pub fn stage_node_segmented_with_fsync_threshold(
+        &self,
+        shard_id: ShardId,
+        node_id: RaftNodeId,
+        record: &RaftWalRecord,
+        max_segment_bytes: u64,
+        min_keep_segments: usize,
+        slow_fsync_threshold_ms: u64,
+    ) -> io::Result<StagedWalAppend> {
         let max_segment_bytes = max_segment_bytes.max(1);
         let min_keep_segments = min_keep_segments.max(1);
         let segment_dir = self.node_segment_dir(shard_id, node_id);
@@ -228,9 +293,12 @@ impl LocalRaftWal {
             .append(true)
             .open(&active_path)?;
         file.write_all(&encoded)?;
-        let fsync_started = Instant::now();
-        file.sync_data()?;
-        let last_fsync_elapsed_ms = fsync_started.elapsed().as_millis() as u64;
+        // The bytes are in the file now, so claim a barrier -- but do not take it here. Taking it
+        // under the cursor lock is what kept barriers-per-write pinned at 1.0 however many
+        // writers there were: each queued for the lock and then paid for an fsync that would have
+        // covered all of them. The barrier is taken below, once the lock is released.
+        let gate = self.flush_gates.gate((shard_id, node_id));
+        let ticket = gate.register_write();
 
         // Update the in-memory segment metadata to mirror what a fresh on-disk scan
         // (`node_segments` -> `inspect_segment_sequences`) would report.
@@ -274,6 +342,49 @@ impl LocalRaftWal {
         }
         cursor.persisted_last_index = log_last_index;
         cursor.persisted_last_term = log_last_term;
+
+        // Everything the cursor must record about this append is in place, so the lock can go
+        // before the expensive part. Writers blocked behind it now proceed and register against
+        // the same gate, and one barrier covers all of them.
+        drop(cursors);
+        Ok(StagedWalAppend {
+            gate,
+            ticket,
+            file,
+            shard_id,
+            node_id,
+            min_keep_segments,
+            slow_fsync_threshold_ms,
+        })
+    }
+
+    /// Take (or ride) the barrier a staged append owes, then prune and report.
+    ///
+    /// Pruning happens strictly after the barrier: dropping an old segment before the new record
+    /// is durable would trade a retention rule for a hole in the log.
+    pub fn finish_staged(&self, staged: StagedWalAppend) -> io::Result<RaftWalSegmentReport> {
+        let StagedWalAppend {
+            gate,
+            ticket,
+            file,
+            shard_id,
+            node_id,
+            min_keep_segments,
+            slow_fsync_threshold_ms,
+        } = staged;
+        let last_fsync_elapsed_ms = gate.await_durable(ticket, || {
+            crate::durability_metrics::record_barrier("raft_wal_append");
+            file.sync_data()
+        })?;
+        let mut cursors = self.cursors.lock().expect("raft wal cursor lock poisoned");
+        let Some(cursor) = cursors.get_mut(&(shard_id, node_id)) else {
+            // A concurrent `recover_node_segmented` dropped the cached cursor so the next append
+            // rebuilds it from disk. This append is already durable -- the barrier above saw to
+            // that -- and only the in-memory bookkeeping is gone, so read the report off disk
+            // rather than insist on state that was deliberately discarded.
+            drop(cursors);
+            return self.segment_report(shard_id, node_id);
+        };
 
         // Prune the oldest segments, keeping at least `min_keep_segments`. Removing a
         // segment drops its records from the retained window, so the next sequence
@@ -446,10 +557,43 @@ impl LocalRaftWal {
                         let mut entries = base
                             .map(|base| base.entries)
                             .unwrap_or_default();
-                        entries.retain(|entry| entry.index <= delta.from_index);
+                        // A raft log is in ascending index order, and both trims below depend on
+                        // that: each is a prefix or a suffix, never a scattered subset.
+                        debug_assert!(
+                            entries.windows(2).all(|pair| pair[0].index <= pair[1].index),
+                            "replay assumes the accumulated log is ordered by index"
+                        );
+                        // Drop what a conflict superseded. Testing the LAST entry first makes the
+                        // ordinary case -- an append that supersedes nothing -- O(1) instead of a
+                        // scan of everything accumulated so far. Scanning every time is what made
+                        // replay quadratic in record count, so a long-lived node paid for its
+                        // whole history on every restart.
+                        if entries
+                            .last()
+                            .map_or(false, |entry| entry.index > delta.from_index)
+                        {
+                            let keep =
+                                entries.partition_point(|entry| entry.index <= delta.from_index);
+                            crate::durability_metrics::record_scan(
+                                "replay_entries_scanned",
+                                (entries.len() - keep) as u64,
+                            );
+                            entries.truncate(keep);
+                        }
                         entries.extend(appended);
-                        if delta.log_first_index > 0 {
-                            entries.retain(|entry| entry.index >= delta.log_first_index);
+                        // Same again for what compaction removed, from the front.
+                        if delta.log_first_index > 0
+                            && entries
+                                .first()
+                                .map_or(false, |entry| entry.index < delta.log_first_index)
+                        {
+                            let drop_upto = entries
+                                .partition_point(|entry| entry.index < delta.log_first_index);
+                            crate::durability_metrics::record_scan(
+                                "replay_entries_scanned",
+                                drop_upto as u64,
+                            );
+                            entries.drain(..drop_upto);
                         }
                         merged.entries = entries;
                         Some(merged)
@@ -527,6 +671,7 @@ impl LocalRaftWal {
             serde_json::to_writer(&mut file, &envelope).map_err(io::Error::other)?;
             file.write_all(b"\n")?;
         }
+        crate::durability_metrics::record_barrier("raft_wal_compact");
         file.sync_data()?;
         Ok(())
     }

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -337,3 +337,361 @@ fn promoted_leader_can_reach_peers_it_knows_nothing_about() {
         assert_eq!(request.target_id, target);
     }
 }
+
+
+/// Concurrent appenders to one node log must SHARE durability barriers, not each take their own.
+///
+/// An fsync makes every byte already written to the file durable, so a barrier taken while other
+/// writers are queued behind it covers them too. This was measured taking one barrier per write
+/// no matter how many writers there were -- the fsync was held inside the cursor lock, so writers
+/// could not even reach it at the same time, and sixteen writers paid sixteen barriers where one
+/// would have done.
+#[test]
+fn concurrent_appends_to_one_node_log_share_barriers() {
+    let dir = tempfile::tempdir().unwrap();
+    // Any well-formed record will do -- this test is about how many barriers the appends cost,
+    // not what they contain.
+    let source = RaftCluster::new_single_shard_with_wal(
+        dir.path().join("source"),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    source
+        .propose(Command::StringSet { key: "seed".into(), value: b"seed".to_vec() })
+        .unwrap();
+    let record = source
+        .inner
+        .read()
+        .unwrap()
+        .wal_record_for(1)
+        .expect("record for node 1")
+        .1;
+
+    let wal = std::sync::Arc::new(LocalRaftWal::new(dir.path().join("target")));
+    let writers = 16usize;
+    let each = 8usize;
+    // Release every thread at the same instant, so they genuinely overlap rather than trickling
+    // through one at a time and each finding no barrier to ride.
+    let start = std::sync::Arc::new(std::sync::Barrier::new(writers));
+
+    crate::durability_metrics::reset();
+    let handles: Vec<_> = (0..writers)
+        .map(|_| {
+            let wal = std::sync::Arc::clone(&wal);
+            let record = record.clone();
+            let start = std::sync::Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                for _ in 0..each {
+                    wal.persist_node_segmented(1, 1, &record, 1 << 20, 4).unwrap();
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let appends = (writers * each) as u64;
+    let barriers = crate::durability_metrics::snapshot()
+        .get("raft_wal_append")
+        .copied()
+        .unwrap_or(0);
+    println!("{appends} concurrent appends cost {barriers} barriers");
+    assert!(barriers >= 1, "some barrier must actually be taken");
+    assert!(
+        barriers < appends,
+        "{barriers} barriers for {appends} concurrent appends -- nothing coalesced"
+    );
+
+    // Sharing a barrier must not cost anyone durability: every append is still on disk, and the
+    // log still reads back cleanly.
+    let recovered = wal.recover_node(1, 1).unwrap();
+    assert!(
+        recovered.valid_records > 0,
+        "the node log must read back after concurrent appends"
+    );
+}
+
+
+/// A propose that returned `Ok` must be on disk, however many proposers were running at once.
+///
+/// Making barriers coalesce moved the flush out from under the cluster locks, which put the
+/// deferral bookkeeping -- shared owner/dirty flags -- in reach of two proposers at once. When
+/// that happened, one proposer's "I owe a barrier" flag could be cleared by another opening its
+/// own deferral, so the first staged nothing and returned success for a write that was never
+/// written at all. Nothing about a single-threaded run shows that up.
+#[test]
+fn every_concurrent_propose_that_returned_ok_survives_a_restore() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = std::sync::Arc::new(
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap(),
+    );
+    cluster.set_local_node_id(1);
+
+    let writers = 8usize;
+    let each = 12usize;
+    let start = std::sync::Arc::new(std::sync::Barrier::new(writers));
+    let handles: Vec<_> = (0..writers)
+        .map(|writer| {
+            let cluster = std::sync::Arc::clone(&cluster);
+            let start = std::sync::Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                let mut accepted = Vec::new();
+                for index in 0..each {
+                    let key = format!("durable-{writer:02}-{index:03}");
+                    // Only keys whose propose actually returned Ok are claimed below. A refusal
+                    // promises nothing and must not be held against the log.
+                    if cluster
+                        .propose(Command::StringSet {
+                            key: key.clone(),
+                            value: key.clone().into_bytes(),
+                        })
+                        .is_ok()
+                    {
+                        accepted.push(key);
+                    }
+                }
+                accepted
+            })
+        })
+        .collect();
+    let accepted: Vec<String> = handles
+        .into_iter()
+        .flat_map(|handle| handle.join().unwrap())
+        .collect();
+    assert_eq!(accepted.len(), writers * each, "every propose should have been accepted");
+
+    // Rebuild from nothing but the WAL. Anything acknowledged but never written is missing here.
+    let restored = RaftCluster::restore_single_shard_from_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    let logged: std::collections::BTreeSet<String> = restored
+        .inner
+        .read()
+        .unwrap()
+        .nodes
+        .get(&1)
+        .expect("node 1 present after restore")
+        .log
+        .clone()
+        .into_iter()
+        .filter_map(|entry| match entry.command {
+            Command::StringSet { key, .. } => Some(key),
+            _ => None,
+        })
+        .collect();
+    let missing: Vec<&String> = accepted.iter().filter(|key| !logged.contains(*key)).collect();
+    assert!(
+        missing.is_empty(),
+        "{} acknowledged writes are absent from the restored log, first: {:?}",
+        missing.len(),
+        missing.first()
+    );
+}
+
+
+/// Replaying an append-only node log must not rescan everything accumulated so far.
+///
+/// Folding one incremental record used to scan the WHOLE running log twice -- once for entries a
+/// conflict superseded, once for entries compaction removed. Each record carries about one new
+/// entry, so the log grows by one per record and those scans cost 1 + 2 + 3 + ... over the
+/// replay: quadratic in record count, meaning a long-lived node pays for its entire history every
+/// time it starts. Nothing about a short log shows that up, and a stopwatch on a shared machine
+/// measures the other tenants, so this asserts the scan is not entered at all.
+#[test]
+fn replaying_an_append_only_log_never_rescans_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(1);
+    let records = 400u64;
+    for index in 0..records {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("append-{index:05}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+
+    let wal = LocalRaftWal::new(dir.path());
+    crate::durability_metrics::reset();
+    let recovered = wal.recover_node(1, 1).unwrap();
+    let counts = crate::durability_metrics::snapshot();
+
+    // Every record here is a plain append: it supersedes nothing and compacts nothing, so the
+    // trims have no work to do and must not walk the accumulated log to discover that. Asserting
+    // on entries EXAMINED rather than on a branch counter is what makes this catch a regression:
+    // an implementation that goes back to scanning unconditionally reports its scan here.
+    let scanned = counts.get("replay_entries_scanned").copied().unwrap_or(0);
+    println!("replay of {records} append-only records examined {scanned} accumulated entries");
+    assert_eq!(
+        scanned, 0,
+        "replaying {records} plain appends examined {scanned} accumulated entries;          scanning the running log per record makes replay quadratic in record count"
+    );
+
+    // ...and the replay must still be right, not merely cheap.
+    let record = recovered.record.expect("a record is recovered");
+    assert_eq!(
+        record.entries.len() as u64,
+        records,
+        "every proposed entry should survive replay"
+    );
+    for (position, entry) in record.entries.iter().enumerate() {
+        match &entry.command {
+            Command::StringSet { key, .. } => {
+                assert_eq!(key, &format!("append-{position:05}"), "entries stay in log order")
+            }
+            other => panic!("unexpected command in the replayed log: {other:?}"),
+        }
+    }
+}
+
+
+/// Building an AppendEntries must cost what it SENDS, not what the log already holds.
+///
+/// The entries a peer still needs sit above its `prev_log_index`, and a raft log is in ascending
+/// index order, so they are a suffix. Finding that suffix by iterating from index 0 and filtering
+/// costs the whole log on every AppendEntries to every peer -- so appending one entry got steadily
+/// more expensive as history accumulated, which is one of the ways write latency ends up growing
+/// with log length rather than staying flat.
+#[test]
+fn building_an_append_entries_does_not_walk_the_whole_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(1);
+    let entries = 500u64;
+    for index in 0..entries {
+        cluster
+            .propose(Command::StringSet {
+                key: format!("hist-{index:05}"),
+                value: b"v".to_vec(),
+            })
+            .unwrap();
+    }
+
+    // Put the peer fully caught up, so the next request carries nothing at all: the ideal case,
+    // and the one that used to cost a full scan of every entry ever appended.
+    {
+        let mut inner = cluster.inner.write().unwrap();
+        let last = inner
+            .nodes
+            .get(&1)
+            .map(|node| node.log.last().map(|entry| entry.index).unwrap_or(0))
+            .unwrap_or(0);
+        if let Some(peer) = inner.nodes.get_mut(&2) {
+            peer.pipeline_state.next_index = last + 1;
+            peer.pipeline_state.inflight_entries = 0;
+            peer.pipeline_state.inflight_bytes = 0;
+        }
+    }
+
+    crate::durability_metrics::reset();
+    let request = cluster.build_append_entries_request(2).unwrap();
+    let examined = crate::durability_metrics::snapshot()
+        .get("replication_entries_examined")
+        .copied()
+        .unwrap_or(0);
+    println!(
+        "with {entries} entries in the log, a caught-up peer's request examined {examined} and carried {}",
+        request.entries.len()
+    );
+    assert!(
+        request.entries.is_empty(),
+        "a caught-up peer should be sent nothing"
+    );
+    assert!(
+        examined < entries,
+        "building a request for a caught-up peer examined {examined} of {entries} entries; \
+         the cost of a request must not grow with the history behind it"
+    );
+}
+
+
+/// A follower that is behind and not converging must not report itself as caught up.
+///
+/// Staleness used to be derivable only by comparing log indices against this process's own shadow
+/// of the peer, and that shadow does not move when the peer rejects -- so a follower that had
+/// stopped converging reported a lag of ZERO while falling further behind. The failure mode
+/// reported itself as health, which is why it went unnoticed. Time cannot be faked the same way:
+/// the comparison is against the commit index the LEADER sent, and the clock advances whether or
+/// not appends are landing.
+#[test]
+fn a_follower_that_stops_converging_cannot_report_zero_lag() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(2);
+
+    let accepted = |index: u64| AppendEntriesRequest {
+        rpc: None,
+        shard_id: 1,
+        term: 1,
+        leader_id: 1,
+        target_id: 2,
+        prev_log_index: index - 1,
+        prev_log_term: if index == 1 { 0 } else { 1 },
+        entries: vec![RaftLogEntry {
+            term: 1,
+            index,
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k-{index}"),
+                value: b"v".to_vec(),
+            },
+        }],
+        leader_commit: index,
+    };
+
+    // Land two entries, so the follower is genuinely caught up with what the leader has committed.
+    cluster.receive_append_entries(accepted(1)).unwrap();
+    cluster.receive_append_entries(accepted(2)).unwrap();
+    cluster.advance_time_ms(30_000);
+    assert_eq!(
+        cluster.replication_stall_ms(2),
+        0,
+        "a caught-up follower must not look stalled just because time passed"
+    );
+
+    // Now the leader moves on, but every append this follower is offered refers to a log position
+    // it does not have, so it rejects them all -- while still hearing from the leader. This is
+    // exactly the shape that used to report lag 0.
+    let mismatched = |index: u64| AppendEntriesRequest {
+        prev_log_index: index + 500,
+        prev_log_term: 1,
+        ..accepted(index)
+    };
+    for index in 3..8 {
+        let response = cluster.receive_append_entries(mismatched(index)).unwrap();
+        assert!(!response.success, "the mismatched append should be rejected");
+        cluster.advance_time_ms(10_000);
+    }
+
+    let stalled = cluster.replication_stall_ms(2);
+    assert!(
+        stalled >= 50_000,
+        "a follower behind the leader and accepting nothing reported a stall of {stalled} ms; \
+         it has not made progress for the whole run"
+    );
+
+    // Once it accepts again, the stall clears -- it is a progress signal, not a one-way latch.
+    cluster.receive_append_entries(accepted(3)).unwrap();
+    assert_eq!(
+        cluster.replication_stall_ms(2),
+        0,
+        "a follower that has caught up must report no stall"
+    );
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -827,6 +827,7 @@ impl LocalWriteAheadLogStore {
             return Ok(());
         }
         let file = OpenOptions::new().read(true).write(true).open(&path)?;
+        crate::durability_metrics::record_barrier("engine_wal_group_commit");
         file.sync_data()?;
         if !entry.dir_synced {
             // First durable append for this shard this process lifetime: make the
@@ -1021,6 +1022,7 @@ impl LocalWriteAheadLogStore {
             });
         }
         let file = OpenOptions::new().read(true).write(true).open(&path)?;
+        crate::durability_metrics::record_barrier("engine_wal_flush");
         file.sync_all()?;
         sync_parent_dir(&path)?;
         let persistent_bytes = path.metadata()?.len();
@@ -1860,6 +1862,7 @@ fn append_record_locked(
     file.write_all(&bytes)?;
     if sync {
         file.flush()?;
+        crate::durability_metrics::record_barrier("engine_wal_append");
         file.sync_data()?;
         // The parent-directory entry for the WAL file only needs a durable barrier when
         // the file is first created; appends grow the file (inode) without changing the
@@ -2181,6 +2184,7 @@ fn command_item_kind(command: &Command) -> WriteAheadLogItemKind {
 fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         if let Ok(dir) = File::open(parent) {
+            crate::durability_metrics::record_barrier("engine_wal_dir");
             dir.sync_all()?;
         }
     }


### PR DESCRIPTION
A write costs roughly `barriers x fsync`, so the first question is where the barriers go. Nothing
counted them, and reasoning about it had produced confident wrong answers twice, so this adds
per-call-site accounting (`src/durability_metrics.rs`) and a profiler (`raft_barrier_profile`).
**Every number below is measured, and every test added here fails without its fix.**

## Barriers were never shared

The count per write was already minimal — one raft barrier, one engine barrier. What was not
happening was *sharing* them. An fsync makes every byte already in the file durable whoever wrote
it, so a barrier taken while other writers are queued behind it covers them too. But barriers per
write measured **dead flat at 1.0 from 1 to 16 concurrent writers**, because the fsync was taken
while holding the very lock every writer had to queue for.

Three places did this, and **all three had to change — fixing any subset measures nothing**:

- the raft node log took its fsync inside the cursor lock,
- the replicated propose path took it under the propose lock,
- both propose paths flushed while holding a cluster lock, which blocks the next proposer for the
  length of an fsync.

`src/flush_gate.rs` keeps at most one barrier in flight per file and lets late arrivals ride the
next one. Writes stay ordered under their lock — records carry the log, and an older record
landing after a newer one would regress it on recovery — while the barrier, which needs no
ordering, happens after the lock is released.

| | before | after |
|---|---|---|
| 128 concurrent node-log appends | 128 barriers | **29** |
| 128 concurrent index-log appends | 128 barriers | **17** |

On three nodes over gp3: **+14% write throughput, p99 −51%, worst case −67%**, with uncontended
latency unchanged to three significant figures — a lone writer still takes exactly one barrier.

## Two paths walked whole logs to find a couple of entries

- **Replay** folded each incremental record with two passes over the *entire* accumulated log —
  quadratic in record count, so a long-lived node paid for its whole history on every start.
  Replaying 400 appends examined **159,999 entries; now 0**.
- **Building an AppendEntries** scanned from index 0 to find the suffix a peer still needed, per
  peer, per write. With 500 entries in the log, a caught-up peer's request examined **all 500 to
  send nothing; now 0**.

Both logs are ascending by index, so both are a binary search.

## Records spelled out every default

A block of zeroed counters cost several hundred bytes to say nothing. Omitting defaults — which
two fields already did — takes a record from **1256 to 782 bytes**. Reading is unchanged: these
fields already carry serde defaults, so an absent field decodes to exactly what was omitted and
existing records still read identically.

## A stalled follower could report itself healthy

Staleness was only derivable by comparing log indices against this process's own shadow of the
peer, and that shadow does not move when the peer rejects — so a follower that had stopped
converging reported a lag of **zero** while falling further behind. `replication_stall_ms`
compares against the commit index the leader sent, which arrives even on rejected appends, and
measures time since the last *accepted* append. A node behind and accepting nothing now reports a
stall that grows without bound; an idle caught-up node reports zero.

## Validation

`cargo test --lib --test-threads=1`: **774 passed, 1 failed** — that one failure reproduces
identically on unmodified `main` (verified in a separate worktree), and is unrelated to this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
