### PR TITLE
Serving-chain residual: snapshot-served fetches, buffered audits, pinned get_all 78 -> 7 ms

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1126,6 +1126,42 @@ fn update_hgetall_snapshot_fields(key: &str, entries: &[(String, Vec<u8>)]) {
     }
 }
 
+/// Fetch the payload values at `locations` ("{shard:06}:{field}") through the shard hash
+/// snapshots, in append order (lexical location order = shard, then zero-padded field).
+///
+/// Reads whole shard hashes via hgetall_map on purpose: HashMultiGet re-reads each field's page
+/// uncached on every call (measured ~0.5 ms/field, never warming), while the snapshot is read
+/// once and then kept current by the write runtimes -- the same coherence the shard walk has
+/// always relied on. A location whose field is missing or empty is a stale index entry: the
+/// record was physically removed after its entry was written, and skipping it is the contract.
+fn fetch_indexed_payload_values(
+    engine: &TemporalEngine,
+    record_hash_key: &str,
+    locations: &std::collections::BTreeSet<String>,
+) -> Result<(Vec<String>, u64), String> {
+    let mut fields_by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for location in locations {
+        if let Some((shard, field)) = location.split_once(':') {
+            fields_by_shard
+                .entry(shard.to_string())
+                .or_default()
+                .push(field.to_string());
+        }
+    }
+    let shards_touched = fields_by_shard.len() as u64;
+    let mut values = Vec::with_capacity(locations.len());
+    for (shard, fields) in fields_by_shard {
+        let snapshot = hgetall_map(engine, format!("{record_hash_key}:{shard}"))?;
+        for field in fields {
+            match snapshot.get(&field) {
+                Some(value) if !value.is_empty() => values.push(value.clone()),
+                _ => {}
+            }
+        }
+    }
+    Ok((values, shards_touched))
+}
+
 fn hgetall_map(engine: &TemporalEngine, key: String) -> Result<BTreeMap<String, String>, String> {
     if let Ok(cache) = hgetall_snapshot_cache().lock() {
         if let Some(cached) = cache.get(&key) {
@@ -1150,8 +1186,14 @@ fn hgetall_map(engine: &TemporalEngine, key: String) -> Result<BTreeMap<String, 
                     .map_err(|error| format!("stored hash value is not UTF-8: {error}"))?;
                 decoded.insert(field, value);
             }
-            if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
-                cache.insert(key, decoded.clone());
+            // An empty read must stay a question, not become an answer: caching it would pin
+            // "no data" for a key no write may ever touch again (observed once as a pinned
+            // get_all stuck at 0 rows after a cold start until restart). An actually-empty hash
+            // re-reads at map-miss cost, no page reads.
+            if !decoded.is_empty() {
+                if let Ok(mut cache) = hgetall_snapshot_cache().lock() {
+                    cache.insert(key, decoded.clone());
+                }
             }
             Ok(decoded)
         }
@@ -1393,55 +1435,8 @@ fn type_index_payloads(
         }
     }
     // BTreeSet order is lexical: shard6 then the zero-padded record field = append order.
-    let mut fields_by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for location in &locations {
-        if let Some((shard, field)) = location.split_once(':') {
-            fields_by_shard
-                .entry(shard.to_string())
-                .or_default()
-                .push(field.to_string());
-        }
-    }
-    let shards_touched = fields_by_shard.len() as u64;
-    let mut values = Vec::with_capacity(locations.len());
-    for (shard, fields) in fields_by_shard {
-        let key = format!("{record_hash_key}:{shard}");
-        let response = engine.execute_durable(ExecuteRequest {
-            shard_id: DEFAULT_SHARD_ID,
-            command: Command::HashMultiGet {
-                key,
-                fields: fields.clone(),
-            },
-        });
-        if !response.status.ok {
-            return Err(format!(
-                "{}: {}",
-                response.status.code, response.status.message
-            ));
-        }
-        match response.response {
-            CommandResponse::Values {
-                values: shard_values,
-            } => {
-                for value in shard_values {
-                    // A missing or empty field is a stale index entry: the record was physically
-                    // removed after its index entry was written. Skipping it is the contract.
-                    let Some(bytes) = value else { continue };
-                    if bytes.is_empty() {
-                        continue;
-                    }
-                    values.push(String::from_utf8(bytes).map_err(|error| {
-                        format!("stored hash value is not UTF-8: {error}")
-                    })?);
-                }
-            }
-            other => {
-                return Err(format!(
-                    "unexpected response for type-index fetch: {other:?}"
-                ))
-            }
-        }
-    }
+    let (values, shards_touched) =
+        fetch_indexed_payload_values(engine, record_hash_key, &locations)?;
     Ok(Some((values, shards_touched)))
 }
 
