### PR TITLE
meta: report the states that became operator levers

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1646,6 +1646,8 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     let proxies = backend_call!(meta, list_proxies).proxies;
     let namespaces = backend_call!(meta, list_namespaces).namespaces;
     let tables = backend_call!(meta, list_tables).tables;
+    let proxy_groups = backend_call!(meta, list_proxy_groups).groups;
+    let reserved = backend_call!(meta, reserved_names).reserved;
     let scheduler_snapshot = scheduler.snapshot();
     let scheduler_executions = scheduler.executions();
     let mut out = String::new();
@@ -1683,6 +1685,9 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
         ("server", servers.len() as u64),
         ("proxy", proxies.len() as u64),
         ("shard", stats.shard_count as u64),
+        ("proxy_group", proxy_groups.len() as u64),
+        ("reserved_namespace", reserved.namespaces.len() as u64),
+        ("reserved_table", reserved.tables.len() as u64),
     ] {
         push_meta_metric(
             &mut out,
@@ -1724,7 +1729,61 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
                 .filter(|table| table.state.as_str() == state)
                 .count() as u64,
         );
+        // A namespace has had a state since it became something an operator can
+        // freeze and drop; nothing reported it.
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_resource_state",
+            &[("resource", "namespace"), ("state", state)],
+            namespaces
+                .iter()
+                .filter(|namespace| namespace.state.as_str() == state)
+                .count() as u64,
+        );
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_resource_state",
+            &[("resource", "proxy_group"), ("state", state)],
+            proxy_groups
+                .iter()
+                .filter(|group| group.state.as_str() == state)
+                .count() as u64,
+        );
     }
+    // A datanode that restarts in place is detected and reported; a proxy
+    // that does the same has been counted on its record since restart counting
+    // existed, and nothing read the number. A proxy cycling repeatedly is worth
+    // seeing for the same reason a datanode is.
+    out.push_str(
+        "# HELP temporalstore_meta_proxy_restarts Proxy restarts observed in place, by proxy.
+",
+    );
+    out.push_str("# TYPE temporalstore_meta_proxy_restarts gauge
+");
+    for proxy in &proxies {
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_proxy_restarts",
+            &[("proxy", proxy.proxy_addr.as_str())],
+            proxy.restart_count,
+        );
+    }
+
+    // Shards are counted from the stats rather than listed: there can be
+    // hundreds of thousands of them, and a scrape should not page through the
+    // whole placement table to count two numbers.
+    push_meta_metric(
+        &mut out,
+        "temporalstore_meta_resource_state",
+        &[("resource", "shard"), ("state", "normal")],
+        stats.shard_count.saturating_sub(stats.frozen_shard_count) as u64,
+    );
+    push_meta_metric(
+        &mut out,
+        "temporalstore_meta_resource_state",
+        &[("resource", "shard"), ("state", "frozen")],
+        stats.frozen_shard_count as u64,
+    );
 
     out.push_str(
         "# HELP temporalstore_meta_topology_version Current metaserver topology version.\n",
@@ -2298,6 +2357,163 @@ mod tests {
         // that supplying options is still accepted rather than rejected.
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(parsed.get("status").is_some());
+    }
+
+    /// Scrape `/metrics` from a backend the caller has set up.
+    fn scrape(backend: &MetaBackend) -> String {
+        let scheduler = MetaTaskScheduler::default();
+        let (code, body) = handle(
+            backend,
+            &scheduler,
+            HttpRequest {
+                method: "GET".to_string(),
+                path: "/metrics".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(code, 200);
+        String::from_utf8(body).expect("utf8")
+    }
+
+    #[test]
+    fn a_proxy_cycling_in_place_is_visible() {
+        // The count has been kept on the proxy's record since restart counting
+        // existed and nothing read it. A datanode that restarts in place is
+        // detected and reported; a proxy doing the same was silent.
+        let meta = SingleNodeMeta::default();
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "ns".to_string(),
+            location: "rack-1".to_string(),
+            config_version: 0,
+            binary_version: "v1".to_string(),
+        });
+        let beat = |boot_time_ms: u64| {
+            meta.proxy_heartbeat(ProxyHeartbeatRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: "ns".to_string(),
+                config_version: 0,
+                boot_time_ms,
+                binary_version: "v1".to_string(),
+            });
+        };
+        beat(100);
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 0"));
+
+        // Same address, different boot time: it came back as a new process.
+        beat(200);
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 1"));
+
+        // A heartbeat from the same process must not count again.
+        beat(200);
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 1"));
+    }
+
+    #[test]
+    fn a_frozen_namespace_shows_up_on_the_dashboard() {
+        // A namespace has had a state since it became something an operator can
+        // freeze and drop, and nothing reported it: you could take a tenant out
+        // of service and see no change on any dashboard.
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string(),
+        });
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend).contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"normal\"} 1"
+        ));
+
+        assert!(
+            meta.freeze_namespace(AddNamespaceRequest {
+                namespace: "tenant".to_string(),
+            })
+            .status
+            .ok
+        );
+        let after = scrape(&backend);
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"frozen\"} 1"
+        ));
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"normal\"} 0"
+        ));
+    }
+
+    #[test]
+    fn a_frozen_shard_shows_up_on_the_dashboard() {
+        let meta = SingleNodeMeta::default();
+        for shard_id in [1, 2] {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend).contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 2"
+        ));
+
+        assert!(meta.freeze_shard(ShardStateRequest { shard_id: 1 }).status.ok);
+        let after = scrape(&backend);
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"frozen\"} 1"
+        ));
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 1"
+        ));
+    }
+
+    #[test]
+    fn the_inventory_counts_groups_and_reserved_names() {
+        let meta = SingleNodeMeta::default();
+        assert!(
+            meta.put_proxy_group(PutProxyGroupRequest {
+                group: "front".to_string(),
+                namespace: "tenant".to_string(),
+                location: String::new(),
+                instance_num: 2,
+            })
+            .status
+            .ok
+        );
+        assert!(
+            meta.set_reserved_names(ReservedNames {
+                namespaces: ["system".to_string()].into_iter().collect(),
+                tables: ["audit".to_string(), "wal".to_string()].into_iter().collect(),
+            })
+            .status
+            .ok
+        );
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"proxy_group\"} 1"));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"reserved_namespace\"} 1"));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"reserved_table\"} 2"));
+    }
+
+    #[test]
+    fn the_shard_states_always_add_up_to_the_total() {
+        // The two rows are derived from one another, so a mistake in either
+        // shows as a total that does not match the inventory.
+        let meta = SingleNodeMeta::default();
+        for shard_id in 1..=5 {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        assert!(meta.freeze_shard(ShardStateRequest { shard_id: 3 }).status.ok);
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"shard\"} 5"));
+        assert!(out.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 4"
+        ));
+        assert!(out.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"frozen\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -889,6 +889,14 @@ pub struct MetaStats {
     pub namespace_count: usize,
     pub table_count: usize,
     pub shard_count: usize,
+    /// How many of those shards are not serving.
+    ///
+    /// A shard can be taken out of service on its own, and nothing counted it:
+    /// an operator could freeze one and see no change on any dashboard. Counted
+    /// here rather than kept as a running total, because a tally maintained
+    /// beside the shards is a second thing to keep in step with them.
+    #[serde(default)]
+    pub frozen_shard_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -155,6 +155,11 @@ pub(super) fn stats_from_state(state: &MetaState, counters: &MetaCounters) -> Me
         namespace_count: state.namespaces.len(),
         table_count: state.tables.len(),
         shard_count: state.shards.len(),
+        frozen_shard_count: state
+            .shards
+            .values()
+            .filter(|location| location.state != MetaEntityState::Normal)
+            .count(),
     }
 }
 


