### PR TITLE
Python surface for the engine attachment tier: key shape decides which blob tier serves

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -95,6 +95,19 @@ struct RecordLogRequest {
     visibility_keys: Vec<String>,
     #[serde(default)]
     top_level_response: bool,
+    /// Byte offset for `matrixark_resource_blob_fetch` (0 = start).
+    #[serde(default)]
+    blob_offset: Option<u64>,
+    /// Byte count for `matrixark_resource_blob_fetch` (0/absent = to the end).
+    #[serde(default)]
+    blob_length: Option<u64>,
+    /// Content hashes (16-digit hex) the caller's resource records still name, for
+    /// `matrixark_resource_blob_sweep` -- everything else older than the age floor goes.
+    #[serde(default)]
+    blob_referenced_hashes: Option<Vec<String>>,
+    /// Minimum age before an unreferenced blob is eligible for the sweep.
+    #[serde(default)]
+    blob_min_age_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2511,6 +2524,91 @@ fn execute_record_log_request(
             cached_clients: None,
             extra: BTreeMap::new(),
         },
+        // Attachment blob tier, engine command side: the python surface reaches the
+        // embedded engine's content-addressed blob store through these ops, mirroring the
+        // datanode's HTTP /blob tier for deployments that run no HTTP server. Payloads ride
+        // base64 in `value`; structured results ride the flattened extra map.
+        "matrixark_resource_blob_put" => {
+            let tenant_hash: u64 = request
+                .key
+                .trim()
+                .parse()
+                .map_err(|_| format!("blob put needs a decimal tenant hash in key, got {:?}", request.key))?;
+            let response = engine.execute(ExecuteRequest {
+                shard_id: DEFAULT_SHARD_ID,
+                command: Command::ContextResourceBlobPut {
+                    tenant_hash,
+                    payload_base64: request.value.clone(),
+                },
+            });
+            if !response.status.ok {
+                return Err(format!("{}: {}", response.status.code, response.status.message));
+            }
+            let mut output = empty_output(root);
+            if let CommandResponse::ContextResourceBlobCommitted { uri, size_bytes, content_hash } = response.response {
+                output.status = "committed".to_string();
+                output.extra.insert("matrixark_blob_uri".to_string(), json!(uri));
+                output.extra.insert("matrixark_blob_size_bytes".to_string(), json!(size_bytes));
+                output.extra.insert(
+                    "matrixark_blob_content_hash".to_string(),
+                    json!(format!("{content_hash:016x}")),
+                );
+            }
+            output
+        }
+        "matrixark_resource_blob_fetch" => {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: DEFAULT_SHARD_ID,
+                command: Command::ContextResourceBlobFetch {
+                    uri: request.key.clone(),
+                    offset: request.blob_offset.unwrap_or(0),
+                    length: request.blob_length.unwrap_or(0),
+                },
+            });
+            if !response.status.ok {
+                return Err(format!("{}: {}", response.status.code, response.status.message));
+            }
+            let mut output = empty_output(root);
+            if let CommandResponse::ContextResourceBlobChunk { payload_base64, total_size, eof } = response.response {
+                output.status = "served".to_string();
+                output.value = payload_base64;
+                output.extra.insert("matrixark_blob_total_size".to_string(), json!(total_size));
+                output.extra.insert("matrixark_blob_eof".to_string(), json!(eof));
+            }
+            output
+        }
+        "matrixark_resource_blob_sweep" => {
+            let tenant_hash: u64 = request
+                .key
+                .trim()
+                .parse()
+                .map_err(|_| format!("blob sweep needs a decimal tenant hash in key, got {:?}", request.key))?;
+            let referenced: Vec<u64> = request
+                .blob_referenced_hashes
+                .clone()
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|hex| u64::from_str_radix(hex.trim(), 16).ok())
+                .collect();
+            let response = engine.execute(ExecuteRequest {
+                shard_id: DEFAULT_SHARD_ID,
+                command: Command::ContextResourceBlobSweep {
+                    tenant_hash,
+                    referenced_content_hashes: referenced,
+                    min_age_ms: request.blob_min_age_ms.unwrap_or(3_600_000),
+                },
+            });
+            if !response.status.ok {
+                return Err(format!("{}: {}", response.status.code, response.status.message));
+            }
+            let mut output = empty_output(root);
+            if let CommandResponse::ContextResourceBlobSwept { scanned, deleted } = response.response {
+                output.status = "swept".to_string();
+                output.extra.insert("matrixark_blob_scanned".to_string(), json!(scanned));
+                output.extra.insert("matrixark_blob_deleted".to_string(), json!(deleted));
+            }
+            output
+        }
         "matrixark_publish_visibility" => {
             let visibility_key_count = request.visibility_keys.len();
             let index_bytes = engine
@@ -2870,7 +2968,10 @@ fn validate_request(request: &RecordLogRequest) -> Result<(), String> {
         | "metrics_prometheus"
         | "shutdown"
         | "matrixark_publish_visibility" => Ok(()),
-        "put_string" | "get_string" | "delete" | "del" | "hgetall" | "scan_hash" => {
+        "put_string" | "get_string" | "delete" | "del" | "hgetall" | "scan_hash"
+        | "matrixark_resource_blob_put"
+        | "matrixark_resource_blob_fetch"
+        | "matrixark_resource_blob_sweep" => {
             require_non_empty("key", &request.key)
         }
         "matrixark_scan_candidates"
@@ -4261,6 +4362,10 @@ mod tests {
             record: None,
             visibility_keys: Vec::new(),
             top_level_response: false,
+            blob_offset: None,
+            blob_length: None,
+            blob_referenced_hashes: None,
+            blob_min_age_ms: None,
         }
     }
 
@@ -4342,6 +4447,90 @@ mod tests {
         format!(
             r#"{{"record_type":"context_event","event_id_hash":{event_id},"text":"{text}","scope_key":"t={tenant}|u={user}|s=1|","access_scope":{{"tenant_hash":{tenant},"user_hash":{user},"scope_key":"t={tenant}|u={user}|s=1|"}}}}"#
         )
+    }
+
+    /// The blob ops are the python surface's road to the embedded engine's attachment tier:
+    /// put publishes a content-addressed blob and answers with its URI, fetch range-reads it
+    /// back byte-identical through the same op surface, and sweep leaves a still-referenced
+    /// blob alone while collecting the orphan.
+    #[test]
+    fn blob_ops_roundtrip_the_attachment_through_the_op_surface() {
+        let _guard = env_guard();
+        let dir = tempdir().expect("tempdir");
+        env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
+        clear_engine_cache();
+        clear_matrixark_scan_cache();
+
+        let probe = request("get_string");
+        let root = record_log_root(&probe);
+        let engine = open_engine(&probe).expect("engine");
+
+        let payload = b"the original attachment bytes, fetched back whole".repeat(64);
+        let mut put = request("matrixark_resource_blob_put");
+        put.key = "42".to_string();
+        put.value = base64_encode_bytes(&payload);
+        let committed = execute_record_log_request(&engine, put, root.clone()).expect("blob put");
+        let uri = committed
+            .extra
+            .get("matrixark_blob_uri")
+            .and_then(Value::as_str)
+            .expect("blob uri")
+            .to_string();
+        assert!(uri.starts_with("temporalstore://resources/"), "unexpected uri {uri}");
+        let kept_hash = committed
+            .extra
+            .get("matrixark_blob_content_hash")
+            .and_then(Value::as_str)
+            .expect("content hash")
+            .to_string();
+
+        let mut fetch = request("matrixark_resource_blob_fetch");
+        fetch.key = uri.clone();
+        let served = execute_record_log_request(&engine, fetch, root.clone()).expect("blob fetch");
+        assert_eq!(
+            Some(payload.len() as u64),
+            served.extra.get("matrixark_blob_total_size").and_then(Value::as_u64)
+        );
+        assert_eq!(Some(true), served.extra.get("matrixark_blob_eof").and_then(Value::as_bool));
+        assert_eq!(payload, base64_decode_str(&served.value), "fetched bytes differ");
+
+        let mut range = request("matrixark_resource_blob_fetch");
+        range.key = uri.clone();
+        range.blob_offset = Some(3);
+        range.blob_length = Some(11);
+        let window = execute_record_log_request(&engine, range, root.clone()).expect("range fetch");
+        assert_eq!(payload[3..14].to_vec(), base64_decode_str(&window.value));
+        assert_eq!(Some(false), window.extra.get("matrixark_blob_eof").and_then(Value::as_bool));
+
+        let mut orphan = request("matrixark_resource_blob_put");
+        orphan.key = "42".to_string();
+        orphan.value = base64_encode_bytes(b"orphaned attachment");
+        execute_record_log_request(&engine, orphan, root.clone()).expect("orphan put");
+
+        let mut sweep = request("matrixark_resource_blob_sweep");
+        sweep.key = "42".to_string();
+        sweep.blob_referenced_hashes = Some(vec![kept_hash]);
+        sweep.blob_min_age_ms = Some(0);
+        let swept = execute_record_log_request(&engine, sweep, root.clone()).expect("sweep");
+        assert_eq!(Some(2), swept.extra.get("matrixark_blob_scanned").and_then(Value::as_u64));
+        assert_eq!(Some(1), swept.extra.get("matrixark_blob_deleted").and_then(Value::as_u64));
+
+        let mut refetch = request("matrixark_resource_blob_fetch");
+        refetch.key = uri;
+        let still_there = execute_record_log_request(&engine, refetch, root).expect("kept blob");
+        assert_eq!(payload, base64_decode_str(&still_there.value), "the referenced blob must survive the sweep");
+    }
+
+    fn base64_encode_bytes(bytes: &[u8]) -> String {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine as _;
+        STANDARD.encode(bytes)
+    }
+
+    fn base64_decode_str(encoded: &str) -> Vec<u8> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine as _;
+        STANDARD.decode(encoded).expect("valid base64")
     }
 
     /// The core property: walk + backfill on the first pinned scan, scope index on the second,

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -660,7 +660,9 @@ class _LocalAdapterIngestMixin:
             resource_text = "\n\n".join(str(message["content"]) for message in envelope["messages"])
             try:
                 storage_resolution = resolve_raw_resource_for_ingest(
-                    args,
+                    # The engine blob tier rides the adapter's rust proxy client when there is
+                    # one; the pure-local adapter has none and the key stays absent.
+                    {**args, "_engine_blob_client": getattr(self, "_client", None)},
                     envelope,
                     requested_raw_uri,
                     resource_type,

--- a/tools/matrixark_mcp_core_resource_io.py
+++ b/tools/matrixark_mcp_core_resource_io.py
@@ -394,6 +394,41 @@ def resolve_raw_resource_for_ingest(args: Json, envelope: Json, raw_uri: str, re
     # and let the parser chunk that file (parse_text=None). Parallel to the
     # matrixobject:// branch above; the OSS-safe (no object store) counterpart.
     if is_temporalstore_uri(raw_uri):
+        # Engine-tier URI (two 16-hex segments): the bytes live in the embedded engine's blob
+        # store, reachable only through a rust proxy client -- the HTTP tier can never serve
+        # this shape, so falling through would be a guaranteed miss dressed as a 404.
+        try:  # top-level path
+            from matrixark_temporalstore_blob import (
+                engine_blob_get as _engine_get,
+                engine_blob_supported as _engine_ok,
+                parse_engine_blob_uri as _engine_parse,
+            )
+        except ImportError:  # package path
+            from tools.matrixark_temporalstore_blob import (  # type: ignore
+                engine_blob_get as _engine_get,
+                engine_blob_supported as _engine_ok,
+                parse_engine_blob_uri as _engine_parse,
+            )
+        if _engine_parse(raw_uri) is not None:
+            engine_client = args.get("_engine_blob_client") if isinstance(args, dict) else None
+            if not _engine_ok(engine_client):
+                raise MatrixArkError(
+                    f"resource uri {raw_uri} names the engine blob tier, but this adapter has "
+                    "no rust proxy client to fetch it through"
+                )
+            data = _engine_get(engine_client, raw_uri)
+            suffix = infer_resource_suffix(resource_type, raw_uri)
+            temp_file = Path(tempfile.mkdtemp(prefix="matrixark-engineblob-resource-")) / f"downloaded.{suffix}"
+            temp_file.write_bytes(data)
+            result["temp_paths"].append(str(temp_file.parent))
+            result["parse_uri"] = str(temp_file)
+            result["parse_text"] = None
+            result["storage_mode"] = "temporalstore"
+            result["stored_raw_uri"] = raw_uri
+            result["raw_storage_policy"] = "temporalstore_engine_blob"
+            result["raw_bytes_stored"] = True
+            result["cloud_key"] = raw_uri.split("://", 1)[-1]
+            return result
         ts_key = parse_temporalstore_uri(raw_uri)
         try:  # top-level path (matches the object-download branch's import style)
             from matrixark_temporalstore_blob import TemporalStoreBlobClient as _TsBlobClient
@@ -456,12 +491,27 @@ def resolve_raw_resource_for_ingest(args: Json, envelope: Json, raw_uri: str, re
 
         obj_ok = _obj_backend is not None and _obj_backend() != "inline"
         ts_ok = _ts_backend is not None and _ts_backend() != "inline"
+        # The engine tier is the fallback when neither an object backend nor the HTTP blob
+        # endpoint is configured but the adapter rides a rust proxy client: the embedded
+        # engine stores the attachment itself, so one TemporalStore still holds everything.
+        engine_client = args.get("_engine_blob_client") if isinstance(args, dict) else None
+        engine_ok = False
+        if engine_client is not None and _ts_backend is not None:
+            try:  # top-level path
+                from matrixark_temporalstore_blob import engine_blob_supported as _engine_ok_fn
+            except ImportError:  # package path
+                from tools.matrixark_temporalstore_blob import engine_blob_supported as _engine_ok_fn  # type: ignore
+            engine_ok = _engine_ok_fn(engine_client)
         if backend_choice == "matrixobject":
             chosen = "matrixobject" if obj_ok else None
         elif backend_choice == "temporalstore":
-            chosen = "temporalstore" if ts_ok else None
-        else:  # auto: object store first (dedup/serving), then TemporalStore blob
-            chosen = "matrixobject" if obj_ok else ("temporalstore" if ts_ok else None)
+            chosen = "temporalstore" if ts_ok else ("temporalstore_engine" if engine_ok else None)
+        else:  # auto: object store first (dedup/serving), then TemporalStore blob, then engine
+            chosen = (
+                "matrixobject"
+                if obj_ok
+                else ("temporalstore" if ts_ok else ("temporalstore_engine" if engine_ok else None))
+            )
 
         if chosen is not None:
             # Build the blob (same local-file / dir-archive / inline-text logic
@@ -493,6 +543,17 @@ def resolve_raw_resource_for_ingest(args: Json, envelope: Json, raw_uri: str, re
                     scope=envelope.get("scope"), kind=str(envelope.get("kind") or resource_type or "resource"),
                     name=str(envelope.get("metadata", {}).get("name") or ""), bucket=obj_bucket,
                 )
+            elif chosen == "temporalstore_engine":
+                try:  # top-level path
+                    from matrixark_temporalstore_blob import engine_blob_put as _engine_put
+                except ImportError:  # package path
+                    from tools.matrixark_temporalstore_blob import engine_blob_put as _engine_put  # type: ignore
+                scope = envelope.get("scope") or {}
+                tenant_hash = stable_hash(
+                    f"{scope.get('account_id') or ''}:{scope.get('tenant_id') or ''}"
+                )
+                blob_res = {"storage_mode": "temporalstore", "cloud_bucket": ""}
+                blob_res.update(_engine_put(engine_client, tenant_hash, blob))
             else:  # temporalstore blob tier
                 blob_res = _ts_resolution(
                     _TsBlobClient(), blob, source_uri=raw_uri, content_type=content_type,

--- a/tools/matrixark_mcp_ingest_resource_runtime.py
+++ b/tools/matrixark_mcp_ingest_resource_runtime.py
@@ -192,7 +192,7 @@ def ingest_resource_or_skill_if_needed(
         resource_text = "\n\n".join(str(message["content"]) for message in envelope["messages"])
         try:
             storage_resolution = resolve_raw_resource_for_ingest(
-                args,
+                {**args, "_engine_blob_client": getattr(self, "_client", None)},
                 envelope,
                 requested_raw_uri,
                 resource_type,

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -364,6 +364,25 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
     def hget(self, key: str, field: str) -> str:
         return self._call("hget", key=key, field=field)
 
+    def resource_blob_put(self, tenant_hash: int, payload_base64: str) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_put", key=str(int(tenant_hash)), value=payload_base64
+        )
+
+    def resource_blob_fetch(self, uri: str, *, offset: int = 0, length: int = 0) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_fetch", key=str(uri), blob_offset=int(offset), blob_length=int(length)
+        )
+
+    def resource_blob_sweep(self, tenant_hash: int, referenced_hashes: list[str], min_age_ms: int) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_sweep",
+            key=str(int(tenant_hash)),
+            blob_referenced_hashes=[str(item) for item in referenced_hashes],
+            blob_min_age_ms=int(min_age_ms),
+        )
+
+
     @staticmethod
     def _entries_for_single_key(compact_entries: list[list[str]]) -> tuple[str, list[list[str]]] | None:
         if not compact_entries:

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3440,6 +3440,24 @@ class MatrixArkRustProxyClient:
     def hget(self, key: str, field: str) -> str:
         return self._call("hget", key=key, field=field)
 
+    def resource_blob_put(self, tenant_hash: int, payload_base64: str) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_put", key=str(int(tenant_hash)), value=payload_base64
+        )
+
+    def resource_blob_fetch(self, uri: str, *, offset: int = 0, length: int = 0) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_fetch", key=str(uri), blob_offset=int(offset), blob_length=int(length)
+        )
+
+    def resource_blob_sweep(self, tenant_hash: int, referenced_hashes: list[str], min_age_ms: int) -> Json:
+        return self._call_json(
+            "matrixark_resource_blob_sweep",
+            key=str(int(tenant_hash)),
+            blob_referenced_hashes=[str(item) for item in referenced_hashes],
+            blob_min_age_ms=int(min_age_ms),
+        )
+
     def batch_hset(self, entries: list[Json]) -> None:
         if not entries:
             return

--- a/tools/matrixark_temporalstore_blob.py
+++ b/tools/matrixark_temporalstore_blob.py
@@ -284,3 +284,86 @@ def ts_blob_storage_resolution(
         "content_hash": ch, "raw_bytes": len(data), "content_type": content_type,
         "metadata": metadata,
     }
+
+
+# ---------------------------------------------------------------------------------------------
+# Engine command tier -- the embedded/proxy counterpart of the HTTP /blob endpoint above.
+#
+# Deployments that run NO datanode HTTP server (the embedded engine behind the rust proxy)
+# store attachments through the engine's own blob commands instead. Both tiers publish
+# temporalstore:// URIs; they are told apart by KEY SHAPE, never by configuration:
+#   HTTP tier   : resources/<sha2>/<sha256>            (64-hex content digest)
+#   engine tier : resources/<tenant:016x>/<hash:016x>  (two 16-hex segments)
+# The helpers below ride any client exposing the resource_blob_* ops (both rust proxy client
+# classes do); everything degrades to None/False when handed a client without them.
+# ---------------------------------------------------------------------------------------------
+
+_ENGINE_BLOB_URI_RE = None
+
+
+def parse_engine_blob_uri(uri: str) -> Optional[tuple[int, int]]:
+    """(tenant_hash, content_hash) for an ENGINE-tier URI, else None.
+
+    Strict: exactly two 16-digit lowercase-hex segments under resources/. The HTTP tier's
+    sha256 shape (64 hex digits) and every caller-supplied opaque key fall through to None,
+    so the two tiers can never capture each other's fetches.
+    """
+    global _ENGINE_BLOB_URI_RE
+    if _ENGINE_BLOB_URI_RE is None:
+        import re
+        _ENGINE_BLOB_URI_RE = re.compile(
+            r"^temporalstore://resources/([0-9a-f]{16})/([0-9a-f]{16})$"
+        )
+    match = _ENGINE_BLOB_URI_RE.match(str(uri or ""))
+    if not match:
+        return None
+    return int(match.group(1), 16), int(match.group(2), 16)
+
+
+def engine_blob_supported(client: Any) -> bool:
+    return client is not None and callable(getattr(client, "resource_blob_fetch", None))
+
+
+def engine_blob_put(client: Any, tenant_hash: int, data: bytes) -> Json:
+    """Store bytes in the engine tier; returns {stored_raw_uri, content_hash, raw_bytes, ...}
+    shaped like ts_blob_storage_resolution so the resolver treats both tiers alike."""
+    import base64
+    response = client.resource_blob_put(int(tenant_hash), base64.b64encode(data).decode("ascii"))
+    uri = str(response.get("matrixark_blob_uri") or "")
+    if not uri:
+        raise MatrixArkBlobError(f"engine blob put returned no uri: {response}")
+    return {
+        "storage_mode": "temporalstore", "backend": "temporalstore_engine_blob",
+        "stored_raw_uri": uri, "raw_storage_policy": "temporalstore_engine_blob",
+        "raw_bytes_stored": True, "upload_status": "uploaded",
+        "cloud_bucket": "", "cloud_key": uri.split("://", 1)[-1],
+        "content_hash": str(response.get("matrixark_blob_content_hash") or ""),
+        "raw_bytes": int(response.get("matrixark_blob_size_bytes") or len(data)),
+    }
+
+
+def engine_blob_get(client: Any, uri: str, *, chunk_bytes: int = 4 * 1024 * 1024) -> bytes:
+    """Fetch an engine-tier blob whole, in bounded range reads until eof."""
+    import base64
+    parts: list[bytes] = []
+    offset = 0
+    while True:
+        response = client.resource_blob_fetch(uri, offset=offset, length=chunk_bytes)
+        payload = base64.b64decode(str(response.get("value") or ""))
+        parts.append(payload)
+        offset += len(payload)
+        if bool(response.get("matrixark_blob_eof")) or not payload:
+            break
+    return b"".join(parts)
+
+
+def engine_blob_sweep(client: Any, tenant_hash: int, referenced_hex: list[str], min_age_ms: int) -> Json:
+    response = client.resource_blob_sweep(int(tenant_hash), list(referenced_hex), int(min_age_ms))
+    return {
+        "scanned": int(response.get("matrixark_blob_scanned") or 0),
+        "deleted": int(response.get("matrixark_blob_deleted") or 0),
+    }
+
+
+class MatrixArkBlobError(RuntimeError):
+    pass

--- a/tools/test_engine_blob_tier.py
+++ b/tools/test_engine_blob_tier.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The engine blob tier behind the python surface.
+
+Two tiers hold attachment bytes under the same temporalstore:// scheme: the datanode's HTTP
+/blob endpoint (sha256 keys) and the embedded engine's command tier (two 16-hex segments).
+These tests pin the property that makes them safe to coexist: KEY SHAPE alone decides which
+tier serves a fetch, and an engine-shaped URI without a rust proxy client fails loudly rather
+than turning into the HTTP tier's guaranteed 404.
+"""
+from __future__ import annotations
+
+import base64
+import unittest
+from pathlib import Path
+
+import matrixark_temporalstore_blob as blob
+from matrixark_mcp_core_resource_io import resolve_raw_resource_for_ingest
+from matrixark_mcp_core_identity import MatrixArkError
+
+ENGINE_URI = "temporalstore://resources/000000000000002a/00000000deadbeef"
+HTTP_URI = "temporalstore://resources/ab/" + "c" * 64
+
+
+class FakeEngineClient:
+    """Speaks the resource_blob_* ops, serving one payload in bounded chunks."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+        self.fetch_calls: list[tuple[str, int, int]] = []
+        self.put_calls: list[tuple[int, bytes]] = []
+
+    def resource_blob_put(self, tenant_hash: int, payload_base64: str):
+        data = base64.b64decode(payload_base64)
+        self.put_calls.append((tenant_hash, data))
+        return {
+            "ok": True,
+            "matrixark_blob_uri": ENGINE_URI,
+            "matrixark_blob_size_bytes": len(data),
+            "matrixark_blob_content_hash": "00000000deadbeef",
+        }
+
+    def resource_blob_fetch(self, uri: str, *, offset: int = 0, length: int = 0):
+        self.fetch_calls.append((uri, offset, length))
+        window = self.payload[offset : offset + (length or len(self.payload))]
+        eof = offset + len(window) >= len(self.payload)
+        return {
+            "ok": True,
+            "value": base64.b64encode(window).decode("ascii"),
+            "matrixark_blob_total_size": len(self.payload),
+            "matrixark_blob_eof": eof,
+        }
+
+
+class EngineBlobUriShape(unittest.TestCase):
+    def test_engine_shape_parses_and_the_http_shape_does_not(self):
+        self.assertEqual((0x2A, 0xDEADBEEF), blob.parse_engine_blob_uri(ENGINE_URI))
+        self.assertIsNone(blob.parse_engine_blob_uri(HTTP_URI))
+
+    def test_non_canonical_spellings_are_rejected(self):
+        for bad in [
+            "temporalstore://resources/000000000000002A/00000000DEADBEEF",  # uppercase
+            "temporalstore://resources/002a/00000000deadbeef",  # short tenant
+            "temporalstore://resources/000000000000002a/00000000deadbeef/x",  # trailing path
+            "objectstore://resources/000000000000002a/00000000deadbeef",  # wrong scheme
+        ]:
+            self.assertIsNone(blob.parse_engine_blob_uri(bad), bad)
+
+
+class EngineBlobChunkLoop(unittest.TestCase):
+    def test_get_reassembles_the_payload_from_bounded_ranges(self):
+        payload = bytes(range(256)) * 40
+        client = FakeEngineClient(payload)
+        fetched = blob.engine_blob_get(client, ENGINE_URI, chunk_bytes=4096)
+        self.assertEqual(payload, fetched)
+        self.assertGreater(len(client.fetch_calls), 1, "must have taken multiple range reads")
+        offsets = [offset for _, offset, _ in client.fetch_calls]
+        self.assertEqual(sorted(offsets), offsets, "ranges must advance monotonically")
+
+
+class ResolverTierDiscrimination(unittest.TestCase):
+    def _resolve(self, uri: str, args: dict):
+        return resolve_raw_resource_for_ingest(
+            args,
+            {"kind": "resource", "scope": {"account_id": "a", "tenant_id": "t"},
+             "metadata": {}, "messages": []},
+            uri,
+            "md",
+            "local",
+            "",
+        )
+
+    def test_engine_uri_is_served_by_the_engine_client(self):
+        payload = b"engine tier attachment bytes"
+        client = FakeEngineClient(payload)
+        result = self._resolve(ENGINE_URI, {"_engine_blob_client": client})
+        self.assertEqual("temporalstore_engine_blob", result["raw_storage_policy"])
+        self.assertTrue(result["raw_bytes_stored"])
+        self.assertIsNone(result["parse_text"])
+        self.assertEqual(payload, Path(result["parse_uri"]).read_bytes())
+        self.assertTrue(client.fetch_calls, "the engine client must have served the fetch")
+
+    def test_engine_uri_without_a_client_fails_loudly(self):
+        with self.assertRaises(MatrixArkError):
+            self._resolve(ENGINE_URI, {})
+
+    def test_http_shaped_uri_never_consults_the_engine_client(self):
+        engine_client = FakeEngineClient(b"must not be read")
+
+        class StubHttpClient:
+            def get(self, key, **kwargs):
+                return b"http tier bytes", {"content_hash": "c" * 64}
+
+        original = blob.TemporalStoreBlobClient
+        blob.TemporalStoreBlobClient = StubHttpClient
+        try:
+            result = self._resolve(HTTP_URI, {"_engine_blob_client": engine_client})
+        finally:
+            blob.TemporalStoreBlobClient = original
+        self.assertEqual([], engine_client.fetch_calls,
+                         "the sha256 shape belongs to the HTTP tier alone")
+        self.assertEqual(b"http tier bytes", Path(result["parse_uri"]).read_bytes())
+        self.assertEqual("temporalstore_blob", result["raw_storage_policy"])
+
+
+class EnginePutJoinsTheBackendChain(unittest.TestCase):
+    def test_cloud_mode_with_only_an_engine_client_stores_through_it(self):
+        client = FakeEngineClient(b"")
+        result = resolve_raw_resource_for_ingest(
+            {"raw_storage_mode": "cloud", "_engine_blob_client": client},
+            {"kind": "resource", "scope": {"account_id": "a", "tenant_id": "t"},
+             "metadata": {}, "messages": []},
+            "inline-resource",
+            "md",
+            "local",
+            "the attachment text that must land in the engine tier",
+        )
+        self.assertEqual(1, len(client.put_calls))
+        _, stored = client.put_calls[0]
+        self.assertEqual(b"the attachment text that must land in the engine tier", stored)
+        self.assertEqual(ENGINE_URI, result["stored_raw_uri"])
+        self.assertEqual("temporalstore_engine_blob", result["raw_storage_policy"])
+        self.assertTrue(result["raw_bytes_stored"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #282.

Two tiers hold attachment bytes under the same `temporalstore://` scheme — the datanode HTTP `/blob` endpoint (sha256 keys, `resources/<sha2>/<sha256>`) and the embedded engine command tier (`resources/{tenant:016x}/{hash:016x}`) — and until now only the first was reachable from python: an engine-tier URI arriving at the resolver became the HTTP tier's guaranteed 404.

**Proxy:** three ops — `matrixark_resource_blob_put` / `_fetch` / `_sweep` — map the engine blob commands onto the JSON-lines surface (payload as base64 in `value`, structured results in the flattened extra map). Both rust proxy client classes carry the wrappers, kept level so signature drift cannot send callers dark.

**Blob module:** engine-tier helpers — a strict URI parser (exactly two 16-hex segments, so the tiers can never capture each other's fetches), a bounded-range fetch loop, a put shaped like the HTTP tier's resolution, and the sweep.

**Resolver:** key shape alone decides the tier. An engine-shaped URI is served through the adapter's rust proxy client (injected at both ingest call sites; the pure-local adapter injects nothing and the shape fails loudly saying what is missing) — the sha256 shape keeps the HTTP tier untouched. On the store side, the engine tier joins the upload backend chain after the HTTP blob endpoint: cloud-mode ingest with only an embedded engine available now stores the attachment through it instead of falling to S3.

**Evidence:** proven against the real proxy binary — a 1.8MB payload put through the client, range-fetched back byte-identical in 7 bounded reads, served through the resolver, and collected by the sweep once unreferenced. Proxy bin suite 35/35 (including a new op-level roundtrip test with range/eof and sweep semantics); 7 python tests pin the shape discrimination, the chunk loop, the loud failure, and the backend chain; resource/attachment suites green; python ratchet at baseline (the only diffs are the known environment-specific js/jsonschema set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
