### PR TITLE
Report what the divergence check did not examine

### DIFF
--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -425,6 +425,45 @@ impl SingleNodeMeta {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_server_the_check_skipped_is_not_reported_as_consistent() {
+        // The check skips a server that has never reported shard states -- it
+        // `continue`s, so that server's shards are never examined. Without this
+        // reported, `diverged 0` means either "nothing diverged" or "the servers
+        // that mattered were never looked at", and nothing tells them apart.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
+                server_addr: "quiet".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+
+        let mut checker = ShardChecker::new(ShardCheckOptions::default());
+        let (report, _) = meta.check_shard_divergence(&mut checker);
+        assert!(report.diverged.is_empty());
+        assert_eq!(report.skipped_without_shard_reports.len(), 1, "{report:?}");
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains(
+                "temporalstore_meta_divergence_skipped{reason=\"no_shard_reports\"} 1"
+            ),
+            "a server the check never examined was not reported:\n{exported}"
+        );
+        // And the clean reason stays at zero, so the two are distinguishable.
+        assert!(
+            exported
+                .contains("temporalstore_meta_divergence_skipped{reason=\"reboot_grace\"} 0"),
+            "{exported}"
+        );
+    }
+
     use super::*;
 
     fn owners(pairs: &[(ShardId, &str)]) -> BTreeMap<ShardId, String> {

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -61,6 +61,8 @@ struct SubsystemMetricsState {
     divergence_rate_limited: u64,
     retention_blocked_servers: u64,
     retention_capped: u64,
+    freeze_aging_capped: u64,
+    divergence_skipped: BTreeMap<String, u64>,
 }
 
 /// Shared recorder for background-subsystem outcomes.
@@ -115,6 +117,18 @@ impl SubsystemMetrics {
             state.diverged_now = report.diverged.len() as u64;
             state.settling_now = report.settling.len() as u64;
             state.divergence_rate_limited = report.rate_limited as u64;
+            // Servers the check declined to look at. Without these, a reported
+            // zero means either "nothing diverged" or "the servers that mattered
+            // were never examined", and an operator cannot tell which. A server
+            // that has never reported shard states is skipped outright.
+            for (reason, servers) in [
+                ("reboot_grace", &report.skipped_in_reboot_grace),
+                ("no_shard_reports", &report.skipped_without_shard_reports),
+            ] {
+                state
+                    .divergence_skipped
+                    .insert(reason.to_string(), servers.len() as u64);
+            }
         });
     }
 
@@ -152,6 +166,10 @@ impl SubsystemMetrics {
             ] {
                 *state.aged_total.entry(kind.to_string()).or_default() += count as u64;
             }
+            // Retention reports the work its per-round cap held back; freeze
+            // aging has the same field and was not reporting it, so a round
+            // doing less than it wanted looked like a round with less to do.
+            state.freeze_aging_capped = plan.capped as u64;
         });
     }
 
@@ -369,6 +387,24 @@ fn render(state: &SubsystemMetricsState) -> String {
         state.retention_blocked_servers,
     );
 
+    out.push_str("# HELP temporalstore_meta_freeze_aging_capped Freeze-aging work the per-round cap held back last round.\n");
+    out.push_str("# TYPE temporalstore_meta_freeze_aging_capped gauge\n");
+    push(
+        &mut out,
+        "temporalstore_meta_freeze_aging_capped",
+        &[],
+        state.freeze_aging_capped,
+    );
+    out.push_str("# HELP temporalstore_meta_divergence_skipped Servers the divergence check did not examine last round.\n");
+    out.push_str("# TYPE temporalstore_meta_divergence_skipped gauge\n");
+    for (reason, value) in &state.divergence_skipped {
+        push(
+            &mut out,
+            "temporalstore_meta_divergence_skipped",
+            &[("reason", reason)],
+            *value,
+        );
+    }
     out.push_str("# HELP temporalstore_meta_retention_capped Purges the per-round cap held back last round.\n");
     out.push_str("# TYPE temporalstore_meta_retention_capped gauge\n");
     push(


### PR DESCRIPTION
> Independent of the other open work — `main` base, two files.

## A divergence check that examined nothing reported the same as one that found nothing

`check_shard_divergence` skips servers outright — it `continue`s past a server
that has never reported shard states, and past one inside its reboot grace. Those
servers' shards are never examined. Both lists are on the report:

```rust
pub skipped_in_reboot_grace: Vec<String>,
pub skipped_without_shard_reports: Vec<String>,
```

Neither reached the metrics. So `temporalstore_meta_shard_divergence_total 0`
meant either "nothing diverged" or "the servers that mattered were never looked
at", with no way to tell them apart. The `diverged` field's own doc says the
report keeps "the full picture" — it does, and the exported view did not.

That is the failure mode `missed_events` exists to prevent elsewhere in this
metaserver: a gap that reads as quiet.

## And freeze aging never reported its cap

Retention records the work its per-round cap held back (`retention_capped`).
Freeze aging has the identical `capped` field on its plan and recorded nothing,
so a round doing less than it wanted looked like a round with less to do.

## The change

Both follow the recorders already there:

```
temporalstore_meta_divergence_skipped{reason="no_shard_reports"}
temporalstore_meta_divergence_skipped{reason="reboot_grace"}
temporalstore_meta_freeze_aging_capped
```

The skip reasons are labels on one gauge rather than two metrics, matching the
labelled families already exported.

## Test

A server registered but never reporting shard states: the check skips it, finds
no divergence, and the export now says so — `no_shard_reports 1` alongside
`reason="reboot_grace" 0`, so the two causes stay distinguishable. Mutation-checked:
dropping the recording fails it.

## Verification

- `cargo check --all-targets` — 0 errors
- `cargo test --bin metaserver -- --test-threads=1` — 26/26
- `cargo test --lib -- --test-threads=1` — 1207 passed, 3 failed

Two of those three are environmental and were checked rather than assumed:
`proxy::…topology_check_stays_off_the_request_path` and
`raft::…http_raft_transport…` each pass **6/6 and 3/3 in isolation**, and the
proxy one passes 6/6 on unmodified `main` too; its body references nothing this
change touches. The third, `data_node::…jitter_backoff…`, fails 3/3 in isolation
on unmodified `main` and is genuinely pre-existing.
