### PR TITLE
Fix the targets that --lib never compiled

### DIFF
--- a/crates/temporalstore-rust/examples/inmemory_dirty_check.rs
+++ b/crates/temporalstore-rust/examples/inmemory_dirty_check.rs
@@ -76,7 +76,9 @@ fn main() {
     mark(&e, 42, 2_000, 1);
     let m = query(&e, 42, 0, 10_000);
     assert_eq!(m.len(), 1, "coalesce to one");
-    assert_eq!(m[0].event_time_ms, 3_000, "latest ts wins");
+    assert_eq!(m[0].last_event_time_ms, 3_000, "latest ts wins");
+    assert_eq!(m[0].first_event_time_ms, 1_000, "and the span keeps the earliest");
+    assert_eq!(m[0].mark_count, 3, "three marks, one entry");
     assert_eq!(m[0].propagate_depth, 2, "max depth wins");
 
     // 2) Distinct nodes independent.
@@ -96,7 +98,9 @@ fn main() {
     }
     let m2 = query(&e2, 42, 0, 10_000_000);
     assert_eq!(m2.len(), 1, "500 marks -> 1 coalesced marker");
-    assert_eq!(m2[0].event_time_ms, 1_499);
+    assert_eq!(m2[0].last_event_time_ms, 1_499);
+    assert_eq!(m2[0].first_event_time_ms, 1_000);
+    assert_eq!(m2[0].mark_count, 500, "500 marks recorded, still one entry");
     assert_eq!(m2[0].propagate_depth, 3);
 
     println!("inmemory_dirty_check: OK (coalescing, latest-ts, max-depth, window-filter, bounded 500->1)");

--- a/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
+++ b/crates/temporalstore-rust/src/bin/context_workflow_harness.rs
@@ -2056,10 +2056,10 @@ fn ingest_external_benchmark_sources(
         });
         commands.push(Command::ContextMarkSummaryDirty {
             tenant_hash,
-            node_hash: dirty_node_hash,
+            node_hash: dirty_marker.node_hash,
             event_time_ms: dirty_marker.last_event_time_ms,
-            reason: dirty_reason,
-            propagate_depth: dirty_propagate_depth,
+            reason: dirty_marker.reason,
+            propagate_depth: dirty_marker.propagate_depth,
         });
         node_hashes.push(node_hash);
     }
@@ -2987,10 +2987,10 @@ fn context_pipeline_commands(extract: &temporalstore_rust::ContextExtractReport)
         },
         Command::ContextMarkSummaryDirty {
             tenant_hash: 20260616,
-            node_hash: extract.dirty_node_hash,
+            node_hash: extract.dirty_marker.node_hash,
             event_time_ms: extract.dirty_marker.last_event_time_ms,
-            reason: extract.dirty_reason,
-            propagate_depth: extract.dirty_propagate_depth,
+            reason: extract.dirty_marker.reason,
+            propagate_depth: extract.dirty_marker.propagate_depth,
         },
     ]
 }

--- a/crates/temporalstore-rust/tests/inmemory_dirty_summary.rs
+++ b/crates/temporalstore-rust/tests/inmemory_dirty_summary.rs
@@ -104,15 +104,23 @@ fn repeated_marks_for_one_node_coalesce_to_latest_and_max_depth() {
         1,
         "three marks for one node must coalesce into a single dirty marker"
     );
-    let marker = &nodes[0];
-    assert_eq!(node_hash, 42);
+    let entry = &nodes[0];
+    assert_eq!(entry.node_hash, 42);
     assert_eq!(
-        event_time_ms, 3_000,
-        "coalesced marker keeps the latest event time"
+        entry.last_event_time_ms, 3_000,
+        "the coalesced entry keeps the latest event time"
     );
     assert_eq!(
-        propagate_depth, 2,
-        "coalesced marker keeps the deepest requested propagate depth"
+        entry.first_event_time_ms, 1_000,
+        "and the earliest, which is the half a single timestamp used to hide"
+    );
+    assert_eq!(
+        entry.mark_count, 3,
+        "three marks arrived, and the entry says so"
+    );
+    assert_eq!(
+        entry.propagate_depth, 2,
+        "the coalesced entry keeps the deepest requested propagate depth"
     );
 }
 
@@ -126,8 +134,8 @@ fn distinct_nodes_are_tracked_independently() {
     let node_99 = query(&engine, 99, 0, 10_000);
     assert_eq!(node_42.len(), 1);
     assert_eq!(node_99.len(), 1);
-    assert_eq!(node_42[0].event_time_ms, 1_000);
-    assert_eq!(node_99[0].event_time_ms, 5_000);
+    assert_eq!(node_42[0].last_event_time_ms, 1_000);
+    assert_eq!(node_99[0].last_event_time_ms, 5_000);
     assert_eq!(node_99[0].propagate_depth, 3);
 }
 
@@ -160,6 +168,6 @@ fn coalescing_is_bounded_regardless_of_mark_count() {
         1,
         "500 marks for one node must remain a single coalesced dirty marker"
     );
-    assert_eq!(nodes[0].event_time_ms, 1_499, "latest event time wins");
+    assert_eq!(nodes[0].last_event_time_ms, 1_499, "latest event time wins");
     assert_eq!(nodes[0].propagate_depth, 3, "max depth across marks wins");
 }

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -365,6 +365,7 @@ fn response_kind(response: &CommandResponse) -> &'static str {
         CommandResponse::ContextEntities { .. } => "context_entities",
         CommandResponse::ContextChildRefs { .. } => "context_child_refs",
         CommandResponse::ContextEmbeddings { .. } => "context_embeddings",
+        CommandResponse::ContextNodeEmbeddings { .. } => "context_node_embeddings",
         CommandResponse::ContextEmbeddingDirtyNodes { .. } => "context_embedding_dirty_markers",
         CommandResponse::ContextTraversedNodes { .. } => "context_traversed_nodes",
         CommandResponse::ContextSummaries { .. } => "context_summaries",


### PR DESCRIPTION
main does not currently pass `cargo check --all-targets`: `tests/inmemory_dirty_summary.rs`, the `inmemory_dirty_check` example, `context_workflow_harness` and the unified corpus test all fail to compile. Every one is my own breakage from #201 and #203.

### How it got through

`cargo test --lib` builds the crate and its unit tests and **nothing else** — not `tests/`, not `examples/`, not `src/bin`. Three changes in a row were judged green by a command that never touched the files they broke.

The damage itself was mechanical: a rename pass rewrote `marker.node_hash` into a bare `node_hash` in files it should not have touched, and one match over `CommandResponse` was missed when `ContextNodeEmbeddings` was added.

### While fixing the assertions

The tests were reaching for what the coalescing map knows, so they now check it: alongside the latest event time, the **earliest** and the **mark count** — the half a single timestamp used to hide.

### Verification

- `cargo check --all-targets` clean
- `cargo test --test inmemory_dirty_summary` — 4 passed
- `cargo run --example inmemory_dirty_check` — OK