### PR TITLE
Port: bound the node log with state-image compaction; space out failure-wave topology syncs

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -2121,6 +2121,10 @@ fn env_bool(name: &str, default: bool) -> bool {
 fn raft_config_from_env() -> RaftConfig {
     let defaults = RaftConfig::default();
     RaftConfig {
+        // 8 MB of applied log per shard before the periodic check compacts it into a
+        // state-image snapshot. Left unbounded, every segment rotation rewrites an
+        // ever-growing base record, and restart replays all of it.
+        max_applied_log_bytes: env_u64("TS_RAFT_MAX_APPLIED_LOG_BYTES", 8 * 1024 * 1024),
         replication_deadline_ms: env_u64(
             "TS_RAFT_REPLICATION_DEADLINE_MS",
             defaults.replication_deadline_ms,

--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -660,6 +660,9 @@ struct ClientMetaSyncTableState {
     consecutive_errors: u64,
     last_error: String,
     shards_without_primary: u64,
+    /// When a request failure last forced a topology sync for this table, out of band from
+    /// the scheduled one. Used to space those out; see `refresh_table_topology_after_status`.
+    last_forced_sync_unix_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1482,8 +1485,20 @@ impl TemporalStoreTable {
         self.http_options()
     }
 
+    /// Re-sync this table's topology because a request failed in a way that suggests the
+    /// cached one is wrong.
+    ///
+    /// Spaced by `topo_error_retry_interval_ms`. The per-request guard above stops one command
+    /// doing this twice, but says nothing about the other requests in flight: a shard moving
+    /// makes MANY requests fail at once, and each one arriving here unthrottled is a separate
+    /// metaserver round-trip -- a sync storm aimed at the metaserver at the moment it is
+    /// working through a topology change. One request's failure is enough to learn what all of
+    /// them need.
     fn refresh_table_topology_after_status(&self) {
         if self.client.inner.options.meta_addr.is_none() {
+            return;
+        }
+        if !self.client.forced_sync_is_due(&self.namespace, &self.table_name) {
             return;
         }
         let _ = self

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -864,6 +864,7 @@ impl TemporalStoreClient {
                 consecutive_errors: 0,
                 last_error: String::new(),
                 shards_without_primary: 0,
+                last_forced_sync_unix_ms: 0,
             });
     }
 
@@ -881,6 +882,47 @@ impl TemporalStoreClient {
             .get(&key)
             .map(|state| state.last_topology_version)
             .unwrap_or(0)
+    }
+
+    /// Whether a failure-driven topology sync for this table is due, claiming the slot if so.
+    ///
+    /// Claimed as it answers, so concurrent failures cannot all decide they are due and fire
+    /// the same sync. Losing that race means skipping a sync another thread is already making,
+    /// which is the outcome wanted.
+    pub(super) fn forced_sync_is_due(&self, namespace: &str, table_name: &str) -> bool {
+        let interval = self.inner.options.topo_error_retry_interval_ms;
+        if interval == 0 {
+            return true;
+        }
+        let now = now_unix_ms();
+        let key = table_combine_name(namespace, table_name);
+        let mut states = self
+            .inner
+            .meta_sync_tables
+            .lock()
+            .expect("client meta sync table lock poisoned");
+        let state = states
+            .entry(key)
+            .or_insert_with(|| ClientMetaSyncTableState {
+                namespace: namespace.to_string(),
+                table_name: table_name.to_string(),
+                sync_generation: 0,
+                last_success_unix_ms: 0,
+                last_error_unix_ms: 0,
+                next_sync_after_unix_ms: 0,
+                last_topology_version: 0,
+                consecutive_errors: 0,
+                last_error: String::new(),
+                shards_without_primary: 0,
+                last_forced_sync_unix_ms: 0,
+            });
+        let last = state.last_forced_sync_unix_ms;
+        // A clock that went backwards should not lock the refresh out until it catches up.
+        if last != 0 && now >= last && now.saturating_sub(last) < interval {
+            return false;
+        }
+        state.last_forced_sync_unix_ms = now;
+        true
     }
 
     pub(super) fn record_meta_sync_success(
@@ -910,6 +952,7 @@ impl TemporalStoreClient {
                 consecutive_errors: 0,
                 last_error: String::new(),
                 shards_without_primary: 0,
+                last_forced_sync_unix_ms: 0,
             });
         state.sync_generation = state.sync_generation.saturating_add(1);
         state.last_success_unix_ms = now;
@@ -946,6 +989,7 @@ impl TemporalStoreClient {
                 consecutive_errors: 0,
                 last_error: String::new(),
                 shards_without_primary: 0,
+                last_forced_sync_unix_ms: 0,
             });
         state.sync_generation = state.sync_generation.saturating_add(1);
         state.last_error_unix_ms = now;

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -264,6 +264,53 @@ fn client_metasync_backoff_deadline_and_topology_refresh_survive_outage_churn() 
 }
 
 #[test]
+fn failure_driven_topology_syncs_are_spaced_out() {
+    // A request that fails in a way suggesting the cached topology is wrong triggers a
+    // re-sync. The guard on that is per REQUEST, which says nothing about the other requests
+    // in flight -- and a shard moving fails many at once. Unthrottled, each one is its own
+    // metaserver round-trip: a sync storm aimed at the metaserver exactly while it is working
+    // through the topology change that caused the failures. One failure is enough to learn
+    // what all of them need.
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: "127.0.0.1:1".to_string(),
+        meta_addr: Some("127.0.0.1:1".to_string()),
+        topo_error_retry_interval_ms: 5_000,
+        ..ClientOptions::default()
+    });
+
+    assert!(
+        client.forced_sync_is_due("ns", "tbl"),
+        "the first failure should learn the topology"
+    );
+    for attempt in 0..8 {
+        assert!(
+            !client.forced_sync_is_due("ns", "tbl"),
+            "concurrent failure {attempt} must not each fire their own sync"
+        );
+    }
+
+    // Per table, not global: another table's failure is its own question.
+    assert!(
+        client.forced_sync_is_due("ns", "other"),
+        "a different table must not be throttled by this one"
+    );
+
+    // Zero disables the spacing, which is the older behaviour, kept reachable.
+    let eager = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: "127.0.0.1:1".to_string(),
+        meta_addr: Some("127.0.0.1:1".to_string()),
+        topo_error_retry_interval_ms: 0,
+        ..ClientOptions::default()
+    });
+    for attempt in 0..4 {
+        assert!(
+            eager.forced_sync_is_due("ns", "tbl"),
+            "with spacing off, attempt {attempt} should still sync"
+        );
+    }
+}
+
+#[test]
 fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -117,6 +117,11 @@ pub struct RaftSnapshot {
     /// gate-off path deserialize unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_image: Option<RaftSnapshotStateImage>,
+    /// True when the image lives in its own file beside the log rather than inside the record.
+    /// A record is written per persist and the image is large; embedding it re-serialized the
+    /// whole image into every record that followed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub state_image_externalized: bool,
 }
 
 /// S2: an opaque engine STATE IMAGE — the exported served index plus every referenced page slab —
