### PR TITLE
Decide the delete-before-extract guard from the tombstones, not a full raw-log read

### DIFF
--- a/tools/matrixark_local_adapter_session_commit.py
+++ b/tools/matrixark_local_adapter_session_commit.py
@@ -111,11 +111,9 @@ class _LocalAdapterSessionCommitMixin:
         # so on a log with none the raw read below is pure cost, once per commit, over the whole
         # store. A backend that can answer the question cheaply says so; the default answers it
         # by doing the read, exactly as before.
-        _surviving_event_ids = (
-            surviving_source_event_ids(self._read_raw_records())
-            if self.memory_tombstones_may_exist()
-            else None
-        )
+        # The backend answers from its tombstones alone when it can; the base implementation
+        # is the probe-then-full-read this block used to inline.
+        _surviving_event_ids = self.surviving_ids_for_pending_events(pending_all_unfiltered)
         if _surviving_event_ids is not None:
             pending_all_unfiltered = [
                 record

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4728,6 +4728,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     # (the purged log replays to the same logical state). DEFERRED (separate parallel workstream):
     # rust-datanode-native StringDelete/CommonDelete/FeatureDelete wiring, and true re-derivation
     # (re-extraction) of a demoted multi-source entity/summary -- we trim evidence, not re-summarize.
+    def surviving_ids_for_pending_events(self, pending: list[Json]) -> set[str] | None:
+        """Which of `pending`'s event ids survive the tombstone sweep? None = all of them.
+
+        The delete-before-extract guard's question, asked as a method so a backend can answer it
+        without reading the whole log. This base implementation IS the old behaviour: skip when no
+        tombstone can exist, otherwise run the order-aware sweep over the full raw log.
+        """
+        if not pending:
+            return None
+        if not self.memory_tombstones_may_exist():
+            return None
+        return surviving_source_event_ids(self._read_raw_records())
+
     def memory_tombstones_may_exist(self) -> bool:
         """Could the durable log hold a memory tombstone? Conservative: True means "look properly".
 

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1093,9 +1093,27 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         and let a deleted event be re-materialised by extraction; a false positive only costs the
         read the guard used to do unconditionally.
         """
+        # No scanner at all is not the same as a scan that failed: without the capability the
+        # base implementation answers accurately from the raw log (what would run anyway), while
+        # a FAILED scan means the engine could not answer and the only safe report is True.
+        if not callable(getattr(self._client, "matrixark_scan_candidates", None)):
+            return super().memory_tombstones_may_exist()
+        records = self._memory_tombstone_records()
+        if records is None:
+            return True
+        return bool(records)
+
+    def _memory_tombstone_records(self) -> list[Json] | None:
+        """Every memory tombstone in the store, from one type-filtered scan. None = could not ask.
+
+        None and [] mean different things and the callers depend on it: [] is an authoritative
+        "no tombstones" (skip the guard entirely), None sends the caller to the expensive, correct
+        path. Collapsing them would either re-run full reads on every clean store or skip the
+        guard on an unreachable engine.
+        """
         scanner = getattr(self._client, "matrixark_scan_candidates", None)
         if not callable(scanner):
-            return super().memory_tombstones_may_exist()
+            return None
         try:
             from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         except ModuleNotFoundError:  # Direct script execution from tools/.
@@ -1111,17 +1129,87 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 selected_node_hashes=[],
             )
         except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
-            return True
+            return None
         if not isinstance(response, dict):
-            return True
+            return None
         records = response.get("records")
         if not isinstance(records, list):
