### PR TITLE
Let pipelined proposers run concurrently, so the senders get batches

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -4511,6 +4511,17 @@ impl RaftCluster {
     where
         T: RaftTransport + Clone + Send + 'static,
     {
+        // With the senders on, proposers skip the serialize gate entirely: order to any one
+        // follower is that follower's single sender thread, and entry order is the write
+        // lock's index assignment. Serializing proposers here starved the senders of batches --
+        // every entry paid the whole doorbell -> sender -> ack -> commit-signal chain alone,
+        // which is exactly the concurrency collapse measured on small machines. =0 falls back
+        // to one propose at a time through the same senders.
+        if follower_pipeline::follower_pipeline_enabled()
+            && raft_env_flag_default_on("TS_RAFT_PIPELINE_CONCURRENT_PROPOSE")
+        {
+            return self.propose_pipelined_concurrent(command, transport);
+        }
         // P2: serialize proposes into the log in order. Concurrent proposers otherwise append
         // under the write lock (sequential indices) but release it before the async network phase,
         // so their AppendEntries race and can reach a follower out of order -> `prev_log` mismatch
@@ -4602,6 +4613,147 @@ impl RaftCluster {
             }
         }
         // Never ack a write whose barrier failed: a flush error wins over a successful propose.
+        match (outcome, flushed) {
+            (Ok(response), Ok(())) => Ok(response),
+            (Ok(_), Err(err)) => Err(err),
+            (Err(err), _) => Err(err),
+        }
+    }
+
+    /// Propose through the per-follower senders WITHOUT the propose-serialize gate.
+    ///
+    /// The gate exists for the fan-out, where concurrent proposers each send their own
+    /// AppendEntries and the network can reorder them. The senders make it not just
+    /// unnecessary but harmful: with one sender thread per follower carrying every append in
+    /// log order, serializing proposers guarantees the senders never see more than one new
+    /// entry at a time, so each propose pays the whole doorbell -> sender -> ack ->
+    /// commit-signal chain by itself. Appending concurrently under the write lock keeps index
+    /// order, the senders batch whatever has accumulated, and one wake chain carries every
+    /// waiting proposer.
+    ///
+    /// Durability: the entry's record bytes are staged under the write lock (which orders
+    /// them) and the barrier is taken on a side thread while the senders replicate, then
+    /// joined before the ack -- nothing is acknowledged before its bytes are durable, and
+    /// concurrent proposers share barriers through the WAL flush gate. The commit index stays
+    /// recoverable and is never waited on. No deferral bookkeeping: that machinery assumes one
+    /// owning proposer, which is the constraint this path removes.
+    fn propose_pipelined_concurrent<T>(
+        &self,
+        command: Command,
+        transport: &T,
+    ) -> Result<CommandResponse, RaftError>
+    where
+        T: RaftTransport + Clone + Send + 'static,
+    {
+        self.ensure_follower_pipeline(transport);
+        let (entry_index, staged) = {
+            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+            inner.ensure_live_leader()?;
+            let entry_bytes = command_size_bytes(&command);
+            if entry_bytes > inner.config.max_memory_replicate_log_bytes {
+                let leader_id = inner.leader_id;
+                if let Some(leader) = inner.nodes.get_mut(&leader_id) {
+                    leader.pipeline_state.oversized_log_rejections = leader
+                        .pipeline_state
+                        .oversized_log_rejections
+                        .saturating_add(1);
+                    leader.pipeline_state.memory_backpressure_rejections = leader
+                        .pipeline_state
+                        .memory_backpressure_rejections
+                        .saturating_add(1);
+                }
+                inner.persist_configured_wal()?;
+                return Err(RaftError::LogEntryTooLarge {
+                    bytes: entry_bytes,
+                    limit: inner.config.max_memory_replicate_log_bytes,
+                });
+            }
+            if let Some((live, required)) = inner.joint_majority_failure() {
+                return Err(RaftError::NoMajority { live, required });
+            }
+            let required = inner.required_majority();
+            let live = inner.live_quorum_participants();
+            if live < required {
+                return Err(RaftError::NoMajority { live, required });
+            }
+            if !inner.leader_lease_valid() {
+                return Err(RaftError::LeaderUnavailable);
+            }
+            let leader_id = inner.leader_id;
+            let shard_id = inner.shard_id;
+            let leader = inner
+                .nodes
+                .get(&leader_id)
+                .filter(|node| node.alive && node.role == RaftRole::Leader)
+                .ok_or(RaftError::LeaderUnavailable)?;
+            let entry = RaftLogEntry {
+                term: leader.current_term,
+                index: node_next_log_index(leader),
+                shard_id,
+                command,
+            };
+            let index = entry.index;
+            let leader = inner
+                .nodes
+                .get_mut(&leader_id)
+                .ok_or(RaftError::LeaderUnavailable)?;
+            append_entry(leader, entry);
+            inner.response_waiters.insert(index);
+            // Write the record's bytes while the lock orders them; the barrier happens below,
+            // off the lock, shared with every concurrent proposer through the flush gate.
+            let staged = inner.stage_configured_wal()?;
+            (index, staged)
+        };
+
+        // The leader's disk wait runs alongside the followers' replication, exactly like the
+        // fan-out's overlapped barrier -- joined before the ack, never skipped.
+        let entry_barrier = if staged.is_empty() {
+            None
+        } else {
+            let cluster = self.clone();
+            Some(thread::spawn(move || cluster.finish_staged_unlocked(staged)))
+        };
+
+        self.ring_replication();
+
+        let deadline_ms = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let configured = inner.config.replication_deadline_ms;
+            if configured == 0 {
+                default_replication_deadline_ms()
+            } else {
+                configured
+            }
+        };
+        let committed =
+            self.wait_for_quorum_commit(entry_index, Duration::from_millis(deadline_ms));
+
+        let outcome = {
+            let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+            inner.response_waiters.remove(&entry_index);
+            if !committed {
+                inner.pending_responses.remove(&entry_index);
+                let required = inner.required_majority();
+                let live = inner.live_quorum_participants();
+                // The entry stays in the log and may commit later; the caller only learns that
+                // it did not commit within the deadline, which is all a replication deadline
+                // ever meant.
+                Err(RaftError::NoMajority { live, required })
+            } else {
+                Ok(inner
+                    .pending_responses
+                    .remove(&entry_index)
+                    .unwrap_or(CommandResponse::Empty))
+            }
+        };
+
+        // Never ack a write whose barrier failed, and never report a flush error as success.
+        let flushed = match entry_barrier {
+            Some(handle) => handle
+                .join()
+                .unwrap_or_else(|_| Err(RaftError::Wal("barrier thread panicked".to_string()))),
+            None => Ok(()),
+        };
         match (outcome, flushed) {
             (Ok(response), Ok(())) => Ok(response),
             (Ok(_), Err(err)) => Err(err),

--- a/crates/temporalstore-rust/src/raft/cluster_inner.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_inner.rs
@@ -726,7 +726,7 @@ impl RaftClusterInner {
     }
 
     /// Write what this node must persist, WITHOUT taking the barrier for it.
-    fn stage_configured_wal(&mut self) -> Result<Vec<local_wal::StagedWalAppend>, RaftError> {
+    pub(super) fn stage_configured_wal(&mut self) -> Result<Vec<local_wal::StagedWalAppend>, RaftError> {
         // P4: this thread owes a barrier rather than skipping one -- `flush_deferred_persist`
         // takes it before the propose acks. Only the thread that opened the deferral defers, so
         // a vote grant or heartbeat racing this propose still fsyncs before it answers.

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1410,3 +1410,57 @@ fn off_lock_image_build_yields_consistent_images_under_writes() {
     stop.store(true, std::sync::atomic::Ordering::SeqCst);
     writer.join().unwrap();
 }
+
+/// The =0 fallback -- one propose at a time through the same senders -- must stay correct too.
+#[test]
+fn serialized_pipeline_fallback_holds_the_invariant() {
+    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
+    let _serial = super::part4::EnvFlagGuard::off("TS_RAFT_PIPELINE_CONCURRENT_PROPOSE");
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig::default(),
+    )
+    .unwrap();
+    let transport = OneInFlightTransport {
+        cluster: cluster.clone(),
+        in_flight: Default::default(),
+        max_seen: Default::default(),
+    };
+    let cluster = std::sync::Arc::new(cluster);
+    let handles: Vec<_> = (0..4)
+        .map(|writer| {
+            let cluster = std::sync::Arc::clone(&cluster);
+            let transport = transport.clone();
+            std::thread::spawn(move || {
+                let mut accepted = 0usize;
+                for index in 0..4 {
+                    if cluster
+                        .propose_distributed(
+                            Command::StringSet {
+                                key: format!("serial-{writer:02}-{index:02}"),
+                                value: format!("v{writer}-{index}").into_bytes(),
+                            },
+                            &transport,
+                        )
+                        .is_ok()
+                    {
+                        accepted += 1;
+                    }
+                }
+                accepted
+            })
+        })
+        .collect();
+    let accepted: usize = handles.into_iter().map(|handle| handle.join().unwrap()).sum();
+    let max_in_flight = transport
+        .max_seen
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        max_in_flight <= 1,
+        "{max_in_flight} appends were in flight to one follower at once"
+    );
+    assert_eq!(accepted, 16, "every propose should commit through the serialized fallback");
+}


### PR DESCRIPTION
## What this does

Finds and fixes the pipeline's throughput collapse: **the propose-serialize gate was starving the senders of batches.**

The sender arms measure correct on every axis on hardware — the only arms ever to serve every replica read, zero reorder, zero stale-term — and still lost more than half their throughput to the fan-out under concurrency. Diagnosis went in three steps, each free:

1. **Loopback bench** cleared the machinery: at one writer the senders *win* (commit piggybacking halves the round trips).
2. **The same bench pinned to 2 CPUs** reproduced the hardware collapse locally — it appears only under concurrency on starved CPUs.
3. That signature is the wake chain: every propose paid doorbell → sender → ack → commit-signal **alone, serially**, because the serialize gate only ever let the senders see one new entry at a time.

The gate exists for the fan-out, where concurrent proposers each send their own AppendEntries and the network can reorder them. The senders make it harmful: order to any one follower *is* that follower's single sender thread, and entry order is the write lock's index assignment. With the pipeline on, proposers now skip the gate — they append concurrently under the write lock, the senders batch whatever has accumulated, and one wake chain carries every waiting proposer. `TS_RAFT_PIPELINE_CONCURRENT_PROPOSE=0` falls back to one propose at a time through the same senders.

**Durability unchanged in kind**: record bytes staged under the write lock (ordered), barrier on a side thread overlapping replication, joined before the ack on success and failure paths alike; concurrent proposers share barriers through the WAL flush gate. The single-owner deferral machinery doesn't apply — the single owner is the constraint this removes.

## Measured

Back-to-back on one heavily loaded box (load 22), 10 s cells, 8 writers:

| arm | qps | p50 | p99 |
|---|---|---|---|
| fan-out | 7.1 | 1096 ms | 1404 ms |
| senders, serialized | 10.0 | 760 ms | 1040 ms |
| **senders, concurrent** | **42.1** | **166 ms** | 515 ms |

5.9× the fan-out, 4.2× the serialized senders, zero errors, zero node warnings. At one writer the two sender modes tie at ~2× the fan-out. The pipeline flag itself stays default-off pending a hardware window with this in.

## Validation

- Invariant tests hold on both modes: at most one append in flight per follower with the senders proven to be the ones doing the sending; every concurrent proposer gets its own response; a new test pins the `=0` fallback.
- Pipeline-on raft suite 223 parallel; defaults 221 with the three failures being the known fixed-port and box-load flakes, each passing isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
