### PR TITLE
Score traversal from the vector the node itself carries

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1544,7 +1544,7 @@ pub(crate) fn extract_context_gated(
         String::new()
     };
     let l2_ref = summaries.l2_ref;
-    let node = ContextNode {
+    let mut node = ContextNode {
         node_hash,
         parent_hash: 0,
         kind: source_kind_code(request.source_kind),
@@ -1720,6 +1720,13 @@ pub(crate) fn extract_context_gated(
         // index 0 is the L0 summary, index 1 the L1 summary when emitted, and the event last.
         if let Some(vector) = embedding_vectors.first() {
             summary_l0.vector = vector.clone();
+            // The node itself carries its L0 vector too: the traversal scores children from
+            // node.vector first, and without this the happy path would leave it empty on every
+            // fresh ingest -- only the drainer's deferred path would ever fill it, so the
+            // fallback to the separate record could never be retired.
+            node.vector = vector.clone();
+            node.embedding_model_hash = context_embedding_model_hash(&provider.model);
+            node.embedding_updated_at_ms = timestamp_ms;
         }
         if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.get(1)) {
             summary.vector = vector.clone();

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -1463,6 +1463,24 @@ fn context_reference_blocks_and_provider_model_switches_are_reported() {
                     && embeddings.iter().all(|embedding| embedding.vector.len() == 16)
                     && embeddings.iter().all(|embedding| embedding.updated_at_ms == extract.event.event_time_ms)
         ));
+
+        // The node itself must carry its L0 vector off the same ingest -- the traversal scores
+        // from node.vector first, so a happy-path ingest that left it empty would strand every
+        // fresh node on the separate-record fallback and the records could never be retired.
+        let node = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextGetNode {
+                tenant_hash: 20260620,
+                node_hash: extract.node.node_hash,
+            },
+        });
+        assert!(matches!(
+            node.response,
+            CommandResponse::ContextNode { node: Some(ref node), .. }
+                if node.vector.len() == 16
+                    && node.embedding_model_hash != 0
+                    && node.embedding_updated_at_ms == extract.event.event_time_ms
+        ));
     }
 
     let retrieve = retrieve_context(&engine, ingest.retrieve_request);

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -795,6 +795,29 @@ pub(super) fn load_context_children(
         .unwrap_or_default()
 }
 
