### PR TITLE
Stop naming the legacy implementation's language in field names

### DIFF
--- a/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
+++ b/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
@@ -22,7 +22,7 @@ struct OpsScaleReadinessReport {
     real_process_roles: Vec<String>,
     distributed_raft_load_ready: bool,
     raft_load_checks: Vec<String>,
-    cplusplus_workload_replay_ready: bool,
+    legacy_workload_replay_ready: bool,
     workload_families: Vec<String>,
     scale_slo_report: DockerAwsScaleSloEvidence,
     harnesses: Vec<HarnessEvidence>,
@@ -142,7 +142,7 @@ fn main() {
             covered_families.push(family.to_string());
         }
     }
-    let cplusplus_workload_replay_ready = [
+    let legacy_workload_replay_ready = [
         "feature_packed_timestamped_pages",
         "control_state_counter_window",
         "redis_compatible_set_core",
@@ -155,10 +155,10 @@ fn main() {
     let scale_slo_report = DockerAwsScaleSloEvidence {
         docker_or_aws_slo_evidence_ready: docker_scale_run_ready
             && distributed_raft_load_ready
-            && cplusplus_workload_replay_ready,
+            && legacy_workload_replay_ready,
         storage_deployment_scale_slo_ready: docker_scale_run_ready
             && distributed_raft_load_ready
-            && cplusplus_workload_replay_ready,
+            && legacy_workload_replay_ready,
         metaserver_process_ready: docker_scale_run_ready,
         proxy_process_ready: docker_scale_run_ready,
         client_process_ready: docker_scale_run_ready,
@@ -167,7 +167,7 @@ fn main() {
         storage_pressure_ready: docker_scale_run_ready,
         cache_pressure_ready: docker_scale_run_ready,
         proxy_convergence_ready: docker_scale_run_ready,
-        workload_replay_ready: cplusplus_workload_replay_ready,
+        workload_replay_ready: legacy_workload_replay_ready,
         collectors: vec![
             "cpu".to_string(),
             "memory".to_string(),
@@ -220,7 +220,7 @@ fn main() {
             ],
         },
         HarnessEvidence {
-            name: "unified_cplusplus_rust_workload_replay".to_string(),
+            name: "unified_legacy_rust_workload_replay".to_string(),
             command: "python3 tools/run_temporalstore_unified_tests.py --rust-only".to_string(),
             covers: covered_families.clone(),
         },
@@ -273,7 +273,7 @@ fn main() {
     );
     push_missing(
         &mut missing,
-        cplusplus_workload_replay_ready,
+        legacy_workload_replay_ready,
         "workload replay/golden corpus evidence",
     );
     push_missing(
@@ -306,7 +306,7 @@ fn main() {
             "membership".to_string(),
             "secondary_reads_under_load".to_string(),
         ],
-        cplusplus_workload_replay_ready,
+        legacy_workload_replay_ready,
         workload_families: covered_families,
         scale_slo_report,
         harnesses,

--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -252,7 +252,7 @@ pub struct ClientMigrationCompatibilityReport {
     pub compatibility_mode: ClientCompatibilityMode,
     pub rust_native_http_ready: bool,
     pub rust_native_tonic_ready: bool,
-    pub legacy_cplusplus_wire_in_scope: bool,
+    pub legacy_wire_in_scope: bool,
     pub native_wire_compatible_ready: bool,
     pub migration_layer_ready: bool,
     #[serde(default)]
@@ -276,7 +276,7 @@ impl Default for ClientMigrationCompatibilityReport {
             compatibility_mode: ClientCompatibilityMode::WireMigrationOutOfScope,
             rust_native_http_ready: true,
             rust_native_tonic_ready: true,
-            legacy_cplusplus_wire_in_scope: false,
+            legacy_wire_in_scope: false,
             native_wire_compatible_ready: false,
             migration_layer_ready: false,
             typed_table_client_ready: true,
@@ -298,7 +298,7 @@ impl Default for ClientMigrationCompatibilityReport {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ClientProductionReplacementContract {
     pub compatibility_decision: String,
-    pub legacy_cplusplus_wire_protocols_in_scope: Vec<String>,
+    pub legacy_wire_protocols_in_scope: Vec<String>,
     pub production_protocols: Vec<String>,
     pub supported_command_families: Vec<String>,
     pub typed_table_client_preserved: bool,
@@ -329,7 +329,7 @@ impl Default for ClientProductionReplacementContract {
             compatibility_decision:
                 "legacy wire migration shims are out of scope; use Rust-native migration contract"
                     .to_string(),
-            legacy_cplusplus_wire_protocols_in_scope: Vec::new(),
+            legacy_wire_protocols_in_scope: Vec::new(),
             production_protocols: vec![
                 "HTTP/JSON".to_string(),
                 "RESP".to_string(),
@@ -891,7 +891,7 @@ impl TemporalStoreClient {
             && replacement.http_json_contract_tested
             && replacement.resp_contract_tested
             && replacement.tonic_contract_tested
-            && !migration.legacy_cplusplus_wire_in_scope;
+            && !migration.legacy_wire_in_scope;
         let typed_table_client_ready =
             migration.typed_table_client_ready && replacement.typed_table_client_tested;
 

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -92,7 +92,7 @@ fn client_exposes_neptune_placement_hooks_and_migration_scope() {
     );
     assert!(migration.rust_native_http_ready);
     assert!(migration.rust_native_tonic_ready);
-    assert!(!migration.legacy_cplusplus_wire_in_scope);
+    assert!(!migration.legacy_wire_in_scope);
     assert!(!migration.native_wire_compatible_ready);
     assert!(!migration.migration_layer_ready);
     assert!(migration.typed_table_client_ready);

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -537,7 +537,7 @@ impl Default for ProxyTonicStreamingContract {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProxyMigrationContract {
     pub compatibility_decision: String,
-    pub legacy_cplusplus_wire_in_scope: bool,
+    pub legacy_wire_in_scope: bool,
     pub native_wire_proxy_transport_ready: bool,
     pub production_protocols: Vec<String>,
     pub http_json_aliases_ready: bool,
@@ -567,7 +567,7 @@ impl Default for ProxyMigrationContract {
             compatibility_decision:
                 "legacy command transport is out of scope; use Rust-native HTTP/JSON, RESP, and tonic"
                     .to_string(),
-            legacy_cplusplus_wire_in_scope: false,
+            legacy_wire_in_scope: false,
             native_wire_proxy_transport_ready: false,
             production_protocols: vec![
                 "HTTP/JSON".to_string(),
@@ -1851,7 +1851,7 @@ mod tests {
             migration.compatibility_decision,
             "legacy command transport is out of scope; use Rust-native HTTP/JSON, RESP, and tonic"
         );
-        assert!(!migration.legacy_cplusplus_wire_in_scope);
+        assert!(!migration.legacy_wire_in_scope);
         assert!(!migration.native_wire_proxy_transport_ready);
         assert!(migration.http_json_aliases_ready);
         assert!(migration.resp_migration_ready);

--- a/crates/temporalstore-rust/src/readiness.rs
+++ b/crates/temporalstore-rust/src/readiness.rs
@@ -222,7 +222,7 @@ pub struct ClientRoutingReadinessReport {
     pub rust_native_http_json_ready: bool,
     pub rust_native_resp_ready: bool,
     pub rust_native_tonic_ready: bool,
-    pub legacy_cplusplus_wire_out_of_scope: bool,
+    pub legacy_wire_out_of_scope: bool,
     pub compatibility_result_ready: bool,
     pub native_wire_migration_ready: bool,
     pub local_client_ready: bool,
@@ -246,7 +246,7 @@ pub struct ProxyServingReadinessReport {
     pub proxy_command_aliases_ready: bool,
     pub route_invalidation_ready: bool,
     pub route_quarantine_ready: bool,
-    pub legacy_cplusplus_wire_out_of_scope: bool,
+    pub legacy_wire_out_of_scope: bool,
     pub compatibility_result_ready: bool,
     pub native_wire_proxy_transport_ready: bool,
     pub local_proxy_ready: bool,
@@ -456,14 +456,14 @@ pub fn client_routing_readiness_report() -> ClientRoutingReadinessReport {
     let rust_native_http_json_ready = replacement_contract.http_json_contract_tested;
     let rust_native_resp_ready = replacement_contract.resp_contract_tested;
     let rust_native_tonic_ready = replacement_contract.tonic_contract_tested;
-    let legacy_cplusplus_wire_out_of_scope = true;
+    let legacy_wire_out_of_scope = true;
     let native_wire_migration_ready = false;
     let compatibility_result_ready = wire_compatibility_decision_tracked
         && rust_native_migration_contract_ready
         && rust_native_http_json_ready
         && rust_native_resp_ready
         && rust_native_tonic_ready
-        && legacy_cplusplus_wire_out_of_scope
+        && legacy_wire_out_of_scope
         && !native_wire_migration_ready;
     let local_client_ready = typed_table_client_ready
         && route_refresh_ready
@@ -496,7 +496,7 @@ pub fn client_routing_readiness_report() -> ClientRoutingReadinessReport {
         rust_native_http_json_ready,
         rust_native_resp_ready,
         rust_native_tonic_ready,
-        legacy_cplusplus_wire_out_of_scope,
+        legacy_wire_out_of_scope,
         compatibility_result_ready,
         native_wire_migration_ready,
         local_client_ready,
@@ -522,7 +522,7 @@ pub fn proxy_serving_readiness_report() -> ProxyServingReadinessReport {
     let proxy_command_aliases_ready = migration_contract.command_aliases_tested;
     let route_invalidation_ready = topology_refresh_ready;
     let route_quarantine_ready = migration_contract.backend_quarantine_preserved;
-    let legacy_cplusplus_wire_out_of_scope = true;
+    let legacy_wire_out_of_scope = true;
     let native_wire_proxy_transport_ready = false;
     let compatibility_result_ready = wire_compatibility_decision_tracked
         && rust_native_proxy_migration_contract_ready
@@ -535,7 +535,7 @@ pub fn proxy_serving_readiness_report() -> ProxyServingReadinessReport {
         && route_quarantine_ready
         && migration_contract.admission_policy_tested
         && migration_contract.typed_client_delegation_tested
-        && legacy_cplusplus_wire_out_of_scope
+        && legacy_wire_out_of_scope
         && !native_wire_proxy_transport_ready;
     let local_proxy_ready = http_execute_routes_ready
         && heartbeat_config_ready
@@ -568,7 +568,7 @@ pub fn proxy_serving_readiness_report() -> ProxyServingReadinessReport {
         proxy_command_aliases_ready,
         route_invalidation_ready,
         route_quarantine_ready,
-        legacy_cplusplus_wire_out_of_scope,
+        legacy_wire_out_of_scope,
         compatibility_result_ready,
         native_wire_proxy_transport_ready,
         local_proxy_ready,
@@ -870,7 +870,7 @@ mod tests {
         assert!(client.rust_native_http_json_ready);
         assert!(client.rust_native_resp_ready);
         assert!(client.rust_native_tonic_ready);
-        assert!(client.legacy_cplusplus_wire_out_of_scope);
+        assert!(client.legacy_wire_out_of_scope);
         assert!(client.compatibility_result_ready);
         assert!(!client.native_wire_migration_ready);
         assert!(client.production_ready);
@@ -902,7 +902,7 @@ mod tests {
         assert!(proxy.proxy_command_aliases_ready);
         assert!(proxy.route_invalidation_ready);
         assert!(proxy.route_quarantine_ready);
-        assert!(proxy.legacy_cplusplus_wire_out_of_scope);
+        assert!(proxy.legacy_wire_out_of_scope);
         assert!(proxy.compatibility_result_ready);
         assert!(!proxy.native_wire_proxy_transport_ready);
         assert!(proxy.production_ready);

--- a/crates/temporalstore-rust/src/readiness/production_report.rs
+++ b/crates/temporalstore-rust/src/readiness/production_report.rs
@@ -604,7 +604,7 @@ pub(crate) fn evidence_field_for(area: &str, capability: &str) -> &'static str {
             "metaserver_scheduler_report.durable_membership_coupling_ready"
         }
         "storage_cache" if capability.contains("golden") || capability.contains("corpus") => {
-            "storage_cplusplus_corpus_report.external_corpus_publication_ready"
+            "storage_legacy_corpus_report.external_corpus_publication_ready"
         }
         "storage_cache"
             if capability.contains("object-store") =>
@@ -649,7 +649,7 @@ pub(crate) fn evidence_field_for(area: &str, capability: &str) -> &'static str {
         "client" => "client_migration_contract.compatibility_result",
         "proxy" => "proxy_migration_contract.compatibility_result",
         "scale_testing" if capability.contains("workload") || capability.contains("corpus") => {
-            "scale_slo_report.cplusplus_workload_replay_ready"
+            "scale_slo_report.legacy_workload_replay_ready"
         }
         "scale_testing" if capability.contains("global production storage readiness") => {
             "scale_slo_report.storage_deployment_scale_slo_ready"

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -1839,7 +1839,7 @@ fn verify_proxy_operational_surface_aliases() {
     }
 
     let migration = proxy.native_migration_contract();
-    assert!(!migration.legacy_cplusplus_wire_in_scope);
+    assert!(!migration.legacy_wire_in_scope);
     assert!(migration.http_json_aliases_ready);
     assert!(migration.resp_migration_ready);
     assert!(migration.tonic_streaming_ready);


### PR DESCRIPTION
Thirty identifiers across the readiness reports, the client and the proxy named the
language the earlier implementation was written in. They are field names, so they
were in the serialized output too.

Renamed to say what they mean instead: legacy_wire_in_scope, legacy_wire_out_of_scope,
legacy_wire_protocols_in_scope, legacy_workload_replay_ready,
unified_legacy_rust_workload_replay, storage_legacy_corpus_report. "Legacy" is the
distinction those fields are actually drawing; the language was never the point.

Renamed rather than aliased on purpose. A serde alias would have kept JSON
compatibility, but it keeps the old spelling in the source, which is the thing being
removed. These are readiness and report fields, so the cost is a changed key in
diagnostic output rather than anything on a data path.

Worth recording how thirty of these survived a scrub that has been running on every
change for weeks. The scrub matched the language two ways, and the spelling used here is neither of
them: spelled out in words it shares no substring with either form the scrub knew. A
pattern narrowed to avoid false positives had quietly stopped covering one of the
spellings it existed for.

That is the second one of these found today. The other was a type prefix that put a
letter in front of a forbidden name, which a start-of-token match read as clean.
Both have the same shape: the narrowing that suppresses noise is also what creates
the hole, and it gets tested against the words it should ignore but not against the
identifiers it should catch.