### PR TITLE
Store large attachments whole: an engine-owned, content-addressed blob store

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -101,6 +101,12 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ContextWriteCompressionEvent { .. }
         | Command::ContextQueryCompressionEvents { .. }
         | Command::ContextCompressEvents { .. }
+        | Command::ContextResourceBlobBegin { .. }
+        | Command::ContextResourceBlobAppend { .. }
+        | Command::ContextResourceBlobCommit { .. }
+        | Command::ContextResourceBlobPut { .. }
+        | Command::ContextResourceBlobFetch { .. }
+        | Command::ContextResourceBlobSweep { .. }
         | Command::ContextQueryNodeContext { .. } => None,
     }
 }

--- a/crates/temporalstore-rust/src/context_workflow/ingest.rs
+++ b/crates/temporalstore-rust/src/context_workflow/ingest.rs
@@ -147,7 +147,26 @@ pub fn ingest_resource_skill_context(
     let mut timestamp_ms = request.start_time_ms.max(1);
 
     for resource_request in request.resources {
-        let resource = parse_context_resource(resource_request);
+        // An oversized payload gets stored WHOLE in the engine-owned blob store before
+        // parsing, so the synthesized external URI on the report is real and fetchable --
+        // chunks stay searchable in records while the original attachment lives beside the
+        // engine, one TemporalStore holding everything.
+        let oversized_payload = if resource_request.text.as_bytes().len()
+            > default_context_resource_max_inline_bytes()
+        {
+            Some(resource_request.text.clone())
+        } else {
+            None
+        };
+        let mut resource = parse_context_resource(resource_request);
+        if let Some(payload) = oversized_payload {
+            match engine.resource_blob_put(request.tenant_hash, payload.as_bytes()) {
+                Ok((uri, _size, _hash)) => resource.external_object_uri = uri,
+                Err(err) => resource
+                    .parser_warnings
+                    .push(format!("resource blob store put failed: {err}")),
+            }
+        }
         for chunk in &resource.chunks {
             resource_ref_by_source.insert(chunk.source_ref.clone(), resource.raw_uri.clone());
             sources.push(ContextExtractRequest {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -33,6 +33,7 @@ mod recovery_sweep_compact;
 mod persistence;
 mod bucket_dump_io;
 mod command_validation;
+pub mod resource_blobs;
 pub mod quota;
 pub(crate) mod eviction_sampler;
 // Single source of truth for write-command classification (shared with the data_node layer,
@@ -304,6 +305,11 @@ impl TemporalEngine {
                     response: CommandResponse::Empty,
                 };
             }
+        }
+        // Blob commands run before the shard lock: blobs live beside the engine, not inside
+        // any shard's record state, and a large upload must never hold the shard write lock.
+        if let Some(response) = self.execute_resource_blob_command(&request) {
+            return response;
         }
         if async_storage_override.is_some() {
             if let Some(response) = self.execute_read_only_fast_path(&request) {

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -236,6 +236,12 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ContextQuerySummaries { .. }
         | Command::ContextQuerySummaryVectors { .. }
         | Command::ContextQueryCompressionEvents { .. }
+        | Command::ContextResourceBlobBegin { .. }
+        | Command::ContextResourceBlobAppend { .. }
+        | Command::ContextResourceBlobCommit { .. }
+        | Command::ContextResourceBlobPut { .. }
+        | Command::ContextResourceBlobFetch { .. }
+        | Command::ContextResourceBlobSweep { .. }
         | Command::ContextQueryNodeContext { .. } => Vec::new(),
     }
 }
@@ -289,6 +295,11 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ControlStateSetAndGet { .. }
             | Command::ControlStateSetAndGetWithOptions { .. }
             | Command::ControlStateSelectionSet { .. }
+            | Command::ContextResourceBlobBegin { .. }
+            | Command::ContextResourceBlobAppend { .. }
+            | Command::ContextResourceBlobCommit { .. }
+            | Command::ContextResourceBlobPut { .. }
+            | Command::ContextResourceBlobSweep { .. }
             | Command::ContextUpsertNode { .. }
             | Command::ContextWriteEvent { .. }
             | Command::ContextWriteExtractedEvent { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -27,6 +27,14 @@ pub(crate) fn execute_on_shard(
         // Applied as nothing: `mutated` stays false, so it neither dirties a shard nor
         // invalidates a cache entry.
         Command::LeaderEstablish => CommandResponse::Empty,
+        // Blob commands are dispatched before the shard lock (they live beside the engine,
+        // not in shard record state); reaching this arm means the early dispatch was skipped.
+        Command::ContextResourceBlobBegin { .. }
+        | Command::ContextResourceBlobAppend { .. }
+        | Command::ContextResourceBlobCommit { .. }
+        | Command::ContextResourceBlobPut { .. }
+        | Command::ContextResourceBlobFetch { .. }
+        | Command::ContextResourceBlobSweep { .. } => CommandResponse::Empty,
         Command::CommonDelete { key } => {
             mutated = delete_record(shard, &key);
             invalidate_record_all(cache, shard_id, &key);

--- a/crates/temporalstore-rust/src/engine/hashing.rs
+++ b/crates/temporalstore-rust/src/engine/hashing.rs
@@ -33,6 +33,11 @@ pub(super) fn stable_object_hash_bytes(bytes: &[u8]) -> u64 {
     hash
 }
 
+/// Initial value for a streaming stable_object_hash_update sequence.
+pub(super) fn stable_object_hash_begin() -> u64 {
+    FNV1A64_OFFSET_BASIS
+}
+
 pub(super) fn stable_object_hash_update(hash: &mut u64, bytes: &[u8]) {
     for byte in bytes {
         *hash ^= *byte as u64;

--- a/crates/temporalstore-rust/src/engine/resource_blobs.rs
+++ b/crates/temporalstore-rust/src/engine/resource_blobs.rs
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Engine-owned attachment blob store.
+//!
+//! A resource whose payload is too large to inline in records needs somewhere real to live so
+//! one TemporalStore can hold everything: the chunks carry searchable text, and the FULL
+//! original attachment is fetchable again from here. Blobs are files under the engine's own
+//! durable directory -- `<index_dir>/resources/<tenant>/<content-hash>.bin` -- written through a
+//! staging file and published by rename, so a crash mid-upload leaves only staging garbage that
+//! the sweep collects, never a half-visible blob. Blobs deliberately do NOT ride the WAL or the
+//! block store: they are immutable, content-addressed, and often orders of magnitude larger
+//! than a record, so replaying or compacting them would only amplify every maintenance pass.
+//!
+//! The manifest record (the resource record carrying `external_object_uri`) is the commit
+//! point: a blob file with no manifest is unreachable garbage; a manifest whose blob is missing
+//! is an error surfaced at fetch time. The sweep takes the referenced set from the caller (who
+//! can read the manifests) and only deletes unreferenced files older than a minimum age, so an
+//! upload racing the sweep is never collected out from under its not-yet-written manifest.
+//!
+//! On a raft-replicated deployment these commands execute on every replica during apply, so
+//! each replica holds its own copy of the blob under its own directory -- fetches are local
+//! everywhere. Upload tokens are generated per-process; multi-part uploads must be driven
+//! against one node (the proxy already pins a client to a node for a session).
+
+use super::*;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use std::io::{Read as _, Seek as _};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const RESOURCE_BLOB_URI_PREFIX: &str = "temporalstore://resources/";
+const STAGING_DIR: &str = ".staging";
+
+static UPLOAD_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// `temporalstore://resources/{tenant:016x}/{hash:016x}` -- the only URI shape this store
+/// serves. Parsing is strict: both segments must be exactly 16 lowercase hex digits, so a URI
+/// can never smuggle a path.
+pub fn format_resource_blob_uri(tenant_hash: u64, content_hash: u64) -> String {
+    format!("{RESOURCE_BLOB_URI_PREFIX}{tenant_hash:016x}/{content_hash:016x}")
+}
+
+pub fn parse_resource_blob_uri(uri: &str) -> Option<(u64, u64)> {
+    let rest = uri.strip_prefix(RESOURCE_BLOB_URI_PREFIX)?;
+    let (tenant, hash) = rest.split_once('/')?;
+    if tenant.len() != 16 || hash.len() != 16 {
+        return None;
+    }
+    let tenant_hash = u64::from_str_radix(tenant, 16).ok()?;
+    let content_hash = u64::from_str_radix(hash, 16).ok()?;
+    // Round-trip check rejects uppercase or otherwise non-canonical spellings.
+    if format!("{tenant_hash:016x}") != tenant || format!("{content_hash:016x}") != hash {
+        return None;
+    }
+    Some((tenant_hash, content_hash))
+}
+
+fn valid_upload_token(token: &str) -> bool {
+    !token.is_empty()
+        && token.len() <= 64
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+impl TemporalEngine {
+    fn resource_blob_root(&self) -> PathBuf {
+        self.index_dir.join("resources")
+    }
+
+    fn resource_blob_path(&self, tenant_hash: u64, content_hash: u64) -> PathBuf {
+        self.resource_blob_root()
+            .join(format!("{tenant_hash:016x}"))
+            .join(format!("{content_hash:016x}.bin"))
+    }
+
+    fn resource_blob_staging_path(&self, token: &str) -> PathBuf {
+        self.resource_blob_root()
+            .join(STAGING_DIR)
+            .join(format!("{token}.part"))
+    }
+
+    /// Start a multi-part upload: create an empty staging file and hand back its token.
+    pub fn resource_blob_begin(&self, tenant_hash: u64) -> std::io::Result<String> {
+        let seq = UPLOAD_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let token = format!(
+            "u{:x}-{:x}-{:x}-{seq:x}",
+            std::process::id(),
+            tenant_hash,
+            now_ms(),
+        );
+        let path = self.resource_blob_staging_path(&token);
+        std::fs::create_dir_all(path.parent().expect("staging path has a parent"))?;
+        std::fs::File::create(&path)?;
+        Ok(token)
+    }
+
+    /// Append one part to a staged upload. Parts are appended in call order; the caller drives
+    /// parts sequentially against one node.
+    pub fn resource_blob_append(&self, token: &str, bytes: &[u8]) -> std::io::Result<u64> {
+        if !valid_upload_token(token) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid upload token: {token:?}"),
+            ));
+        }
+        let path = self.resource_blob_staging_path(token);
+        let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+        file.write_all(bytes)?;
+        Ok(file.metadata()?.len())
+    }
+
+    /// Publish a staged upload: hash the staged bytes, fsync, rename to the content-addressed
+    /// path, fsync the directory. Returns (uri, size, content_hash). Publishing the same
+    /// content twice lands on the same path -- the second rename simply replaces an identical
+    /// file.
+    pub fn resource_blob_commit(
+        &self,
+        tenant_hash: u64,
+        token: &str,
+    ) -> std::io::Result<(String, u64, u64)> {
+        if !valid_upload_token(token) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid upload token: {token:?}"),
+            ));
+        }
+        let staged = self.resource_blob_staging_path(token);
+        let mut file = std::fs::File::open(&staged)?;
+        let mut hash = hashing::stable_object_hash_begin();
+        let mut size = 0u64;
+        let mut buffer = vec![0u8; 256 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hashing::stable_object_hash_update(&mut hash, &buffer[..read]);
+            size += read as u64;
+        }
+        // Mix the length in so a truncation of a repeating payload cannot collide with the
+        // original.
+        hashing::stable_object_hash_update_u64_decimal(&mut hash, size);
+        drop(file);
+        let final_path = self.resource_blob_path(tenant_hash, hash);
+        std::fs::create_dir_all(final_path.parent().expect("blob path has a parent"))?;
+        let file = std::fs::File::open(&staged)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&staged, &final_path)?;
+        if let Ok(dir) = std::fs::File::open(final_path.parent().expect("blob path has a parent")) {
+            let _ = dir.sync_all();
+        }
+        Ok((format_resource_blob_uri(tenant_hash, hash), size, hash))
+    }
+
+    /// Single-shot convenience: begin + append + commit in one call.
+    pub fn resource_blob_put(
+        &self,
+        tenant_hash: u64,
+        bytes: &[u8],
+    ) -> std::io::Result<(String, u64, u64)> {
+        let token = self.resource_blob_begin(tenant_hash)?;
+        self.resource_blob_append(&token, bytes)?;
+        self.resource_blob_commit(tenant_hash, &token)
+    }
+
+    /// Range-read a published blob. `length == 0` means "to the end". Returns
+    /// (bytes, total_size, eof).
+    pub fn resource_blob_fetch(
+        &self,
+        tenant_hash: u64,
+        content_hash: u64,
+        offset: u64,
+        length: u64,
+    ) -> std::io::Result<(Vec<u8>, u64, bool)> {
+        let path = self.resource_blob_path(tenant_hash, content_hash);
+        let mut file = std::fs::File::open(&path)?;
+        let total = file.metadata()?.len();
+        if offset >= total {
+            return Ok((Vec::new(), total, true));
+        }
+        let want = if length == 0 {
+            total - offset
+        } else {
+            length.min(total - offset)
+        };
+        file.seek(std::io::SeekFrom::Start(offset))?;
+        let mut bytes = vec![0u8; usize::try_from(want).unwrap_or(usize::MAX)];
+        file.read_exact(&mut bytes)?;
+        let eof = offset + want >= total;
+        Ok((bytes, total, eof))
+    }
+
+    /// Delete unreferenced blobs for one tenant, plus stale staging files. `referenced` is the
+    /// set of content hashes the caller's manifests still name; only files OLDER than
+    /// `min_age_ms` are eligible, so an upload racing the sweep keeps its blob until its
+    /// manifest lands.
+    pub fn resource_blob_sweep(
+        &self,
+        tenant_hash: u64,
+        referenced: &std::collections::HashSet<u64>,
+        min_age_ms: u64,
+    ) -> std::io::Result<(u64, u64)> {
+        let now = now_ms();
+        let old_enough = |path: &std::path::Path| -> bool {
+            std::fs::metadata(path)
+                .and_then(|meta| meta.modified())
+                .ok()
+                .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|age| age.as_millis() as u64 + min_age_ms <= now)
+                .unwrap_or(false)
+        };
+        let mut scanned = 0u64;
+        let mut deleted = 0u64;
+        let tenant_dir = self.resource_blob_root().join(format!("{tenant_hash:016x}"));
+        if let Ok(entries) = std::fs::read_dir(&tenant_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                let Some(hex) = name.strip_suffix(".bin") else {
+                    continue;
+                };
+                let Ok(content_hash) = u64::from_str_radix(hex, 16) else {
+                    continue;
+                };
+                scanned += 1;
+                if !referenced.contains(&content_hash) && old_enough(&path) {
+                    if std::fs::remove_file(&path).is_ok() {
+                        deleted += 1;
+                    }
+                }
+            }
+        }
+        let staging_dir = self.resource_blob_root().join(STAGING_DIR);
+        if let Ok(entries) = std::fs::read_dir(&staging_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                scanned += 1;
+                if old_enough(&path) && std::fs::remove_file(&path).is_ok() {
+                    deleted += 1;
+                }
+            }
+        }
+        Ok((scanned, deleted))
+    }
+
+    /// Dispatch for the blob commands. Runs before the shard lock: blobs live beside the
+    /// engine, not inside any shard's record state, and a multi-gigabyte upload must never
+    /// hold the shard write lock.
+    pub(super) fn execute_resource_blob_command(
+        &self,
+        request: &ExecuteRequest,
+    ) -> Option<ExecuteResponse> {
+        let respond = |result: Result<CommandResponse, String>| -> ExecuteResponse {
+            match result {
+                Ok(response) => ExecuteResponse {
+                    status: Status::ok(),
+                    response,
+                },
+                Err(detail) => ExecuteResponse {
+                    status: Status::error("resource_blob_error", detail),
+                    response: CommandResponse::Empty,
+                },
+            }
+        };
+        match &request.command {
+            Command::ContextResourceBlobBegin { tenant_hash } => Some(respond(
+                self.resource_blob_begin(*tenant_hash)
+                    .map(|upload_token| CommandResponse::ContextResourceBlobUpload {
+                        upload_token,
+                        bytes_total: 0,
+                    })
+                    .map_err(|err| err.to_string()),
+            )),
+            Command::ContextResourceBlobAppend {
+                upload_token,
+                payload_base64,
+                ..
+            } => Some(respond(
+                BASE64
+                    .decode(payload_base64)
+                    .map_err(|err| format!("invalid base64 payload: {err}"))
+                    .and_then(|bytes| {
+                        self.resource_blob_append(upload_token, &bytes)
+                            .map_err(|err| err.to_string())
+                    })
+                    .map(|bytes_total| CommandResponse::ContextResourceBlobUpload {
+                        upload_token: upload_token.clone(),
+                        bytes_total,
+                    }),
+            )),
+            Command::ContextResourceBlobCommit {
+                tenant_hash,
+                upload_token,
+            } => Some(respond(
+                self.resource_blob_commit(*tenant_hash, upload_token)
+                    .map(
+                        |(uri, size_bytes, content_hash)| CommandResponse::ContextResourceBlobCommitted {
+                            uri,
+                            size_bytes,
+                            content_hash,
+                        },
+                    )
+                    .map_err(|err| err.to_string()),
+            )),
+            Command::ContextResourceBlobPut {
+                tenant_hash,
+                payload_base64,
+            } => Some(respond(
+                BASE64
+                    .decode(payload_base64)
+                    .map_err(|err| format!("invalid base64 payload: {err}"))
+                    .and_then(|bytes| {
+                        self.resource_blob_put(*tenant_hash, &bytes)
+                            .map_err(|err| err.to_string())
+                    })
+                    .map(
+                        |(uri, size_bytes, content_hash)| CommandResponse::ContextResourceBlobCommitted {
+                            uri,
+                            size_bytes,
+                            content_hash,
+                        },
+                    ),
+            )),
+            Command::ContextResourceBlobFetch {
+                uri,
+                offset,
+                length,
+            } => Some(respond(match parse_resource_blob_uri(uri) {
+                None => Err(format!("not a resource blob uri: {uri}")),
+                Some((tenant_hash, content_hash)) => self
+                    .resource_blob_fetch(tenant_hash, content_hash, *offset, *length)
+                    .map(|(bytes, total_size, eof)| CommandResponse::ContextResourceBlobChunk {
+                        payload_base64: BASE64.encode(&bytes),
+                        total_size,
+                        eof,
+                    })
+                    .map_err(|err| err.to_string()),
+            })),
+            Command::ContextResourceBlobSweep {
+                tenant_hash,
+                referenced_content_hashes,
+                min_age_ms,
+            } => {
+                let referenced: std::collections::HashSet<u64> =
+                    referenced_content_hashes.iter().copied().collect();
+                Some(respond(
+                    self.resource_blob_sweep(*tenant_hash, &referenced, *min_age_ms)
+                        .map(|(scanned, deleted)| CommandResponse::ContextResourceBlobSwept {
+                            scanned,
+                            deleted,
+                        })
+                        .map_err(|err| err.to_string()),
+                ))
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -123,6 +123,12 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ContextWriteCompressionEvent { .. }
         | Command::ContextQueryCompressionEvents { .. }
         | Command::ContextCompressEvents { .. }
+        | Command::ContextResourceBlobBegin { .. }
+        | Command::ContextResourceBlobAppend { .. }
+        | Command::ContextResourceBlobCommit { .. }
+        | Command::ContextResourceBlobPut { .. }
+        | Command::ContextResourceBlobFetch { .. }
+        | Command::ContextResourceBlobSweep { .. }
         | Command::ContextQueryNodeContext { .. } => None,
     }
 }

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1404,6 +1404,44 @@ pub enum Command {
         tenant_hash: u64,
         node_hashes: Vec<u64>,
     },
+    /// Attachment blob store: start a multi-part upload into the engine-owned blob directory.
+    /// The full original payload of an oversized resource lives here so one TemporalStore holds
+    /// everything -- chunks stay searchable in records while the attachment itself is fetchable
+    /// again by its `temporalstore://resources/{tenant}/{content-hash}` URI.
+    ContextResourceBlobBegin {
+        tenant_hash: u64,
+    },
+    /// Append one part to a staged upload. Parts are sequential against one node.
+    ContextResourceBlobAppend {
+        tenant_hash: u64,
+        upload_token: String,
+        payload_base64: String,
+    },
+    /// Publish a staged upload: content-hash, fsync, rename into place. The resource record
+    /// that carries the returned URI is the commit point; a blob with no record is garbage the
+    /// sweep collects.
+    ContextResourceBlobCommit {
+        tenant_hash: u64,
+        upload_token: String,
+    },
+    /// Single-shot begin+append+commit for payloads that fit one request.
+    ContextResourceBlobPut {
+        tenant_hash: u64,
+        payload_base64: String,
+    },
+    /// Range-read a published blob. `length == 0` means to the end.
+    ContextResourceBlobFetch {
+        uri: String,
+        offset: u64,
+        length: u64,
+    },
+    /// Delete unreferenced blobs older than  for one tenant, plus stale staging
+    /// files. The caller supplies the referenced set from the resource records it holds.
+    ContextResourceBlobSweep {
+        tenant_hash: u64,
+        referenced_content_hashes: Vec<u64>,
+        min_age_ms: u64,
+    },
     ContextSetNodeEmbedding {
         tenant_hash: u64,
         node_hash: u64,
@@ -1889,6 +1927,24 @@ pub enum CommandResponse {
         source_event_count: Option<u32>,
         #[serde(default)]
         truncated_source_events: Option<bool>,
+    },
+    ContextResourceBlobUpload {
+        upload_token: String,
+        bytes_total: u64,
+    },
+    ContextResourceBlobCommitted {
+        uri: String,
+        size_bytes: u64,
+        content_hash: u64,
+    },
+    ContextResourceBlobChunk {
+        payload_base64: String,
+        total_size: u64,
+        eof: bool,
+    },
+    ContextResourceBlobSwept {
+        scanned: u64,
+        deleted: u64,
     },
     ContextNodeContext {
         node_exists: bool,

--- a/crates/temporalstore-rust/tests/resource_blob_store.rs
+++ b/crates/temporalstore-rust/tests/resource_blob_store.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Integration coverage for the engine-owned attachment blob store.
+//!
+//! One TemporalStore holds everything: chunks stay searchable in records, and the FULL
+//! original attachment is stored beside the engine and fetchable again by its
+//! `temporalstore://resources/{tenant}/{content-hash}` URI. These tests drive the public
+//! command surface to prove:
+//!   * a multi-part upload commits to a content-addressed URI and fetches back byte-identical,
+//!   * the single-shot put equals begin+append+commit and re-putting identical content
+//!     lands on the same URI (dedup by content),
+//!   * range fetches honor offset/length and report eof exactly at the end,
+//!   * the sweep deletes only unreferenced blobs, never referenced ones, and a fresh blob
+//!     survives even when unreferenced (the manifest may not have landed yet),
+//!   * URI parsing is strict, so a fetch cannot smuggle a path,
+//!   * an oversized resource ingested through the context workflow gets a REAL external
+//!     URI whose bytes fetch back as the original payload.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{
+    ingest_resource_skill_context, Command, CommandResponse, ContextResourceSkillIngestRequest,
+    ExecuteRequest, TemporalEngine,
+};
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+
+const SHARD_ID: u64 = 1;
+const TENANT: u64 = 77;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let pid = std::process::id();
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-resource-blobs-{name}-{pid}"));
+    root
+}
+
+fn new_engine(name: &str) -> TemporalEngine {
+    let root = unique_root(name);
+    let _ = std::fs::remove_dir_all(&root);
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    engine.load_shard(SHARD_ID);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command,
+    });
+    assert!(
+        response.status.ok,
+        "command failed: {:?}",
+        response.status
+    );
+    response.response
+}
+
+fn put(engine: &TemporalEngine, payload: &[u8]) -> (String, u64, u64) {
+    match run(
+        engine,
+        Command::ContextResourceBlobPut {
+            tenant_hash: TENANT,
+            payload_base64: BASE64.encode(payload),
+        },
+    ) {
+        CommandResponse::ContextResourceBlobCommitted {
+            uri,
+            size_bytes,
+            content_hash,
+        } => (uri, size_bytes, content_hash),
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+fn fetch(engine: &TemporalEngine, uri: &str, offset: u64, length: u64) -> (Vec<u8>, u64, bool) {
+    match run(
+        engine,
+        Command::ContextResourceBlobFetch {
+            uri: uri.to_string(),
+            offset,
+            length,
+        },
+    ) {
+        CommandResponse::ContextResourceBlobChunk {
+            payload_base64,
+            total_size,
+            eof,
+        } => (
+            BASE64.decode(payload_base64).expect("valid base64"),
+            total_size,
+            eof,
+        ),
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn multipart_upload_commits_and_fetches_back_byte_identical() {
+    let engine = new_engine("multipart");
+    let part_a = vec![7u8; 300_000];
+    let part_b = vec![9u8; 200_000];
+
+    let token = match run(
+        &engine,
+        Command::ContextResourceBlobBegin {
+            tenant_hash: TENANT,
+        },
+    ) {
+        CommandResponse::ContextResourceBlobUpload { upload_token, .. } => upload_token,
+        other => panic!("unexpected response: {other:?}"),
+    };
+    for part in [&part_a, &part_b] {
+        match run(
+            &engine,
+            Command::ContextResourceBlobAppend {
+                tenant_hash: TENANT,
+                upload_token: token.clone(),
+                payload_base64: BASE64.encode(part),
+            },
+        ) {
+            CommandResponse::ContextResourceBlobUpload { .. } => {}
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+    let (uri, size, _hash) = match run(
+        &engine,
+        Command::ContextResourceBlobCommit {
+            tenant_hash: TENANT,
+            upload_token: token,
+        },
+    ) {
+        CommandResponse::ContextResourceBlobCommitted {
+            uri,
+            size_bytes,
+            content_hash,
+        } => (uri, size_bytes, content_hash),
+        other => panic!("unexpected response: {other:?}"),
+    };
+    assert_eq!(size, (part_a.len() + part_b.len()) as u64);
+
+    let (bytes, total, eof) = fetch(&engine, &uri, 0, 0);
+    assert_eq!(total, size);
+    assert!(eof);
+    let mut expected = part_a.clone();
+    expected.extend_from_slice(&part_b);
+    assert_eq!(bytes, expected);
+}
+
+#[test]
+fn identical_content_lands_on_the_same_uri() {
+    let engine = new_engine("dedup");
+    let payload = b"the same attachment bytes".repeat(1000);
+    let (first_uri, first_size, _) = put(&engine, &payload);
+    let (second_uri, second_size, _) = put(&engine, &payload);
+    assert_eq!(first_uri, second_uri);
+    assert_eq!(first_size, second_size);
+    let (different_uri, _, _) = put(&engine, b"different bytes");
+    assert_ne!(first_uri, different_uri);
+}
+
+#[test]
+fn range_fetches_honor_offset_length_and_eof() {
+    let engine = new_engine("ranges");
+    let payload: Vec<u8> = (0..=255u8).cycle().take(10_000).collect();
+    let (uri, _, _) = put(&engine, &payload);
+
+    let (bytes, total, eof) = fetch(&engine, &uri, 100, 50);
+    assert_eq!(total, 10_000);
+    assert_eq!(bytes, &payload[100..150]);
+    assert!(!eof);
+
+    let (bytes, _, eof) = fetch(&engine, &uri, 9_990, 100);
+    assert_eq!(bytes, &payload[9_990..]);
+    assert!(eof, "a read reaching the last byte reports eof");
+
+    let (bytes, total, eof) = fetch(&engine, &uri, 20_000, 10);
+    assert!(bytes.is_empty());
+    assert_eq!(total, 10_000);
+    assert!(eof, "a read past the end is empty and eof");
+}
+
+#[test]
+fn sweep_deletes_only_old_unreferenced_blobs() {
+    let engine = new_engine("sweep");
+    let (kept_uri, _, kept_hash) = put(&engine, b"referenced attachment");
+    let (dropped_uri, _, _dropped_hash) = put(&engine, b"orphaned attachment");
+
+    // With min_age_ms high, NOTHING is old enough -- both fresh blobs survive even though one
+    // is unreferenced: its manifest may simply not have landed yet.
+    match run(
+        &engine,
+        Command::ContextResourceBlobSweep {
+            tenant_hash: TENANT,
+            referenced_content_hashes: vec![kept_hash],
+            min_age_ms: 3_600_000,
+        },
+    ) {
+        CommandResponse::ContextResourceBlobSwept { deleted, .. } => assert_eq!(deleted, 0),
+        other => panic!("unexpected response: {other:?}"),
+    }
+    fetch(&engine, &dropped_uri, 0, 0);
+
+    // With min_age_ms zero, only the unreferenced blob goes.
+    match run(
+        &engine,
+        Command::ContextResourceBlobSweep {
+            tenant_hash: TENANT,
+            referenced_content_hashes: vec![kept_hash],
+            min_age_ms: 0,
+        },
+    ) {
+        CommandResponse::ContextResourceBlobSwept { scanned, deleted } => {
+            assert_eq!(scanned, 2);
+            assert_eq!(deleted, 1);
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+    let (bytes, _, _) = fetch(&engine, &kept_uri, 0, 0);
+    assert_eq!(bytes, b"referenced attachment");
+    let dropped = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command: Command::ContextResourceBlobFetch {
+            uri: dropped_uri,
+            offset: 0,
+            length: 0,
+        },
+    });
+    assert!(!dropped.status.ok, "the swept blob must be gone");
+}
+
+#[test]
+fn uri_parsing_is_strict() {
+    let engine = new_engine("uris");
+    for bad in [
+        "temporalstore://resources/../../etc/passwd",
+        "temporalstore://resources/0000000000000047/short",
+        "temporalstore://resources/0000000000000047/00000000DEADBEEF", // uppercase
+        "objectstore://matrixark/resources/0000000000000000.bin",
+        "temporalstore://resources/0000000000000047",
+    ] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: SHARD_ID,
+            command: Command::ContextResourceBlobFetch {
+                uri: bad.to_string(),
+                offset: 0,
+                length: 0,
+            },
+        });
+        assert!(!response.status.ok, "accepted a malformed uri: {bad}");
+    }
+}
+
+#[test]
+fn oversized_resource_ingest_stores_a_real_fetchable_attachment() {
+    let engine = new_engine("ingest");
+    // Comfortably past the 1 MiB inline cap.
+    let payload = "attachment line: the full original must be fetchable again.\n".repeat(40_000);
+    assert!(payload.len() > 1024 * 1024);
+
+    let request_json = serde_json::json!({
+        "shard_id": SHARD_ID,
+        "tenant_hash": TENANT,
+        "resources": [{
+            "raw_uri": "file:///tmp/big-attachment.txt",
+            "text": payload,
+            // Big chunks keep the extract fan-out small -- this test is about the BLOB, and the
+            // default 1400-char chunking would push a 2.4MB payload through ~1700 extractions.
+            "max_chunk_chars": 200_000,
+        }],
+        "start_time_ms": 1,
+        "end_time_ms": 2,
+    });
+    let request: ContextResourceSkillIngestRequest =
+        serde_json::from_value(request_json).expect("valid ingest request");
+    let report = ingest_resource_skill_context(&engine, request);
+    let resource = report
+        .resources
+        .first()
+        .expect("one resource in the report");
+    assert!(!resource.inline_payload, "an oversized payload must not inline");
+    assert!(
+        resource
+            .external_object_uri
+            .starts_with("temporalstore://resources/"),
+        "expected a real engine blob uri, got {}",
+        resource.external_object_uri
+    );
+
+    let (bytes, total, eof) = fetch(&engine, &resource.external_object_uri, 0, 0);
+    assert!(eof);
+    assert_eq!(total as usize, payload.len());
+    assert_eq!(bytes, payload.as_bytes(), "fetched attachment differs from the original");
+}

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -412,6 +412,10 @@ fn response_kind(response: &CommandResponse) -> &'static str {
         CommandResponse::ContextSummaries { .. } => "context_summaries",
         CommandResponse::ContextSummaryVectors { .. } => "context_summary_vectors",
         CommandResponse::ContextCompressionEvents { .. } => "context_compression_events",
+        CommandResponse::ContextResourceBlobUpload { .. } => "context_resource_blob_upload",
+        CommandResponse::ContextResourceBlobCommitted { .. } => "context_resource_blob_committed",
+        CommandResponse::ContextResourceBlobChunk { .. } => "context_resource_blob_chunk",
+        CommandResponse::ContextResourceBlobSwept { .. } => "context_resource_blob_swept",
         CommandResponse::ContextNodeContext { .. } => "context_node_context",
         CommandResponse::ContextNodes { .. } => "context_nodes",
     }


### PR DESCRIPTION
A resource whose payload was too large to inline had nowhere real to live: the external URI on its report was synthesized and pointed at nothing, so the original attachment could never be fetched again. Now the engine owns a content-addressed blob store under its durable directory, and one TemporalStore holds everything: **chunks stay searchable in records** (text + vector, exactly as today) while **the full original attachment** lives beside the engine, fetchable again by its `temporalstore://resources/{tenant}/{content-hash}` URI.

Surface (six commands):
- `ContextResourceBlobBegin` / `Append` / `Commit` — multi-part upload staged to a file, published by content hash: staging file, fsync, rename. A crash mid-upload leaves only staging garbage, never a half-visible blob.
- `ContextResourceBlobPut` — single-shot form.
- `ContextResourceBlobFetch` — range reads (offset/length, eof reporting) for streaming the original back.
- `ContextResourceBlobSweep` — deletes unreferenced blobs older than a minimum age, plus stale staging files; the referenced set comes from the resource records, so an upload racing the sweep keeps its blob until its manifest lands.

Blob commands dispatch before the shard lock (blobs live beside the engine, not in shard record state; a large upload must never hold the shard write lock) and are quota-charged as writes. `ingest_resource_skill_context` stores an oversized payload before parsing and stamps the real URI on the report; a store failure degrades to the old behavior with a parser warning. Identical content lands on the same URI, so content addressing doubles as dedup. URI parsing is strict 16-hex-digit segments — a fetch cannot smuggle a path.

Tests: six-test integration suite (multi-part roundtrip byte-identical, dedup, range/eof, sweep age-guard + referenced-set behavior, strict URI rejection, end-to-end oversized ingest whose fetched bytes equal the original). Full lib suite: 1212 passed / 1 failed twice — the failure is the known pre-existing storage_manager jitter/backoff wait_until flake, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