+pub(super) fn load_context_node(
+    cache: &MultiLayerCache,
+    page_store: &LocalBlockStore,
+    shard_id: ShardId,
+    shard: &ShardState,
+    tenant_hash: u64,
+    node_hash: u64,
+) -> Option<ContextNode> {
+    // Same two-step lookup as the ContextGetNode command: current nodes live in the hashes map
+    // under the CONTEXT_NODE_FIELD slot; context_nodes is the pre-hashes location still read for
+    // blocks written before that move.
+    let object_key = context_node_key(tenant_hash, node_hash);
+    shard
+        .hashes
+        .get(&object_key)
+        .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
+        .or_else(|| shard.context_nodes.get(&object_key))
+        .and_then(|address| {
+            read_page_bytes(cache, page_store, shard_id, address)
+                .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
+        })
+}
+
 pub(super) fn load_context_embedding(
     cache: &MultiLayerCache,
     page_store: &LocalBlockStore,
@@ -967,30 +990,48 @@ pub(super) fn traverse_context_tree(
             children.sort_by_key(|child_ref| (child_ref.updated_at_ms, child_ref.child_hash));
             children.truncate(child_limit);
             for child in children {
-                // Address the embedding the way WRITERS store it. This passed the child's raw
-                // node hash, but every writer stores under
-                // context_embedding_ref_hash(tenant, owner, level) -- a hash of those three --
-                // which can never equal a bare node hash. So the lookup missed for every child,
-                // `continue` fired every iteration, and the cosine scoring below was
-                // unreachable. The test did not catch it because it wrote its embedding under
-                // the raw node hash too, constructing the data the way this READER expected
-                // rather than the way writers actually write it.
-                let ref_hash = crate::context_workflow::context_embedding_ref_hash(
-                    tenant_hash,
-                    child.child_hash,
-                    "node_l0",
-                );
-                let Some(embedding) = load_context_embedding(
+                // Score from the vector the node itself carries -- the write path has set it
+                // since nodes gained one -- and fall back to the separate embedding record for
+                // nodes embedded before that. The fallback is what lets those records be retired
+                // without a flag day: by the time they are dropped, nothing here needs them.
+                //
+                // The fallback must address the record the way WRITERS store it: under
+                // context_embedding_ref_hash(tenant, owner, level), a one-way hash of those
+                // three. An earlier version passed the child's raw node hash, which can never
+                // equal that, so the lookup missed for every child and the cosine scoring was
+                // unreachable -- and the test missed it by writing its embedding under the raw
+                // hash too, constructing data the way the reader expected rather than the way
+                // writers write it.
+                let vector = load_context_node(
                     cache,
                     page_store,
                     shard_id,
                     shard,
                     tenant_hash,
-                    ref_hash,
-                ) else {
+                    child.child_hash,
+                )
+                .filter(|node| !node.vector.is_empty())
+                .map(|node| node.vector)
+                .or_else(|| {
+                    let ref_hash = crate::context_workflow::context_embedding_ref_hash(
+                        tenant_hash,
+                        child.child_hash,
+                        "node_l0",
+                    );
+                    load_context_embedding(
+                        cache,
+                        page_store,
+                        shard_id,
+                        shard,
+                        tenant_hash,
+                        ref_hash,
+                    )
+                    .map(|embedding| embedding.vector)
+                });
+                let Some(vector) = vector else {
                     continue;
                 };
-                let score = cosine_similarity(query_vector, &embedding.vector);
+                let score = cosine_similarity(query_vector, &vector);
                 if score > 0.0 {
                     scored_layer.push(ContextTraversedNode {
                         node_hash: child.child_hash,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3044,3 +3044,199 @@ fn asking_by_owner_and_by_ref_hash_give_the_same_vector() {
     assert_eq!(vector, by_owner);
     assert_eq!(by_ref_hash, by_owner, "the two read paths disagree");
 }
+
+// shared-corpus: context_traversal_scores_from_inline_vector
+#[test]
+fn traversal_scores_a_child_whose_only_vector_is_on_the_node() {
+    // The retirement-readiness assertion: NO separate embedding record exists here. If the
+    // traversal still reaches for one, dropping those records would silently turn every
+    // tree query into an empty answer -- so this test must hold BEFORE they can go.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 5001;
+    const ROOT: u64 = 1;
+    const NEAR: u64 = 2;
+    const FAR: u64 = 3;
+    const EVENT_TIME: u64 = 1_781_600_000_000;
+
+    for (node_hash, name) in [(ROOT, "root"), (NEAR, "near"), (FAR, "far")] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: if node_hash == ROOT { 0 } else { ROOT },
+                    kind: 1,
+                    canonical_name: name.to_string(),
+                    l0: format!("{name} text"),
+                    status: 0,
+                    last_event_time_ms: EVENT_TIME,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+        assert!(response.status.ok);
+    }
+    for child_hash in [NEAR, FAR] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertChildRef {
+                tenant_hash: TENANT,
+                child_ref: ContextChildRef {
+                    parent_hash: ROOT,
+                    child_hash,
+                    updated_at_ms: EVENT_TIME,
+                },
+            },
+        });
+        assert!(response.status.ok);
+    }
+    // Vectors arrive ONLY through the node-addressed write -- no ContextUpsertEmbedding at all.
+    for (node_hash, first, second) in [(NEAR, 1.0, 0.0), (FAR, 0.0, 1.0)] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: TENANT,
+                node_hash,
+                model_hash: 7,
+                vector: vec![first, second],
+                updated_at_ms: EVENT_TIME,
+            },
+        });
+        assert!(response.status.ok);
+    }
+
+    let traversal = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextTraverseTree {
+            tenant_hash: TENANT,
+            start_node_hash: ROOT,
+            query_vector: vec![1.0, 0.0],
+            max_depth: Some(2),
+            top_k_per_depth: Some(1),
+            max_children_scored_per_parent: Some(10),
+            max_candidate_nodes: Some(4),
+            leaf_only: true,
+        },
+    });
+    assert!(
+        matches!(
+            traversal.response,
+            CommandResponse::ContextTraversedNodes { ref nodes }
+                if nodes.len() == 1 && nodes[0].node_hash == NEAR && nodes[0].score > 0.99
+        ),
+        "a child whose only vector lives on the node must be scored"
+    );
+}
+
+// shared-corpus: context_traversal_inline_vector_wins_over_record
+#[test]
+fn traversal_prefers_the_node_vector_over_a_stale_separate_record() {
+    // When both exist, the node's own vector must win: the node-addressed write is the one
+    // re-embedding goes through, so a disagreement means the separate record is the stale copy.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    const TENANT: u64 = 5002;
+    const ROOT: u64 = 1;
+    const CHILD: u64 = 2;
+    const EVENT_TIME: u64 = 1_781_600_000_000;
+
+    for node_hash in [ROOT, CHILD] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: if node_hash == ROOT { 0 } else { ROOT },
+                    kind: 1,
+                    canonical_name: format!("n{node_hash}"),
+                    l0: "text".to_string(),
+                    status: 0,
+                    last_event_time_ms: EVENT_TIME,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+    }
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertChildRef {
+            tenant_hash: TENANT,
+            child_ref: ContextChildRef {
+                parent_hash: ROOT,
+                child_hash: CHILD,
+                updated_at_ms: EVENT_TIME,
+            },
+        },
+    });
+    // The separate record points AWAY from the query; the node's own vector points at it.
+    let ref_hash =
+        crate::context_workflow::context_embedding_ref_hash(TENANT, CHILD, "node_l0");
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertEmbedding {
+            tenant_hash: TENANT,
+            embedding: ContextEmbedding {
+                ref_hash,
+                level: 1,
+                model_hash: 1,
+                vector: vec![0.0, 1.0],
+                updated_at_ms: EVENT_TIME,
+            },
+        },
+    });
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextSetNodeEmbedding {
+            tenant_hash: TENANT,
+            node_hash: CHILD,
+            model_hash: 2,
+            vector: vec![1.0, 0.0],
+            updated_at_ms: EVENT_TIME + 1,
+        },
+    });
+
+    let traversal = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextTraverseTree {
+            tenant_hash: TENANT,
+            start_node_hash: ROOT,
+            query_vector: vec![1.0, 0.0],
+            max_depth: Some(1),
+            top_k_per_depth: Some(1),
+            max_children_scored_per_parent: Some(10),
+            max_candidate_nodes: Some(4),
+            leaf_only: false,
+        },
+    });
+    assert!(
+        matches!(
+            traversal.response,
+            CommandResponse::ContextTraversedNodes { ref nodes }
+                if nodes.len() == 1 && nodes[0].node_hash == CHILD && nodes[0].score > 0.99
+        ),
+        "the node's own vector must outrank the stale separate record"
+    );
+}


