### PR TITLE
Proxy test: unpublished async writes survive a clean reopen

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -110,3 +110,11 @@ jobs:
         timeout-minutes: 45
         continue-on-error: true
         run: cargo test --release -p temporalstore-rust --lib --tests -- --test-threads=1
+
+      # Bin unit tests are not covered by --lib/--tests, so a failing test in a
+      # service binary can sit on main unnoticed. Run the proxy bin's suite as a
+      # hard gate. Deliberately NOT --bins: some bin test harnesses run servers
+      # that never exit, which would hang the job.
+      - name: cargo test (matrixark_rust_proxy bin, single-threaded, release)
+        timeout-minutes: 20
+        run: cargo test --release -p temporalstore-rust --bin matrixark_rust_proxy -- --test-threads=1

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -5097,6 +5097,11 @@ mod tests {
             .expect("get targeted hash field"),
             r#"{"record_type":"context_event","text":"target published"}"#
         );
+        // Every acked write lands a WAL record even under async storage -- async only
+        // defers the fsync barrier, it does not skip the log -- so a clean reopen
+        // replays the log and restores writes the publish did not target. Targeted
+        // publish governs which keys get their index snapshot persisted (asserted
+        // above via the publish diagnostics), not which writes survive replay.
         assert_eq!(
             read_bytes(
                 &reopened,
@@ -5106,7 +5111,7 @@ mod tests {
                 },
             )
             .expect("get untargeted hash field"),
-            ""
+            r#"{"record_type":"context_event","text":"target not published"}"#
         );
 
         clear_engine_cache();


### PR DESCRIPTION
## What

`tests::matrixark_publish_visibility_can_target_only_written_keys` asserted that a write not named by a targeted `matrixark_publish_visibility` reads back **empty** after the engine is reopened.

That assertion encoded an older async-storage behavior, where an async write had no durable home until a dump or an explicit publish. Today every acked write records a WAL entry — async storage only defers the fsync barrier — so a clean reopen replays the log and restores every write, published or not. The engine is behaving as designed; the test was asserting behavior that was deliberately removed when the async write path gained its durability anchor.

The test now asserts the unpublished write survives the reopen, with a comment stating the current durability model. Targeting semantics are still covered by the unchanged assertions: publish diagnostics report the key fanout and non-full-shard scope, and republishing the same clean keys writes zero bytes.

## CI

`cargo test --lib --tests` never runs bin unit tests, so a failing bin test could sit on main unnoticed. The build-and-test job now also runs the proxy bin's suite as a hard gate (deliberately not `--bins`: some bin test harnesses run servers that never exit).

## Verification

`cargo test --release -p temporalstore-rust --bin matrixark_rust_proxy -- --test-threads=1`: 34 passed, 0 failed.
