### PR TITLE
Point the install instructions at a repository the reader can actually clone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "source": "./integrations/claude-plugin",
       "description": "Time-aware long-term memory for Claude Code, backed by the Rust TemporalStore engine: automatic ingest/inject lifecycle hooks plus MCP recall/remember tools.",
       "homepage": "https://temporalstore.ai/benchmarks.html",
-      "repository": "https://github.com/bjmeetsfo/TemporalStore",
+      "repository": "https://github.com/matrixarkai/TemporalStore",
       "license": "Apache-2.0",
       "category": "productivity",
       "keywords": ["memory", "context", "temporalstore", "matrixark"],

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 description = "Rust-native TemporalStore engine, storage, client/proxy, and production Raft readiness surfaces."
 readme = "README.md"
-repository = "https://github.com/bjmeetsfo/TemporalStore"
-homepage = "https://github.com/bjmeetsfo/TemporalStore"
+repository = "https://github.com/matrixarkai/TemporalStore"
+homepage = "https://github.com/matrixarkai/TemporalStore"
 keywords = ["temporalstore", "database", "storage", "raft", "memory"]
 categories = ["database-implementations", "data-structures"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 # First-party MatrixArkAI crates consumed as git dependencies.
 allow-git = [
-    "https://github.com/bjmeetsfo/MatrixRaft.git",
-    "https://github.com/bjmeetsfo/MatrixCache.git",
+    "https://github.com/matrixarkai/MatrixRaft.git",
+    "https://github.com/matrixarkai/MatrixCache.git",
     "https://github.com/bjmeetsfo/MatrixObjectStore.git",
 ]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -34,7 +34,7 @@ build, because the whole toolchain lives inside the image's build stage. (Don't
 have Docker yet? See [Step 0](#step-0-install-docker-if-you-dont-have-it).)
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 docker compose -f docker-compose.single-node.yml up --build -d   # -d runs it in the background
 ```
@@ -162,7 +162,7 @@ the image build stage.
 You also need a local clone of this repository:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 ```
 
@@ -180,8 +180,8 @@ from public GitHub, so `cargo build` fetches them automatically on the first
 build — you never clone them by hand:
 
 ```text
-matrixraft            https://github.com/bjmeetsfo/MatrixRaft.git         Raft consensus
-matrixcache           https://github.com/bjmeetsfo/MatrixCache.git        tiered cache + RocksDB SSD store
+matrixraft            https://github.com/matrixarkai/MatrixRaft.git         Raft consensus
+matrixcache           https://github.com/matrixarkai/MatrixCache.git        tiered cache + RocksDB SSD store
 matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  optional (--features matrixobject)
 ```
 
@@ -204,7 +204,7 @@ offline/air-gapped builds, run `cargo vendor` on a connected host, or add
 Use Ubuntu 22.04 LTS or Ubuntu 26.04 when possible.
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 ./tools/install_linux_temporalstore.sh --check-prereqs
 ./tools/install_linux_temporalstore.sh --build
@@ -272,7 +272,7 @@ source "$HOME/.cargo/env"
 Then build and run:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 ./tools/install_macos_temporalstore.sh --check-prereqs
 ./tools/install_macos_temporalstore.sh --build
@@ -326,7 +326,7 @@ Install Docker Desktop and use Linux containers. Then open PowerShell in the
 repository root:
 
 ```powershell
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 powershell -ExecutionPolicy Bypass `
   -File .\tools\install_windows_docker_temporalstore.ps1 `

--- a/docs/linux_deploy.md
+++ b/docs/linux_deploy.md
@@ -73,7 +73,7 @@ RocksDB from source (via `librocksdb-sys`, which uses `bindgen`/libclang).
 Then clone and enter the repo:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 ```
 
@@ -94,8 +94,8 @@ dependencies from public GitHub, so `cargo build` fetches them automatically on
 the first build:
 
 ```text
-matrixraft            https://github.com/bjmeetsfo/MatrixRaft.git         (Raft consensus)
-matrixcache           https://github.com/bjmeetsfo/MatrixCache.git        (tiered cache + RocksDB SSD store)
+matrixraft            https://github.com/matrixarkai/MatrixRaft.git         (Raft consensus)
+matrixcache           https://github.com/matrixarkai/MatrixCache.git        (tiered cache + RocksDB SSD store)
 matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  (optional; enable with --features matrixobject)
 ```
 
@@ -107,7 +107,7 @@ build.
 
 Offline or air-gapped builds: run `cargo vendor` on a connected host and commit
 the generated `.cargo/config.toml`, or clone MatrixCache/MatrixRaft locally and
-add `[patch."https://github.com/bjmeetsfo/MatrixCache.git"]` / MatrixRaft path
+add `[patch."https://github.com/matrixarkai/MatrixCache.git"]` / MatrixRaft path
 overrides to a workspace `Cargo.toml`.
 
 ## One-Command Build And Deploy

--- a/docs/macos_deploy.md
+++ b/docs/macos_deploy.md
@@ -73,8 +73,8 @@ dependencies from public GitHub (see `crates/temporalstore-rust/Cargo.toml`), so
 `cargo build` fetches them automatically on the first build:
 
 ```text
-matrixraft            https://github.com/bjmeetsfo/MatrixRaft.git         (Raft consensus)
-matrixcache           https://github.com/bjmeetsfo/MatrixCache.git        (tiered cache + RocksDB SSD store)
+matrixraft            https://github.com/matrixarkai/MatrixRaft.git         (Raft consensus)
+matrixcache           https://github.com/matrixarkai/MatrixCache.git        (tiered cache + RocksDB SSD store)
 matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  (optional; enable with --features matrixobject)
 ```
 
@@ -88,7 +88,7 @@ local MatrixCache/MatrixRaft clones.
 From the repo:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 ./tools/install_macos_temporalstore.sh --check-prereqs
 ```

--- a/docs/windows_docker_install.md
+++ b/docs/windows_docker_install.md
@@ -84,7 +84,7 @@ git, rustc, cargo inside WSL
 Clone the repo and run commands from the repo root:
 
 ```powershell
-git clone https://github.com/bjmeetsfo/TemporalStore.git
+git clone https://github.com/matrixarkai/TemporalStore.git
 cd TemporalStore
 powershell -ExecutionPolicy Bypass `
   -File .\tools\install_windows_docker_temporalstore.ps1 `

--- a/integrations/PLUGINS.md
+++ b/integrations/PLUGINS.md
@@ -16,7 +16,7 @@ slash commands. It drives a **TemporalStore checkout** on your machine (`matrixa
 ## Prerequisite (both)
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore
+git clone https://github.com/matrixarkai/TemporalStore
 cd TemporalStore
 ```
 
@@ -71,4 +71,4 @@ they emit a benign result and never block or slow a turn.
 `integrations/agent-hooks/` is the earlier, settings.json-based hook installer (still supported).
 These plugin packages are the modern, marketplace/`config.toml` distribution of the same engine.
 
-Apache-2.0 · part of [TemporalStore](https://github.com/bjmeetsfo/TemporalStore).
+Apache-2.0 · part of [TemporalStore](https://github.com/matrixarkai/TemporalStore).

--- a/integrations/agent-hooks/DESIGN.md
+++ b/integrations/agent-hooks/DESIGN.md
@@ -34,7 +34,7 @@ The launcher converts Codex, Claude, and custom payloads into this common shape:
   "session_id": "019f66b3-...",
   "session_id_source": "payload.session_id",
   "workspace_root": "/opt/github-services/TemporalStore",
-  "repo_remote": "https://github.com/bjmeetsfo/TemporalStore.git",
+  "repo_remote": "https://github.com/matrixarkai/TemporalStore.git",
   "project": "TemporalStore",
   "role": "user",
   "text": "user prompt text",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
     "url": "https://temporalstore.ai"
   },
   "homepage": "https://temporalstore.ai/benchmarks.html",
-  "repository": "https://github.com/bjmeetsfo/TemporalStore",
+  "repository": "https://github.com/matrixarkai/TemporalStore",
   "license": "Apache-2.0",
   "keywords": ["memory", "context", "temporalstore", "matrixark"],
   "defaultEnabled": false,

--- a/integrations/claude-plugin/README.md
+++ b/integrations/claude-plugin/README.md
@@ -19,7 +19,7 @@ The plugin is the packaging layer; it drives a **TemporalStore checkout** on you
 Clone and build it once:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore
+git clone https://github.com/matrixarkai/TemporalStore
 # note the absolute path — you'll set it as matrixark_home below
 ```
 
@@ -63,4 +63,4 @@ integrations/claude-plugin/
 └── README.md
 ```
 
-Apache-2.0 · part of [TemporalStore](https://github.com/bjmeetsfo/TemporalStore).
+Apache-2.0 · part of [TemporalStore](https://github.com/matrixarkai/TemporalStore).

--- a/integrations/codex-plugin/README.md
+++ b/integrations/codex-plugin/README.md
@@ -15,7 +15,7 @@ Same engine benchmarked on LOCOMO & LongMemEval_s (<https://temporalstore.ai/ben
 A TemporalStore checkout on your machine:
 
 ```bash
-git clone https://github.com/bjmeetsfo/TemporalStore
+git clone https://github.com/matrixarkai/TemporalStore
 ```
 
 ## Install
@@ -50,4 +50,4 @@ Codex also supports lifecycle hooks (`[features] hooks = true` + `hooks.json`). 
 injection/ingest through the dedicated Rust codex hook, point a command hook at
 `tools/run_rust_codex_context_hook.sh`. See the Codex hooks docs for the current event schema.
 
-Apache-2.0 · part of [TemporalStore](https://github.com/bjmeetsfo/TemporalStore).
+Apache-2.0 · part of [TemporalStore](https://github.com/matrixarkai/TemporalStore).

--- a/tools/install_linux_temporalstore.sh
+++ b/tools/install_linux_temporalstore.sh
@@ -210,7 +210,7 @@ need_cmd python3 "sudo apt-get install -y python3"
 if [[ ! -f "$repo/Cargo.toml" ]]; then
   echo "repo does not look like a TemporalStore checkout: $repo" >&2
   echo "clone it first, then run this script from the repo root:" >&2
-  echo "  git clone https://github.com/bjmeetsfo/TemporalStore.git" >&2
+  echo "  git clone https://github.com/matrixarkai/TemporalStore.git" >&2
   echo "  cd TemporalStore" >&2
   exit 1
 fi

--- a/tools/install_macos_temporalstore.sh
+++ b/tools/install_macos_temporalstore.sh
@@ -207,7 +207,7 @@ need_cmd python3 "brew install python"
 if [[ ! -f "$repo/Cargo.toml" ]]; then
   echo "repo does not look like a TemporalStore checkout: $repo" >&2
   echo "clone it first, then run this script from the repo root:" >&2
-  echo "  git clone https://github.com/bjmeetsfo/TemporalStore.git" >&2
+  echo "  git clone https://github.com/matrixarkai/TemporalStore.git" >&2
   echo "  cd TemporalStore" >&2
   exit 1
 fi

--- a/tools/test_backend_policy_part1.py
+++ b/tools/test_backend_policy_part1.py
@@ -354,7 +354,7 @@ class _BackendPolicyPart1:
                         "Exit code: 0\n"
                         "Ran 86 tests in 1.59s\n"
                         "OK\n"
-                        "To https://github.com/bjmeetsfo/TemporalStore.git\n"
+                        "To https://github.com/matrixarkai/TemporalStore.git\n"
                         "abbf5f23 HEAD -> main\n"
                         "More streaming logs that do not carry final evidence."
                     ),

--- a/tools/test_codex_hook_output_part2.py
+++ b/tools/test_codex_hook_output_part2.py
@@ -1089,7 +1089,7 @@ class _CodexHookOutputPart2:
                 "Exit code: 0",
                 "Ran 32 tests in 0.508s",
                 "OK",
-                "To https://github.com/bjmeetsfo/TemporalStore.git",
+                "To https://github.com/matrixarkai/TemporalStore.git",
                 "002fbd45034c69ce4487a64ab40d90135a55ae1a refs/heads/main",
                 "another verbose blob " * 200,
             ]
@@ -1114,7 +1114,7 @@ class _CodexHookOutputPart2:
         raw = "\n".join(
             [
                 "Enumerating objects: 7, done.",
-                "To https://github.com/bjmeetsfo/TemporalStore.git",
+                "To https://github.com/matrixarkai/TemporalStore.git",
                 "   b223ca8c..4eafaf9c  HEAD -> main",
             ]
         )

--- a/tools/test_matrixark_codex_hook_pipeline.py
+++ b/tools/test_matrixark_codex_hook_pipeline.py
@@ -339,7 +339,7 @@ class MatrixArkCodexHookPipelineTest(unittest.TestCase, _CodexPipelinePart5, _Co
                 "compiling temporalstore v0.1.0",
                 "warning: many unrelated build lines",
                 "test result: ok. 132 passed; 0 failed; 0 ignored; finished in 12.34s",
-                "To https://github.com/bjmeetsfo/TemporalStore.git",
+                "To https://github.com/matrixarkai/TemporalStore.git",
                 "   39f93050..e2f645c5  HEAD -> main",
             ]
         )
@@ -391,7 +391,7 @@ class MatrixArkCodexHookPipelineTest(unittest.TestCase, _CodexPipelinePart5, _Co
                 "build line " * 120,
                 "Exit code: 0",
                 "Ran 45 tests in 0.02s",
-                "To https://github.com/bjmeetsfo/TemporalStore.git",
+                "To https://github.com/matrixarkai/TemporalStore.git",
                 "   39f93050..bee1234  HEAD -> main",
             ]
         )

--- a/tools/test_matrixark_popular_agent_hooks.py
+++ b/tools/test_matrixark_popular_agent_hooks.py
@@ -816,7 +816,7 @@ class MatrixArkPopularAgentHooksTest(unittest.TestCase):
                     "Exit code: 0",
                     "Ran 89 tests in 4.51s",
                     "OK",
-                    "To https://github.com/bjmeetsfo/TemporalStore.git",
+                    "To https://github.com/matrixarkai/TemporalStore.git",
                     "ca8f8a96 HEAD -> main",
                     "More streaming output that should be ignored.",
                 ]


### PR DESCRIPTION
The first thing the install guide asks the reader to do is clone a URL that returns 404 for them.

Every `git clone` line in `docs/INSTALL.md` and the Linux, macOS and Windows guides, both plugin
manifests, the agent-hooks design note, the two install scripts, and the crate's own `repository`
and `homepage` all named a repository the public cannot reach. So did `deny.toml`'s allowed
git-sources list, so a from-scratch build could not resolve them either.

**36 URLs across 18 files**, rewritten to the public repositories that exist under the same names:
TemporalStore, MatrixCache, MatrixRaft.

## Left alone deliberately

Four names have no public counterpart. Rewriting those would turn a 404 into a URL that does not
exist at all, which is worse than leaving it legible:

| what | where | why it stays |
| --- | --- | --- |
| `TemporalStoreTestCorpus` | `.gitmodules` | `clone --recursive` still fails for an outside reader — worth fixing separately, with a decision about the corpus itself |
| `MatrixObjectStore` | `deny.toml`, three deploy guides | the enterprise object store; an optional feature that is inert without it |
| `RustRaft` | a planning document, one validator | no public counterpart |

## How the targets were checked

Anonymous `ls-remote` with the credential helper disabled. An authenticated check passes for private
repositories too, so it would have confirmed nothing — which is the same reason the broken URLs
survived this long: they work for anyone who already has access.
