### PR TITLE
Audits default to off: a read-heavy workload must not grow the store without bound

### DIFF
--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -1086,13 +1086,18 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
         return verify_matrixark_password(password, credential)
 
     def _append_audit_record(self, record: Json) -> None:
-        """Route one audit record to storage.
+        """Route one audit record to storage -- or drop it when auditing is off (the default).
 
-        Record-log metadata: through the adapter's buffered audit path (MATRIXARK_DIRECT_AUDIT_MODE
-        governs it; "buffered" coalesces into one durable append_many per flush interval instead of
-        a WAL+fsync append per audited request). Any other metadata backend (SQL) keeps its own
-        append -- audits live in its tables, not the record log.
+        Audit records live in the main record log, so with auditing on every audited call grows
+        the store forever; MATRIXARK_AUDIT_MODE (default off) is the one knob, shared with the
+        server's audit policy. When on and the metadata backend is the record log, the write goes
+        through the adapter's buffered audit path (MATRIXARK_DIRECT_AUDIT_MODE governs it;
+        "buffered" coalesces into one durable append_many per flush interval). Any other metadata
+        backend (SQL) keeps its own append -- audits live in its tables, not the record log.
         """
+        mode = os.environ.get("MATRIXARK_AUDIT_MODE", "off").strip().lower() or "off"
+        if mode in {"off", "none", "disabled"}:
+            return
         appender = getattr(self.adapter, "append_audit", None)
         if callable(appender) and getattr(self.metadata, "backend_name", "") == "record_log":
             appender(record)
@@ -1127,7 +1132,7 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
         account_id = canonical_account_id(str(scope.get("account_id") or args.get("account_id") or "")) if (scope.get("account_id") or args.get("account_id")) else ""
         tenant_id = canonical_tenant_id(str(scope.get("tenant_id") or args.get("tenant_id") or "")) if (scope.get("tenant_id") or args.get("tenant_id")) else ""
         hashes = identity_hashes(account_id, tenant_id, str(scope.get("user_id") or ""), str(scope.get("session_id") or "")) if account_id and tenant_id else {}
-        self.metadata.append(
+        self._append_audit_record(
             {
                 "record_type": "matrixark_audit_log",
                 "audit_id_hash": stable_hash(f"denied:{action}:{secret_hash(api_key) if api_key else 'no_key'}:{now_ms()}"),

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -284,7 +284,10 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         self._retrieve_shed_cooldown_ms = max(0, int(os.environ.get("MATRIXARK_RETRIEVE_SHED_COOLDOWN_MS", "0")))
         self._retrieve_shed_until_perf = 0.0
         self._retrieve_shed_lock = threading.Lock()
-        self._audit_mode_default = os.environ.get("MATRIXARK_AUDIT_MODE", "async").strip().lower() or "async"
+        # Audits default OFF: audit records live in the main record log, so with auditing on a
+        # read-heavy workload grows the store without bound. MATRIXARK_AUDIT_MODE=async restores
+        # the off-request-path auditing; full/sync restore per-call durability.
+        self._audit_mode_default = os.environ.get("MATRIXARK_AUDIT_MODE", "off").strip().lower() or "off"
         self._audit_executor = ThreadPoolExecutor(max_workers=max(1, int(os.environ.get("MATRIXARK_AUDIT_WORKERS", "2"))))
         self._operation_limiters = {
             group: threading.BoundedSemaphore(max(1, int(capacity)))

--- a/tools/test_matrixark_access_governance.py
+++ b/tools/test_matrixark_access_governance.py
@@ -22,6 +22,15 @@ class MatrixArkAccessGovernanceTest(unittest.TestCase):
     def make_server(self) -> MatrixArkMcpServer:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
+        # Auditing is off by default; these tests verify what auditing records when it is on.
+        previous = os.environ.get("MATRIXARK_AUDIT_MODE")
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_AUDIT_MODE", None)
+            else:
+                os.environ["MATRIXARK_AUDIT_MODE"] = previous
+        self.addCleanup(restore)
         return MatrixArkMcpServer(MatrixArkLocalAdapter(Path(tmp.name) / "events.jsonl"), line_json=True, access_mode="dev")
 
     def test_api_key_hash_only_and_role_limited_viewer(self) -> None:


### PR DESCRIPTION
Audit records live in the main record log, so with auditing on every audited call adds a record forever -- an unbounded memory-footprint tax on read-heavy workloads. Default flips to off behind the existing MATRIXARK_AUDIT_MODE knob at both gates (server policy + access-manager writer; denied audits route through the same writer). async restores buffered off-request-path auditing; full/sync restore per-call durability. The governance suite enables auditing explicitly, which is what it verifies. Strict conformance 22/22; standalone reset repro exact.