### PR TITLE
Answer history from a three-type scan, not a raw read of the whole log

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5607,6 +5607,16 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return {"recorded": True, "memory_id": memory_id, "feedback": rating,
                 "feedback_reason": reason}
 
+    def raw_records_for_history(self) -> list[Json]:
+        """The records `history` walks. Base implementation: the whole raw log.
+
+        History consumes three record types -- the memory's event rows, the tombstones that
+        target or created it, and its feedback ratings -- in append order. A backend that can
+        fetch that subset cheaply overrides this; the contract is that history's OUTPUT for any
+        memory id is unchanged.
+        """
+        return self._read_raw_records()
+
     def history(self, args: Json) -> Json:
         """Return the ordered change history for a memory id (mem0 ``history``). Because the store is
         event-sourced, this is the RAW (un-compacted, un-tombstoned) event log filtered to the id:
@@ -5617,7 +5627,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             raise MatrixArkError("history requires a memory_id")
         events: list[Json] = []
         seen_ingested = False
-        for record in self._read_raw_records():
+        for record in self.raw_records_for_history():
             record_type = str(record.get("record_type") or "")
             ts = record.get("updated_at_ms") or record.get("timestamp_key_ms") or record.get("event_time_ms") or record.get("created_at_ms")
             if record_type == "context_event" and str(record.get("event_id_hash")) == memory_id:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1117,7 +1117,9 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         appends are expanded engine-side, so a record stored inside a bundle whose wrapper carries
         no record_type is still returned.
         """
-        scanner = getattr(self._client, "matrixark_scan_candidates", None)
+        # An adapter with no client at all (partial construction, stubs) is the same answer as
+        # a client without the scan: the question cannot be asked here.
+        scanner = getattr(getattr(self, "_client", None), "matrixark_scan_candidates", None)
         if not callable(scanner):
             return None
         try:
