### PR TITLE
Name the points a test can stop at, instead of hand-building what a crash leaves

### DIFF
--- a/crates/temporalstore-rust/src/fault.rs
+++ b/crates/temporalstore-rust/src/fault.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Named points where a test can make the code stop or stall.
+//!
+//! A durable operation is usually several steps -- write, sync, rename, sync again -- and the
+//! interesting failures live BETWEEN them. Testing those by hand means building the post-crash
+//! state yourself: delete this, truncate that, reopen, check. That is only a test of the real
+//! window if the state you built is the state the crash would have left, and getting that wrong
+//! produces a test that passes for the wrong reason.
+//!
+//! A named point removes the guessing. Arm `wal/roll/after_rename`, run the roll, and the process
+//! stops exactly there -- so what is on disk is, by construction, what a crash at that line leaves.
+//!
+//! ```ignore
+//! let _armed = fault::arm("wal/roll/after_rename", FaultAction::Stop);
+//! let outcome = std::panic::catch_unwind(|| store.append(...));
+//! assert!(outcome.is_err());        // stopped mid-roll
+//! // ... reopen and assert recovery does the right thing
+//! ```
+//!
+//! Arming is per THREAD and lasts until the guard drops. That is deliberate: this suite runs
+//! ~1200 tests across 16 threads, and its most persistent flakiness comes from tests reaching for
+//! process-wide state. A point armed process-wide would stop unrelated tests at the same line.
+//!
+//! Cost when nothing is armed is one thread-local read. Points belong at rare, structural moments
+//! -- a roll, a reclaim, a manifest install -- not on the per-record path.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// What an armed point does when reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FaultAction {
+    /// Stop here, by panicking. The caller catches it; on disk, everything up to this line has
+    /// happened and nothing after it has, which is what a crash at this line leaves behind.
+    Stop,
+    /// Stall here, to open a window another thread can act inside.
+    Hang(Duration),
+}
+
+thread_local! {
+    static ARMED: RefCell<HashMap<&'static str, FaultAction>> = RefCell::new(HashMap::new());
+}
+
+/// Arm `name` on THIS thread until the returned guard drops.
+pub fn arm(name: &'static str, action: FaultAction) -> FaultGuard {
+    ARMED.with(|armed| armed.borrow_mut().insert(name, action));
+    FaultGuard { name }
+}
+
+/// Disarms its point when dropped, including while a panic unwinds -- which is the normal way a
+/// `Stop` point ends, so leaving it armed would strand it for every later test on this thread.
+pub struct FaultGuard {
+    name: &'static str,
+}
+
+impl Drop for FaultGuard {
+    fn drop(&mut self) {
+        ARMED.with(|armed| armed.borrow_mut().remove(self.name));
+    }
+}
+
+/// Reach a named point. Does nothing unless this thread has armed it.
+#[inline]
+pub fn point(name: &'static str) {
+    let action = ARMED.with(|armed| armed.borrow().get(name).cloned());
+    match action {
+        None => {}
+        Some(FaultAction::Stop) => panic!("fault point reached: {name}"),
+        Some(FaultAction::Hang(duration)) => std::thread::sleep(duration),
+    }
+}
+
+/// Whether `name` is armed on this thread. For assertions that a point was actually reachable --
+/// a crash test that never reaches its point passes while testing nothing.
+pub fn is_armed(name: &'static str) -> bool {
+    ARMED.with(|armed| armed.borrow().contains_key(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_point_nobody_armed_does_nothing() {
+        for _ in 0..1_000 {
+            point("wal/roll/after_rename");
+        }
+    }
+
+    #[test]
+    fn an_armed_point_stops_there() {
+        let _armed = arm("test/stop", FaultAction::Stop);
+        let outcome = std::panic::catch_unwind(|| {
+            point("test/stop");
+            "kept going"
+        });
+        assert!(outcome.is_err(), "the point should have stopped it");
+    }
+
+    #[test]
+    fn arming_ends_with_the_guard() {
+        {
+            let _armed = arm("test/scoped", FaultAction::Stop);
+            assert!(is_armed("test/scoped"));
+        }
+        assert!(!is_armed("test/scoped"), "the guard should have disarmed it");
+        point("test/scoped");
+    }
+
+    #[test]
+    fn the_guard_disarms_even_when_the_stop_unwinds() {
+        let outcome = std::panic::catch_unwind(|| {
+            let _armed = arm("test/unwind", FaultAction::Stop);
+            point("test/unwind");
+        });
+        assert!(outcome.is_err());
+        assert!(
+            !is_armed("test/unwind"),
+            "a point left armed by its own panic would stop every later test on this thread"
+        );
+    }
+
+    #[test]
+    fn one_point_being_armed_does_not_arm_another() {
+        let _armed = arm("test/one", FaultAction::Stop);
+        point("test/two");
+    }
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -34,6 +34,7 @@ pub mod storage_config;
 pub mod storage_descriptor;
 pub mod telemetry;
 pub mod types;
+pub mod fault;
 pub mod wal;
 pub mod record_framing;
 pub mod index_log_record;

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4828,22 +4828,30 @@ mod tests {
     /// durable. That leaves a window where the piece exists and the header does not, and an empty
     /// piece reads as starting at log id zero, which the sealed pieces already own. An empty piece
     /// therefore has to be treated as one that was never started.
+    ///
+    /// Entered by stopping in it, so the state on disk is what a crash at that line leaves rather
+    /// than what this test guessed it would leave.
     #[test]
     fn a_crash_before_the_header_reaches_disk_does_not_reuse_addresses() {
         set_wal_segment_bytes_for_test(Some(2 * 1024));
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
 
-        // Stop the moment a roll has happened, so the piece being written holds NO records yet.
-        // That is the window this is about: the piece was created and its header had not reached
-        // disk. Truncating a piece that already holds records is a different event -- it destroys
-        // those records, and reusing their addresses afterwards is correct, because nothing can
-        // still be pointing at them.
+        // Stop inside the roll, between creating the piece and writing its header. Reproducing
+        // this window by hand instead -- appending until the piece happens to hold no records, then
+        // truncating it -- would encode two unchecked assumptions: that such a piece is where the
+        // roll left off, and that truncating to zero is what a crash before the header leaves.
+        // Stopping AT the line needs neither: what is on disk afterwards is what that line leaves.
         let mut written = Vec::new();
         let mut index = 0u64;
-        loop {
-            let (record, log_id) = store
-                .append_with_sync_reporting(
+        let mut stopped = false;
+        while index < 5_000 {
+            let armed = crate::fault::arm(
+                "wal/roll/after_create",
+                crate::fault::FaultAction::Stop,
+            );
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                store.append_with_sync_reporting(
                     1,
                     Command::StringSet {
                         key: format!("k{index:06}"),
@@ -4851,31 +4859,32 @@ mod tests {
                     },
                     false,
                 )
-                .unwrap();
-            written.push((record.sequence, log_id));
-            index += 1;
-            let active = write_ahead_log_path(dir.path(), 1);
-            let (_, header_len) = read_wal_base(&active).unwrap();
-            if active.metadata().map(|m| m.len()).unwrap_or(0) == header_len && index >= 50 {
-                break;
+            }));
+            drop(armed);
+            match outcome {
+                Ok(Ok((record, log_id))) => written.push((record.sequence, log_id)),
+                Ok(Err(err)) => panic!("append failed: {err}"),
+                Err(_) => {
+                    stopped = true;
+                    break;
+                }
             }
-            assert!(index < 5_000, "never caught the log just after a roll");
+            index += 1;
         }
+        assert!(stopped, "never reached a roll, so this tested nothing");
         assert!(
             wal_segment_paths(dir.path(), 1).len() > 1,
             "the log should be in more than one piece"
         );
         drop(store);
 
-        // The crash: the piece exists, its header never reached disk. No record is lost with it,
-        // because the piece held none.
+        // And this is what that line left: the piece exists and has nothing in it.
         let active = write_ahead_log_path(dir.path(), 1);
-        OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(&active)
-            .unwrap();
-        assert_eq!(active.metadata().unwrap().len(), 0, "the piece should be empty");
+        assert_eq!(
+            active.metadata().unwrap().len(),
+            0,
+            "the piece should exist and be empty -- that is the window"
+        );
 
         let reopened = LocalWriteAheadLogStore::new(dir.path());
         let (_, log_id) = reopened

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1634,11 +1634,17 @@ fn roll_wal_segment_if_due(
     let sealed = sealed_wal_path(&inner.root, shard_id, base);
     fs::rename(&path, &sealed)?;
     sync_parent_dir(&sealed)?;
+    // Sealed, and nothing to append to yet. A crash here leaves a log whose pieces are all sealed,
+    // and an absent piece reads as starting at log id zero -- which those pieces already own.
+    crate::fault::point("wal/roll/after_rename");
 
     // Start the next piece where this one ended. If a crash lands before this, the next append
     // derives the same starting point from the sealed pieces.
     let next_base = base.saturating_add(holds);
     let mut file = File::create(&path)?;
+    // Created, no header yet. A crash here leaves a piece of zero length, which reads as starting
+    // at log id zero for the same reason.
+    crate::fault::point("wal/roll/after_create");
     file.write_all(&crate::log_framing::encode_base_header(next_base))?;
     file.flush()?;
     // No barrier for the header, and none for the directory entry. The header rides the barrier
@@ -4954,6 +4960,95 @@ mod tests {
             at(&mut r, 1.0),
         );
         assert!(!rolled.is_empty(), "nothing rolled, so this measured nothing");
+        set_wal_segment_bytes_for_test(None);
+    }
+
+    /// The window between sealing a piece and starting the next one, entered by stopping there.
+    ///
+    /// There is already a test for this window that builds its state by hand -- it removes the
+    /// piece being written and reopens. That is only a test of this window if removing that file is
+    /// what a crash there leaves behind, and nothing checks the claim. Applying the same reasoning
+    /// one window over produced a test that failed for the wrong reason, so the reasoning is worth
+    /// removing rather than repeating: here the roll is stopped AT the line, and whatever is on
+    /// disk afterwards is what a crash at that line leaves, by construction.
+    #[test]
+    fn stopping_a_roll_after_the_rename_does_not_reuse_addresses() {
+        set_wal_segment_bytes_for_test(Some(2 * 1024));
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+
+        // Write until a roll is about to happen, with the point disarmed.
+        let mut written = Vec::new();
+        let mut index = 0u64;
+        let mut stopped = false;
+        while index < 5_000 {
+            let armed = crate::fault::arm(
+                "wal/roll/after_rename",
+                crate::fault::FaultAction::Stop,
+            );
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                store.append_with_sync_reporting(
+                    1,
+                    Command::StringSet {
+                        key: format!("k{index:06}"),
+                        value: vec![118u8; 64],
+                    },
+                    false,
+                )
+            }));
+            drop(armed);
+            match outcome {
+                Ok(Ok((record, log_id))) => written.push((record.sequence, log_id)),
+                Ok(Err(err)) => panic!("append failed: {err}"),
+                Err(_) => {
+                    // The roll stopped after the rename. The store's lock is poisoned by that
+                    // unwind, which is exactly what a crash would cost us: this handle is done.
+                    stopped = true;
+                    break;
+                }
+            }
+            index += 1;
+        }
+        assert!(stopped, "never reached a roll, so this tested nothing");
+        drop(store);
+
+        // Everything is sealed and there is nothing to append to -- the state a crash there leaves.
+        let active = write_ahead_log_path(dir.path(), 1);
+        assert!(!active.exists(), "the piece being written should be gone");
+        assert!(
+            wal_segment_paths(dir.path(), 1).iter().any(|p| p != &active),
+            "the sealed pieces should still be there"
+        );
+
+        let reopened = LocalWriteAheadLogStore::new(dir.path());
+        let (_, log_id) = reopened
+            .append_with_sync_reporting(
+                1,
+                Command::StringSet {
+                    key: "after".to_string(),
+                    value: b"v".to_vec(),
+                },
+                false,
+            )
+            .unwrap();
+        assert!(
+            written.iter().all(|(_, earlier)| *earlier < log_id),
+            "a record written after the crash took an address an earlier one already owns"
+        );
+        // And every address handed out before the crash still resolves to its own record.
+        for (sequence, earlier) in &written {
+            if let Some(bytes) = reopened.read_at_log_id(1, *earlier, 4096).unwrap() {
+                let end = bytes
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(bytes.len(), |at| at + 1);
+                assert_eq!(
+                    decode_wal_line(&bytes[..end]).unwrap().sequence,
+                    *sequence,
+                    "log id {earlier} resolved to the wrong record"
+                );
+            }
+        }
         set_wal_segment_bytes_for_test(None);
     }
 }


### PR DESCRIPTION
Every crash-safety test here builds the post-crash state by hand: delete this file, truncate that
one, reopen, check recovery. That is a test of the real window **only if the state it built is the
state a crash would leave** — and nothing checks that claim. Twice recently it was wrong:

- one test deleted a piece that still held records. That is not the window it claimed to test but a
  different event — losing records — so it **passed for the wrong reason**;
- another truncated a piece that held records and **failed for the wrong reason**, because reusing
  the addresses of records the truncation itself destroyed is correct.

A named point removes the guessing. The test says *stop inside the roll, after the rename*, the code
stops exactly there, and what is on disk afterwards is what a crash at that line leaves — because it
**is** what that line leaves.

## Two points, at the two windows that matter

| point | what a crash there leaves |
| --- | --- |
| `wal/roll/after_rename` | every piece sealed, nothing to append to |
| `wal/roll/after_create` | a piece of zero length, no header |

Both leave a log whose next address would be read as **zero** — an address the sealed pieces already
own.

## The test earns its keep

`stopping_a_roll_after_the_rename_does_not_reuse_addresses` enters the window by stopping in it
rather than by removing a file. With the recovery guard taken out it fails with:

```
a record written after the crash took an address an earlier one already owns
```

so it is testing the guard, not passing beside it.

## Armed per thread, and only until the guard drops

Deliberate. This suite runs ~1200 tests across 16 threads, and its most persistent flakiness comes
from tests reaching for process-wide state — a point armed process-wide would stop unrelated tests
at the same line.

The guard also disarms **during unwinding**, which is the normal way a stopping point ends. Leaving
it armed would strand it for every later test on that thread, so there is a test for exactly that.

## Cost

One thread-local read when nothing is armed. These belong at rare structural moments — a roll, a
reclaim, a manifest install — not on the per-record path.

68 WAL and fault tests pass; `cargo check --all-targets` clean.
