### PR TITLE
Read node_l0 vectors from the nodes; leave the rows as fallback only

### DIFF
--- a/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
+++ b/crates/temporalstore-rust/src/bin/context_embed_backfill.rs
@@ -86,9 +86,41 @@ fn load_existing_embedding_refs(
     tenant_hash: u64,
     node_hashes: &[u64],
 ) -> HashSet<u64> {
+    // "Already embedded" is answered from the node record first: since the fold, the write path
+    // carries the vector on the node itself, and the separate node_l0 rows are on their way out.
+    // A node with an empty vector may still have a row from before the fold, so those (and nodes
+    // the engine does not return) are checked against the rows as before. The result is keyed by
+    // ref hash either way, because that is what every caller compares against.
     let mut out = HashSet::new();
     for chunk in node_hashes.chunks(512) {
-        let ref_hashes: Vec<u64> = chunk
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextGetNodes {
+                tenant_hash,
+                node_hashes: chunk.to_vec(),
+            },
+        });
+        let mut row_check: Vec<u64> = Vec::new();
+        let mut returned = HashSet::new();
+        if let CommandResponse::ContextNodes { nodes } = response.response {
+            for node in nodes {
+                returned.insert(node.node_hash);
+                if node.vector.is_empty() {
+                    row_check.push(node.node_hash);
+                } else {
+                    out.insert(context_embedding_ref_hash(tenant_hash, node.node_hash, "node_l0"));
+                }
+            }
+        }
+        for node_hash in chunk {
+            if !returned.contains(node_hash) {
+                row_check.push(*node_hash);
+            }
+        }
+        if row_check.is_empty() {
+            continue;
+        }
+        let ref_hashes: Vec<u64> = row_check
             .iter()
             .map(|node_hash| context_embedding_ref_hash(tenant_hash, *node_hash, "node_l0"))
             .collect();
@@ -97,7 +129,7 @@ fn load_existing_embedding_refs(
             command: Command::ContextQueryEmbeddings {
                 tenant_hash,
                 ref_hashes,
-                limit: Some(chunk.len().max(1)),
+                limit: Some(row_check.len().max(1)),
             },
         });
         if let CommandResponse::ContextEmbeddings { embeddings } = resp.response {
@@ -518,26 +550,43 @@ fn main() {
                 failed += chunk.len() as u64;
                 continue;
             }
-            let mut commands = Vec::with_capacity(chunk.len());
+            // Two commands per node, like the drainer and the live ingest: the separate row
+            // (still what node_l1-era readers and pre-fold data use) and the same vector on the
+            // node itself. A backfill that wrote only the row would leave node.vector empty and
+            // strand exactly the nodes it repaired on the fallback path forever.
+            let mut commands = Vec::with_capacity(chunk.len().saturating_mul(2));
             for ((node_hash, _), vector) in chunk.iter().zip(vectors.into_iter()) {
                 let embedding = ContextEmbedding {
                     ref_hash: context_embedding_ref_hash(tenant_hash, *node_hash, "node_l0"),
                     level: 1,
                     model_hash: stable_hash64(&format!("embedding_model:{}", embedding_model)),
-                    vector,
+                    vector: vector.clone(),
                     updated_at_ms,
                 };
                 commands.push(Command::ContextUpsertEmbedding {
                     tenant_hash,
                     embedding,
                 });
+                commands.push(Command::ContextSetNodeEmbedding {
+                    tenant_hash,
+                    node_hash: *node_hash,
+                    model_hash: stable_hash64(&format!("embedding_model:{}", embedding_model)),
+                    vector,
+                    updated_at_ms,
+                });
             }
             let response = engine.batch_execute(BatchExecuteRequest {
                 shard_id: 1,
                 commands,
             });
-            let ok = response.responses.iter().filter(|r| r.status.ok).count();
-            let bad = response.responses.len().saturating_sub(ok);
+            // Responses pair up with the commands; judge each node by its ROW write so the
+            // ok/bad accounting means exactly what it meant before the node write existed.
+            let ok = response
+                .responses
+                .chunks(2)
+                .filter(|pair| pair.first().map(|r| r.status.ok).unwrap_or(false))
+                .count();
+            let bad = chunk.len().saturating_sub(ok);
             embedded += ok as u64;
             failed += bad as u64;
         }

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1078,6 +1078,11 @@ pub struct ContextFanoutPlanReport {
     pub event_expanded_nodes: usize,
     pub skipped_node_count: usize,
     pub summary_lookup_batches: usize,
+    // Candidate nodes whose L0 vector had to come from the separate embedding row because the
+    // node record carried none. The node_l0 rows can only be retired once this reads zero in
+    // production -- see the retirement issue. serde(default) so older reports still decode.
+    #[serde(default)]
+    pub l0_row_fallback_nodes: usize,
     #[serde(default)]
     pub event_query_budget: usize,
     #[serde(default)]
@@ -1921,16 +1926,64 @@ pub fn retrieve_context(
         }
     };
     trace_stage("query_embedding");
