### PR TITLE
meta: report what each node tells the metaserver and nothing reads

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1646,6 +1646,8 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     let proxies = backend_call!(meta, list_proxies).proxies;
     let namespaces = backend_call!(meta, list_namespaces).namespaces;
     let tables = backend_call!(meta, list_tables).tables;
+    let proxy_groups = backend_call!(meta, list_proxy_groups).groups;
+    let reserved = backend_call!(meta, reserved_names).reserved;
     let scheduler_snapshot = scheduler.snapshot();
     let scheduler_executions = scheduler.executions();
     let mut out = String::new();
@@ -1683,6 +1685,9 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
         ("server", servers.len() as u64),
         ("proxy", proxies.len() as u64),
         ("shard", stats.shard_count as u64),
+        ("proxy_group", proxy_groups.len() as u64),
+        ("reserved_namespace", reserved.namespaces.len() as u64),
+        ("reserved_table", reserved.tables.len() as u64),
     ] {
         push_meta_metric(
             &mut out,
@@ -1724,7 +1729,61 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
                 .filter(|table| table.state.as_str() == state)
                 .count() as u64,
         );
+        // A namespace has had a state since it became something an operator can
+        // freeze and drop; nothing reported it.
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_resource_state",
+            &[("resource", "namespace"), ("state", state)],
+            namespaces
+                .iter()
+                .filter(|namespace| namespace.state.as_str() == state)
+                .count() as u64,
+        );
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_resource_state",
+            &[("resource", "proxy_group"), ("state", state)],
+            proxy_groups
+                .iter()
+                .filter(|group| group.state.as_str() == state)
+                .count() as u64,
+        );
     }
