### PR TITLE
Stop discarding metadata changes after a snapshot install

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -601,7 +601,15 @@ impl MetaRaftCluster {
             .ok_or(RaftError::LeaderUnavailable)?;
         let entry = MetaLogEntry {
             term: leader.current_term,
-            index: leader.log.last().map(|entry| entry.index + 1).unwrap_or(1),
+            // Numbered from the log *or the installed snapshot*, whichever is
+            // further along. Installing a meta snapshot truncates the log and
+            // marks everything up to the snapshot applied, so taking the next
+            // index from the log alone restarted numbering at 1 -- indices the
+            // node had already applied. Every proposal after an install was
+            // skipped as a duplicate, and `propose_mutation` turns "not applied"
+            // into `Status::ok`, so the change was discarded and reported
+            // successful.
+            index: meta_node_last_log_or_snapshot_index(leader) + 1,
             command,
         };
         let mut replicated = 0;

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1013,6 +1013,102 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
     assert!(response.status.message.contains("majority"));
 }
 
+fn cluster_with_an_installed_snapshot() -> MetaRaftCluster {
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "before".to_string()
+        })
+        .status
+        .ok);
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    meta
+}
+
+#[test]
+fn a_change_after_a_snapshot_install_actually_takes_effect() {
+    // Installing a meta snapshot truncates the log and marks everything up to
+    // the snapshot applied. The next index came from the log alone, so
+    // numbering restarted at 1 -- indices the node had already applied. Every
+    // proposal after an install was skipped as a duplicate and reported ok, so
+    // the cluster accepted metadata changes and silently discarded them.
+    let meta = cluster_with_an_installed_snapshot();
+
+    let added = meta.add_namespace(AddNamespaceRequest {
+        namespace: "after".to_string(),
+    });
+    assert!(added.status.ok, "{:?}", added.status);
+
+    let namespaces = meta
+        .read_meta()
+        .expect("a readable replica")
+        .list_namespaces()
+        .namespaces;
+    assert!(
+        namespaces.iter().any(|namespace| namespace.namespace == "after"),
+        "a change reported as accepted never took effect: {namespaces:?}"
+    );
+    // What the snapshot carried is still there too.
+    assert!(namespaces.iter().any(|namespace| namespace.namespace == "before"));
+}
+
+#[test]
+fn changes_keep_taking_effect_after_a_snapshot_install() {
+    // One change could succeed by luck if the numbering only collided once.
+    let meta = cluster_with_an_installed_snapshot();
+    for round in 0..5u64 {
+        let name = format!("ns-{round}");
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: name.clone()
+            })
+            .status
+            .ok);
+        let namespaces = meta
+            .read_meta()
+            .expect("a readable replica")
+            .list_namespaces()
+            .namespaces;
+        assert!(
+            namespaces.iter().any(|namespace| namespace.namespace == name),
+            "change {round} was accepted and discarded: {namespaces:?}"
+        );
+    }
+}
+
+#[test]
+fn a_snapshot_install_does_not_rewind_the_commit_index() {
+    // The reused index was also written straight into commit_index, walking it
+    // backwards past entries the cluster had already committed.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    for round in 0..3u64 {
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: format!("ns-{round}")
+            })
+            .status
+            .ok);
+    }
+    let before = meta.status().commit_index;
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "after".to_string()
+        })
+        .status
+        .ok);
+    assert!(
+        meta.status().commit_index >= before,
+        "commit index went backwards: {} then {}",
+        before,
+        meta.status().commit_index
+    );
+}
+
 #[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);


### PR DESCRIPTION
> Independent of the other open work — `main` base, one line of behaviour change.

## After installing a meta snapshot, the cluster accepts metadata changes and throws them away

```
add_namespace         -> ok=true, code=ok
namespaces afterwards -> []
```

The change is reported successful. It never happened. Every metadata change
after a meta snapshot install is discarded this way, and nothing says so, until
the process restarts.

Snapshot install is reachable from the metaserver's snapshot-restore routes, so
this is the state an operator is left in immediately after restoring one.

## Why

`propose_inner` numbers the next entry from the log alone:

```rust
index: leader.log.last().map(|entry| entry.index + 1).unwrap_or(1),
```

`install_meta_snapshot_state` truncates the log to entries **above** the
snapshot — which empties it — and marks `applied = 1..=last_included_index`. So
after an install `log.last()` is `None`, the next index is **1**, and 1 is
already in `applied`. The entry is skipped as a duplicate.

Two things then hide it:

- `propose_mutation` ends in `.unwrap_or_else(Status::ok)`, so "no apply
  happened" is indistinguishable from "applied fine" and comes back as success.
- `node.commit_index = entry.index` writes the reused index straight in, walking
  the commit index **backwards** past entries already committed.

## The change

One line. The codebase already has the right notion of the next index and this
call site simply was not using it:

```rust
index: meta_node_last_log_or_snapshot_index(leader) + 1,
```

`meta_node_last_log_or_snapshot_index` falls back to `installed_snapshot_index`
when the log is empty, which is exactly the case an install creates.

## Tests

- a change after a snapshot install actually takes effect
- changes keep taking effect after a snapshot install — five in a row, because
  one could survive a single numbering collision by luck
- a snapshot install does not rewind the commit index

All three fail on an unmodified tree.

## Left alone, deliberately

`propose_mutation` still turns "not applied" into `Status::ok`. That is what made
this silent rather than what made it happen, and with the numbering fixed it no
longer fires. Changing it means deciding what a proposal that legitimately
produces no status should report, which is a separate question and yours — but
it is worth knowing that the same disguise is still in place for any future bug
of this shape.

## How this was found

Sideways. A test for something unrelated failed with the resource in exactly the
state that should have caused a refusal, so the refusal had to be running against
state that was never written. Checking what the code did rather than what the
test asserted is what turned up the numbering.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`

The `data_node::…jitter_backoff…` and `engine::…recovery_validates_…` failures
reproduce on an unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