@@ -244,7 +249,11 @@ fn raft_leader_ready_barrier_on() -> bool {
 /// replaying O(total history); install reconstructs state from the image. Default OFF -> the
 /// snapshot still carries entries and behavior is byte-identical.
 fn raft_snapshot_state_image_on() -> bool {
-    raft_env_flag_on("TS_RAFT_SNAPSHOT_STATE_IMAGE")
+    // Default ON since the restore path learned to install images and compaction proved to
+    // bound the log with them (a restart after compaction serves every value; the log stays a
+    // fraction of the history). TS_RAFT_SNAPSHOT_STATE_IMAGE=0 opts back to entry-carrying
+    // snapshots, which re-encode history rather than reduce it.
+    raft_env_flag_default_on("TS_RAFT_SNAPSHOT_STATE_IMAGE")
 }
 
 /// P1 (fsync coalescing): skip a node's WAL fdatasync when none of its DURABILITY-relevant state
@@ -1378,6 +1387,9 @@ pub struct RaftWalSegmentReport {
 
 #[derive(Debug, Clone, Default)]
 struct NodeWalCursor {
+    /// Snapshot boundary of the last marker this node persisted, so an incremental record can
+    /// omit an unchanged marker the way it omits already-persisted entries.
+    persisted_marker_index: Option<u64>,
     next_sequence: u64,
     segments: Vec<RaftWalSegmentInfo>,
     released_segment_count: u64,
@@ -5668,12 +5680,26 @@ fn apply_committed(node: &mut RaftNode) -> Option<CommandResponse> {
 
 fn install_snapshot_state(node: &mut RaftNode, snapshot: RaftSnapshot) {
     let engine = TemporalEngine::default();
-    engine.load_shard(snapshot.shard_id);
-    for entry in &snapshot.entries {
-        engine.execute_raft_apply(ExecuteRequest {
-            shard_id: entry.shard_id,
-            command: entry.command.clone(),
-        });
+    if let Some(image) = &snapshot.state_image {
+        // Reconstruct from the opaque state image in O(state): install the slabs and the served
+        // index, then load the shard so the index is read in. Every path a snapshot can land on
+        // must handle this -- an image snapshot fed to an entries-only installer replays nothing
+        // and quietly leaves an EMPTY engine, which is exactly what happened to a restart that
+        // restored an image-carrying record before this installer learned about images.
+        let block_store = engine.block_store();
+        for slab in &image.slabs {
+            let _ = block_store.install_slab(slab.page_slab_id, &slab.bytes);
+        }
+        let _ = engine.install_index_bytes(snapshot.shard_id, &image.index_bytes);
+        engine.load_shard(snapshot.shard_id);
+    } else {
+        engine.load_shard(snapshot.shard_id);
+        for entry in &snapshot.entries {
+            engine.execute_raft_apply(ExecuteRequest {
+                shard_id: entry.shard_id,
+                command: entry.command.clone(),
+            });
+        }
     }
     node.engine = engine;
     // votedFor is per-term (Raft Fig-2): clear a stale vote when a snapshot raises the term,

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -489,6 +489,7 @@ impl RaftCluster {
                 external_snapshot_ref: None,
                 entries,
                 state_image,
+                state_image_externalized: false,
             },
         );
         {
@@ -589,6 +590,7 @@ impl RaftCluster {
                     external_snapshot_ref: None,
                     entries: Vec::new(),
                     state_image: Some(image),
+                    state_image_externalized: false,
                 });
             }
         }
@@ -621,6 +623,7 @@ impl RaftCluster {
             external_snapshot_ref: None,
             entries,
             state_image: None,
+            state_image_externalized: false,
         })
     }
 

--- a/crates/temporalstore-rust/src/raft/follower_pipeline.rs
+++ b/crates/temporalstore-rust/src/raft/follower_pipeline.rs
@@ -287,6 +287,39 @@ impl RaftCluster {
 
     /// Fold successful replication into the quorum commit, waking every waiting proposer.
     pub(crate) fn advance_quorum_commit(&self) {
+        // Cheap pre-check under the read lock: every sender calls this after every response, and
+        // most calls have nothing to advance. Taking the write lock for those serializes the
+        // senders against the proposers appending under the same lock.
+        {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let leader_id = inner.leader_id;
+            let Some(leader) = inner.nodes.get(&leader_id) else {
+                return;
+            };
+            if leader.role != RaftRole::Leader {
+                return;
+            }
+            let required = inner.required_majority();
+            let leader_last = node_next_log_index(leader).saturating_sub(1);
+            let mut matched: Vec<u64> = Vec::new();
+            for (id, node) in &inner.nodes {
+                if !node.replica_role.participates_in_quorum() {
+                    continue;
+                }
+                matched.push(if *id == leader_id {
+                    leader_last
+                } else {
+                    node.pipeline_state.match_index
+                });
+            }
+            if matched.len() < required {
+                return;
+            }
+            matched.sort_unstable_by(|left, right| right.cmp(left));
+            if matched[required - 1] <= leader.commit_index {
+                return;
+            }
+        }
         let advanced = {
             let mut inner = self.inner.write().expect("raft cluster lock poisoned");
             let advanced = inner.maybe_advance_quorum_commit();

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -19,6 +19,9 @@ pub struct StagedWalAppend {
     node_id: RaftNodeId,
     min_keep_segments: usize,
     slow_fsync_threshold_ms: u64,
+    /// Whether this append wrote a base whose snapshot boundary ADVANCED -- the one kind of
+    /// record that supersedes on-disk history. Its barrier makes earlier segments prunable.
+    compacting_base: bool,
 }
 
 impl LocalRaftWal {
@@ -76,6 +79,124 @@ impl LocalRaftWal {
     ) -> io::Result<()> {
         self.append_node_record(shard_id, node_id, record)?;
         self.compact_node_records(shard_id, node_id, keep_last)
+    }
+
+    /// The file a snapshot's state image lives in, named by the snapshot's boundary index.
+    fn image_path(&self, shard_id: ShardId, node_id: RaftNodeId, index: u64) -> PathBuf {
+        self.node_segment_dir(shard_id, node_id)
+            .join(format!("image-{index:020}.bin"))
+    }
+
+    /// Move a record's in-memory image into its own durable file, returning a record that
+    /// references it. The file is fsynced BEFORE any record naming it can be written, so a
+    /// record that says "my image is in a file" is never durable ahead of the file itself.
+    /// Older image files are pruned: recovery folds records forward, so only the newest
+    /// snapshot's image is ever read back.
+    fn externalize_state_image(
+        &self,
+        shard_id: ShardId,
+        node_id: RaftNodeId,
+        record: &RaftWalRecord,
+    ) -> io::Result<Option<RaftWalRecord>> {
+        let Some(snapshot) = &record.installed_snapshot else {
+            return Ok(None);
+        };
+        let Some(image) = &snapshot.state_image else {
+            return Ok(None);
+        };
+        let index = snapshot.last_included_index;
+        let path = self.image_path(shard_id, node_id, index);
+        if !path.exists() {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let message = crate::sdk::v1::WalStateImage {
+                index: image.index_bytes.clone(),
+                next_page_id: image.next_page_id,
+                slabs: image
+                    .slabs
+                    .iter()
+                    .map(|slab| crate::sdk::v1::WalStateImageSlab {
+                        page_slab_id: slab.page_slab_id,
+                        slab: slab.bytes.clone(),
+                    })
+                    .collect(),
+            };
+            let bytes = prost::Message::encode_to_vec(&message);
+            let tmp = path.with_extension("tmp");
+            {
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&tmp)?;
+                file.write_all(&crate::log_framing::encode_line(&bytes))?;
+                file.sync_data()?;
+            }
+            fs::rename(&tmp, &path)?;
+            // Prune superseded images: recovery only ever reattaches the newest.
+            if let Ok(entries) = fs::read_dir(self.node_segment_dir(shard_id, node_id)) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    if let Some(stem) = name.strip_prefix("image-").and_then(|rest| {
+                        rest.strip_suffix(".bin")
+                    }) {
+                        if stem.parse::<u64>().map(|old| old < index).unwrap_or(false) {
+                            let _ = fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+        }
+        let mut externalized = record.clone();
+        if let Some(snapshot) = externalized.installed_snapshot.as_mut() {
+            snapshot.state_image = None;
+            snapshot.state_image_externalized = true;
+        }
+        Ok(Some(externalized))
+    }
+
+    /// Reattach an externalized image to a recovered record. A record that references a file
+    /// which does not exist is COMMITTED corruption -- the file is made durable before any
+    /// record naming it, so a torn tail cannot produce this.
+    fn reattach_state_image(
+        &self,
+        shard_id: ShardId,
+        node_id: RaftNodeId,
+        record: &mut RaftWalRecord,
+    ) -> io::Result<()> {
+        let Some(snapshot) = record.installed_snapshot.as_mut() else {
+            return Ok(());
+        };
+        if !snapshot.state_image_externalized || snapshot.state_image.is_some() {
+            return Ok(());
+        }
+        let path = self.image_path(shard_id, node_id, snapshot.last_included_index);
+        let raw = fs::read(&path).map_err(|err| {
+            io::Error::other(format!(
+                "snapshot image file missing for index {}: {err}",
+                snapshot.last_included_index
+            ))
+        })?;
+        let payload = crate::log_framing::decode_line(raw.strip_suffix(b"\n").unwrap_or(&raw))
+            .map_err(io::Error::other)?;
+        let message = <crate::sdk::v1::WalStateImage as prost::Message>::decode(payload)
+            .map_err(io::Error::other)?;
+        snapshot.state_image = Some(RaftSnapshotStateImage {
+            index_bytes: message.index,
+            next_page_id: message.next_page_id,
+            slabs: message
+                .slabs
+                .into_iter()
+                .map(|slab| RaftSnapshotStateImageSlab {
+                    page_slab_id: slab.page_slab_id,
+                    bytes: slab.slab,
+                })
+                .collect(),
+        });
+        snapshot.state_image_externalized = false;
+        Ok(())
     }
 
     pub fn persist_node_segmented(
@@ -151,6 +272,15 @@ impl LocalRaftWal {
         min_keep_segments: usize,
         slow_fsync_threshold_ms: u64,
     ) -> io::Result<StagedWalAppend> {
+        // A state image is written once, to its own file, before any record that references it;
+        // the record then carries the reference. Embedding it re-serialized the whole image into
+        // every subsequent record.
+        let externalized = self.externalize_state_image(shard_id, node_id, record)?;
+        let record = externalized.as_ref().unwrap_or(record);
+        let marker_index = record
+            .installed_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.last_included_index);
         let max_segment_bytes = max_segment_bytes.max(1);
         let min_keep_segments = min_keep_segments.max(1);
         let segment_dir = self.node_segment_dir(shard_id, node_id);
@@ -222,7 +352,18 @@ impl LocalRaftWal {
                     replica_role: record.replica_role,
                     joint_membership: record.joint_membership.clone(),
                     latest_external_snapshot_ref: record.latest_external_snapshot_ref.clone(),
-                    installed_snapshot: record.installed_snapshot.clone(),
+                    // An unchanged marker folds forward from the base, exactly as entries do.
+                    installed_snapshot: if record
+                        .installed_snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.last_included_index)
+                        == cursor.persisted_marker_index
+                        && cursor.persisted_marker_index.is_some()
+                    {
+                        None
+                    } else {
+                        record.installed_snapshot.clone()
+                    },
                     apply_snapshot_fence: record.apply_snapshot_fence.clone(),
                     storage_apply_fence: record.storage_apply_fence.clone(),
                     // Telemetry counters are not durability-relevant (the fingerprint zeroes
@@ -276,7 +417,15 @@ impl LocalRaftWal {
         } else {
             max_segment_bytes
         };
-        let rotate = active_len > 0 && active_len + encoded.len() as u64 > rotate_threshold;
+        // Size-based rotation as before -- plus: a COMPACTING base opens a segment. When the
+        // snapshot boundary advanced, the base supersedes the history in the current segment,
+        // and only at a segment boundary can pruning reclaim it. Ordinary re-bases (an empty
+        // log, a conflict) stay in-segment: rotating on every one turned each read-index
+        // persist into file churn and erased the record trail the legacy contract promises.
+        let marker_advanced =
+            marker_index.is_some() && marker_index != cursor.persisted_marker_index;
+        let rotate = (active_len > 0 && active_len + encoded.len() as u64 > rotate_threshold)
+            || (wrote_base && marker_advanced && active_len > 0);
         if rotate {
             active_segment_id += 1;
             if !wrote_base {
@@ -341,6 +490,11 @@ impl LocalRaftWal {
         }
         cursor.persisted_last_index = log_last_index;
         cursor.persisted_last_term = log_last_term;
+        cursor.persisted_marker_index = record
+            .installed_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.last_included_index)
+            .or(cursor.persisted_marker_index);
 
         // Everything the cursor must record about this append is in place, so the lock can go
         // before the expensive part. Writers blocked behind it now proceed and register against
@@ -354,6 +508,7 @@ impl LocalRaftWal {
             node_id,
             min_keep_segments,
             slow_fsync_threshold_ms,
+            compacting_base: wrote_base && marker_advanced,
         })
     }
 
@@ -370,6 +525,7 @@ impl LocalRaftWal {
             node_id,
             min_keep_segments,
             slow_fsync_threshold_ms,
+            compacting_base,
         } = staged;
         let last_fsync_elapsed_ms = gate.await_durable(ticket, || {
             crate::durability_metrics::record_barrier("raft_wal_append");
@@ -391,8 +547,16 @@ impl LocalRaftWal {
         // where the sequence was `recover().valid_records + 1` over the surviving
         // segments only.
         let mut released_segment_count = 0u64;
-        if cursor.segments.len() > min_keep_segments {
-            let remove = cursor.segments.len() - min_keep_segments;
+        // A durable COMPACTING base supersedes every earlier segment; one predecessor is kept
+        // so a torn tail on the active segment still has somewhere to recover from. Ordinary
+        // appends keep the configured count.
+        let effective_keep = if compacting_base {
+            min_keep_segments.min(2)
+        } else {
+            min_keep_segments
+        };
+        if cursor.segments.len() > effective_keep {
+            let remove = cursor.segments.len() - effective_keep;
             let pruned: Vec<RaftWalSegmentInfo> = cursor.segments.drain(0..remove).collect();
             for segment in &pruned {
                 fs::remove_file(&segment.path)?;
@@ -425,9 +589,15 @@ impl LocalRaftWal {
         node_id: RaftNodeId,
     ) -> io::Result<NodeWalCursor> {
         let recovery = self.recover_node_segmented_scan(shard_id, node_id)?;
+        let recovered_marker = recovery
+            .record
+            .as_ref()
+            .and_then(|record| record.installed_snapshot.as_ref())
+            .map(|snapshot| snapshot.last_included_index);
         let segments = self.node_segments(shard_id, node_id)?;
         let runtime_state = self.read_segment_runtime_state(shard_id, node_id);
         Ok(NodeWalCursor {
+            persisted_marker_index: recovered_marker,
             next_sequence: recovery.valid_records as u64 + 1,
             segments,
             released_segment_count: runtime_state.released_segment_count,
@@ -491,7 +661,11 @@ impl LocalRaftWal {
         if let Ok(mut cursors) = self.cursors.lock() {
             cursors.remove(&(shard_id, node_id));
         }
-        self.recover_node_segmented_scan(shard_id, node_id)
+        let mut recovery = self.recover_node_segmented_scan(shard_id, node_id)?;
+        if let Some(record) = recovery.record.as_mut() {
+            self.reattach_state_image(shard_id, node_id, record)?;
+        }
+        Ok(recovery)
     }
 
     fn recover_node_segmented_scan(
@@ -535,6 +709,14 @@ impl LocalRaftWal {
                         // `from_index` were superseded (conflict overwrite), and anything
                         // below `log_first_index` was compacted away.
                         let mut merged = envelope.record;
+                        // A marker the record omitted is unchanged: inherit the base's, the
+                        // same way unchanged entries fold forward.
+                        if merged.installed_snapshot.is_none() {
+                            if let Some(previous) = last_record.as_ref() {
+                                merged.installed_snapshot =
+                                    previous.installed_snapshot.clone();
+                            }
+                        }
                         let appended = std::mem::take(&mut merged.entries);
                         let base = last_record;
                         // An incremental record omits the volatile telemetry blocks; carry

--- a/crates/temporalstore-rust/src/raft/tests/part1.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part1.rs
@@ -1217,6 +1217,7 @@ fn install_snapshot_clears_stale_vote_on_term_raise() {
                     },
                 }],
                 state_image: None,
+                state_image_externalized: false,
             },
         )
         .unwrap();

--- a/crates/temporalstore-rust/src/raft/tests/part2.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part2.rs
@@ -75,6 +75,9 @@ fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn streaming_snapshot_chunks_install_only_after_all_chunks_arrive() {
+    // This test is about ENTRY chunking; a state image is one small unit and
+    // completes in a single chunk, which is not what these assertions probe.
+    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(21, [1, 2, 3]);
     cluster.set_alive(3, false).unwrap();
     for index in 0..5 {
@@ -128,6 +131,9 @@ fn streaming_snapshot_chunks_install_only_after_all_chunks_arrive() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn matrixraft_snapshot_chunk_retry_releases_backpressure_and_installs_chunk() {
+    // This test is about ENTRY chunking; a state image is one small unit and
+    // completes in a single chunk, which is not what these assertions probe.
+    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let transport = FlakyTransport {
         cluster: RaftCluster::new_single_shard(213, [1, 2, 3]),
         failures_left: Arc::new(Mutex::new(1)),
@@ -177,6 +183,9 @@ fn matrixraft_snapshot_chunk_retry_releases_backpressure_and_installs_chunk() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn matrixraft_snapshot_lifecycle_reports_timeout_rate_limit_rollback_membership_and_rejoin() {
+    // This test is about ENTRY chunking; a state image is one small unit and
+    // completes in a single chunk, which is not what these assertions probe.
+    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard_with_config(
         214,
         [1, 2, 3],
@@ -308,6 +317,9 @@ fn raft_snapshot_transport_rejects_stale_term_before_install() {
 // shared-corpus: raft_matrixraft_snapshot_chunk_retry_rollback_matrix raft_matrixraft_snapshot_lifecycle_depth
 #[test]
 fn raft_snapshot_chunk_transport_rejects_stale_term_before_buffering() {
+    // This test is about ENTRY chunking; a state image is one small unit and
+    // completes in a single chunk, which is not what these assertions probe.
+    let _entries = super::part4::EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(212, [1, 2, 3]);
     for index in 0..3 {
         cluster

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2225,19 +2225,19 @@ fn wal_recovery_rejects_ahead_of_storage_apply_fence() {
 
 /// Sets an env gate for the duration of a test and removes it on drop (even on panic), so a
 /// gated-behavior test never leaks its flag into the rest of the single-threaded suite.
-struct EnvFlagGuard {
+pub(super) struct EnvFlagGuard {
     name: &'static str,
 }
 
 impl EnvFlagGuard {
-    fn set(name: &'static str) -> Self {
+    pub(super) fn set(name: &'static str) -> Self {
         std::env::set_var(name, "1");
         Self { name }
     }
 
     /// Explicitly DISABLES a gate for the test's lifetime. Needed because the shipped fixes are
     /// default-ON: leaving the variable unset now selects the fixed path, not the legacy one.
-    fn off(name: &'static str) -> Self {
+    pub(super) fn off(name: &'static str) -> Self {
         std::env::set_var(name, "0");
         Self { name }
     }
@@ -2465,6 +2465,7 @@ fn s2_state_image_snapshot_travels_through_chunk_stream() {
 /// so behavior is byte-identical to before.
 #[test]
 fn s2_snapshot_gate_off_still_carries_entries_and_no_image() {
+    let _gate = EnvFlagGuard::off("TS_RAFT_SNAPSHOT_STATE_IMAGE");
     let cluster = RaftCluster::new_single_shard(1, [1, 2, 3]);
     for i in 0..4 {
         cluster
@@ -2946,6 +2947,7 @@ fn r8_snapshot_install_with_divergent_boundary_discards_whole_log() {
                 external_snapshot_ref: None,
                 entries: vec![r8_branch_entry(2, 5, "winning")],
                 state_image: None,
+                state_image_externalized: false,
             },
         )
         .unwrap();
@@ -3012,6 +3014,7 @@ fn r8_snapshot_install_with_matching_boundary_retains_tail() {
                 external_snapshot_ref: None,
                 entries: vec![r8_branch_entry(2, 1, "v2")],
                 state_image: None,
+                state_image_externalized: false,
             },
         )
         .unwrap();

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -815,6 +815,8 @@ impl RaftTransport for OneInFlightTransport {
 /// Eight concurrent proposers, and never two appends in flight to one follower.
 #[test]
 fn at_most_one_append_in_flight_per_follower() {
+    // This test IS the pipeline's invariant; it must not silently test the default.
+    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -878,6 +880,8 @@ fn at_most_one_append_in_flight_per_follower() {
 /// happened to apply last in the same commit batch.
 #[test]
 fn concurrent_proposers_get_their_own_responses() {
+    // This test IS the pipeline's invariant; it must not silently test the default.
+    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
     let dir = tempfile::tempdir().unwrap();
     let cluster = RaftCluster::new_single_shard_with_wal(
         dir.path(),
@@ -932,6 +936,131 @@ fn concurrent_proposers_get_their_own_responses() {
             other => panic!("proposer {key} got {other:?}"),
         }
     }
+}
+
+
+/// After compacting into a state-image snapshot, a restart must serve every value.
+///
+/// The image path installed correctly on the live install route, but the RESTORE path used an
+/// installer that only knew entry-carrying snapshots -- an image snapshot restored there
+/// replayed nothing and produced an empty engine. That hole is why the image stayed dark; this
+/// is the test that proves it closed, through the binary record encoding and the on-disk WAL.
+#[test]
+fn restart_after_state_image_compaction_serves_every_value() {
+    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    let dir = tempfile::tempdir().unwrap();
+    let config = RaftConfig {
+        // Compact as soon as anything is applied, so the test exercises the image path.
+        max_applied_log_bytes: 1,
+        ..RaftConfig::default()
+    };
+    let written: Vec<(String, Vec<u8>)> = (0..40)
+        .map(|index| (format!("img-{index:03}"), format!("value-{index:03}").into_bytes()))
+        .collect();
+    {
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], config.clone())
+                .unwrap();
+        for (key, value) in &written {
+            cluster
+                .propose(Command::StringSet {
+                    key: key.clone(),
+                    value: value.clone(),
+                })
+                .unwrap();
+        }
+        let report = cluster.maybe_trigger_snapshot().unwrap();
+        assert!(report.triggered, "compaction must fire: {}", report.reason);
+        // The log behind the snapshot is gone; the marker carries the image, not the history.
+        let status = cluster.status();
+        assert!(status.commit_index >= 40);
+        // A few more writes AFTER compaction land in the retained tail.
+        for index in 40..44 {
+            cluster
+                .propose(Command::StringSet {
+                    key: format!("img-{index:03}"),
+                    value: format!("value-{index:03}").into_bytes(),
+                })
+                .unwrap();
+        }
+    }
+    let restored =
+        RaftCluster::restore_single_shard_from_wal(dir.path(), 1, [1, 2, 3], config).unwrap();
+    for index in 0..44 {
+        let key = format!("img-{index:03}");
+        let response = restored
+            .read_local(1, Command::StringGet { key: key.clone() })
+            .unwrap();
+        match response {
+            CommandResponse::Bytes { value: Some(value) } => assert_eq!(
+                value,
+                format!("value-{index:03}").into_bytes(),
+                "{key} came back wrong after an image restart"
+            ),
+            other => panic!("{key} unreadable after an image restart: {other:?}"),
+        }
+    }
+}
+
+/// Compaction must actually bound the bytes on disk: with it firing, the log directory stays a
+/// fraction of what the uncompacted history costs -- the difference between a record that
+/// carries state and one that re-encodes history.
+#[test]
+fn state_image_compaction_bounds_wal_bytes() {
+    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    fn wal_bytes(root: &std::path::Path) -> u64 {
+        fn walk(path: &std::path::Path, total: &mut u64) {
+            if let Ok(entries) = std::fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    let Ok(meta) = entry.metadata() else { continue };
+                    if meta.is_dir() {
+                        walk(&entry.path(), total);
+                    } else {
+                        *total += meta.len();
+                    }
+                }
+            }
+        }
+        let mut total = 0;
+        walk(root, &mut total);
+        total
+    }
+    let run = |compact: bool| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let cluster = RaftCluster::new_single_shard_with_wal(
+            dir.path(),
+            1,
+            [1, 2, 3],
+            RaftConfig {
+                max_applied_log_bytes: 64 * 1024,
+                ..RaftConfig::default()
+            },
+        )
+        .unwrap();
+        cluster.set_local_node_id(1);
+        for index in 0..600 {
+            cluster
+                .propose(Command::StringSet {
+                    // Overwrite a small key set: state stays bounded while history grows, which
+                    // is the workload compaction exists for. With unique keys, state equals
+                    // history and there is nothing for a snapshot to save.
+                    key: format!("b-{:02}", index % 20),
+                    value: vec![0x41u8; 512],
+                })
+                .unwrap();
+            if compact && index % 100 == 99 {
+                let _ = cluster.maybe_trigger_snapshot();
+            }
+        }
+        wal_bytes(dir.path())
+    };
+    let unbounded = run(false);
+    let bounded = run(true);
+    println!("wal bytes: unbounded={unbounded} bounded={bounded}");
+    assert!(
+        bounded * 2 < unbounded,
+        "compaction should bound the log: {bounded} vs {unbounded}"
+    );
 }
 
 

--- a/crates/temporalstore-rust/src/raft/wal_proto.rs
+++ b/crates/temporalstore-rust/src/raft/wal_proto.rs
@@ -328,11 +328,36 @@ pub(super) fn binary_replication_enabled() -> bool {
 /// Encode one envelope as a binary message.
 pub(super) fn encode_envelope(envelope: &RaftWalEnvelope) -> io::Result<Vec<u8>> {
     let record = &envelope.record;
+    // The snapshot gets first-class fields: its state image is slab and index BYTES, and in
+    // the side blob those become text again -- re-inflating exactly what compaction bounds.
+    let installed_snapshot = match &record.installed_snapshot {
+        None => None,
+        Some(snapshot) => {
+            let mut sans_image = snapshot.clone();
+            let image = sans_image.state_image.take();
+            Some(v1::WalInstalledSnapshot {
+                snapshot_sans_image: serde_json::to_vec(&sans_image)
+                    .map_err(io::Error::other)?,
+                state_image: image.map(|image| v1::WalStateImage {
+                    index: image.index_bytes,
+                    next_page_id: image.next_page_id,
+                    slabs: image
+                        .slabs
+                        .into_iter()
+                        .map(|slab| v1::WalStateImageSlab {
+                            page_slab_id: slab.page_slab_id,
+                            slab: slab.bytes,
+                        })
+                        .collect(),
+                }),
+            })
+        }
+    };
     let rest = RaftWalRecordRest {
         replica_role: record.replica_role,
         joint_membership: record.joint_membership.clone(),
         latest_external_snapshot_ref: record.latest_external_snapshot_ref.clone(),
-        installed_snapshot: record.installed_snapshot.clone(),
+        installed_snapshot: None,
         pipeline_state: record.pipeline_state.clone(),
         read_safety_state: record.read_safety_state.clone(),
         membership_evidence: record.membership_evidence.clone(),
@@ -384,6 +409,7 @@ pub(super) fn encode_envelope(envelope: &RaftWalEnvelope) -> io::Result<Vec<u8>>
                 .iter()
                 .map(entry_to_proto)
                 .collect::<io::Result<Vec<_>>>()?,
+            installed_snapshot,
             rest: rest_bytes,
         }),
         delta: envelope.delta.as_ref().map(|delta| v1::WalEntryDelta {
@@ -411,6 +437,27 @@ pub(super) fn decode_envelope(bytes: &[u8]) -> io::Result<RaftWalEnvelope> {
         serde_json::from_slice(&record.rest).map_err(io::Error::other)?
     };
 
+    let installed_snapshot = match record.installed_snapshot {
+        Some(snapshot) => {
+            let mut decoded: RaftSnapshot =
+                serde_json::from_slice(&snapshot.snapshot_sans_image).map_err(io::Error::other)?;
+            decoded.state_image = snapshot.state_image.map(|image| RaftSnapshotStateImage {
+                index_bytes: image.index,
+                next_page_id: image.next_page_id,
+                slabs: image
+                    .slabs
+                    .into_iter()
+                    .map(|slab| RaftSnapshotStateImageSlab {
+                        page_slab_id: slab.page_slab_id,
+                        bytes: slab.slab,
+                    })
+                    .collect(),
+            });
+            Some(decoded)
+        }
+        // Records written before the native field carried the snapshot in the side blob.
+        None => rest.installed_snapshot,
+    };
     Ok(RaftWalEnvelope {
         sequence: message.sequence,
         checksum: checksum_from_bytes(&message.checksum, message.checksum_is_text),
@@ -428,7 +475,7 @@ pub(super) fn decode_envelope(bytes: &[u8]) -> io::Result<RaftWalEnvelope> {
             replica_role: rest.replica_role,
             joint_membership: rest.joint_membership,
             latest_external_snapshot_ref: rest.latest_external_snapshot_ref,
-            installed_snapshot: rest.installed_snapshot,
+            installed_snapshot,
             apply_snapshot_fence: RaftApplySnapshotFence {
                 applied_index: apply_snapshot_fence.applied_index,
                 commit_index: apply_snapshot_fence.commit_index,

--- a/proto/temporalstore/v1/temporalstore.proto
+++ b/proto/temporalstore/v1/temporalstore.proto
@@ -450,12 +450,33 @@ message WalEntryDelta {
   uint64 log_last_index = 3;
 }
 
+message WalStateImageSlab {
+  uint64 page_slab_id = 1;
+  bytes slab = 2;
+}
+
+// An engine state image: what a snapshot carries instead of the entry history, so installing it
+// is O(state) and the log behind it can actually be dropped.
+message WalStateImage {
+  bytes index = 1;
+  uint64 next_page_id = 2;
+  repeated WalStateImageSlab slabs = 3;
+}
+
+// An installed snapshot, split so the image's bytes stay bytes: everything else about the
+// snapshot travels in its existing encoding in `snapshot_sans_image`.
+message WalInstalledSnapshot {
+  bytes snapshot_sans_image = 1;
+  WalStateImage state_image = 2;
+}
+
 message WalRecord {
   WalHardState hard_state = 1;
   WalMembership membership = 2;
   WalApplySnapshotFence apply_snapshot_fence = 3;
   WalStorageApplyFence storage_apply_fence = 4;
   repeated WalLogEntry entries = 5;
+  WalInstalledSnapshot installed_snapshot = 7;
   // The record's remaining fields -- replica role, joint membership, snapshot refs and
   // runtime telemetry -- which sit at their default on almost every record and are omitted
   // entirely when they do. Carried in their existing encoding so none of them can be lost.


### PR DESCRIPTION
Two changes the private tree merged first, ported per-PR so the trees stay level.

**Bound the node log with state-image compaction.** The raft node log could grow without bound between snapshots. Compaction can now fold the applied prefix into an opaque engine state image externalized to its own file: the image is fsynced before any record naming it is written, markers fold like entries, and compacting bases rotate and prune. The restore path knows image snapshots, so a restart after image compaction serves every value — covered by tests through the binary record encoding and the on-disk WAL, including the peer-credit guard (compaction never records progress a peer never made).

**Space out the topology syncs a wave of failures triggers.** A burst of node failures used to trigger a thundering herd of topology syncs; they are now spaced out.

Raft lib suite: 222 passed / 0 failed under --test-threads=1 (twice; one earlier single-test failure did not reproduce and coincided with heavy parallel builds on the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)