@@ -1547,50 +1542,8 @@ fn scope_index_payloads(
                 .collect();
         }
     }
-    let mut fields_by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for location in &positions {
-        if let Some((shard, field)) = location.split_once(':') {
-            fields_by_shard
-                .entry(shard.to_string())
-                .or_default()
-                .push(field.to_string());
-        }
-    }
-    let shards_touched = fields_by_shard.len() as u64;
-    let mut values = Vec::with_capacity(positions.len());
-    for (shard, fields) in fields_by_shard {
-        let key = format!("{record_hash_key}:{shard}");
-        let response = engine.execute_durable(ExecuteRequest {
-            shard_id: DEFAULT_SHARD_ID,
-            command: Command::HashMultiGet { key, fields },
-        });
-        if !response.status.ok {
-            return Err(format!(
-                "{}: {}",
-                response.status.code, response.status.message
-            ));
-        }
-        match response.response {
-            CommandResponse::Values {
-                values: shard_values,
-            } => {
-                for value in shard_values {
-                    let Some(bytes) = value else { continue };
-                    if bytes.is_empty() {
-                        continue;
-                    }
-                    values.push(String::from_utf8(bytes).map_err(|error| {
-                        format!("stored hash value is not UTF-8: {error}")
-                    })?);
-                }
-            }
-            other => {
-                return Err(format!(
-                    "unexpected response for scope-index fetch: {other:?}"
-                ))
-            }
-        }
-    }
+    let (values, shards_touched) =
+        fetch_indexed_payload_values(engine, record_hash_key, &positions)?;
     Ok(Some((values, shards_touched)))
 }
 
@@ -1710,50 +1663,8 @@ fn id_scoped_payloads(
             positions.insert(location);
         }
     }
-    let mut fields_by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for location in &positions {
-        if let Some((shard, field)) = location.split_once(':') {
-            fields_by_shard
-                .entry(shard.to_string())
-                .or_default()
-                .push(field.to_string());
-        }
-    }
-    let shards_touched = fields_by_shard.len() as u64;
-    let mut values = Vec::with_capacity(positions.len());
-    for (shard, fields) in fields_by_shard {
-        let key = format!("{record_hash_key}:{shard}");
-        let response = engine.execute_durable(ExecuteRequest {
-            shard_id: DEFAULT_SHARD_ID,
-            command: Command::HashMultiGet { key, fields },
-        });
-        if !response.status.ok {
-            return Err(format!(
-                "{}: {}",
-                response.status.code, response.status.message
-            ));
-        }
-        match response.response {
-            CommandResponse::Values {
-                values: shard_values,
-            } => {
-                for value in shard_values {
-                    let Some(bytes) = value else { continue };
-                    if bytes.is_empty() {
-                        continue;
-                    }
-                    values.push(String::from_utf8(bytes).map_err(|error| {
-                        format!("stored hash value is not UTF-8: {error}")
-                    })?);
-                }
-            }
-            other => {
-                return Err(format!(
-                    "unexpected response for id-scoped fetch: {other:?}"
-                ))
-            }
-        }
-    }
+    let (values, shards_touched) =
+        fetch_indexed_payload_values(engine, record_hash_key, &positions)?;
     Ok(Some((values, shards_touched)))
 }
 
