### PR TITLE
meta: let the metaserver actually ask a proxy to shed load

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4947,6 +4947,132 @@ mod tests {
         }
     }
 
+    /// A proxy attached to a group serving one namespace.
+    fn shedding_meta(drop_percent: u8) -> SingleNodeMeta {
+        let meta = SingleNodeMeta::default();
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "tenant".to_string(),
+            location: "rack-1".to_string(),
+            config_version: 0,
+            binary_version: "v1".to_string(),
+        });
+        assert!(
+            meta.put_proxy_group(PutProxyGroupRequest {
+                group: "front".to_string(),
+                namespace: "tenant".to_string(),
+                location: String::new(),
+                instance_num: 1,
+                drop_percent,
+            })
+            .status
+            .ok
+        );
+        assert!(
+            meta.set_proxy_group(ProxyAttachment {
+                proxy_addr: "proxy-a".to_string(),
+                group: "front".to_string(),
+            })
+            .status
+            .ok
+        );
+        meta
+    }
+
+    fn beat_proxy(meta: &SingleNodeMeta, config_version: u64) -> ProxyHeartbeatResponse {
+        meta.proxy_heartbeat(ProxyHeartbeatRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "tenant".to_string(),
+            config_version,
+            boot_time_ms: 1,
+            binary_version: "v1".to_string(),
+        })
+    }
+
+    #[test]
+    fn the_metaserver_can_tell_a_proxy_to_shed_load() {
+        // The proxy has always implemented this -- it reads the figure from its
+        // heartbeat, applies it, and exports it as a metric -- but every
+        // response carried a hard-coded zero, so the only way to pull the lever
+        // was to restart each proxy with different configuration.
+        let meta = shedding_meta(25);
+        assert_eq!(beat_proxy(&meta, 0).drop_percent, 25);
+    }
+
+    #[test]
+    fn a_group_that_asks_for_nothing_sheds_nothing() {
+        let meta = shedding_meta(0);
+        assert_eq!(beat_proxy(&meta, 0).drop_percent, 0);
+    }
+
+    #[test]
+    fn changing_the_share_tells_the_proxy_to_re_read() {
+        // The proxy only re-reads when the config version moves, so a change
+        // nobody is told about is a change that does not happen.
+        let meta = shedding_meta(0);
+        let settled = beat_proxy(&meta, 0).config_version;
+
+        assert!(
+            meta.put_proxy_group(PutProxyGroupRequest {
+                group: "front".to_string(),
+                namespace: "tenant".to_string(),
+                location: String::new(),
+                instance_num: 1,
+                drop_percent: 40,
+            })
+            .status
+            .ok
+        );
+        let after = beat_proxy(&meta, settled);
+        assert!(
+            after.config_version > settled,
+            "the version did not move, so an attached proxy would never re-read"
+        );
+        assert!(after.config_changed);
+        assert_eq!(after.drop_percent, 40);
+    }
+
+    #[test]
+    fn an_unattached_proxy_is_not_told_to_shed_anything() {
+        // It is not serving a namespace, so a share of its traffic is a share
+        // of nothing.
+        let meta = shedding_meta(60);
+        assert!(
+            meta.set_proxy_group(ProxyAttachment {
+                proxy_addr: "proxy-a".to_string(),
+                group: String::new(),
+            })
+            .status
+            .ok
+        );
+        assert_eq!(beat_proxy(&meta, 0).drop_percent, 0);
+    }
+
+    #[test]
+    fn the_share_survives_snapshot_and_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("shed-mutations.jsonl");
+        {
+            let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+            assert!(
+                meta.put_proxy_group(PutProxyGroupRequest {
+                    group: "front".to_string(),
+                    namespace: "tenant".to_string(),
+                    location: String::new(),
+                    instance_num: 1,
+                    drop_percent: 35,
+                })
+                .status
+                .ok
+            );
+            let peer = SingleNodeMeta::default();
+            assert!(peer.install_snapshot(meta.export_snapshot()).status.ok);
+            assert_eq!(peer.list_proxy_groups().groups[0].drop_percent, 35);
+        }
+        let recovered = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
+        assert_eq!(recovered.list_proxy_groups().groups[0].drop_percent, 35);
+    }
+
     #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -54,7 +54,24 @@ pub struct ProxyGroupInfo {
     /// can tell from its heartbeat that it must re-read.
     #[serde(default)]
     pub config_version: u64,
