### PR TITLE
Say something when a follower is behind every dump we kept, instead of pruning them in silence

### DIFF
--- a/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
@@ -226,6 +226,25 @@ pub(super) fn bucket_dump_manifest_prune_plan_at(
             manifest.wal_sequence <= cursor.wal_sequence
                 && manifest.index_log_sequence <= cursor.index_log_sequence
         }) else {
+            // Behind every manifest: nothing kept can serve this follower. Pruning here throws
+            // away its last chance of catching up from a dump and says nothing about it, so keep
+            // the oldest -- the only one that could ever help -- and report it. Unconditionally:
+            // the point is that the follower is unservable, not that anything extra was kept.
+            if let Some(oldest) = manifests
+                .iter()
+                .min_by_key(|manifest| (manifest.wal_sequence, manifest.index_log_sequence))
+            {
+                retained.insert(oldest.manifest_id.clone());
+                follower_blocks.push(BucketDumpFollowerRetentionBlock {
+                    follower_id: cursor.follower_id.clone(),
+                    manifest_id: oldest.manifest_id.clone(),
+                    manifest_wal_sequence: oldest.wal_sequence,
+                    manifest_index_log_sequence: oldest.index_log_sequence,
+                    cursor_wal_sequence: cursor.wal_sequence,
+                    cursor_index_log_sequence: cursor.index_log_sequence,
+                    reason: "follower_cursor_precedes_every_manifest".to_string(),
+                });
+            }
             continue;
         };
         if retained.insert(anchor.manifest_id.clone()) {
@@ -248,6 +267,25 @@ pub(super) fn bucket_dump_manifest_prune_plan_at(
             manifest.wal_sequence <= snapshot.wal_sequence
                 && manifest.index_log_sequence <= snapshot.index_log_sequence
         }) else {
+            // As above: a snapshot reference older than every manifest cannot be served by any of
+            // them, and the operator needs to know that rather than have it pruned in silence.
+            if let Some(oldest) = manifests
+                .iter()
+                .min_by_key(|manifest| (manifest.wal_sequence, manifest.index_log_sequence))
+            {
+                retained.insert(oldest.manifest_id.clone());
+                raft_snapshot_blocks.push(BucketDumpRaftSnapshotRetentionBlock {
+                    snapshot_id: snapshot.snapshot_id.clone(),
+                    manifest_id: oldest.manifest_id.clone(),
+                    manifest_wal_sequence: oldest.wal_sequence,
+                    manifest_index_log_sequence: oldest.index_log_sequence,
+                    snapshot_wal_sequence: snapshot.wal_sequence,
+                    snapshot_index_log_sequence: snapshot.index_log_sequence,
+                    last_included_index: snapshot.last_included_index,
+                    last_included_term: snapshot.last_included_term,
+                    reason: "raft_snapshot_precedes_every_manifest".to_string(),
+                });
+            }
             continue;
         };
         if retained.insert(anchor.manifest_id.clone()) {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -1441,6 +1441,70 @@ fn dump_clears_dumped_buckets_so_they_are_not_redumped() {
     );
 }
 
+/// A follower behind EVERY dump must be reported, not passed over in silence.
+///
+/// A cursor pins the newest dump at or below it. One that sits below all of them matched nothing
+/// and fell straight through, so the case where NO retained dump can serve a follower -- the one
+/// that most needs saying -- produced no signal at all, and pruning went ahead and threw away the
+/// only dump that could ever have helped. The oldest is kept instead, and reported with a reason
+/// that separates "pins an older dump" from "is behind everything we kept".
+#[test]
+fn a_follower_behind_every_dump_is_reported_and_keeps_the_oldest() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for value in ["v1", "v2", "v3"] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "behind".to_string(),
+                value: value.as_bytes().to_vec(),
+            },
+        });
+        engine.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+    }
+    let plan_before = engine.bucket_dump_manifest_prune_plan(1);
+    let oldest = plan_before
+        .prunable_manifest_ids
+        .first()
+        .cloned()
+        .expect("older dumps are prunable when nothing pins them");
+
+    // A follower older than every dump: sequence zero precedes them all.
+    let plan = engine.bucket_dump_manifest_prune_plan_with_follower_cursors(
+        1,
+        vec![BucketDumpFollowerReplayCursor {
+            follower_id: "follower-behind-everything".to_string(),
+            shard_id: 1,
+            wal_sequence: 0,
+            index_log_sequence: 0,
+        }],
+    );
+
+    assert_eq!(
+        plan.follower_blocks.len(),
+        1,
+        "a follower no retained dump can serve must be reported, not skipped: {plan:?}"
+    );
+    assert_eq!(
+        plan.follower_blocks[0].reason,
+        "follower_cursor_precedes_every_manifest"
+    );
+    assert!(
+        plan.retained_manifest_ids.contains(&plan.follower_blocks[0].manifest_id),
+        "the dump reported as blocking must actually be kept"
+    );
+    assert!(
+        !plan.prunable_manifest_ids.contains(&oldest),
+        "the oldest dump is this follower's only chance and must not be pruned"
+    );
+}
+
 #[test]
 fn bucket_dump_manifest_prune_is_blocked_by_lagging_follower_cursor() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
A follower's replay cursor pins the newest dump at or below it, so that dump survives pruning and
the follower can still be caught up from it. A cursor sitting below **all** of them matched
nothing and fell straight through to the next cursor.

That is the case that most needed saying. No retained dump can serve such a follower, so pruning
deletes the oldest one — its only remaining chance — and reports nothing at all.

**Measured** on three dumps with a cursor below every one of them, before the change:

```
follower_blocks: []
prunable_manifest_ids: ["1-1-…", "1-2-…"]     <- both older dumps, about to go
```

The oldest is now kept and reported, with a reason that separates *"this follower pins an older
dump"* from *"this follower is behind everything we kept"*. The same applies to a snapshot ref
older than every dump.

Neither changes the ordinary case: a cursor that matches a dump behaves exactly as before, and one
that has caught up to the newest still pins nothing and still reports nothing — which the existing
tests pin down and which still pass.

## Validation

`cargo test --lib -- --test-threads=1`: engine **215 passed, 0 failed**; data_node **46 passed, 1
failed** — that one failure is long-standing on unmodified `main` and unrelated (see below).

## Unrelated, but worth recording

`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags` has been red on
`main` for some time, asserting `follower_cursor_retention_blockers >= 1`. Retention pressure is
measured at the **start** of a cycle, before that cycle dumps anything, and the fixture has no dump
manifests in existence for the shard its cursor names — so the count is necessarily zero and the
assertion cannot hold as written. It needs a dump to exist for that shard before the assertion, not
a change to the counting; I left it alone rather than guess at the fixture's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
