### PR TITLE
Report the freezes the default failure detector makes

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2074,6 +2074,79 @@ mod tests {
     }
 
     #[test]
+    fn the_default_detector_reports_what_it_freezes() {
+        // temporalstore_meta_convicted_total is exported unconditionally, and
+        // only the adaptive detector was recording into it. The adaptive one is
+        // off unless asked for, so on a default metaserver the counter sat at
+        // zero while this detector froze servers and proxies -- a confident
+        // wrong number, which reads worse than an absent series.
+        let meta = SingleNodeMeta::default();
+        register(&meta, "server-a");
+        assert!(meta
+            .register_proxy(RegisterProxyRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let report = meta.freeze_stale_resources(0);
+        assert!(report.status.ok);
+        assert_eq!(report.frozen_servers.len(), 1, "{report:?}");
+        assert_eq!(report.frozen_proxies.len(), 1, "{report:?}");
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_convicted_total{tier=\"server\"} 1"),
+            "the detector froze a server and the counter did not move:\n{exported}"
+        );
+        assert!(
+            exported.contains("temporalstore_meta_convicted_total{tier=\"proxy\"} 1"),
+            "the detector froze a proxy and the counter did not move:\n{exported}"
+        );
+    }
+
+    #[test]
+    fn each_tier_counts_only_its_own_freezes() {
+        // `record_conviction` sums both lists, so one call carrying servers and
+        // proxies together would count every freeze under both tiers. The
+        // counts are deliberately asymmetric -- two servers, one proxy -- so
+        // any cross-contamination shows up as a wrong number rather than a
+        // coincidentally equal one.
+        let meta = SingleNodeMeta::default();
+        register(&meta, "server-a");
+        register(&meta, "server-b");
+        assert!(meta
+            .register_proxy(RegisterProxyRequest {
+                proxy_addr: "proxy-a".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        assert!(meta.freeze_stale_resources(0).status.ok);
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_convicted_total{tier=\"server\"} 2"),
+            "two servers frozen must count two under server:
+{exported}"
+        );
+        assert!(
+            exported.contains("temporalstore_meta_convicted_total{tier=\"proxy\"} 1"),
+            "one proxy frozen must count one under proxy:
+{exported}"
+        );
+    }
+
+    #[test]
     fn a_convicted_server_cannot_register_its_way_back_into_service() {
         // Without this the freeze cooldown is the only guard, and it defaults to
         // zero -- so the convicted node clears the metaserver's decision simply

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -5,6 +5,29 @@
 
 use super::*;
 
+/// One round of the simple failure detector, in the shape the metrics recorder
+/// takes.
+///
+/// The fields left empty belong to the adaptive detector: safe-mode holds,
+/// per-location damage, reboot detection, the orphan guard. This detector has
+/// none of them, so empty is what actually happened rather than a placeholder.
+fn simple_conviction_round(
+    frozen_servers: Vec<String>,
+    frozen_proxies: Vec<String>,
+) -> AdaptiveConvictionReport {
+    AdaptiveConvictionReport {
+        status: Status::ok(),
+        frozen_servers,
+        frozen_proxies,
+        held_by_safe_mode: Vec::new(),
+        damage: Vec::new(),
+        rebooted: Vec::new(),
+        detector_paused: false,
+        held_by_orphan_guard: Vec::new(),
+        orphaned_shards: Vec::new(),
+    }
+}
+
 impl SingleNodeMeta {
     pub fn get_table_topology(&self, request: GetTableTopologyRequest) -> TableTopologyResponse {
         self.counters.topology_query_total.fetch_add(1, Ordering::Relaxed);
@@ -247,6 +270,25 @@ impl SingleNodeMeta {
         }
 
         let proxy_report = self.freeze_stale_proxies(stale_after_ms, policy);
+        // Recorded per tier, the way the adaptive detector records its own
+        // rounds. `record_conviction` counts both lists, so one call carrying
+        // both would double every freeze; the adaptive path calls it once per
+        // tier with the other list empty, and this matches it.
+        //
+        // Without this the counter is exported unconditionally and sits at zero
+        // while this detector -- the default one, since
+        // TS_META_ADAPTIVE_FAILURE_DETECTOR is off unless asked for -- freezes
+        // servers and proxies. A confident wrong number reads worse than an
+        // absent series: `absent()` catches a missing one, nothing catches a
+        // zero.
+        self.metrics.record_conviction(
+            TIER_SERVER,
+            &simple_conviction_round(frozen_servers.clone(), Vec::new()),
+        );
+        self.metrics.record_conviction(
+            TIER_PROXY,
+            &simple_conviction_round(Vec::new(), proxy_report.frozen_proxies.clone()),
+        );
         StaleResourceReport {
             status: proxy_report.status,
             frozen_servers,


### PR DESCRIPTION
> Independent of the other open work — `main` base.

## The default failure detector froze resources and reported nothing

`temporalstore_meta_convicted_total` is exported unconditionally:

```
# HELP temporalstore_meta_convicted_total Resources frozen by the failure detector.
```

`record_conviction` had exactly two production callers, both in
`failure_detector.rs` — the **adaptive** detector, which is off unless
`TS_META_ADAPTIVE_FAILURE_DETECTOR` asks for it. The default path is
`start_failure_detector_loop` → `freeze_stale_resources`, and it recorded
nothing.

So on a default metaserver the counter sat at **zero** while servers and proxies
were being frozen. That is worse than a missing series: `absent()` catches a
metric that is not there, and nothing catches one that is confidently wrong.

The freeze itself was never invisible — it goes through `apply_set_server_state`,
which emits a `server_state` topology event. The history and the counter simply
disagreed, and the counter is what an alert watches.

## The change

The simple detector now records each round, per tier, the way the adaptive one
already does.

**Per tier, with the other list empty**, because `record_conviction` counts
`frozen_servers.len() + frozen_proxies.len()`. A single call carrying both would
count every freeze under both tiers.

The helper's empty fields are not placeholders. Safe-mode holds, per-location
damage, reboot detection and the orphan guard belong to the adaptive detector;
this one has none of them, so "held back nothing, assessed nothing, never
paused" is what actually happened in its round.

## Tests

- **the default detector reports what it freezes** — fails without the recording
- **each tier counts only its own freezes** — two servers and one proxy,
  deliberately asymmetric

The second one earned its shape the hard way. My first version used only
servers, so when I injected the double-count bug it still passed — a test named
for a guarantee it could not check. Asymmetric counts make cross-contamination
show up as a wrong number rather than a coincidentally equal one, and it now
fails when the bug is injected.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1`
- `cargo test --lib -- --test-threads=1`

Both tests mutation-checked in both directions: remove the recording and they
fail; introduce the double count and the tier test fails.