-            return True
-        return any(
-            isinstance(record, dict)
+            return None
+        return [
+            record for record in records
+            if isinstance(record, dict)
             and str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE
-            for record in records
-        )
+        ]
+
+    def surviving_ids_for_pending_events(self, pending: list[Json]) -> set[str] | None:
+        """Decide the guard from the tombstones alone, without reading the whole raw log.
+
+        Per pending event, against each scanned tombstone that `_tombstone_kills_record` says
+        matches it:
+
+        * `delete` kind: the id is unique to one ingest and the tombstone was written to remove
+          it, so the tombstone postdates the event by construction -- matching alone kills it.
+        * `forget`/`reset` kind: only records PRECEDING the tombstone die, and a re-ingest after a
+          forget must survive. Order comes from timestamps; a strict comparison decides, and a tie
+          or a missing timestamp makes the event AMBIGUOUS -- the whole commit then takes the full
+          raw read, because guessing either way is a real bug (resurrected deleted content one
+          way, silently unextracted memory the other).
+
+        Returns None for "keep everything" so the caller's contract is unchanged.
+        """
+        if not pending:
+            return None
+        tombstones = self._memory_tombstone_records()
+        if tombstones is None:
+            return super().surviving_ids_for_pending_events(pending)
+        if not tombstones:
+            return None
+        try:
+            from tools.matrixark_mcp_local_adapter import _tombstone_kills_record
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import _tombstone_kills_record
+
+        def event_time_ms(record: Json) -> int:
+            # The same resolution order the commit path uses for pending events.
+            try:
+                return int(
+                    (record.get("envelope") or {}).get("ingestion_time_ms")
+                    or record.get("updated_at_ms")
+                    or record.get("timestamp_key_ms")
+                    or 0
+                )
+            except (TypeError, ValueError):
+                return 0
+
+        surviving: set[str] = set()
+        for event in pending:
+            if not isinstance(event, dict):
+                continue
+            event_id = str(event.get("event_id_hash") or "")
+            if not event_id:
+                continue
+            killed = False
+            for tombstone in tombstones:
+                if not _tombstone_kills_record(tombstone, event):
+                    continue
+                kind = str(tombstone.get("tombstone_kind") or "")
+                if kind == "delete":
+                    killed = True
+                    break
+                event_ms = event_time_ms(event)
+                try:
+                    tombstone_ms = int(tombstone.get("created_at_ms") or 0)
+                except (TypeError, ValueError):
+                    tombstone_ms = 0
+                if not event_ms or not tombstone_ms or event_ms == tombstone_ms:
+                    # Cannot order them: ambiguous, so this commit takes the full, correct read.
+                    return super().surviving_ids_for_pending_events(pending)
+                if tombstone_ms > event_ms:
+                    killed = True
+                    break
+            if not killed:
+                surviving.add(event_id)
+        return surviving
 
     def _purge_scope_in_engine(self, scope: Json) -> Json:
         """Ask the engine to physically remove every record matching `scope`.

--- a/tools/test_guard_from_tombstones.py
+++ b/tools/test_guard_from_tombstones.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The delete-before-extract guard decides from the tombstones, not from the whole raw log.
+
+One tombstone anywhere in the store used to send EVERY later commit back to a full raw-log read --
+the probe only helped tombstone-free stores. The decision per pending event needs the tombstones
+plus one ordering rule, so it is computable from a type-filtered scan.
+
+The parts a wrong implementation would get silently wrong, pinned here:
+
+* a `delete` of a pending id kills it with NO timestamp check -- ids are unique per ingest, so the
+  tombstone postdates the event by construction, and demanding order would let a same-ms delete
+  resurrect content;
+* a re-ingest AFTER a forget survives -- kill-on-match without order would silently drop it from
+  extraction;
+* a timestamp TIE is ambiguous and takes the full read -- guessing either way is a real bug.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+
+TENANT = 11
+USER = 22
+SCOPE_KEY = f"t={TENANT}|u={USER}|s=33|"
+
+
+def _event(event_id, *, at_ms):
+    return {
+        "record_type": "context_event",
+        "event_id_hash": event_id,
+        "text": "pending text %s" % event_id,
+        "scope_key": SCOPE_KEY,
+        "access_scope": {"tenant_hash": TENANT, "user_hash": USER, "scope_key": SCOPE_KEY},
+        "updated_at_ms": at_ms,
+    }
+
+
+def _delete(target_id):
+    return {"record_type": "matrixark_memory_tombstone", "tombstone_kind": "delete",
+            "target_memory_id": str(target_id), "created_at_ms": 5000}
+
+
+def _forget(*, at_ms):
+    return {"record_type": "matrixark_memory_tombstone", "tombstone_kind": "forget",
+            "target_tenant_hash": TENANT, "target_user_hash": USER,
+            "target_scope_key": SCOPE_KEY, "created_at_ms": at_ms}
+
+
+class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
+    def __init__(self, tombstones):
+        self.tombstones = tombstones
+        self.full_reads = 0
+
+    def _memory_tombstone_records(self):
+        return self.tombstones
+
+    def memory_tombstones_may_exist(self):  # the base fallback consults this
+        return bool(self.tombstones) or self.tombstones is None
+
+    def _read_raw_records(self):
+        self.full_reads += 1
+        return []  # the fallback ran; content does not matter for these tests
+
+
+class GuardFromTombstonesTests(unittest.TestCase):
+    def test_no_tombstones_keeps_everything_without_any_read(self):
+        adapter = _Adapter([])
+        self.assertIsNone(adapter.surviving_ids_for_pending_events([_event("1", at_ms=100)]))
+        self.assertEqual(0, adapter.full_reads)
+
+    def test_a_delete_of_a_pending_id_kills_it_without_needing_order(self):
+        adapter = _Adapter([_delete("2")])
+        surviving = adapter.surviving_ids_for_pending_events(
+            [_event("1", at_ms=100), _event("2", at_ms=100)])
+        self.assertEqual({"1"}, surviving)
+        self.assertEqual(0, adapter.full_reads)
+
+    def test_a_forget_after_the_event_kills_it(self):
+        adapter = _Adapter([_forget(at_ms=200)])
+        surviving = adapter.surviving_ids_for_pending_events([_event("1", at_ms=100)])
+        self.assertEqual(set(), surviving)
+        self.assertEqual(0, adapter.full_reads)
+
+    def test_a_reingest_after_the_forget_survives(self):
+        """The order-awareness the sweep guarantees; kill-on-match would silently drop this."""
+        adapter = _Adapter([_forget(at_ms=200)])
+        surviving = adapter.surviving_ids_for_pending_events([_event("9", at_ms=300)])
+        self.assertEqual({"9"}, surviving)
+        self.assertEqual(0, adapter.full_reads)
+
+    def test_a_forget_for_another_subject_changes_nothing(self):
+        other = {"record_type": "matrixark_memory_tombstone", "tombstone_kind": "forget",
+                 "target_tenant_hash": 99, "target_user_hash": 88, "created_at_ms": 200}
+        adapter = _Adapter([other])
+        self.assertEqual({"1"}, adapter.surviving_ids_for_pending_events([_event("1", at_ms=100)]))
+
+    def test_a_timestamp_tie_takes_the_full_read(self):
+        """Ambiguity must not be guessed: either guess is a real bug in one direction."""
+        adapter = _Adapter([_forget(at_ms=100)])
+        adapter.surviving_ids_for_pending_events([_event("1", at_ms=100)])
+        self.assertEqual(1, adapter.full_reads)
+
+    def test_a_missing_event_timestamp_takes_the_full_read(self):
+        adapter = _Adapter([_forget(at_ms=100)])
+        event = _event("1", at_ms=100)
+        del event["updated_at_ms"]
+        adapter.surviving_ids_for_pending_events([event])
+        self.assertEqual(1, adapter.full_reads)
+
+    def test_an_unanswerable_scan_takes_the_full_read(self):
+        adapter = _Adapter(None)
+        adapter.surviving_ids_for_pending_events([_event("1", at_ms=100)])
+        self.assertEqual(1, adapter.full_reads)
+
+    def test_no_pending_events_asks_nothing(self):
+        adapter = _Adapter(None)  # even an unanswerable scan must not be consulted
+        self.assertIsNone(adapter.surviving_ids_for_pending_events([]))
+        self.assertEqual(0, adapter.full_reads)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The guard protects one thing: extraction must not re-materialize a pending event that a delete or
forget removed while it sat in the buffer. The tombstone probe already skips it on a tombstone-free
store -- but the moment a store holds ANY tombstone, one delete ever, every later commit went back
to reading the entire raw log to decide the fate of a handful of pending events. Caught live in a
stack dump under load: a commit thread inside `_read_raw_records` over ~2500 records, once per
commit, on a store whose intrinsic `add` p50 had climbed to 27.7s.

The full log is not needed. The per-event decision depends only on the tombstones, which one
type-filtered engine scan returns:

* a `delete` tombstone matching a pending event's id was necessarily appended AFTER that id
  existed -- ids are unique per ingest -- so matching alone decides it, no ordering required;
* a `forget`/`reset` kills only records that PRECEDE it, and a re-ingest after the forget must
  survive, so scope-matching tombstones are ordered by timestamp against the event's ingestion
  time. A strict comparison decides. A tie or a missing timestamp is AMBIGUOUS, and ambiguity
  takes the full raw read for that one commit -- guessing either way is a real bug (resurrected
  deleted content one way, silently unextracted memory the other) -- and ties are rare and not
  load-correlated, so the expensive path cannot become the common path again.

Matching reuses `_tombstone_kills_record`, the predicate the real sweep runs; re-deriving the
matching rules here is exactly the drift this tree keeps getting bitten by.

Measured, same store, same planted tombstone, three finalize ingests per arm:

    before   3 full raw-log reads (one per commit)
    after    0

The seam is a shared-adapter method whose base implementation IS the old inline behaviour
(probe, then the order-aware sweep over the full raw log), so the JSONL backend is unchanged;
only the native adapter overrides it. The native probe also keeps its old contract: a client
without the scan capability falls back to the accurate base answer, while a scan that FAILED
reports "a tombstone may exist" -- the two cases used to be pinned by tests and stay distinct.

9 new tests: no tombstones = keep everything with zero reads, a delete killing without an order
check, a forget after the event killing, a re-ingest after the forget surviving, another subject's
forget changing nothing, a timestamp tie and a missing timestamp each taking the full read, an
unanswerable scan taking the full read, and no pending events asking nothing at all. The 10-test
delete-before-extract suite and the 9-test probe suite pass unchanged, the five memory suites are
green, and live conformance is 22/22 on a store holding a pre-existing tombstone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