+    /// What percentage of traffic attached proxies should shed, 0 to 100.
+    ///
+    /// The proxy has always implemented this -- it reads the figure from its
+    /// heartbeat, applies it, and exports it as a metric -- but the metaserver
+    /// sent a hard-coded zero in every response, so the lever could only be
+    /// pulled by restarting each proxy with different configuration, during
+    /// exactly the incident where restarting proxies is least welcome.
+    #[serde(default)]
+    pub drop_percent: u8,
     pub state: MetaEntityState,
+}
+
+/// What an attached proxy should be serving, as resolved from its group.
+pub(super) struct ProxyServedConfig {
+    pub changed: bool,
+    pub namespace: String,
+    pub config_version: u64,
+    pub drop_percent: u8,
 }
 
 /// Create a group, or update the target and placement of an existing one.
@@ -65,6 +82,10 @@ pub struct PutProxyGroupRequest {
     #[serde(default)]
     pub location: String,
     pub instance_num: u64,
+    /// Percentage of traffic attached proxies should shed. Omitted means none,
+    /// which is what every existing group means.
+    #[serde(default)]
+    pub drop_percent: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -304,6 +325,7 @@ impl SingleNodeMeta {
             Some(previous)
                 if previous.namespace == request.namespace
                     && previous.location == request.location
+                    && previous.drop_percent == request.drop_percent
                     && previous.state == MetaEntityState::Normal =>
             {
                 previous.config_version
@@ -312,6 +334,7 @@ impl SingleNodeMeta {
             None => 1,
         };
         let info = ProxyGroupInfo {
+            drop_percent: request.drop_percent.min(100),
             group: request.group.clone(),
             namespace: request.namespace,
             location: request.location,
@@ -324,7 +347,10 @@ impl SingleNodeMeta {
             &mut state,
             "put_proxy_group",
             format!("proxy_group:{}", request.group),
-            format!("instance_num={},config_version={config_version}", request.instance_num),
+            format!(
+                "instance_num={},drop_percent={},config_version={config_version}",
+                request.instance_num, request.drop_percent
+            ),
         );
         AckResponse {
             status: Status::ok(),
@@ -484,7 +510,7 @@ impl SingleNodeMeta {
         proxy_addr: &str,
         reported_namespace: &str,
         reported_config_version: u64,
-    ) -> (bool, String, u64) {
+    ) -> ProxyServedConfig {
         let attached = state
             .proxies
             .get(proxy_addr)
@@ -502,10 +528,21 @@ impl SingleNodeMeta {
             Some(group) => {
                 let changed = group.namespace != reported_namespace
                     || group.config_version > reported_config_version;
-                (changed, group.namespace.clone(), group.config_version)
+                ProxyServedConfig {
+                    changed,
+                    namespace: group.namespace.clone(),
+                    config_version: group.config_version,
+                    drop_percent: group.drop_percent,
+                }
             }
-            // Unattached: it must stop serving whatever it thinks it serves.
-            None => (!reported_namespace.is_empty(), String::new(), 0),
+            // Unattached: it must stop serving whatever it thinks it serves,
+            // and shedding a share of nothing is meaningless.
+            None => ProxyServedConfig {
+                changed: !reported_namespace.is_empty(),
+                namespace: String::new(),
+                config_version: 0,
+                drop_percent: 0,
+            },
         }
     }
 }
@@ -516,6 +553,7 @@ mod tests {
 
     fn group(name: &str, ns: &str, location: &str, want: u64) -> ProxyGroupInfo {
         ProxyGroupInfo {
+            drop_percent: 0,
             group: name.to_string(),
             namespace: ns.to_string(),
             location: location.to_string(),
@@ -752,6 +790,7 @@ mod tests {
             .ok);
         assert!(meta
             .put_proxy_group(PutProxyGroupRequest {
+                drop_percent: 0,
                 group: "orders".to_string(),
                 namespace: "ns".to_string(),
                 location: "us-east/dc1".to_string(),
@@ -805,6 +844,7 @@ mod tests {
             boot_time_ms: 1,
         });
         meta.put_proxy_group(PutProxyGroupRequest {
+            drop_percent: 0,
             group: "orders".to_string(),
             namespace: "ns".to_string(),
             location: String::new(),
@@ -839,6 +879,7 @@ mod tests {
             let meta = SingleNodeMeta::with_mutation_log(&log_path).unwrap();
             assert!(meta
                 .put_proxy_group(PutProxyGroupRequest {
+                    drop_percent: 0,
                     group: "orders".to_string(),
                     namespace: "ns".to_string(),
                     location: "us-east/dc1".to_string(),
@@ -866,6 +907,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         let put = || {
             meta.put_proxy_group(PutProxyGroupRequest {
+                drop_percent: 0,
                 group: "orders".to_string(),
                 namespace: "ns".to_string(),
                 location: "rack-1".to_string(),
@@ -880,6 +922,7 @@ mod tests {
         // Changing what it serves does bump it.
         assert!(meta
             .put_proxy_group(PutProxyGroupRequest {
+                drop_percent: 0,
                 group: "orders".to_string(),
                 namespace: "other".to_string(),
                 location: "rack-1".to_string(),

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -370,12 +370,14 @@ impl SingleNodeMeta {
         // The attached group is the authority on what this proxy serves, so the
         // heartbeat is where a reassignment -- or a release back to idle --
         // reaches the proxy.
-        let (group_changed, namespace, config_version) = Self::proxy_group_config(
+        let served = Self::proxy_group_config(
             &state,
             &proxy_addr,
             &request.namespace,
             request.config_version,
         );
+        let (group_changed, namespace, config_version) =
+            (served.changed, served.namespace, served.config_version);
         let attached = state
             .proxies
             .get(&proxy_addr)
@@ -401,7 +403,9 @@ impl SingleNodeMeta {
             namespace,
             config_version,
             serving_mode,
-            drop_percent: 0,
+            // What the group asks its proxies to shed. Zero unless an operator
+            // has said otherwise, which is what every group means by default.
+            drop_percent: if attached { served.drop_percent } else { 0 },
         }
     }
 


### PR DESCRIPTION
## A load-shedding lever, fully built and permanently switched off

The proxy implements traffic shedding end to end. It reads `drop_percent` from its heartbeat response, applies it to its options, exports it as `temporalstore_proxy_drop_percent`, and the client actually drops commands against it.

The metaserver sent a hard-coded `0`. All three response paths:

```rust
drop_percent: 0,
drop_percent: 0,
drop_percent: 0,
```

So the only way to shed traffic was `TS_PROXY_DROP_PERCENT` on each proxy — restarting every proxy with new configuration, during exactly the incident where restarting the routing tier is least welcome.

## What this changes

A proxy group carries a `drop_percent`, set through the existing `PUT` and sent to every proxy attached to it. The group is the right home: it is already what resolves a proxy's namespace and config version on each heartbeat, so this travels the path that exists.

- **Unattached proxies are told zero.** They are not serving a namespace, so a share of their traffic is a share of nothing.
- **Changing the share bumps the config version**, which is how an attached proxy learns it must re-read. A change nobody is told about is a change that does not happen.
- **Values above 100 are clamped** on the way in, rather than stored and left for the proxy's own `<= 100` guard to reject.

## Two bugs my own tests caught

Worth recording, because both would have shipped as a feature that quietly does nothing:

**The literal-filler defeated the feature.** Adding the field to `ProxyGroupInfo` meant filling every construction site, and my filler wrote `drop_percent: 0` into `apply_put_proxy_group` — the one site that must carry the *requested* value. The field existed, the API accepted it, and the stored group was always zero.

**Changing the share did not move the config version.** The version only bumps when something "proxies must act on" changes, and that condition listed namespace, location and state. A group re-put with a new share kept its old version, so no attached proxy would ever re-read it.

The second is exactly what `changing_the_share_tells_the_proxy_to_re_read` was written to check, and it failed on the first run.

## Tests

5 new: the metaserver telling a proxy to shed; a group asking for nothing shedding nothing; changing the share moving the version *and* reaching the proxy; an unattached proxy told zero; and the share surviving snapshot install and mutation-log replay.

Verification:

- `cargo test -p temporalstore-rust --lib meta:: -- --test-threads=1` — **295 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

Both new fields are `#[serde(default)]`, so existing groups and existing callers mean "shed nothing", which is what they meant before.
