### PR TITLE
Break the idempotency congestion spiral, and wire the append router that never ran

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -572,16 +572,38 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         """
         self._ensure_idempotency_index()
         import json as _json
+        import time as _time
 
-        try:
-            raw = self._client.hget(self._idempotency_index_key(), self._idempotency_index_field(key_hash))
-        except Exception:  # noqa: BLE001 - scan rather than wrongly report "never seen".
-            return self.find_idempotency_record_in_log(key_hash)
+        # A failed point-read must NOT fall back to the scanning lookup. The scan is a full-store
+        # read, this lookup runs first on EVERY tool call, and the point-read only fails when the
+        # lanes are already starved -- so the fallback launched store-wide reads at the exact
+        # moment the system could least afford them, starving the lanes further and making the
+        # next point-read fail too. Caught live: two of three request threads inside that scan
+        # while metrics timed out at 120s. Retry the cheap read, then let the failure propagate as
+        # the retryable error it is; answering "never seen" here instead would double-apply the
+        # request, and the scan would not have answered under these conditions either.
+        raw = None
+        last_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                raw = self._client.hget(
+                    self._idempotency_index_key(), self._idempotency_index_field(key_hash)
+                )
+                last_error = None
+                break
+            except Exception as exc:  # noqa: BLE001 - retried, then propagated below.
+                last_error = exc
+                if attempt < 2:
+                    _time.sleep(0.2 * (attempt + 1))
+        if last_error is not None:
+            raise last_error
         if not raw:
             return None
         try:
             record = _json.loads(raw)
         except (TypeError, ValueError):
+            # The index held bytes the log never produced: corruption, not load. The log is the
+            # source of truth, and this path is rare and not load-correlated, so the scan is safe.
             return self.find_idempotency_record_in_log(key_hash)
         return record if isinstance(record, dict) else None
 

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -313,7 +313,13 @@ class _TemporalDirectWriteMixin:
                 located_bundles.append((bundle, record_key, record_id))
                 sequence += 1
             native_index_entries = self._native_side_index_entries_for_bundles(located_bundles)
-            append_records = getattr(self._client, "matrixark_batch_append_records", None)
+            # Route the append through the type router, so a summary/audit-only bundle can ride the
+            # dedicated summary client instead of the foreground write lane. This is the ONLY
+            # append call site, and it ignored the router -- which made the router, the dedicated
+            # client, and its gate dead code, and put every background summary append in front of
+            # foreground ingests. Gate off (the default) the router returns self._client unchanged.
+            append_client = self._append_client_for_records(records_to_append)
+            append_records = getattr(append_client, "matrixark_batch_append_records", None)
             if callable(append_records):
                 self._write_with_backoff(
                     lambda: self._matrixark_batch_append_records_with_options(

--- a/tools/test_idempotency_no_scan_fallback.py
+++ b/tools/test_idempotency_no_scan_fallback.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A failed idempotency point-read propagates; it never becomes a full-store scan.
+
+The scan fallback was a congestion amplifier, caught live: the point-read only fails when the
+proxy lanes are already starved, this lookup runs first on EVERY tool call, and the fallback
+launched a full-store `read_all()` at exactly that moment -- starving the lanes further so the
+next point-read failed too. Two of three request threads were sitting in that scan while metrics
+timed out at 120s.
+
+The invariants pinned here: an engine failure is retried on the CHEAP read and then raised, and
+the scan survives only for a value that does not parse -- corruption, which is rare and not
+load-correlated, so scanning there cannot spiral.
+"""
+import json
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+
+
+class _Client:
+    def __init__(self, *, value=None, fail_times=0):
+        self.value = value
+        self.fail_times = fail_times
+        self.hget_calls = 0
+
+    def hget(self, key, field):
+        self.hget_calls += 1
+        if self.hget_calls <= self.fail_times:
+            raise RuntimeError("lane starved: request timed out")
+        return self.value or ""
+
+
+def _adapter(client):
+    adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+    adapter._storage_prefix = "matrixark:mcp"
+    adapter._client = client
+    adapter._idempotency_index_built = True  # the backfill is not under test
+    adapter.scans = 0
+
+    def _scan(key_hash):
+        adapter.scans += 1
+        return {"from": "scan", "key_hash": key_hash}
+
+    adapter.find_idempotency_record_in_log = _scan
+    return adapter
+
+
+class IdempotencyLookupTests(unittest.TestCase):
+    def test_a_hit_is_served_from_the_point_read(self):
+        stored = json.dumps({"tool_name": "matrixark_ingest", "key_hash": 7})
+        adapter = _adapter(_Client(value=stored))
+        record = adapter.find_idempotency_record(7)
+        self.assertEqual("matrixark_ingest", record["tool_name"])
+        self.assertEqual(0, adapter.scans)
+
+    def test_a_miss_is_none_without_a_scan(self):
+        adapter = _adapter(_Client(value=""))
+        self.assertIsNone(adapter.find_idempotency_record(7))
+        self.assertEqual(0, adapter.scans)
+
+    def test_a_transient_failure_is_retried_on_the_cheap_read(self):
+        """One blip must heal with another point-read, not a store-wide one."""
+        stored = json.dumps({"tool_name": "matrixark_ingest"})
+        client = _Client(value=stored, fail_times=1)
+        adapter = _adapter(client)
+        record = adapter.find_idempotency_record(7)
+        self.assertEqual("matrixark_ingest", record["tool_name"])
+        self.assertEqual(2, client.hget_calls)
+        self.assertEqual(0, adapter.scans)
+
+    def test_a_persistent_failure_raises_and_never_scans(self):
+        """The amplifier: under lane starvation the old code launched a full-store read here."""
+        client = _Client(fail_times=99)
+        adapter = _adapter(client)
+        with self.assertRaises(RuntimeError):
+            adapter.find_idempotency_record(7)
+        self.assertEqual(3, client.hget_calls, "retried twice, then propagated")
+        self.assertEqual(0, adapter.scans, "an engine failure must never become a scan")
+
+    def test_corruption_still_falls_back_to_the_log(self):
+        """The one surviving scan: bytes the log never produced. Rare, and not load-correlated."""
+        adapter = _adapter(_Client(value="{not json"))
+        record = adapter.find_idempotency_record(7)
+        self.assertEqual("scan", record["from"])
+        self.assertEqual(1, adapter.scans)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects, found by stack-dumping a loaded gateway whose metrics endpoint had stopped answering
(`backend_timeout: backend did not respond within 120.0s`) while a scale test showed per-API
latency growing 21-41x for a 4x store.

