### PR TITLE
Make silence mean "commit the buckets before truncating the index log"

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2871,6 +2871,11 @@ pub struct StorageLifecycleRequest {
     pub warm_cache: bool,
 }
 
+/// Index-log truncation waits for dirty buckets by default; see the field this serves.
+fn commit_dirty_buckets_before_truncation_default() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageManagerCycleRequest {
     pub shard_id: ShardId,
@@ -2938,7 +2943,14 @@ pub struct StorageManagerCycleRequest {
     pub index_gc_usage_ratio_trigger_basis_points: u64,
     #[serde(default)]
     pub index_gc_max_entries_per_round: usize,
-    #[serde(default)]
+    /// Whether index-log truncation waits for the buckets it describes to be dumped.
+    ///
+    /// Defaulted explicitly rather than with a bare `#[serde(default)]`: on a bool that decodes an
+    /// ABSENT field to `false`, which is the unsafe order, regardless of what this type's own
+    /// `Default` says. The request is parsed from a request body, so an absent field is what every
+    /// caller who does not name it gets -- and discarding index-log records before the buckets
+    /// they describe are durable loses exactly the record needed to rebuild them.
+    #[serde(default = "commit_dirty_buckets_before_truncation_default")]
     #[serde(rename = "index_gc_commit_dirty_slots_before_truncation")]
     pub index_gc_commit_dirty_buckets_before_truncation: bool,
     /// Reclaim only bands whose garbage ratio is at least this many basis points

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3902,3 +3902,43 @@ fn an_unlimited_expiry_window_returns_every_match() {
     assert_eq!(after.len(), 20, "the cursor is exclusive");
     assert_eq!(after.first().map(|(key, _)| key.as_str()), Some("key-0020"));
 }
+
+
+/// A cycle request that does not mention the ordering guard must still get it.
+///
+/// Index-log records may only be discarded once the buckets they describe have been dumped;
+/// truncating first throws away the record of state that is not durable anywhere else. The guard
+/// that enforces that is a field on the request, and the request is parsed from an HTTP body --
+/// so what an OMITTED field decodes to is the behaviour every caller gets who does not name it.
+/// `#[serde(default)]` on a bool decodes to `false`, which is the unsafe order, even though the
+/// type's own `Default` says true.
+#[test]
+fn omitting_the_commit_before_truncate_guard_still_commits_before_truncating() {
+    // Take a well-formed body and remove ONLY the guard, so this tests what silence means rather
+    // than whether every other field happens to be optional.
+    let mut body: serde_json::Value =
+        serde_json::to_value(StorageManagerCycleRequest::default()).unwrap();
+    let removed = body
+        .as_object_mut()
+        .unwrap()
+        .remove("index_gc_commit_dirty_slots_before_truncation");
+    assert!(removed.is_some(), "the guard should be present in a serialised request");
+
+    let silent: StorageManagerCycleRequest = serde_json::from_value(body).unwrap();
+    assert!(
+        silent.index_gc_commit_dirty_buckets_before_truncation,
+        "a request that does not mention the guard decoded to the unsafe order: index-log records \
+         would be discarded before the buckets they describe had been dumped"
+    );
+
+    // Naming it false is still allowed -- this is about what silence means, not about removing
+    // the choice.
+    let mut off: serde_json::Value =
+        serde_json::to_value(StorageManagerCycleRequest::default()).unwrap();
+    off.as_object_mut().unwrap().insert(
+        "index_gc_commit_dirty_slots_before_truncation".to_string(),
+        serde_json::Value::Bool(false),
+    );
+    let explicit: StorageManagerCycleRequest = serde_json::from_value(off).unwrap();
+    assert!(!explicit.index_gc_commit_dirty_buckets_before_truncation);
+}


### PR DESCRIPTION
Index-log records may only be discarded once the buckets they describe have been dumped.
Truncating first throws away the record of state that is not durable anywhere else — exactly what
is needed to rebuild those buckets after a crash.

The guard enforcing that order is a field on the cycle request, and **that request is parsed from a
request body** (`bin/server.rs`), so what an *absent* field decodes to is the behaviour every caller
gets who does not name it.

The field carried a bare `#[serde(default)]`. On a `bool` that decodes an absent field to
**`false`** — the unsafe order — no matter that the type's own `Default` says `true`:

```rust
#[serde(default)]                                     // -> false when omitted
#[serde(rename = "index_gc_commit_dirty_slots_before_truncation")]
pub index_gc_commit_dirty_buckets_before_truncation: bool,
```

```rust
StorageManagerCycleRequest::default()
    .index_gc_commit_dirty_buckets_before_truncation   // true
```

So a caller sending a cycle request without mentioning the guard was silently choosing to truncate
first. Now defaulted explicitly, so an omitted field decodes to what the type already said it
should be. Naming it `false` still works — this is about what silence means, not about removing the
choice.

The new test takes a well-formed body and removes **only** that field, so it tests what silence
means rather than whether every other field happens to be optional. It fails without the change.

## Validation

`cargo test --lib -- --test-threads=1`: engine **216 passed, 0 failed**; data_node **46 passed, 1
failed** — that one is long-standing on unmodified `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
