### PR TITLE
Feed the summary-refresh pass from a typed scan, with the full serving chain

### DIFF
--- a/tools/matrixark_local_adapter_summaries.py
+++ b/tools/matrixark_local_adapter_summaries.py
@@ -1206,7 +1206,7 @@ class _LocalAdapterSummariesMixin:
         } if isinstance(args.get("skip_dirty_reasons"), list) else set()
         # One read for the pass. The embedding step below reuses it only when nothing was
         # written -- see there.
-        pass_records = self.read_all()
+        pass_records = self.records_for_summary_refresh()
         result = self.refresh_dirty_node_summaries(
             records=pass_records,
             scope=scope,

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5607,6 +5607,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return {"recorded": True, "memory_id": memory_id, "feedback": rating,
                 "feedback_reason": reason}
 
+    def records_for_summary_refresh(self) -> list[Json]:
+        """The live records a summary-refresh pass reads. Base implementation: the whole store.
+
+        The pass's consumers touch a closed set of record types; a backend that can fetch that
+        subset cheaply overrides this. The contract is that a pass fed the subset produces the
+        same refreshes as one fed `read_all()`.
+        """
+        return self.read_all()
+
     def raw_records_for_history(self, memory_id: str | None = None) -> list[Json]:
         """The records `history` walks. Base implementation: the whole raw log.
 

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -661,10 +661,13 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
         secondary_index_groups: list[list[str]],
         selected_node_hashes: list[int],
         record_ids: list[str] | None = None,
+        return_index_records: bool = False,
     ) -> Json:
         extra: Json = {}
         if record_ids:
             extra["record_ids"] = [str(item) for item in record_ids]
+        if return_index_records:
+            extra["return_index_records"] = True
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1133,14 +1133,18 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 record_types=list(record_types),
                 secondary_index_groups=[],
                 selected_node_hashes=[],
+                # The scan's serving default drops embedding/index rows AFTER filtering, which
+                # silently overrides an explicit request for those types. This helper's contract
+                # is "records of exactly these types": for requests without them the type filter
+                # already excluded them and the flag is a no-op.
+                return_index_records=True,
                 **({"record_ids": [str(item) for item in record_ids]} if record_ids else {}),
             )
         except TypeError:
-            # An older client without the record_ids parameter: ask untargeted; the caller's own
-            # filters still apply, so this is the slow answer, not a wrong one.
-            if not record_ids:
-                return None
-            return self._scan_records_of_types(record_types)
+            # A client whose signature lacks one of the newer parameters. The full-read fallback
+            # is always correct; retrying with fewer kwargs is not -- a scan without
+            # return_index_records silently eats the embedding rows a caller asked for.
+            return None
         except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
             return None
         if not isinstance(response, dict):
@@ -1161,6 +1165,137 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         except ModuleNotFoundError:  # Direct script execution from tools/.
             from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         return self._scan_records_of_types([MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    # Every record type the refresh pass's consumers filter on, enumerated from the consumers
+    # themselves. Deliberately absent: context_index -- the store's largest class, whose only
+    # serving-chain effect (posting compaction) rewrites index rows nothing here reads -- and the
+    # audit/telemetry/idempotency families.
+    _SUMMARY_REFRESH_RECORD_TYPES = (
+        "context_event",
+        "context_summary",
+        "context_summary_dirty",
+        "context_summary_refresh_audit",
+        "context_debug_record",
+        "context_child_ref",
+        "context_entity",
+        "context_segment",
+        "context_node",
+        "context_embedding",
+        "context_compression_event",
+        "context_session_boundary",
+    )
+
+    def records_for_summary_refresh(self) -> list[Json]:
+        """The refresh pass's view from a typed scan, through the SAME serving chain as read_all.
+
+        Chain parity is the whole correctness story: the full read is
+        fold(raw + latest-state) -> compact_and_apply_tombstones -> filter_live, and this applies
+        exactly that to the subset. The fold's index-posting step is a no-op here because index
+        rows are excluded by design and nothing this pass reads consumes them.
+
+        Any failure serves the full read. With MATRIXARK_REFRESH_SHADOW_COMPARE=1 both views are
+        computed and compared -- skipping the comparison when the store moved between the two
+        reads, because a foreground write landing in the window is a race, not a divergence --
+        and the FULL view is served.
+        """
+        import os as _os
+
+        try:
+            from tools.matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from tools.matrixark_mcp_serving_records import compact_latest_context_state_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from matrixark_mcp_serving_records import compact_latest_context_state_records
+
+        shadow = _os.environ.get("MATRIXARK_REFRESH_SHADOW_COMPARE", "").strip()
+        shadow_on = shadow not in {"", "0", "false", "no", "off"}
+        count_before = None
+        if shadow_on:
+            try:
+                count_before = int(self._get_count())
+            except Exception:  # noqa: BLE001
+                count_before = None
+
+        wanted = list(self._SUMMARY_REFRESH_RECORD_TYPES) + [
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        ]
+        subset = self._scan_records_of_types(wanted)
+        if subset is None:
+            return self.read_all()
+        try:
+            latest_state = self._load_latest_context_state_records()
+        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+            return self.read_all()
+        folded = compact_latest_context_state_records(list(subset) + list(latest_state))
+        live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
+
+        if shadow_on:
+            full = self.read_all()
+            count_after = None
+            try:
+                count_after = int(self._get_count())
+            except Exception:  # noqa: BLE001
+                count_after = None
+            log_path = _os.environ.get("MATRIXARK_REFRESH_SHADOW_LOG",
+                                       "/tmp/matrixark_refresh_shadow.log")
+            if count_before is None or count_after is None or count_before != count_after:
+                try:
+                    with open(log_path, "a", encoding="utf-8") as log:
+                        log.write("SKIPPED racy window count %r -> %r\n"
+                                  % (count_before, count_after))
+                except OSError:
+                    pass
+                return full
+
+            kept = set(wanted)
+
+            def project(records: list[Json]) -> list[tuple]:
+                out = []
+                for record in records:
+                    record_type = str(record.get("record_type") or "")
+                    if record_type not in kept:
+                        continue
+                    identity = ""
+                    for field in ("event_id_hash", "summary_hash", "entity_hash", "dirty_hash",
+                                  "segment_hash", "node_hash", "ref_hash", "child_hash",
+                                  "compression_id_hash", "boundary_hash"):
+                        value = record.get(field)
+                        if value not in (None, ""):
+                            identity = "%s=%s" % (field, value)
+                            break
+                    out.append((record_type, identity, int(record.get("updated_at_ms") or 0)))
+                return out
+
+            expected, got = project(full), project(live_subset)
+            if expected != got:
+                try:
+                    with open(log_path, "a", encoding="utf-8") as log:
+                        log.write("MISMATCH full=%d subset=%d only_full=%r only_subset=%r\n" % (
+                            len(expected), len(got),
+                            [row for row in expected if row not in set(got)][:4],
+                            [row for row in got if row not in set(expected)][:4],
+                        ))
+                except OSError:
+                    pass
+            else:
+                try:
+                    with open(log_path, "a", encoding="utf-8") as log:
+                        log.write("CLEAN %d records\n" % len(got))
+                except OSError:
+                    pass
+            return full
+        return live_subset
 
     def raw_records_for_history(self, memory_id: str | None = None) -> list[Json]:
         """History's records from a three-type scan instead of a raw read of the whole log.
@@ -2263,10 +2398,12 @@ class MatrixArkRustCdylibClient:
             append_options=append_options,
         )
 
