### PR TITLE
Add mem0 feedback: rate a memory, and read the rating back

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -388,6 +388,8 @@ MATRIXARK_TOOL_SCOPES: dict[str, set[str]] = {
     "matrixark_get_memory_by_key": {"context:retrieve"},
     "matrixark_update_memory": {"context:ingest"},
     "matrixark_memory_history": {"context:retrieve"},
+    # A write about a memory, so it gates like a write rather than like a read.
+    "matrixark_memory_feedback": {"context:ingest"},
     "matrixark_ingestion_dashboard": {"context:replay"},
     "matrixark_management_portal": {"portal:read"},
     "matrixark_auth_sso_login": set(),

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -85,6 +85,15 @@ class MatrixArkError(ValueError):
     pass
 
 
+class MatrixArkInvalidRequestError(MatrixArkError):
+    """The request itself is malformed -- a value outside its allowed vocabulary, say.
+
+    A distinct type so the edge can answer 400. Not applied wholesale: `MatrixArkError` is raised
+    for both bad input and internal failures throughout the adapter, and reclassifying all of it
+    would turn real faults into 400s. Used where the classification is unambiguous.
+    """
+
+
 class MatrixArkNotFoundError(MatrixArkError):
     """The thing the request addressed does not exist.
 

--- a/tools/matrixark_mcp_dispatch.py
+++ b/tools/matrixark_mcp_dispatch.py
@@ -218,6 +218,18 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         server.access.append_audit("skill.update", identity, status="ok", details={"skill_hash": result.get("skill_hash"), "skill_status": result.get("status")})
         response = {**result, "access": args.get("_matrixark_auth", {})}
         return server._finalize_write_response(name, args, identity, hook, response)
+    if name == "matrixark_memory_feedback":
+        result = server.adapter.memory_feedback(args, hook=hook)
+        server.append_audit_policy(
+            "context.memory_feedback",
+            identity,
+            status="ok",
+            details={"memory_id": result.get("memory_id"), "feedback": result.get("feedback")},
+            args=args,
+            hot_path=True,
+        )
+        response = {**result, "access": args.get("_matrixark_auth", {})}
+        return server._finalize_write_response(name, args, identity, hook, response)
     if name == "matrixark_feedback":
         started_perf = time.perf_counter()
         try:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5484,6 +5484,67 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             "reingest_scope": clean_scope,
         }
 
+    MEMORY_FEEDBACK_RECORD_TYPE = "matrixark_memory_feedback"
+    MEMORY_FEEDBACK_RATINGS = ("POSITIVE", "NEGATIVE", "VERY_NEGATIVE")
+
+    def memory_feedback(self, args: Json, hook: Json | None = None) -> Json:
+        """Attach a rating to an existing memory (mem0 ``feedback``).
+
+        Deliberately NOT a `context_event`: a rating is not a memory, and storing it as one would
+        make it show up in `get_all` and compete for retrieval. It is its own record type, and
+        `history(memory_id)` surfaces it beside the ingest / supersede / delete events -- which is
+        where a caller looks for what happened to a memory, and the only place this is readable.
+
+        The rating vocabulary is closed. An unrecognised value is refused rather than stored,
+        because a rating nobody can interpret is worse than no rating: it reads as feedback that
+        was recorded and understood.
+        """
+        memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
+        if not memory_id:
+            raise MatrixArkInvalidRequestError("feedback requires a memory_id")
+        rating = str(args.get("feedback") or args.get("rating") or "").strip().upper()
+        if not rating:
+            raise MatrixArkInvalidRequestError(
+                "feedback requires a feedback value (%s)"
+                % ", ".join(self.MEMORY_FEEDBACK_RATINGS))
+        if rating not in self.MEMORY_FEEDBACK_RATINGS:
+            raise MatrixArkInvalidRequestError(
+                "feedback must be one of %s (got %r)"
+                % (", ".join(self.MEMORY_FEEDBACK_RATINGS), rating))
+        reason = args.get("feedback_reason")
+        reason = str(reason).strip() if isinstance(reason, str) and reason.strip() else None
+
+        target: Json | None = None
+        for record in self.read_all():
+            if (str(record.get("record_type") or "") == "context_event"
+                    and str(record.get("event_id_hash")) == memory_id):
+                target = record
+                break
+        if target is None:
+            raise MatrixArkNotFoundError(
+                "feedback target memory not found (already deleted, or not a memory id)")
+
+        # Tenant isolation, the same rule `update` applies: an authenticated request pins a tenant,
+        # and a rating must not cross from one tenant to another's memory.
+        request_scope = optional_object(args, "scope")
+        request_tenant, _ = self._resolve_subject_hashes(request_scope) if request_scope else (0, 0)
+        target_tenant, _ = _record_scope_hashes(target)
+        if request_tenant and target_tenant and request_tenant != target_tenant:
+            raise MatrixArkError("feedback refused: the memory belongs to another tenant")
+
+        record = {
+            "record_type": self.MEMORY_FEEDBACK_RECORD_TYPE,
+            "target_memory_id": memory_id,
+            "feedback": rating,
+            "scope_key": str(target.get("scope_key") or ""),
+            "created_at_ms": now_ms(),
+        }
+        if reason:
+            record["feedback_reason"] = reason
+        self.append(record)
+        return {"recorded": True, "memory_id": memory_id, "feedback": rating,
+                "feedback_reason": reason}
+
     def history(self, args: Json) -> Json:
         """Return the ordered change history for a memory id (mem0 ``history``). Because the store is
         event-sourced, this is the RAW (un-compacted, un-tombstoned) event log filtered to the id:
@@ -5516,6 +5577,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 elif str(record.get("superseded_by")) == memory_id:
                     events.append({"event": "created", "record_type": record_type, "memory_id": memory_id,
                                    "created_at_ms": ts, "supersedes_memory_id": record.get("target_memory_id")})
+            elif (record_type == self.MEMORY_FEEDBACK_RECORD_TYPE
+                    and str(record.get("target_memory_id") or "") == memory_id):
+                entry = {"event": "feedback", "record_type": record_type, "memory_id": memory_id,
+                         "created_at_ms": ts, "feedback": record.get("feedback")}
+                if record.get("feedback_reason"):
+                    entry["feedback_reason"] = record.get("feedback_reason")
+                events.append(entry)
         return {"memory_id": memory_id, "history": events, "count": len(events)}
 
     # --------------------------------------------------------------------------------------------

--- a/tools/matrixark_mcp_schemas.py
+++ b/tools/matrixark_mcp_schemas.py
@@ -1251,6 +1251,26 @@ TOOLS: list[Json] = [
         },
     },
     {
+        "name": "matrixark_memory_feedback",
+        "description": "Rate an existing memory (mem0 feedback). The rating is stored against the memory, not as a memory of its own -- it does not appear in get_all or search. Read it back with matrixark_memory_history.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["memory_id", "feedback"],
+            "properties": {
+                "api_key": API_KEY_SCHEMA,
+                "scope": SCOPE_SCHEMA,
+                "memory_id": {"type": "string", "description": "The memory id (event_id_hash) to rate."},
+                "feedback": {
+                    "type": "string",
+                    "enum": ["POSITIVE", "NEGATIVE", "VERY_NEGATIVE"],
+                    "description": "The rating. An unrecognised value is refused rather than stored.",
+                },
+                "feedback_reason": {"type": "string", "description": "Optional free-text reason for the rating."},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
         "name": "matrixark_memory_history",
         "description": "Return the ordered change history for a memory id (mem0 history): ingest -> update/supersede -> delete, with timestamps.",
         "inputSchema": {

--- a/tools/matrixark_mem0_compat.py
+++ b/tools/matrixark_mem0_compat.py
@@ -430,6 +430,22 @@ class Memory:
         body: Json = {"memory_id": str(memory_id)}
         return _post_json(self._base_url, self._api_key, "/v1/delete", body, self._timeout)
 
+    def feedback(self, memory_id: str, feedback: str, feedback_reason: Optional[str] = None,
+                 **kw: Any) -> Json:
+        """Rate an existing memory (mem0 ``feedback``).
+
+        The rating is stored against the memory, not as a memory: it does not appear in `get_all`
+        or `search`. Read it back with `history(memory_id)`, where it appears as an event beside
+        the ingest and supersede entries.
+
+        `feedback` is one of POSITIVE, NEGATIVE, VERY_NEGATIVE. An unknown value is refused by the
+        server rather than stored.
+        """
+        body: Json = {"memory_id": str(memory_id), "feedback": str(feedback)}
+        if feedback_reason:
+            body["feedback_reason"] = str(feedback_reason)
+        return _post_json(self._base_url, self._api_key, "/v1/memory/feedback", body, self._timeout)
+
     def batch_update(self, memories: Any, **kw: Any) -> Json:
         """Update many memories in one call (mem0 ``batch_update``).
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -171,6 +171,9 @@ _DATA_ROUTES: dict[str, Tuple[str, str]] = {
     "/v1/resource/content": ("matrixark_get_resource_content", "retrieve"),
     # update = supersede (ingest an amended version + tombstone the old id): gates on context:ingest.
     "/v1/update": ("matrixark_update_memory", "ingest"),
+    # mem0 feedback(): rate an existing memory. A write about a memory, so it gates like one; the
+    # rating is read back through GET /v1/memory/<id>/history, not as a memory of its own.
+    "/v1/memory/feedback": ("matrixark_memory_feedback", "ingest"),
     # get (GET /v1/memory/<id>) and history (GET /v1/memory/<id>/history) are handled by dedicated
     # GET branches below (data routes are POST-only), gated on context:retrieve.
 }
@@ -181,6 +184,8 @@ _BACKPRESSURE_ERRORS = {"MatrixArkBackpressureError"}
 # The addressed thing does not exist -- the caller's own state to fix, not a server fault. Matched
 # by class name, like the sets above, so a message that merely contains "not found" is unaffected.
 _NOT_FOUND_ERRORS = {"MatrixArkNotFoundError"}
+# The request is malformed -- the caller's to fix, and not worth a retry.
+_INVALID_REQUEST_ERRORS = {"MatrixArkInvalidRequestError"}
 _STORAGE_QUOTA_ERRORS = {
     "MatrixArkStorageQuotaError",
     "StorageQuotaExceeded",
@@ -1053,6 +1058,8 @@ def _classify_backend_error(exc: Exception) -> int:
         return 429
     if name in _NOT_FOUND_ERRORS:
         return 404
+    if name in _INVALID_REQUEST_ERRORS:
+        return 400
     return 500
 
 

--- a/tools/test_memory_feedback.py
+++ b/tools/test_memory_feedback.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""mem0 `feedback`: rate an existing memory, without the rating becoming a memory.
+
+There was already a `matrixark_feedback` tool, but it means something else -- it ingests feedback
+TEXT as a new memory. mem0's `feedback` attaches a rating to an EXISTING memory, and nothing did
+that.
+
+The two things worth pinning are what it must NOT do. A rating stored as a `context_event` would
+show up in `get_all` and compete for retrieval with real memories, which is worse than not storing
+it. And a rating stored somewhere nothing reads would be a feature only on paper -- so it has to
+come back out of `history`.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as adapter_mod
+    from tools import matrixark_v1_gateway as gateway
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as adapter_mod
+    import matrixark_v1_gateway as gateway
+
+SCOPE_KEY = "t=11|u=22|s=33|"
+
+
+class _Adapter(adapter_mod.MatrixArkLocalAdapter):
+    """An adapter whose log is a list, so the record this writes can be inspected directly."""
+
+    def __init__(self, memories):
+        self.appended = []
+        self._log = list(memories)
+
+    def read_all(self):
+        return list(self._log) + list(self.appended)
+
+    def _read_raw_records(self):
+        return list(self._log) + list(self.appended)
+
+    def append(self, record):
+        self.appended.append(record)
+
+    def _resolve_subject_hashes(self, scope):
+        return (int(scope.get("tenant_hash") or 0), int(scope.get("user_hash") or 0))
+
+
+def _memory(memory_id="777"):
+    return {"record_type": "context_event", "event_id_hash": memory_id,
+            "text": "The escalation contact is Dana.", "scope_key": SCOPE_KEY,
+            "access_scope": {"tenant_hash": 11, "user_hash": 22, "scope_key": SCOPE_KEY},
+            "updated_at_ms": 1000}
+
+
+class MemoryFeedbackTests(unittest.TestCase):
+    def test_a_rating_is_recorded_against_the_memory(self):
+        adapter = _Adapter([_memory()])
+        out = adapter.memory_feedback({"memory_id": "777", "feedback": "POSITIVE"})
+        self.assertTrue(out["recorded"])
+        self.assertEqual(1, len(adapter.appended))
+        self.assertEqual("777", adapter.appended[0]["target_memory_id"])
+        self.assertEqual("POSITIVE", adapter.appended[0]["feedback"])
+
+    def test_the_rating_is_not_stored_as_a_memory(self):
+        """A context_event here would surface in get_all and compete for retrieval."""
+        adapter = _Adapter([_memory()])
+        adapter.memory_feedback({"memory_id": "777", "feedback": "NEGATIVE"})
+        self.assertNotEqual("context_event", adapter.appended[0]["record_type"])
+        self.assertEqual(adapter.MEMORY_FEEDBACK_RECORD_TYPE, adapter.appended[0]["record_type"])
+
+    def test_history_reports_it_beside_the_ingest(self):
+        adapter = _Adapter([_memory()])
+        adapter.memory_feedback({"memory_id": "777", "feedback": "POSITIVE", "feedback_reason": "spot on"})
+        events = adapter.history({"memory_id": "777"})["history"]
+        self.assertEqual(["ingested", "feedback"], [e["event"] for e in events])
+        self.assertEqual("POSITIVE", events[1]["feedback"])
+        self.assertEqual("spot on", events[1]["feedback_reason"])
+
+    def test_a_rating_for_another_memory_is_not_reported(self):
+        adapter = _Adapter([_memory("777"), _memory("888")])
+        adapter.memory_feedback({"memory_id": "888", "feedback": "NEGATIVE"})
+        events = adapter.history({"memory_id": "777"})["history"]
+        self.assertEqual(["ingested"], [e["event"] for e in events])
+
+    def test_the_reason_is_optional(self):
+        adapter = _Adapter([_memory()])
+        adapter.memory_feedback({"memory_id": "777", "feedback": "POSITIVE"})
+        self.assertNotIn("feedback_reason", adapter.appended[0])
+
+    def test_a_rating_outside_the_vocabulary_is_refused(self):
+        """Refused, not stored: a rating nobody can interpret reads as feedback that was understood."""
+        adapter = _Adapter([_memory()])
+        with self.assertRaises(adapter_mod.MatrixArkInvalidRequestError):
+            adapter.memory_feedback({"memory_id": "777", "feedback": "AMAZING"})
+        self.assertEqual([], adapter.appended)
+
+    def test_the_rating_is_case_insensitive(self):
+        adapter = _Adapter([_memory()])
+        adapter.memory_feedback({"memory_id": "777", "feedback": "positive"})
+        self.assertEqual("POSITIVE", adapter.appended[0]["feedback"])
+
+    def test_a_missing_rating_is_refused(self):
+        adapter = _Adapter([_memory()])
+        with self.assertRaises(adapter_mod.MatrixArkInvalidRequestError):
+            adapter.memory_feedback({"memory_id": "777"})
+
+    def test_a_missing_memory_id_is_refused(self):
+        adapter = _Adapter([_memory()])
+        with self.assertRaises(adapter_mod.MatrixArkInvalidRequestError):
+            adapter.memory_feedback({"feedback": "POSITIVE"})
+
+    def test_an_unknown_memory_raises_not_found(self):
+        adapter = _Adapter([_memory()])
+        with self.assertRaises(adapter_mod.MatrixArkNotFoundError):
+            adapter.memory_feedback({"memory_id": "does-not-exist", "feedback": "POSITIVE"})
+        self.assertEqual([], adapter.appended)
+
+    def test_another_tenants_memory_cannot_be_rated(self):
+        adapter = _Adapter([_memory()])
+        with self.assertRaises(adapter_mod.MatrixArkError):
+            adapter.memory_feedback({"memory_id": "777", "feedback": "POSITIVE",
+                                     "scope": {"tenant_hash": 99, "user_hash": 22}})
+        self.assertEqual([], adapter.appended)
+
+
+class FeedbackStatusTests(unittest.TestCase):
+    def test_a_bad_rating_maps_to_400(self):
+        self.assertEqual(400, gateway._classify_backend_error(
+            adapter_mod.MatrixArkInvalidRequestError("feedback must be one of ...")))
+
+    def test_an_unknown_memory_maps_to_404(self):
+        self.assertEqual(404, gateway._classify_backend_error(
+            adapter_mod.MatrixArkNotFoundError("feedback target memory not found")))
+
+    def test_an_ordinary_failure_still_maps_to_500(self):
+        self.assertEqual(500, gateway._classify_backend_error(
+            adapter_mod.MatrixArkError("the backend fell over")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`feedback` was the last named method of the mem0 client with nothing behind it. There IS a
`matrixark_feedback` tool, but it means something else -- it ingests feedback TEXT as a new memory.
mem0's `feedback` attaches a rating to an EXISTING memory, and nothing did that.

Two things it deliberately does not do:

* The rating is NOT a `context_event`. Stored as one it would appear in `get_all` and compete with
  real memories for retrieval, which is worse than not storing it. It has its own record type.
* It is not write-only. `history(memory_id)` reports it beside the ingest / supersede / delete
  events, which is where a caller looks for what happened to a memory. A rating nothing can read
  back would be a feature only on paper.

The rating vocabulary is closed -- POSITIVE, NEGATIVE, VERY_NEGATIVE, case-insensitive. An
unrecognised value is refused rather than stored, because a rating nobody can interpret reads as
feedback that was recorded and understood.

Status codes are part of the API, so this endpoint gets them right rather than inheriting a wrong
default: a bad rating answers 400, an unknown memory 404, a real failure still 500. That needed a
`MatrixArkInvalidRequestError` alongside the not-found type. It is used only here on purpose --
`MatrixArkError` is raised for both bad input and internal failures throughout the adapter, so
reclassifying it wholesale would turn real faults into 400s. The type now exists, which makes the
wider sweep a mechanical follow-up rather than a guess.

Registered in three places, because a dispatch branch alone is not a tool: the schema (so it
appears in `tools/list` and a model can discover it -- verified live, 42 tools advertised with this
one among them), the permission map (so the gate has a rule: it gates like a write), and the
gateway route.

Verified end to end against the running gateway: recorded, one `feedback` event in history carrying
the reason, still exactly one memory in `get_all`, the reason text absent from search results, a
bad rating 400, an unknown memory 404.

14 tests: recording, the record type NOT being a memory, history reporting it, another memory's
rating not being reported, the optional reason, the closed vocabulary, case-insensitivity, missing
rating and missing id, unknown memory, cross-tenant refusal, and the three status mappings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