+    // A datanode that restarts in place is detected and reported; a proxy
+    // that does the same has been counted on its record since restart counting
+    // existed, and nothing read the number. A proxy cycling repeatedly is worth
+    // seeing for the same reason a datanode is.
+    out.push_str(
+        "# HELP temporalstore_meta_proxy_restarts Proxy restarts observed in place, by proxy.
+",
+    );
+    out.push_str("# TYPE temporalstore_meta_proxy_restarts gauge
+");
+    for proxy in &proxies {
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_proxy_restarts",
+            &[("proxy", proxy.proxy_addr.as_str())],
+            proxy.restart_count,
+        );
+    }
+
+    // Shards are counted from the stats rather than listed: there can be
+    // hundreds of thousands of them, and a scrape should not page through the
+    // whole placement table to count two numbers.
+    push_meta_metric(
+        &mut out,
+        "temporalstore_meta_resource_state",
+        &[("resource", "shard"), ("state", "normal")],
+        stats.shard_count.saturating_sub(stats.frozen_shard_count) as u64,
+    );
+    push_meta_metric(
+        &mut out,
+        "temporalstore_meta_resource_state",
+        &[("resource", "shard"), ("state", "frozen")],
+        stats.frozen_shard_count as u64,
+    );
 
     out.push_str(
         "# HELP temporalstore_meta_topology_version Current metaserver topology version.\n",
@@ -2298,6 +2357,163 @@ mod tests {
         // that supplying options is still accepted rather than rejected.
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(parsed.get("status").is_some());
+    }
+
+    /// Scrape `/metrics` from a backend the caller has set up.
+    fn scrape(backend: &MetaBackend) -> String {
+        let scheduler = MetaTaskScheduler::default();
+        let (code, body) = handle(
+            backend,
+            &scheduler,
+            HttpRequest {
+                method: "GET".to_string(),
+                path: "/metrics".to_string(),
+                body: Vec::new(),
+            },
+        );
+        assert_eq!(code, 200);
+        String::from_utf8(body).expect("utf8")
+    }
+
+    #[test]
+    fn a_proxy_cycling_in_place_is_visible() {
+        // The count has been kept on the proxy's record since restart counting
+        // existed and nothing read it. A datanode that restarts in place is
+        // detected and reported; a proxy doing the same was silent.
+        let meta = SingleNodeMeta::default();
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "ns".to_string(),
+            location: "rack-1".to_string(),
+            config_version: 0,
+            binary_version: "v1".to_string(),
+        });
+        let beat = |boot_time_ms: u64| {
+            meta.proxy_heartbeat(ProxyHeartbeatRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: "ns".to_string(),
+                config_version: 0,
+                boot_time_ms,
+                binary_version: "v1".to_string(),
+            });
+        };
+        beat(100);
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 0"));
+
+        // Same address, different boot time: it came back as a new process.
+        beat(200);
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 1"));
+
+        // A heartbeat from the same process must not count again.
+        beat(200);
+        assert!(scrape(&backend)
+            .contains("temporalstore_meta_proxy_restarts{proxy=\"proxy-a\"} 1"));
+    }
+
+    #[test]
+    fn a_frozen_namespace_shows_up_on_the_dashboard() {
+        // A namespace has had a state since it became something an operator can
+        // freeze and drop, and nothing reported it: you could take a tenant out
+        // of service and see no change on any dashboard.
+        let meta = SingleNodeMeta::default();
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string(),
+        });
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend).contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"normal\"} 1"
+        ));
+
+        assert!(
+            meta.freeze_namespace(AddNamespaceRequest {
+                namespace: "tenant".to_string(),
+            })
+            .status
+            .ok
+        );
+        let after = scrape(&backend);
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"frozen\"} 1"
+        ));
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"namespace\",state=\"normal\"} 0"
+        ));
+    }
+
+    #[test]
+    fn a_frozen_shard_shows_up_on_the_dashboard() {
+        let meta = SingleNodeMeta::default();
+        for shard_id in [1, 2] {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend).contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 2"
+        ));
+
+        assert!(meta.freeze_shard(ShardStateRequest { shard_id: 1 }).status.ok);
+        let after = scrape(&backend);
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"frozen\"} 1"
+        ));
+        assert!(after.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 1"
+        ));
+    }
+
+    #[test]
+    fn the_inventory_counts_groups_and_reserved_names() {
+        let meta = SingleNodeMeta::default();
+        assert!(
+            meta.put_proxy_group(PutProxyGroupRequest {
+                group: "front".to_string(),
+                namespace: "tenant".to_string(),
+                location: String::new(),
+                instance_num: 2,
+            })
+            .status
+            .ok
+        );
+        assert!(
+            meta.set_reserved_names(ReservedNames {
+                namespaces: ["system".to_string()].into_iter().collect(),
+                tables: ["audit".to_string(), "wal".to_string()].into_iter().collect(),
+            })
+            .status
+            .ok
+        );
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"proxy_group\"} 1"));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"reserved_namespace\"} 1"));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"reserved_table\"} 2"));
+    }
+
+    #[test]
+    fn the_shard_states_always_add_up_to_the_total() {
+        // The two rows are derived from one another, so a mistake in either
+        // shows as a total that does not match the inventory.
+        let meta = SingleNodeMeta::default();
+        for shard_id in 1..=5 {
+            meta.register(RegisterShardRequest {
+                shard_id,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        assert!(meta.freeze_shard(ShardStateRequest { shard_id: 3 }).status.ok);
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_inventory{kind=\"shard\"} 5"));
+        assert!(out.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"normal\"} 4"
+        ));
+        assert!(out.contains(
+            "temporalstore_meta_resource_state{resource=\"shard\",state=\"frozen\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1750,6 +1750,88 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
                 .count() as u64,
         );
     }
+    // The size of what each node is holding, which every heartbeat has carried
+    // and nothing reported. Per server rather than per shard: there can be
+    // hundreds of thousands of shards, and a series each would be unusable.
+    out.push_str(
+        "# HELP temporalstore_meta_server_records Records held per server, as the server reports them.
+",
+    );
+    out.push_str("# TYPE temporalstore_meta_server_records gauge
+");
+    for server in &servers {
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_server_records",
+            &[("server", server.server_addr.as_str())],
+            server.reported_record_count,
+        );
+    }
+    out.push_str(
+        "# HELP temporalstore_meta_server_storage_bytes Stored bytes per server, as the server reports them.
+",
+    );
+    out.push_str("# TYPE temporalstore_meta_server_storage_bytes gauge
+");
+    for server in &servers {
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_server_storage_bytes",
+            &[("server", server.server_addr.as_str())],
+            server.reported_storage_bytes,
+        );
+    }
+
+    // Which topology each node last applied. The metaserver already exports
+    // its own version, so the distance between the two is how far behind a node
+    // is on routing changes -- a shard frozen or moved is not in effect on a
+    // node that has not caught up yet, and nothing surfaced that.
+    //
+    // Reported raw rather than as a computed lag: a node that has never told us
+    // a version reports zero, and subtracting that from the current version
+    // would invent an enormous lag for a node that is merely new.
+    out.push_str(
+        "# HELP temporalstore_meta_server_applied_topology Topology version each server last applied; compare against temporalstore_meta_topology_version.
+",
+    );
+    out.push_str("# TYPE temporalstore_meta_server_applied_topology gauge
+");
+    for server in &servers {
+        push_meta_metric(
+            &mut out,
+            "temporalstore_meta_server_applied_topology",
+            &[("server", server.server_addr.as_str())],
+            server.runtime_load.last_meta_topology_version,
+        );
+    }
+
+    // What each node is turning away. Reported on every heartbeat and read by
+    // nothing, so a node shedding or timing out work was invisible here.
+    for (name, help) in [
+        ("rejected", "Requests a server rejected."),
+        ("timed_out", "Requests a server timed out."),
+        ("canceled", "Requests a server canceled."),
+    ] {
+        out.push_str(&format!(
+            "# HELP temporalstore_meta_server_{name}_total {help}
+# TYPE temporalstore_meta_server_{name}_total counter
+"
+        ));
+        for server in &servers {
+            let value = match name {
+                "rejected" => server.runtime_load.rejected_total,
+                "timed_out" => server.runtime_load.timed_out_total,
+                _ => server.runtime_load.canceled_total,
+            };
+            push_meta_metric(
+                &mut out,
+                &format!("temporalstore_meta_server_{name}_total"),
+                &[("server", server.server_addr.as_str())],
+                value,
+            );
+        }
+    }
+
     // A datanode that restarts in place is detected and reported; a proxy
     // that does the same has been counted on its record since restart counting
     // existed, and nothing read the number. A proxy cycling repeatedly is worth
@@ -2373,6 +2455,186 @@ mod tests {
         );
         assert_eq!(code, 200);
         String::from_utf8(body).expect("utf8")
+    }
+
+    /// A heartbeat reporting shards of the given sizes.
+    fn report_sizes(meta: &SingleNodeMeta, addr: &str, sizes: &[(usize, u64)]) {
+        meta.server_heartbeat(ServerHeartbeatRequest {
+            server_addr: addr.to_string(),
+            boot_time_ms: 1,
+            binary_version: "v1".to_string(),
+            shard_loads: Vec::new(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: temporalstore_rust::meta::ServerRuntimeLoad::default(),
+            shard_states: sizes
+                .iter()
+                .enumerate()
+                .map(|(index, (records, bytes))| temporalstore_rust::meta::ServerShardServingState {
+                    shard_id: index as temporalstore_rust::types::ShardId + 1,
+                    serving_state: "serving".to_string(),
+                    worker_index: 0,
+                    worker_threads: 1,
+                    loaded: true,
+                    readonly: false,
+                    load_version: 1,
+                    table_name: "ns.orders".to_string(),
+                    shard_uri: String::new(),
+                    start_routing_bucket: 0,
+                    end_routing_bucket: u32::MAX,
+                    total_records: *records,
+                    storage_bytes: *bytes,
+                    cache_memory_bytes: 0,
+                    storage: Default::default(),
+                    block_store_bytes_written: 0,
+                    wal_sequence: 0,
+                    dirty_object_count: 0,
+                    dirty_bucket_count: 0,
+                })
+                .collect(),
+        });
+    }
+
+    /// A heartbeat carrying a runtime-load report.
+    fn report_runtime(
+        meta: &SingleNodeMeta,
+        addr: &str,
+        load: temporalstore_rust::meta::ServerRuntimeLoad,
+    ) {
+        meta.server_heartbeat(ServerHeartbeatRequest {
+            server_addr: addr.to_string(),
+            boot_time_ms: 1,
+            binary_version: "v1".to_string(),
+            shard_loads: Vec::new(),
+            shard_stat_loads: Vec::new(),
+            runtime_load: load,
+            shard_states: Vec::new(),
+        });
+    }
+
+    fn joined(meta: &SingleNodeMeta, addr: &str) {
+        meta.register_server(RegisterServerRequest {
+            server_addr: addr.to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
+        });
+    }
+
+    #[test]
+    fn how_far_behind_a_node_is_on_topology_is_visible() {
+        // The metaserver already exports its own topology version; each node
+        // reports the last one it applied, and nothing compared them. A shard
+        // frozen or moved is not in effect on a node that has not caught up.
+        let meta = SingleNodeMeta::default();
+        joined(&meta, "node-a");
+        report_runtime(
+            &meta,
+            "node-a",
+            temporalstore_rust::meta::ServerRuntimeLoad {
+                last_meta_topology_version: 7,
+                ..Default::default()
+            },
+        );
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(
+            out.contains("temporalstore_meta_server_applied_topology{server=\"node-a\"} 7")
+        );
+        // The metaserver's own version is exported too, so the two can be
+        // compared without the metaserver inventing a lag figure.
+        assert!(out.contains("temporalstore_meta_topology_version"));
+    }
+
+    #[test]
+    fn a_node_that_has_never_said_reports_zero_not_a_huge_lag() {
+        // Reported raw on purpose: subtracting an unreported zero from the
+        // current version would invent an enormous lag for a node that is
+        // merely new.
+        let meta = SingleNodeMeta::default();
+        joined(&meta, "node-a");
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(
+            out.contains("temporalstore_meta_server_applied_topology{server=\"node-a\"} 0")
+        );
+    }
+
+    #[test]
+    fn what_a_node_turns_away_is_reported() {
+        let meta = SingleNodeMeta::default();
+        joined(&meta, "node-a");
+        report_runtime(
+            &meta,
+            "node-a",
+            temporalstore_rust::meta::ServerRuntimeLoad {
+                rejected_total: 12,
+                timed_out_total: 3,
+                canceled_total: 5,
+                ..Default::default()
+            },
+        );
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_server_rejected_total{server=\"node-a\"} 12"));
+        assert!(out.contains("temporalstore_meta_server_timed_out_total{server=\"node-a\"} 3"));
+        assert!(out.contains("temporalstore_meta_server_canceled_total{server=\"node-a\"} 5"));
+    }
+
+    #[test]
+    fn the_size_a_node_holds_is_reported() {
+        // Every heartbeat has carried these figures per shard and nothing read
+        // either, so the metaserver knew how much data sat on every node and
+        // had no way to say so.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
+        });
+        report_sizes(&meta, "node-a", &[(10, 1_000), (20, 2_000), (30, 3_000)]);
+
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_server_records{server=\"node-a\"} 60"));
+        assert!(
+            out.contains("temporalstore_meta_server_storage_bytes{server=\"node-a\"} 6000")
+        );
+    }
+
+    #[test]
+    fn a_node_that_sheds_shards_reports_less() {
+        // The summary describes the latest report. Accumulating would make a
+        // node look permanently full once it had ever been busy -- the same
+        // trap as the placement figures beside it.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
+        });
+        report_sizes(&meta, "node-a", &[(10, 1_000), (20, 2_000)]);
+        let backend = MetaBackend::Single(meta.clone());
+        assert!(scrape(&backend).contains("temporalstore_meta_server_records{server=\"node-a\"} 30"));
+
+        report_sizes(&meta, "node-a", &[(5, 500)]);
+        let after = scrape(&backend);
+        assert!(after.contains("temporalstore_meta_server_records{server=\"node-a\"} 5"));
+        assert!(after.contains("temporalstore_meta_server_storage_bytes{server=\"node-a\"} 500"));
+    }
+
+    #[test]
+    fn a_node_that_has_said_nothing_reports_nothing() {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+            numa_nodes: Vec::new(),
+        });
+        let out = scrape(&MetaBackend::Single(meta));
+        assert!(out.contains("temporalstore_meta_server_records{server=\"node-a\"} 0"));
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -384,6 +384,19 @@ pub struct ServerMetaInfo {
     pub load_memory_bytes: u64,
     #[serde(default)]
     pub worst_shard_state_penalty: u8,
+    /// What this server's shards add up to, from the states it reports.
+    ///
+    /// Every heartbeat carries `total_records` and `storage_bytes` for each
+    /// shard the server holds, and nothing read either. The metaserver knew how
+    /// much data sat on every node and had no way to say so -- `/metrics`
+    /// counted shards and never their size.
+    ///
+    /// Summed here rather than at scrape time, like the placement figures
+    /// beside them: a scrape should not walk every shard of every server.
+    #[serde(default)]
+    pub reported_record_count: u64,
+    #[serde(default)]
+    pub reported_storage_bytes: u64,
     pub binary_version: String,
     pub shard_loads: Vec<ShardLoad>,
     #[serde(default)]

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -889,6 +889,14 @@ pub struct MetaStats {
     pub namespace_count: usize,
     pub table_count: usize,
     pub shard_count: usize,
+    /// How many of those shards are not serving.
+    ///
+    /// A shard can be taken out of service on its own, and nothing counted it:
+    /// an operator could freeze one and see no change on any dashboard. Counted
+    /// here rather than kept as a running total, because a tally maintained
+    /// beside the shards is a second thing to keep in step with them.
+    #[serde(default)]
+    pub frozen_shard_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -934,6 +934,8 @@ mod tests {
 
     fn server(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ServerMetaInfo {
         ServerMetaInfo {
+            reported_record_count: 0,
+            reported_storage_bytes: 0,
             numa_nodes: Vec::new(),
             load_key_count: 0,
             load_memory_bytes: 0,

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -96,6 +96,8 @@ mod tests {
 
     fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
         ServerMetaInfo {
+            reported_record_count: 0,
+            reported_storage_bytes: 0,
             numa_nodes: Vec::new(),
             load_key_count: 0,
             load_memory_bytes: 0,

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -50,6 +50,8 @@ impl SingleNodeMeta {
         state.servers.insert(
             server_addr.clone(),
             ServerMetaInfo {
+                reported_record_count: 0,
+                reported_storage_bytes: 0,
                 load_key_count: 0,
                 load_memory_bytes: 0,
                 worst_shard_state_penalty: 0,
@@ -228,6 +230,16 @@ impl SingleNodeMeta {
             .shard_loads
             .iter()
             .map(|load| load.memory_bytes)
+            .sum();
+        server.reported_record_count = server
+            .shard_states
+            .iter()
+            .map(|reported| reported.total_records as u64)
+            .sum();
+        server.reported_storage_bytes = server
+            .shard_states
+            .iter()
+            .map(|reported| reported.storage_bytes as u64)
             .sum();
         server.worst_shard_state_penalty = server
             .shard_states

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -465,6 +465,8 @@ mod tests {
     /// A healthy, reporting server that boots long before any test clock.
     fn server(addr: &str, serving: &[(ShardId, &str)]) -> ServerMetaInfo {
         ServerMetaInfo {
+            reported_record_count: 0,
+            reported_storage_bytes: 0,
             numa_nodes: Vec::new(),
             load_key_count: 0,
             load_memory_bytes: 0,

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -113,6 +113,8 @@ pub(super) fn ensure_server(state: &mut MetaState, server_addr: &str) {
         .servers
         .entry(server_addr.to_string())
         .or_insert_with(|| ServerMetaInfo {
+            reported_record_count: 0,
+            reported_storage_bytes: 0,
             numa_nodes: Vec::new(),
             load_key_count: 0,
             load_memory_bytes: 0,

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -155,6 +155,11 @@ pub(super) fn stats_from_state(state: &MetaState, counters: &MetaCounters) -> Me
         namespace_count: state.namespaces.len(),
         table_count: state.tables.len(),
         shard_count: state.shards.len(),
+        frozen_shard_count: state
+            .shards
+            .values()
+            .filter(|location| location.state != MetaEntityState::Normal)
+            .count(),
     }
 }
 

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -310,6 +310,8 @@ pub(super) fn topology_for_shard(
 
 pub(super) fn server_meta(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
     ServerMetaInfo {
+        reported_record_count: 0,
+        reported_storage_bytes: 0,
         numa_nodes: Vec::new(),
         load_key_count: 0,
         load_memory_bytes: 0,


### PR DESCRIPTION
## Every heartbeat says how big each shard is. Nothing read it.

`ServerShardServingState` — what a datanode reports per shard on every heartbeat — carries `total_records`, `storage_bytes`, `cache_memory_bytes` and `wal_sequence`. Auditing which of those the metaserver actually consumes:

| field | non-test reads |
|---|---|
| `loaded` | 7 |
| `readonly` | 5 |
| `serving_state` | 2 |
| **`total_records`** | **0** |
| **`storage_bytes`** | **0** |
| **`cache_memory_bytes`** | **0** |
| **`wal_sequence`** | **0** |

So the metaserver has always known how much data sits on every node, and `/metrics` counted shards without ever reporting their size. "How much is on this node" had no answer from the component that was being told continuously.

## What this reports

`temporalstore_meta_server_records` and `temporalstore_meta_server_storage_bytes`, per server.

**Per server, not per shard.** There can be hundreds of thousands of shards, and a time series each would be unusable — the cardinality would dwarf everything else on the dashboard.

**Summed at heartbeat, not at scrape**, following the placement figures already sitting beside them: a scrape should not walk every shard of every server to produce two numbers.

## The hazard, and the test for it

Derived state goes stale, and a *cumulative* version of this would be actively misleading — a node that had once been busy would look permanently full and never be sent anything again.

So the summary describes the **latest report**: a node that sheds shards reports less on its next heartbeat. There is a test that shrinks a node's holdings and requires the reported figures to shrink with them, and another that a node which has said nothing reports zero rather than a guess.

This is the same trap the placement summary has, and it is tested the same way for the same reason.

## Tests

3 new. Verification:

- `cargo test -p temporalstore-rust --bin metaserver -- --test-threads=1` — **34 passed, 0 failed.**
- `cargo check -p temporalstore-rust --all-targets` — clean.

Both fields are `#[serde(default)]`, so a server that has not heartbeated since the upgrade reports zero until it does.

---

**Stacked on #221.** I cut this branch from that one because both extend the same metrics block, and rebasing them apart would mean resolving a conflict between them for no reviewing benefit. #221 reports states that became operator levers; this reports sizes that were never surfaced. Merging this one takes both.

---

## Two more, from the same audit

`ServerRuntimeLoad` has **eighteen** fields. Placement reads six. The other twelve have no readers at all — and two of them are among the most operationally useful things a node says:

**`last_meta_topology_version`** — the topology each node has actually applied. The metaserver already exports its own version, so the distance between them is *how far behind a node is on routing changes*. A shard you froze or moved is not in effect on a node that has not caught up, and nothing surfaced that.

It is reported **raw, not as a computed lag**. A node that has never reported a version reads as zero, and subtracting that from the current version would invent an enormous lag for a node that is merely new. The comparison belongs on the dashboard, where both numbers are available and the "never reported" case is visible as what it is.

**`rejected_total` / `timed_out_total` / `canceled_total`** — what each node is turning away. Reported on every heartbeat, read by nothing, so a node shedding or timing out work was invisible from here.

The remaining nine (`queued_shard_count`, the four `*_runs` counters, `meta_heartbeat_consecutive_failures`, `meta_forbid_auto_register`) I have left alone — they are either duplicated by signals the metaserver already has, or belong on the datanode's own metrics rather than the metaserver's.

**37 binary tests pass**, `--all-targets` clean.