-    let mut summary_ref_owners = BTreeMap::new();
-    let mut summary_ref_hashes = Vec::with_capacity(node_hashes.len().saturating_mul(2));
-    for node_hash in &node_hashes {
-        for label in ["node_l0", "node_l1"] {
-            let ref_hash = context_embedding_ref_hash(request.tenant_hash, *node_hash, label);
-            summary_ref_owners.insert(ref_hash, *node_hash);
-            summary_ref_hashes.push(ref_hash);
+    let mut summary_scores_by_node = BTreeMap::<u64, (i64, usize)>::new();
+    // node_l0 comes from the node records themselves: the write path has carried the vector on
+    // the node since the fold, and the node is addressable by the hash already in hand -- no
+    // one-way ref hash to reconstruct. Nodes with an empty vector (embedded before the fold, or
+    // not embedded at all) fall back to the separate rows below, which is what lets those rows
+    // be retired without a flag day. Chunked like the row query: a single oversized command is
+    // rejected outright, not truncated, and an unscored node silently collapses to the
+    // lexical/recency fallback.
+    let mut l0_row_fallback: Vec<u64> = Vec::new();
+    for chunk in node_hashes.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
+        if chunk.is_empty() {
+            continue;
+        }
+        let response = engine.execute(ExecuteRequest {
+            shard_id: request.shard_id,
+            command: Command::ContextGetNodes {
+                tenant_hash: request.tenant_hash,
+                node_hashes: chunk.to_vec(),
+            },
+        });
+        let mut returned = BTreeSet::new();
+        if let CommandResponse::ContextNodes { nodes } = response.response {
+            for node in nodes {
+                returned.insert(node.node_hash);
+                if node.vector.is_empty() {
+                    l0_row_fallback.push(node.node_hash);
+                } else {
+                    let score =
+                        context_embedding_similarity_micros(&query_embedding, &node.vector);
+                    let entry = summary_scores_by_node.entry(node.node_hash).or_default();
+                    entry.0 = entry.0.max(score);
+                    entry.1 = entry.1.saturating_add(1);
+                }
+            }
+        }
+        // A node the engine did not return cannot carry a vector; its row (if any) still can.
+        for node_hash in chunk {
+            if !returned.contains(node_hash) {
+                l0_row_fallback.push(*node_hash);
+            }
         }
     }
-    let mut summary_scores_by_node = BTreeMap::<u64, (i64, usize)>::new();
+    fanout_plan.l0_row_fallback_nodes = l0_row_fallback.len();
+    let mut summary_ref_owners = BTreeMap::new();
+    let mut summary_ref_hashes =
+        Vec::with_capacity(l0_row_fallback.len().saturating_add(node_hashes.len()));
+    for node_hash in &l0_row_fallback {
+        let ref_hash = context_embedding_ref_hash(request.tenant_hash, *node_hash, "node_l0");
+        summary_ref_owners.insert(ref_hash, *node_hash);
+        summary_ref_hashes.push(ref_hash);
+    }
+    // node_l1 still reads the separate rows: its owner-side home is the L1 summary's vector,
+    // and switching that read belongs to the summary-side step, not this one.
+    for node_hash in &node_hashes {
+        let ref_hash = context_embedding_ref_hash(request.tenant_hash, *node_hash, "node_l1");
+        summary_ref_owners.insert(ref_hash, *node_hash);
+        summary_ref_hashes.push(ref_hash);
+    }
     // The engine caps a single ContextQueryEmbeddings at CONTEXT_MAX_LIMIT
     // ref_hashes -- command validation REJECTS a larger request outright rather
     // than truncating it. A large (bulk-ingested) namespace has many more nodes

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2679,3 +2679,117 @@ fn resource_ingest_uses_live_embeddings_and_summary_retrieval() {
     handle.join().unwrap();
     std::env::remove_var("TS_CONTEXT_TEST_KEY");
 }
+
+#[test]
+fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
+    // No separate embedding rows exist anywhere in this store. If the summary-scoring pass
+    // still read node_l0 through the rows, every node here would score zero, selection would
+    // collapse to the lexical/recency fallback, and dropping the rows would degrade retrieval
+    // silently -- this test is what makes that impossible to miss.
+    let engine = test_engine();
+    const TENANT: u64 = 6001;
+    const EVENT_TIME: u64 = 1_781_700_000_000;
+    let provider = ContextModelProviderConfig::default();
+    let query = "how do we deploy the ingest service";
+    let query_vector = query::context_query_embedding(&provider, query).unwrap();
+    // An orthogonal-ish vector: shift every component's mass to a different slot so the cosine
+    // against the query is far from 1.
+    let mut away = query_vector.clone();
+    away.rotate_left(1);
+
+    // The decoy is built to win every path EXCEPT embedding scoring: its summary text repeats
+    // the query's own words (so the lexical fallback prefers it) and it is the most recent (so
+    // recency ordering prefers it). Only a real cosine score against the inline vectors puts
+    // the matching node ahead -- which is what failing over to the rows (all absent) would lose.
+    for (node_hash, name, summary, at, vector) in [
+        (11u64, "matching", "release runbook notes".to_string(),
+         EVENT_TIME, query_vector.clone()),
+        (12, "decoy", format!("{query} {query}"), EVENT_TIME + 500, away.clone()),
+        (13, "other", "unrelated text".to_string(), EVENT_TIME, away.clone()),
+    ] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: name.to_string(),
+                    l0: summary.clone(),
+                    status: 0,
+                    last_event_time_ms: at,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+        assert!(response.status.ok);
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: ContextSummary {
+                    node_hash,
+                    level: 1,
+                    text: summary.clone(),
+                    valid_from_ms: at,
+                    vector: Vec::new(),
+                },
+            },
+        });
+        assert!(response.status.ok);
+        // The ONLY place the vector goes: the node itself.
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: TENANT,
+                node_hash,
+                model_hash: 1,
+                vector,
+                updated_at_ms: at,
+            },
+        });
+        assert!(response.status.ok);
+    }
+
+    let retrieve = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: TENANT,
+            node_hashes: vec![11, 12, 13],
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: EVENT_TIME + 1_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider,
+        },
+    );
+    assert!(retrieve.status.ok, "{:?}", retrieve.status);
+    let summary_nodes: Vec<u64> = retrieve
+        .blocks
+        .iter()
+        .filter(|block| block.tier == ContextTier::L0)
+        .map(|block| block.node_hash)
+        .collect();
+    assert_eq!(
+        vec![11u64],
+        summary_nodes,
+        "with one summary slot, the node whose inline vector matches the query must win it"
+    );
+    assert_eq!(
+        0, retrieve.fanout_plan.l0_row_fallback_nodes,
+        "every node here carries its vector inline, so nothing may fall back to the rows"
+    );
+}


