### PR TITLE
Remove the placement rule that was replaced but never taken out

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2197,6 +2197,89 @@ mod tests {
         );
     }
 
+    fn one_rack_cluster(meta: &SingleNodeMeta, servers: &[&str], replica_count: u64) -> Vec<String> {
+        for (index, addr) in servers.iter().enumerate() {
+            assert!(meta
+                .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
+                    server_addr: addr.to_string(),
+                    node_id: index as u64 + 1,
+                    // One rack: the ladder can separate nothing, so every
+                    // replica after the first comes from the fallback fill.
+                    location: "us-east/dc1/az1/rack1".to_string(),
+                    binary_version: "v1".to_string(),
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "ns".to_string()
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                first_shard_id: 700,
+                shard_count: 1,
+                replica_count,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+        meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "t".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        })
+        .shards
+        .into_iter()
+        .next()
+        .expect("one shard")
+        .replicas
+    }
+
+    #[test]
+    fn a_shard_does_not_stack_its_replicas_on_one_host() {
+        // Four datanodes, two per physical host, all in one rack -- an ordinary
+        // small deployment. Both replicas landed on host-a while host-b sat
+        // idle: the shard reported two replicas and lost both to one host.
+        let meta = SingleNodeMeta::default();
+        let replicas = one_rack_cluster(
+            &meta,
+            &["host-a:1001", "host-a:1002", "host-b:1001", "host-b:1002"],
+            2,
+        );
+        let hosts: BTreeSet<String> = replicas
+            .iter()
+            .map(|addr| super::topology_helpers::server_host(addr))
+            .collect();
+        assert_eq!(replicas.len(), 2, "{replicas:?}");
+        assert_eq!(
+            hosts.len(),
+            2,
+            "both replicas share a host while another was free: {replicas:?}"
+        );
+    }
+
+    #[test]
+    fn a_host_is_reused_only_when_there_is_no_other() {
+        // The point is to spread, not to refuse. With one host there is nothing
+        // to spread across, and the shard must still reach its replica count
+        // rather than come back short.
+        let meta = SingleNodeMeta::default();
+        let replicas = one_rack_cluster(&meta, &["host-a:1001", "host-a:1002"], 2);
+        assert_eq!(
+            replicas.len(),
+            2,
+            "spreading turned a fill into a shortfall: {replicas:?}"
+        );
+    }
+
     #[test]
     fn replicas_spread_across_availability_units_not_just_racks() {
         // Four servers, two availability units, two racks each. Comparing whole

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -194,18 +194,36 @@ pub(super) fn build_shards(
                 );
             }
         }
-        for candidate in &normal_servers {
-            if replicas.len() >= table.replica_count as usize {
-                break;
+        // Whatever the ladder could not place is filled here. Two passes, not
+        // one: a host already holding a replica of this shard is taken only
+        // when nothing else is left.
+        //
+        // This used to be a single unconditional pass. `push_replica` records
+        // `used_hosts` but does not enforce it -- only the ladder above checked
+        // it -- so when every server shares a location the ladder rejects them
+        // all, every replica after the first came from here, and a shard could
+        // put two replicas on one host while another host sat idle. It reported
+        // the full replica count and lost all of them to one host failure.
+        for allow_used_host in [false, true] {
+            for candidate in &normal_servers {
+                if replicas.len() >= table.replica_count as usize {
+                    break;
+                }
+                if !allow_used_host {
+                    let host = server_host(candidate.server_addr);
+                    if !host.is_empty() && used_hosts.contains(&host) {
+                        continue;
+                    }
+                }
+                push_replica(
+                    state,
+                    &mut replicas,
+                    &mut seen_replicas,
+                    &mut used_locations,
+                    &mut used_hosts,
+                    candidate.server_addr,
+                );
             }
-            push_replica(
-                state,
-                &mut replicas,
-                &mut seen_replicas,
-                &mut used_locations,
-                &mut used_hosts,
-                candidate.server_addr,
-            );
         }
         let primary = match state.shards.get(&shard_id) {
             // A recorded owner that is not serving leaves the shard with no

--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -109,7 +109,6 @@ pub(super) fn build_shards(
         let end_bucket = (bucket_count * (offset + 1) / table.shard_count).saturating_sub(1);
         let mut replicas = Vec::new();
         let mut seen_replicas = BTreeSet::new();
-        let mut used_locations = BTreeSet::new();
         let mut used_hosts = BTreeSet::new();
         let mut placed_locations: Vec<Location> = Vec::new();
         // A shard that is not serving gets no placement at all. Skipping only
@@ -148,7 +147,6 @@ pub(super) fn build_shards(
                 state,
                 &mut replicas,
                 &mut seen_replicas,
-                &mut used_locations,
                 &mut used_hosts,
                 &location.server_addr,
             );
@@ -188,7 +186,6 @@ pub(super) fn build_shards(
                     state,
                     &mut replicas,
                     &mut seen_replicas,
-                    &mut used_locations,
                     &mut used_hosts,
                     candidate.server_addr,
                 );
@@ -219,7 +216,6 @@ pub(super) fn build_shards(
                     state,
                     &mut replicas,
                     &mut seen_replicas,
-                    &mut used_locations,
                     &mut used_hosts,
                     candidate.server_addr,
                 );

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -49,17 +49,11 @@ pub(super) fn push_replica(
     state: &MetaState,
     replicas: &mut Vec<String>,
     seen_replicas: &mut BTreeSet<String>,
-    used_locations: &mut BTreeSet<String>,
     used_hosts: &mut BTreeSet<String>,
     server_addr: &str,
 ) {
     if !seen_replicas.insert(server_addr.to_string()) {
         return;
-    }
-    if let Some(server) = state.servers.get(server_addr) {
-        if !server.location.is_empty() {
-            used_locations.insert(server.location.clone());
-        }
     }
     let host = server_host(server_addr);
     if !host.is_empty() {


### PR DESCRIPTION
> **Stacked on #232.** Both touch the same fill loop in `meta/partitioning.rs`;
> a separate base would only guarantee a conflict.

## What this removes

`used_locations` is written and never read. It is created per shard, threaded
through a `push_replica` parameter and three call sites, inserted into on every
replica placed — and **nothing anywhere consults it**.

```
used_locations:  1 declaration, 3 call sites, 1 insert, 0 reads
used_hosts:      same plumbing, and it is actually checked
```

It is the vestige of the placement rule the separation ladder replaced. The
comment a few lines above says so:

> Comparing whole location strings, as this used to, treats two racks in one
> availability unit as "different locations"…

That comparison is gone; the set it was built from stayed.

## Why bother

Not the dead code itself — the disguise. A `BTreeSet` named `used_locations`,
populated identically to `used_hosts` and sitting right beside it, reads as
though the location rule is enforced here. It is not.

That is exactly the shape that hid the bug in #232, where `used_hosts` was
recorded at five sites and checked at one. Leaving a second, fully unread copy
of the same pattern next to the code that just got fixed invites the same
mistake again.

It also costs a set allocation per shard and a `String` clone per replica on
`get_table_topology` — which the code notes is "a call every client and proxy
makes."

## Verification

Pure removal — no behaviour change, so the placement tests are the check:

- `cargo check --all-targets` — 0 errors
- `cargo test --lib -- --test-threads=1`
- `cargo test --bin metaserver -- --test-threads=1`

The `data_node::…jitter_backoff…` and `engine::…recovery_validates_…` failures
reproduce on an unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
