### PR TITLE
Make the conviction lock reach a raft-backed metaserver

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2066,6 +2066,13 @@ fn runtime_options_from_env() -> ProductionMetaRaftRuntimeOptions {
         election_tick_ms: env_u64("TS_META_RAFT_ELECTION_TICK_MS", 50),
         failure_detector_interval_ms: env_u64("TS_META_FAILURE_DETECTOR_INTERVAL_MS", 10_000),
         stale_server_after_ms: env_u64("TS_META_STALE_AFTER_MS", 30_000),
+        // Read here as well as on the single-node path: `from_env` returns the
+        // raft backend before it reaches that one, so this setting used to do
+        // nothing at all on a raft-backed metaserver.
+        forbid_self_clearing_conviction: env_bool(
+            "TS_META_FORBID_SELF_CLEARING_CONVICTION",
+            false,
+        ),
     }
 }
 
@@ -2575,6 +2582,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let snapshot_path = dir.path().join("meta-raft-route-snapshot.json");
         let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            forbid_self_clearing_conviction: false,
             snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,
@@ -2702,6 +2710,7 @@ mod tests {
         assert_eq!(servers.servers[0].state, MetaEntityState::Normal);
 
         let restored_runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            forbid_self_clearing_conviction: false,
             snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,
@@ -3780,6 +3789,7 @@ mod tests {
     #[test]
     fn raft_backed_metaserver_scheduler_drives_lifecycle_workflow() {
         let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            forbid_self_clearing_conviction: false,
             snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,

--- a/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver_raft_harness.rs
@@ -85,6 +85,7 @@ fn main() {
     std::fs::create_dir_all(&options.root).expect("failed to create harness root");
     let started = Instant::now();
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1201,6 +1201,14 @@ impl Default for SingleNodeMeta {
 }
 
 impl SingleNodeMeta {
+    /// Set the conviction lock on a meta that already exists.
+    ///
+    /// The builder cannot reach a raft node's meta: those are constructed inside
+    /// the cluster, long after the process read its configuration.
+    pub fn set_conviction_lock(&mut self, forbid: bool) {
+        self.forbid_self_clearing_conviction = forbid;
+    }
+
     /// Refuse to let a resource the metaserver convicted register its way back
     /// into service; only an explicit unfreeze returns it. Off by default.
     pub fn with_conviction_lock(mut self, forbid: bool) -> Self {

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -37,6 +37,19 @@ impl MetaRaftCluster {
         })
     }
 
+    /// Apply the conviction lock to every node's metadata.
+    ///
+    /// `TS_META_FORBID_SELF_CLEARING_CONVICTION` was read after `from_env` had
+    /// already returned the raft backend, so it reached the single-node
+    /// metaserver and nothing else. The checks that consult it run on these
+    /// nodes, against a flag that was always false.
+    pub fn set_conviction_lock(&self, forbid: bool) {
+        let mut inner = self.inner.write().expect("meta raft lock poisoned");
+        for node in inner.nodes.values_mut() {
+            node.meta.set_conviction_lock(forbid);
+        }
+    }
+
     pub fn propose(&self, command: MetaCommand) -> Result<(), RaftError> {
         self.propose_inner(command).map(|_| ())
     }
@@ -962,12 +975,17 @@ impl MetaRaftCluster {
         };
         for node in inner.nodes.values_mut().filter(|node| node.alive) {
             install_meta_snapshot_state(node, raft_snapshot.clone());
-            let meta = SingleNodeMeta::default();
-            let status = meta.install_snapshot(snapshot.clone()).status;
+            // Installed into the node's own metadata rather than into a fresh
+            // default that replaces it. A snapshot carries metadata, not the
+            // configuration of the process holding it, and replacing the whole
+            // meta discarded the conviction lock along with the event bus, the
+            // metrics recorder and the counters -- the last three documented as
+            // shared by clone, so every handle taken before the install was
+            // quietly left writing to an orphan.
+            let status = node.meta.install_snapshot(snapshot.clone()).status;
             if !status.ok {
                 return Err(RaftError::InvalidConfig(status.message));
             }
-            node.meta = meta;
         }
         Ok(())
     }

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -601,7 +601,15 @@ impl MetaRaftCluster {
             .ok_or(RaftError::LeaderUnavailable)?;
         let entry = MetaLogEntry {
             term: leader.current_term,
-            index: leader.log.last().map(|entry| entry.index + 1).unwrap_or(1),
+            // Numbered from the log *or the installed snapshot*, whichever is
+            // further along. Installing a meta snapshot truncates the log and
+            // marks everything up to the snapshot applied, so taking the next
+            // index from the log alone restarted numbering at 1 -- indices the
+            // node had already applied. Every proposal after an install was
+            // skipped as a duplicate, and `propose_mutation` turns "not applied"
+            // into `Status::ok`, so the change was discarded and reported
+            // successful.
+            index: meta_node_last_log_or_snapshot_index(leader) + 1,
             command,
         };
         let mut replicated = 0;

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -667,6 +667,12 @@ pub struct ProductionMetaRaftRuntimeOptions {
     /// config already said to compact at a threshold, but no loop ever called
     /// it -- so the log grew for the life of the process.
     pub snapshot_check_interval_ms: u64,
+    /// Refuse to let a resource the metaserver convicted register its way back
+    /// into service; only an explicit unfreeze returns it.
+    ///
+    /// Carried here because a raft node's metadata is built inside the cluster,
+    /// so the process cannot configure it through the usual builder.
+    pub forbid_self_clearing_conviction: bool,
 }
 
 impl ProductionMetaRaftRuntimeOptions {
@@ -715,6 +721,7 @@ impl ProductionMetaRaftRuntime {
         options.validate()?;
         let cluster =
             MetaRaftCluster::new_with_config(options.voter_ids(), options.config.clone())?;
+        cluster.set_conviction_lock(options.forbid_self_clearing_conviction);
         Ok(Self { options, cluster })
     }
 

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1013,6 +1013,102 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
     assert!(response.status.message.contains("majority"));
 }
 
+fn cluster_with_an_installed_snapshot() -> MetaRaftCluster {
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "before".to_string()
+        })
+        .status
+        .ok);
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    meta
+}
+
+#[test]
+fn a_change_after_a_snapshot_install_actually_takes_effect() {
+    // Installing a meta snapshot truncates the log and marks everything up to
+    // the snapshot applied. The next index came from the log alone, so
+    // numbering restarted at 1 -- indices the node had already applied. Every
+    // proposal after an install was skipped as a duplicate and reported ok, so
+    // the cluster accepted metadata changes and silently discarded them.
+    let meta = cluster_with_an_installed_snapshot();
+
+    let added = meta.add_namespace(AddNamespaceRequest {
+        namespace: "after".to_string(),
+    });
+    assert!(added.status.ok, "{:?}", added.status);
+
+    let namespaces = meta
+        .read_meta()
+        .expect("a readable replica")
+        .list_namespaces()
+        .namespaces;
+    assert!(
+        namespaces.iter().any(|namespace| namespace.namespace == "after"),
+        "a change reported as accepted never took effect: {namespaces:?}"
+    );
+    // What the snapshot carried is still there too.
+    assert!(namespaces.iter().any(|namespace| namespace.namespace == "before"));
+}
+
+#[test]
+fn changes_keep_taking_effect_after_a_snapshot_install() {
+    // One change could succeed by luck if the numbering only collided once.
+    let meta = cluster_with_an_installed_snapshot();
+    for round in 0..5u64 {
+        let name = format!("ns-{round}");
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: name.clone()
+            })
+            .status
+            .ok);
+        let namespaces = meta
+            .read_meta()
+            .expect("a readable replica")
+            .list_namespaces()
+            .namespaces;
+        assert!(
+            namespaces.iter().any(|namespace| namespace.namespace == name),
+            "change {round} was accepted and discarded: {namespaces:?}"
+        );
+    }
+}
+
+#[test]
+fn a_snapshot_install_does_not_rewind_the_commit_index() {
+    // The reused index was also written straight into commit_index, walking it
+    // backwards past entries the cluster had already committed.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    for round in 0..3u64 {
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: format!("ns-{round}")
+            })
+            .status
+            .ok);
+    }
+    let before = meta.status().commit_index;
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "after".to_string()
+        })
+        .status
+        .ok);
+    assert!(
+        meta.status().commit_index >= before,
+        "commit index went backwards: {} then {}",
+        before,
+        meta.status().commit_index
+    );
+}
+
 #[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -626,6 +626,7 @@ fn metaserver_raft_freeze_stale_server_is_replicated_mutation() {
 #[test]
 fn production_meta_raft_runtime_ticks_failover_and_failure_detection() {
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
@@ -689,6 +690,7 @@ fn production_meta_raft_runtime_ticks_failover_and_failure_detection() {
 #[test]
 fn production_meta_raft_runtime_matches_multinode_control_and_fault_contract() {
     let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
@@ -765,6 +767,7 @@ fn production_meta_raft_runtime_matches_multinode_control_and_fault_contract() {
 #[test]
 fn metaserver_owns_data_raft_membership_workflow() {
     let meta = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
@@ -958,6 +961,7 @@ fn meta_owned_membership_report_covers_networked_scheduler_contract() {
 #[test]
 fn metaserver_membership_workflow_requires_meta_majority() {
     let meta = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms: 0,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,
@@ -1107,6 +1111,127 @@ fn a_snapshot_install_does_not_rewind_the_commit_index() {
         before,
         meta.status().commit_index
     );
+}
+
+fn convicted_proxy_cluster(forbid: bool) -> MetaRaftCluster {
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    meta.set_conviction_lock(forbid);
+    assert!(meta
+        .register_proxy(RegisterProxyRequest {
+            proxy_addr: "proxy-a".to_string(),
+            namespace: "ns".to_string(),
+            location: "rack-1".to_string(),
+            config_version: 1,
+            binary_version: "v1".to_string(),
+        })
+        .status
+        .ok);
+    // Frozen for a reason that counts as conviction, which is what the lock is
+    // about: a resource the metaserver took out, not one an operator did.
+    assert!(meta
+        .freeze_proxy(StateChangeRequest {
+            endpoint: "proxy-a".to_string(),
+            reason: crate::meta::FreezeReason::Unresponsive,
+            freeze_cooldown_ms: 0,
+        })
+        .status
+        .ok);
+    meta
+}
+
+fn rejoin(meta: &MetaRaftCluster) -> Status {
+    meta.register_proxy(RegisterProxyRequest {
+        proxy_addr: "proxy-a".to_string(),
+        namespace: "ns".to_string(),
+        location: "rack-1".to_string(),
+        config_version: 1,
+        binary_version: "v1".to_string(),
+    })
+    .status
+}
+
+#[test]
+fn the_conviction_lock_holds_on_a_raft_backed_metaserver() {
+    // The setting is read after `from_env` has already returned the raft
+    // backend, so it reached the single-node metaserver and nothing else. The
+    // check that consults it runs on these nodes -- against a flag that was
+    // always false, which let a convicted resource register its way back in.
+    let meta = convicted_proxy_cluster(true);
+    let refused = rejoin(&meta);
+    assert!(!refused.ok, "a convicted proxy registered its way back in");
+    assert_eq!(refused.code, "conviction_requires_unfreeze");
+
+    // An explicit unfreeze is the way back, or the lock would be a dead end.
+    assert!(meta
+        .unfreeze_proxy(StateChangeRequest {
+            endpoint: "proxy-a".to_string(),
+            reason: crate::meta::FreezeReason::Unspecified,
+            freeze_cooldown_ms: 0,
+        })
+        .status
+        .ok);
+    assert!(rejoin(&meta).ok, "an unfrozen proxy could not rejoin");
+}
+
+#[test]
+fn the_runtime_carries_the_conviction_lock_to_its_nodes() {
+    // The setter alone proves nothing about production: what was broken is that
+    // the option never reached the nodes, because the flag is read on a path the
+    // raft backend returns before.
+    let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: true,
+        snapshot_check_interval_ms: 0,
+        engine: ProductionRaftEngineKind::TemporalRaft,
+        local_node_id: 1,
+        nodes: vec![ProductionRaftNode {
+            node_id: 1,
+            addr: "127.0.0.1:18147".to_string(),
+        }],
+        config: RaftConfig::default(),
+        heartbeat_interval_ms: 100,
+        election_tick_ms: 50,
+        failure_detector_interval_ms: 1_000,
+        stale_server_after_ms: 30_000,
+    })
+    .unwrap();
+    assert_eq!(
+        runtime
+            .cluster()
+            .read_meta()
+            .expect("a readable replica")
+            .conviction_lock_enabled(),
+        true,
+        "the runtime did not carry the setting to its nodes"
+    );
+}
+
+#[test]
+fn the_conviction_lock_stays_off_when_it_is_not_asked_for() {
+    // Off by default on purpose: the automatic recovery it removes is
+    // load-bearing wherever the freeze cooldown is left at zero.
+    let meta = convicted_proxy_cluster(false);
+    assert!(
+        rejoin(&meta).ok,
+        "a setting nobody asked for locked a proxy out"
+    );
+}
+
+#[test]
+fn installing_a_snapshot_does_not_clear_the_conviction_lock() {
+    // Each node's metadata used to be rebuilt from `Default` on install, which
+    // discarded everything configured on it -- the lock along with the event
+    // bus, the metrics recorder and the counters.
+    let meta = convicted_proxy_cluster(true);
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+
+    let refused = rejoin(&meta);
+    assert!(
+        !refused.ok,
+        "a snapshot install turned the conviction lock off"
+    );
+    assert_eq!(refused.code, "conviction_requires_unfreeze");
 }
 
 #[test]
@@ -1458,6 +1583,7 @@ fn meta_runtime_for_snapshot_wiring(
     base_port: u16,
 ) -> ProductionMetaRaftRuntime {
     ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+        forbid_self_clearing_conviction: false,
         snapshot_check_interval_ms,
         engine: ProductionRaftEngineKind::TemporalRaft,
         local_node_id: 10,


### PR DESCRIPTION
> **Stacked on #236.** One of the tests here only passes once that lands — it was
> failing on the discard bug, not on anything in this change.

## The conviction lock never applied on a raft-backed metaserver

`TS_META_FORBID_SELF_CLEARING_CONVICTION` stops a resource the metaserver
convicted from registering its way back into service. `MetaBackend::from_env`
returns the raft backend **before** the line that reads it:

```rust
if env_bool("TS_META_RAFT", false) || std::env::var("TS_META_RAFT_NODES").is_ok() {
    return Ok(Self::Raft(...));                      // ← returns here
}
...
let meta = meta.with_conviction_lock(env_bool(
    "TS_META_FORBID_SELF_CLEARING_CONVICTION", false));   // ← only Single reaches this
```

`with_conviction_lock` has exactly one production call site, and it is below that
return. Meanwhile the flag *is* consulted in `apply_register_server` and
`apply_register_proxy`, which do run on raft nodes — against a value that is
permanently false. A convicted datanode walks straight back in.

Conviction itself does happen on raft (the runtime's timer loop runs failure
detection), so this is live, not moot.

## Two halves, because fixing one exposes the other

**The option now reaches the nodes.** A raft node's metadata is built inside the
cluster, long after the process read its configuration, so the builder cannot
reach it: `ProductionMetaRaftRuntimeOptions` carries the setting and `start`
applies it to every node.

**Installing a snapshot no longer discards it.** The per-node install rebuilt
each node's metadata from `Default` and replaced it wholesale, which would have
cleared the setting again the moment it was plumbed through. A snapshot carries
metadata, not the configuration of the process holding it, so it now installs
*into* the node's own metadata.

That also stops the install swapping out the event bus, the metrics recorder and
the counters — all three documented as "shared by clone", so every handle taken
before an install was quietly left writing to an orphan.

## Tests

- the conviction lock holds on a raft-backed metaserver, and an explicit
  unfreeze is still the way back
- it stays off when it is not asked for — off by default is deliberate, since the
  automatic recovery it removes is load-bearing wherever the freeze cooldown is
  zero
- **the runtime carries the setting to its nodes** — the cluster-level setter
  proves nothing about production; what was broken is the plumbing
- installing a snapshot does not clear it

Each half was checked independently: dropping the `start` call fails the plumbing
test, and restoring the replace-with-default install fails the snapshot test.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`

The `data_node::…jitter_backoff…` and `engine::…recovery_validates_…` failures
reproduce on an unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