### PR DESCRIPTION
Works toward #222: the last real readers of the `node_l0` embedding rows now prefer the vector the node itself carries, and the report exposes the counter #222 names as the retirement gate.

### Retrieval summary scoring

Fetched `node_l0` and `node_l1` rows for every candidate. The `node_l0` half now scores from `ContextGetNodes` vectors, chunked at the same cap as the row query -- an oversized command is rejected outright, not truncated, and an unscored node silently collapses to the lexical fallback, which is exactly the failure mode the original chunking comment warns about. Only nodes whose inline vector is empty fall back to the rows. `node_l1` is deliberately untouched: its owner-side home is the L1 summary's `vector`, and that switch is the summary-side step.

`fanout_plan.l0_row_fallback_nodes` reports how many candidates had to reach for a row. Retirement waits for that to read zero in production.

### The backfill tool

Decided "already embedded" from the rows -- and **wrote only the row**, so every node it repaired got an empty `node.vector` and was stranded on the fallback path forever. Detection now asks the node first (rows only for nodes carrying no vector), and the writer emits both copies like the drainer and the live ingest, with the ok/bad accounting judged by the row write so it means what it meant before.

### The test that keeps the retirement honest

A store with **no embedding rows anywhere**, and a decoy built to win every path except embedding scoring: its summary text repeats the query's own words (the lexical fallback prefers it) and it is the most recent (recency prefers it). With one summary slot, only a real cosine score against the inline vectors puts the matching node ahead.

The first version of this test passed with the change reverted -- the right node won by tie-break, proving nothing. It was strengthened until reverting the change makes the decoy win (`left: [11], right: [12]`), verified both ways before committing. It also pins the fallback counter at zero for the inline-only store.

`cb_retrieve --probe-embeddings` still probes the rows on purpose -- it is a diagnostic of the row path and follows the rows out when they go.

### Verification

- workflow + engine slices: 63 green; the discriminating test verified to fail with the change reverted
- full lib suite, serial: **1187 passed / 2 failed** -- the known pre-existing pair, unchanged