### PR DESCRIPTION
## Two things became operator levers, and no dashboard learned about them

`temporalstore_meta_resource_state` reports counts by state for **servers, proxies and tables**. Since it was written, two more entities gained lifecycle states:

- a **namespace** can be frozen and dropped
- a **shard** can be frozen on its own

Neither was counted. You could take a whole tenant out of service, or freeze an individual shard, and every dashboard would look exactly as it did a moment before. That is the specific failure metrics exist to prevent.

Proxy groups and reserved names were likewise absent from the inventory.

## What this reports

`temporalstore_meta_resource_state` gains `namespace`, `shard` and `proxy_group` rows alongside the existing three.

`temporalstore_meta_inventory` gains `proxy_group`, `reserved_namespace` and `reserved_table`.

## One decision about cost

Namespaces, tables, proxies and proxy groups are counted by filtering lists the scrape already holds — there are tens of them.

**Shards are not.** There can be hundreds of thousands, and paging through the placement table on every scrape to count two numbers is the kind of per-request work worth avoiding. The count comes from a new `frozen_shard_count` on `MetaStats`, computed in the same pass that already produces the other counts, and the serving count is the total minus it.

I did *not* keep a running tally beside the shards. A counter maintained alongside the thing it counts is a second source of truth that drifts, and the drift is silent — which is worse than the walk it saves.

## Tests

4 new: a frozen namespace appearing (and its `normal` row dropping to zero); a frozen shard likewise; the inventory counting groups and reserved names; and the two shard rows always summing to the inventory total — which is the check that catches a mistake in either, since one is derived from the other.

Verification:

- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — **30 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

`frozen_shard_count` is `#[serde(default)]`, so an older snapshot reads as zero frozen until the metaserver next computes its stats.

---

## A third thing counted and never read

While auditing which fields anything actually consumes, `ProxyMetaInfo.restart_count` turned out to be **incremented on every proxy restart and read nowhere outside tests**.

The asymmetry is the point: a datanode that restarts in place is detected, reported, and acted on — the divergence check declines to judge it, and `temporalstore_meta_reboots_detected_total` counts it. A proxy doing exactly the same thing had its restart recorded on its own row and then ignored.

`temporalstore_meta_proxy_restarts` now reports it per proxy, so a proxy cycling repeatedly is as visible as a datanode doing it.

The test covers the part that would be easy to get wrong: a proxy coming back with a *different* boot time counts once, and a further heartbeat from the *same* process does not count again.

**31 binary tests pass**, `--all-targets` clean.
