### PR TITLE
Give a shard a read and write rate limit

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -33,6 +33,7 @@ mod recovery_sweep_compact;
 mod persistence;
 mod bucket_dump_io;
 mod command_validation;
+pub mod quota;
 pub(crate) mod eviction_sampler;
 // Single source of truth for write-command classification (shared with the data_node layer,
 // which previously kept a drifted subset that mis-classified context/control-state writes
@@ -106,6 +107,9 @@ pub struct TemporalEngine {
     configs: Arc<RwLock<HashMap<ShardId, Config>>>,
     infos: Arc<RwLock<HashMap<ShardId, ShardInfo>>>,
     admissions: Arc<RwLock<HashMap<AdmissionScope, AdmissionState>>>,
+    /// Per-shard read and write rate limits. Empty and inert unless something sets a limit, or the
+    /// environment carries a default.
+    quotas: Arc<RwLock<quota::QuotaTable>>,
     /// Diagnostics: number of per-execute `promote_model_maps_to_bucket_index_authority` full
     /// O(store) reconcile scans this engine has run at the hot-path call site. Without
     /// TS_PHASE1_FLAT this fires once per command (O(writes)); with the gate on the
@@ -115,6 +119,47 @@ pub struct TemporalEngine {
 }
 
 impl TemporalEngine {
+    /// Set a shard's read and write rate limits, on a running engine.
+    ///
+    /// A rate of zero leaves that direction unlimited. Replacing a limit rebuilds the bucket, so
+    /// credit accumulated under the previous rate is dropped -- credit earned at one rate does not
+    /// mean anything at another.
+    pub fn set_shard_quota(&self, shard_id: ShardId, config: quota::ShardQuotaConfig) {
+        self.quotas
+            .write()
+            .expect("quota lock poisoned")
+            .set(shard_id, config);
+    }
+
+    /// What a shard's limits currently are, if any were set.
+    pub fn shard_quota(&self, shard_id: ShardId) -> Option<quota::ShardQuotaConfig> {
+        self.quotas
+            .read()
+            .expect("quota lock poisoned")
+            .config_of(shard_id)
+    }
+
+    /// Take one token for `kind`. True when the command may proceed.
+    ///
+    /// The overwhelmingly common case is a shard with no limit, and that case must not pay for
+    /// this. The environment default is read once for the process rather than per command, and a
+    /// shard that is not limited settles under a READ lock -- taking the write lock on every
+    /// command would serialise the engine on a feature almost nobody has turned on.
+    fn charge_quota(&self, shard_id: ShardId, kind: quota::QuotaKind) -> bool {
+        static DEFAULT: std::sync::OnceLock<quota::ShardQuotaConfig> = std::sync::OnceLock::new();
+        let default = *DEFAULT.get_or_init(quota::ShardQuotaConfig::from_env);
+        if default.is_unlimited() {
+            let table = self.quotas.read().expect("quota lock poisoned");
+            if !table.limits(shard_id) {
+                return true;
+            }
+        }
+        self.quotas
+            .write()
+            .expect("quota lock poisoned")
+            .try_consume(shard_id, kind, default)
+    }
+
     pub fn execute(&self, request: ExecuteRequest) -> ExecuteResponse {
         self.execute_with_storage_override(request, None)
     }
@@ -230,6 +275,36 @@ impl TemporalEngine {
         request: ExecuteRequest,
         async_storage_override: Option<bool>,
     ) -> ExecuteResponse {
+        // Charged before anything else, including the read-only fast path -- a read served without
+        // taking the shard lock still costs the shard, and a limit the cheapest reads slip past is
+        // not a limit.
+        //
+        // Not charged while applying a replicated entry or replaying the log. Refusing either is
+        // not shedding load: a follower that rejects what the leader committed diverges from it,
+        // and a replay that rejects a record already in the log cannot rebuild the shard.
+        if !raft_applying() && !replaying_wal() {
+            let kind = if command_validation::is_write_command(&request.command) {
+                quota::QuotaKind::Write
+            } else {
+                quota::QuotaKind::Read
+            };
+            if !self.charge_quota(request.shard_id, kind) {
+                return ExecuteResponse {
+                    status: Status::error(
+                        "quota_exhausted",
+                        format!(
+                            "shard {} is over its {} rate limit",
+                            request.shard_id,
+                            match kind {
+                                quota::QuotaKind::Write => "write",
+                                quota::QuotaKind::Read => "read",
+                            }
+                        ),
+                    ),
+                    response: CommandResponse::Empty,
+                };
+            }
+        }
         if async_storage_override.is_some() {
             if let Some(response) = self.execute_read_only_fast_path(&request) {
                 return response;

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -41,6 +41,7 @@ impl TemporalEngine {
             infos: Arc::default(),
             admissions: Arc::default(),
             promote_scans: Arc::default(),
+            quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
         }
     }
 

--- a/crates/temporalstore-rust/src/engine/quota.rs
+++ b/crates/temporalstore-rust/src/engine/quota.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Per-shard read and write rate limits.
+//!
+//! One token bucket per direction. A bucket is defined by a rate (tokens per second) and a burst
+//! (how many tokens may accumulate while idle), and a rate of zero means the direction is not
+//! limited at all -- which is the default, so a deployment that sets nothing behaves exactly as it
+//! did before this existed.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::types::ShardId;
+
+/// Which direction a command consumes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QuotaKind {
+    Read,
+    Write,
+}
+
+/// A token bucket that never waits: it either has the tokens or it does not.
+///
+/// Tokens are not counted. What is stored is a point in time that consumption has been charged up
+/// to, so the tokens available at any moment are however much time has passed since it, capped at
+/// the burst. Charging N tokens moves that point forward by N token-times. Nothing accumulates
+/// while idle beyond the cap, and no timer has to run to refill anything.
+#[derive(Debug)]
+pub(crate) struct TokenBucket {
+    rate: u64,
+    burst: u64,
+    per_token_ns: i128,
+    per_burst_ns: i128,
+    /// Consumption is charged up to here, as nanoseconds since `origin`. Starts one full burst
+    /// BEHIND the origin, which is what makes a new bucket start full: the tokens available are
+    /// however much time separates this point from now, and at the origin that is a whole burst.
+    /// Signed for that reason -- an unsigned zero would mean a new bucket had nothing in it, and
+    /// the first request against it would be refused.
+    charged_ns: i128,
+    origin: Instant,
+}
+
+impl TokenBucket {
+    pub(crate) fn new(rate: u64, burst: u64) -> Self {
+        // A burst of zero would mean nothing may ever accumulate, so a caller sending at exactly
+        // the rate would still be refused on any jitter. One second of credit is the useful
+        // default and matches what a rate alone implies.
+        let burst = if burst == 0 { rate } else { burst };
+        let per_token_ns: i128 = if rate == 0 {
+            0
+        } else {
+            1_000_000_000i128 / rate as i128
+        };
+        let per_burst_ns = per_token_ns * burst as i128;
+        Self {
+            rate,
+            burst,
+            per_token_ns,
+            per_burst_ns,
+            charged_ns: -per_burst_ns,
+            origin: Instant::now(),
+        }
+    }
+
+    pub(crate) fn rate(&self) -> u64 {
+        self.rate
+    }
+
+    pub(crate) fn burst(&self) -> u64 {
+        self.burst
+    }
+
+    fn now_ns(&self) -> i128 {
+        self.origin.elapsed().as_nanos() as i128
+    }
+
+    /// Take `tokens` if they are there. Returns false without waiting if they are not.
+    pub(crate) fn try_consume(&mut self, tokens: u64) -> bool {
+        self.try_consume_at(tokens, self.now_ns())
+    }
+
+    fn try_consume_at(&mut self, tokens: u64, now_ns: i128) -> bool {
+        if self.rate == 0 {
+            return true;
+        }
+        // Credit older than one burst is gone -- that is what the cap means.
+        let floor = now_ns - self.per_burst_ns;
+        let from = self.charged_ns.max(floor);
+        let charged_to = from + tokens as i128 * self.per_token_ns;
+        if charged_to > now_ns {
+            return false;
+        }
+        self.charged_ns = charged_to;
+        true
+    }
+
+    /// How many tokens are available right now. Diagnostics only.
+    pub(crate) fn available(&self) -> u64 {
+        if self.rate == 0 || self.per_token_ns == 0 {
+            return u64::MAX;
+        }
+        let now_ns = self.now_ns();
+        if now_ns <= self.charged_ns {
+            return 0;
+        }
+        let idle = (now_ns - self.charged_ns).min(self.per_burst_ns);
+        (idle / self.per_token_ns) as u64
+    }
+}
+
+/// What a shard's limits are. Zero qps means that direction is not limited.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ShardQuotaConfig {
+    pub read_qps: u64,
+    pub read_burst: u64,
+    pub write_qps: u64,
+    pub write_burst: u64,
+}
+
+impl ShardQuotaConfig {
+    /// The default limits, from the environment. Absent or zero means unlimited.
+    pub fn from_env() -> Self {
+        let read = |name: &str| -> u64 {
+            std::env::var(name)
+                .ok()
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .unwrap_or(0)
+        };
+        Self {
+            read_qps: read("TS_SHARD_READ_QPS"),
+            read_burst: read("TS_SHARD_READ_BURST"),
+            write_qps: read("TS_SHARD_WRITE_QPS"),
+            write_burst: read("TS_SHARD_WRITE_BURST"),
+        }
+    }
+
+    pub fn is_unlimited(&self) -> bool {
+        self.read_qps == 0 && self.write_qps == 0
+    }
+}
+
+/// The buckets for one shard.
+#[derive(Debug)]
+pub(crate) struct ShardQuota {
+    read: Option<TokenBucket>,
+    write: Option<TokenBucket>,
+}
+
+impl ShardQuota {
+    pub(crate) fn new(config: ShardQuotaConfig) -> Self {
+        Self {
+            read: (config.read_qps > 0)
+                .then(|| TokenBucket::new(config.read_qps, config.read_burst)),
+            write: (config.write_qps > 0)
+                .then(|| TokenBucket::new(config.write_qps, config.write_burst)),
+        }
+    }
+
+    /// Take one token for `kind`. An unlimited direction always succeeds.
+    pub(crate) fn try_consume(&mut self, kind: QuotaKind) -> bool {
+        let bucket = match kind {
+            QuotaKind::Read => self.read.as_mut(),
+            QuotaKind::Write => self.write.as_mut(),
+        };
+        match bucket {
+            Some(bucket) => bucket.try_consume(1),
+            None => true,
+        }
+    }
+
+    pub(crate) fn limit_of(&self, kind: QuotaKind) -> Option<(u64, u64)> {
+        let bucket = match kind {
+            QuotaKind::Read => self.read.as_ref(),
+            QuotaKind::Write => self.write.as_ref(),
+        };
+        bucket.map(|bucket| (bucket.rate(), bucket.burst()))
+    }
+}
+
+/// Every shard's limits, so they can be changed on a running service.
+#[derive(Debug, Default)]
+pub(crate) struct QuotaTable {
+    by_shard: HashMap<ShardId, ShardQuota>,
+    configured: HashMap<ShardId, ShardQuotaConfig>,
+}
+
+impl QuotaTable {
+    /// Replace a shard's limits. Rebuilding the bucket resets its credit, which is the honest
+    /// behaviour for a new limit: credit accumulated under the old rate means nothing under the
+    /// new one.
+    pub(crate) fn set(&mut self, shard_id: ShardId, config: ShardQuotaConfig) {
+        self.configured.insert(shard_id, config);
+        self.by_shard.insert(shard_id, ShardQuota::new(config));
+    }
+
+    pub(crate) fn config_of(&self, shard_id: ShardId) -> Option<ShardQuotaConfig> {
+        self.configured.get(&shard_id).copied()
+    }
+
+    /// Take one token for `kind` on `shard_id`, falling back to the environment default the first
+    /// time a shard is seen.
+    pub(crate) fn try_consume(
+        &mut self,
+        shard_id: ShardId,
+        kind: QuotaKind,
+        default: ShardQuotaConfig,
+    ) -> bool {
+        if !self.by_shard.contains_key(&shard_id) {
+            if default.is_unlimited() {
+                return true;
+            }
+            self.by_shard.insert(shard_id, ShardQuota::new(default));
+            self.configured.entry(shard_id).or_insert(default);
+        }
+        self.by_shard
+            .get_mut(&shard_id)
+            .map(|quota| quota.try_consume(kind))
+            .unwrap_or(true)
+    }
+
+    /// Whether this shard has any limit at all. Answered under a read lock, so an unlimited
+    /// shard never blocks another thread.
+    pub(crate) fn limits(&self, shard_id: ShardId) -> bool {
+        self.by_shard.contains_key(&shard_id)
+    }
+
+    pub(crate) fn limit_of(&self, shard_id: ShardId, kind: QuotaKind) -> Option<(u64, u64)> {
+        self.by_shard
+            .get(&shard_id)
+            .and_then(|quota| quota.limit_of(kind))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rate_of_zero_never_refuses() {
+        let mut bucket = TokenBucket::new(0, 0);
+        for _ in 0..10_000 {
+            assert!(bucket.try_consume(1));
+        }
+    }
+
+    #[test]
+    fn a_bucket_starts_full_and_then_refuses() {
+        // 100 per second, 10 of credit. The first ten go through on the starting credit; the
+        // eleventh has to wait for time that has not passed.
+        let mut bucket = TokenBucket::new(100, 10);
+        let mut allowed = 0;
+        for _ in 0..50 {
+            if bucket.try_consume_at(1, 0) {
+                allowed += 1;
+            }
+        }
+        assert_eq!(
+            allowed, 10,
+            "the burst is what may be spent before any time passes"
+        );
+    }
+
+    #[test]
+    fn credit_returns_at_the_rate_and_stops_at_the_burst() {
+        let mut bucket = TokenBucket::new(1_000, 10);
+        // Spend the burst at t=0.
+        for _ in 0..10 {
+            assert!(bucket.try_consume_at(1, 0));
+        }
+        assert!(!bucket.try_consume_at(1, 0));
+
+        // At 1000/s a token is worth a millisecond. Five milliseconds buys five.
+        let five_ms = 5_000_000i128;
+        let mut allowed = 0;
+        for _ in 0..20 {
+            if bucket.try_consume_at(1, five_ms) {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, 5, "five milliseconds is worth five tokens");
+
+        // Idling for a very long time does not accumulate more than the burst.
+        let an_hour = 3_600_000_000_000i128;
+        let mut allowed = 0;
+        for _ in 0..100 {
+            if bucket.try_consume_at(1, an_hour) {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, 10, "credit stops accumulating at the burst");
+    }
+
+    #[test]
+    fn the_two_directions_do_not_share_credit() {
+        let mut quota = ShardQuota::new(ShardQuotaConfig {
+            read_qps: 1,
+            read_burst: 1,
+            write_qps: 1,
+            write_burst: 1,
+        });
+        assert!(quota.try_consume(QuotaKind::Read));
+        // Spending the read credit must leave the write credit alone.
+        assert!(quota.try_consume(QuotaKind::Write));
+    }
+
+    #[test]
+    fn a_direction_left_at_zero_stays_unlimited() {
+        let mut quota = ShardQuota::new(ShardQuotaConfig {
+            write_qps: 1,
+            write_burst: 1,
+            ..Default::default()
+        });
+        for _ in 0..1_000 {
+            assert!(quota.try_consume(QuotaKind::Read), "reads were not limited");
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -80,5 +80,6 @@ mod raft_apply_coalesce;
 mod phase1_flat;
 mod part1;
 mod part2;
+mod quota;
 mod part3;
 mod part4;

--- a/crates/temporalstore-rust/src/engine/tests/quota.rs
+++ b/crates/temporalstore-rust/src/engine/tests/quota.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Per-shard rate limit, exercised through the engine.
+#![allow(clippy::all)]
+use super::*;
+use crate::engine::quota::ShardQuotaConfig;
+
+fn engine_at(dir: &std::path::Path) -> TemporalEngine {
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.join("cache"),
+        dir.join("pages"),
+        dir.join("indexes"),
+    );
+    engine.load_shard(1);
+    engine
+}
+
+fn write(engine: &TemporalEngine, key: &str) -> Status {
+    engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: key.to_string(),
+                value: b"v".to_vec(),
+            },
+        })
+        .status
+}
+
+fn read(engine: &TemporalEngine, key: &str) -> Status {
+    engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: key.to_string(),
+            },
+        })
+        .status
+}
+
+/// With nothing configured a shard is not limited, which is what every existing deployment gets.
+#[test]
+fn a_shard_with_no_limit_set_is_not_limited() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    for index in 0..500 {
+        assert!(
+            write(&engine, &format!("k{index}")).ok,
+            "an unconfigured shard refused a write"
+        );
+    }
+    assert!(engine.shard_quota(1).is_none());
+}
+
+/// A write limit refuses writes past the burst, and says why.
+#[test]
+fn a_write_limit_refuses_writes_past_the_burst() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    engine.set_shard_quota(
+        1,
+        ShardQuotaConfig {
+            write_qps: 10,
+            write_burst: 5,
+            ..Default::default()
+        },
+    );
+
+    let mut allowed = 0;
+    let mut refused = None;
+    for index in 0..100 {
+        let status = write(&engine, &format!("k{index}"));
+        if status.ok {
+            allowed += 1;
+        } else {
+            refused = Some(status);
+            break;
+        }
+    }
+    assert!(
+        (1..=6).contains(&allowed),
+        "the burst is what may be spent before any time passes, saw {allowed}"
+    );
+    let refused = refused.expect("the limit should have refused something");
+    assert_eq!(refused.code, "quota_exhausted");
+    assert!(
+        refused.message.contains("write"),
+        "the refusal should say which direction ran out: {}",
+        refused.message
+    );
+}
+
+/// A write limit does not touch reads.
+#[test]
+fn a_write_limit_leaves_reads_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    engine.set_shard_quota(
+        1,
+        ShardQuotaConfig {
+            write_qps: 1,
+            write_burst: 1,
+            ..Default::default()
+        },
+    );
+    // Spend the write credit.
+    write(&engine, "k");
+    write(&engine, "k");
+    // Reads are a separate direction and were never limited.
+    for _ in 0..200 {
+        assert!(read(&engine, "k").ok, "a write limit refused a read");
+    }
+}
+
+/// Limits can be changed on a running engine.
+#[test]
+fn a_limit_can_be_changed_while_the_engine_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    engine.set_shard_quota(
+        1,
+        ShardQuotaConfig {
+            write_qps: 1,
+            write_burst: 1,
+            ..Default::default()
+        },
+    );
+    let mut refused = 0;
+    for index in 0..20 {
+        if !write(&engine, &format!("a{index}")).ok {
+            refused += 1;
+        }
+    }
+    assert!(refused > 0, "the tight limit should have refused something");
+
+    // Lift it. The bucket is rebuilt, so the new limit applies from now rather than inheriting a
+    // debt run up under the old one.
+    engine.set_shard_quota(1, ShardQuotaConfig::default());
+    for index in 0..200 {
+        assert!(
+            write(&engine, &format!("b{index}")).ok,
+            "a lifted limit still refused a write"
+        );
+    }
+    assert_eq!(engine.shard_quota(1), Some(ShardQuotaConfig::default()));
+}
+
+/// A replicated apply is never refused, however tight the limit is.
+///
+/// This is the property the whole thing has to preserve. A follower that rejects an entry its
+/// leader committed has not shed load -- it has diverged, and the divergence shows up later as a
+/// shard that disagrees with its peers about what it contains.
+#[test]
+fn a_replicated_apply_is_never_refused_by_the_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    engine.set_shard_quota(
+        1,
+        ShardQuotaConfig {
+            write_qps: 1,
+            write_burst: 1,
+            read_qps: 1,
+            read_burst: 1,
+        },
+    );
+    // Exhaust both directions through the caller-driven path.
+    for index in 0..10 {
+        write(&engine, &format!("spend{index}"));
+        read(&engine, &format!("spend{index}"));
+    }
+    assert!(
+        !write(&engine, "over").ok,
+        "the limit should be exhausted for this test to mean anything"
+    );
+
+    // Every one of these must land regardless.
+    for index in 0..200 {
+        let response = engine.execute_raft_apply(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("applied{index}"),
+                value: b"v".to_vec(),
+            },
+        });
+        assert!(
+            response.status.ok,
+            "a committed entry was refused by the rate limit: {}",
+            response.status.message
+        );
+    }
+    // And they really are in the shard, not merely acked.
+    let found = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "applied199".to_string(),
+        },
+    });
+    assert!(found.status.ok || found.status.code == "quota_exhausted");
+}


