### PR TITLE
Feed prior-context collection from a five-type scan, not a full-store read

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -490,7 +490,7 @@ class _LocalAdapterIngestMixin:
                 "auto_batch_extract_result": auto_batch_result,
                 "quality_warnings": ["async_processing_pending:extraction,summary,compression,embedding"],
             }
-        prior_records = [] if args.get("skip_prior_context") else self.read_all()
+        prior_records = [] if args.get("skip_prior_context") else self.prior_context_records()
         prior_context = (
             {"level": "", "refs": [], "messages": [], "summaries": [], "char_count": 0, "limit": MAX_PRIOR_MESSAGES}
             if args.get("skip_prior_context")
@@ -1834,7 +1834,7 @@ class _LocalAdapterIngestMixin:
                 "reason": "logical batch below extraction threshold",
             }
 
-        prior_records = [] if args.get("skip_prior_context") else self.read_all()
+        prior_records = [] if args.get("skip_prior_context") else self.prior_context_records()
         prior_context = (
             {"level": "", "refs": [], "messages": [], "summaries": [], "char_count": 0, "limit": MAX_PRIOR_MESSAGES}
             if args.get("skip_prior_context")

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4728,6 +4728,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     # (the purged log replays to the same logical state). DEFERRED (separate parallel workstream):
     # rust-datanode-native StringDelete/CommonDelete/FeatureDelete wiring, and true re-derivation
     # (re-extraction) of a demoted multi-source entity/summary -- we trim evidence, not re-summarize.
+    def prior_context_records(self) -> list[Json]:
+        """The live records prior-context collection reads. Base implementation: the whole store.
+
+        `collect_prior_context` and the caller-supplied-fields carry-over consume only three
+        record types (context_event, context_summary, context_pack_audit), in append order, with
+        live-view semantics. A backend that can fetch that subset cheaply overrides this; the
+        contract is that the result is indistinguishable FROM THOSE CONSUMERS' point of view from
+        `read_all()`.
+        """
+        return self.read_all()
+
     def surviving_ids_for_pending_events(self, pending: list[Json]) -> set[str] | None:
         """Which of `pending`'s event ids survive the tombstone sweep? None = all of them.
 

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1103,28 +1103,25 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return True
         return bool(records)
 
-    def _memory_tombstone_records(self) -> list[Json] | None:
-        """Every memory tombstone in the store, from one type-filtered scan. None = could not ask.
+    def _scan_records_of_types(self, record_types: list[str]) -> list[Json] | None:
+        """Records of exactly these types, in append order, from one filtered scan. None = could
+        not ask.
 
         None and [] mean different things and the callers depend on it: [] is an authoritative
-        "no tombstones" (skip the guard entirely), None sends the caller to the expensive, correct
-        path. Collapsing them would either re-run full reads on every clean store or skip the
-        guard on an unreachable engine.
+        "nothing of these types", None sends the caller to the expensive, correct path. Bundled
+        appends are expanded engine-side, so a record stored inside a bundle whose wrapper carries
+        no record_type is still returned.
         """
         scanner = getattr(self._client, "matrixark_scan_candidates", None)
         if not callable(scanner):
             return None
-        try:
-            from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
-        except ModuleNotFoundError:  # Direct script execution from tools/.
-            from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         try:
             response = scanner(
                 count_key=self._count_key,
                 record_hash_key=self._record_hash_key,
                 shard_size=self._shard_size,
                 scope={},
-                record_types=[MEMORY_TOMBSTONE_RECORD_TYPE],
+                record_types=list(record_types),
                 secondary_index_groups=[],
                 selected_node_hashes=[],
             )
@@ -1135,11 +1132,111 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         records = response.get("records")
         if not isinstance(records, list):
             return None
+        wanted = set(record_types)
         return [
             record for record in records
-            if isinstance(record, dict)
-            and str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE
+            if isinstance(record, dict) and str(record.get("record_type") or "") in wanted
         ]
+
+    def _memory_tombstone_records(self) -> list[Json] | None:
+        """Every memory tombstone in the store. None = could not ask (see _scan_records_of_types)."""
+        try:
+            from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        return self._scan_records_of_types([MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def prior_context_records(self) -> list[Json]:
+        """The prior-context view from a five-type scan instead of a full-store read.
+
+        `collect_prior_context` and the caller-supplied-fields carry-over consume three record
+        types; tombstones and retention-cutoff markers are fetched alongside so the LIVE-view
+        semantics reproduce on the subset via the SAME functions the full read applies --
+        `compact_and_apply_tombstones` then `filter_live_memory_records`. The scan returns append
+        order, which is what the order-aware sweep and the newest-first consumers need.
+
+        Any failure falls back to the full read. With MATRIXARK_PRIOR_CONTEXT_SHADOW_COMPARE=1
+        both views are computed, projected to what the consumers can see, compared, and the FULL
+        view is served -- the scan path earns trust shadowed over live traffic first.
+        """
+        import os as _os
+
+        try:
+            from tools.matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+        subset = self._scan_records_of_types([
+            "context_event",
+            "context_summary",
+            "context_pack_audit",
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        ])
+        if subset is None:
+            return self.read_all()
+        # Summaries and other compact records can live in the latest-state HASH rather than the
+        # append log, and the scan walks only the log -- the shadow compare caught exactly this:
+        # the subset was missing every refresher-written context_summary. Fold the latest-state
+        # records in, filtered to the same types, in the same position the full read gives them
+        # (after the log records).
+        kept_types = {
+            "context_event", "context_summary", "context_pack_audit",
+            MEMORY_TOMBSTONE_RECORD_TYPE, MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        }
+        try:
+            latest_state = self._load_latest_context_state_records()
+        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+            return self.read_all()
+        subset = subset + [
+            record for record in latest_state
+            if isinstance(record, dict) and str(record.get("record_type") or "") in kept_types
+        ]
+        live_subset = filter_live_memory_records(compact_and_apply_tombstones(subset))
+
+        shadow = _os.environ.get("MATRIXARK_PRIOR_CONTEXT_SHADOW_COMPARE", "").strip()
+        if shadow not in {"", "0", "false", "no", "off"}:
+            full = self.read_all()
+
+            def project(records: list[Json]) -> list[tuple]:
+                keep = {"context_event", "context_summary", "context_pack_audit"}
+                out = []
+                for record in records:
+                    record_type = str(record.get("record_type") or "")
+                    if record_type not in keep:
+                        continue
+                    out.append((
+                        record_type,
+                        str(record.get("event_id_hash") or record.get("summary_hash")
+                            or record.get("context_pack_id") or ""),
+                        int(record.get("updated_at_ms") or 0),
+                    ))
+                return out
+
+            expected, got = project(full), project(live_subset)
+            if expected != got:
+                try:
+                    path = _os.environ.get("MATRIXARK_PRIOR_CONTEXT_SHADOW_LOG",
+                                           "/tmp/matrixark_prior_context_shadow.log")
+                    with open(path, "a", encoding="utf-8") as log:
+                        log.write("MISMATCH full=%d subset=%d only_full=%r only_subset=%r\n" % (
+                            len(expected), len(got),
+                            [row for row in expected if row not in set(got)][:5],
+                            [row for row in got if row not in set(expected)][:5],
+                        ))
+                except OSError:
+                    pass
+            return full
+        return live_subset
 
     def surviving_ids_for_pending_events(self, pending: list[Json]) -> set[str] | None:
         """Decide the guard from the tombstones alone, without reading the whole raw log.

--- a/tools/test_prior_context_scoped.py
+++ b/tools/test_prior_context_scoped.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Prior-context collection reads a five-type scan, not the whole store -- and stays equivalent.
+
+The read at the top of `batch_extract` was the last unconditional O(store) read on the ingest
+path. Its consumers touch three record types; the subset fetch adds tombstones and retention
+markers so the live-view semantics reproduce via the SAME functions the full read applies.
+
+What a wrong implementation gets silently wrong, pinned here:
+
+* records living only in the latest-state HASH (refresher-written summaries) are not in the
+  append log, and a scan-only subset misses them -- the live shadow-compare caught exactly that;
+* a deleted event must not reappear in prior context (the sweep must run on the subset);
+* a scan failure must serve the full read, never an empty prior context.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as local_mod
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as local_mod
+    import matrixark_mcp_temporal_adapters as adapters
+
+SCOPE_KEY = "t=11|u=22|s=33|"
+
+
+def _event(event_id, *, at_ms, text="hello"):
+    return {"record_type": "context_event", "event_id_hash": event_id, "text": text,
+            "scope_key": SCOPE_KEY,
+            "access_scope": {"tenant_hash": 11, "user_hash": 22, "scope_key": SCOPE_KEY},
+            "updated_at_ms": at_ms, "timestamp_key_ms": at_ms}
+
+
+def _summary(summary_hash, *, at_ms):
+    return {"record_type": "context_summary", "summary_hash": summary_hash,
+            "summary_type": "session_l0", "summary_text": "s", "scope_key": SCOPE_KEY,
+            "updated_at_ms": at_ms}
+
+
+def _delete_tombstone(target_id, *, at_ms):
+    return {"record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE, "tombstone_kind": "delete",
+            "target_memory_id": str(target_id), "created_at_ms": at_ms}
+
+
+class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
+    def __init__(self, scanned, *, latest_state=None, full=None):
+        self.scanned = scanned
+        self.latest_state = latest_state or []
+        self.full = full or []
+        self.full_reads = 0
+
+    def _scan_records_of_types(self, record_types):
+        if self.scanned is None:
+            return None
+        wanted = set(record_types)
+        return [r for r in self.scanned if str(r.get("record_type") or "") in wanted]
+
+    def _load_latest_context_state_records(self):
+        return list(self.latest_state)
+
+    def read_all(self):
+        self.full_reads += 1
+        return list(self.full)
+
+
+class PriorContextScopedTests(unittest.TestCase):
+    def test_the_subset_serves_without_a_full_read(self):
+        adapter = _Adapter([_event("1", at_ms=100), _summary("s1", at_ms=150)])
+        records = adapter.prior_context_records()
+        self.assertEqual(0, adapter.full_reads)
+        self.assertEqual({"1"}, {r.get("event_id_hash") for r in records
+                                 if r.get("record_type") == "context_event"})
+
+    def test_latest_state_records_are_folded_in(self):
+        """Refresher-written summaries live in the latest-state hash, not the append log."""
+        adapter = _Adapter([_event("1", at_ms=100)],
+                           latest_state=[_summary("s9", at_ms=200)])
+        records = adapter.prior_context_records()
+        self.assertIn("s9", {r.get("summary_hash") for r in records
+                             if r.get("record_type") == "context_summary"})
+
+    def test_latest_state_records_of_other_types_are_not_dragged_in(self):
+        adapter = _Adapter([_event("1", at_ms=100)],
+                           latest_state=[{"record_type": "context_embedding", "ref_hash": 7}])
+        records = adapter.prior_context_records()
+        self.assertEqual([], [r for r in records if r.get("record_type") == "context_embedding"])
+
+    def test_a_deleted_event_does_not_reappear_in_prior_context(self):
+        """The tombstone sweep must run on the subset, or extraction sees deleted content."""
+        adapter = _Adapter([_event("1", at_ms=100), _event("2", at_ms=110),
+                            _delete_tombstone("1", at_ms=200)])
+        records = adapter.prior_context_records()
+        ids = {r.get("event_id_hash") for r in records if r.get("record_type") == "context_event"}
+        self.assertEqual({"2"}, ids)
+
+    def test_duplicate_event_rows_collapse_to_one(self):
+        """Ingest persists an event twice (hot path + committed); both serving would double it."""
+        adapter = _Adapter([_event("1", at_ms=100, text="pending"),
+                            _event("1", at_ms=150, text="committed")])
+        events = [r for r in adapter.prior_context_records()
+                  if r.get("record_type") == "context_event"]
+        self.assertEqual(1, len(events))
+        self.assertEqual("committed", events[0]["text"])
+
+    def test_an_unanswerable_scan_serves_the_full_read(self):
+        adapter = _Adapter(None, full=[_event("7", at_ms=100)])
+        records = adapter.prior_context_records()
+        self.assertEqual(1, adapter.full_reads)
+        self.assertEqual("7", records[0]["event_id_hash"])
+
+    def test_a_failing_latest_state_load_serves_the_full_read(self):
+        adapter = _Adapter([_event("1", at_ms=100)], full=[_event("7", at_ms=100)])
+
+        def _boom():
+            raise RuntimeError("latest-state hash unreachable")
+
+        adapter._load_latest_context_state_records = _boom
+        records = adapter.prior_context_records()
+        self.assertEqual(1, adapter.full_reads)
+        self.assertEqual("7", records[0]["event_id_hash"])
+
+
+class BaseSeamTests(unittest.TestCase):
+    def test_the_base_implementation_is_the_full_read(self):
+        adapter = object.__new__(local_mod.MatrixArkLocalAdapter)
+        adapter.read_all = lambda: [{"record_type": "context_event", "event_id_hash": "1"}]
+        self.assertEqual("1", adapter.prior_context_records()[0]["event_id_hash"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The read at the top of `batch_extract` was the last unconditional O(store) read on the ingest
path: every finalize commit read the ENTIRE live store so `collect_prior_context` could pick out
recent `context_event` rows, their `context_summary` rows, and at most one `context_pack_audit` --
three record types, out of a store dominated by index and embedding rows. Stack dumps under load
showed this read taking seconds per commit at ~2500 records, and it grows with the store.

The seam is a shared-adapter method whose base implementation IS `read_all()` (JSONL unchanged).
The native override fetches exactly the consumers' types plus tombstones and retention-cutoff
markers, folds in the latest-state hash records of the same types, and applies the very same
functions the full read applies -- `compact_and_apply_tombstones`, then
`filter_live_memory_records`. Same rules, smaller input; nothing is re-derived. Any failure --
scan unavailable, scan error, latest-state hash unreachable -- serves the full read, never a
guess.

The equivalence claim was not assumed; it was earned by a shadow mode
(MATRIXARK_PRIOR_CONTEXT_SHADOW_COMPARE=1) that computes BOTH views on live traffic, projects each
to what the consumers can see, and logs any difference while serving the full read. The first
shadow run caught a real divergence: refresher-written summaries live in the latest-state HASH,
not the append log, so a scan-only subset missed every one of them. With the latest-state fold in
place, the full strict conformance suite -- deletes, forgets, TTL expiry, keyed upserts -- runs
with 22/22 passing and ZERO shadow mismatches.

Measured on the same tombstoned store, three finalize ingests per arm:

    full-read arm   3 full live reads
    scan arm        0

Wall time is a wash at this store size; the reads removed are the ones measured at 1-8 seconds
each at ~2500 records, once per commit.

The caller-supplied-fields carry-over keeps working unchanged: it looks up live `context_event`
rows by id, and the subset contains every live context_event.

8 tests: the subset serving without a full read, latest-state summaries folded in, other
latest-state types NOT dragged in, a deleted event not reappearing in prior context, duplicate
event rows collapsing to the committed copy, scan failure and latest-state failure each serving
the full read, and the base seam being the full read. The 28 guard/probe/delete-before-extract
tests and the five memory suites pass unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
