### PR TITLE
Stop publishing where the optional object-store backend can be obtained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,5 +32,4 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/matrixarkai/MatrixRaft.git",
     "https://github.com/matrixarkai/MatrixCache.git",
-    "https://github.com/bjmeetsfo/MatrixObjectStore.git",
 ]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -182,8 +182,9 @@ build — you never clone them by hand:
 ```text
 matrixraft            https://github.com/matrixarkai/MatrixRaft.git         Raft consensus
 matrixcache           https://github.com/matrixarkai/MatrixCache.git        tiered cache + RocksDB SSD store
-matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  optional (--features matrixobject)
 ```
+
+An optional object-store backend sits behind `--features matrixobject`. It is not part of this build: the feature ships as an empty stub, so nothing is fetched for it and nothing needs to be.
 
 Each is pinned to an exact revision, so builds are reproducible. Because
 `matrixcache` enables the `rocksdb-ssd` feature, the first build compiles RocksDB

--- a/docs/linux_deploy.md
+++ b/docs/linux_deploy.md
@@ -96,8 +96,9 @@ the first build:
 ```text
 matrixraft            https://github.com/matrixarkai/MatrixRaft.git         (Raft consensus)
 matrixcache           https://github.com/matrixarkai/MatrixCache.git        (tiered cache + RocksDB SSD store)
-matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  (optional; enable with --features matrixobject)
 ```
+
+An optional object-store backend sits behind `--features matrixobject`. It is not part of this build: the feature ships as an empty stub, so nothing is fetched for it and nothing needs to be.
 
 Each dependency is pinned to an exact revision, so builds are reproducible. You
 do not clone these repos by hand — you only need `git` and network access to

--- a/docs/macos_deploy.md
+++ b/docs/macos_deploy.md
@@ -75,8 +75,9 @@ dependencies from public GitHub (see `crates/temporalstore-rust/Cargo.toml`), so
 ```text
 matrixraft            https://github.com/matrixarkai/MatrixRaft.git         (Raft consensus)
 matrixcache           https://github.com/matrixarkai/MatrixCache.git        (tiered cache + RocksDB SSD store)
-matrixobjectstore-rs  https://github.com/bjmeetsfo/MatrixObjectStore.git  (optional; enable with --features matrixobject)
 ```
+
+An optional object-store backend sits behind `--features matrixobject`. It is not part of this build: the feature ships as an empty stub, so nothing is fetched for it and nothing needs to be.
 
 Each is pinned to an exact revision, so you never clone them by hand — you only
 need `git` and network access to `github.com`. For offline builds, run


### PR DESCRIPTION
Three deploy guides list the build's git dependencies under the sentence *"pulls them as pinned Git
dependencies from public GitHub"*, and the last row of each table pointed at an enterprise product
in a repository the public cannot reach.

Both halves of that were wrong for a reader here: the URL does not resolve for them, and nothing
fetches it anyway — the shipped feature is the empty stub `matrixobject = []`, and the real
dependency is added only in enterprise builds. `deny.toml` carried a matching `allow-git` entry for
a dependency this build does not have.

Removed from `docs/INSTALL.md`, `docs/linux_deploy.md`, `docs/macos_deploy.md` and `deny.toml`. The
table row is replaced by a sentence that still tells the reader the optional backend exists, and
stops implying `cargo build` will go and get it. Every remaining row is genuinely public, so the
sentence above them is now true.

## What stays

Code that **talks to** that backend is untouched and belongs here: the feature-gated bridge
`matrixobject_store.rs` and the gated server front-end, both inert without the private dependency.
What goes is only the pointer telling the public where to obtain the product itself.

## Effect on the build

None. The feature was already a stub, and the `allow-git` entry governed a dependency that was never
resolved in a public build.
