### PR TITLE
Client: a table sync that changed nothing costs one round-trip, not two

### DIFF
--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -59,10 +59,22 @@ impl TemporalStoreClient {
             self.record_meta_sync_error(&namespace, &table_name, "table topology missing");
             ClientError::Status("table topology missing".to_string())
         })?;
-        let route_topology_version = self
-            .current_meta_topology_version()
-            .unwrap_or(table.topology_version)
-            .max(table.topology_version);
+        // Asked for only when it is going to be used. Stamping routes needs the cluster's
+        // topology version, and getting it is its own metaserver round-trip -- but an
+        // unchanged reply installs no routes, so on that path the version is wanted for the
+        // sync record alone, and the table's own version is already the right answer: the
+        // metaserver has just confirmed it is current, which is why it answered unchanged.
+        //
+        // Asking anyway made every sync cost two round-trips instead of one, and since the
+        // unchanged reply is the common case once a topology settles, that was the usual cost
+        // rather than an occasional one.
+        let route_topology_version = if topology.unchanged {
+            table.topology_version
+        } else {
+            self.current_meta_topology_version()
+                .unwrap_or(table.topology_version)
+                .max(table.topology_version)
+        };
         let serving_options = table.serving_options.clone();
         let default_serving_options = crate::meta::TableServingOptions::default();
         let options = TableOptions {

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -277,10 +277,12 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
     // deleted them all. Both halves are needed, in that order.
     let seen_versions = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
     let builds = std::sync::Arc::new(AtomicUsize::new(0));
+    let seen_version_calls = std::sync::Arc::new(AtomicUsize::new(0));
     let meta_addr = free_local_addr();
     let meta_addr_for_listener = meta_addr.clone();
     let versions = seen_versions.clone();
     let built = builds.clone();
+    let version_calls = seen_version_calls.clone();
     std::thread::spawn(move || {
         serve(&meta_addr_for_listener, move |request| {
             match (request.method.as_str(), request.path.as_str()) {
@@ -331,6 +333,13 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
                         },
                     )
                 }
+                // Only the CALL is interesting here. What comes back does not matter: an
+                // unparsed answer just falls back to the table's own version, and what this
+                // test measures is whether the call is made at all.
+                ("POST", "/meta/topology_version") => {
+                    version_calls.fetch_add(1, Ordering::SeqCst);
+                    json_response(503, &Status::error("unavailable", "not part of this test"))
+                }
                 _ => json_response(404, &Status::error("not_found", "no route")),
             }
         })
@@ -348,6 +357,7 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
         .sync_table_topology("ns".to_string(), "tbl".to_string())
         .expect("first sync succeeds");
     assert_eq!(client.topology_cache_report().route_count, 1);
+    let version_calls_after_first = seen_version_calls.load(Ordering::SeqCst);
 
     client
         .sync_table_topology("ns".to_string(), "tbl".to_string())
@@ -373,6 +383,11 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
         client.topology_cache_report().route_count,
         1,
         "an unchanged reply carries no shards and must not be read as having none"
+    );
+    assert_eq!(
+        seen_version_calls.load(Ordering::SeqCst),
+        version_calls_after_first,
+        "a sync that changed nothing should cost one round-trip, not two -- the cluster          topology version is only needed to stamp routes, and an unchanged reply installs none"
     );
 }
 


### PR DESCRIPTION
Syncing a table's topology fetched the cluster's topology version as well, always.
That version is needed to stamp the routes being installed -- but when the
metaserver answers that nothing changed, no routes are installed, and the version is
wanted only for the sync record. The table's own version is already the right answer
there: the metaserver has just confirmed it is current, which is why it said
unchanged.

So every sync made two metaserver round-trips where one would do, and the second was
a question whose answer was already in hand.

It is now fetched only on the path that uses it.

This matters more than it would have a few changes ago. Once a client started
declaring the version it already has, the unchanged reply became the ordinary answer
rather than an occasional one -- which turned this second call from an edge cost
into the usual one. Removing it takes the steady-state cost of keeping a table's
topology fresh down to a single request.

Measured by counting what the metaserver received: two syncs made four calls before,
and make two after.