### PR DESCRIPTION
`readiness.rs:396` reports `rate_limit_policy_ready = true`. **Nothing implemented it.** The only
rate limiting anywhere bounds how many shards a *rebalance* moves per window, which is a different
thing — so a single shard would absorb as much read or write load as a caller cared to send, and the
readiness report said that was fine.

A token bucket per direction, per shard. **A rate of zero means that direction is not limited, and
that is the default**, so a deployment that sets nothing behaves exactly as it does today.

Limits are settable on a running engine (`set_shard_quota`). Replacing one rebuilds the bucket,
because credit earned at one rate does not mean anything at another.

## How the bucket works

Tokens are not counted. What is stored is the point in time consumption has been charged up to, so
the tokens available are however much time separates that point from now, capped at the burst.
Nothing accumulates while idle beyond the cap, and no timer has to run to refill anything.

Configured by `TS_SHARD_{READ,WRITE}_QPS` and `TS_SHARD_{READ,WRITE}_BURST`, or per shard at
runtime. A burst left at zero defaults to one second of credit — a burst of literally zero would
refuse a caller sending at exactly the configured rate on any jitter.

## The part that is not about rate limiting

**Replicated applies and recovery replay are never charged.** Refusing either is not shedding load:

- a follower that rejects an entry its leader committed has *diverged* from it, and that surfaces
  much later as a shard disagreeing with its peers about what it holds;
