### PR TITLE
Write the raft node log in a compact binary encoding

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -69,6 +69,11 @@ name = "matrixark_rust_metaserver"
 path = "src/bin/matrixark_rust_metaserver.rs"
 
 [[bin]]
+name = "matrixobject_store_server"
+path = "src/bin/matrixobject_store_server.rs"
+required-features = ["matrixobject"]
+
+[[bin]]
 name = "raft_barrier_profile"
 path = "src/bin/raft_barrier_profile.rs"
 

--- a/crates/temporalstore-rust/src/bin/matrixobject_store_server.rs
+++ b/crates/temporalstore-rust/src/bin/matrixobject_store_server.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Networked object-store server backed by the real MatrixObject store.
+//!
+//! Speaks the same wire protocol as `objstore_smoke_server`, so every existing client of
+//! `matrixobject://host:port` works unchanged -- but where the smoke server keeps objects in a
+//! process-local map with a best-effort disk mirror and no durability at all, this one routes
+//! every operation through `MatrixObjectObjectStore` rooted on disk, so what it acknowledges is
+//! what a restart serves. Use the smoke server for wiring tests; use this when the numbers or the
+//! data matter.
+//!
+//! Usage mirrors the smoke server: `matrixobject_store_server <bind-addr> <store-dir>`.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+
+use temporalstore_rust::matrixobject_store::MatrixObjectObjectStore;
+use temporalstore_snapshot::object_store::ObjectStore;
+
+const MORP1_MAGIC: &[u8; 5] = b"MORP1";
+const BUCKET: &str = "temporalstore";
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let bind = args.next().unwrap_or_else(|| "0.0.0.0:17200".to_string());
+    let dir = args.next().unwrap_or_else(|| "./matrixobject-store".to_string());
+
+    let store = Arc::new(
+        MatrixObjectObjectStore::with_persistent_dir(BUCKET, &dir)
+            .expect("open the on-disk object store"),
+    );
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("tokio runtime"),
+    );
+
+    let listener = TcpListener::bind(&bind).expect("bind");
+    eprintln!("matrixobject store serving {bind} from {dir}");
+    for stream in listener.incoming() {
+        let Ok(stream) = stream else { continue };
+        let store = Arc::clone(&store);
+        let runtime = Arc::clone(&runtime);
+        std::thread::spawn(move || serve_conn(stream, store, runtime));
+    }
+}
+
+fn serve_conn(
+    mut stream: TcpStream,
+    store: Arc<MatrixObjectObjectStore>,
+    runtime: Arc<tokio::runtime::Runtime>,
+) {
+    loop {
+        let mut header = [0u8; 18];
+        if stream.read_exact(&mut header).is_err() {
+            return; // client dropped the pooled connection
+        }
+        if &header[..5] != MORP1_MAGIC {
+            return;
+        }
+        let op = header[5];
+        let key_len = u32::from_le_bytes(header[6..10].try_into().unwrap()) as usize;
+        let value_len = u64::from_le_bytes(header[10..18].try_into().unwrap()) as usize;
+        let mut key_bytes = vec![0u8; key_len];
+        if stream.read_exact(&mut key_bytes).is_err() {
+            return;
+        }
+        let mut value = vec![0u8; value_len];
+        if stream.read_exact(&mut value).is_err() {
+            return;
+        }
+        let key = String::from_utf8_lossy(&key_bytes).to_string();
+
+        let (status, body) = match op {
+            // PUT: not acknowledged until the store has committed it.
+            1 => match runtime.block_on(store.put(&key, value.into())) {
+                Ok(()) => (0u8, Vec::new()),
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // GET: status 1 with the key echoed back is the wire's "not found".
+            2 => match runtime.block_on(store.get(&key)) {
+                Ok(bytes) => (0u8, bytes.to_vec()),
+                Err(_) => (1u8, key.into_bytes()),
+            },
+            3 => match runtime.block_on(store.delete(&key)) {
+                Ok(()) => (0u8, Vec::new()),
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // LIST prefix -> newline-joined keys, sorted.
+            4 => match runtime.block_on(store.list(&key)) {
+                Ok(mut keys) => {
+                    keys.sort();
+                    (0u8, keys.join("\n").into_bytes())
+                }
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // LIST_AFTER: prefix in the key field, exclusive lower bound in the value field.
+            5 => {
+                let after = String::from_utf8_lossy(&value).to_string();
+                match runtime.block_on(store.list(&key)) {
+                    Ok(mut keys) => {
+                        keys.retain(|candidate| candidate.as_str() > after.as_str());
+                        keys.sort();
+                        (0u8, keys.join("\n").into_bytes())
+                    }
+                    Err(err) => (2u8, err.to_string().into_bytes()),
+                }
+            }
+            // GET_MANY: newline-joined keys in; count + (key_len, value_len, key, value)* out.
+            // Absent keys are simply omitted, exactly as the smoke server omits them.
+            6 => {
+                let mut entries = Vec::new();
+                for wanted in String::from_utf8_lossy(&value)
+                    .split('\n')
+                    .filter(|wanted| !wanted.is_empty())
+                {
+                    if let Ok(bytes) = runtime.block_on(store.get(wanted)) {
+                        entries.push((wanted.to_string(), bytes.to_vec()));
+                    }
+                }
+                let mut out = Vec::new();
+                out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+                for (entry_key, entry_value) in entries {
+                    out.extend_from_slice(&(entry_key.len() as u32).to_le_bytes());
+                    out.extend_from_slice(&(entry_value.len() as u64).to_le_bytes());
+                    out.extend_from_slice(entry_key.as_bytes());
+                    out.extend_from_slice(&entry_value);
+                }
+                (0u8, out)
+            }
+            // PUT_MANY: count + (key_len, value_len, key, value)* in the value field. All-or-error
+            // is not promised by the wire; each object is committed as it lands, like the loop of
+            // single PUTs it replaces.
+            7 => {
+                let mut status = 0u8;
+                let mut message = Vec::new();
+                let mut off = 4usize;
+                let count = if value.len() >= 4 {
+                    u32::from_le_bytes(value[0..4].try_into().unwrap()) as usize
+                } else {
+                    status = 2;
+                    message = b"short PUT_MANY body".to_vec();
+                    0
+                };
+                for _ in 0..count {
+                    if off + 12 > value.len() {
+                        status = 2;
+                        message = b"truncated PUT_MANY entry".to_vec();
+                        break;
+                    }
+                    let entry_key_len =
+                        u32::from_le_bytes(value[off..off + 4].try_into().unwrap()) as usize;
+                    off += 4;
+                    let entry_value_len =
+                        u64::from_le_bytes(value[off..off + 8].try_into().unwrap()) as usize;
+                    off += 8;
+                    if off + entry_key_len + entry_value_len > value.len() {
+                        status = 2;
+                        message = b"truncated PUT_MANY entry".to_vec();
+                        break;
+                    }
+                    let entry_key =
+                        String::from_utf8_lossy(&value[off..off + entry_key_len]).to_string();
+                    off += entry_key_len;
+                    let entry_value = value[off..off + entry_value_len].to_vec();
+                    off += entry_value_len;
+                    if let Err(err) = runtime.block_on(store.put(&entry_key, entry_value.into())) {
+                        status = 2;
+                        message = err.to_string().into_bytes();
+                        break;
+                    }
+                }
+                (status, message)
+            }
+            _ => (2u8, b"unknown op".to_vec()),
+        };
+
+        let mut resp = Vec::with_capacity(14 + body.len());
+        resp.extend_from_slice(MORP1_MAGIC);
+        resp.push(status);
+        resp.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        resp.extend_from_slice(&body);
+        if stream.write_all(&resp).is_err() {
+            return;
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/bin/server/raft_route.rs
+++ b/crates/temporalstore-rust/src/bin/server/raft_route.rs
@@ -540,6 +540,13 @@ fn command_response(
 fn incoming_raft_peer_id(request: &HttpRequest) -> Option<RaftNodeId> {
     match request.path.as_str() {
         "/raft/append_entries" | "/raft/install_snapshot" | "/raft/install_snapshot_chunk" => {
+            // A binary body has no field to read out by name, so decode it. Returning None
+            // here would quietly stop attributing the request to the peer that sent it.
+            if temporalstore_rust::raft::is_binary_rpc(&request.body) {
+                return temporalstore_rust::raft::decode_append_entries(&request.body)
+                    .ok()
+                    .map(|decoded| decoded.leader_id);
+            }
             serde_json::from_slice::<serde_json::Value>(&request.body)
                 .ok()?
                 .get("leader_id")?

--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -26,6 +26,8 @@ pub(super) fn command_is_dropped(command: &Command, drop_percent: u8) -> bool {
 
 pub(super) fn command_key(command: &Command) -> Option<&str> {
     match command {
+        // Names no key: it exists to be committed, not to touch a record.
+        Command::LeaderEstablish => None,
         Command::CommonDelete { key }
         | Command::CommonExpire { key, .. }
         | Command::CommonTtl { key }

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -35,6 +35,8 @@ pub(super) fn command_touched_keys(command: &Command) -> Vec<String> {
 
 pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
     match command {
+        // Touches no object, so it holds no object keys.
+        Command::LeaderEstablish => Vec::new(),
         Command::CommonDelete { key } => associated_record_keys(key),
         Command::CommonExpire { key, .. }
         | Command::StringSet { key, .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -24,6 +24,9 @@ pub(crate) fn execute_on_shard(
     shard.control_distinct_sketch = control_distinct_sketch;
     let mut mutated = false;
     let response = match command {
+        // Applied as nothing: `mutated` stays false, so it neither dirties a shard nor
+        // invalidates a cache entry.
+        Command::LeaderEstablish => CommandResponse::Empty,
         Command::CommonDelete { key } => {
             mutated = delete_record(shard, &key);
             invalidate_record_all(cache, shard_id, &key);

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -184,6 +184,171 @@ pub(crate) fn decode_line(line: &[u8]) -> Result<&[u8], FramingError> {
     Ok(payload)
 }
 
+/// Introduces a record whose payload is binary rather than text.
+///
+/// A binary payload may contain a newline, so a record carrying one cannot be found by splitting
+/// on newlines. Readers use [`next_frame`] or [`read_frame`] instead, which take the length the
+/// frame already declares rather than looking for a delimiter.
+pub(crate) const BINARY_PAYLOAD_MAGIC: u8 = 0xA7;
+
+/// Read the next record from `bytes`, returning how many bytes it occupied and its payload.
+///
+/// `Ok(None)` means there is nothing further to read, or that what remains is shorter than the
+/// record it declares -- a torn tail from a crash mid-append, which the caller truncates. A
+/// complete record whose digest does not match is committed corruption and returns `Err`. The
+/// checksum is picked by prefix, exactly as [`decode_line`] picks it.
+pub(crate) fn next_frame(bytes: &[u8]) -> Result<Option<(usize, &[u8])>, FramingError> {
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let (checksum_of, header_prefix_len): (fn(&[u8]) -> String, usize) =
+        if bytes.starts_with(FRAME_MAGIC_V2) {
+            (crc_digest_hex, FRAME_MAGIC_V2.len())
+        } else if bytes.starts_with(FRAME_MAGIC_V1) {
+            (sha256_digest_hex, FRAME_MAGIC_V1.len())
+        } else {
+            // Unframed: the record ends at the newline, and the whole line is the payload.
+            // Without a newline the record was never finished being written -- a torn tail.
+            let Some(position) = bytes.iter().position(|byte| *byte == b'\n') else {
+                return Ok(None);
+            };
+            let line_len = position + 1;
+            return Ok(Some((line_len, strip_trailing_newline(&bytes[..line_len]))));
+        };
+    let rest = &bytes[header_prefix_len..];
+    let (len_field, after_len) = split_once_space(rest)
+        .ok_or_else(|| FramingError("framed record missing length field".to_string()))?;
+    let (digest_field, after_digest) = split_once_space(after_len)
+        .ok_or_else(|| FramingError("framed record missing digest field".to_string()))?;
+    let declared_len: usize = std::str::from_utf8(len_field)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| FramingError("framed record has an unparseable length field".to_string()))?;
+    if after_digest.len() < declared_len {
+        // Fewer bytes present than the record declares: the append was interrupted. That is a
+        // torn tail to be truncated, not damage to a record that was completely written.
+        return Ok(None);
+    }
+    let payload = &after_digest[..declared_len];
+    let actual = checksum_of(payload);
+    if actual.as_bytes() != digest_field {
+        return Err(FramingError(
+            "framed record digest does not match its payload".to_string(),
+        ));
+    }
+    let header_len = bytes.len() - after_digest.len();
+    let mut consumed = header_len + declared_len;
+    if bytes.get(consumed) == Some(&b'\n') {
+        consumed += 1; // the newline the encoder appends
+    }
+    Ok(Some((consumed, payload)))
+}
+
+/// Read one record from a stream, returning how many bytes it occupied and its payload.
+///
+/// The streaming twin of [`next_frame`], for the paths that face the largest logs there are:
+/// memory stays bounded by the biggest single record rather than by the file.
+pub(crate) fn read_frame<R: std::io::BufRead>(
+    reader: &mut R,
+) -> Result<Option<(usize, Vec<u8>)>, FramingError> {
+    let longest_magic = FRAME_MAGIC_V1.len().max(FRAME_MAGIC_V2.len());
+    let mut header = Vec::with_capacity(longest_magic + 32);
+    let mut spaces = 0usize;
+    loop {
+        let mut byte = [0u8; 1];
+        match reader.read_exact(&mut byte) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
+                // Nothing at all is a clean end; a partial header is a torn tail.
+                return Ok(None);
+            }
+            Err(err) => return Err(FramingError(err.to_string())),
+        }
+        header.push(byte[0]);
+        if header.len() <= longest_magic {
+            let still_v1 = FRAME_MAGIC_V1.starts_with(&header[..header.len().min(FRAME_MAGIC_V1.len())])
+                && header.len() <= FRAME_MAGIC_V1.len();
+            let still_v2 = FRAME_MAGIC_V2.starts_with(&header[..header.len().min(FRAME_MAGIC_V2.len())])
+                && header.len() <= FRAME_MAGIC_V2.len();
+            if header.as_slice() == FRAME_MAGIC_V1 || header.as_slice() == FRAME_MAGIC_V2 {
+                spaces = 1; // the magic ends with the space that follows it
+                continue;
+            }
+            if still_v1 || still_v2 {
+                continue;
+            }
+            // Not a framed record: an unframed one runs to the next newline.
+            return read_unframed(reader, header);
+        }
+        if byte[0] == b' ' {
+            spaces += 1;
+            if spaces == 3 {
+                break;
+            }
+        }
+    }
+    let checksum_of: fn(&[u8]) -> String = if header.starts_with(FRAME_MAGIC_V2) {
+        crc_digest_hex
+    } else {
+        sha256_digest_hex
+    };
+    let magic_len = if header.starts_with(FRAME_MAGIC_V2) {
+        FRAME_MAGIC_V2.len()
+    } else {
+        FRAME_MAGIC_V1.len()
+    };
+    let rest = &header[magic_len..];
+    let (len_field, after_len) = split_once_space(rest)
+        .ok_or_else(|| FramingError("framed record missing length field".to_string()))?;
+    let (digest_field, _) = split_once_space(after_len)
+        .ok_or_else(|| FramingError("framed record missing digest field".to_string()))?;
+    let declared_len: usize = std::str::from_utf8(len_field)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| FramingError("framed record has an unparseable length field".to_string()))?;
+    let digest_expected = digest_field.to_vec();
+    let mut payload = vec![0u8; declared_len];
+    if reader.read_exact(&mut payload).is_err() {
+        // Fewer bytes than the record declares: the append was interrupted.
+        return Ok(None);
+    }
+    let actual = checksum_of(&payload);
+    if actual.as_bytes() != digest_expected.as_slice() {
+        return Err(FramingError(
+            "framed record digest does not match its payload".to_string(),
+        ));
+    }
+    let mut trailing = [0u8; 1];
+    let consumed_newline =
+        matches!(reader.read_exact(&mut trailing), Ok(())) && trailing[0] == b'\n';
+    let consumed = header.len() + declared_len + usize::from(consumed_newline);
+    Ok(Some((consumed, payload)))
+}
+
+/// Finish reading a record that is not framed: it runs to the next newline, and without one it
+/// was never finished being written.
+fn read_unframed<R: std::io::BufRead>(
+    reader: &mut R,
+    mut started: Vec<u8>,
+) -> Result<Option<(usize, Vec<u8>)>, FramingError> {
+    if started.last() == Some(&b'\n') {
+        let consumed = started.len();
+        let payload = strip_trailing_newline(&started).to_vec();
+        return Ok(Some((consumed, payload)));
+    }
+    let mut rest = Vec::new();
+    let read = reader
+        .read_until(b'\n', &mut rest)
+        .map_err(|err| FramingError(err.to_string()))?;
+    if read == 0 || !rest.ends_with(b"\n") {
+        return Ok(None);
+    }
+    let consumed = started.len() + rest.len();
+    started.extend_from_slice(&rest);
+    let payload = strip_trailing_newline(&started).to_vec();
+    Ok(Some((consumed, payload)))
+}
+
 fn strip_trailing_newline(line: &[u8]) -> &[u8] {
     if line.last() == Some(&b'\n') {
         &line[..line.len() - 1]

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -49,6 +49,8 @@ pub(super) fn proxy_command_is_write(command: &Command) -> bool {
 
 fn proxy_command_key(command: &Command) -> Option<&str> {
     match command {
+        // Names no key: it exists to be committed, not to touch a record.
+        Command::LeaderEstablish => None,
         Command::CommonDelete { key }
         | Command::CommonExpire { key, .. }
         | Command::CommonTtl { key }

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -42,6 +42,7 @@ mod readiness;
 mod cluster_snapshot;
 mod production_runtime;
 mod local_wal;
+pub(crate) mod wal_proto;
 mod cluster_meta;
 mod cluster_meta_inner;
 mod cluster_inner;
@@ -1980,8 +1981,26 @@ impl RaftTransport for HttpRaftTransport {
         &self,
         request: AppendEntriesRequest,
     ) -> Result<AppendEntriesResponse, RaftError> {
+        let addr = self.peer_addr(request.target_id)?.to_string();
+        if wal_proto::binary_replication_enabled() {
+            let body = wal_proto::encode_append_entries(&request)
+                .map_err(|err| RaftError::Transport(err.to_string()))?;
+            // The response is a handful of integers either way, so it stays as it was; the size
+            // that matters is the entries travelling out.
+            let raw = crate::http::request_bytes_with_options(
+                &addr,
+                "POST",
+                "/raft/append_entries",
+                &body,
+                "application/x-protobuf",
+                self.options,
+            )
+            .map_err(|err| RaftError::Transport(err.to_string()))?;
+            return serde_json::from_slice(&raw)
+                .map_err(|err| RaftError::Transport(err.to_string()));
+        }
         Ok(post_json_with_options(
-            self.peer_addr(request.target_id)?,
+            &addr,
             "/raft/append_entries",
             &request,
             self.options,
@@ -2026,8 +2045,30 @@ impl RaftTransport for HttpRaftTransport {
     }
 }
 
+/// Whether a request body carries the binary encoding rather than text.
+pub fn is_binary_rpc(body: &[u8]) -> bool {
+    wal_proto::is_binary_rpc(body)
+}
+
+/// Decode a binary replicated batch. Callers that only need a field from the header still have to
+/// decode, since a binary body has no fields to read out by name.
+pub fn decode_append_entries(body: &[u8]) -> std::io::Result<AppendEntriesRequest> {
+    wal_proto::decode_append_entries(body)
+}
+
 pub fn handle_raft_http(cluster: &RaftCluster, request: HttpRequest) -> (u16, Vec<u8>) {
     match (request.method.as_str(), request.path.as_str()) {
+        // Accept either encoding: a body starting with the magic byte is binary, and a text
+        // body always starts with `{`.
+        ("POST", "/raft/append_entries") if wal_proto::is_binary_rpc(&request.body) => {
+            match wal_proto::decode_append_entries(&request.body) {
+                Ok(req) => match cluster.receive_append_entries(req) {
+                    Ok(response) => json_response(200, &response),
+                    Err(err) => json_response(500, &err.to_string()),
+                },
+                Err(err) => json_response(400, &err.to_string()),
+            }
+        }
         ("POST", "/raft/append_entries") => match parse_json::<AppendEntriesRequest>(&request.body)
         {
             Ok(req) => match cluster.receive_append_entries(req) {
@@ -2086,6 +2127,14 @@ fn raft_rpc_metadata_for_http_request(
 ) -> Result<Option<RaftRpcMetadata>, RaftError> {
     match (request.method.as_str(), request.path.as_str()) {
         ("POST", "/raft/append_entries") => {
+            // A binary body carries its rpc metadata inside the message, not as a JSON field.
+            // Parsing it as JSON here fails, and that failure surfaced as a 403 on EVERY binary
+            // append -- the authenticated wrapper choked before dispatch ever saw the request.
+            if wal_proto::is_binary_rpc(&request.body) {
+                let req = wal_proto::decode_append_entries(&request.body)
+                    .map_err(|err| RaftError::Transport(err.to_string()))?;
+                return Ok(req.rpc);
+            }
             let req = parse_json::<AppendEntriesRequest>(&request.body)
                 .map_err(|err| RaftError::Transport(err.to_string()))?;
             Ok(req.rpc)
@@ -4428,18 +4477,42 @@ impl RaftCluster {
                 .expect("raft cluster lock poisoned")
                 .begin_deferred_persist();
         }
-        let outcome = self.propose_distributed_one_locked(command, transport);
+        let mut entry_barrier = None;
+        let outcome =
+            self.propose_distributed_one_locked(command, transport, &mut entry_barrier);
         if !deferring {
+            // An overlapped barrier is still joined before the ack, whatever path leaves here.
+            if let Some(handle) = entry_barrier {
+                let joined = handle
+                    .join()
+                    .unwrap_or_else(|_| Err(RaftError::Wal("barrier thread panicked".to_string())));
+                return match (outcome, joined) {
+                    (Ok(response), Ok(())) => Ok(response),
+                    (Ok(_), Err(err)) => Err(err),
+                    (Err(err), _) => Err(err),
+                };
+            }
             return outcome;
         }
         // Write what the deferral owes while the propose lock still orders it. Records carry the
         // log, so an older record landing after a newer one would regress the log on recovery --
         // the write must stay ordered.
-        let staged = self
-            .inner
-            .write()
-            .expect("raft cluster lock poisoned")
-            .stage_deferred_persist();
+        //
+        // With the barrier overlapped, the entry is already written and being flushed, and what
+        // is owed here is only the commit index -- which is recoverable and so is left for the
+        // next record to carry rather than paid for on this write's critical path.
+        let staged = if entry_barrier.is_some() {
+            self.inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .discard_deferred_persist();
+            Ok(Vec::new())
+        } else {
+            self.inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .stage_deferred_persist()
+        };
         // The barrier needs no such ordering: an fsync makes every byte already in the file
         // durable whoever wrote it. Releasing the lock here is what finally gives group commit a
         // queue to coalesce -- while the barrier was taken under this lock only one writer ever
@@ -4447,10 +4520,20 @@ impl RaftCluster {
         // Nothing is acknowledged before its barrier: the flush still happens below, on the
         // failure path as well as the success path.
         drop(_propose_guard);
-        let flushed = match staged {
+        let mut flushed = match staged {
             Ok(staged) => self.finish_staged_unlocked(staged),
             Err(err) => Err(err),
         };
+        // Join the overlapped barrier before acknowledging: the entry has to be durable here, it
+        // just did not have to wait for replication to start becoming so.
+        if let Some(handle) = entry_barrier {
+            let joined = handle
+                .join()
+                .unwrap_or_else(|_| Err(RaftError::Wal("barrier thread panicked".to_string())));
+            if flushed.is_ok() {
+                flushed = joined;
+            }
+        }
         // Never ack a write whose barrier failed: a flush error wins over a successful propose.
         match (outcome, flushed) {
             (Ok(response), Ok(())) => Ok(response),
@@ -4463,6 +4546,7 @@ impl RaftCluster {
         &self,
         command: Command,
         transport: &T,
+        entry_barrier: &mut Option<thread::JoinHandle<Result<(), RaftError>>>,
     ) -> Result<CommandResponse, RaftError>
     where
         T: RaftTransport + Clone + Send + 'static,
@@ -4528,6 +4612,30 @@ impl RaftCluster {
             target_ids.extend(fallback_target_ids);
             (entry, leader_id, target_ids, required)
         };
+
+        // The entry is in the log. Write it and start its barrier NOW, so the leader's disk wait
+        // runs alongside the followers' instead of after them. The commit index is not known yet
+        // and does not need to be: it is recoverable, so it never has to be durable before the
+        // acknowledgement.
+        if wal_proto::overlap_leader_barrier_enabled() {
+            let staged = self
+                .inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .stage_deferred_persist();
+            if let Ok(staged) = staged {
+                if !staged.is_empty() {
+                    let cluster = self.clone();
+                    *entry_barrier =
+                        Some(thread::spawn(move || cluster.finish_staged_unlocked(staged)));
+                }
+            }
+            // Anything persisted from here on is the commit index, which this path discards.
+            self.inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .begin_deferred_persist();
+        }
 
         let mut replicated = {
             let inner = self.inner.read().expect("raft cluster lock poisoned");

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -754,6 +754,18 @@ impl RaftClusterInner {
         self.finish_staged_wal(staged)
     }
 
+    /// End the deferral WITHOUT writing what it owes.
+    ///
+    /// Used for the commit index once the entry itself is already durable. Raft treats the commit
+    /// index as recoverable -- a restarting node learns it from its leader, and a leader
+    /// re-establishes it by committing an entry of its own term -- so it does not have to be made
+    /// durable before a write is acknowledged. The next record written carries the current value
+    /// anyway.
+    pub(super) fn discard_deferred_persist(&mut self) {
+        self.persist_deferred_owner = None;
+        self.persist_dirty = false;
+    }
+
     /// End the deferral by WRITING what is owed, leaving the barrier to the caller.
     ///
     /// This is what lets the propose path drop its lock before flushing: the write happens while

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -58,8 +58,10 @@ impl LocalRaftWal {
             delta: None,
         };
         let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
-        serde_json::to_writer(&mut file, &envelope).map_err(io::Error::other)?;
-        file.write_all(b"\n")?;
+        file.write_all(&wal_proto::encode_record_line(
+            &envelope,
+            wal_proto::binary_records_enabled(),
+        )?)?;
         crate::durability_metrics::record_barrier("raft_wal_append_unsegmented");
         file.sync_data()?;
         Ok(())
@@ -249,10 +251,7 @@ impl LocalRaftWal {
                     delta: None,
                 }
             };
-            let mut buf = Vec::new();
-            serde_json::to_writer(&mut buf, &envelope).map_err(io::Error::other)?;
-            buf.push(b'\n');
-            Ok(buf)
+            wal_proto::encode_record_line(&envelope, wal_proto::binary_records_enabled())
         };
 
         let mut wrote_base = !delta_safe;
@@ -515,19 +514,13 @@ impl LocalRaftWal {
             let mut valid_until = 0usize;
             while offset < bytes.len() {
                 let remaining = &bytes[offset..];
-                let line_len = remaining
-                    .iter()
-                    .position(|byte| *byte == b'\n')
-                    .map(|pos| pos + 1)
-                    .unwrap_or(remaining.len());
-                let raw_line = &remaining[..line_len];
-                let line = raw_line.strip_suffix(b"\n").unwrap_or(raw_line);
-                if line.is_empty() {
-                    valid_until = offset + line_len;
-                    offset += line_len;
+                // Blank padding is not a record, but it is not damage either.
+                if remaining.first() == Some(&b'\n') {
+                    valid_until = offset + 1;
+                    offset += 1;
                     continue;
                 }
-                let Ok(envelope) = serde_json::from_slice::<RaftWalEnvelope>(line) else {
+                let Some((line_len, envelope)) = wal_proto::next_envelope(remaining) else {
                     break;
                 };
                 if envelope.checksum != raft_wal_checksum(&envelope.record)? {
@@ -638,18 +631,11 @@ impl LocalRaftWal {
         let mut offset = 0usize;
         while offset < bytes.len() {
             let remaining = &bytes[offset..];
-            let line_len = remaining
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map(|pos| pos + 1)
-                .unwrap_or(remaining.len());
-            let raw_line = &remaining[..line_len];
-            let line = raw_line.strip_suffix(b"\n").unwrap_or(raw_line);
-            if line.is_empty() {
-                offset += line_len;
+            if remaining.first() == Some(&b'\n') {
+                offset += 1;
                 continue;
             }
-            let Ok(envelope) = serde_json::from_slice::<RaftWalEnvelope>(line) else {
+            let Some((line_len, envelope)) = wal_proto::next_envelope(remaining) else {
                 break;
             };
             if envelope.checksum != raft_wal_checksum(&envelope.record)? {
@@ -667,9 +653,11 @@ impl LocalRaftWal {
             .write(true)
             .truncate(true)
             .open(&path)?;
+        // Rewriting the retained records adopts whichever encoding is current; a reader
+        // handles either, but a file written whole in one encoding is easier to reason about.
+        let binary = wal_proto::binary_records_enabled();
         for envelope in retained {
-            serde_json::to_writer(&mut file, &envelope).map_err(io::Error::other)?;
-            file.write_all(b"\n")?;
+            file.write_all(&wal_proto::encode_record_line(&envelope, binary)?)?;
         }
         crate::durability_metrics::record_barrier("raft_wal_compact");
         file.sync_data()?;
@@ -731,19 +719,12 @@ impl LocalRaftWal {
         let mut valid_records = 0usize;
         while offset < bytes.len() {
             let remaining = &bytes[offset..];
-            let line_len = remaining
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map(|pos| pos + 1)
-                .unwrap_or(remaining.len());
-            let raw_line = &remaining[..line_len];
-            let line = raw_line.strip_suffix(b"\n").unwrap_or(raw_line);
-            if line.is_empty() {
-                valid_until = offset + line_len;
-                offset += line_len;
+            if remaining.first() == Some(&b'\n') {
+                valid_until = offset + 1;
+                offset += 1;
                 continue;
             }
-            let Ok(envelope) = serde_json::from_slice::<RaftWalEnvelope>(line) else {
+            let Some((line_len, envelope)) = wal_proto::next_envelope(remaining) else {
                 break;
             };
             if envelope.checksum != raft_wal_checksum(&envelope.record)? {
@@ -866,20 +847,26 @@ impl LocalRaftWal {
     }
 
     pub(super) fn inspect_segment_sequences(path: &Path) -> io::Result<(u64, u64, u64, u64, u64)> {
-        let file = OpenOptions::new().read(true).open(path)?;
+        let bytes = fs::read(path)?;
         let mut record_count = 0u64;
         let mut first_sequence = 0u64;
         let mut last_sequence = 0u64;
         let mut first_log_index = 0u64;
         let mut last_log_index = 0u64;
-        for line in BufReader::new(file).lines() {
-            let line = line?;
-            if line.trim().is_empty() {
+        let mut offset = 0usize;
+        while offset < bytes.len() {
+            let remaining = &bytes[offset..];
+            // Blank padding is not a record.
+            if remaining.first() == Some(&b'\n') {
+                offset += 1;
                 continue;
             }
-            let Ok(envelope) = serde_json::from_str::<RaftWalEnvelope>(&line) else {
-                continue;
+            // A record that will not decode leaves no way to find where the next one begins, so
+            // stop here -- the same place the recovery path stops on the same file.
+            let Some((consumed, envelope)) = wal_proto::next_envelope(remaining) else {
+                break;
             };
+            offset += consumed;
             record_count = record_count.saturating_add(1);
             if first_sequence == 0 {
                 first_sequence = envelope.sequence;

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -574,6 +574,39 @@ impl ProductionRaftRuntime {
                                 // timeouts fire and supersede it.
                                 force_heartbeat = true;
                                 last_contact_epoch = cluster.leader_contact_epoch();
+                                // Commit one entry of this term, which moves the commit point to
+                                // cover everything before it. Until that happens a leader cannot
+                                // safely treat older entries as committed however many replicas
+                                // hold them, so entries above the commit point it restarted with
+                                // would stay unapplied on an idle cluster.
+                                //
+                                // Off this thread: proposing takes the propose lock and a network
+                                // round trip, and the timer loop has heartbeats to send.
+                                {
+                                    let cluster = cluster.clone();
+                                    let transport = transport.clone();
+                                    thread::spawn(move || {
+                                        match cluster.propose_distributed(
+                                            Command::LeaderEstablish,
+                                            &transport,
+                                        ) {
+                                            Ok(_) => tracing::info!(
+                                                kind = "data",
+                                                node_id = local_node_id,
+                                                "raft: new leader established its commit point"
+                                            ),
+                                            // Not fatal: the next write establishes it instead.
+                                            // Worth saying, because until then a restarted leader
+                                            // serves whatever commit point it came back with.
+                                            Err(err) => tracing::warn!(
+                                                kind = "data",
+                                                node_id = local_node_id,
+                                                error = %err,
+                                                "raft: new leader could not establish its commit point"
+                                            ),
+                                        }
+                                    });
+                                }
                                 continue;
                             }
                         }

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -695,3 +695,59 @@ fn a_follower_that_stops_converging_cannot_report_zero_lag() {
         "a follower that has caught up must report no stall"
     );
 }
+
+
+/// The AUTHENTICATED http entry point must accept a binary append body.
+///
+/// It extracts the rpc auth metadata before dispatching, and it did that by parsing the body as
+/// JSON -- so with binary replication on, every append got a 403 from the auth wrapper and the
+/// cluster could not replicate at all. The unauthenticated handler (which the other tests use)
+/// was fine, which is exactly why this test targets the authenticated one.
+#[test]
+fn authenticated_route_accepts_a_binary_append() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    cluster.set_local_node_id(2);
+    let request = AppendEntriesRequest {
+        rpc: None,
+        shard_id: 1,
+        term: 1,
+        leader_id: 1,
+        target_id: 2,
+        prev_log_index: 0,
+        prev_log_term: 0,
+        entries: vec![RaftLogEntry {
+            term: 1,
+            index: 1,
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "auth".into(),
+                value: b"binary".to_vec(),
+            },
+        }],
+        leader_commit: 0,
+    };
+    let body = wal_proto::encode_append_entries(&request).unwrap();
+    let (code, response) = handle_authenticated_raft_http(
+        &cluster,
+        HttpRequest {
+            method: "POST".to_string(),
+            path: "/raft/append_entries".to_string(),
+            body,
+        },
+        "",
+    );
+    assert_eq!(
+        code, 200,
+        "the authenticated route rejected a binary append: {}",
+        String::from_utf8_lossy(&response)
+    );
+    let parsed: AppendEntriesResponse = serde_json::from_slice(&response).unwrap();
+    assert!(parsed.success, "the append must actually be accepted");
+}

--- a/crates/temporalstore-rust/src/raft/wal_proto.rs
+++ b/crates/temporalstore-rust/src/raft/wal_proto.rs
@@ -1,0 +1,760 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Encode a WAL record as a compact binary message rather than text.
+//!
+//! The text encoding spells out every field name on every record and has no byte-string type, so
+//! a binary value becomes an array of decimal numbers. Measured: a record carrying a 20-byte
+//! payload cost 782 bytes, and one carrying a 1,034-byte payload cost 3,823 -- roughly three
+//! bytes written for every byte of data. Every one of those bytes is paid twice: once writing it,
+//! and again on each replay that parses it back.
+//!
+//! **Fidelity comes before compactness here.** This is the durability path, so a command this
+//! module does not model explicitly is carried byte for byte in the previous encoding rather than
+//! approximated by the nearest match. Modelled commands can then be added one at a time, and a
+//! command this module has never heard of still replays exactly. The same applies to the record's
+//! rarely-set fields, which travel whole in `rest`.
+
+use std::io;
+
+use prost::Message;
+
+use super::*;
+use crate::sdk::v1;
+
+/// The record fields that sit at their default on nearly every record.
+///
+/// They are carried together in their existing encoding rather than modelled field by field:
+/// modelling them would add a conversion to get wrong for each one, and save nothing on the
+/// records that actually dominate the log, where every one of them is absent.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+struct RaftWalRecordRest {
+    #[serde(default, skip_serializing_if = "RaftReplicaRole::is_default")]
+    replica_role: RaftReplicaRole,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    joint_membership: Option<JointConsensusMembership>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    latest_external_snapshot_ref: Option<RaftExternalSnapshotRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    installed_snapshot: Option<RaftSnapshot>,
+    #[serde(default, skip_serializing_if = "RaftPeerPipelineRuntimeState::is_default")]
+    pipeline_state: RaftPeerPipelineRuntimeState,
+    #[serde(default, skip_serializing_if = "RaftReadSafetyRuntimeState::is_default")]
+    read_safety_state: RaftReadSafetyRuntimeState,
+    #[serde(default, skip_serializing_if = "RaftMembershipRuntimeEvidence::is_default")]
+    membership_evidence: RaftMembershipRuntimeEvidence,
+}
+
+impl RaftWalRecordRest {
+    fn is_empty(&self) -> bool {
+        *self == RaftWalRecordRest::default()
+    }
+}
+
+/// Split a checksum into the bytes to store and whether they are its text rather than its digest.
+///
+/// A checksum is a hex digest in practice, and storing the digest costs half what its text does.
+/// Anything that is not a clean round-trip through hex is kept as its own bytes instead, so this
+/// never has to assume what a checksum looks like in order to return it unchanged.
+fn checksum_to_bytes(checksum: &str) -> (Vec<u8>, bool) {
+    match decode_hex(checksum) {
+        Some(digest) if encode_hex(&digest) == checksum => (digest, false),
+        _ => (checksum.as_bytes().to_vec(), true),
+    }
+}
+
+fn checksum_from_bytes(bytes: &[u8], is_text: bool) -> String {
+    if is_text {
+        String::from_utf8_lossy(bytes).into_owned()
+    } else {
+        encode_hex(bytes)
+    }
+}
+
+fn decode_hex(text: &str) -> Option<Vec<u8>> {
+    if text.len() % 2 != 0 || text.is_empty() {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(text.len() / 2);
+    for pair in bytes.chunks(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        out.push(((hi << 4) | lo) as u8);
+    }
+    Some(out)
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Map a command onto its modelled form, or carry it verbatim.
+///
+/// A modelled arm is used ONLY when it can reproduce the command exactly. `StringSetEx` with a
+/// zero TTL is the trap: the modelled form distinguishes the two commands by whether the TTL is
+/// non-zero, so a zero-TTL `StringSetEx` would come back as a plain `StringSet`. It goes verbatim
+/// instead -- a command that cannot round-trip through a modelled arm must not use one.
+pub(crate) fn command_to_proto(command: &Command) -> io::Result<v1::wal_command::Kind> {
+    Ok(match command {
+        Command::StringSet { key, value } => v1::wal_command::Kind::StringSet(v1::StringSet {
+            key: key.clone(),
+            value: value.clone(),
+            ttl_ms: 0,
+        }),
+        Command::StringSetEx { key, value, ttl_ms } if *ttl_ms > 0 => {
+            v1::wal_command::Kind::StringSet(v1::StringSet {
+                key: key.clone(),
+                value: value.clone(),
+                ttl_ms: *ttl_ms,
+            })
+        }
+        Command::HashSet { key, field, value } => v1::wal_command::Kind::HashSet(v1::HashSet {
+            key: key.clone(),
+            field: field.clone(),
+            value: value.clone(),
+        }),
+        other => v1::wal_command::Kind::Verbatim(
+            serde_json::to_vec(other).map_err(io::Error::other)?,
+        ),
+    })
+}
+
+pub(crate) fn command_from_proto(kind: v1::wal_command::Kind) -> io::Result<Command> {
+    Ok(match kind {
+        v1::wal_command::Kind::StringSet(command) => {
+            if command.ttl_ms > 0 {
+                Command::StringSetEx {
+                    key: command.key,
+                    value: command.value,
+                    ttl_ms: command.ttl_ms,
+                }
+            } else {
+                Command::StringSet {
+                    key: command.key,
+                    value: command.value,
+                }
+            }
+        }
+        v1::wal_command::Kind::HashSet(command) => Command::HashSet {
+            key: command.key,
+            field: command.field,
+            value: command.value,
+        },
+        v1::wal_command::Kind::Verbatim(bytes) => {
+            serde_json::from_slice(&bytes).map_err(io::Error::other)?
+        }
+    })
+}
+
+fn entry_to_proto(entry: &RaftLogEntry) -> io::Result<v1::WalLogEntry> {
+    Ok(v1::WalLogEntry {
+        term: entry.term,
+        index: entry.index,
+        shard_id: entry.shard_id,
+        command: Some(v1::WalCommand {
+            kind: Some(command_to_proto(&entry.command)?),
+        }),
+    })
+}
+
+fn entry_from_proto(entry: v1::WalLogEntry) -> io::Result<RaftLogEntry> {
+    let kind = entry
+        .command
+        .and_then(|command| command.kind)
+        .ok_or_else(|| io::Error::other("wal log entry is missing its command"))?;
+    Ok(RaftLogEntry {
+        term: entry.term,
+        index: entry.index,
+        shard_id: entry.shard_id,
+        command: command_from_proto(kind)?,
+    })
+}
+
+/// Introduces a length-prefixed binary record. Chosen so it cannot be confused with either text
+/// form: a record written before this change starts with `{`, and one wrapped in the integrity
+/// envelope starts with `#`.
+pub(super) const BINARY_RECORD_MAGIC: u8 = 0xA7;
+
+/// Whether new records are written in the binary encoding. Off unless asked for: reading it is
+/// safe from the moment the code lands, but writing it is a one-way step for any reader that
+/// predates this, so the switch is deliberate.
+pub(super) fn binary_records_enabled() -> bool {
+    // Default ON since the encoding proved out on real hardware; the env var now
+    // opts OUT. Old records read back fine: reads dispatch on the first byte.
+    std::env::var("TS_RAFT_WAL_BINARY_RECORDS")
+        .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
+}
+
+/// Encode one record as it should appear in a segment file.
+pub(super) fn encode_record_line(
+    envelope: &RaftWalEnvelope,
+    binary: bool,
+) -> io::Result<Vec<u8>> {
+    if !binary {
+        let mut out = serde_json::to_vec(envelope).map_err(io::Error::other)?;
+        out.push(b'\n');
+        return Ok(out);
+    }
+    let payload = encode_envelope(envelope)?;
+    let mut out = Vec::with_capacity(payload.len() + 5);
+    out.push(BINARY_RECORD_MAGIC);
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(&payload);
+    Ok(out)
+}
+
+/// Read the next record, in whichever encoding it was written.
+///
+/// Returns how many bytes it occupied along with the record. `None` means what follows is not a
+/// complete, decodable record -- a torn tail from a crash mid-append -- and the caller truncates
+/// there, exactly as it did when every record was text.
+pub(super) fn next_envelope(bytes: &[u8]) -> Option<(usize, RaftWalEnvelope)> {
+    match bytes.first()? {
+        &BINARY_RECORD_MAGIC => {
+            let length_end = 5usize;
+            if bytes.len() < length_end {
+                return None;
+            }
+            let length =
+                u32::from_le_bytes(bytes[1..length_end].try_into().ok()?) as usize;
+            let end = length_end.checked_add(length)?;
+            // A length running past the end of what was written is a torn tail, not a record.
+            if bytes.len() < end {
+                return None;
+            }
+            Some((end, decode_envelope(&bytes[length_end..end]).ok()?))
+        }
+        _ => {
+            let line_len = bytes
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map(|position| position + 1)
+                .unwrap_or(bytes.len());
+            let raw_line = &bytes[..line_len];
+            let line = raw_line.strip_suffix(b"\n").unwrap_or(raw_line);
+            Some((
+                line_len,
+                serde_json::from_slice::<RaftWalEnvelope>(line).ok()?,
+            ))
+        }
+    }
+}
+
+/// Encode a replicated batch for the wire, behind the same magic byte the log uses.
+///
+/// A receiver tells the two encodings apart by the first byte: a text body always starts with
+/// `{`, so a body starting with the magic can only be binary.
+pub(super) fn encode_append_entries(
+    request: &AppendEntriesRequest,
+) -> io::Result<Vec<u8>> {
+    let message = v1::RaftAppendEntriesRequest {
+        shard_id: request.shard_id,
+        term: request.term,
+        leader_id: request.leader_id,
+        target_id: request.target_id,
+        prev_log_index: request.prev_log_index,
+        prev_log_term: request.prev_log_term,
+        entries: request
+            .entries
+            .iter()
+            .map(entry_to_proto)
+            .collect::<io::Result<Vec<_>>>()?,
+        leader_commit: request.leader_commit,
+        rpc: match &request.rpc {
+            Some(rpc) => serde_json::to_vec(rpc).map_err(io::Error::other)?,
+            None => Vec::new(),
+        },
+    };
+    let mut out = Vec::with_capacity(message.encoded_len() + 1);
+    out.push(BINARY_RECORD_MAGIC);
+    message.encode(&mut out).map_err(io::Error::other)?;
+    Ok(out)
+}
+
+/// Whether a body is the binary encoding rather than text.
+pub(crate) fn is_binary_rpc(body: &[u8]) -> bool {
+    body.first() == Some(&BINARY_RECORD_MAGIC)
+}
+
+/// Decode a replicated batch that arrived in the binary encoding.
+pub(crate) fn decode_append_entries(body: &[u8]) -> io::Result<AppendEntriesRequest> {
+    let message = v1::RaftAppendEntriesRequest::decode(&body[1..]).map_err(io::Error::other)?;
+    Ok(AppendEntriesRequest {
+        rpc: if message.rpc.is_empty() {
+            None
+        } else {
+            serde_json::from_slice(&message.rpc).map_err(io::Error::other)?
+        },
+        shard_id: message.shard_id,
+        term: message.term,
+        leader_id: message.leader_id,
+        target_id: message.target_id,
+        prev_log_index: message.prev_log_index,
+        prev_log_term: message.prev_log_term,
+        entries: message
+            .entries
+            .into_iter()
+            .map(entry_from_proto)
+            .collect::<io::Result<Vec<_>>>()?,
+        leader_commit: message.leader_commit,
+    })
+}
+
+/// Whether a leader takes its durability barrier alongside replication rather than after it.
+///
+/// Off unless asked for: it relies on the commit index being recoverable, which holds only once
+/// every leader commits an entry of its own term on taking office.
+pub(super) fn overlap_leader_barrier_enabled() -> bool {
+    std::env::var("TS_RAFT_OVERLAP_LEADER_BARRIER")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Whether replicated batches are sent in the binary encoding. Off unless asked for: a receiver
+/// accepts either, but a sender must not switch before every peer can read it.
+pub(super) fn binary_replication_enabled() -> bool {
+    std::env::var("TS_RAFT_BINARY_REPLICATION")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Encode one envelope as a binary message.
+pub(super) fn encode_envelope(envelope: &RaftWalEnvelope) -> io::Result<Vec<u8>> {
+    let record = &envelope.record;
+    let rest = RaftWalRecordRest {
+        replica_role: record.replica_role,
+        joint_membership: record.joint_membership.clone(),
+        latest_external_snapshot_ref: record.latest_external_snapshot_ref.clone(),
+        installed_snapshot: record.installed_snapshot.clone(),
+        pipeline_state: record.pipeline_state.clone(),
+        read_safety_state: record.read_safety_state.clone(),
+        membership_evidence: record.membership_evidence.clone(),
+    };
+    // Omit the block entirely when every field in it is at its default, which is the common case.
+    let rest_bytes = if rest.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::to_vec(&rest).map_err(io::Error::other)?
+    };
+
+    let (fence_checksum, fence_checksum_is_text) =
+        checksum_to_bytes(&record.storage_apply_fence.checksum);
+    let (checksum, checksum_is_text) = checksum_to_bytes(&envelope.checksum);
+
+    let message = v1::WalEnvelope {
+        sequence: envelope.sequence,
+        checksum,
+        checksum_is_text,
+        record: Some(v1::WalRecord {
+            hard_state: Some(v1::WalHardState {
+                current_term: record.hard_state.current_term,
+                voted_for: record.hard_state.voted_for,
+                commit_index: record.hard_state.commit_index,
+            }),
+            membership: Some(v1::WalMembership {
+                shard_id: record.membership.shard_id,
+                voters: record.membership.voters.clone(),
+                leader_id: record.membership.leader_id,
+            }),
+            apply_snapshot_fence: Some(v1::WalApplySnapshotFence {
+                applied_index: record.apply_snapshot_fence.applied_index,
+                commit_index: record.apply_snapshot_fence.commit_index,
+                installed_snapshot_index: record.apply_snapshot_fence.installed_snapshot_index,
+                first_retained_log_index: record.apply_snapshot_fence.first_retained_log_index,
+            }),
+            storage_apply_fence: Some(v1::WalStorageApplyFence {
+                shard_id: record.storage_apply_fence.shard_id,
+                raft_term: record.storage_apply_fence.raft_term,
+                committed_index: record.storage_apply_fence.committed_index,
+                applied_index: record.storage_apply_fence.applied_index,
+                snapshot_id: record.storage_apply_fence.snapshot_id.clone(),
+                storage_epoch: record.storage_apply_fence.storage_epoch,
+                checksum: fence_checksum,
+                checksum_is_text: fence_checksum_is_text,
+            }),
+            entries: record
+                .entries
+                .iter()
+                .map(entry_to_proto)
+                .collect::<io::Result<Vec<_>>>()?,
+            rest: rest_bytes,
+        }),
+        delta: envelope.delta.as_ref().map(|delta| v1::WalEntryDelta {
+            from_index: delta.from_index,
+            log_first_index: delta.log_first_index,
+            log_last_index: delta.log_last_index,
+        }),
+    };
+    Ok(message.encode_to_vec())
+}
+
+/// Decode one binary message back into an envelope.
+pub(super) fn decode_envelope(bytes: &[u8]) -> io::Result<RaftWalEnvelope> {
+    let message = v1::WalEnvelope::decode(bytes).map_err(io::Error::other)?;
+    let record = message
+        .record
+        .ok_or_else(|| io::Error::other("wal envelope is missing its record"))?;
+    let hard_state = record.hard_state.unwrap_or_default();
+    let membership = record.membership.unwrap_or_default();
+    let apply_snapshot_fence = record.apply_snapshot_fence.unwrap_or_default();
+    let storage_apply_fence = record.storage_apply_fence.unwrap_or_default();
+    let rest: RaftWalRecordRest = if record.rest.is_empty() {
+        RaftWalRecordRest::default()
+    } else {
+        serde_json::from_slice(&record.rest).map_err(io::Error::other)?
+    };
+
+    Ok(RaftWalEnvelope {
+        sequence: message.sequence,
+        checksum: checksum_from_bytes(&message.checksum, message.checksum_is_text),
+        record: RaftWalRecord {
+            hard_state: RaftHardState {
+                current_term: hard_state.current_term,
+                voted_for: hard_state.voted_for,
+                commit_index: hard_state.commit_index,
+            },
+            membership: RaftMembership {
+                shard_id: membership.shard_id,
+                voters: membership.voters,
+                leader_id: membership.leader_id,
+            },
+            replica_role: rest.replica_role,
+            joint_membership: rest.joint_membership,
+            latest_external_snapshot_ref: rest.latest_external_snapshot_ref,
+            installed_snapshot: rest.installed_snapshot,
+            apply_snapshot_fence: RaftApplySnapshotFence {
+                applied_index: apply_snapshot_fence.applied_index,
+                commit_index: apply_snapshot_fence.commit_index,
+                installed_snapshot_index: apply_snapshot_fence.installed_snapshot_index,
+                first_retained_log_index: apply_snapshot_fence.first_retained_log_index,
+            },
+            storage_apply_fence: RaftStorageApplyFence {
+                shard_id: storage_apply_fence.shard_id,
+                raft_term: storage_apply_fence.raft_term,
+                committed_index: storage_apply_fence.committed_index,
+                applied_index: storage_apply_fence.applied_index,
+                snapshot_id: storage_apply_fence.snapshot_id,
+                storage_epoch: storage_apply_fence.storage_epoch,
+                checksum: checksum_from_bytes(
+                    &storage_apply_fence.checksum,
+                    storage_apply_fence.checksum_is_text,
+                ),
+            },
+            pipeline_state: rest.pipeline_state,
+            read_safety_state: rest.read_safety_state,
+            membership_evidence: rest.membership_evidence,
+            entries: record
+                .entries
+                .into_iter()
+                .map(entry_from_proto)
+                .collect::<io::Result<Vec<_>>>()?,
+        },
+        delta: message.delta.map(|delta| RaftWalEntryDelta {
+            from_index: delta.from_index,
+            log_first_index: delta.log_first_index,
+            log_last_index: delta.log_last_index,
+        }),
+    })
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope_with(command: Command) -> RaftWalEnvelope {
+        RaftWalEnvelope {
+            sequence: 7,
+            checksum: "9e0126c499690a34b92dc5cac030ea79a3b75a6d92cd9636afc7bfa457b34a01".into(),
+            record: RaftWalRecord {
+                hard_state: RaftHardState {
+                    current_term: 3,
+                    voted_for: Some(2),
+                    commit_index: 41,
+                },
+                membership: RaftMembership {
+                    shard_id: 1,
+                    voters: vec![1, 2, 3],
+                    leader_id: 1,
+                },
+                storage_apply_fence: RaftStorageApplyFence {
+                    shard_id: 1,
+                    raft_term: 3,
+                    committed_index: 41,
+                    applied_index: 41,
+                    snapshot_id: None,
+                    storage_epoch: 41,
+                    checksum: "5d694524421e20e2c7be7c646b30d7a13b4266dfffd1231e2b4e10b3bbd4a6f7"
+                        .into(),
+                },
+                entries: vec![RaftLogEntry {
+                    term: 3,
+                    index: 42,
+                    shard_id: 1,
+                    command,
+                }],
+                replica_role: RaftReplicaRole::default(),
+                joint_membership: None,
+                latest_external_snapshot_ref: None,
+                installed_snapshot: None,
+                apply_snapshot_fence: RaftApplySnapshotFence::default(),
+                pipeline_state: RaftPeerPipelineRuntimeState::default(),
+                read_safety_state: RaftReadSafetyRuntimeState::default(),
+                membership_evidence: RaftMembershipRuntimeEvidence::default(),
+            },
+            delta: Some(RaftWalEntryDelta {
+                from_index: 41,
+                log_first_index: 1,
+                log_last_index: 42,
+            }),
+        }
+    }
+
+    fn assert_round_trips(command: Command) {
+        let envelope = envelope_with(command);
+        let encoded = encode_envelope(&envelope).expect("encode");
+        let decoded = decode_envelope(&encoded).expect("decode");
+        assert_eq!(
+            decoded, envelope,
+            "a record must decode back to exactly what was encoded"
+        );
+    }
+
+    #[test]
+    fn a_modelled_command_round_trips() {
+        assert_round_trips(Command::StringSet {
+            key: "k".into(),
+            value: b"hello".to_vec(),
+        });
+        assert_round_trips(Command::HashSet {
+            key: "k".into(),
+            field: "f".into(),
+            value: b"hello".to_vec(),
+        });
+        assert_round_trips(Command::StringSetEx {
+            key: "k".into(),
+            value: b"hello".to_vec(),
+            ttl_ms: 5_000,
+        });
+    }
+
+    /// The modelled form tells `StringSet` and `StringSetEx` apart by whether the TTL is
+    /// non-zero, so a zero-TTL `StringSetEx` cannot use it -- it would come back as a plain
+    /// `StringSet`, quietly dropping the fact that an expiry was set at all. It must take the
+    /// verbatim path instead.
+    #[test]
+    fn a_zero_ttl_expiring_set_does_not_decay_into_a_plain_set() {
+        let command = Command::StringSetEx {
+            key: "k".into(),
+            value: b"hello".to_vec(),
+            ttl_ms: 0,
+        };
+        assert_round_trips(command.clone());
+        let encoded = encode_envelope(&envelope_with(command)).expect("encode");
+        let decoded = decode_envelope(&encoded).expect("decode");
+        assert!(
+            matches!(
+                decoded.record.entries[0].command,
+                Command::StringSetEx { ttl_ms: 0, .. }
+            ),
+            "it must still be an expiring set after a round trip"
+        );
+    }
+
+    /// A command this module does not model must still round-trip exactly, because the log has to
+    /// replay commands the encoding has never been taught about.
+    #[test]
+    fn an_unmodelled_command_round_trips_verbatim() {
+        assert_round_trips(Command::StringDelete { key: "k".into() });
+        assert_round_trips(Command::SetAdd {
+            key: "k".into(),
+            member: b"a".to_vec(),
+        });
+    }
+
+    /// Payload bytes must survive whatever they contain -- including bytes a text encoding would
+    /// have to escape, and bytes that are not valid UTF-8 at all.
+    #[test]
+    fn arbitrary_payload_bytes_survive() {
+        assert_round_trips(Command::StringSet {
+            key: "k".into(),
+            value: (0u8..=255).collect(),
+        });
+        assert_round_trips(Command::StringSet {
+            key: "quote\"newline\n".into(),
+            value: vec![0, 0x1b, 0xff, 0xfe],
+        });
+    }
+
+    /// A checksum is a hex digest in practice and is stored as one, but the encoding must not
+    /// assume that: anything else is kept as its own bytes and returned unchanged.
+    #[test]
+    fn a_checksum_that_is_not_a_hex_digest_is_returned_unchanged() {
+        let mut envelope = envelope_with(Command::StringSet {
+            key: "k".into(),
+            value: b"v".to_vec(),
+        });
+        envelope.checksum = "not-a-digest".into();
+        envelope.record.storage_apply_fence.checksum = "also/not/hex".into();
+        let encoded = encode_envelope(&envelope).expect("encode");
+        assert_eq!(decode_envelope(&encoded).expect("decode"), envelope);
+    }
+
+    /// A hex digest must actually be stored as its digest rather than its text, since that is
+    /// where the saving comes from.
+    #[test]
+    fn a_hex_digest_is_stored_as_bytes_not_text() {
+        let digest = "9e0126c499690a34b92dc5cac030ea79a3b75a6d92cd9636afc7bfa457b34a01";
+        let (bytes, is_text) = checksum_to_bytes(digest);
+        assert!(!is_text);
+        assert_eq!(bytes.len(), 32, "64 hex characters are 32 bytes");
+        assert_eq!(checksum_from_bytes(&bytes, is_text), digest);
+    }
+
+    /// The record's rarely-set fields travel whole, so a record that does set them still comes
+    /// back intact.
+    #[test]
+    fn the_rarely_set_record_fields_survive() {
+        let mut envelope = envelope_with(Command::StringSet {
+            key: "k".into(),
+            value: b"v".to_vec(),
+        });
+        envelope.record.membership_evidence.learner_add_count = 4;
+        envelope.record.apply_snapshot_fence.applied_index = 9;
+        let encoded = encode_envelope(&envelope).expect("encode");
+        assert_eq!(decode_envelope(&encoded).expect("decode"), envelope);
+    }
+
+    /// The point of the exercise: the same record, both ways.
+    #[test]
+    fn encodes_far_smaller_than_the_text_form() {
+        for payload in [10usize, 1024] {
+            let envelope = envelope_with(Command::StringSet {
+                key: "fmt-001999".into(),
+                value: vec![0x41; payload],
+            });
+            let text = serde_json::to_vec(&envelope).expect("json");
+            let binary = encode_envelope(&envelope).expect("proto");
+            println!(
+                "payload {payload:>5}B -> text {:>6}B, binary {:>6}B ({:.2}x smaller)",
+                text.len(),
+                binary.len(),
+                text.len() as f64 / binary.len() as f64
+            );
+            assert!(
+                binary.len() < text.len(),
+                "the binary form must be smaller ({} vs {})",
+                binary.len(),
+                text.len()
+            );
+        }
+    }
+
+    /// What one AppendEntries costs on the wire, both ways. Replication sends this to every
+    /// follower for every write, so the ratio here is paid once per follower per write.
+    #[test]
+    fn replication_body_cost() {
+        for payload in [10usize, 1024] {
+            let entries = vec![RaftLogEntry {
+                term: 3,
+                index: 42,
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: "k".into(),
+                    value: vec![0x41; payload],
+                },
+            }];
+            let request = AppendEntriesRequest {
+                rpc: None,
+                shard_id: 1,
+                term: 3,
+                leader_id: 1,
+                target_id: 2,
+                prev_log_index: 41,
+                prev_log_term: 3,
+                entries: entries.clone(),
+                leader_commit: 41,
+            };
+            let text = serde_json::to_vec(&request).expect("json");
+            // The entries are what scales; the rest of the request is a handful of integers.
+            let binary: usize = entries
+                .iter()
+                .map(|entry| {
+                    let proto = entry_to_proto(entry).expect("proto");
+                    prost::Message::encoded_len(&proto)
+                })
+                .sum();
+            println!(
+                "append_entries payload {payload:>5}B -> json {:>6}B, entries as binary {:>6}B ({:.2}x)",
+                text.len(),
+                binary,
+                text.len() as f64 / binary.max(1) as f64
+            );
+        }
+    }
+
+    /// A replicated batch must arrive as exactly what was sent. Anything lost here is a follower
+    /// applying something different from its leader, which is the one thing consensus exists to
+    /// prevent.
+    #[test]
+    fn a_replicated_batch_round_trips() {
+        let request = AppendEntriesRequest {
+            rpc: None,
+            shard_id: 1,
+            term: 3,
+            leader_id: 1,
+            target_id: 2,
+            prev_log_index: 41,
+            prev_log_term: 3,
+            entries: vec![
+                RaftLogEntry {
+                    term: 3,
+                    index: 42,
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: "k".into(),
+                        // Bytes a text encoding would have to escape, and bytes that are not
+                        // valid text at all.
+                        value: (0u8..=255).collect(),
+                    },
+                },
+                RaftLogEntry {
+                    term: 3,
+                    index: 43,
+                    shard_id: 1,
+                    // An unmodelled command still has to arrive intact.
+                    command: Command::StringDelete { key: "gone".into() },
+                },
+            ],
+            leader_commit: 41,
+        };
+        let encoded = encode_append_entries(&request).expect("encode");
+        assert!(is_binary_rpc(&encoded), "a binary body must be recognisable as one");
+        assert_eq!(decode_append_entries(&encoded).expect("decode"), request);
+    }
+
+    /// A text body must never be mistaken for a binary one -- they share a route.
+    #[test]
+    fn a_text_body_is_not_mistaken_for_binary() {
+        let json = serde_json::to_vec(&AppendEntriesRequest {
+            rpc: None,
+            shard_id: 1,
+            term: 1,
+            leader_id: 1,
+            target_id: 2,
+            prev_log_index: 0,
+            prev_log_term: 0,
+            entries: Vec::new(),
+            leader_commit: 0,
+        })
+        .unwrap();
+        assert!(!is_binary_rpc(&json));
+    }
+}

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1178,6 +1178,13 @@ impl ContextWire for ContextCompressionEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Command {
+    /// Appended by a leader when it takes office, and applied as nothing.
+    ///
+    /// A leader may not conclude that entries from an earlier term are committed just because a
+    /// majority holds them; it has to commit something of its own term first. Without that, a
+    /// node that restarts and takes office keeps whatever commit point it had, and entries above
+    /// it sit in the log unapplied until the next write happens to arrive.
+    LeaderEstablish,
     CommonDelete {
         key: String,
     },

--- a/proto/temporalstore/v1/temporalstore.proto
+++ b/proto/temporalstore/v1/temporalstore.proto
@@ -380,3 +380,182 @@ message CommonExpire {
 message CommonExists {
   string key = 1;
 }
+
+// ---------------------------------------------------------------------------
+// Write-ahead log records.
+//
+// Fidelity before compactness: this is the durability path, so anything the schema does not
+// model explicitly is carried verbatim in its existing encoding. A record can therefore never
+// lose a field because the schema had not caught up with it.
+// ---------------------------------------------------------------------------
+
+message WalHardState {
+  uint64 current_term = 1;
+  optional uint64 voted_for = 2;
+  uint64 commit_index = 3;
+}
+
+message WalMembership {
+  uint64 shard_id = 1;
+  repeated uint64 voters = 2;
+  uint64 leader_id = 3;
+}
+
+message WalApplySnapshotFence {
+  uint64 applied_index = 1;
+  uint64 commit_index = 2;
+  uint64 installed_snapshot_index = 3;
+  uint64 first_retained_log_index = 4;
+}
+
+message WalStorageApplyFence {
+  uint64 shard_id = 1;
+  uint64 raft_term = 2;
+  uint64 committed_index = 3;
+  uint64 applied_index = 4;
+  optional string snapshot_id = 5;
+  uint64 storage_epoch = 6;
+  // Raw digest bytes: stored as text, the same digest costs twice the space to say the same
+  // thing. A checksum that is not a hex digest is kept as its own bytes with `checksum_is_text`
+  // set, so nothing has to assume what a checksum looks like to round-trip it.
+  bytes checksum = 7;
+  bool checksum_is_text = 8;
+}
+
+// One command as it appears in the log.
+//
+// The modelled arms exist because they carry the bulk of the bytes: their payloads are byte
+// strings, which a text encoding inflates roughly threefold. Every other command uses
+// `verbatim`, which holds exactly the bytes the previous encoding produced.
+message WalCommand {
+  oneof kind {
+    StringSet string_set = 1;
+    HashSet hash_set = 2;
+    bytes verbatim = 99;
+  }
+}
+
+message WalLogEntry {
+  uint64 term = 1;
+  uint64 index = 2;
+  uint64 shard_id = 3;
+  WalCommand command = 4;
+}
+
+// Present on an incremental record, whose entries hold only what was appended since
+// `from_index`. Absent on a self-sufficient base record.
+message WalEntryDelta {
+  uint64 from_index = 1;
+  uint64 log_first_index = 2;
+  uint64 log_last_index = 3;
+}
+
+message WalRecord {
+  WalHardState hard_state = 1;
+  WalMembership membership = 2;
+  WalApplySnapshotFence apply_snapshot_fence = 3;
+  WalStorageApplyFence storage_apply_fence = 4;
+  repeated WalLogEntry entries = 5;
+  // The record's remaining fields -- replica role, joint membership, snapshot refs and
+  // runtime telemetry -- which sit at their default on almost every record and are omitted
+  // entirely when they do. Carried in their existing encoding so none of them can be lost.
+  bytes rest = 6;
+}
+
+message WalEnvelope {
+  uint64 sequence = 1;
+  bytes checksum = 2;
+  WalRecord record = 3;
+  WalEntryDelta delta = 4;
+  bool checksum_is_text = 5;
+}
+
+// One engine write-ahead log record.
+//
+// The command carries the value, which is where the bytes are, so it uses the same encoding as
+// the node log: modelled arms for the commands that carry byte strings, and everything else
+// verbatim in its previous encoding.
+message EngineWalRecord {
+  uint64 shard_id = 1;
+  uint64 sequence = 2;
+  WalCommand command = 3;
+  // Absent on a record written outside a batch.
+  EngineWalMetadata metadata = 4;
+}
+
+// What a record did to storage, flat enough that the whole thing costs a handful of bytes.
+enum WalItemKind {
+  WAL_ITEM_KIND_UNSPECIFIED = 0;
+  WAL_ITEM_KIND_KV = 1;
+  WAL_ITEM_KIND_BLOCK = 2;
+  WAL_ITEM_KIND_TTL = 3;
+  WAL_ITEM_KIND_DELETE_OBJECT = 4;
+  WAL_ITEM_KIND_QUERY = 5;
+  WAL_ITEM_KIND_ADMIN = 6;
+}
+
+enum WalItemModel {
+  WAL_ITEM_MODEL_UNSPECIFIED = 0;
+  WAL_ITEM_MODEL_COMMON = 1;
+  WAL_ITEM_MODEL_STRING = 2;
+  WAL_ITEM_MODEL_HASH = 3;
+  WAL_ITEM_MODEL_SET = 4;
+  WAL_ITEM_MODEL_FEATURE = 5;
+  WAL_ITEM_MODEL_SEQUENCE = 6;
+  WAL_ITEM_MODEL_CONTROL_STATE = 7;
+  WAL_ITEM_MODEL_CONTEXT = 8;
+  WAL_ITEM_MODEL_ADMIN = 9;
+  WAL_ITEM_MODEL_UNKNOWN = 10;
+}
+
+message EngineWalItem {
+  WalItemKind item_kind = 1;
+  WalItemModel model = 2;
+  optional string object_key = 3;
+  optional uint64 bucket_id = 4;
+  optional uint64 object_id = 5;
+  optional uint64 block_id = 6;
+  optional uint64 ttl_ms = 7;
+  bool deleted = 8;
+  bool meta_log = 9;
+  bool block_log = 10;
+}
+
+message EngineWalMetadata {
+  uint32 version = 1;
+  uint64 timestamp_ms = 2;
+  repeated EngineWalItem items = 3;
+  // All three are set together for a batched write, and all absent for a standalone one.
+  optional uint64 batch_id = 4;
+  optional uint32 batch_size = 5;
+  optional uint32 batch_index = 6;
+}
+
+// One replicated batch of entries, as it travels between nodes.
+//
+// The entries carry the values, which is where the bytes are; the rest of the message is a
+// handful of integers.
+message RaftAppendEntriesRequest {
+  uint64 shard_id = 1;
+  uint64 term = 2;
+  uint64 leader_id = 3;
+  uint64 target_id = 4;
+  uint64 prev_log_index = 5;
+  uint64 prev_log_term = 6;
+  repeated WalLogEntry entries = 7;
+  uint64 leader_commit = 8;
+  // Set only when the caller attached tracing metadata, and carried in its existing encoding so
+  // none of its fields depend on this schema keeping up.
+  bytes rpc = 9;
+}
+
+// Just enough of an engine log record to decide whether it is wanted.
+//
+// Reading a record as this skips the command and the metadata entirely rather than decoding and
+// discarding them, which is most of the work when recovery is stepping over records it has
+// already applied. The field numbers match EngineWalRecord, which is what makes it readable as
+// one.
+message EngineWalRecordHeader {
+  uint64 shard_id = 1;
+  uint64 sequence = 2;
+}


### PR DESCRIPTION
Binary (protobuf) records for the raft node log behind a one-byte format dispatch — reads accept every format unconditionally, writes default to binary after hardware measurement (latency within noise, 3.2x fewer WAL bytes, identical restart, zero read mismatches on a 3-shard x 6-replica cluster). `TS_RAFT_WAL_BINARY_RECORDS=0` opts back to text. Unmodelled commands travel verbatim, so every variant round-trips. Binary replication and the overlapped leader barrier ship default-OFF (details in the commit message). Engine log untouched: this tree's sidecar-payload design composes with the binary encoding in a follow-up, not a port. Validated here: 290/290 raft+wal tests with defaults and with the opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)