### PR TITLE
Client: ask the metaserver only for the topology it does not already have

### DIFF
--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -31,7 +31,7 @@ impl TemporalStoreClient {
                 client_location: String::new(),
                 namespace: namespace.clone(),
                 table_name: table_name.clone(),
-                old_topology_version: 0,
+                old_topology_version: self.last_synced_topology_version(&namespace, &table_name),
             },
             self.inner.options.meta_sync_http_options(),
         ) {
@@ -178,6 +178,25 @@ impl TemporalStoreClient {
             .lock()
             .expect("client table cache lock poisoned")
             .insert(table_key.clone(), options.clone());
+
+        // "unchanged" means the metaserver did not rebuild the shard list because we already
+        // have this version -- so the response carries NO shards, and running the route
+        // surgery below against an empty list would delete every route this table has. The
+        // serving options still came back and are applied above; the routes are already right.
+        //
+        // This has to be handled before the version is sent, not after: while the request was
+        // hardcoded to version 0 the metaserver could never answer unchanged, which is the
+        // only reason the wipe never happened.
+        if topology.unchanged {
+            self.record_meta_sync_success(
+                &namespace,
+                &table_name,
+                route_topology_version,
+                0,
+            );
+            return Ok(options);
+        }
+
         let mut route_cache = self
             .inner
             .routes
@@ -834,6 +853,22 @@ impl TemporalStoreClient {
                 last_error: String::new(),
                 shards_without_primary: 0,
             });
+    }
+
+    /// The topology version this client last synced for a table, or 0 if it has none.
+    ///
+    /// Sent with the next fetch so the metaserver can answer "unchanged" instead of rebuilding
+    /// and shipping the whole shard list. Both halves of that negotiation already existed --
+    /// the request field and the metaserver's reply -- with nothing connecting them.
+    fn last_synced_topology_version(&self, namespace: &str, table_name: &str) -> u64 {
+        let key = table_combine_name(namespace, table_name);
+        self.inner
+            .meta_sync_tables
+            .lock()
+            .expect("client meta sync table lock poisoned")
+            .get(&key)
+            .map(|state| state.last_topology_version)
+            .unwrap_or(0)
     }
 
     pub(super) fn record_meta_sync_success(

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -264,6 +264,119 @@ fn client_metasync_backoff_deadline_and_topology_refresh_survive_outage_churn() 
 }
 
 #[test]
+fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // The request has always carried old_topology_version and the metaserver has always
+    // answered "unchanged" when it is current -- with the shard list omitted, because there is
+    // no point rebuilding what the caller already has. The client hardcoded 0, so that answer
+    // could never be given: every sync of every table rebuilt and shipped the whole shard list.
+    //
+    // It could not simply start sending the version either. An unchanged reply carries no
+    // shards, and the route surgery would have read that as "this table has no shards" and
+    // deleted them all. Both halves are needed, in that order.
+    let seen_versions = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+    let builds = std::sync::Arc::new(AtomicUsize::new(0));
+    let meta_addr = free_local_addr();
+    let meta_addr_for_listener = meta_addr.clone();
+    let versions = seen_versions.clone();
+    let built = builds.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => {
+                    let req = parse_json::<crate::meta::GetTableTopologyRequest>(&request.body)
+                        .unwrap();
+                    versions.lock().unwrap().push(req.old_topology_version);
+                    let table = crate::meta::TableMetaInfo {
+                        table_id: 1,
+                        namespace: "ns".to_string(),
+                        table_name: "tbl".to_string(),
+                        state: crate::meta::MetaEntityState::Normal,
+                        topology_version: 7,
+                        first_shard_id: 1,
+                        shard_count: 1,
+                        replica_count: 1,
+                        partition_version: 0,
+                        serving_options: crate::meta::TableServingOptions::default(),
+                    };
+                    // Exactly what the metaserver does: current version in, no shards back.
+                    if req.old_topology_version >= table.topology_version {
+                        return json_response(
+                            200,
+                            &TableTopologyResponse {
+                                status: Status::ok(),
+                                table: Some(table),
+                                shards: Vec::new(),
+                                unchanged: true,
+                            },
+                        );
+                    }
+                    built.fetch_add(1, Ordering::SeqCst);
+                    json_response(
+                        200,
+                        &TableTopologyResponse {
+                            status: Status::ok(),
+                            table: Some(table),
+                            shards: vec![TableShard {
+                                shard_id: 1,
+                                start_bucket: 0,
+                                end_bucket: u64::MAX,
+                                primary: Some("127.0.0.1:29101".to_string()),
+                                replicas: Vec::new(),
+                                primary_endpoint: None,
+                                replica_endpoints: Vec::new(),
+                            }],
+                            unchanged: false,
+                        },
+                    )
+                }
+                _ => json_response(404, &Status::error("not_found", "no route")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: meta_addr.clone(),
+        meta_addr: Some(meta_addr.clone()),
+        ..ClientOptions::default()
+    });
+
+    client
+        .sync_table_topology("ns".to_string(), "tbl".to_string())
+        .expect("first sync succeeds");
+    assert_eq!(client.topology_cache_report().route_count, 1);
+
+    client
+        .sync_table_topology("ns".to_string(), "tbl".to_string())
+        .expect("second sync succeeds");
+
+    let versions = seen_versions.lock().unwrap().clone();
+    assert_eq!(
+        versions.first().copied(),
+        Some(0),
+        "the first sync has nothing to declare"
+    );
+    assert_eq!(
+        versions.get(1).copied(),
+        Some(7),
+        "the second sync must declare what it already has, or the metaserver cannot skip work"
+    );
+    assert_eq!(
+        builds.load(Ordering::SeqCst),
+        1,
+        "the shard list should be built once, not once per sync"
+    );
+    assert_eq!(
+        client.topology_cache_report().route_count,
+        1,
+        "an unchanged reply carries no shards and must not be read as having none"
+    );
+}
+
+#[test]
 fn a_topology_missing_a_primary_keeps_the_route_it_cannot_replace() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 


### PR DESCRIPTION
The table topology request has always carried old_topology_version, and the
metaserver has always answered "unchanged" when that version is current -- returning
the table without rebuilding or shipping the shard list. The client sent 0 every
time, so that answer could never be given. Every periodic sync of every table
rebuilt the full shard list on the metaserver and shipped it back, whether or not
anything had moved.

The version was already being tracked. It was simply never sent.

Sending it is only half the change, and the smaller half. An unchanged reply carries
no shards, and the code that installs routes reads the response's shard list as the
table's complete set: it purges the table's routes and inserts what it finds. Given
an empty list, it would have deleted every route for that table and reported a
successful sync. Sending the version without handling the reply would have converted
a wasteful sync into a route-wiping one.

So: handle unchanged first, then send the version.

Both halves are checked, and the wipe is demonstrated rather than asserted. Send the
version but skip the unchanged handling and the route count drops from 1 to 0 --
that is the latent bug, made to happen. Keep the handling but go back to sending 0
and the negotiation goes dead again: the second sync declares version 0 and the
metaserver rebuilds the shard list a second time.

The saving scales with what a deployment actually has. Every table, every sync
interval, for as long as the topology is stable -- which is nearly always, since
topology changes are rare and syncs are periodic.