### PR TITLE
Make the metadata-change mute work on a raft-backed metaserver

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -915,6 +915,20 @@ pub struct MetaPreflightReport {
     pub degraded_reasons: Vec<String>,
 }
 
+impl MetaMutation {
+    /// Whether this change may still be made while metadata change is muted.
+    ///
+    /// Only the lever itself and the retention purge. The lever, because muting
+    /// must not be a one-way door -- refusing it would leave no way back. The
+    /// purge, because the single-node path has always allowed it: its one
+    /// caller is the retention loop, which the mute stops separately, and the
+    /// two backends have to agree on what the mute means rather than each
+    /// inventing an answer.
+    pub(crate) fn allowed_while_muted(&self) -> bool {
+        matches!(self, Self::SetMetaChangeMuted(_) | Self::PurgeMeta(_))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", content = "request", rename_all = "snake_case")]
 pub enum MetaMutation {
@@ -1394,13 +1408,17 @@ impl SingleNodeMeta {
 
     /// The refusal every guarded entry point returns while muted, or `None` when
     /// metadata change is flowing normally.
+    /// The refusal a muted metaserver answers with, so both backends phrase it
+    /// identically.
+    pub(crate) fn muted_status() -> Status {
+        Status::error(
+            "meta_change_muted",
+            "metadata change is muted; resume it before making changes",
+        )
+    }
+
     fn meta_change_refusal(&self) -> Option<Status> {
-        self.is_meta_change_muted().then(|| {
-            Status::error(
-                "meta_change_muted",
-                "metadata change is muted; resume it before making changes",
-            )
-        })
+        self.is_meta_change_muted().then(Self::muted_status)
     }
 
     /// The names currently held back from creation.

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -557,8 +557,40 @@ impl MetaRaftCluster {
     }
 
     pub(super) fn mutation_status(&self, mutation: MetaMutation) -> Status {
+        // The mute is the incident lever: while it is set, the metaserver is
+        // meant to refuse every recorded metadata mutation. That check lived
+        // only in SingleNodeMeta's public methods, and this path proposes
+        // straight past them -- so on a raft-backed metaserver, which is what a
+        // real deployment runs, setting the mute changed nothing at all.
+        //
+        // Checked before proposing rather than while applying: replay has to
+        // reapply what was already accepted, including changes recorded before
+        // the mute was set.
+        if !mutation.allowed_while_muted() {
+            // An unreadable cluster is left to propose and fail on its own
+            // terms. Refusing here would turn "cannot tell" into "muted".
+            if self.peek_meta_change_muted() == Some(true) {
+                return SingleNodeMeta::muted_status();
+            }
+        }
         self.propose_mutation(mutation)
             .unwrap_or_else(|err| Status::error("raft_error", err.to_string()))
+    }
+
+    /// Whether the readable replica reports metadata change as muted.
+    ///
+    /// Deliberately not `read_meta()`: that clones the entire metadata state,
+    /// and this runs on every mutation. `None` means no replica could answer,
+    /// which is not the same as "not muted".
+    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+        let inner = self.inner.read().expect("meta raft lock poisoned");
+        let leader_commit_index = inner.nodes.get(&inner.leader_id)?.commit_index;
+        inner
+            .nodes
+            .values()
+            .filter(|node| node.alive && node.commit_index >= leader_commit_index)
+            .min_by_key(|node| node.id)
+            .map(|node| node.meta.is_meta_change_muted())
     }
 
     pub(super) fn read_meta(&self) -> Result<SingleNodeMeta, Status> {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1014,6 +1014,37 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
 }
 
 #[test]
+fn muting_metadata_change_refuses_changes_on_the_raft_path_too() {
+    // The mute is the incident lever: while it is set the metaserver is meant
+    // to refuse every recorded metadata mutation. That check lived only in
+    // SingleNodeMeta's public methods, and the raft backend proposes straight
+    // past them -- so on a raft-backed metaserver, which is what a real
+    // deployment runs, setting the mute changed nothing.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta.set_meta_change_muted(true).status.ok);
+
+    let muted = meta.add_namespace(AddNamespaceRequest {
+        namespace: "during-an-incident".to_string(),
+    });
+    assert!(
+        !muted.status.ok,
+        "the cluster was muted and the change went through anyway"
+    );
+    assert_eq!(muted.status.code, "meta_change_muted");
+
+    // And the lever has to be releasable, or muting would be a one-way door.
+    assert!(meta.set_meta_change_muted(false).status.ok);
+    assert!(
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "after-the-incident".to_string(),
+        })
+        .status
+        .ok,
+        "unmuting did not restore metadata change"
+    );
+}
+
+#[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {


### PR DESCRIPTION
## The problem

The metadata-change mute is the metaserver's incident lever. Its own doc says it
"refuses every recorded metadata mutation", and it exists precisely so an
operator can stop the metaserver changing things mid-incident without a restart.

**On a raft-backed metaserver it did nothing at all.**

The check lived only in `SingleNodeMeta`'s public methods. `MetaRaftCluster`
proposes straight past them:

```
MetaRaftCluster::add_namespace
  -> mutation_status(MetaMutation::AddNamespace(..))
    -> propose_mutation(..)        // no gate
      -> replicated, then apply_add_namespace(..)   // no gate either
```

Before this change, `raft/cluster_meta.rs` contained **zero** mentions of the
mute. Set it, and every mutation still went through — on the deployment mode a
real cluster runs.

A test proving it is included; it fails on an unmodified tree with
"the cluster was muted and the change went through anyway".

## The change

`mutation_status` is the single funnel for raft mutations, so the gate goes
there. Two details worth review:

**Checked before proposing, not while applying.** Replay has to reapply what was
already accepted, including changes recorded before the mute was set. Gating the
apply path would corrupt recovery.

**It does not clone the cluster's metadata.** The obvious implementation reaches
for `read_meta()`, which deep-copies the entire metadata state — on every write.
`peek_meta_change_muted()` reuses the same replica selection and reads one bool
under the lock.

An unreadable cluster is left to propose and fail on its own terms. Refusing
there would turn "cannot tell" into "muted".

## What may be made while muted

Put on `MetaMutation` itself, so the rule cannot drift between the backend that
checks it and the backend that does not:

- **the lever itself** — otherwise muting is a one-way door with no way back
- **the retention purge** — because the single-node path has always allowed it

## One thing I did not change, and think you should look at

That purge exemption is inherited, not endorsed. `purge_expired_meta` is the
only recorded mutation that skips the gate on the single-node path, and it is
the most destructive one there is — it permanently forgets dropped resources.

It is not reachable while muted today: its only caller is the retention loop,
which the mute stops separately, and there is no HTTP route to it. So this is
latent, not live. I matched the existing behaviour rather than silently
tightening the semantics of a destructive operation. If you would rather the
mute mean *everything*, that is a one-line change to `allowed_while_muted`.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1` — 26/26
- `cargo test --lib -- --test-threads=1` — 1188 passed, 2 failed

Both failures — `data_node::…jitter_backoff…` and
`engine::…recovery_validates_all_timestamped_kv_page_families` — reproduce on an
unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