@@ -1150,6 +1152,28 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         except ModuleNotFoundError:  # Direct script execution from tools/.
             from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         return self._scan_records_of_types([MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def raw_records_for_history(self) -> list[Json]:
+        """History's records from a three-type scan instead of a raw read of the whole log.
+
+        The raw read hauls the entire store -- summaries, embeddings, index postings -- to answer
+        one id, and it grows with the store. The scan returns the three types history reports, in
+        append order, which is the order history walks. Duplicate event rows need no special care:
+        history collapses them to one "ingested" entry either way. Any failure falls back to the
+        raw read.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        subset = self._scan_records_of_types([
+            "context_event",
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            self.MEMORY_FEEDBACK_RECORD_TYPE,
+        ])
+        if subset is None:
+            return super().raw_records_for_history()
+        return subset
 
     def prior_context_records(self) -> list[Json]:
         """The prior-context view from a five-type scan instead of a full-store read.

--- a/tools/test_history_scoped.py
+++ b/tools/test_history_scoped.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""History walks a three-type scan, and its output is unchanged.
+
+The raw read hauled the whole store to answer one memory id. What history actually reports:
+the id's ingest, its supersede/delete tombstones, its creation-by-supersede link, and its
+feedback ratings -- three record types. The test drives `history()` itself through both the
+subset path and the raw fallback and requires identical output, because the seam's contract is
+output equivalence, not input similarity.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as local_mod
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as local_mod
+    import matrixark_mcp_temporal_adapters as adapters
+
+TOMBSTONE = local_mod.MEMORY_TOMBSTONE_RECORD_TYPE
+
+
+def _story():
+    """A memory's full life: ingested twice (hot+committed), rated, superseded, deleted."""
+    return [
+        {"record_type": "context_event", "event_id_hash": "77", "text": "pending",
+         "extraction_phase": "hot_path", "updated_at_ms": 100},
+        {"record_type": "context_summary", "summary_hash": "s1", "summary_text": "noise",
+         "updated_at_ms": 110},
+        {"record_type": "context_event", "event_id_hash": "77", "text": "committed",
+         "extraction_phase": "final", "updated_at_ms": 150},
+        {"record_type": local_mod.MatrixArkLocalAdapter.MEMORY_FEEDBACK_RECORD_TYPE,
+         "target_memory_id": "77", "feedback": "POSITIVE", "created_at_ms": 200},
+        {"record_type": TOMBSTONE, "tombstone_kind": "delete", "tombstone_reason": "supersede",
+         "target_memory_id": "77", "superseded_by": "88", "created_at_ms": 300},
+        {"record_type": "context_event", "event_id_hash": "88", "text": "the new version",
+         "updated_at_ms": 300},
+        {"record_type": TOMBSTONE, "tombstone_kind": "delete", "target_memory_id": "88",
+         "created_at_ms": 400},
+        {"record_type": "context_embedding", "ref_hash": 77, "updated_at_ms": 410},
+    ]
+
+
+class _NativeAdapter(adapters.MatrixArkTemporalStoreDirectAdapter):
+    def __init__(self, records, *, scan_available=True):
+        self._records = records
+        self._scan_available = scan_available
+        self.scan_calls = 0
+        self.raw_reads = 0
+
+    def _scan_records_of_types(self, record_types):
+        self.scan_calls += 1
+        if not self._scan_available:
+            return None
+        wanted = set(record_types)
+        return [r for r in self._records if str(r.get("record_type") or "") in wanted]
+
+    def _read_raw_records(self):
+        self.raw_reads += 1
+        return list(self._records)
+
+
+class HistoryScopedTests(unittest.TestCase):
+    def _events(self, adapter, memory_id):
+        return [(e["event"], e.get("superseded_by") or e.get("supersedes_memory_id")
+                 or e.get("feedback"))
+                for e in adapter.history({"memory_id": memory_id})["history"]]
+
+    def test_the_subset_answers_without_a_raw_read(self):
+        adapter = _NativeAdapter(_story())
+        events = self._events(adapter, "77")
+        self.assertEqual(0, adapter.raw_reads)
+        self.assertEqual([("ingested", None), ("feedback", "POSITIVE"),
+                          ("superseded", "88")], events)
+
+    def test_the_subset_output_equals_the_raw_output(self):
+        """The contract: history() itself, both paths, identical answers -- for every id."""
+        for memory_id in ("77", "88"):
+            scan = _NativeAdapter(_story())
+            raw = _NativeAdapter(_story(), scan_available=False)
+            self.assertEqual(
+                raw.history({"memory_id": memory_id}),
+                scan.history({"memory_id": memory_id}),
+                "path divergence for id %s" % memory_id,
+            )
+
+    def test_a_superseding_memory_reports_its_creation_link(self):
+        adapter = _NativeAdapter(_story())
+        events = self._events(adapter, "88")
+        self.assertEqual([("created", "77"), ("ingested", None), ("deleted", None)], events)
+
+    def test_an_unavailable_scan_falls_back_to_the_raw_read(self):
+        adapter = _NativeAdapter(_story(), scan_available=False)
+        events = self._events(adapter, "77")
+        self.assertEqual(1, adapter.raw_reads)
+        self.assertEqual([("ingested", None), ("feedback", "POSITIVE"),
+                          ("superseded", "88")], events)
+
+    def test_duplicate_event_rows_still_collapse_to_one_ingest(self):
+        adapter = _NativeAdapter(_story())
+        events = [e for e, _ in self._events(adapter, "77")]
+        self.assertEqual(1, events.count("ingested"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`history(memory_id)` deliberately reads the RAW log -- a memory's change history IS the tombstones
and superseded rows the live view hides -- but it consumes exactly three record types: the id's
`context_event` rows, the tombstones that target it or created it as a supersede, and its feedback
ratings. The raw read hauled the entire store (summaries, embeddings, index postings) to answer
one id: measured at 38.5s p50 at the ~2200-record scale in one loaded run, growing with the store.

The native override fetches only those three types through the filtered engine scan, in append
order, which is the order history walks. Duplicate event rows (hot-path + committed) need no
special care -- history already collapses them to one "ingested" entry, unchanged. Any failure to
scan falls back to the raw read.

The seam's contract is OUTPUT equivalence, and the test enforces it directly: `history()` itself,
driven through both paths over a memory's full life -- ingested twice, rated, superseded, the
successor deleted -- must produce identical answers for every id.

Also hardened `_scan_records_of_types` to treat an adapter with no client at all (partial
construction, test stubs) the same as a client without the scan: "cannot ask", so the caller takes
its fallback rather than an AttributeError.

5 tests: subset answers without a raw read, both-path output equality for every id in the story,
the creation-by-supersede link, the raw fallback, and duplicate collapse. The five memory suites
and the 26 guard/probe/prior-context tests pass unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