1. A failed idempotency point-read became a full-store scan -- on every tool call.

`find_idempotency_record` fell back to the scanning lookup whenever its `hget` raised. The
point-read only fails when the proxy lanes are already starved, this lookup runs FIRST on every
tool call (reads included), and the fallback launched a full-store `read_all()` at exactly that
moment -- starving the lanes further, so the next point-read timed out too. A congestion
amplifier: two of three request threads were sitting inside that scan in the live dump.

The fallback also did not buy the safety it was written for ("scan rather than wrongly report
never-seen"): the scan rides the same starved lanes that failed the point-read, so under the only
condition that triggers it, it times out as well -- after amplifying the congestion for everyone.

Now the cheap read is retried twice with short backoff, then the failure PROPAGATES as the
retryable error it is. The scan survives for exactly one case: a stored value that does not parse
(index corruption, where the log is the truth) -- rare, and not load-correlated, so it cannot
spiral. After the fix the scan is absent from stack dumps under the same load and the metrics
endpoint answers again.

2. The append-client router existed, was overridden, and was never called.

`_append_client_for_records` routes summary/audit-only bundles to a dedicated summary client --
gate, constructor, and type table all built -- but the single call site that appends records
grabbed `self._client` directly, so none of it ever ran. Measured cost of that dead seam: with a
deep summary backlog the refresher spends ~90% of its time in `append_many` (py-spy, 9-11 of 12
samples), every append riding the SAME write lane foreground ingests need; a foreground add
reached p50 158s with the refresher churning versus 27.7s with it off, on the same store.

The call site now consults the router. With the gate off -- the default -- the router returns
`self._client` and behaviour is unchanged; the five memory suites pass identically. The gate-ON
mode was also tried on an embedded-store rig and is NOT safe there: a dedicated read client is a
separate proxy process, and a fresh write was not visible to it (add answered "served +0"). The
router is wired so the mechanism is real where the deployment supports it; the gate stays off by
default, and turning it on for an embedded store breaks read-your-writes.

5 tests: a hit from the point-read, a miss without a scan, a transient failure healing on the
cheap read, a persistent failure raising after two retries without ever scanning, and corruption
still falling back to the log.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