### PR DESCRIPTION
Third step of the embedding fold: the traversal now **reads** the vector the node carries, and the ingest happy path now **writes** it.

### The read side

The tree traversal scored each child by fetching the separate embedding record, addressed by the one-way hash of `(tenant, owner, level)`. It now reads `node.vector` first and falls back to the separate record only for nodes embedded before the fold. When both exist and disagree, the node's own vector wins -- re-embedding goes through the node-addressed write, so a disagreement means the separate record is the stale copy.

### The write side, and the hole this closes

The happy-path ingest copied vectors onto the L0 summary, the L1 summary and the event -- **but not onto the node**. Only the drainer, which runs for *deferred* embeddings, wrote the node-addressed copy. So every node whose embedding succeeded live would have had an empty `node.vector`, the traversal would have fallen back for exactly the common case, and the separate records could never have been retired.

### Retirement readiness, pinned

One new test gives a child a vector **only** through the node-addressed write -- no separate record anywhere -- and requires the traversal to score it. If the traversal still reached for the record, dropping the records would silently turn every tree query into an empty answer, and no existing test would have noticed: they all wrote both. A second test pins the disagreement rule, and the existing round-trip (separate record only) pins the fallback.

`load_context_node` is the `ContextGetNode` lookup extracted into `engine/context.rs` so the traversal and the command arm cannot drift apart on where nodes live.

### Verification

- 3 traversal tests + the workflow ingest suite (27) green; the ingest test now fetches the node afterward and requires vector, model hash and timestamp on it.
- Full lib suite, serial: **1167 passed / 2 failed** -- both failures are the known pre-existing pair (`storage_manager_runtime_...jitter_backoff...`, `recovery_validates_all_timestamped_kv_page_families`), verified failing identically at the base commit before any of this branch.

### What remains before the separate node_l0 records can go

The engine-side readers are covered here. The out-of-engine readers (`cb_retrieve`, the backfill tool) still address by ref hash; once those follow, the node_l0 rows can stop being written and a sweep can drop the existing ones.