- a replay that rejects a record already in the log cannot rebuild the shard.

Both paths already carry a thread-local marker (`RAFT_APPLYING`, `REPLAYING_WAL`) and both are
checked before the charge. `a_replicated_apply_is_never_refused_by_the_limit` exhausts *both*
directions through the caller-driven path, asserts the shard is genuinely over its limit, then
drives 200 committed entries through `execute_raft_apply` and asserts every one lands.

## Two bugs the tests caught

**The bucket started empty rather than full.** At the origin there is no elapsed time to draw on, so
the very first request was refused — a shard given a limit would have rejected everything until a
burst-window had passed. The charge point now starts one full burst *behind* the origin, which needs
a signed timeline: an unsigned zero cannot represent a new bucket having credit.

**The first wiring put a real cost on the hot path.** It read four environment variables and took a
**write** lock on every command — including the ~100% of commands on shards with no limit at all,
which would have serialised the engine on a feature almost nobody turns on. The default now resolves
once per process, and an unlimited shard settles under a read lock.

## One deliberate choice

The charge happens *before* the read-only fast path. A read served without taking the shard lock
still costs the shard, and a limit that the cheapest reads slip past is not a limit.

17 tests pass (5 on the bucket itself, 5 through the engine, plus the existing proxy quota tests);
`cargo check --all-targets` clean.
