### PR TITLE
Apply the guards the raft propose path was skipping

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1460,6 +1460,50 @@ impl SingleNodeMeta {
     /// mute: the mutation log then holds only creations that were accepted, so
     /// replay does not have to re-decide against a reserved set that has since
     /// changed.
+    /// Why this change must not be admitted, judged against current state.
+    ///
+    /// These guards lived only in the public methods. `apply_mutation` dispatches
+    /// straight to the `apply_*` functions, so the raft propose path went around
+    /// every one of them: a reserved namespace could be created, and a namespace
+    /// could be dropped out from under a table that was still live, stranding it.
+    ///
+    /// Judged before proposing and never while applying. Replay has to reapply
+    /// what was already accepted -- a name reserved today must not invalidate a
+    /// namespace legitimately created before it.
+    pub(crate) fn admission_refusal(&self, mutation: &MetaMutation) -> Option<Status> {
+        match mutation {
+            MetaMutation::AddNamespace(request) => {
+                self.reserved_name_refusal(&request.namespace, None)
+            }
+            MetaMutation::AddTable(request) => {
+                self.reserved_name_refusal(&request.namespace, Some(&request.table_name))
+            }
+            MetaMutation::SetNamespaceState(request, MetaEntityState::Dropped) => {
+                self.namespace_not_empty_refusal(&request.namespace)
+            }
+            _ => None,
+        }
+    }
+
+    /// Refuses dropping a namespace that still holds a table which is not itself
+    /// dropped, so dropping a namespace cannot strand one.
+    fn namespace_not_empty_refusal(&self, namespace: &str) -> Option<Status> {
+        let state = self.inner.read().expect("meta lock poisoned");
+        state
+            .tables
+            .values()
+            .any(|table| {
+                table.info.namespace == namespace
+                    && table.info.state != MetaEntityState::Dropped
+            })
+            .then(|| {
+                Status::error(
+                    "namespace_not_empty",
+                    "namespace still holds a table that is not dropped",
+                )
+            })
+    }
+
     fn reserved_name_refusal(&self, namespace: &str, table: Option<&str>) -> Option<Status> {
         let state = self.inner.read().expect("meta lock poisoned");
         if state.reserved_names.namespaces.contains(namespace) {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -915,6 +915,20 @@ pub struct MetaPreflightReport {
     pub degraded_reasons: Vec<String>,
 }
 
+impl MetaMutation {
+    /// Whether this change may still be made while metadata change is muted.
+    ///
+    /// Only the lever itself and the retention purge. The lever, because muting
+    /// must not be a one-way door -- refusing it would leave no way back. The
+    /// purge, because the single-node path has always allowed it: its one
+    /// caller is the retention loop, which the mute stops separately, and the
+    /// two backends have to agree on what the mute means rather than each
+    /// inventing an answer.
+    pub(crate) fn allowed_while_muted(&self) -> bool {
+        matches!(self, Self::SetMetaChangeMuted(_) | Self::PurgeMeta(_))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", content = "request", rename_all = "snake_case")]
 pub enum MetaMutation {
@@ -1394,13 +1408,17 @@ impl SingleNodeMeta {
 
     /// The refusal every guarded entry point returns while muted, or `None` when
     /// metadata change is flowing normally.
+    /// The refusal a muted metaserver answers with, so both backends phrase it
+    /// identically.
+    pub(crate) fn muted_status() -> Status {
+        Status::error(
+            "meta_change_muted",
+            "metadata change is muted; resume it before making changes",
+        )
+    }
+
     fn meta_change_refusal(&self) -> Option<Status> {
-        self.is_meta_change_muted().then(|| {
-            Status::error(
-                "meta_change_muted",
-                "metadata change is muted; resume it before making changes",
-            )
-        })
+        self.is_meta_change_muted().then(Self::muted_status)
     }
 
     /// The names currently held back from creation.

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -469,20 +469,11 @@ impl SingleNodeMeta {
                     status: Status::error("not_modified", "namespace state is unchanged"),
                 };
             }
-            if next == MetaEntityState::Dropped {
-                let live = state.tables.values().any(|table| {
-                    table.info.namespace == request.namespace
-                        && table.info.state != MetaEntityState::Dropped
-                });
-                if live {
-                    return AckResponse {
-                        status: Status::error(
-                            "namespace_not_empty",
-                            "namespace still holds a table that is not dropped",
-                        ),
-                    };
-                }
-            }
+        }
+        if let Some(status) =
+            self.admission_refusal(&MetaMutation::SetNamespaceState(request.clone(), next))
+        {
+            return AckResponse { status };
         }
         self.record_mutation(MetaMutation::SetNamespaceState(request.clone(), next));
         self.apply_set_namespace_state(request, next)

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -573,16 +573,27 @@ impl MetaRaftCluster {
                 return SingleNodeMeta::muted_status();
             }
         }
+        // The same guards the public methods apply. `apply_mutation` dispatches
+        // straight to the `apply_*` functions, so without this the propose path
+        // goes around every one of them.
+        if let Some(Some(status)) =
+            self.with_readable_meta(|meta| meta.admission_refusal(&mutation))
+        {
+            return status;
+        }
         self.propose_mutation(mutation)
             .unwrap_or_else(|err| Status::error("raft_error", err.to_string()))
     }
 
-    /// Whether the readable replica reports metadata change as muted.
+    /// Ask the readable replica a question without copying it.
     ///
     /// Deliberately not `read_meta()`: that clones the entire metadata state,
-    /// and this runs on every mutation. `None` means no replica could answer,
-    /// which is not the same as "not muted".
-    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+    /// and everything here runs on every mutation. `None` means no replica could
+    /// answer, which is not the same as an answer of "no".
+    pub(super) fn with_readable_meta<T>(
+        &self,
+        ask: impl FnOnce(&SingleNodeMeta) -> T,
+    ) -> Option<T> {
         let inner = self.inner.read().expect("meta raft lock poisoned");
         let leader_commit_index = inner.nodes.get(&inner.leader_id)?.commit_index;
         inner
@@ -590,7 +601,11 @@ impl MetaRaftCluster {
             .values()
             .filter(|node| node.alive && node.commit_index >= leader_commit_index)
             .min_by_key(|node| node.id)
-            .map(|node| node.meta.is_meta_change_muted())
+            .map(|node| ask(&node.meta))
+    }
+
+    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+        self.with_readable_meta(SingleNodeMeta::is_meta_change_muted)
     }
 
     pub(super) fn read_meta(&self) -> Result<SingleNodeMeta, Status> {

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -557,8 +557,40 @@ impl MetaRaftCluster {
     }
 
     pub(super) fn mutation_status(&self, mutation: MetaMutation) -> Status {
+        // The mute is the incident lever: while it is set, the metaserver is
+        // meant to refuse every recorded metadata mutation. That check lived
+        // only in SingleNodeMeta's public methods, and this path proposes
+        // straight past them -- so on a raft-backed metaserver, which is what a
+        // real deployment runs, setting the mute changed nothing at all.
+        //
+        // Checked before proposing rather than while applying: replay has to
+        // reapply what was already accepted, including changes recorded before
+        // the mute was set.
+        if !mutation.allowed_while_muted() {
+            // An unreadable cluster is left to propose and fail on its own
+            // terms. Refusing here would turn "cannot tell" into "muted".
+            if self.peek_meta_change_muted() == Some(true) {
+                return SingleNodeMeta::muted_status();
+            }
+        }
         self.propose_mutation(mutation)
             .unwrap_or_else(|err| Status::error("raft_error", err.to_string()))
+    }
+
+    /// Whether the readable replica reports metadata change as muted.
+    ///
+    /// Deliberately not `read_meta()`: that clones the entire metadata state,
+    /// and this runs on every mutation. `None` means no replica could answer,
+    /// which is not the same as "not muted".
+    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+        let inner = self.inner.read().expect("meta raft lock poisoned");
+        let leader_commit_index = inner.nodes.get(&inner.leader_id)?.commit_index;
+        inner
+            .nodes
+            .values()
+            .filter(|node| node.alive && node.commit_index >= leader_commit_index)
+            .min_by_key(|node| node.id)
+            .map(|node| node.meta.is_meta_change_muted())
     }
 
     pub(super) fn read_meta(&self) -> Result<SingleNodeMeta, Status> {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1044,6 +1044,91 @@ fn muting_metadata_change_refuses_changes_on_the_raft_path_too() {
     );
 }
 
+fn table_in(meta: &MetaRaftCluster, namespace: &str, table_name: &str) -> Status {
+    meta.add_table(AddTableRequest {
+        namespace: namespace.to_string(),
+        table_name: table_name.to_string(),
+        first_shard_id: 500,
+        shard_count: 1,
+        replica_count: 1,
+        partition_version: 0,
+        serving_options: crate::meta::TableServingOptions::default(),
+    })
+    .status
+}
+
+#[test]
+fn a_reserved_name_cannot_be_taken_on_the_raft_path() {
+    // Reserved names exist to hold a name back from creation. The check lived
+    // in the public method, and the raft path proposes past it, so on a
+    // raft-backed metaserver the reservation held nothing back at all.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    let mut reserved = crate::meta::ReservedNames::default();
+    reserved.namespaces.insert("system".to_string());
+    reserved.tables.insert("internal".to_string());
+    assert!(meta.set_reserved_names(reserved).status.ok);
+
+    let taken = meta.add_namespace(AddNamespaceRequest {
+        namespace: "system".to_string(),
+    });
+    assert!(!taken.status.ok, "a reserved namespace was created anyway");
+    assert_eq!(taken.status.code, "name_reserved");
+
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok);
+    let table = table_in(&meta, "tenant", "internal");
+    assert!(!table.ok, "a reserved table name was created anyway");
+    assert_eq!(table.code, "name_reserved");
+
+    // And an unreserved name is still allowed, so the guard is not a blanket no.
+    assert!(table_in(&meta, "tenant", "orders").ok);
+}
+
+#[test]
+fn dropping_a_namespace_cannot_strand_a_live_table_on_the_raft_path() {
+    // The single-node path refuses this precisely so a drop cannot leave tables
+    // behind in a namespace that no longer exists. The raft path did not.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok);
+    assert!(table_in(&meta, "tenant", "orders").ok);
+
+    let stranding = meta.drop_namespace(AddNamespaceRequest {
+        namespace: "tenant".to_string(),
+    });
+    assert!(
+        !stranding.status.ok,
+        "a namespace was dropped out from under a live table"
+    );
+    assert_eq!(stranding.status.code, "namespace_not_empty");
+
+    // Once the table is gone the namespace can be dropped, or the guard would
+    // make a namespace undroppable rather than merely safe to drop.
+    assert!(meta
+        .delete_table(DeleteTableRequest {
+            namespace: "tenant".to_string(),
+            table_name: "orders".to_string(),
+        })
+        .status
+        .ok);
+    assert!(
+        meta.drop_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok,
+        "an empty namespace could not be dropped"
+    );
+}
+
 #[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1014,6 +1014,37 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
 }
 
 #[test]
+fn muting_metadata_change_refuses_changes_on_the_raft_path_too() {
+    // The mute is the incident lever: while it is set the metaserver is meant
+    // to refuse every recorded metadata mutation. That check lived only in
+    // SingleNodeMeta's public methods, and the raft backend proposes straight
+    // past them -- so on a raft-backed metaserver, which is what a real
+    // deployment runs, setting the mute changed nothing.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta.set_meta_change_muted(true).status.ok);
+
+    let muted = meta.add_namespace(AddNamespaceRequest {
+        namespace: "during-an-incident".to_string(),
+    });
+    assert!(
+        !muted.status.ok,
+        "the cluster was muted and the change went through anyway"
+    );
+    assert_eq!(muted.status.code, "meta_change_muted");
+
+    // And the lever has to be releasable, or muting would be a one-way door.
+    assert!(meta.set_meta_change_muted(false).status.ok);
+    assert!(
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "after-the-incident".to_string(),
+        })
+        .status
+        .ok,
+        "unmuting did not restore metadata change"
+    );
+}
+
+#[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {


