### PR TITLE
Refuse to publish a cached view that was already behind the log

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -3958,7 +3958,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             except Exception:
                 pass
 
-    def _update_read_cache_after_append(self, records: list[Json]) -> None:
+    def _update_read_cache_after_append(
+        self, records: list[Json], *, pre_size: int | None = None
+    ) -> None:
+        """Fold freshly appended records into every read cache -- but only into a view that
+        actually covered the log up to this write.
+
+        ``pre_size`` is the retained-log byte total as it stood before this instance's write,
+        captured under the event-log lock. A cached view is only allowed to absorb the append
+        when the bytes it covers equal that number: the signature alone cannot catch a stale
+        view, because it describes the log at WRITE time, so a list missing another writer's
+        records still stamps the current signature and gets served to cold readers as if it
+        were complete.
+        """
         if not records:
             return
         cache_key = str(self.event_log.resolve())
@@ -3970,6 +3982,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # is not this instance's own append-only one -- see _write_durable_read_cache.
         durable_epoch: int | None = None
         with self._read_cache_lock:
+            if (
+                pre_size is not None
+                and self._read_cache_records is not None
+                and self._read_cache_size >= 0
+                and self._read_cache_size != pre_size
+            ):
+                # Another writer appended since this view was established. Extending it would
+                # stamp the current signature onto a list missing their records, and a cold
+                # reader would silently lose them. Drop it; the next read re-derives from disk.
+                self._read_cache_records = None
+                self._read_cache_size = -1
+                self._read_cache_mtime_ns = -1
+                self._read_cache_source = "empty"
             if self._read_cache_records is not None:
                 before = len(self._read_cache_records)
                 self._read_cache_records.extend(records)
@@ -3991,6 +4016,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_source = "empty"
         with _LOCAL_READ_CACHE_LOCK:
             cached = _LOCAL_READ_CACHE.get(cache_key)
+            if cached is not None and pre_size is not None and cached[0] != pre_size:
+                # The shared entry does not cover the log as it stood before this write either
+                # (a writer in another process got in), so it is stale the same way.
+                _LOCAL_READ_CACHE.pop(cache_key, None)
+                cached = None
             if cached is not None:
                 _, _, cached_records = cached
                 cached_records = compact_and_apply_tombstones(list(cached_records) + list(records))
@@ -4182,8 +4212,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if self._queue_batched_records(records):
             return
         sanitized = [self._sanitize_jsonl_record(item) for item in records]
+        pre_size: int | None = None
         if self._local_jsonl_enabled:
             with self._event_log_lock:
+                # Log bytes as they stand BEFORE this write. If this differs from the bytes the
+                # cached view covers, another writer appended in between and the cached view is
+                # missing their records -- see _update_read_cache_after_append.
+                pre_size = int(self._jsonl_cache_signature_detail().get("total_size", -1))
                 jsonl_records = self._encode_records_for_log(sanitized)
                 jsonl_lines = [json.dumps(item, separators=(",", ":")) + "\n" for item in jsonl_records]
                 self._rotate_jsonl_if_needed_locked(sum(len(line.encode("utf-8")) for line in jsonl_lines))
@@ -4194,7 +4229,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         self._update_latest_entity_cache(records)
         # The read caches hold the fully-expanded (interning-free) view, so serve the sanitized
         # records -- expansion of the on-disk interned form yields exactly these.
-        self._update_read_cache_after_append(sanitized)
+        self._update_read_cache_after_append(sanitized, pre_size=pre_size)
         self._maintain_event_membership_after_append(records)
 
     def append_many(self, records: list[Json]) -> None:
@@ -4209,8 +4244,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if self._queue_batched_records(records):
             return
         sanitized = [self._sanitize_jsonl_record(record) for record in records]
+        pre_size: int | None = None
         if self._local_jsonl_enabled:
             with self._event_log_lock:
+                # Same interloper capture as append() -- see _update_read_cache_after_append.
+                pre_size = int(self._jsonl_cache_signature_detail().get("total_size", -1))
                 jsonl_records = self._encode_records_for_log(sanitized)
                 jsonl_lines = [json.dumps(record, separators=(",", ":")) + "\n" for record in jsonl_records]
                 self._rotate_jsonl_if_needed_locked(sum(len(line.encode("utf-8")) for line in jsonl_lines))
@@ -4219,7 +4257,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         handle.write(line)
                 self._prune_jsonl_retention_locked()
         self._update_latest_entity_cache(records)
