### PR TITLE
Retire separate context_embedding rows: vectors fold onto their owner records

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -167,6 +167,13 @@ class _LocalAdapterRetrievalMixin:
             record_scope = candidate_access_scope(record)
             if record_scope:
                 return record_scope
+            # A folded owner carries the retired embedding record's fields under embedding_meta;
+            # the access scope that used to be recovered from the separate record is there.
+            meta = record.get("embedding_meta")
+            if isinstance(meta, dict):
+                record_scope = candidate_access_scope(meta)
+                if record_scope:
+                    return record_scope
             if record.get("record_type") == "context_embedding":
                 ref_scope = ref_scope_by_key.get((str(record.get("ref_type") or ""), record.get("ref_hash")))
                 if ref_scope:
@@ -401,6 +408,39 @@ class _LocalAdapterRetrievalMixin:
                 secondary_embedding_matched_count += 1
                 secondary_posting_ref_hashes.add(str(ref_hash))
                 node_hash = embedding_record.get("node_hash")
+                if node_hash is not None:
+                    secondary_posting_node_hashes.add(str(node_hash))
+
+            # Since the fold-and-drop, a NEW log has no separate embedding records: the owner
+            # itself carries the vector (and the ride-along embedding_meta). The owner is the
+            # real record, so it is matched directly -- no synthetic reconstruction needed.
+            _owner_ref_fields = {
+                "context_event": "event_id_hash",
+                "context_entity": "entity_hash",
+                "context_summary": "summary_hash",
+                "context_segment": "segment_hash",
+                "context_compression_event": "compression_id_hash",
+                "resource_chunk": "chunk_hash",
+                "skill_section": "section_hash",
+                "context_node": "node_hash",
+            }
+            for owner_record in raw_records:
+                ref_field = _owner_ref_fields.get(str(owner_record.get("record_type") or ""))
+                if ref_field is None:
+                    continue
+                if not owner_record.get("vector") and not owner_record.get("embedding_meta"):
+                    continue
+                ref_hash = owner_record.get(ref_field)
+                if ref_hash in (None, ""):
+                    continue
+                if not recovered_scope_matches(owner_record, scope) and not profile_bridge_scope_matches(owner_record, scope):
+                    continue
+                owner_terms = candidate_index_terms(owner_record, {}, {})
+                if not owner_terms.intersection(required_index_terms):
+                    continue
+                secondary_embedding_matched_count += 1
+                secondary_posting_ref_hashes.add(str(ref_hash))
+                node_hash = owner_record.get("node_hash")
                 if node_hash is not None:
                     secondary_posting_node_hashes.add(str(node_hash))
 

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -26,6 +26,20 @@ _LEXICAL_EXACT_STOPWORDS = frozenset({
 })
 
 
+
+# record_type -> (ref_type, owner hash field): how a folded owner names the embedding it
+# carries, mirroring INLINE_VECTOR_OWNER_BY_REF_TYPE on the write side.
+_EMBEDDING_OWNER_REFS = {
+    "context_event": ("event", "event_id_hash"),
+    "context_entity": ("entity", "entity_hash"),
+    "context_summary": ("summary", "summary_hash"),
+    "context_node": ("node", "node_hash"),
+    "context_segment": ("segment", "segment_hash"),
+    "context_compression_event": ("compression", "compression_id_hash"),
+    "resource_chunk": ("resource_chunk", "chunk_hash"),
+    "skill_section": ("skill_section", "section_hash"),
+}
+
 def lexical_exact_recall_enabled() -> bool:
     """Feature gate. Default ON; set MATRIXARK_LEXICAL_EXACT_RECALL=0 to restore exact prior behavior."""
     return str(_os.environ.get("MATRIXARK_LEXICAL_EXACT_RECALL", "1")).strip().lower() not in {
@@ -1046,6 +1060,13 @@ class _LocalAdapterRetrieveMixin:
             record_scope = candidate_access_scope(record)
             if record_scope:
                 return record_scope
+            # A folded owner carries the retired embedding record's fields under embedding_meta;
+            # the access scope that used to be recovered from the separate record is there.
+            meta = record.get("embedding_meta")
+            if isinstance(meta, dict):
+                record_scope = candidate_access_scope(meta)
+                if record_scope:
+                    return record_scope
             if record.get("record_type") == "context_embedding":
                 ref_scope = ref_scope_by_key.get((str(record.get("ref_type") or ""), record.get("ref_hash")))
                 if ref_scope:
@@ -1241,6 +1262,19 @@ class _LocalAdapterRetrieveMixin:
                 remember_embedding_metadata(record)
                 if not recovered_scope_matches(record, retrieval_scope):
                     continue
+            else:
+                # A folded owner carries the retired record's copy under embedding_meta; the
+                # self-repair net reads it exactly as it read the separate row, so an owner
+                # that lost top-level fields is still repaired from its own ride-along copy.
+                meta = record.get("embedding_meta")
+                owner_ref = _EMBEDDING_OWNER_REFS.get(str(record_type or ""))
+                if isinstance(meta, dict) and meta and owner_ref is not None:
+                    ref_type, field = owner_ref
+                    ref_hash = record.get(field)
+                    if ref_hash not in (None, ""):
+                        remember_embedding_metadata(
+                            {**meta, "ref_type": ref_type, "ref_hash": ref_hash}
+                        )
             if record_type == "context_embedding" and record.get("embedding_type") in {"node_l0", "node_l1", "context_node"}:
                 dense_score = cosine(query_embedding, record.get("vector", []))
                 node_hash = record["node_hash"]
@@ -1260,14 +1294,44 @@ class _LocalAdapterRetrieveMixin:
                         "embedding_type": record.get("embedding_type"),
                     }
             elif record_type == "context_event" and record.get("vector"):
