### PR TITLE
Client: a topology snapshot with no primary no longer deletes the route it cannot replace

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -525,6 +525,13 @@ pub struct ClientMetaSyncTableReport {
     pub last_topology_version: u64,
     pub consecutive_errors: u64,
     pub last_error: String,
+    /// Shards the last sync could not route because the topology named no primary for them.
+    ///
+    /// Their previous routes are kept rather than discarded -- a snapshot taken while a
+    /// primary is being elected should not destroy a working route -- but the sync is not a
+    /// clean one, and reporting it as clean is how this stayed invisible.
+    #[serde(default)]
+    pub shards_without_primary: u64,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -652,6 +659,7 @@ struct ClientMetaSyncTableState {
     last_topology_version: u64,
     consecutive_errors: u64,
     last_error: String,
+    shards_without_primary: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -128,6 +128,16 @@ impl TemporalStoreClient {
             ..TableOptions::default()
         };
         let table_key = table_combine_name(&namespace, &table_name);
+        // Shards the topology names but cannot route, because it gives them no primary. This
+        // happens while a primary is being elected. Their previous routes are deliberately
+        // NOT discarded below: a snapshot taken mid-election should not destroy a route that
+        // still works, and the old one either still serves or fails and gets refreshed.
+        let unroutable: Vec<ShardId> = topology
+            .shards
+            .iter()
+            .filter(|partition| partition.primary.is_none())
+            .map(|partition| partition.shard_id)
+            .collect();
         let routes = topology
             .shards
             .iter()
@@ -177,6 +187,10 @@ impl TemporalStoreClient {
             .first_shard_id
             .saturating_add(table.shard_count.saturating_sub(1));
         route_cache.retain(|shard_id, route| {
+            // Keep what the new topology cannot replace.
+            if unroutable.contains(shard_id) {
+                return true;
+            }
             if route.table_key == table_key {
                 return false;
             }
@@ -185,7 +199,12 @@ impl TemporalStoreClient {
         for (shard_id, route) in routes {
             route_cache.insert(shard_id, route);
         }
-        self.record_meta_sync_success(&namespace, &table_name, route_topology_version);
+        self.record_meta_sync_success(
+            &namespace,
+            &table_name,
+            route_topology_version,
+            unroutable.len() as u64,
+        );
         Ok(options)
     }
 
@@ -460,6 +479,7 @@ impl TemporalStoreClient {
                 next_sync_after_unix_ms: state.next_sync_after_unix_ms,
                 last_topology_version: state.last_topology_version,
                 consecutive_errors: state.consecutive_errors,
+                shards_without_primary: state.shards_without_primary,
                 last_error: state.last_error.clone(),
             })
             .collect::<Vec<_>>();
@@ -812,10 +832,17 @@ impl TemporalStoreClient {
                 last_topology_version: 0,
                 consecutive_errors: 0,
                 last_error: String::new(),
+                shards_without_primary: 0,
             });
     }
 
-    pub(super) fn record_meta_sync_success(&self, namespace: &str, table_name: &str, topology_version: u64) {
+    pub(super) fn record_meta_sync_success(
+        &self,
+        namespace: &str,
+        table_name: &str,
+        topology_version: u64,
+        shards_without_primary: u64,
+    ) {
         let key = table_combine_name(namespace, table_name);
         let now = now_unix_ms();
         let mut states = self
@@ -835,6 +862,7 @@ impl TemporalStoreClient {
                 last_topology_version: 0,
                 consecutive_errors: 0,
                 last_error: String::new(),
+                shards_without_primary: 0,
             });
         state.sync_generation = state.sync_generation.saturating_add(1);
         state.last_success_unix_ms = now;
@@ -846,6 +874,7 @@ impl TemporalStoreClient {
         ));
         state.last_topology_version = topology_version;
         state.consecutive_errors = 0;
+        state.shards_without_primary = shards_without_primary;
         state.last_error.clear();
     }
 
@@ -869,6 +898,7 @@ impl TemporalStoreClient {
                 last_topology_version: 0,
                 consecutive_errors: 0,
                 last_error: String::new(),
+                shards_without_primary: 0,
             });
         state.sync_generation = state.sync_generation.saturating_add(1);
         state.last_error_unix_ms = now;

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -264,6 +264,101 @@ fn client_metasync_backoff_deadline_and_topology_refresh_survive_outage_churn() 
 }
 
 #[test]
