### PR TITLE
Add the missing SPDX header to durability_metrics.rs

### DIFF
--- a/crates/temporalstore-rust/src/durability_metrics.rs
+++ b/crates/temporalstore-rust/src/durability_metrics.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
 //! Counts durability barriers by the call site that takes them.
 //!
 //! A write's latency is roughly `barriers x fsync`, so a total barrier count per write says how


### PR DESCRIPTION
The Governance gate checks every Rust source for the Apache-2.0 SPDX header, and this file landed without one -- so the license-headers check has been failing on every PR since, including ones that touch no Rust at all (#207, #208 both show it red for this reason).

One file, two header lines. Local run of the same check is clean afterward.