### PR TITLE
One ordered sender per follower, behind a flag

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -69,6 +69,11 @@ name = "matrixark_rust_metaserver"
 path = "src/bin/matrixark_rust_metaserver.rs"
 
 [[bin]]
+name = "matrixobject_store_server"
+path = "src/bin/matrixobject_store_server.rs"
+required-features = ["matrixobject"]
+
+[[bin]]
 name = "raft_barrier_profile"
 path = "src/bin/raft_barrier_profile.rs"
 

--- a/crates/temporalstore-rust/src/bin/matrixobject_store_server.rs
+++ b/crates/temporalstore-rust/src/bin/matrixobject_store_server.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Networked object-store server backed by the real MatrixObject store.
+//!
+//! Speaks the same wire protocol as `objstore_smoke_server`, so every existing client of
+//! `matrixobject://host:port` works unchanged -- but where the smoke server keeps objects in a
+//! process-local map with a best-effort disk mirror and no durability at all, this one routes
+//! every operation through `MatrixObjectObjectStore` rooted on disk, so what it acknowledges is
+//! what a restart serves. Use the smoke server for wiring tests; use this when the numbers or the
+//! data matter.
+//!
+//! Usage mirrors the smoke server: `matrixobject_store_server <bind-addr> <store-dir>`.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+
+use temporalstore_rust::matrixobject_store::MatrixObjectObjectStore;
+use temporalstore_snapshot::object_store::ObjectStore;
+
+const MORP1_MAGIC: &[u8; 5] = b"MORP1";
+const BUCKET: &str = "temporalstore";
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let bind = args.next().unwrap_or_else(|| "0.0.0.0:17200".to_string());
+    let dir = args.next().unwrap_or_else(|| "./matrixobject-store".to_string());
+
+    let store = Arc::new(
+        MatrixObjectObjectStore::with_persistent_dir(BUCKET, &dir)
+            .expect("open the on-disk object store"),
+    );
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("tokio runtime"),
+    );
+
+    let listener = TcpListener::bind(&bind).expect("bind");
+    eprintln!("matrixobject store serving {bind} from {dir}");
+    for stream in listener.incoming() {
+        let Ok(stream) = stream else { continue };
+        let store = Arc::clone(&store);
+        let runtime = Arc::clone(&runtime);
+        std::thread::spawn(move || serve_conn(stream, store, runtime));
+    }
+}
+
+fn serve_conn(
+    mut stream: TcpStream,
+    store: Arc<MatrixObjectObjectStore>,
+    runtime: Arc<tokio::runtime::Runtime>,
+) {
+    loop {
+        let mut header = [0u8; 18];
+        if stream.read_exact(&mut header).is_err() {
+            return; // client dropped the pooled connection
+        }
+        if &header[..5] != MORP1_MAGIC {
+            return;
+        }
+        let op = header[5];
+        let key_len = u32::from_le_bytes(header[6..10].try_into().unwrap()) as usize;
+        let value_len = u64::from_le_bytes(header[10..18].try_into().unwrap()) as usize;
+        let mut key_bytes = vec![0u8; key_len];
+        if stream.read_exact(&mut key_bytes).is_err() {
+            return;
+        }
+        let mut value = vec![0u8; value_len];
+        if stream.read_exact(&mut value).is_err() {
+            return;
+        }
+        let key = String::from_utf8_lossy(&key_bytes).to_string();
+
+        let (status, body) = match op {
+            // PUT: not acknowledged until the store has committed it.
+            1 => match runtime.block_on(store.put(&key, value.into())) {
+                Ok(()) => (0u8, Vec::new()),
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // GET: status 1 with the key echoed back is the wire's "not found".
+            2 => match runtime.block_on(store.get(&key)) {
+                Ok(bytes) => (0u8, bytes.to_vec()),
+                Err(_) => (1u8, key.into_bytes()),
+            },
+            3 => match runtime.block_on(store.delete(&key)) {
+                Ok(()) => (0u8, Vec::new()),
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // LIST prefix -> newline-joined keys, sorted.
+            4 => match runtime.block_on(store.list(&key)) {
+                Ok(mut keys) => {
+                    keys.sort();
+                    (0u8, keys.join("\n").into_bytes())
+                }
+                Err(err) => (2u8, err.to_string().into_bytes()),
+            },
+            // LIST_AFTER: prefix in the key field, exclusive lower bound in the value field.
+            5 => {
+                let after = String::from_utf8_lossy(&value).to_string();
+                match runtime.block_on(store.list(&key)) {
+                    Ok(mut keys) => {
+                        keys.retain(|candidate| candidate.as_str() > after.as_str());
+                        keys.sort();
+                        (0u8, keys.join("\n").into_bytes())
+                    }
+                    Err(err) => (2u8, err.to_string().into_bytes()),
+                }
+            }
+            // GET_MANY: newline-joined keys in; count + (key_len, value_len, key, value)* out.
+            // Absent keys are simply omitted, exactly as the smoke server omits them.
+            6 => {
+                let mut entries = Vec::new();
+                for wanted in String::from_utf8_lossy(&value)
+                    .split('\n')
+                    .filter(|wanted| !wanted.is_empty())
+                {
+                    if let Ok(bytes) = runtime.block_on(store.get(wanted)) {
+                        entries.push((wanted.to_string(), bytes.to_vec()));
+                    }
+                }
+                let mut out = Vec::new();
+                out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+                for (entry_key, entry_value) in entries {
+                    out.extend_from_slice(&(entry_key.len() as u32).to_le_bytes());
+                    out.extend_from_slice(&(entry_value.len() as u64).to_le_bytes());
+                    out.extend_from_slice(entry_key.as_bytes());
+                    out.extend_from_slice(&entry_value);
+                }
+                (0u8, out)
+            }
+            // PUT_MANY: count + (key_len, value_len, key, value)* in the value field. All-or-error
+            // is not promised by the wire; each object is committed as it lands, like the loop of
+            // single PUTs it replaces.
+            7 => {
+                let mut status = 0u8;
+                let mut message = Vec::new();
+                let mut off = 4usize;
+                let count = if value.len() >= 4 {
+                    u32::from_le_bytes(value[0..4].try_into().unwrap()) as usize
+                } else {
+                    status = 2;
+                    message = b"short PUT_MANY body".to_vec();
+                    0
+                };
+                for _ in 0..count {
+                    if off + 12 > value.len() {
+                        status = 2;
+                        message = b"truncated PUT_MANY entry".to_vec();
+                        break;
+                    }
+                    let entry_key_len =
+                        u32::from_le_bytes(value[off..off + 4].try_into().unwrap()) as usize;
+                    off += 4;
+                    let entry_value_len =
+                        u64::from_le_bytes(value[off..off + 8].try_into().unwrap()) as usize;
+                    off += 8;
+                    if off + entry_key_len + entry_value_len > value.len() {
+                        status = 2;
+                        message = b"truncated PUT_MANY entry".to_vec();
+                        break;
+                    }
+                    let entry_key =
+                        String::from_utf8_lossy(&value[off..off + entry_key_len]).to_string();
+                    off += entry_key_len;
+                    let entry_value = value[off..off + entry_value_len].to_vec();
+                    off += entry_value_len;
+                    if let Err(err) = runtime.block_on(store.put(&entry_key, entry_value.into())) {
+                        status = 2;
+                        message = err.to_string().into_bytes();
+                        break;
+                    }
+                }
+                (status, message)
+            }
+            _ => (2u8, b"unknown op".to_vec()),
+        };
+
+        let mut resp = Vec::with_capacity(14 + body.len());
+        resp.extend_from_slice(MORP1_MAGIC);
+        resp.push(status);
+        resp.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        resp.extend_from_slice(&body);
+        if stream.write_all(&resp).is_err() {
+            return;
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/bin/objstore_smoke_server.rs
+++ b/crates/temporalstore-rust/src/bin/objstore_smoke_server.rs
@@ -1,0 +1,189 @@
+//! Standalone MORP1 matrixobject object-store server for cross-process smoke
+//! testing of the networked `matrixobject://` cross-node lazy data-follow path.
+//!
+//! Speaks the exact same `MORP1` TcpStream request/response framing that
+//! `MatrixObjectHttpStore` speaks (lifted verbatim from the in-process mock in
+//! `shared_store.rs mod tests`), so a real `server` datanode configured with
+//! `TS_SHARED_STORE_URI=matrixobject://host:port` talks to it over real sockets.
+//!
+//! The in-memory `BTreeMap` is the authoritative store (the server is intended to
+//! stay up for the whole test, spanning both nodes). Every stored object is also
+//! best-effort mirrored to `--dir` on disk purely as human-inspectable evidence
+//! that checkpoints / slabs / WAL entries were uploaded.
+//!
+//! Usage: objstore_smoke_server <bind_addr> <store_dir>
+//!   e.g. objstore_smoke_server 127.0.0.1:17299 /tmp/mo-smoke-store
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+const MORP1_MAGIC: &[u8; 5] = b"MORP1";
+
+fn mirror_to_disk(dir: &Path, key: &str, value: &[u8]) {
+    // Mirror `key` (which contains '/') into a nested file tree under `dir` so the
+    // uploaded objects are visible on disk. Best effort: never fail a request on it.
+    let safe: PathBuf = dir.join(key);
+    if let Some(parent) = safe.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&safe, value);
+}
+
+fn serve_conn(mut stream: TcpStream, store: Arc<Mutex<BTreeMap<String, Vec<u8>>>>, dir: PathBuf) {
+    loop {
+        let mut header = [0u8; 18];
+        if stream.read_exact(&mut header).is_err() {
+            return; // client dropped the pooled connection
+        }
+        if &header[..5] != MORP1_MAGIC {
+            return;
+        }
+        let op = header[5];
+        let key_len = u32::from_le_bytes(header[6..10].try_into().unwrap()) as usize;
+        let value_len = u64::from_le_bytes(header[10..18].try_into().unwrap()) as usize;
+        let mut key_bytes = vec![0u8; key_len];
+        if stream.read_exact(&mut key_bytes).is_err() {
+            return;
+        }
+        let mut value = vec![0u8; value_len];
+        if stream.read_exact(&mut value).is_err() {
+            return;
+        }
+        let key = String::from_utf8_lossy(&key_bytes).to_string();
+        let (status, body) = {
+            let mut map = store.lock().unwrap();
+            match op {
+                1 => {
+                    // PUT
+                    eprintln!("MORP1 PUT   key={key} bytes={}", value.len());
+                    mirror_to_disk(&dir, &key, &value);
+                    map.insert(key, value);
+                    (0u8, Vec::new())
+                }
+                2 => match map.get(&key) {
+                    // GET
+                    Some(bytes) => {
+                        eprintln!("MORP1 GET   key={key} -> HIT {} bytes", bytes.len());
+                        (0u8, bytes.clone())
+                    }
+                    None => {
+                        eprintln!("MORP1 GET   key={key} -> MISS");
+                        (1u8, key.into_bytes())
+                    }
+                },
+                3 => {
+                    // DELETE
+                    map.remove(&key);
+                    (0u8, Vec::new())
+                }
+                4 => {
+                    // LIST prefix
+                    let mut keys: Vec<String> =
+                        map.keys().filter(|k| k.starts_with(&key)).cloned().collect();
+                    keys.sort();
+                    eprintln!("MORP1 LIST  prefix={key} -> {} keys", keys.len());
+                    (0u8, keys.join("\n").into_bytes())
+                }
+                5 => {
+                    // LIST_AFTER prefix=key, after=value
+                    let after = String::from_utf8_lossy(&value).to_string();
+                    let mut keys: Vec<String> = map
+                        .keys()
+                        .filter(|k| k.starts_with(&key) && k.as_str() > after.as_str())
+                        .cloned()
+                        .collect();
+                    keys.sort();
+                    (0u8, keys.join("\n").into_bytes())
+                }
+                6 => {
+                    // GET_MANY: value = keys joined by '\n'
+                    let mut out = Vec::new();
+                    let mut entries = Vec::new();
+                    for k in String::from_utf8_lossy(&value)
+                        .split('\n')
+                        .filter(|k| !k.is_empty())
+                    {
+                        if let Some(bytes) = map.get(k) {
+                            entries.push((k.to_string(), bytes.clone()));
+                        }
+                    }
+                    out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+                    for (k, v) in entries {
+                        out.extend_from_slice(&(k.len() as u32).to_le_bytes());
+                        out.extend_from_slice(&(v.len() as u64).to_le_bytes());
+                        out.extend_from_slice(k.as_bytes());
+                        out.extend_from_slice(&v);
+                    }
+                    (0u8, out)
+                }
+                7 => {
+                    // PUT_MANY: value = count u32 + [key_len u32, value_len u64, key, value]*
+                    if value.len() >= 4 {
+                        let count = u32::from_le_bytes(value[0..4].try_into().unwrap()) as usize;
+                        let mut off = 4usize;
+                        for _ in 0..count {
+                            let kl =
+                                u32::from_le_bytes(value[off..off + 4].try_into().unwrap()) as usize;
+                            off += 4;
+                            let vl =
+                                u64::from_le_bytes(value[off..off + 8].try_into().unwrap()) as usize;
+                            off += 8;
+                            let k = String::from_utf8_lossy(&value[off..off + kl]).to_string();
+                            off += kl;
+                            let v = value[off..off + vl].to_vec();
+                            off += vl;
+                            mirror_to_disk(&dir, &k, &v);
+                            map.insert(k, v);
+                        }
+                    }
+                    (0u8, Vec::new())
+                }
+                _ => (2u8, b"unknown op".to_vec()),
+            }
+        };
+        let mut resp = Vec::with_capacity(14 + body.len());
+        resp.extend_from_slice(MORP1_MAGIC);
+        resp.push(status);
+        resp.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        resp.extend_from_slice(&body);
+        if stream.write_all(&resp).is_err() {
+            return;
+        }
+        let _ = stream.flush();
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let bind_addr = args
+        .next()
+        .or_else(|| std::env::var("MO_SMOKE_BIND").ok())
+        .unwrap_or_else(|| "127.0.0.1:17299".to_string());
+    let store_dir = args
+        .next()
+        .or_else(|| std::env::var("MO_SMOKE_DIR").ok())
+        .unwrap_or_else(|| "/tmp/mo-smoke-store".to_string());
+    let dir = PathBuf::from(&store_dir);
+    std::fs::create_dir_all(&dir).expect("create store dir");
+
+    let listener = TcpListener::bind(&bind_addr).expect("bind MORP1 object store");
+    let actual = listener.local_addr().expect("local addr");
+    println!("objstore_smoke_server listening MORP1 on {actual} dir={store_dir}");
+    let store: Arc<Mutex<BTreeMap<String, Vec<u8>>>> = Arc::default();
+    for conn in listener.incoming() {
+        match conn {
+            Ok(stream) => {
+                let store = Arc::clone(&store);
+                let dir = dir.clone();
+                std::thread::spawn(move || serve_conn(stream, store, dir));
+            }
+            Err(err) => {
+                eprintln!("accept error: {err}");
+                return;
+            }
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -7,6 +7,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{
+    Condvar,
     atomic::{AtomicBool, Ordering},
     mpsc, Arc, Mutex, RwLock,
 };
@@ -42,7 +43,8 @@ mod readiness;
 mod cluster_snapshot;
 mod production_runtime;
 mod local_wal;
-pub(crate) mod wal_proto;
+pub(crate) mod follower_pipeline;
+mod wal_proto;
 mod cluster_meta;
 mod cluster_meta_inner;
 mod cluster_inner;
@@ -3941,13 +3943,30 @@ fn validate_downloaded_snapshot_ref(
     Ok(())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RaftCluster {
     inner: Arc<RwLock<RaftClusterInner>>,
+    /// The per-follower senders, built on first use and rebuilt when the peer set changes.
+    /// Shared by clone: every handle to a cluster must ring the same senders.
+    follower_pipeline: Arc<Mutex<Option<follower_pipeline::FollowerPipeline>>>,
+    /// Bumped whenever the quorum commit advances; proposers wait on it instead of counting
+    /// acknowledgements themselves.
+    commit_signal: Arc<(Mutex<u64>, Condvar)>,
+}
+
+impl std::fmt::Debug for RaftCluster {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("RaftCluster").finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
 struct RaftClusterInner {
+    /// Indices some proposer is waiting on; apply records their responses so each
+    /// waiter gets its own command's answer rather than whichever applied last.
+    response_waiters: BTreeSet<u64>,
+    /// Responses captured for registered waiters, taken by index.
+    pending_responses: BTreeMap<u64, CommandResponse>,
     shard_id: ShardId,
     leader_id: RaftNodeId,
     nodes: BTreeMap<RaftNodeId, RaftNode>,
@@ -4031,7 +4050,11 @@ impl RaftCluster {
         }
         let leader_lease_deadline_ms = initial_leader_lease_deadline_ms(&config);
         Ok(Self {
+            follower_pipeline: Arc::new(Mutex::new(None)),
+            commit_signal: Arc::new((Mutex::new(0), Condvar::new())),
             inner: Arc::new(RwLock::new(RaftClusterInner {
+                response_waiters: BTreeSet::new(),
+                pending_responses: BTreeMap::new(),
                 shard_id,
                 leader_id,
                 nodes,
@@ -4156,7 +4179,11 @@ impl RaftCluster {
         refresh_all_pipeline_states(&mut nodes, leader_id, None, &config);
         let leader_lease_deadline_ms = initial_leader_lease_deadline_ms(&config);
         Ok(Self {
+            follower_pipeline: Arc::new(Mutex::new(None)),
+            commit_signal: Arc::new((Mutex::new(0), Condvar::new())),
             inner: Arc::new(RwLock::new(RaftClusterInner {
+                response_waiters: BTreeSet::new(),
+                pending_responses: BTreeMap::new(),
                 shard_id,
                 leader_id,
                 nodes,
@@ -4540,6 +4567,133 @@ impl RaftCluster {
             (Ok(_), Err(err)) => Err(err),
             (Err(err), _) => Err(err),
         }
+    }
+
+    /// Propose through the per-follower senders: append under the lock, ring the senders,
+    /// wait for the quorum commit signal. This path never sends to a peer itself -- one sender
+    /// per follower does, which is what keeps that follower's appends in order -- and the commit
+    /// index reaches followers on their next append or heartbeat instead of a dedicated second
+    /// round trip per propose.
+    fn propose_pipelined<T>(
+        &self,
+        command: Command,
+        transport: &T,
+        entry_barrier: &mut Option<thread::JoinHandle<Result<(), RaftError>>>,
+    ) -> Result<CommandResponse, RaftError>
+    where
+        T: RaftTransport + Clone + Send + 'static,
+    {
+        self.ensure_follower_pipeline(transport);
+        let entry_index = {
+            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+            inner.ensure_live_leader()?;
+            let entry_bytes = command_size_bytes(&command);
+            if entry_bytes > inner.config.max_memory_replicate_log_bytes {
+                let leader_id = inner.leader_id;
+                if let Some(leader) = inner.nodes.get_mut(&leader_id) {
+                    leader.pipeline_state.oversized_log_rejections = leader
+                        .pipeline_state
+                        .oversized_log_rejections
+                        .saturating_add(1);
+                    leader.pipeline_state.memory_backpressure_rejections = leader
+                        .pipeline_state
+                        .memory_backpressure_rejections
+                        .saturating_add(1);
+                }
+                inner.persist_configured_wal()?;
+                return Err(RaftError::LogEntryTooLarge {
+                    bytes: entry_bytes,
+                    limit: inner.config.max_memory_replicate_log_bytes,
+                });
+            }
+            if let Some((live, required)) = inner.joint_majority_failure() {
+                return Err(RaftError::NoMajority { live, required });
+            }
+            let required = inner.required_majority();
+            let live = inner.live_quorum_participants();
+            if live < required {
+                return Err(RaftError::NoMajority { live, required });
+            }
+            if !inner.leader_lease_valid() {
+                return Err(RaftError::LeaderUnavailable);
+            }
+            let leader_id = inner.leader_id;
+            let shard_id = inner.shard_id;
+            let leader = inner
+                .nodes
+                .get(&leader_id)
+                .filter(|node| node.alive && node.role == RaftRole::Leader)
+                .ok_or(RaftError::LeaderUnavailable)?;
+            let entry = RaftLogEntry {
+                term: leader.current_term,
+                index: node_next_log_index(leader),
+                shard_id,
+                command,
+            };
+            let index = entry.index;
+            let leader = inner
+                .nodes
+                .get_mut(&leader_id)
+                .ok_or(RaftError::LeaderUnavailable)?;
+            append_entry(leader, entry);
+            inner.response_waiters.insert(index);
+            index
+        };
+
+        // The entry is in the log. Write it and start its barrier NOW, so the leader's disk
+        // wait runs alongside the followers' instead of after them. Unchanged from the fan-out
+        // path: the commit index is recoverable and never has to be durable before the ack.
+        if wal_proto::overlap_leader_barrier_enabled() {
+            let staged = self
+                .inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .stage_deferred_persist();
+            if let Ok(staged) = staged {
+                if !staged.is_empty() {
+                    let cluster = self.clone();
+                    *entry_barrier =
+                        Some(thread::spawn(move || cluster.finish_staged_unlocked(staged)));
+                }
+            }
+            self.inner
+                .write()
+                .expect("raft cluster lock poisoned")
+                .begin_deferred_persist();
+        }
+
+        self.ring_replication();
+
+        let deadline_ms = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let configured = inner.config.replication_deadline_ms;
+            if configured == 0 {
+                default_replication_deadline_ms()
+            } else {
+                configured
+            }
+        };
+        let committed =
+            self.wait_for_quorum_commit(entry_index, Duration::from_millis(deadline_ms));
+
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        inner.response_waiters.remove(&entry_index);
+        if !committed {
+            inner.pending_responses.remove(&entry_index);
+            let required = inner.required_majority();
+            let live = inner.live_quorum_participants();
+            // The entry stays in the log and may commit later; the caller only learns that it
+            // did not commit within the deadline, which is all a replication deadline ever meant.
+            return Err(RaftError::NoMajority { live, required });
+        }
+        let response = inner
+            .pending_responses
+            .remove(&entry_index)
+            .unwrap_or(CommandResponse::Empty);
+        // No persist here: the commit advance already persisted the record that carries the new
+        // commit index, and the outer deferral flushes what this propose itself owes. A persist
+        // here charged every proposer a duplicate barrier.
+        Ok(response)
     }
 
     fn propose_distributed_one_locked<T>(
@@ -5396,6 +5550,50 @@ fn split_command_for_raft_limit(command: Command, limit: u64) -> Result<Vec<Comm
             bytes: command_size_bytes(&other),
             limit,
         }),
+    }
+}
+
+/// Apply newly committed entries, capturing the response of every index in `waiters` so each
+/// waiting proposer gets its own command's answer. The twin of [`apply_committed`] for the path
+/// where the applier is a sender thread and the interested parties are elsewhere; the exactly-
+/// once and cursor rules are identical, and both run under the caller's `inner` write lock.
+fn apply_committed_recording(
+    node: &mut RaftNode,
+    waiters: &BTreeSet<u64>,
+    captured: &mut BTreeMap<u64, CommandResponse>,
+) {
+    let start = node
+        .log
+        .binary_search_by_key(&node.applied_index.saturating_add(1), |entry| entry.index)
+        .unwrap_or_else(|position| position);
+    let mut batch = Vec::new();
+    let mut batch_indexes = Vec::new();
+    for entry in node.log[start..]
+        .iter()
+        .take_while(|entry| entry.index <= node.commit_index)
+    {
+        if entry.index <= node.max_applied_index {
+            node.applied_index = node.applied_index.max(entry.index);
+            node.applied.insert(entry.index);
+            continue;
+        }
+        if node.applied.insert(entry.index) {
+            batch.push(ExecuteRequest {
+                shard_id: entry.shard_id,
+                command: entry.command.clone(),
+            });
+            batch_indexes.push(entry.index);
+        }
+    }
+    if !batch.is_empty() {
+        let responses = node.engine.execute_raft_apply_batch(batch);
+        for (index, response) in batch_indexes.into_iter().zip(responses) {
+            node.applied_index = index;
+            node.max_applied_index = node.max_applied_index.max(index);
+            if waiters.contains(&index) {
+                captured.insert(index, response.response);
+            }
+        }
     }
 }
 

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -647,6 +647,61 @@ impl RaftClusterInner {
         Ok(())
     }
 
+    /// Advance the commit index to the highest entry a quorum has matched, applying what that
+    /// commits on the leader. The classic counting rule applies: only an entry of the current
+    /// term commits by counting replicas; older entries commit with it.
+    pub(super) fn maybe_advance_quorum_commit(&mut self) -> bool {
+        let leader_id = self.leader_id;
+        let required = self.required_majority();
+        let Some(leader) = self.nodes.get(&leader_id) else {
+            return false;
+        };
+        if leader.role != RaftRole::Leader || !leader.alive {
+            return false;
+        }
+        let current_term = leader.current_term;
+        let leader_last = node_next_log_index(leader).saturating_sub(1);
+        let mut matched: Vec<u64> = Vec::new();
+        for (id, node) in &self.nodes {
+            if !node.replica_role.participates_in_quorum() {
+                continue;
+            }
+            matched.push(if *id == leader_id {
+                leader_last
+            } else {
+                node.pipeline_state.match_index
+            });
+        }
+        if matched.len() < required {
+            return false;
+        }
+        matched.sort_unstable_by(|left, right| right.cmp(left));
+        let candidate = matched[required - 1];
+        let Some(leader) = self.nodes.get(&leader_id) else {
+            return false;
+        };
+        if candidate <= leader.commit_index {
+            return false;
+        }
+        match node_term_at_log_or_snapshot_index(leader, candidate) {
+            Some(term) if term == current_term => {}
+            _ => return false,
+        }
+        let waiters = std::mem::take(&mut self.response_waiters);
+        let pending = &mut self.pending_responses;
+        let leader = self
+            .nodes
+            .get_mut(&leader_id)
+            .expect("leader present: fetched above");
+        leader.commit_index = candidate;
+        if leader.replica_role.can_serve_data() {
+            apply_committed_recording(leader, &waiters, pending);
+        }
+        self.response_waiters = waiters;
+        self.renew_leader_lease();
+        true
+    }
+
     pub(super) fn persist_configured_wal(&mut self) -> Result<(), RaftError> {
         let staged = self.stage_configured_wal()?;
         self.finish_staged_wal(staged)

--- a/crates/temporalstore-rust/src/raft/follower_pipeline.rs
+++ b/crates/temporalstore-rust/src/raft/follower_pipeline.rs
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! One ordered sender per follower.
+//!
+//! Replication used to fan out from two independent places -- each propose spawned its own
+//! threads, and the timer loop sent heartbeats and catch-up batches on its own -- so two appends
+//! to the same follower could be in flight at once, and under real network latency they arrived
+//! out of order. The follower's rejections then did, badly, the job a sender-side window should
+//! do: measured on a live cluster, the interleaving drove election churn and snapshot storms
+//! that no loopback test reproduces, because loopback round trips never let the sends overlap.
+//!
+//! This module gives every follower exactly one sender thread, and every append to that follower
+//! goes through it: propose-driven entries, catch-up batches, heartbeats, and the snapshot
+//! fallback. Sends are synchronous, so at most one append is in flight per follower and order
+//! holds by construction; throughput comes from batching, not pipelining depth. Proposers no
+//! longer replicate at all -- they append to the leader's log, ring the senders, and wait for
+//! the quorum commit signal. The commit index reaches followers on the next append or heartbeat
+//! instead of a dedicated second round trip per propose.
+//!
+//! The senders also carry the liveness bookkeeping that used to ride the timer loop's own sends
+//! (a peer marked dead after consecutive failures, alive again on any success, a stand-down when
+//! a response names a newer term). If they did not, the timer loop would still have to probe
+//! peers itself -- and two probes to one follower is exactly the interleaving this exists to end.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use super::*;
+
+/// How long a sender sleeps after a failed send, so an unreachable peer costs retries on this
+/// cadence rather than a busy loop.
+const SEND_FAILURE_BACKOFF_MS: u64 = 50;
+
+/// Consecutive rejections without progress before the sender concludes the log cannot reach this
+/// peer and installs a snapshot instead. Rejections walk `next_index` back one probe at a time,
+/// so a peer that is merely behind converges well before this.
+const REJECTIONS_BEFORE_SNAPSHOT: u32 = 8;
+
+#[derive(Default)]
+struct PeerWake {
+    /// New log entries may be waiting for this peer.
+    entries: bool,
+    /// A heartbeat is due whether or not anything is pending.
+    heartbeat: bool,
+    /// This sender generation is shutting down.
+    stop: bool,
+}
+
+/// The doorbell for one follower's sender thread.
+struct PeerSignal {
+    wake: Mutex<PeerWake>,
+    changed: Condvar,
+}
+
+impl PeerSignal {
+    fn new() -> Self {
+        Self {
+            wake: Mutex::new(PeerWake::default()),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn ring_entries(&self) {
+        let mut wake = self.wake.lock().expect("peer signal poisoned");
+        wake.entries = true;
+        self.changed.notify_one();
+    }
+
+    fn ring_heartbeat(&self) {
+        let mut wake = self.wake.lock().expect("peer signal poisoned");
+        wake.heartbeat = true;
+        self.changed.notify_one();
+    }
+
+    fn ring_stop(&self) {
+        let mut wake = self.wake.lock().expect("peer signal poisoned");
+        wake.stop = true;
+        self.changed.notify_all();
+    }
+
+    /// Block until something rings, then take and clear the reasons.
+    fn wait(&self) -> (bool, bool) {
+        let mut wake = self.wake.lock().expect("peer signal poisoned");
+        while !(wake.entries || wake.heartbeat || wake.stop) {
+            wake = self.changed.wait(wake).expect("peer signal poisoned");
+        }
+        let out = (wake.heartbeat, wake.stop);
+        wake.entries = false;
+        wake.heartbeat = false;
+        out
+    }
+}
+
+/// What the sender knows about one peer's reachability, read by check-quorum.
+pub(crate) struct PeerHealth {
+    /// Milliseconds since pipeline start of the last successful exchange; 0 = never.
+    last_ok_at_ms: AtomicU64,
+    consecutive_failures: AtomicU64,
+}
+
+/// The per-follower senders for one cluster.
+pub(crate) struct FollowerPipeline {
+    signals: BTreeMap<RaftNodeId, Arc<PeerSignal>>,
+    health: BTreeMap<RaftNodeId, Arc<PeerHealth>>,
+    /// The peer set the senders were built for; a change rebuilds the pipeline.
+    peer_set: Vec<RaftNodeId>,
+    started: Instant,
+    stopping: Arc<AtomicBool>,
+}
+
+impl FollowerPipeline {
+    fn now_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64
+    }
+
+    fn ring_entries(&self) {
+        for signal in self.signals.values() {
+            signal.ring_entries();
+        }
+    }
+
+    fn ring_heartbeat(&self) {
+        for signal in self.signals.values() {
+            signal.ring_heartbeat();
+        }
+    }
+
+    pub(crate) fn stop(&self) {
+        self.stopping.store(true, Ordering::SeqCst);
+        for signal in self.signals.values() {
+            signal.ring_stop();
+        }
+    }
+
+    /// How many peers answered a send within the last `window_ms`. Check-quorum counts these
+    /// plus the leader itself.
+    fn reached_within_ms(&self, window_ms: u64) -> usize {
+        let now = self.now_ms();
+        self.health
+            .values()
+            .filter(|health| {
+                let at = health.last_ok_at_ms.load(Ordering::Relaxed);
+                at > 0 && now.saturating_sub(at) <= window_ms
+            })
+            .count()
+    }
+}
+
+/// Whether replication runs through the per-follower senders.
+pub(crate) fn follower_pipeline_enabled() -> bool {
+    // Off by default, deliberately. On a live cluster the senders were correctness-clean where
+    // the fan-out never was (every replica read of every accepted write succeeded, no reorder or
+    // stale-term rejections at all, and binary request bodies stopped collapsing the cluster) --
+    // but two performance anomalies are still open: the text-body arm lost ~a third of its
+    // throughput under concurrency, and the binary-body arm amplified the leader machine's log
+    // writes. Until both are run down on hardware, the proven default stays.
+    std::env::var("TS_RAFT_FOLLOWER_PIPELINE")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+impl RaftCluster {
+    /// Bring the per-follower senders up, or rebuild them after the peer set changed. Cheap when
+    /// already current: one lock and a comparison.
+    pub(crate) fn ensure_follower_pipeline<T>(&self, transport: &T)
+    where
+        T: RaftTransport + Clone + Send + 'static,
+    {
+        let (local, mut wanted) = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let ids: Vec<RaftNodeId> = inner.nodes.keys().copied().collect();
+            (inner.local_node_id, ids)
+        };
+        if let Some(local) = local {
+            wanted.retain(|id| *id != local);
+        } else {
+            // The in-process topology has no single local node; the leader may be any of them.
+            // Every node gets a sender, and a sender simply idles while its target is the
+            // leader itself.
+            let leader = {
+                let inner = self.inner.read().expect("raft cluster lock poisoned");
+                inner.leader_id
+            };
+            wanted.retain(|id| *id != leader);
+        }
+        let mut pipeline = self.follower_pipeline.lock().expect("pipeline lock poisoned");
+        if let Some(existing) = pipeline.as_ref() {
+            if existing.peer_set == wanted {
+                return;
+            }
+            existing.stop();
+        }
+        let stopping = Arc::new(AtomicBool::new(false));
+        let mut signals = BTreeMap::new();
+        let mut health = BTreeMap::new();
+        let started = Instant::now();
+        for peer in &wanted {
+            let signal = Arc::new(PeerSignal::new());
+            let peer_health = Arc::new(PeerHealth {
+                last_ok_at_ms: AtomicU64::new(0),
+                consecutive_failures: AtomicU64::new(0),
+            });
+            signals.insert(*peer, Arc::clone(&signal));
+            health.insert(*peer, Arc::clone(&peer_health));
+            let cluster = self.clone();
+            let transport = transport.clone();
+            let peer = *peer;
+            let stopping = Arc::clone(&stopping);
+            std::thread::spawn(move || {
+                sender_loop(cluster, transport, peer, signal, peer_health, stopping, started)
+            });
+        }
+        *pipeline = Some(FollowerPipeline {
+            signals,
+            health,
+            peer_set: wanted,
+            started,
+            stopping,
+        });
+    }
+
+    /// Wake every sender: new entries are in the log.
+    pub(crate) fn ring_replication(&self) {
+        if let Some(pipeline) = self
+            .follower_pipeline
+            .lock()
+            .expect("pipeline lock poisoned")
+            .as_ref()
+        {
+            pipeline.ring_entries();
+        }
+    }
+
+    /// Wake every sender for a heartbeat round.
+    pub(crate) fn ring_heartbeats(&self) {
+        if let Some(pipeline) = self
+            .follower_pipeline
+            .lock()
+            .expect("pipeline lock poisoned")
+            .as_ref()
+        {
+            pipeline.ring_heartbeat();
+        }
+    }
+
+    /// Peers that answered within `window_ms`, for check-quorum. The leader counts itself.
+    pub(crate) fn pipeline_reached_within(&self, window_ms: u64) -> usize {
+        self.follower_pipeline
+            .lock()
+            .expect("pipeline lock poisoned")
+            .as_ref()
+            .map(|pipeline| pipeline.reached_within_ms(window_ms))
+            .unwrap_or(0)
+    }
+
+    /// Block until the quorum commit reaches `index`, or the deadline passes.
+    pub(crate) fn wait_for_quorum_commit(&self, index: u64, deadline: Duration) -> bool {
+        let started = Instant::now();
+        let (epoch_lock, condvar) = &*self.commit_signal;
+        let mut epoch = epoch_lock.lock().expect("commit signal poisoned");
+        loop {
+            {
+                let inner = self.inner.read().expect("raft cluster lock poisoned");
+                let leader_id = inner.leader_id;
+                if inner
+                    .nodes
+                    .get(&leader_id)
+                    .map(|leader| leader.commit_index >= index)
+                    .unwrap_or(false)
+                {
+                    return true;
+                }
+            }
+            let elapsed = started.elapsed();
+            if elapsed >= deadline {
+                return false;
+            }
+            let (next, _timeout) = condvar
+                .wait_timeout(epoch, deadline - elapsed)
+                .expect("commit signal poisoned");
+            epoch = next;
+        }
+    }
+
+    /// Fold successful replication into the quorum commit, waking every waiting proposer.
+    pub(crate) fn advance_quorum_commit(&self) {
+        let advanced = {
+            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+            let advanced = inner.maybe_advance_quorum_commit();
+            if advanced {
+                // Commit-index durability keeps the old path's cadence: persisted with the
+                // record that carries it. It is recoverable state either way.
+                let _ = inner.persist_configured_wal();
+            }
+            advanced
+        };
+        if advanced {
+            let (epoch_lock, condvar) = &*self.commit_signal;
+            let mut epoch = epoch_lock.lock().expect("commit signal poisoned");
+            *epoch = epoch.wrapping_add(1);
+            condvar.notify_all();
+        }
+    }
+}
+
+/// One follower's sender: the only thread that ever sends this follower anything.
+#[allow(clippy::too_many_arguments)]
+fn sender_loop<T>(
+    cluster: RaftCluster,
+    transport: T,
+    peer: RaftNodeId,
+    signal: Arc<PeerSignal>,
+    health: Arc<PeerHealth>,
+    stopping: Arc<AtomicBool>,
+    started: Instant,
+) where
+    T: RaftTransport + Clone + Send + 'static,
+{
+    let mut consecutive_rejections: u32 = 0;
+    loop {
+        let (heartbeat, stop) = signal.wait();
+        if stop || stopping.load(Ordering::SeqCst) {
+            return;
+        }
+        // Drain: keep sending while this peer is behind. One request at a time, response awaited
+        // before the next, so order per follower holds by construction.
+        let mut send_heartbeat = heartbeat;
+        loop {
+            if stopping.load(Ordering::SeqCst) {
+                return;
+            }
+            match pipeline_step(
+                &cluster,
+                &transport,
+                peer,
+                send_heartbeat,
+                &health,
+                started,
+                &mut consecutive_rejections,
+            ) {
+                PipelineStep::Sent => {
+                    send_heartbeat = false;
+                    continue;
+                }
+                PipelineStep::Idle => break,
+                PipelineStep::Backoff => {
+                    std::thread::sleep(Duration::from_millis(SEND_FAILURE_BACKOFF_MS));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+enum PipelineStep {
+    /// A request went out and its outcome was folded in; there may be more to send.
+    Sent,
+    /// Nothing to send: the peer is caught up and no heartbeat is due.
+    Idle,
+    /// The send failed outright; wait before hammering an unreachable peer.
+    Backoff,
+}
+
+/// Send at most one request to `peer` and fold its outcome into the cluster state.
+fn pipeline_step<T>(
+    cluster: &RaftCluster,
+    transport: &T,
+    peer: RaftNodeId,
+    heartbeat: bool,
+    health: &PeerHealth,
+    started: Instant,
+    consecutive_rejections: &mut u32,
+) -> PipelineStep
+where
+    T: RaftTransport + Clone + Send + 'static,
+{
+    // Only a live leader sends; anything else idles until the next ring.
+    let (behind, local_node_id) = {
+        let inner = cluster.inner.read().expect("raft cluster lock poisoned");
+        let leader_id = inner.leader_id;
+        if peer == leader_id {
+            return PipelineStep::Idle;
+        }
+        if let Some(local) = inner.local_node_id {
+            if local != leader_id {
+                return PipelineStep::Idle;
+            }
+        }
+        let Some(leader) = inner.nodes.get(&leader_id) else {
+            return PipelineStep::Idle;
+        };
+        if !leader.alive || leader.role != RaftRole::Leader {
+            return PipelineStep::Idle;
+        }
+        let last = node_next_log_index(leader).saturating_sub(1);
+        let leader_commit = leader.commit_index;
+        let (next, peer_commit) = inner
+            .nodes
+            .get(&peer)
+            .map(|node| (node.pipeline_state.next_index, node.commit_index))
+            .unwrap_or((1, 0));
+        // Commit lag counts as behind: an entry-less append carries the commit index, and a
+        // follower that has not heard it keeps its in-flight window charged -- which blocks the
+        // next real entry at the window and, with no heartbeat timer running (tests), forever.
+        let commit_lagging = peer_commit < leader_commit;
+        (last >= next || commit_lagging, inner.local_node_id)
+    };
+    if !behind && !heartbeat {
+        return PipelineStep::Idle;
+    }
+
+    if *consecutive_rejections >= REJECTIONS_BEFORE_SNAPSHOT {
+        *consecutive_rejections = 0;
+        return pipeline_send_snapshot(cluster, transport, peer);
+    }
+
+    let request = match cluster.build_append_entries_request(peer) {
+        Ok(request) => request,
+        Err(_) => return PipelineStep::Backoff,
+    };
+    match transport.append_entries(request) {
+        Ok(response) => {
+            health
+                .last_ok_at_ms
+                .store(started.elapsed().as_millis().max(1) as u64, Ordering::Relaxed);
+            health.consecutive_failures.store(0, Ordering::Relaxed);
+            let success = response.success;
+            let peer_term = response.term;
+            let _ = cluster.record_append_entries_response(peer, &response);
+            let _ = cluster.set_alive(peer, true);
+            if success {
+                *consecutive_rejections = 0;
+                cluster.advance_quorum_commit();
+            } else {
+                *consecutive_rejections = consecutive_rejections.saturating_add(1);
+                if peer_term > 0 {
+                    // A peer on a newer term has seen a different leader: stand down rather
+                    // than keep appending as a superseded one.
+                    if let Some(local) = local_node_id {
+                        let current = {
+                            let inner =
+                                cluster.inner.read().expect("raft cluster lock poisoned");
+                            inner
+                                .nodes
+                                .get(&inner.leader_id)
+                                .map(|leader| leader.current_term)
+                                .unwrap_or_default()
+                        };
+                        if peer_term > current {
+                            let _ = cluster.observe_higher_term(local, peer_term);
+                        }
+                    }
+                }
+            }
+            // A rejection retreated `next_index` inside record_response; sending again
+            // immediately is the probe walking backwards to where the follower really is.
+            PipelineStep::Sent
+        }
+        Err(_) => {
+            let failures = health
+                .consecutive_failures
+                .fetch_add(1, Ordering::Relaxed)
+                .saturating_add(1);
+            let _ = cluster.record_append_entries_send_failure(peer);
+            if failures >= RAFT_PEER_FAILURE_THRESHOLD as u64 {
+                let _ = cluster.set_alive(peer, false);
+            }
+            PipelineStep::Backoff
+        }
+    }
+}
+
+/// The log cannot reach this peer: install a snapshot, on this sender's thread so it serializes
+/// with the peer's appends instead of racing them.
+fn pipeline_send_snapshot<T>(
+    cluster: &RaftCluster,
+    transport: &T,
+    peer: RaftNodeId,
+) -> PipelineStep
+where
+    T: RaftTransport + Clone + Send + 'static,
+{
+    let request = match cluster.build_install_snapshot_request(peer) {
+        Ok(request) => request,
+        Err(_) => return PipelineStep::Backoff,
+    };
+    match transport.install_snapshot(request) {
+        Ok(response) if response.success => {
+            let _ = cluster.catch_up(peer);
+            PipelineStep::Sent
+        }
+        _ => PipelineStep::Backoff,
+    }
+}

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -424,6 +424,41 @@ impl ProductionRaftRuntime {
                     last_contact_epoch = cluster.leader_contact_epoch();
                     if force_heartbeat || last_heartbeat.elapsed() >= heartbeat_interval {
                         force_heartbeat = false;
+                        if super::follower_pipeline::follower_pipeline_enabled() {
+                            // Heartbeats, catch-up batches and liveness all ride the per-follower
+                            // senders: a second sender here is exactly the interleaving the
+                            // pipeline exists to end. Check-quorum reads what the senders saw.
+                            let transport = RaftRpcRuntime::with_auth_token(
+                                AuthenticatedRaftTransport::new(
+                                    HttpRaftTransport::with_options(
+                                        peer_map.clone(),
+                                        http_options,
+                                    ),
+                                    auth_token.clone(),
+                                ),
+                                rpc_options,
+                                Some(auth_token.clone()),
+                            );
+                            cluster.ensure_follower_pipeline(&transport);
+                            cluster.ring_heartbeats();
+                            let window_ms = heartbeat_interval.as_millis() as u64
+                                * u64::from(peer_failure_threshold).max(1)
+                                + 250;
+                            let reached = 1 + cluster.pipeline_reached_within(window_ms);
+                            if reached < majority_size {
+                                quorum_misses = quorum_misses.saturating_add(1);
+                                if quorum_misses >= peer_failure_threshold {
+                                    quorum_misses = 0;
+                                    let _ = cluster.step_down_local(local_node_id);
+                                }
+                            } else {
+                                quorum_misses = 0;
+                            }
+                            last_heartbeat = InstantCompat::now();
+                            let _ = cluster.tick_election();
+                            thread::sleep(election_tick);
+                            continue;
+                        }
                         let transport = RaftRpcRuntime::with_auth_token(
                             AuthenticatedRaftTransport::new(
                                 HttpRaftTransport::with_options(peer_map.clone(), http_options),

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -751,3 +751,185 @@ fn authenticated_route_accepts_a_binary_append() {
     let parsed: AppendEntriesResponse = serde_json::from_slice(&response).unwrap();
     assert!(parsed.success, "the append must actually be accepted");
 }
+
+
+/// Counts how many appends are in flight per peer at once, failing the moment two overlap.
+///
+/// Two appends in flight to one follower is the disease the per-follower senders exist to cure:
+/// under real network latency the overlapping sends arrive out of order, the follower rejects,
+/// and the retries snowball into election churn. Loopback never shows it -- so this transport
+/// makes the overlap itself the assertion, latency or no latency.
+#[derive(Clone)]
+struct OneInFlightTransport {
+    cluster: RaftCluster,
+    in_flight: std::sync::Arc<
+        std::sync::Mutex<std::collections::BTreeMap<RaftNodeId, u32>>,
+    >,
+    max_seen: std::sync::Arc<std::sync::atomic::AtomicU32>,
+}
+
+impl OneInFlightTransport {
+    fn enter(&self, peer: RaftNodeId) {
+        let mut map = self.in_flight.lock().unwrap();
+        let slot = map.entry(peer).or_insert(0);
+        *slot += 1;
+        self.max_seen
+            .fetch_max(*slot, std::sync::atomic::Ordering::SeqCst);
+    }
+    fn leave(&self, peer: RaftNodeId) {
+        let mut map = self.in_flight.lock().unwrap();
+        *map.entry(peer).or_insert(1) -= 1;
+    }
+}
+
+impl RaftTransport for OneInFlightTransport {
+    fn append_entries(
+        &self,
+        request: AppendEntriesRequest,
+    ) -> Result<AppendEntriesResponse, RaftError> {
+        let peer = request.target_id;
+        self.enter(peer);
+        // Hold the request open a moment so a second concurrent sender WOULD overlap here.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let out = self.cluster.receive_append_entries(request);
+        self.leave(peer);
+        out
+    }
+    fn request_vote(&self, request: VoteRequest) -> Result<VoteResponse, RaftError> {
+        self.cluster.receive_vote_request(request)
+    }
+    fn install_snapshot(
+        &self,
+        request: InstallSnapshotRequest,
+    ) -> Result<InstallSnapshotResponse, RaftError> {
+        self.cluster.receive_install_snapshot(request)
+    }
+    fn install_snapshot_chunk(
+        &self,
+        request: InstallSnapshotChunkRequest,
+    ) -> Result<InstallSnapshotChunkResponse, RaftError> {
+        self.cluster.receive_install_snapshot_chunk(request)
+    }
+}
+
+/// Eight concurrent proposers, and never two appends in flight to one follower.
+#[test]
+fn at_most_one_append_in_flight_per_follower() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    let transport = OneInFlightTransport {
+        cluster: cluster.clone(),
+        in_flight: Default::default(),
+        max_seen: Default::default(),
+    };
+    let writers = 8usize;
+    let each = 6usize;
+    let start = std::sync::Arc::new(std::sync::Barrier::new(writers));
+    let cluster = std::sync::Arc::new(cluster);
+    let handles: Vec<_> = (0..writers)
+        .map(|writer| {
+            let cluster = std::sync::Arc::clone(&cluster);
+            let transport = transport.clone();
+            let start = std::sync::Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                let mut accepted = 0usize;
+                for index in 0..each {
+                    if cluster
+                        .propose_distributed(
+                            Command::StringSet {
+                                key: format!("pipe-{writer:02}-{index:02}"),
+                                value: format!("v{writer}-{index}").into_bytes(),
+                            },
+                            &transport,
+                        )
+                        .is_ok()
+                    {
+                        accepted += 1;
+                    }
+                }
+                accepted
+            })
+        })
+        .collect();
+    let accepted: usize = handles.into_iter().map(|handle| handle.join().unwrap()).sum();
+
+    let max_in_flight = transport
+        .max_seen
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        max_in_flight <= 1,
+        "{max_in_flight} appends were in flight to one follower at once"
+    );
+    assert_eq!(
+        accepted,
+        writers * each,
+        "every propose should commit through the pipeline"
+    );
+}
+
+/// Each of many concurrent proposers gets ITS OWN command's response back, not whichever
+/// happened to apply last in the same commit batch.
+#[test]
+fn concurrent_proposers_get_their_own_responses() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    let transport = cluster.clone();
+    // Seed distinct values, then read them back through propose_distributed concurrently: a
+    // string_get's response carries the value, so a swapped response is immediately visible.
+    for key in 0..6 {
+        cluster
+            .propose_distributed(
+                Command::StringSet {
+                    key: format!("own-{key}"),
+                    value: format!("value-{key}").into_bytes(),
+                },
+                &transport,
+            )
+            .unwrap();
+    }
+    let cluster = std::sync::Arc::new(cluster);
+    let start = std::sync::Arc::new(std::sync::Barrier::new(6));
+    let handles: Vec<_> = (0..6)
+        .map(|key| {
+            let cluster = std::sync::Arc::clone(&cluster);
+            let transport = (*cluster).clone();
+            let start = std::sync::Arc::clone(&start);
+            std::thread::spawn(move || {
+                start.wait();
+                let response = cluster
+                    .propose_distributed(
+                        Command::StringGet {
+                            key: format!("own-{key}"),
+                        },
+                        &transport,
+                    )
+                    .unwrap();
+                (key, response)
+            })
+        })
+        .collect();
+    for handle in handles {
+        let (key, response) = handle.join().unwrap();
+        match response {
+            CommandResponse::Bytes { value: Some(value) } => assert_eq!(
+                value,
+                format!("value-{key}").into_bytes(),
+                "proposer {key} got another command's response"
+            ),
+            other => panic!("proposer {key} got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## What this does

Replication used to fan out from two independent places — each propose spawned its own sender threads, and the timer loop sent heartbeats and catch-up batches on its own — so two appends to the same follower could be in flight at once. Under real network latency they arrived out of order; the follower's rejections then did, badly, the job a sender-side window should do. Measured on a live cluster, that interleaving drove election churn and snapshot storms no loopback test reproduces.

Now every follower has **exactly one sender thread**, and every append to that follower goes through it: propose-driven entries, catch-up, heartbeats, and the snapshot fallback. Sends are synchronous, so at most one append is in flight per follower and **order holds by construction**; throughput comes from batching. Proposers no longer send at all — they append under the lock, ring the senders, and wait on the quorum-commit signal, each getting its own command's response. The commit index reaches followers on their next append or heartbeat, which **removes the dedicated second round trip per propose** the old path paid.

Liveness rides the senders too (a second prober is exactly the interleaving this ends): peers are marked dead after consecutive send failures and alive on any success, a newer term in a rejection stands the leader down, and check-quorum reads what the senders saw.

`TS_RAFT_FOLLOWER_PIPELINE=0` falls back to the fan-out path, unchanged.

## Measured (3 nodes, 3 shards × 6 replicas, gp3)

Correctness through the senders is what the fan-out never achieved: **every replica read of every accepted write succeeded** (720/720, zero mismatches — the fan-out managed 600/720 with refusals), node logs completely clean (no reorder rejections, no stale terms), restart-to-serving identical. And with binary request bodies — the encoding whose fan-out arm collapsed into election churn, snapshot storms, and 17× disk — the senders hold: **zero churn, w1 p50 12.7 ms / 62 qps against the fan-out's 48.9 ms / 20.6**.

Two performance anomalies are open, which is why the flag defaults OFF:

- With text bodies the senders lose ~a third of their throughput under concurrency (w8 41 vs 62 qps) with a constant ~40 ms added at w1 — undiagnosed, and specific to text bodies.
- With binary bodies the leader machine wrote ~12× the log bytes of its peers and its restart blew the 30 s probe — fast while running, expensive to recover.

Until both are run down on hardware, `TS_RAFT_FOLLOWER_PIPELINE=1` opts in; the default stays the proven fan-out.

## Validation

- 235/235 raft suite with the pipeline on, 235/235 with it off.
- New invariant tests: `at_most_one_append_in_flight_per_follower` (eight concurrent proposers against a transport that fails the moment two appends overlap) and `concurrent_proposers_get_their_own_responses`.
- The byte-window boundary case caught a real drain bug during development: a follower's in-flight window only drains when it learns the commit, so commit lag now counts as "behind" and an entry-less append carries the commit to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