+fn a_topology_missing_a_primary_keeps_the_route_it_cannot_replace() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // A topology snapshot taken while a primary is being elected names the shard but gives it
+    // no primary. That entry used to be dropped, AND the purge that precedes the insert
+    // removed the shard's previous route -- so a working route was destroyed on the strength
+    // of an incomplete snapshot, and the sync reported success. The route is now kept, and
+    // the sync says how many shards it could not route.
+    let round = std::sync::Arc::new(AtomicUsize::new(0));
+    let meta_addr = free_local_addr();
+    let meta_addr_for_listener = meta_addr.clone();
+    let r = round.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => {
+                    // First sync: a healthy topology. Second: the same shard, no primary.
+                    let healthy = r.fetch_add(1, Ordering::SeqCst) == 0;
+                    json_response(
+                        200,
+                        &TableTopologyResponse {
+                            status: Status::ok(),
+                            table: Some(crate::meta::TableMetaInfo {
+                                table_id: 1,
+                                namespace: "ns".to_string(),
+                                table_name: "tbl".to_string(),
+                                state: crate::meta::MetaEntityState::Normal,
+                                topology_version: if healthy { 7 } else { 8 },
+                                first_shard_id: 1,
+                                shard_count: 1,
+                                replica_count: 1,
+                                partition_version: 0,
+                                serving_options: crate::meta::TableServingOptions::default(),
+                            }),
+                            shards: vec![TableShard {
+                                shard_id: 1,
+                                start_bucket: 0,
+                                end_bucket: u64::MAX,
+                                primary: if healthy {
+                                    Some("127.0.0.1:29001".to_string())
+                                } else {
+                                    None
+                                },
+                                replicas: Vec::new(),
+                                primary_endpoint: None,
+                                replica_endpoints: Vec::new(),
+                            }],
+                            unchanged: false,
+                        },
+                    )
+                }
+                _ => json_response(404, &Status::error("not_found", "no route")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: meta_addr.clone(),
+        meta_addr: Some(meta_addr.clone()),
+        ..ClientOptions::default()
+    });
+
+    client
+        .sync_table_topology("ns".to_string(), "tbl".to_string())
+        .expect("first sync succeeds");
+    assert_eq!(
+        client.topology_cache_report().route_count,
+        1,
+        "the healthy topology should install a route"
+    );
+
+    client
+        .sync_table_topology("ns".to_string(), "tbl".to_string())
+        .expect("second sync still succeeds");
+    assert_eq!(
+        client.topology_cache_report().route_count,
+        1,
+        "a topology with no primary must not delete the route it cannot replace"
+    );
+
+    let synced = client.meta_sync_report();
+    let table = synced
+        .tables
+        .iter()
+        .find(|table| table.table_name == "tbl")
+        .expect("the table is reported");
+    assert_eq!(
+        table.shards_without_primary, 1,
+        "an incomplete sync must say so rather than reporting a clean success"
+    );
+}
+
+#[test]
 fn client_applies_metaserver_table_serving_options() {
     let meta_addr = free_local_addr();
     let meta_addr_for_listener = meta_addr.clone();


### PR DESCRIPTION
A table topology sync purges the cached routes for the table and its shard range,
then inserts what the new topology gives it. A shard the topology names but gives no
primary is skipped on the way in -- but it was still purged on the way out. So the
shard ended up with no route at all, and the sync recorded a clean success.

The snapshot that does this is not a corrupt one. It is the ordinary state of a
shard whose primary is being elected: the metaserver knows the shard, and does not
yet know who serves it. Answering that with "forget where this shard lives" throws
away information that was still good, on the strength of a moment.

Routes for such shards are now kept. The old route either still serves, or fails and
gets refreshed by the path that already exists for exactly that -- both of which are
better than having nothing and having to ask again from scratch.

The sync also stops calling that a clean success. shards_without_primary is reported
per table, so a table sitting in this state is visible rather than looking healthy.
It was reporting success with a hole in it, which is the part that would have made
this hard to find from the outside.

What this does NOT do is refuse the whole update. A shard with no primary for a long
time would then freeze every other shard's topology too, and the shards that did
change are exactly the ones a sync exists to deliver. Partial application is right
here; silently destroying what it could not replace was not.

Checked rather than asserted: two syncs, the second naming the same shard with no
primary. With the fix the route survives and the count reports 1. Remove the
preservation and the test fails with left 0, right 1 -- the route is gone.