-        self._update_read_cache_after_append(sanitized)
+        self._update_read_cache_after_append(sanitized, pre_size=pre_size)
 
     def _update_latest_entity_cache(self, records: list[Json]) -> None:
         if not hasattr(self, "_session_buffer_cache_lock"):

--- a/tools/test_incremental_read_cache.py
+++ b/tools/test_incremental_read_cache.py
@@ -97,14 +97,13 @@ class IncrementalReadCacheCase(unittest.TestCase):
         self.assertNotIn(adapter._durable_read_cache_delta_path().name, globbed)
         self.assertNotIn(adapter._durable_read_cache_head_path().name, globbed)
 
-    @unittest.expectedFailure
     def test_a_second_writer_does_not_corrupt_the_view(self):
-        """KNOWN DEFECT, predates the tail path -- kept as a live repro.
-
-        Two adapters over one log each hold their own record list. Whichever writes last stamps
-        the CURRENT log signature onto a view missing the other adapter records, so a cold reader
-        accepts the cache and silently loses them (55 of 75 here). Reproduces identically with the
-        tail path reverted, so it is not a regression from it. Remove this marker with the fix.
+        """Two adapters over one log each hold their own record list, and the signature alone
+        cannot catch a stale one -- it describes the log at WRITE time, so whichever adapter
+        wrote last used to stamp the current signature onto a view missing the other's records,
+        and a cold reader silently lost them (55 of 75 here). The append path now compares the
+        bytes its cached view covers against the log as it stood before its own write, and
+        refuses to publish a view that was already behind.
         """
         first = self._primed()
         second = A.MatrixArkLocalAdapter(self.path)
@@ -112,6 +111,24 @@ class IncrementalReadCacheCase(unittest.TestCase):
         second.read_all()
         for record in _records(self.SEED + 20, 5):
             first.append(record)
+        total = self.SEED + 25
+        view = self._fresh_view()
+        self.assertEqual(total, len(view))
+        self.assertEqual(list(range(total)), sorted(r["event_id_hash"] for r in view))
+        self.assertEqual(self._log_view(), view)
+
+    def test_a_writer_in_another_process_does_not_corrupt_the_view(self):
+        """Same staleness, harder case: the interloper's records never pass through this
+        process, so the shared in-process cache cannot repair the view -- the only tell is
+        that the log grew by bytes this instance never accounted for. Simulated by writing
+        lines straight to the log file between two adapters' appends.
+        """
+        adapter = self._primed()
+        with self.path.open("a", encoding="utf-8") as handle:
+            for record in _records(self.SEED, 20):
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        for record in _records(self.SEED + 20, 5):
+            adapter.append(record)
         total = self.SEED + 25
         view = self._fresh_view()
         self.assertEqual(total, len(view))


### PR DESCRIPTION
Fixes #179.

When two adapters share one event log, whichever wrote last stamped the **current** log signature onto its own record list -- a list missing everything the other adapter had appended. The signature is computed at write time, so it describes the log, not the list; a cold reader accepted the cache and silently lost records (55 of 75 in the repro).

### The guard

The append path captures the retained-log byte total **under the event-log lock, before its own write**. A cached view may only absorb the append when the bytes it covers equal that number. Otherwise another writer got in between, the view is provably missing their records, and it is dropped rather than published -- the next read re-derives from disk.

The shared in-process entry is held to the same test. That also catches the harder case: a writer in **another process**, whose records never pass through any cache in this one. There the log growing by bytes this instance never accounted for is the only tell that exists.

### Why not repair instead of drop

The in-process cache usually *could* be repaired (the second adapter's appends flow through it), but a repair path that works for one interleaving and not the other is exactly how the original bug survived -- it looked correct whenever both writers shared a process. Dropping is unconditional and the cost is one re-read.

### Tests

- `test_a_second_writer_does_not_corrupt_the_view` -- shipped with #180 as `@unittest.expectedFailure`; the marker is now removed and it asserts for real.
- `test_a_writer_in_another_process_does_not_corrupt_the_view` -- new; appends straight to the log file so nothing passes through this process's caches.
- Full `test_incremental_read_cache` suite: 9/9. `test_intern_record_metadata` (reload fidelity): 11/11. mem0 read-your-writes and the inline-vector suites green.
- Ratchet: no confirmed additions beyond the known machine-specific set (js-runtime tests), verified identical on unmodified main.