-    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None) -> Json:
+    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False) -> Json:
         payload: Json = {"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}
         if record_ids:
             payload["record_ids"] = [str(item) for item in record_ids]
+        if return_index_records:
+            payload["return_index_records"] = True
         request = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
         def call() -> Json:
             out = self._ctypes.c_void_p()
@@ -3348,10 +3485,13 @@ class MatrixArkRustProxyClient:
         secondary_index_groups: list[list[str]],
         selected_node_hashes: list[int],
         record_ids: list[str] | None = None,
+        return_index_records: bool = False,
     ) -> Json:
         extra: Json = {}
         if record_ids:
             extra["record_ids"] = [str(item) for item in record_ids]
+        if return_index_records:
+            extra["return_index_records"] = True
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,

--- a/tools/test_refresh_scoped2.py
+++ b/tools/test_refresh_scoped2.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The refresh pass's typed subset runs the SAME serving chain as the full read.
+
+The first attempt at this seam was stopped by its own shadow harness; this version earned zero
+mismatches on live traffic by fixing three things these tests pin:
+
+* chain parity -- the subset goes through the latest-state fold BEFORE the tombstone sweep and
+  expiry filter, in the full read's order (skipping the fold silently dropped profile-shadowing
+  and copy-collapse behaviour);
+* the scan must not let the serving default eat requested types -- without return_index_records
+  the scan drops embedding rows AFTER filtering, which showed as 78 embeddings missing from every
+  compared pass, one direction, every time;
+* signature drift between the two proxy-client classes fails SAFE: a TypeError sends the caller
+  to the full read, never to a retry whose scan silently lacks the rows it asked for.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_local_adapter as local_mod
+    from tools import matrixark_mcp_temporal_adapters as adapters
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_local_adapter as local_mod
+    import matrixark_mcp_temporal_adapters as adapters
+
+
+class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
+    def __init__(self, scanned, *, latest_state=None, full=None):
+        self.scanned = scanned
+        self.latest_state = latest_state or []
+        self.full = full or []
+        self.full_reads = 0
+        self.scan_kwargs = None
+
+    def _scan_records_of_types(self, record_types, record_ids=None):
+        self.scan_kwargs = {"record_types": list(record_types), "record_ids": record_ids}
+        if self.scanned is None:
+            return None
+        wanted = set(record_types)
+        return [r for r in self.scanned if str(r.get("record_type") or "") in wanted]
+
+    def _load_latest_context_state_records(self):
+        return list(self.latest_state)
+
+    def read_all(self):
+        self.full_reads += 1
+        return list(self.full)
+
+    def _get_count(self):
+        return 7
+
+
+def _event(event_id, at_ms):
+    return {"record_type": "context_event", "event_id_hash": event_id, "text": "e%s" % event_id,
+            "updated_at_ms": at_ms}
+
+
+class RefreshSubsetTests(unittest.TestCase):
+    def test_the_subset_serves_without_a_full_read(self):
+        adapter = _Adapter([_event("1", 100)])
+        records = adapter.records_for_summary_refresh()
+        self.assertEqual(0, adapter.full_reads)
+        self.assertEqual(["1"], [r["event_id_hash"] for r in records])
+
+    def test_embeddings_are_requested_and_survive(self):
+        """The class of row the serving default used to eat."""
+        adapter = _Adapter([
+            _event("1", 100),
+            {"record_type": "context_embedding", "embedding_type": "node_l0",
+             "ref_type": "node", "ref_hash": 9, "node_hash": 9, "updated_at_ms": 150},
+        ])
+        records = adapter.records_for_summary_refresh()
+        self.assertIn("context_embedding", adapter.scan_kwargs["record_types"])
+        self.assertEqual(1, len([r for r in records
+                                 if r.get("record_type") == "context_embedding"]))
+
+    def test_a_deleted_event_does_not_reach_the_pass(self):
+        adapter = _Adapter([
+            _event("1", 100),
+            {"record_type": local_mod.MEMORY_TOMBSTONE_RECORD_TYPE, "tombstone_kind": "delete",
+             "target_memory_id": "1", "created_at_ms": 200},
+        ])
+        records = adapter.records_for_summary_refresh()
+        self.assertEqual([], [r for r in records if r.get("record_type") == "context_event"])
+
+    def test_latest_state_rows_are_folded_in(self):
+        adapter = _Adapter([_event("1", 100)],
+                           latest_state=[{"record_type": "context_summary", "summary_hash": "s9",
+                                          "summary_text": "from the hash", "updated_at_ms": 150}])
+        records = adapter.records_for_summary_refresh()
+        self.assertIn("s9", {r.get("summary_hash") for r in records
+                             if r.get("record_type") == "context_summary"})
+
+    def test_an_unanswerable_scan_serves_the_full_read(self):
+        adapter = _Adapter(None, full=[_event("7", 100)])
+        records = adapter.records_for_summary_refresh()
+        self.assertEqual(1, adapter.full_reads)
+        self.assertEqual("7", records[0]["event_id_hash"])
+
+    def test_a_failing_latest_state_load_serves_the_full_read(self):
+        adapter = _Adapter([_event("1", 100)], full=[_event("7", 100)])
+
+        def _boom():
+            raise RuntimeError("latest-state hash unreachable")
+
+        adapter._load_latest_context_state_records = _boom
+        records = adapter.records_for_summary_refresh()
+        self.assertEqual(1, adapter.full_reads)
+        self.assertEqual("7", records[0]["event_id_hash"])
+
+    def test_index_postings_are_not_requested(self):
+        """The store's largest class stays out of the pass on purpose."""
+        adapter = _Adapter([_event("1", 100)])
+        adapter.records_for_summary_refresh()
+        self.assertNotIn("context_index", adapter.scan_kwargs["record_types"])
+
+
+class TypeErrorFailsSafeTests(unittest.TestCase):
+    def test_signature_drift_sends_the_caller_to_its_fallback(self):
+        """A client missing a newer kwarg must yield None, never a degraded scan."""
+        adapter = object.__new__(adapters.MatrixArkTemporalStoreDirectAdapter)
+        adapter._count_key = "k"
+        adapter._record_hash_key = "r"
+        adapter._shard_size = 1024
+
+        class _OldClient:
+            def matrixark_scan_candidates(self, *, count_key, record_hash_key, shard_size,
+                                          scope, record_types, secondary_index_groups,
+                                          selected_node_hashes):
+                raise AssertionError("must not be reached with newer kwargs")
+
+        adapter._client = _OldClient()
+        self.assertIsNone(adapter._scan_records_of_types(["context_event"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The refresh pass's one remaining read was the WHOLE live store, once per pass, on a timer for the
life of the process. Its consumers touch a closed set of record types; what they never touch is
the store's largest class, index postings, and the audit/telemetry/idempotency families.

A first attempt at this was stopped by its own shadow harness and reverted. This version earned
ZERO mismatches on live refresher traffic, and the three differences are the story:

* The same chain, in the same order. The full read folds records through the latest-state serving fold BEFORE the
  tombstone sweep and expiry filter; the first attempt skipped the fold and applied the other two
  stages in a different order, silently losing profile shadowing and copy collapse. The subset now
  runs fold(subset + latest-state) -> compact_and_apply_tombstones -> filter_live -- the same
  functions in the same order. The fold's index-posting step is a no-op here because index rows
  are excluded by design and nothing this pass reads consumes them.

* The scan's serving default was eating requested rows. Without return_index_records the
  candidate scan drops embedding and index rows AFTER all other filtering -- so an explicit
  request for context_embedding returned none of them. That showed as 78 embeddings missing from
  every compared pass, one direction, every time. The typed-scan helper now always sets the flag:
  its contract is "records of exactly these types", and for requests without those types the type
  filter has already excluded them, which is why every earlier shadow run stayed clean.

* Signature drift between the two proxy-client classes now fails SAFE. The flag reached one
  client class and not the other; the adapter in use called the other, took a TypeError, and the
  helper's old fallback silently sent every caller to its full read -- the fast paths went dark
  with nothing visibly failing (the shadow instrumentation is what noticed). Both clients now
  carry the parameter, and a TypeError returns None outright: the full read is always correct,
  while retrying with fewer kwargs would hand callers a scan missing the rows they asked for.

* The comparison itself no longer races. The two views are read at different instants under live
  traffic, so the shadow reads the record count around the pair and SKIPS the comparison when the
  store moved -- logged as skipped, never counted as clean.

Validation: the live shadow gauntlet (multi-user, multi-session ingests, a delete, a TTL expiry,
refresher churning) compares clean with racy windows correctly skipped; strict conformance is
22/22 both with the shadow comparing and with the subset actually serving; 33 tests across the
refresh/history/prior-context suites and the five memory suites pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