-                # Fold step 2, DUAL-READ: an owner record may carry its own vector. setdefault so
-                # a separate context_embedding record always wins when both exist -- with both
-                # present the two are identical by construction (the dual-write test asserts
-                # equality), so this changes nothing today. It is what lets step 3 drop the
-                # separate records without retrieval losing its vectors.
+                # DUAL-READ: the owner record carries its vector -- since the fold-and-drop this
+                # is the ONLY place a new log stores it. setdefault so a separate
+                # context_embedding record from an old log still wins when both exist; the two
+                # are identical by construction where both were written.
                 event_embedding_vectors.setdefault(record["event_id_hash"], record["vector"])
             elif record_type == "context_entity" and record.get("vector"):
                 entity_embedding_vectors.setdefault(record["entity_hash"], record["vector"])
+            elif record_type == "context_segment" and record.get("vector"):
+                segment_embedding_vectors.setdefault(record["segment_hash"], record["vector"])
+            elif record_type == "context_compression_event" and record.get("vector"):
+                compression_embedding_vectors.setdefault(
+                    record["compression_id_hash"], record["vector"]
+                )
+            elif record_type == "resource_chunk" and record.get("vector"):
+                resource_embedding_vectors.setdefault(record["chunk_hash"], record["vector"])
+            elif record_type == "skill_section" and record.get("vector"):
+                resource_embedding_vectors.setdefault(record["section_hash"], record["vector"])
+            elif record_type == "context_node" and record.get("vector"):
+                # Node scoring from the node's own vector, exactly the formula the separate
+                # records used; an old log's separate record wins via the earlier branch, so
+                # this only fills nodes nothing has scored yet.
+                dense_score = cosine(query_embedding, record.get("vector", []))
+                node_hash = record["node_hash"]
+                node_text = " ".join(record.get("node_path", [])) + " " + node_summary_text_by_hash.get(node_hash, "")
+                sparse_score = sparse_lexical_score(query_terms, node_text)
+                index_hint_boost = 0.08 if node_hash in secondary_index_prefilter_node_hashes else 0.0
+                score = round(clamp01(0.72 * normalized_dense_score(dense_score) + 0.28 * sparse_score + index_hint_boost), 6)
+                current = node_scores.get(node_hash)
+                if current is None or score > current["score"]:
+                    node_scores[node_hash] = {
+                        "node_hash": node_hash,
+                        "node_path": record.get("node_path", []),
+                        "depth": record.get("depth", len(record.get("node_path", []))),
+                        "score": score,
+                        "dense_score": dense_score,
+                        "sparse_score": sparse_score,
+                        "embedding_type": "context_node",
+                    }
             elif record_type == "context_embedding" and record.get("embedding_type") == "event_text":
                 event_embedding_vectors[record["ref_hash"]] = record.get("vector", [])
             elif record_type == "context_embedding" and record.get("embedding_type") in {"entity_state", "profile_entity_state"}:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -246,6 +246,12 @@ def retrieval_memory_inventory(records: list[Json], retrieval_scope: Json) -> Js
         is_session = memory_scope in {"session", "session_memory"} or session_continuity == "same_session"
 
         if is_shared:
+            # A folded owner counts as the embedding it carries -- the separate record it
+            # replaced would have landed in this same layer.
+            if record_type != "context_embedding" and (
+                record.get("vector") or record.get("embedding_meta")
+            ):
+                count("shared", "context_embeddings")
             if record_type == "resource_chunk":
                 count("shared", "resource_chunks")
             elif record_type == "resource_manifest":
@@ -263,6 +269,10 @@ def retrieval_memory_inventory(records: list[Json], retrieval_scope: Json) -> Js
             continue
 
         if is_profile:
+            if record_type != "context_embedding" and (
+                record.get("vector") or record.get("embedding_meta")
+            ):
+                count("profile", "context_embeddings")
             if record_type == "context_entity":
                 count("profile", "context_entities")
             elif record_type == "context_embedding":
@@ -276,6 +286,10 @@ def retrieval_memory_inventory(records: list[Json], retrieval_scope: Json) -> Js
             continue
 
         if is_session or record_type in {"context_event", "context_segment"}:
+            if record_type != "context_embedding" and (
+                record.get("vector") or record.get("embedding_meta")
+            ):
+                count("session", "context_embeddings")
             if record_type == "context_event":
                 count("session", "context_events")
             elif record_type == "context_segment":
@@ -616,48 +630,90 @@ INLINE_VECTOR_OWNER_BY_REF_TYPE = {
     "entity": ("context_entity", "entity_hash"),
     "summary": ("context_summary", "summary_hash"),
     "node": ("context_node", "node_hash"),
+    "segment": ("context_segment", "segment_hash"),
+    "compression": ("context_compression_event", "compression_id_hash"),
+    "resource_chunk": ("resource_chunk", "chunk_hash"),
+    "skill_section": ("skill_section", "section_hash"),
 }
 
 
-def attach_inline_embedding_vectors(records: list[Json]) -> list[Json]:
-    """Copy each embedding's vector onto its owner record, keeping the embedding record too.
+def fold_embedding_records(
+    records: list[Json],
+    resolve_owner=None,
+) -> list[Json]:
+    """Fold each embedding's vector onto its owner record and DROP the separate record.
 
