### PR TITLE
A change that applies nothing no longer reports success

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -601,7 +601,15 @@ impl MetaRaftCluster {
             .ok_or(RaftError::LeaderUnavailable)?;
         let entry = MetaLogEntry {
             term: leader.current_term,
-            index: leader.log.last().map(|entry| entry.index + 1).unwrap_or(1),
+            // Numbered from the log *or the installed snapshot*, whichever is
+            // further along. Installing a meta snapshot truncates the log and
+            // marks everything up to the snapshot applied, so taking the next
+            // index from the log alone restarted numbering at 1 -- indices the
+            // node had already applied. Every proposal after an install was
+            // skipped as a duplicate, and `propose_mutation` turns "not applied"
+            // into `Status::ok`, so the change was discarded and reported
+            // successful.
+            index: meta_node_last_log_or_snapshot_index(leader) + 1,
             command,
         };
         let mut replicated = 0;

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -44,7 +44,22 @@ impl MetaRaftCluster {
     pub fn propose_mutation(&self, mutation: MetaMutation) -> Result<Status, RaftError> {
         Ok(self
             .propose_inner(MetaCommand::ApplyMutation(mutation))?
-            .unwrap_or_else(Status::ok))
+            .unwrap_or_else(|| {
+                // `apply_meta_committed` answers `None` only when it applied
+                // nothing, which for a change just appended and committed means
+                // the entry was skipped as already applied. Reporting that as
+                // success is what let a numbering defect discard every metadata
+                // change after a snapshot install while every caller was told
+                // the change had been made.
+                //
+                // Not reachable today, and that is the point: this is the
+                // difference between the next defect of that shape being loud
+                // and being silent.
+                Status::error(
+                    "mutation_not_applied",
+                    "the metaserver committed this change and applied nothing",
+                )
+            }))
     }
 
     pub fn register(&self, request: RegisterShardRequest) -> RegisterShardResponse {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1110,6 +1110,28 @@ fn a_snapshot_install_does_not_rewind_the_commit_index() {
 }
 
 #[test]
+fn an_ordinary_change_still_reports_success() {
+    // The guard on "committed but applied nothing" must not catch the normal
+    // path: every real change still has to come back ok, before and after a
+    // snapshot install.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "before".to_string()
+        })
+        .status
+        .ok);
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    let after = meta.add_namespace(AddNamespaceRequest {
+        namespace: "after".to_string(),
+    });
+    assert!(after.status.ok, "{:?}", after.status);
+    assert_ne!(after.status.code, "mutation_not_applied");
+}
+
+#[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1013,6 +1013,102 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
     assert!(response.status.message.contains("majority"));
 }
 
+fn cluster_with_an_installed_snapshot() -> MetaRaftCluster {
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "before".to_string()
+        })
+        .status
+        .ok);
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    meta
+}
+
+#[test]
+fn a_change_after_a_snapshot_install_actually_takes_effect() {
+    // Installing a meta snapshot truncates the log and marks everything up to
+    // the snapshot applied. The next index came from the log alone, so
+    // numbering restarted at 1 -- indices the node had already applied. Every
+    // proposal after an install was skipped as a duplicate and reported ok, so
+    // the cluster accepted metadata changes and silently discarded them.
+    let meta = cluster_with_an_installed_snapshot();
+
+    let added = meta.add_namespace(AddNamespaceRequest {
+        namespace: "after".to_string(),
+    });
+    assert!(added.status.ok, "{:?}", added.status);
+
+    let namespaces = meta
+        .read_meta()
+        .expect("a readable replica")
+        .list_namespaces()
+        .namespaces;
+    assert!(
+        namespaces.iter().any(|namespace| namespace.namespace == "after"),
+        "a change reported as accepted never took effect: {namespaces:?}"
+    );
+    // What the snapshot carried is still there too.
+    assert!(namespaces.iter().any(|namespace| namespace.namespace == "before"));
+}
+
+#[test]
+fn changes_keep_taking_effect_after_a_snapshot_install() {
+    // One change could succeed by luck if the numbering only collided once.
+    let meta = cluster_with_an_installed_snapshot();
+    for round in 0..5u64 {
+        let name = format!("ns-{round}");
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: name.clone()
+            })
+            .status
+            .ok);
+        let namespaces = meta
+            .read_meta()
+            .expect("a readable replica")
+            .list_namespaces()
+            .namespaces;
+        assert!(
+            namespaces.iter().any(|namespace| namespace.namespace == name),
+            "change {round} was accepted and discarded: {namespaces:?}"
+        );
+    }
+}
+
+#[test]
+fn a_snapshot_install_does_not_rewind_the_commit_index() {
+    // The reused index was also written straight into commit_index, walking it
+    // backwards past entries the cluster had already committed.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    for round in 0..3u64 {
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: format!("ns-{round}")
+            })
+            .status
+            .ok);
+    }
+    let before = meta.status().commit_index;
+    let snapshot = meta.export_meta_snapshot().expect("a snapshot");
+    meta.install_meta_snapshot_on_live_nodes(snapshot)
+        .expect("the snapshot installs");
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "after".to_string()
+        })
+        .status
+        .ok);
+    assert!(
+        meta.status().commit_index >= before,
+        "commit index went backwards: {} then {}",
+        before,
+        meta.status().commit_index
+    );
+}
+
 #[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);


### PR DESCRIPTION
> **Stacked on #236.** That fixes the defect; this stops the next one of its
> shape from being silent.

## A change that applies nothing no longer reports success

```rust
.unwrap_or_else(Status::ok)
```

`propose_mutation` ended there. `apply_meta_committed` answers `None` **only**
when it applied nothing — and for a change just appended and committed, that
means the entry was skipped as already applied. Reporting it as success is what
let #236 discard every metadata change after a snapshot install while every
caller was told the change had been made.

There is no legitimate case behind that `None`. The entry is appended, the commit
index is set to its own index, and the apply runs — so a real proposal always
produces a status. `None` is a defect signal and nothing else.

## It is not dead code

The obvious objection to a guard like this is that it can never fire, so it
cannot be tested. Measured rather than argued — restoring #236's numbering
defect on top of this change:

```
with the numbering defect restored: ok=false code=mutation_not_applied
```

Before: `ok=true`, and the change silently gone. After: a named error at the
call site, in exactly the scenario that produced the data loss.

## Tests

One: **an ordinary change still reports success**, across a snapshot install.
The risk in a guard like this is catching the normal path, so that is the thing
worth pinning.

I have not added a test that asserts the error, because reaching it requires the
defect #236 removes. The demonstration above is how I checked it, not something
the suite can keep checking — which is worth saying plainly rather than dressing
the guard up with a test that only proves the happy path twice.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`

The `data_node::…jitter_backoff…` and `engine::…recovery_validates_…` failures
reproduce on an unmodified tree at this base and are untouched here.


---

### Correction to the verification note above

I described **two** failures as reproducing on an unmodified tree. Re-checked on
a quiet machine with disk headroom, run in isolation against unmodified `main`:

| test | unmodified main |
|---|---|
| `data_node::…jitter_backoff…` | **fails 3/3** — genuinely pre-existing, deterministic |
| `engine::…recovery_validates_all_timestamped_kv_page_families` | **passes 3/3** |

Only the first is pre-existing. My original evidence for the second came from a
run taken immediately after the disk hit 100%, so it was environmental — that
test is sensitive to disk pressure and load, not broken on `main`.

The conclusion this change is not responsible for either failure is unchanged.
The evidence offered for half of it was wrong, and the record should say so.
