### PR TITLE
Stop reporting an execution as durable when persisting it failed

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2881,6 +2881,58 @@ mod tests {
         assert_eq!(run.queue_len, 1);
     }
 
+    fn one_execution_record() -> MetaSchedulerExecutionRecord {
+        MetaSchedulerExecutionRecord {
+            task_id: 1,
+            node_addr: "127.0.0.1:1".to_string(),
+            status: Status::ok(),
+            scheduler_result: SchedulerTaskResult::Ok,
+            retry_times: 0,
+            next_run_time_ms: None,
+            calls: Vec::new(),
+            lifecycle_token: None,
+            lifecycle_state: None,
+            raft_membership_report: None,
+            queue_len: 0,
+        }
+    }
+
+    #[test]
+    fn an_execution_that_cannot_be_persisted_says_so() {
+        // `persist_current` writes the execution history and the scheduler
+        // snapshot together. Its result used to be dropped here while `submit`,
+        // `run_next` and `restore` all return theirs, so a failed write left the
+        // post-execution state non-durable with nobody told -- and a restart
+        // could hand out a task that had already run.
+        let dir = tempfile::tempdir().unwrap();
+        // A regular file where a directory would have to be: `create_dir_all`
+        // cannot make a directory under it, so persisting fails for a reason
+        // that has nothing to do with the execution itself.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"not a directory").unwrap();
+        let scheduler =
+            MetaTaskScheduler::with_snapshot_path(blocker.join("sub").join("scheduler.json"))
+                .unwrap();
+
+        let persisted = scheduler.record_execution(one_execution_record());
+        assert!(
+            !persisted.ok,
+            "persisting was impossible and it reported success"
+        );
+        assert_eq!(persisted.code, "scheduler_persist_failed");
+    }
+
+    #[test]
+    fn an_execution_that_persists_reports_ok() {
+        // The other half: the guard must not turn a healthy round into an error.
+        let dir = tempfile::tempdir().unwrap();
+        let scheduler =
+            MetaTaskScheduler::with_snapshot_path(dir.path().join("scheduler.json")).unwrap();
+        let persisted = scheduler.record_execution(one_execution_record());
+        assert!(persisted.ok, "{persisted:?}");
+        assert_eq!(scheduler.executions().executions.len(), 1);
+    }
+
     #[test]
     fn metaserver_scheduler_execute_next_dry_run_preserves_queue() {
         let backend = MetaBackend::Single(SingleNodeMeta::default());

--- a/crates/temporalstore-rust/src/bin/metaserver/task_scheduler.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/task_scheduler.rs
@@ -205,7 +205,8 @@ impl MetaTaskScheduler {
             raft_membership_report: execution.raft_membership_report.clone(),
             queue_len: run.queue_len,
         };
-        self.record_execution(MetaSchedulerExecutionRecord {
+        let mut response = response;
+        let persisted = self.record_execution(MetaSchedulerExecutionRecord {
             task_id: task.id,
             node_addr: response.node_addr.clone(),
             status: response.status.clone(),
@@ -225,6 +226,12 @@ impl MetaTaskScheduler {
             raft_membership_report: response.raft_membership_report.clone(),
             queue_len: response.queue_len,
         });
+        // Only when the execution itself succeeded. An execution that already
+        // failed has the more useful error, and the three sibling paths have no
+        // separate outcome to lose so they simply return theirs.
+        if response.status.ok && !persisted.ok {
+            response.status = persisted;
+        }
         response
     }
 
@@ -321,7 +328,15 @@ impl MetaTaskScheduler {
         Ok(())
     }
 
-    fn record_execution(&self, record: MetaSchedulerExecutionRecord) {
+    /// Record one execution and return what persisting it did.
+    ///
+    /// The status used to be dropped here while `submit`, `run_next` and
+    /// `restore` all fold theirs into the response they return. `persist_current`
+    /// writes the execution history *and* the scheduler snapshot, so a failed
+    /// write left the post-execution state non-durable while the caller was told
+    /// the execution succeeded -- and a restart could hand out a task that had
+    /// already run.
+    fn record_execution(&self, record: MetaSchedulerExecutionRecord) -> Status {
         {
             let mut executions = self
                 .executions
@@ -334,7 +349,7 @@ impl MetaTaskScheduler {
                 executions.drain(0..overflow);
             }
         }
-        let _ = self.persist_current();
+        self.persist_current()
     }
 
     fn persist_current(&self) -> Status {


### PR DESCRIPTION
> Independent of the other open work — `main` base.

## An execution that could not be persisted reported success

`record_execution` ended in `let _ = self.persist_current();`.

Its three siblings do the opposite — `submit`, `run_next` and `restore` all fold
the persist status into the response they return. Only this one dropped it.

`persist_current` writes the execution history **and** the scheduler snapshot. So
a failed write — a full disk is the obvious way, and this repository's own build
box hit 100% twice today — left the post-execution scheduler state non-durable
while the caller was told the execution succeeded. On the next restart the
scheduler can hand out a task that already ran.

## The change

`record_execution` returns what persisting did, and `execute_next` surfaces it.

**Only when the execution itself succeeded.** The three siblings have no separate
outcome to lose, so they simply return the persist status. Here there is one, and
an execution that already failed carries the more useful error — overwriting it
with a persistence complaint would trade a specific diagnosis for a generic one.

## Tests

- **an execution that cannot be persisted says so** — a regular file where a
  directory would have to be, so `create_dir_all` cannot succeed and the failure
  has nothing to do with the execution
- **an execution that persists reports ok** — the guard must not turn a healthy
  round into an error

Both mutation-checked: restoring the discarded result fails the first and leaves
the second passing, which is the split you want.

## What these tests do not cover

The status override inside `execute_next` is not exercised end to end. Reaching
`record_execution` through that path needs a live node to call — the dry-run
branch returns before recording — and standing one up would test the node
harness rather than this change. The unit that changed is covered directly;
the wiring above it rests on the types and on review.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1` — 28/28

The one full-suite failure on this base, `data_node::…jitter_backoff…`,
fails 3/3 in isolation on unmodified `main` and is untouched here.