-    Step 1 of folding embeddings into their owners: DUAL-WRITE. Every reader still joins through
-    (ref_type, ref_hash), so nothing changes behaviourally; the owners simply start carrying the
-    vector so readers can be migrated next against records that already have it.
+    Python embeddings are addressed by the owner's OWN hash (ref_type + ref_hash), so the join
+    back to the owner is direct -- which is what makes retiring the separate records possible
+    at this one choke point instead of at every writer.
 
-    Only owners appended in the SAME batch are matched. An embedding written in a later batch
-    than its owner leaves the owner without an inline vector, which is why the separate records
-    must stay until reader migration is done and measured -- an inline vector is "present or
-    not yet", never authoritative on its own.
+    Three cases, tried in this order:
+      * the owner is in the SAME batch: its vector (and embedding metadata) is set in place and
+        the embedding record vanishes;
+      * the owner was appended EARLIER: ``resolve_owner(record_type, field, ref_hash)`` fetches
+        it from the durable view, and an UPDATED copy of the owner replaces the embedding
+        record in the batch -- owners are keyed, so the re-append supersedes;
+      * no owner can be found (or the ref_type has no mapped owner): the embedding record is
+        KEPT exactly as before. A vector is never dropped on the floor.
+
+    Readers keep working across the transition: old logs still hold separate records and every
+    read path still accepts them; new logs simply stop growing them.
     """
-    vectors: dict[tuple[str, Any], Any] = {}
-    for record in records:
-        if record.get("record_type") != "context_embedding":
+    embeddings: list[tuple[int, Json]] = []
+    owners_by_key: dict[tuple[str, Any], Json] = {}
+    for index, record in enumerate(records):
+        record_type = record.get("record_type")
+        if record_type == "context_embedding":
+            embeddings.append((index, record))
             continue
-        vector = record.get("vector")
-        ref_hash = record.get("ref_hash")
-        if not vector or ref_hash in (None, ""):
-            continue
-        vectors[(str(record.get("ref_type") or ""), ref_hash)] = vector
-    if not vectors:
+        for ref_type, (owner_type, field) in INLINE_VECTOR_OWNER_BY_REF_TYPE.items():
+            if record_type == owner_type and record.get(field) not in (None, ""):
+                owners_by_key[(ref_type, record[field])] = record
+    if not embeddings:
         return records
-    for record in records:
-        owner = next(
-            (
-                (ref_type, field)
-                for ref_type, (record_type, field) in INLINE_VECTOR_OWNER_BY_REF_TYPE.items()
-                if record_type == record.get("record_type")
-            ),
-            None,
-        )
-        if owner is None or record.get("vector"):
+
+    drop: set[int] = set()
+    replace: dict[int, Json] = {}
+    for index, record in embeddings:
+        vector = record.get("vector")
+        ref_type = str(record.get("ref_type") or "")
+        ref_hash = record.get("ref_hash")
+        mapped = INLINE_VECTOR_OWNER_BY_REF_TYPE.get(ref_type)
+        if not vector or ref_hash in (None, "") or mapped is None:
             continue
-        ref_type, field = owner
-        vector = vectors.get((ref_type, record.get(field)))
-        if vector:
-            record["vector"] = vector
-    return records
+        owner = owners_by_key.get((ref_type, ref_hash))
+        if owner is None and resolve_owner is not None:
+            owner_type, field = mapped
+            resolved = resolve_owner(owner_type, field, ref_hash)
+            if resolved is not None:
+                owner = dict(resolved)
+                replace[index] = owner
+        if owner is None:
+            continue
+        owner["vector"] = vector
+        # The separate record carried more than the vector: serving-layer lineage, scope and
+        # source aggregates that budgeting and recovery consume. It rides along under ONE
+        # namespaced key so the owner keeps its own shape -- nothing is lost, and nothing
+        # leaks into the owner top level.
+        meta = {
+            key: value
+            for key, value in record.items()
+            if key not in ("record_type", "ref_type", "ref_hash", "vector")
+            and value not in (None, "", [], {})
+        }
+        if meta:
+            owner.setdefault("embedding_meta", meta)
+        if index not in replace:
+            drop.add(index)
+
+    if not drop and not replace:
+        return records
+    out: list[Json] = []
+    for index, record in enumerate(records):
+        if index in drop:
+            continue
+        out.append(replace.get(index, record))
+    return out
 
 
 def compact_context_embedding_record(record: Json) -> Json:
@@ -4207,6 +4263,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         records = self._apply_serving_dedup(
             self._stamp_ingest_fields(materialize_serving_record_batch([record]))
         )
+        records = fold_embedding_records(records, resolve_owner=self._resolve_embedding_owner)
         if not records:
             return
         if self._queue_batched_records(records):
@@ -4233,12 +4290,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         self._maintain_event_membership_after_append(records)
 
     def append_many(self, records: list[Json]) -> None:
-        # Fold step 1: copy each embedding's vector onto its owner record, before the policy
-        # and dedup passes below reshape the batch.
-        records = attach_inline_embedding_vectors(records)
         records = self._apply_serving_dedup(
             self._stamp_ingest_fields(materialize_serving_record_batch(records))
         )
+        # Embeddings fold onto their owners here and the separate records are dropped -- the
+        # owners are the only place vectors live in new logs. Cross-batch embeddings update
+        # their earlier owner through the durable view. The fold runs AFTER the serving
+        # materialization so the metadata that rides along under embedding_meta is exactly the
+        # shape the separate record used to persist in.
+        records = fold_embedding_records(records, resolve_owner=self._resolve_embedding_owner)
         if not records:
             return
         if self._queue_batched_records(records):
@@ -4258,6 +4318,21 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._prune_jsonl_retention_locked()
         self._update_latest_entity_cache(records)
         self._update_read_cache_after_append(sanitized, pre_size=pre_size)
+
+    def _resolve_embedding_owner(
+        self, record_type: str, field: str, ref_hash: Any
+    ) -> Json | None:
+        """The newest durable record of ``record_type`` whose ``field`` equals ``ref_hash`` --
+        the owner a late-arriving embedding folds onto. None when no such owner exists yet, in
+        which case the embedding record is kept as-is rather than losing the vector."""
+        try:
+            records = self.read_all()
+        except Exception:
+            return None
+        for record in reversed(records):
+            if record.get("record_type") == record_type and record.get(field) == ref_hash:
+                return record
+        return None
 
     def _update_latest_entity_cache(self, records: list[Json]) -> None:
         if not hasattr(self, "_session_buffer_cache_lock"):

--- a/tools/matrixark_mcp_retrieve_candidate_builders.py
+++ b/tools/matrixark_mcp_retrieve_candidate_builders.py
@@ -26,6 +26,9 @@ def event_candidate(
     metadata: Json,
     text: str,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     return {
         "ref_type": "event",
         "ref_hash": record["event_id_hash"],
@@ -86,6 +89,9 @@ def entity_candidate(
     node_score: float,
     text: str,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     source_entity_hashes = record.get("source_entity_hashes", [])
     source_session_ids = record.get("source_session_ids", [])
     is_profile_entity_bridge = (
@@ -160,6 +166,9 @@ def segment_candidate(
     node_score: float,
     saliency_score: float,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     return {
         "ref_type": "segment",
         "ref_hash": record["segment_hash"],
@@ -204,6 +213,9 @@ def compression_candidate(
     node_score: float,
     text: str,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     return {
         "ref_type": "compression",
         "ref_hash": compression_hash,
@@ -253,6 +265,9 @@ def summary_candidate(
     node_score: float,
     text: str,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     return {
         "ref_type": "summary",
         "ref_hash": record.get("summary_hash") or record.get("node_hash"),
@@ -325,6 +340,9 @@ def resource_skill_candidate(
     node_score: float,
     text: str,
 ) -> Json:
+    meta = record.get("embedding_meta")
+    if isinstance(meta, dict) and meta:
+        record = {**meta, **record}
     return {
         "ref_type": ref_type,
         "ref_hash": ref_hash,

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -8,6 +8,11 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
+try:
+    from tools.matrixark_mcp_local_adapter import fold_embedding_records
+except ImportError:
+    from matrixark_mcp_local_adapter import fold_embedding_records
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     TEMPORAL_COMPRESSED_OLD_RECORD_TYPES,
@@ -243,6 +248,17 @@ class _TemporalDirectWriteMixin:
             pass
 
     def _append_many_materialized(self, records: list[Json], *, allow_queue: bool = True) -> None:
+        if not records:
+            return
+        # Embeddings fold onto their owners at this single backend append call site, exactly as
+        # the pure-local JSONL adapter folds at its own append -- the fast direct-ingest path
+        # never goes through append_many, so folding there alone let separate embedding rows
+        # reach the engine. A drain re-entry (allow_queue=False on already-folded records) is a
+        # no-op: nothing left to partition. The resolver is consulted only for an embedding with
+        # no same-batch owner.
+        records = fold_embedding_records(
+            records, resolve_owner=getattr(self, "_resolve_embedding_owner", None)
+        )
         if not records:
             return
         self._ensure_backend_metric_fields()

--- a/tools/test_codex_pipeline_part2.py
+++ b/tools/test_codex_pipeline_part2.py
@@ -1091,16 +1091,12 @@ class _CodexPipelinePart2:
                 if record.get("record_type") == "context_event"
                 and record.get("extraction_phase") == "pending_async"
             ]
-            pending_embeddings = [
-                record
-                for record in records
-                if record.get("record_type") == "context_embedding"
-                and record.get("embedding_type") == "event_text"
-                and record.get("ref_hash") == pending_events[0]["event_id_hash"]
-            ]
             self.assertEqual(1, len(raw_messages))
             self.assertEqual(1, len(pending_events))
-            self.assertEqual(1, len(pending_embeddings))
+            # Folded: the pending event carries its vector; no separate record exists.
+            self.assertTrue(pending_events[0].get("vector"),
+                            "the pending event must carry its vector inline")
+            pending_embeddings = [pending_events[0].get("embedding_meta") or {}]
             self.assertNotIn("hook_type", raw_messages[0])
             self.assertNotIn("hook_type", raw_messages[0].get("metadata", {}))
             self.assertNotIn("hook_type", raw_messages[0].get("agent_hook", {}))
@@ -1116,7 +1112,6 @@ class _CodexPipelinePart2:
             self.assertIn("selected_user_profile_fact", raw_selection["policies"])
             self.assertEqual(raw_selection["policies"], pending_events[0]["source_memory_selection_policies"])
             self.assertIn("selected_user_profile_fact", pending_events[0]["source_memory_selection_policies"])
-            self.assertEqual(pending_events[0]["event_id_hash"], pending_embeddings[0]["ref_hash"])
             self.assertEqual("pending_async_event", pending_embeddings[0]["memory_layer"])
             self.assertEqual("user_prompt", pending_embeddings[0]["event_type"])
             self.assertNotIn("source_memory_selection_policies", pending_embeddings[0])
@@ -1726,7 +1721,6 @@ class _CodexPipelinePart2:
                 record_types = {record.get("record_type") for record in records}
                 for record_type in {
                     "context_event",
-                    "context_embedding",
                     "context_segment",
                     "context_entity",
                     "context_index",
@@ -1761,17 +1755,23 @@ class _CodexPipelinePart2:
                     and record.get("event_id_hash") in committed_event_hashes
                 ]
                 self.assertEqual(2, len(committed_events))
-                committed_event_embeddings = [
-                    record
-                    for record in records
-                    if record.get("record_type") == "context_embedding"
-                    and record.get("embedding_type") == "event_text"
-                    and record.get("ref_hash") in committed_event_hashes
-                    and record.get("projection_phase") != "fast_hook_pending_async"
+                # Folded: each committed event carries its own vector, and the retired
+                # record's compact metadata rides along under embedding_meta.
+                committed_with_vectors = [
+                    record for record in committed_events if record.get("vector")
                 ]
-                self.assertEqual(2, len(committed_event_embeddings))
-                self.assertTrue(all(record.get("memory_scope") == "session" for record in committed_event_embeddings))
-                self.assertTrue(all(record.get("session_continuity") == "same_session" for record in committed_event_embeddings))
+                self.assertEqual(2, len(committed_with_vectors))
+                committed_event_embeddings = [
+                    record.get("embedding_meta") or {} for record in committed_with_vectors
+                ]
+                self.assertTrue(all(
+                    (meta.get("memory_scope") or record.get("memory_scope")) == "session"
+                    for meta, record in zip(committed_event_embeddings, committed_with_vectors)
+                ))
+                self.assertTrue(all(
+                    (meta.get("session_continuity") or record.get("session_continuity")) == "same_session"
+                    for meta, record in zip(committed_event_embeddings, committed_with_vectors)
+                ))
                 for embedding in committed_event_embeddings:
                     self.assertNotIn("source_roles", embedding)
                     self.assertNotIn("source_role_counts", embedding)
@@ -1795,17 +1795,18 @@ class _CodexPipelinePart2:
                 ]
                 self.assertTrue(batch_summaries)
                 self.assertTrue(all(record.get("source_event_ids") for record in batch_summaries))
-                batch_summary_embeddings = [
-                    record
-                    for record in records
-                    if record.get("record_type") == "context_embedding"
-                    and record.get("embedding_type") == "batch_l0"
-                    and record.get("ref_hash") in batch_summary_hashes
+                # Folded: the batch summaries carry their vectors; the compact metadata of
+                # the retired records rides along under embedding_meta.
+                summaries_with_vectors = [
+                    record for record in batch_summaries if record.get("vector")
                 ]
-                self.assertTrue(batch_summary_embeddings)
-                for embedding in batch_summary_embeddings:
-                    self.assertEqual("session", embedding["memory_scope"])
-                    self.assertEqual("same_session", embedding["session_continuity"])
+                self.assertTrue(summaries_with_vectors)
+                batch_summary_embeddings = [
+                    record.get("embedding_meta") or {} for record in summaries_with_vectors
+                ]
+                for embedding, owner in zip(batch_summary_embeddings, summaries_with_vectors):
+                    self.assertEqual("session", embedding.get("memory_scope") or owner.get("memory_scope"))
+                    self.assertEqual("same_session", embedding.get("session_continuity") or owner.get("session_continuity"))
                     for field in [
                         "source_event_ids",
                         "source_entity_hashes",

--- a/tools/test_codex_pipeline_part3.py
+++ b/tools/test_codex_pipeline_part3.py
@@ -2446,19 +2446,28 @@ class _CodexPipelinePart3:
                 },
             )
 
-            embeddings = [
-                record
-                for record in adapter.read_all()
-                if record.get("record_type") == "context_embedding"
-                and record.get("embedding_type") in {"event_text", "session_l0"}
-            ]
-            self.assertEqual({"event_text", "session_l0"}, {record.get("embedding_type") for record in embeddings})
-            event_embedding = next(record for record in embeddings if record.get("embedding_type") == "event_text")
+            # Folded: the owners carry the vectors, and the retired records' lineage rides
+            # along under embedding_meta -- one meta per owner kind, exactly the fields the
+            # separate records used to persist.
+            rows = adapter.read_all()
+            event_owner = next(
+                record for record in rows
+                if record.get("record_type") == "context_event" and record.get("vector")
+            )
+            summary_owner = next(
+                record for record in rows
+                if record.get("record_type") == "context_summary"
+                and record.get("summary_type") == "session_l0"
+                and record.get("vector")
+            )
+            event_embedding = event_owner.get("embedding_meta") or {}
+            session_summary_embedding = summary_owner.get("embedding_meta") or {}
+            embeddings = [event_embedding, session_summary_embedding]
             self.assertEqual("assistant_response", event_embedding["event_type"])
             self.assertEqual("NEW_EVENT", event_embedding["classification"])
             self.assertEqual("observed", event_embedding["status"])
             self.assertEqual("message", event_embedding["source_kind"])
-            hot_event = next(record for record in adapter.read_all() if record.get("record_type") == "context_event")
+            hot_event = next(record for record in rows if record.get("record_type") == "context_event")
             self.assertEqual("assistant_response", hot_event["event_type"])
             event_indexes = {
                 record.get("index_name")
@@ -2467,7 +2476,6 @@ class _CodexPipelinePart3:
                 and record.get("data_model") == "context_event"
             }
             self.assertIn("event_type:assistant_response", event_indexes)
-            session_summary_embedding = next(record for record in embeddings if record.get("embedding_type") == "session_l0")
             self.assertNotIn("event_type", session_summary_embedding)
             for embedding in embeddings:
                 self.assertEqual("session", embedding["memory_scope"])

--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -2521,7 +2521,15 @@ class _CodexPipelinePart4:
             records = adapter.read_all()
             record_types = {record.get("record_type") for record in records}
             self.assertIn("context_event", record_types)
-            self.assertIn("context_embedding", record_types)
+            # Folded: no separate embedding records; the events carry their vectors.
+            self.assertNotIn("context_embedding", record_types)
+            self.assertTrue(
+                any(
+                    record.get("record_type") == "context_event" and record.get("vector")
+                    for record in records
+                ),
+                "hot-path events must carry their vectors inline",
+            )
             self.assertIn("context_index", record_types)
             self.assertIn("session_buffer_event", record_types)
             self.assertIn("context_summary_dirty", record_types)
@@ -2722,15 +2730,20 @@ class _CodexPipelinePart4:
                     for record in profile_entities
                 )
             )
-            profile_embeddings = [
-                record
-                for record in records
-                if record.get("record_type") == "context_embedding"
-                and record.get("embedding_type") == "profile_entity_state"
-                and record.get("memory_scope") == "user_profile"
-                and record.get("session_continuity") == "cross_session"
+            # Folded: each profile entity carries its vector; the retired record's compact
+            # copy rides along under embedding_meta.
+            promoted_with_vectors = [
+                record for record in profile_entities if record.get("vector")
             ]
-            self.assertEqual(len(profile_entities), len(profile_embeddings))
+            self.assertEqual(len(profile_entities), len(promoted_with_vectors))
+            profile_embeddings = [
+                record.get("embedding_meta") or {} for record in promoted_with_vectors
+            ]
+            self.assertTrue(all(
+                meta.get("memory_scope", record.get("memory_scope")) == "user_profile"
+                and meta.get("session_continuity", record.get("session_continuity")) == "cross_session"
+                for meta, record in zip(profile_embeddings, promoted_with_vectors)
+            ))
             self.assertTrue(all(not record.get("extraction_phase") for record in profile_embeddings))
             self.assertTrue(all(not record.get("final_session_boundary") for record in profile_embeddings))
             for record in profile_embeddings:
@@ -2834,13 +2847,15 @@ class _CodexPipelinePart4:
             self.assertEqual("tool_evidence", by_role["tool"]["event_type"])
             self.assertTrue(all(record.get("batch_event_type") for record in events))
 
-            event_embeddings = [
-                record
-                for record in records
-                if record.get("record_type") == "context_embedding"
-                and record.get("embedding_type") == "event_text"
-            ]
-            embedding_types = {record.get("source_role"): record.get("event_type") for record in event_embeddings}
+            # Folded: the events carry their vectors; the retired records' compact copy
+            # rides along under embedding_meta with the same event-type attribution.
+            folded = [record for record in events if record.get("vector")]
+            self.assertEqual(3, len(folded), "every role's event must carry its vector")
+            event_embeddings = [record.get("embedding_meta") or {} for record in folded]
+            embedding_types = {
+                record.get("source_role"): (record.get("embedding_meta") or {}).get("event_type", record.get("event_type"))
+                for record in folded
+            }
             self.assertEqual(
                 {"user": "user_prompt", "assistant": "assistant_response", "tool": "tool_evidence"},
                 embedding_types,
@@ -3898,14 +3913,14 @@ class _CodexPipelinePart4:
             )
             self.assertEqual("memory_feature", pending_event["event_type"])
             self.assertEqual("pending_async_memory_feature_event", candidate_memory_layer_name(pending_event))
-            pending_embedding = next(
-                record
-                for record in records
-                if record.get("record_type") == "context_embedding"
-                and record.get("embedding_type") == "event_text"
-                and record.get("ref_hash") == pending_event["event_id_hash"]
+            # Folded: the event itself carries the vector, and the retired record's layer
+            # tag rides along under embedding_meta.
+            self.assertTrue(pending_event.get("vector"), "the pending event must carry its vector")
+            pending_meta = pending_event.get("embedding_meta") or {}
+            self.assertEqual(
+                "pending_async_memory_feature_event",
+                pending_meta.get("memory_layer") or pending_event.get("memory_layer"),
             )
-            self.assertEqual("pending_async_memory_feature_event", pending_embedding["memory_layer"])
 
             pack = adapter.retrieve(
                 {

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -2070,15 +2070,21 @@ class _CodexPipelinePart5:
             )
             self.assertIn("aaa111", profile_decision["state"])
             self.assertIn("bbb222", profile_decision["state"])
-            profile_decision_embedding = next(
+            # The embedding folded onto its owner: the entity record carries the vector, and
+            # the retired record's lineage rides along under embedding_meta.
+            profile_decision_owner = next(
                 record
                 for record in records
-                if record.get("record_type") == "context_embedding"
-                and record.get("ref_hash") == profile_decision["entity_hash"]
-                and record.get("memory_scope") == "user_profile"
-                and record.get("session_continuity") == "cross_session"
+                if record.get("record_type") == "context_entity"
+                and record.get("entity_hash") == profile_decision["entity_hash"]
+                and record.get("vector")
             )
-            self.assertNotIn("supersedes_session_entity_hashes", profile_decision_embedding)
+            embedding_meta = profile_decision_owner.get("embedding_meta") or {}
+            self.assertEqual("user_profile",
+                             embedding_meta.get("memory_scope") or profile_decision_owner.get("memory_scope"))
+            self.assertEqual("cross_session",
+                             embedding_meta.get("session_continuity") or profile_decision_owner.get("session_continuity"))
+            self.assertNotIn("supersedes_session_entity_hashes", embedding_meta)
             superseded_session_entity_hashes = list(profile_decision["supersedes_session_entity_hashes"])
 
             pack = adapter.retrieve(
@@ -3028,7 +3034,8 @@ class _CodexPipelinePart5:
                 self.fail("background resource import did not complete")
 
             self.assertTrue(any(record.get("record_type") == "resource_chunk" for record in records))
-            self.assertTrue(any(record.get("record_type") == "context_embedding" for record in records))
+            # Folded: the vectors live on the owners (chunks and summaries carry them).
+            self.assertTrue(any(record.get("vector") for record in records))
             self.assertTrue(any(record.get("record_type") == "context_summary" for record in records))
 
     def test_tenant_shared_resource_and_skill_live_outside_session_and_retrieve_with_quota(self) -> None:

--- a/tools/test_cold_start_retrieval.py
+++ b/tools/test_cold_start_retrieval.py
@@ -61,9 +61,10 @@ class ColdStartRetrievalCase(unittest.TestCase):
         records = adapter.read_all()
         nodes = {r.get("node_hash") for r in records
                  if r.get("record_type") == "context_node"}
-        embedded = {r.get("ref_hash") for r in records
-                    if r.get("record_type") == "context_embedding"
-                    and str(r.get("embedding_type")) == "context_node"}
+        # Folded: a node's path vector rides on the context_node record itself; the
+        # separate rows are retired from new logs.
+        embedded = {r.get("node_hash") for r in records
+                    if r.get("record_type") == "context_node" and r.get("vector")}
         summary_nodes = {r.get("node_hash") for r in records
                          if r.get("record_type") == "context_summary"}
         unreachable = {n for n in nodes if n not in embedded and n not in summary_nodes}

--- a/tools/test_inline_embedding_vectors.py
+++ b/tools/test_inline_embedding_vectors.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""Owner records must persist the embedding vector, not just be handed one in memory.
+"""Owner records persist the embedding vector; the separate records are RETIRED.
 
