### PR TITLE
Wire the pipelined propose in, and make its invariant test able to fail

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -4537,8 +4537,16 @@ impl RaftCluster {
                 .begin_deferred_persist();
         }
         let mut entry_barrier = None;
-        let outcome =
-            self.propose_distributed_one_locked(command, transport, &mut entry_barrier);
+        // The senders replicate when the pipeline is on; this thread then appends, rings them,
+        // and waits on the quorum-commit signal instead of sending to any peer itself. Branching
+        // here keeps both paths inside the same deferral bookkeeping: the caller-side staging
+        // and barrier-join below are what propose_pipelined leaves for its caller, exactly as
+        // the fan-out body does.
+        let outcome = if follower_pipeline::follower_pipeline_enabled() {
+            self.propose_pipelined(command, transport, &mut entry_barrier)
+        } else {
+            self.propose_distributed_one_locked(command, transport, &mut entry_barrier)
+        };
         if !deferring {
             // An overlapped barrier is still joined before the ack, whatever path leaves here.
             if let Some(handle) = entry_barrier {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -2229,23 +2229,66 @@ pub(super) struct EnvFlagGuard {
     name: &'static str,
 }
 
+/// Environment variables are process-global, and the tests that pin one run in parallel. A bare
+/// set-on-create / remove-on-drop guard races destructively: two tests pin the same variable, the
+/// first to finish removes it, and the second silently runs the rest of its body on the DEFAULT
+/// path -- which is how the pipeline invariant test ended up watching fan-out appends. Pins are
+/// therefore refcounted per variable: agreeing pins share the variable, a conflicting pin WAITS
+/// until the holders drop, and only the last holder clears it. Tests that pin several variables
+/// must acquire them in one fixed (alphabetical) order so two waiters cannot deadlock.
+type EnvPinTable = std::sync::Mutex<std::collections::HashMap<&'static str, (usize, &'static str)>>;
+
+fn env_pins() -> &'static (EnvPinTable, std::sync::Condvar) {
+    static PINS: std::sync::OnceLock<(EnvPinTable, std::sync::Condvar)> = std::sync::OnceLock::new();
+    PINS.get_or_init(|| (std::sync::Mutex::new(std::collections::HashMap::new()), std::sync::Condvar::new()))
+}
+
 impl EnvFlagGuard {
-    pub(super) fn set(name: &'static str) -> Self {
-        std::env::set_var(name, "1");
+    fn pin(name: &'static str, value: &'static str) -> Self {
+        let (table, released) = env_pins();
+        let mut pins = table.lock().unwrap();
+        loop {
+            match pins.get_mut(name) {
+                None => {
+                    pins.insert(name, (1, value));
+                    break;
+                }
+                Some((holders, held)) if *held == value => {
+                    *holders += 1;
+                    break;
+                }
+                // Someone holds the opposite value; wait for every holder to drop.
+                Some(_) => pins = released.wait(pins).unwrap(),
+            }
+        }
+        // Set while still holding the table lock, so a var never disagrees with its pin entry.
+        std::env::set_var(name, value);
         Self { name }
+    }
+
+    pub(super) fn set(name: &'static str) -> Self {
+        Self::pin(name, "1")
     }
 
     /// Explicitly DISABLES a gate for the test's lifetime. Needed because the shipped fixes are
     /// default-ON: leaving the variable unset now selects the fixed path, not the legacy one.
     pub(super) fn off(name: &'static str) -> Self {
-        std::env::set_var(name, "0");
-        Self { name }
+        Self::pin(name, "0")
     }
 }
 
 impl Drop for EnvFlagGuard {
     fn drop(&mut self) {
-        std::env::remove_var(self.name);
+        let (table, released) = env_pins();
+        let mut pins = table.lock().unwrap();
+        if let Some((holders, _)) = pins.get_mut(self.name) {
+            *holders -= 1;
+            if *holders == 0 {
+                pins.remove(self.name);
+                std::env::remove_var(self.name);
+                released.notify_all();
+            }
+        }
     }
 }
 

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -869,6 +869,16 @@ fn at_most_one_append_in_flight_per_follower() {
         max_in_flight <= 1,
         "{max_in_flight} appends were in flight to one follower at once"
     );
+    assert!(
+        max_in_flight == 1,
+        "no append ever reached a follower; nothing was replicated"
+    );
+    // Both follower senders must have answered, or the invariant above held vacuously with the
+    // fan-out doing the sending.
+    assert!(
+        cluster.pipeline_reached_within(60_000) >= 2,
+        "the per-follower senders never carried an append"
+    );
     assert_eq!(
         accepted,
         writers * each,


### PR DESCRIPTION
## What this does

Two defects, found because the pipeline's invariant test started failing the moment it was looked at closely.

**The pipelined propose was never wired in.** `propose_pipelined` — append under the lock, ring the per-follower senders, wait on the quorum-commit signal — existed, compiled, and was called from nowhere. Every propose took the fan-out path regardless of the flag. The invariant test ("at most one append in flight per follower") still passed, because the serialized fan-out also happens to keep one append in flight: the test was green while the pipeline carried nothing. The propose path now branches on the flag, inside the same caller-side deferral bookkeeping as the fan-out body, so barrier staging and join behave identically on both paths. The test now proves the senders did the sending — exactly one append in flight, both follower senders answered, every propose committed — and runs in ~2 s where the unwired path took 5–9 s of deadline stalls.

**The env-flag test guard raced destructively.** It was a bare set-on-create / remove-on-drop on a process-global variable: two tests pinning the same variable, the first to finish removes it, and the second silently runs the rest of its body on the default path. That single mechanism produced the shifting sets of gate-test failures that full parallel runs kept showing while every isolated re-run passed. Pins are now refcounted per variable behind one table: agreeing pins share, a conflicting pin waits for the holders to drop, the last holder clears the variable. No call site changed.

## Validation

- part5 parallel: 22/22 (was failing with "3 appends in flight" from mixed-mode replication mid-test).
- Pipeline-on raft suite: 222/222. Defaults raft+wal: 322 passed; the only failures in loaded parallel runs are engine-WAL timing tests, and all 62 pass isolated in 12 s (a loaded shared box skews their latency assertions).
- The pipeline flag remains default-off; nothing changes for the shipped fan-out path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
