### PR TITLE
Id-scoped candidate scans: answer one memory's records without touching every event

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1065,6 +1065,7 @@ fn matrixark_scan_cache_key(command: &RecordLogRequest, count: u64) -> String {
         "shard_size": command.shard_size.unwrap_or(1024).max(1),
         "count": count,
         "record_types": command.record_types,
+        "record_ids": command.record_ids,
         "selected_node_hashes": command.selected_node_hashes,
         "secondary_index_groups": command.secondary_index_groups,
         "scope": command.scope,
@@ -1444,6 +1445,147 @@ fn type_index_payloads(
     Ok(Some((values, shards_touched)))
 }
 
+/// Is this record about one of `ids` -- carrying it, targeting it, or created by superseding it?
+///
+/// `record_addressable_ids` covers what a record CARRIES (its own identity and its ref hashes);
+/// history also needs the records that POINT at an id: a tombstone's `target_memory_id`, and the
+/// supersede link `superseded_by` that marks the successor's creation.
+fn record_id_linked(record: &Value, ids: &HashSet<String>) -> bool {
+    if record_addressable_ids(record)
+        .iter()
+        .any(|id| ids.contains(id.as_str()))
+    {
+        return true;
+    }
+    for field in ["target_memory_id", "superseded_by"] {
+        match record.get(field) {
+            Some(Value::String(text)) if ids.contains(text.as_str()) => return true,
+            Some(Value::Number(number)) if ids.contains(number.to_string().as_str()) => {
+                return true
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Payload values for an id-scoped scan, in append order: the ids' locator locations plus the
+/// type-index locations of every requested type except `context_event` (events carry their own
+/// id, so the locator covers them; tombstones and feedback point at an id without carrying it,
+/// and they are sparse). `Ok(None)` = compose cannot answer; the caller walks.
+fn id_scoped_payloads(
+    engine: &TemporalEngine,
+    record_hash_key: &str,
+    allowed_types: &HashSet<String>,
+    requested_ids: &[String],
+) -> Result<Option<(Vec<String>, u64)>, String> {
+    let ready = read_record_count(engine, &type_index_ready_key(record_hash_key))?;
+    if ready.trim() != "1" {
+        return Ok(None);
+    }
+    // The record hash key is `{prefix}:records`, so the locator key derives from it -- callers
+    // do not reliably send storage_prefix, and the id mode must not depend on an optional field.
+    let Some(prefix) = record_hash_key.strip_suffix(":records") else {
+        return Ok(None);
+    };
+    let locator_key = format!("{prefix}:context_ref_locator");
+    let mut positions: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for id in requested_ids {
+        let raw = read_bytes(
+            engine,
+            Command::HashGet {
+                key: locator_key.clone(),
+                field: id.clone(),
+            },
+        )?;
+        let mut found = 0_usize;
+        if !raw.is_empty() {
+            if let Ok(decoded) = serde_json::from_str::<Value>(&raw) {
+                for location in decoded
+                    .get("locations")
+                    .and_then(Value::as_array)
+                    .map(|items| items.as_slice())
+                    .unwrap_or(&[])
+                {
+                    let key = location.get("key").and_then(Value::as_str).unwrap_or("");
+                    let field = location.get("field").and_then(Value::as_str).unwrap_or("");
+                    if key.is_empty() || field.is_empty() {
+                        continue;
+                    }
+                    // Only locations in THIS record log: the locator is shared per prefix, and a
+                    // location under another base must not leak into this scan.
+                    let Some((base, shard)) = record_shard_key_parts(key) else {
+                        continue;
+                    };
+                    if base != record_hash_key {
+                        continue;
+                    }
+                    positions.insert(format!("{shard}:{field}"));
+                    found += 1;
+                }
+            }
+        }
+        if found == 0 {
+            // An old store predating the side index, or an id that never existed. The walk is
+            // the correct answer for both; guessing "no records" here would erase real history.
+            return Ok(None);
+        }
+    }
+    for record_type in allowed_types {
+        if record_type == "context_event" {
+            continue;
+        }
+        for (location, _) in hgetall_map(engine, type_index_key(record_hash_key, record_type))? {
+            positions.insert(location);
+        }
+    }
+    let mut fields_by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for location in &positions {
+        if let Some((shard, field)) = location.split_once(':') {
+            fields_by_shard
+                .entry(shard.to_string())
+                .or_default()
+                .push(field.to_string());
+        }
+    }
+    let shards_touched = fields_by_shard.len() as u64;
+    let mut values = Vec::with_capacity(positions.len());
+    for (shard, fields) in fields_by_shard {
+        let key = format!("{record_hash_key}:{shard}");
+        let response = engine.execute_durable(ExecuteRequest {
+            shard_id: DEFAULT_SHARD_ID,
+            command: Command::HashMultiGet { key, fields },
+        });
+        if !response.status.ok {
+            return Err(format!(
+                "{}: {}",
+                response.status.code, response.status.message
+            ));
+        }
+        match response.response {
+            CommandResponse::Values {
+                values: shard_values,
+            } => {
+                for value in shard_values {
+                    let Some(bytes) = value else { continue };
+                    if bytes.is_empty() {
+                        continue;
+                    }
+                    values.push(String::from_utf8(bytes).map_err(|error| {
+                        format!("stored hash value is not UTF-8: {error}")
+                    })?);
+                }
+            }
+            other => {
+                return Err(format!(
+                    "unexpected response for id-scoped fetch: {other:?}"
+                ))
+            }
+        }
+    }
+    Ok(Some((values, shards_touched)))
+}
+
 /// Persist a walk-built index and its ready-marker, once. Returns whether it wrote.
 fn persist_type_index_backfill(
     engine: &TemporalEngine,
@@ -1514,8 +1656,23 @@ fn scan_matrixark_candidates(
     // Collect payloads first -- from the type index when it can answer, from the shard walk
     // otherwise -- then run one shared filter loop, so the two paths cannot drift.
     let mut payload_values: Vec<String> = Vec::new();
+    let requested_ids: Vec<String> = command.record_ids.clone().unwrap_or_default();
+    let requested_id_set: HashSet<String> = requested_ids.iter().cloned().collect();
+    let mut id_scoped_used = false;
     let mut type_index_used = false;
-    if !allowed_types.is_empty() && count > 0 {
+    if !requested_ids.is_empty() && count > 0 {
+        if let Some((values, shards_touched)) = id_scoped_payloads(
+            engine,
+            &record_hash_key,
+            &allowed_types,
+            &requested_ids,
+        )? {
+            payload_values = values;
+            placement_partitions_touched = shards_touched;
+            id_scoped_used = true;
+        }
+    }
+    if !id_scoped_used && !allowed_types.is_empty() && count > 0 {
         if let Some((values, shards_touched)) =
             type_index_payloads(engine, &record_hash_key, &allowed_types)?
         {
@@ -1525,7 +1682,7 @@ fn scan_matrixark_candidates(
         }
     }
     let mut type_index_backfilled = false;
-    if !type_index_used && count > 0 {
+    if !id_scoped_used && !type_index_used && count > 0 {
         // The walk this scan pays anyway sees every payload, so it can build the index for every
         // type in the store as a side effect; the marker makes the next scan's miss authoritative.
         let mut backfill: BTreeMap<String, Vec<(String, Vec<u8>)>> = BTreeMap::new();
@@ -1556,6 +1713,10 @@ fn scan_matrixark_candidates(
                     .unwrap_or("");
                 if !allowed_types.is_empty() && !allowed_types.contains(record_type) {
                     dropped_by_type += 1;
+                    continue;
+                }
+                if !requested_id_set.is_empty() && !record_id_linked(&record, &requested_id_set) {
+                    dropped_by_scope += 1; // id-filtered, counted with scope drops
                     continue;
                 }
                 if !scope_matches_record(&record, command.scope.as_ref()) {
@@ -1703,6 +1864,7 @@ fn scan_matrixark_candidates(
             "dropped_by_scope": dropped_by_scope,
             "selected_node_dropped_candidate_count": selected_node_dropped,
             "secondary_index_groups_supplied": secondary_groups.len(),
+            "id_scoped_used": id_scoped_used,
             "type_index_used": type_index_used,
             "type_index_backfilled": type_index_backfilled,
             "secondary_index_matched_candidate_count": secondary_matched,
@@ -4024,6 +4186,115 @@ mod tests {
             payload.to_string(),
         )];
         execute_record_log_request(engine, append, root).expect("append");
+    }
+
+    /// Id mode: the locator finds the id's own rows, the type index finds the rows that point
+    /// at it, and the composed answer equals the walk's -- in the walk's order.
+    #[test]
+    fn id_scoped_scan_matches_the_walk() {
+        let _guard = env_guard();
+        let dir = tempdir().expect("tempdir");
+        env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
+        clear_engine_cache();
+        clear_matrixark_scan_cache();
+
+        let storage_prefix = "matrixark:test:id-scoped";
+        let probe = request("get_string");
+        let root = record_log_root(&probe);
+        let engine = open_engine(&probe).expect("engine");
+        append_one(&engine, storage_prefix, 0,
+            r#"{"record_type":"context_event","event_id_hash":77,"text":"the memory"}"#,
+            root.clone());
+        append_one(&engine, storage_prefix, 1,
+            r#"{"record_type":"context_event","event_id_hash":88,"text":"someone else"}"#,
+            root.clone());
+        append_one(&engine, storage_prefix, 2,
+            r#"{"record_type":"matrixark_memory_tombstone","tombstone_kind":"delete","tombstone_reason":"supersede","target_memory_id":"77","superseded_by":"99"}"#,
+            root.clone());
+        append_one(&engine, storage_prefix, 3,
+            r#"{"record_type":"matrixark_memory_feedback","target_memory_id":"77","feedback":"POSITIVE"}"#,
+            root.clone());
+
+        // The locator entry the adapter's side-index builder would have written: the id's OWN
+        // row only. The tombstone and feedback must come from the type index -- that split is
+        // the design under test.
+        let mut locator = request("hset");
+        locator.key = format!("{storage_prefix}:context_ref_locator");
+        locator.field = "77".to_string();
+        locator.value = format!(
+            r#"{{"locations":[{{"key":"{storage_prefix}:records:000000","field":"{:020}"}}]}}"#,
+            0
+        );
+        execute_record_log_request(&engine, locator, root.clone()).expect("locator entry");
+
+        let id_request = |root: PathBuf| {
+            let mut scan = request("matrixark_scan_candidates");
+            scan.storage_prefix = storage_prefix.to_string();
+            scan.count_key = Some(format!("{storage_prefix}:record_count"));
+            scan.record_hash_key = Some(format!("{storage_prefix}:records"));
+            scan.shard_size = Some(1);
+            scan.record_types = Some(vec![
+                "context_event".to_string(),
+                "matrixark_memory_tombstone".to_string(),
+                "matrixark_memory_feedback".to_string(),
+            ]);
+            scan.record_ids = Some(vec!["77".to_string()]);
+            let output = execute_record_log_request(&engine, scan, root).expect("id scan");
+            Value::Object(output.extra.into_iter().collect())
+        };
+
+        // First run: no marker yet, so the walk answers (id-filtered) and backfills.
+        let walk = id_request(root.clone());
+        let stats = walk.get("scan_stats").expect("stats");
+        assert_eq!(Some(false), stats.get("id_scoped_used").and_then(Value::as_bool));
+        assert_eq!(Some(true), stats.get("type_index_backfilled").and_then(Value::as_bool));
+
+        clear_matrixark_scan_cache();
+        let scoped = id_request(root.clone());
+        let stats = scoped.get("scan_stats").expect("stats");
+        assert_eq!(Some(true), stats.get("id_scoped_used").and_then(Value::as_bool),
+            "the second run must be served by the locator + type-index compose");
+        assert_eq!(scan_record_texts(&walk), scan_record_texts(&scoped),
+            "id-scoped and walk answers must be identical, in the same order");
+        assert_eq!(vec!["the memory", "77", "77"], scan_record_texts(&scoped),
+            "the other memory's event must be absent; order is log order");
+    }
+
+    /// An id the locator has never seen falls back to the walk -- absence must be walked, not
+    /// guessed, because an old store predates the side index.
+    #[test]
+    fn id_scoped_scan_walks_when_the_locator_has_no_entry() {
+        let _guard = env_guard();
+        let dir = tempdir().expect("tempdir");
+        env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
+        clear_engine_cache();
+        clear_matrixark_scan_cache();
+
+        let storage_prefix = "matrixark:test:id-scoped-miss";
+        let probe = request("get_string");
+        let root = record_log_root(&probe);
+        let engine = open_engine(&probe).expect("engine");
+        append_one(&engine, storage_prefix, 0,
+            r#"{"record_type":"context_event","event_id_hash":77,"text":"unlocated"}"#,
+            root.clone());
+
+        let mut scan = request("matrixark_scan_candidates");
+        scan.storage_prefix = storage_prefix.to_string();
+        scan.count_key = Some(format!("{storage_prefix}:record_count"));
+        scan.record_hash_key = Some(format!("{storage_prefix}:records"));
+        scan.shard_size = Some(1);
+        scan.record_types = Some(vec!["context_event".to_string()]);
+        scan.record_ids = Some(vec!["77".to_string()]);
+        let output = execute_record_log_request(&engine, scan.clone(), root.clone()).expect("scan");
+        let first = Value::Object(output.extra.into_iter().collect());
+        clear_matrixark_scan_cache();
+        let output = execute_record_log_request(&engine, scan, root).expect("scan");
+        let second = Value::Object(output.extra.into_iter().collect());
+        for result in [&first, &second] {
+            let stats = result.get("scan_stats").expect("stats");
+            assert_eq!(Some(false), stats.get("id_scoped_used").and_then(Value::as_bool));
+            assert_eq!(vec!["unlocated"], scan_record_texts(result));
+        }
     }
 
     /// The core property: walk + backfill on the first typed scan, index on the second, and the

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5607,8 +5607,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return {"recorded": True, "memory_id": memory_id, "feedback": rating,
                 "feedback_reason": reason}
 
-    def raw_records_for_history(self) -> list[Json]:
+    def raw_records_for_history(self, memory_id: str | None = None) -> list[Json]:
         """The records `history` walks. Base implementation: the whole raw log.
+
+        `memory_id` is a scoping HINT: a backend that can fetch one memory's records cheaply may
+        use it, and history filters by id either way, so ignoring it is always correct.
 
         History consumes three record types -- the memory's event rows, the tombstones that
         target or created it, and its feedback ratings -- in append order. A backend that can
@@ -5627,7 +5630,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             raise MatrixArkError("history requires a memory_id")
         events: list[Json] = []
         seen_ingested = False
-        for record in self.raw_records_for_history():
+        for record in self.raw_records_for_history(memory_id):
             record_type = str(record.get("record_type") or "")
             ts = record.get("updated_at_ms") or record.get("timestamp_key_ms") or record.get("event_time_ms") or record.get("created_at_ms")
             if record_type == "context_event" and str(record.get("event_id_hash")) == memory_id:

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -660,7 +660,11 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
         record_types: list[str],
         secondary_index_groups: list[list[str]],
         selected_node_hashes: list[int],
+        record_ids: list[str] | None = None,
     ) -> Json:
+        extra: Json = {}
+        if record_ids:
+            extra["record_ids"] = [str(item) for item in record_ids]
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,
@@ -670,6 +674,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             record_types=record_types,
             secondary_index_groups=secondary_index_groups,
             selected_node_hashes=selected_node_hashes,
+            **extra,
         )
 
     def metrics_prometheus(self) -> str:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1108,7 +1108,9 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return True
         return bool(records)
 
-    def _scan_records_of_types(self, record_types: list[str]) -> list[Json] | None:
+    def _scan_records_of_types(
+        self, record_types: list[str], record_ids: list[str] | None = None
+    ) -> list[Json] | None:
         """Records of exactly these types, in append order, from one filtered scan. None = could
         not ask.
 
@@ -1131,7 +1133,14 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 record_types=list(record_types),
                 secondary_index_groups=[],
                 selected_node_hashes=[],
+                **({"record_ids": [str(item) for item in record_ids]} if record_ids else {}),
             )
+        except TypeError:
+            # An older client without the record_ids parameter: ask untargeted; the caller's own
+            # filters still apply, so this is the slow answer, not a wrong one.
+            if not record_ids:
+                return None
+            return self._scan_records_of_types(record_types)
         except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
             return None
         if not isinstance(response, dict):
@@ -1153,7 +1162,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         return self._scan_records_of_types([MEMORY_TOMBSTONE_RECORD_TYPE])
 
-    def raw_records_for_history(self) -> list[Json]:
+    def raw_records_for_history(self, memory_id: str | None = None) -> list[Json]:
         """History's records from a three-type scan instead of a raw read of the whole log.
 
         The raw read hauls the entire store -- summaries, embeddings, index postings -- to answer
@@ -1166,13 +1175,16 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         except ModuleNotFoundError:  # Direct script execution from tools/.
             from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
-        subset = self._scan_records_of_types([
-            "context_event",
-            MEMORY_TOMBSTONE_RECORD_TYPE,
-            self.MEMORY_FEEDBACK_RECORD_TYPE,
-        ])
+        subset = self._scan_records_of_types(
+            [
+                "context_event",
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                self.MEMORY_FEEDBACK_RECORD_TYPE,
+            ],
+            record_ids=[str(memory_id)] if memory_id else None,
+        )
         if subset is None:
-            return super().raw_records_for_history()
+            return super().raw_records_for_history(memory_id)
         return subset
 
     def prior_context_records(self) -> list[Json]:
@@ -2251,8 +2263,11 @@ class MatrixArkRustCdylibClient:
             append_options=append_options,
         )
 
-    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int]) -> Json:
-        request = json.dumps({"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None) -> Json:
+        payload: Json = {"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}
+        if record_ids:
+            payload["record_ids"] = [str(item) for item in record_ids]
+        request = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
         def call() -> Json:
             out = self._ctypes.c_void_p()
             error = self._ctypes.c_void_p()
@@ -3332,7 +3347,11 @@ class MatrixArkRustProxyClient:
         record_types: list[str],
         secondary_index_groups: list[list[str]],
         selected_node_hashes: list[int],
+        record_ids: list[str] | None = None,
     ) -> Json:
+        extra: Json = {}
+        if record_ids:
+            extra["record_ids"] = [str(item) for item in record_ids]
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,
@@ -3342,6 +3361,7 @@ class MatrixArkRustProxyClient:
             record_types=record_types,
             secondary_index_groups=secondary_index_groups,
             selected_node_hashes=selected_node_hashes,
+            **extra,
         )
 
     def metrics_prometheus(self) -> str:

--- a/tools/test_history_scoped.py
+++ b/tools/test_history_scoped.py
@@ -49,12 +49,21 @@ class _NativeAdapter(adapters.MatrixArkTemporalStoreDirectAdapter):
         self.scan_calls = 0
         self.raw_reads = 0
 
-    def _scan_records_of_types(self, record_types):
+    def _scan_records_of_types(self, record_types, record_ids=None):
         self.scan_calls += 1
+        self.last_record_ids = list(record_ids or [])
         if not self._scan_available:
             return None
         wanted = set(record_types)
-        return [r for r in self._records if str(r.get("record_type") or "") in wanted]
+        subset = [r for r in self._records if str(r.get("record_type") or "") in wanted]
+        if record_ids:
+            ids = {str(i) for i in record_ids}
+            def linked(r):
+                own = {str(r.get(f)) for f in ("event_id_hash", "target_memory_id", "superseded_by")
+                       if r.get(f) is not None}
+                return bool(own & ids)
+            subset = [r for r in subset if linked(r)]
+        return subset
 
     def _read_raw_records(self):
         self.raw_reads += 1
@@ -71,6 +80,8 @@ class HistoryScopedTests(unittest.TestCase):
         adapter = _NativeAdapter(_story())
         events = self._events(adapter, "77")
         self.assertEqual(0, adapter.raw_reads)
+        self.assertEqual(["77"], adapter.last_record_ids,
+                         "the memory id must reach the scan as its scoping hint")
         self.assertEqual([("ingested", None), ("feedback", "POSITIVE"),
                           ("superseded", "88")], events)
 


### PR DESCRIPTION
The type index made sparse-type scans cheap, but history still fetched EVERY context_event to
answer one id -- events dominate an ingest-heavy store, so history stayed linear in the event
population (11.8ms at ~450 records, 481ms at 3235).

The id mode composes two indexes the store already maintains, engine-side, in exact log order:

* the ref locator already lists the locations of every record CARRYING an id -- an event's own
  row is covered because event_id_hash is one of the ref-hash fields the side-index builder folds
  in; the locator key derives from the record hash key (`{prefix}:records` -> the prefix), because
  callers do not reliably send storage_prefix and the id mode must not depend on an optional
  field -- the first probe of a live request showed exactly that decline (id_scoped=False, 7469
  records fetched through the type index);
* tombstones and feedback point AT an id (target_memory_id / superseded_by) without carrying it
  as a ref hash, so the locator cannot find them -- and they are exactly the sparse types the
  type index serves in a handful of rows.

Every location from either source is a shard + zero-padded field position, so the merged set
sorts into exact append order before fetching. The id predicate runs in the SHARED filter loop --
the composed path and the walk fallback apply the same rule, so they cannot drift -- and the
scan-cache key now carries record_ids, without which an id-scoped result would be served to a
DIFFERENT id at the same store count.

Conservative fallbacks, all to the walk: no type-index marker; an id with zero locator locations
(an old store predating the side index, or an id that never existed -- a walk that returns
nothing is cheap enough for a 404).

Measured on the same 3235-record store, scan-stats verified (id_scoped_used=true, 53 records
fetched instead of 7469):

    history p50   4615 ms (raw read) -> 2380 (typed walk) -> 481 (type index) -> 51 (id-scoped)

and near-flat across store sizes: 12.4ms at ~450 records vs 51.4ms at 3235, the residue being the
sweep store's larger tombstone population and fixed request overhead.

Python side: the scan clients accept record_ids, the typed-scan helper forwards it (with a
TypeError fallback for an older client), and history's seam carries the memory id as a scoping
hint -- the base implementation ignores it, and history filters by id either way, so ignoring the
hint is always correct.

2 engine tests drive the scan through both paths on one story -- the id's event, another memory's
event, a supersede tombstone, a feedback row -- and require identical ordered answers, with the
locator entry planted to cover ONLY the event row so the tombstone and feedback must arrive
through the type index (that split is the design). A third pins the zero-locator fallback. The
binary suite is 29 passed / 1 failed (the pre-existing visibility assertion), the five memory