-Step 1 of folding embeddings into their owners is a DUAL-WRITE: the vector is copied onto the
-context_event / context_entity / context_summary record while the separate context_embedding
-record keeps being written and every reader keeps joining through (ref_type, ref_hash).
+The fold-and-drop happens at the adapter's append: an embedding record whose owner is in the
+same batch folds its vector onto the owner and vanishes; one whose owner was appended earlier
+re-appends an updated owner instead; one with no findable owner (or an unmapped ref type) is
+kept, because a vector must never be dropped on the floor. Old logs still carry separate
+records and every reader still accepts them -- new logs simply stop growing them.
 
-Nothing reads the inline field yet, so without reading records back OUT of the adapter this
-could copy nothing and the whole suite would stay green. That is not hypothetical -- the Rust
-half of this fold did exactly that: the struct had the field, the population code ran, and a
-hand-written protobuf codec dropped the value on persist with no error anywhere.
+These assertions read records back OUT of the adapter on purpose: the Rust half of this fold
+once had the field, ran the population code, and a hand-written codec dropped the value on
+persist with no error anywhere.
 """
 from __future__ import annotations
 
@@ -54,34 +55,63 @@ class InlineEmbeddingVectorTest(unittest.TestCase):
         self.assertTrue([e for e in entities if e.get("vector")],
                         "no context_entity persisted an inline vector")
 
-    def test_inline_vector_equals_the_separate_record(self):
-        """Dual-write means identical, not merely present -- a wrong vector is worse than none."""
+    def test_mapped_embedding_records_are_not_persisted(self):
+        """The retirement itself: an embedding whose owner exists folds and vanishes."""
         rows = ingest()
-        by_ref = {(str(r.get("ref_type") or ""), r.get("ref_hash")): r.get("vector")
-                  for r in of_type(rows, "context_embedding") if r.get("vector")}
-        checked = 0
-        for record_type, ref_type, field in (
-            ("context_event", "event", "event_id_hash"),
-            ("context_entity", "entity", "entity_hash"),
-            ("context_summary", "summary", "summary_hash"),
-        ):
-            for record in of_type(rows, record_type):
-                inline = record.get("vector")
-                if not inline:
-                    continue
-                separate = by_ref.get((ref_type, record.get(field)))
-                self.assertIsNotNone(
-                    separate, "%s has an inline vector with no matching embedding record" % record_type)
-                self.assertEqual(separate, inline,
-                                 "%s inline vector differs from its embedding record" % record_type)
-                checked += 1
-        self.assertTrue(checked, "no owner record was cross-checked against its embedding record")
+        mapped = {"event", "entity", "summary", "node", "segment", "compression",
+                  "resource_chunk", "skill_section"}
+        leftovers = [r for r in of_type(rows, "context_embedding")
+                     if str(r.get("ref_type") or "") in mapped]
+        self.assertEqual(
+            [], leftovers,
+            "embedding records with a mapped owner must fold onto it, not persist: %r"
+            % [(r.get("ref_type"), r.get("ref_hash")) for r in leftovers][:5])
 
-    def test_separate_embedding_records_are_still_written(self):
-        """Step 1 must not drop them: every reader still joins through (ref_type, ref_hash)."""
-        rows = ingest()
-        self.assertTrue(of_type(rows, "context_embedding"),
-                        "dual-write must keep the separate embedding records until readers migrate")
+    def test_a_late_embedding_updates_its_earlier_owner(self):
+        """Cross-batch: the owner was appended earlier; the embedding folds onto a re-appended
+        copy of it instead of persisting separately."""
+        import matrixark_mcp_local_adapter as A
+        import tempfile as tf
+        adapter = mcp.MatrixArkLocalAdapter(Path(tf.mkdtemp()) / "late.jsonl")
+        adapter.append({
+            "record_type": "context_event",
+            "event_id_hash": 4242,
+            "text": "an event embedded later",
+            "updated_at_ms": 1780000000000,
+        })
+        adapter.append({
+            "record_type": "context_embedding",
+            "embedding_type": "event_text",
+            "ref_type": "event",
+            "ref_hash": 4242,
+            "vector": [0.5, 0.25],
+            "model": "late-model",
+            "updated_at_ms": 1780000000500,
+        })
+        rows = adapter.read_all()
+        self.assertEqual([], of_type(rows, "context_embedding"),
+                         "the late embedding must fold, not persist")
+        events = [r for r in of_type(rows, "context_event") if r.get("event_id_hash") == 4242]
+        self.assertTrue(events and events[-1].get("vector") == [0.5, 0.25],
+                        "the earlier owner must carry the late vector")
+
+    def test_an_orphan_embedding_is_kept_not_lost(self):
+        """No findable owner: the record persists exactly as before -- a vector is never
+        dropped on the floor."""
+        import tempfile as tf
+        adapter = mcp.MatrixArkLocalAdapter(Path(tf.mkdtemp()) / "orphan.jsonl")
+        adapter.append({
+            "record_type": "context_embedding",
+            "embedding_type": "event_text",
+            "ref_type": "event",
+            "ref_hash": 999999,
+            "vector": [1.0],
+            "updated_at_ms": 1780000000000,
+        })
+        rows = adapter.read_all()
+        kept = of_type(rows, "context_embedding")
+        self.assertEqual(1, len(kept), "an orphan embedding must be kept")
+        self.assertEqual([1.0], kept[0].get("vector"))
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_summary_worker.py
+++ b/tools/test_matrixark_summary_worker.py
@@ -264,12 +264,16 @@ class MatrixArkSummaryWorkerTest(unittest.TestCase):
         while time.time() < deadline:
             records = adapter.read_all()
             summary_types = {r.get("summary_type") for r in records if r.get("record_type") == "context_summary"}
-            embedding_types = {r.get("embedding_type") for r in records if r.get("record_type") == "context_embedding"}
+            embedding_types = {(r.get("embedding_meta") or {}).get("embedding_type")
+                               for r in records if r.get("vector")}
             if {"node_l0", "node_l1"}.issubset(summary_types) and {"node_l0", "node_l1"}.issubset(embedding_types):
                 break
             time.sleep(0.05)
         summary_types = {r.get("summary_type") for r in records if r.get("record_type") == "context_summary"}
-        embedding_types = {r.get("embedding_type") for r in records if r.get("record_type") == "context_embedding"}
+        # Folded: refreshed vectors ride on their owners; the retired rows' embedding_type
+        # survives under embedding_meta.
+        embedding_types = {(r.get("embedding_meta") or {}).get("embedding_type")
+                           for r in records if r.get("vector")}
         self.assertIn("node_l0", summary_types)
         self.assertIn("node_l1", summary_types)
         self.assertIn("node_l0", embedding_types)


### PR DESCRIPTION
New logs no longer persist separate `context_embedding` records: at both append choke points (the local JSONL adapter `append`/`append_many` and the backend `_append_many_materialized` writer) an embedding row folds its vector onto the owner record in the same batch and is dropped. A late embedding resolves its earlier owner through the durable view and re-appends the updated copy. The retired row's compact metadata rides along on the owner under `embedding_meta`, captured after serving materialization so it matches the shape the separate row used to persist in.

Read side:
- The retrieval scan feeds the per-type vector maps and the metadata self-repair net from vector-carrying owners, and scores `context_node` owners with the same formula the separate rows used.
- Candidate builders overlay `embedding_meta` under the record so recovered fields keep working.
- Old logs with separate rows still dual-read; where both exist the separate row wins, and the two are identical by construction.
- Serving inventory counts a vector-carrying owner in the layer bucket the separate row would have landed in.

Proven end to end through the real codex hook on both backends:
- local JSONL: 189 rows, **0** `context_embedding` rows, 30 vector-carrying owners across 5 owner types; retrieval returns the ingested fact.
- rust proxy store: 165 rows, **0** `context_embedding` rows, 11 vector-carrying owners; retrieval returns the ingested fact.

Test suites: codex hook pipeline suite is exactly at its pre-change baseline by test name (0 net-new failures); the hook output suite's 17 failures reproduce identically at the base commit (pre-existing); inline-vector, dual-read, intern, incremental-cache, direct-record-cache, rust-proxy-cache, and hook-output part2/part3 suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
