### PR TITLE
Remove the last remnants of a data model the engine no longer implements

### DIFF
--- a/sdk/rust/temporalstore/src/direct_ffi_capabilities.rs
+++ b/sdk/rust/temporalstore/src/direct_ffi_capabilities.rs
@@ -4,8 +4,8 @@
 use std::os::raw::{c_char, c_int};
 
 use crate::direct_ffi_types::{
-    CFeatureFilter, CFeaturePoint, CFeaturePointArray, CIpsFeatureArray, CIpsFeatureStat,
-    CSequenceFeatureRow, CSequenceFeatureRowArray, TemporalStoreClientOpaque,
+    CFeatureFilter, CFeaturePoint, CFeaturePointArray, CSequenceFeatureRow,
+    CSequenceFeatureRowArray, TemporalStoreClientOpaque,
 };
 
 extern "C" {
@@ -60,27 +60,6 @@ extern "C" {
     pub(crate) fn temporalstore_sequence_feature_row_array_free(
         rows: *mut CSequenceFeatureRowArray,
     );
-        client: *mut TemporalStoreClientOpaque,
-        table: *const c_char,
-        uid: i64,
-        timestamp_us: i64,
-        action_type: i32,
-        logical_table: i32,
-        features: *const CIpsFeatureStat,
-        feature_count: usize,
-        error_message: *mut *mut c_char,
-    ) -> c_int;
-        client: *mut TemporalStoreClientOpaque,
-        table: *const c_char,
-        uid: i64,
-        action_type: i32,
-        logical_table: i32,
-        slot: i32,
-        top_k: i32,
-        last_instances: i64,
-        features: *mut CIpsFeatureArray,
-        error_message: *mut *mut c_char,
-    ) -> c_int;
     pub(crate) fn temporalstore_control_state_increment(
         client: *mut TemporalStoreClientOpaque,
         key: *const c_char,

--- a/sdk/rust/temporalstore/src/direct_ffi_types.rs
+++ b/sdk/rust/temporalstore/src/direct_ffi_types.rs
@@ -59,17 +59,6 @@ pub(crate) struct CSequenceFeatureRow {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub(crate) struct CIpsFeatureStat {
-    pub(crate) id: i64,
-    pub(crate) slot: i32,
-    pub(crate) has_slot: c_int,
-    pub(crate) kind: i32,
-    pub(crate) v1: i32,
-    pub(crate) v2: i32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
 pub(crate) struct CHashEntry {
     pub(crate) key: *const c_char,
     pub(crate) field: *const c_char,
@@ -99,10 +88,4 @@ pub(crate) struct CFeaturePointArray {
 pub(crate) struct CSequenceFeatureRowArray {
     pub(crate) count: usize,
     pub(crate) rows: *mut CSequenceFeatureRow,
-}
-
-#[repr(C)]
-pub(crate) struct CIpsFeatureArray {
-    pub(crate) count: usize,
-    pub(crate) features: *mut CIpsFeatureStat,
 }

--- a/sdk/rust/temporalstore/src/direct_helpers.rs
+++ b/sdk/rust/temporalstore/src/direct_helpers.rs
@@ -5,7 +5,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
 
 use crate::{
-    temporalstore_free_string, CFeaturePointArray, CIpsFeatureArray, COptions, Error, FeaturePoint,
+    temporalstore_free_string, CFeaturePointArray, COptions, Error, FeaturePoint,
 };
 
 pub(crate) struct CStringOptions {


### PR DESCRIPTION
The engine has no commands for this model at all -- the whole family was removed
some time ago. What survived was surface: type declarations, foreign-function
bindings, a validator asserting evidence for it, and a benchmark note advertising
it. None of it reachable, all of it readable by anyone browsing the tree.

Removed: three dead SDK source files, two repr(C) structs, their bindings and
imports, an evidence-validator entry naming symbols that no longer exist in the
crate it points at, and the benchmark bullet.

Two things worth recording about how it survived.

The SDK's lib.rs is a single self-contained file and declares no modules, so every
other .rs beside it is dead -- not compiled, not linked, invisible to the compiler
and to any build gate. That is how a syntax error survived in one of them: the
earlier removal deleted two function-declaration lines from an extern block and
left their parameter lists behind, dangling with no name. It never broke a build
because nothing builds that file. It is gone now along with the rest.

The other is that the scrub gate could not see part of this. It matched the retired
name only at a token start, which was chosen so ordinary words -- round_trips,
skips, relationships -- do not trip it. The C-binding convention prefixes type names
with C, so those identifiers had a letter in front of the name and read as clean
under the gate while sitting in plain sight. The gate is corrected to match the
prefixed form, and still rejects the ordinary words; that is checked both ways.

Both trees are now clean under the corrected gate, and both SDKs still compile.