### PR TITLE
Write down that an absent piece answering zero is load-bearing

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -964,6 +964,9 @@ impl LocalWriteAheadLogStore {
             // start plus its length says where it ends, so skipping it costs a stat rather than a
             // read of every line in it. This is what makes a windowed scan cost the window: without
             // it the loop below still reads the whole log and merely declines to return most of it.
+            // Also what skips a piece reclaimed since the listing above: an absent piece reads
+            // as base zero with no length, so this says it ends before any window and the loop
+            // moves on rather than opening a file that is gone. See `read_wal_base`.
             let piece_len = path.metadata().map(|meta| meta.len()).unwrap_or(0);
             if base.saturating_add(piece_len.saturating_sub(header_len)) <= start_offset {
                 continue;
@@ -2187,6 +2190,15 @@ fn reclaim_min_freed_percent() -> u32 {
 }
 
 fn read_wal_base(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
+    // An absent piece answers (0, 0) rather than failing, and `scan` DEPENDS on that. A piece can
+    // be reclaimed between being listed and being read -- reclaim removes whole pieces from the
+    // front -- and answering zero here makes the length check in `scan` treat it as ending before
+    // any window, so the loop skips it instead of opening a file that is gone.
+    //
+    // Turning this into an error would surface as shards refusing to load: recovery treats ANY
+    // scan failure as data loss, so a piece legitimately reclaimed mid-scan would stop a shard
+    // coming up. If this ever has to report absence distinctly, `scan` needs to skip on it
+    // explicitly at the same time.
     if !path.exists() {
         return Ok((0, 0));
     }


### PR DESCRIPTION
A piece can be reclaimed between a scan listing it and reading it, and the scan already survives
that — but only because of an interaction nothing says out loud:

`read_wal_base` answers `(0, 0)` for an absent file instead of failing, so `piece_len` is zero, so
the length check in `scan` decides the piece ends before any window and skips it. The open that
would have failed never happens.

That is easy to break while tidying. Making `read_wal_base` report absence as an error looks
obviously correct in isolation, and would surface far away — as **shards refusing to load**, because
recovery treats *any* scan failure as data loss. A piece legitimately reclaimed mid-scan would stop
a shard coming up.

Both sides now say so, and say what would have to change together.

## How this was found

By writing a fix for it as though it were broken. It is not. Two tests were written for that fix and
**both passed with the fix reverted** — the first because deleting the piece before calling `scan`
lets the `exists()` filter catch it so none of the changed code runs, and the second because the
skip described above already handles it. The fix was unreachable error-handling and the tests could
not tell the difference; all three were discarded.

What survived is the only part that was worth anything: the reason it works, written down where
someone would otherwise remove it.

No behaviour changes. 67 WAL tests pass.