@@ -3081,35 +2992,25 @@ fn hash_entries_output(
     key: String,
     root: PathBuf,
 ) -> Result<RecordLogOutput, String> {
-    let response = engine.execute_durable(ExecuteRequest {
-        shard_id: DEFAULT_SHARD_ID,
-        command: Command::HashGetAll { key: key.clone() },
-    });
-    if !response.status.ok {
-        return Err(format!(
-            "{}: {}",
-            response.status.code, response.status.message
-        ));
-    }
-    match response.response {
-        CommandResponse::HashEntries { entries } => {
-            let mut decoded = BTreeMap::new();
+    // Read through the hash snapshot: a raw HashGetAll re-reads every field's page uncached on
+    // each call (measured 14.6 ms warm for a 27-field hash), while the snapshot is read once and
+    // kept current by the write runtimes -- the same coherence every internal hgetall relies on.
+    {
+        let decoded = hgetall_map(engine, key.clone())?;
+        {
             let mut records = Vec::new();
-            for (field, value) in entries {
-                let value = String::from_utf8(value)
-                    .map_err(|error| format!("stored hash value is not UTF-8: {error}"))?;
+            for (field, value) in &decoded {
                 records.push(HashReadRecord {
                     key: key.clone(),
                     field: field.clone(),
                     value: value.clone(),
                 });
-                decoded.insert(field, value);
             }
             let mut extra = BTreeMap::new();
             extra.insert("native_prefix_scan".to_string(), json!(true));
             extra.insert(
                 "prefix_scan_path".to_string(),
-                json!("rust_proxy_scan_hash"),
+                json!("rust_proxy_scan_hash_snapshot"),
             );
             Ok(RecordLogOutput {
                 value: serde_json::to_string(&decoded)
@@ -3127,7 +3028,6 @@ fn hash_entries_output(
                 extra,
             })
         }
-        other => Err(format!("unexpected response for hgetall: {other:?}")),
     }
 }
 

--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -1085,8 +1085,22 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
         """Constant-time PBKDF2 check for email/password login."""
         return verify_matrixark_password(password, credential)
 
+    def _append_audit_record(self, record: Json) -> None:
+        """Route one audit record to storage.
+
+        Record-log metadata: through the adapter's buffered audit path (MATRIXARK_DIRECT_AUDIT_MODE
+        governs it; "buffered" coalesces into one durable append_many per flush interval instead of
+        a WAL+fsync append per audited request). Any other metadata backend (SQL) keeps its own
+        append -- audits live in its tables, not the record log.
+        """
+        appender = getattr(self.adapter, "append_audit", None)
+        if callable(appender) and getattr(self.metadata, "backend_name", "") == "record_log":
+            appender(record)
+            return
+        self.metadata.append(record)
+
     def append_audit(self, action: str, identity: Json, *, status: str, details: Json | None = None) -> None:
-        self.metadata.append(
+        self._append_audit_record(
             {
                 "record_type": "matrixark_audit_log",
                 "audit_id_hash": stable_hash(f"{action}:{identity.get('api_key_id')}:{now_ms()}"),

--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -82,6 +82,13 @@ class MatrixArkRecordLogMetadataStore(MatrixArkMetadataStore):
         self.adapter.append(record)
 
     def read_all(self) -> list[Json]:
+        # Buffered audits must be readable by the reader that asks: flush the adapter's audit
+        # buffer before reading. An empty buffer is a lock-and-return, so the API-key lookups
+        # that run on every call pay nothing; a non-empty one pays the append_many the flusher
+        # would have paid moments later.
+        flusher = getattr(self.adapter, "flush_audits", None)
+        if callable(flusher):
+            flusher()
         return [record for record in self.adapter.read_all() if str(record.get("record_type", "")).startswith("matrixark_")]
 
 

--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -82,13 +82,6 @@ class MatrixArkRecordLogMetadataStore(MatrixArkMetadataStore):
         self.adapter.append(record)
 
     def read_all(self) -> list[Json]:
-        # Buffered audits must be readable by the reader that asks: flush the adapter's audit
-        # buffer before reading. An empty buffer is a lock-and-return, so the API-key lookups
-        # that run on every call pay nothing; a non-empty one pays the append_many the flusher
-        # would have paid moments later.
-        flusher = getattr(self.adapter, "flush_audits", None)
-        if callable(flusher):
-            flusher()
         return [record for record in self.adapter.read_all() if str(record.get("record_type", "")).startswith("matrixark_")]
 
 

--- a/tools/matrixark_access_portal.py
+++ b/tools/matrixark_access_portal.py
@@ -314,6 +314,14 @@ class _AccessPortalMixin:
         }
 
     def audit(self, args: Json, identity: Json) -> Json:
+        # Audit rows have one reading funnel (this method; the portal dashboard calls it too), so
+        # this is where buffered audits must become readable. Flushing here instead of on every
+        # metadata read keeps the per-request auth lookups (find_active_api_key and friends, which
+        # read metadata on every enforced-mode call) from paying the durable append the buffered
+        # path exists to move off the request path.
+        flusher = getattr(self.adapter, "flush_audits", None)
+        if callable(flusher):
+            flusher()
         limit = args.get("limit", 100)
         if not isinstance(limit, int) or limit <= 0:
             raise MatrixArkError("limit must be a positive integer")

--- a/tools/matrixark_mcp_dispatch.py
+++ b/tools/matrixark_mcp_dispatch.py
@@ -339,21 +339,22 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_list_users":
         result = server.adapter.list_memory_subjects(args)
-        server.access.append_audit("context.list_users", identity, status="ok", details={"count": result.get("count")})
+        server.append_audit_policy("context.list_users", identity, status="ok", details={"count": result.get("count")}, args=args, hot_path=True)
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_get_all":
         result = server.adapter.get_all(args)
-        server.access.append_audit("context.get_all", identity, status="ok", details={"count": result.get("count")})
+        server.append_audit_policy("context.get_all", identity, status="ok", details={"count": result.get("count")}, args=args, hot_path=True)
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_get_memory":
         result = server.adapter.get_memory(args)
-        server.access.append_audit("context.get", identity, status="ok", details={"found": result.get("found")})
+        server.append_audit_policy("context.get", identity, status="ok", details={"found": result.get("found")}, args=args, hot_path=True)
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_get_memory_by_key":
         result = server.adapter.get_memory_by_identity_key(args)
-        server.access.append_audit(
+        server.append_audit_policy(
             "context.get_by_key", identity, status="ok",
             details={"found": result.get("found"), "identity_key": result.get("identity_key")},
+            args=args, hot_path=True,
         )
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_update_memory":
@@ -370,7 +371,7 @@ def dispatch_matrixark_tool(server: Any, name: str, args: Json, hook: Json | Non
         return server._finalize_write_response(name, args, identity, hook, response)
     if name == "matrixark_memory_history":
         result = server.adapter.history(args)
-        server.access.append_audit("context.history", identity, status="ok", details={"count": result.get("count")})
+        server.append_audit_policy("context.history", identity, status="ok", details={"count": result.get("count")}, args=args, hot_path=True)
         return {**result, "access": args.get("_matrixark_auth", {})}
     if name == "matrixark_reset":
         result = server.adapter.reset(args, hook=hook)

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -389,6 +389,10 @@ _SUBJECT_RESCOPE_DROP = frozenset({
 
 
 class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, _TemporalDirectWriteMixin, _TemporalDirectReadMixin, _TemporalDirectRetrieveMixin):
+    # The base class precedes the mixins in the MRO, so without this the buffered audit
+    # implementation the __init__ prepares for (MATRIXARK_DIRECT_AUDIT_MODE, buffer, flusher)
+    # is shadowed by the base's durable-append-per-record version.
+    append_audit = _TemporalDirectWriteMixin.append_audit
     """MatrixArk adapter backed by TemporalStore proxy or direct SDK.
 
     Python stays as API/auth/model orchestration. Production retrieval should


### PR DESCRIPTION
OSS port. Three layers found by staged measurement: uncached per-field page reads outside hgetall_map (never warming), a synchronous durable audit append per read (51-53 ms, 87% of the chain), and the buffered audit implementation MRO-shadowed into dead code. Plus hardening: hgetall_map never caches an empty result (cold-start 0-row pin, healed only by restart; verified closed across 8 cold starts). Measured: pinned get_all p50 6.5-8.1 ms on the scaled store with audits on, flat with the small store; shadow gauntlet 0 mismatches; strict 22/22.