### PR DESCRIPTION
> **Stacked on #230.** It fixes the same funnel (`mutation_status`) and reuses the
> replica-peek added there. Basing it on `main` would only guarantee a conflict.
> If #230 is rejected, this goes with it.

## The problem

`apply_mutation` dispatches straight to the `apply_*` functions:

```rust
MetaMutation::AddNamespace(request) => self.apply_add_namespace(request).status,
```

Every guard that lives in a **public** method is therefore skipped when the raft
backend proposes. #230 found this for the mute. It is not the only one.

I probed the raft path against each guard the single-node path applies:

| Guard | Raft path |
|---|---|
| namespace does not exist | refused correctly (the check is in `apply_`) |
| **name is reserved** | **allowed — the reservation held nothing back** |
| **namespace still holds a live table** | **allowed — the table was stranded** |
| state is unchanged (`not_modified`) | allowed (see below) |

Two of these cause real harm:

- **A reserved name could be taken.** Reserved names exist to hold a name back
  from creation; on a raft-backed metaserver the reservation did nothing.
- **A namespace could be dropped out from under a live table.** The single-node
  path refuses this *precisely* so a drop cannot strand tables in a namespace
  that no longer exists. The raft path dropped it and left the table behind.

Both tests fail on the unmodified path — the first with "a reserved namespace was
created anyway", the second with "a namespace was dropped out from under a live
table".

## The change

The guards move into `admission_refusal(&MetaMutation)` — expressed once,
against state either backend can consult — and **the single-node path now defers
to it too**, so the two cannot drift apart again. Drift is what caused this.

Judged before proposing and **never** while applying: replay has to reapply what
was already accepted, and a name reserved today must not invalidate a namespace
legitimately created before it.

`peek_meta_change_muted` from #230 generalises into `with_readable_meta`, so the
admission check also answers without cloning the cluster's metadata on every
write.

## What I did not change

`not_modified` — setting a namespace to the state it is already in succeeds on
the raft path and is refused on the single-node path. It causes no harm beyond a
no-op change being accepted, and turning a success into an error is a
wire-visible behaviour change for anything already calling it. That is your call,
not mine; the guard is one line away in `admission_refusal` if you want it.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`

The `data_node::…jitter_backoff…` and `engine::…recovery_validates_…` failures
reproduce on an unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
