### PR TITLE
Say what the raft backend does not do, instead of implying it does

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -131,7 +131,10 @@ fn main() {
                 ))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself");
+                warn!(
+                    "TS_META_AUTO_REBALANCE ignored: shard rebalancing is not available on the \
+                     raft backend, and nothing else performs it there"
+                );
                 None
             }
         }
@@ -176,7 +179,10 @@ fn main() {
                 Some(start_shard_divergence_loop(meta.clone(), options, interval_ms))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_META_SHARD_DIVERGENCE_CHECK ignored: raft backend manages placement itself");
+                warn!(
+                    "TS_META_SHARD_DIVERGENCE_CHECK ignored: divergence checking is not available \
+                     on the raft backend, and nothing else performs it there"
+                );
                 None
             }
         }
@@ -216,7 +222,10 @@ fn main() {
                 Some(meta.start_freeze_aging_loop(options, interval_ms))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_META_FREEZE_AGING ignored: raft backend owns its own meta state");
+                warn!(
+                    "TS_META_FREEZE_AGING ignored: the raft backend owns its own meta state and \
+                     does not age frozen resources, so they stay frozen until an operator acts"
+                );
                 None
             }
         }
@@ -252,7 +261,10 @@ fn main() {
                 Some(meta.start_meta_retention_loop(options, interval_ms))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_META_RETENTION_GC ignored: raft backend owns its own meta state");
+                warn!(
+                    "TS_META_RETENTION_GC ignored: the raft backend owns its own meta state and \
+                     does not collect tombstones, so dropped resources accumulate"
+                );
                 None
             }
         }
@@ -283,7 +295,10 @@ fn main() {
                 Some(meta.start_proxy_calibration_loop(options, interval_ms))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_META_PROXY_CALIBRATION ignored: raft backend owns its own meta state");
+                warn!(
+                    "TS_META_PROXY_CALIBRATION ignored: the raft backend owns its own meta state \
+                     and does not calibrate proxy groups, so they keep whatever size they have"
+                );
                 None
             }
         }
@@ -309,7 +324,9 @@ fn main() {
                 Some(start_raft_failover_loop(meta.clone(), interval_ms))
             }
             MetaBackend::Raft(_) => {
-                warn!("TS_RAFT_AUTO_FAILOVER ignored: raft backend fails over itself");
+                warn!(
+                    "TS_RAFT_AUTO_FAILOVER ignored: this setting drives failover for datanode                      raft shard groups, which the raft backend does not do -- a frozen datanode                      leaves its groups without a trigger and writes to them stall"
+                );
                 None
             }
         }
@@ -2373,6 +2390,43 @@ mod tests {
             .contains("temporalstore_meta_resource_state{resource=\"proxy\",state=\"frozen\"} 1"));
         assert!(metrics.contains("temporalstore_meta_scheduler_queue_depth 1"));
         assert!(metrics.contains("temporalstore_meta_topology_version"));
+    }
+
+    #[test]
+    fn the_raft_backend_reports_no_background_subsystem_activity() {
+        // The startup warnings tell an operator that rebalancing, divergence
+        // checking, freeze aging, retention and proxy calibration do not happen
+        // on this backend. Two of them used to claim raft "manages placement
+        // itself"; nothing in the raft module plans a rebalance or checks
+        // divergence, and both loops are started only from Single arms.
+        //
+        // This pins the fact those messages now assert, so a future change that
+        // gives raft one of these capabilities has to update the text as well.
+        let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            snapshot_check_interval_ms: 0,
+            engine: ProductionRaftEngineKind::TemporalRaft,
+            local_node_id: 1,
+            nodes: vec![ProductionRaftNode {
+                node_id: 1,
+                addr: "127.0.0.1:18211".to_string(),
+            }],
+            config: RaftConfig::default(),
+            heartbeat_interval_ms: 100,
+            election_tick_ms: 50,
+            failure_detector_interval_ms: 1_000,
+            stale_server_after_ms: 30_000,
+        })
+        .unwrap();
+        let backend = MetaBackend::Raft(runtime);
+        assert!(
+            backend.subsystem_prometheus().is_empty(),
+            "the raft backend reported subsystem activity it does not perform"
+        );
+
+        // The single-node backend does drive them, so an empty report there
+        // would mean the check above proves nothing.
+        let single = MetaBackend::Single(SingleNodeMeta::default());
+        let _ = single.subsystem_prometheus();
     }
 
     #[test]


### PR DESCRIPTION
> Independent of the other open work — `main` base, one file.

## Six startup warnings told an operator the raft backend had work covered

It does not. Each names a setting the raft backend ignores, and each explained
that away.

### Two claimed placement

```
TS_META_AUTO_REBALANCE ignored: raft backend manages placement itself
TS_META_SHARD_DIVERGENCE_CHECK ignored: raft backend manages placement itself
```

Audited three ways: the raft timer loop does **peer failure detection only**;
there is **no rebalance or divergence machinery in the raft module at all**; and
`start_auto_rebalance_loop` / `start_shard_divergence_loop` are called from
exactly two places, both `MetaBackend::Single` arms. `add_node` / `remove_node`
change raft **membership**, not shard placement.

### Three claimed ownership

`TS_META_FREEZE_AGING`, `TS_META_RETENTION_GC` and `TS_META_PROXY_CALIBRATION`
said the backend "owns its own meta state". True, and leaving out what the
operator needs: nothing ages frozen resources, collects tombstones or calibrates
proxy groups there. Tombstones accumulate for the life of the cluster.

### And one conflated two different failovers

```
TS_RAFT_AUTO_FAILOVER ignored: raft backend fails over itself
```

The raft backend does fail over **its own** leader. This setting drives failover
for **datanode raft shard groups**, through `meta/raft_failover.rs`. Different
things:

- `plan_raft_failover` exists only on `SingleNodeMeta`
- `MetaRaftCluster` never calls it
- the `failover_primary()` in the runtime's heartbeat tick acts on the
  metaserver's own cluster

So a frozen datanode leaves its shard groups without a trigger, and that module's
own doc says what follows:

> the surviving replicas are never told their leader is gone… `tick_election`
> never observes a dead leader, and **writes to that group stall indefinitely**

That one is worse than the other five: not a capability quietly absent, but writes
stalling while the operator is told it is handled.

## One is untouched because it is accurate

`TS_META_ADAPTIVE_FAILURE_DETECTOR ignored: raft backend runs its own timer loop`
— it genuinely does run failure detection there.

## What this does not do

It corrects what the metaserver *says*. Whether a raft-backed metaserver should
*drive* datanode failover, rather than only stop claiming it does, is a design
decision and a larger one than the wording.

## Test

A message change has no behaviour to test, so the test pins the **fact** the new
messages assert: the raft backend reports no background subsystem activity. A
future change that gives raft one of these capabilities has to update the text
too, or it fails.

Mutation-checked — making the raft backend report any subsystem activity fails
it. It also exercises the single-node backend, so an empty report there could not
make the check pass vacuously.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1` — 27/27
