### PR TITLE
Scratch stores own their temp directories, and dead ones get swept

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -24,7 +24,7 @@ mod record;
 use paths::{
     delayed_destroy_dir, delayed_destroy_path, band_manifest_path, file_created_unix_ms,
     file_modified_unix_ms, legacy_zone_manifest_path, now_unix_ms, slab_path, sync_dir,
-    sync_parent_dir, system_time_unix_ms, unique_temp_path,
+    sync_parent_dir, system_time_unix_ms,
 };
 use record::{
     decode_page_record, default_page_record_compression_enabled,
@@ -636,6 +636,9 @@ struct BlockStoreInner {
     // attach_shared_slab_source() after a metadata-only restore. When present, a
     // read that misses a slab locally fetches it from here, caches it, then serves.
     shared_slab_source: Option<Arc<dyn SharedSlabSource>>,
+    // Set only by Default: the store owns its minted scratch directory, and the last
+    // clone's drop removes it. Never set for a caller-supplied root.
+    scratch: Option<Arc<crate::scratch::ScratchDirGuard>>,
 }
 
 /// Slab installs allowed to go by before the band manifest is written out.
@@ -726,6 +729,7 @@ impl LocalBlockStore {
                 band_manifest_reconciled_on_open,
                 stats: BlockStoreStats::default(),
                 shared_slab_source: None,
+                scratch: None,
             })),
         }
     }
@@ -1312,13 +1316,40 @@ fn band_zone_usage(
 
 impl Default for LocalBlockStore {
     fn default() -> Self {
-        Self::new(unique_temp_path("pages"))
+        let scratch = crate::scratch::owned_scratch_dir("pages");
+        let store = Self::new(scratch.path());
+        store
+            .inner
+            .lock()
+            .expect("block store lock poisoned")
+            .scratch = Some(scratch);
+        store
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_store_scratch_dir_dies_with_the_last_clone() {
+        let store = LocalBlockStore::default();
+        let root = store.inner.lock().unwrap().root.clone();
+        assert!(root.exists(), "Default must create its scratch dir");
+        let clone = store.clone();
+        drop(store);
+        assert!(root.exists(), "a live clone must keep the scratch dir");
+        drop(clone);
+        assert!(!root.exists(), "the last clone's drop must remove the scratch dir");
+    }
+
+    #[test]
+    fn explicit_root_survives_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalBlockStore::new(dir.path());
+        drop(store);
+        assert!(dir.path().exists(), "a caller-supplied root must never be deleted");
+    }
 
     #[test]
     fn active_slab_torn_tail_is_fenced_on_reopen() {

--- a/crates/temporalstore-rust/src/block_store/paths.rs
+++ b/crates/temporalstore-rust/src/block_store/paths.rs
@@ -70,15 +70,3 @@ pub(super) fn system_time_unix_ms(time: std::time::SystemTime) -> Option<u64> {
         .map(|duration| duration.as_millis() as u64)
 }
 
-pub(super) fn unique_temp_path(kind: &str) -> PathBuf {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "temporalstore-rust-{kind}-{}-{nanos}-{counter}",
-        std::process::id()
-    ))
-}

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -105,6 +105,9 @@ pub struct TemporalEngine {
     wal_store: LocalWriteAheadLogStore,
     index_log_store: LocalIndexLogStore,
     index_dir: PathBuf,
+    // Set only when the engine minted its own index_dir (no caller-supplied one): the
+    // engine owns that scratch directory, and the last clone's drop removes it.
+    index_scratch: Option<Arc<crate::scratch::ScratchDirGuard>>,
     configs: Arc<RwLock<HashMap<ShardId, Config>>>,
     infos: Arc<RwLock<HashMap<ShardId, ShardInfo>>>,
     admissions: Arc<RwLock<HashMap<AdmissionScope, AdmissionState>>>,
@@ -2079,16 +2082,9 @@ fn next_temp_counter() -> u64 {
     COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
+#[cfg(test)]
 fn unique_temp_path(kind: &str) -> PathBuf {
-    let counter = next_temp_counter();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "temporalstore-rust-{kind}-{}-{nanos}-{counter}",
-        std::process::id()
-    ))
+    crate::scratch::unique_temp_path(kind)
 }
 
 fn sha256_hex_bytes(bytes: &[u8]) -> String {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -15,7 +15,11 @@ impl TemporalEngine {
     }
 
     pub fn with_cache_and_block_store(cache: MultiLayerCache, block_store: LocalBlockStore) -> Self {
-        Self::with_cache_block_store_and_index_dir(cache, block_store, unique_temp_path("indexes"))
+        let scratch = crate::scratch::owned_scratch_dir("indexes");
+        let mut engine =
+            Self::with_cache_block_store_and_index_dir(cache, block_store, scratch.path());
+        engine.index_scratch = Some(scratch);
+        engine
     }
 
     pub fn with_cache_block_store_and_index_dir(
@@ -37,6 +41,7 @@ impl TemporalEngine {
             wal_store,
             index_log_store,
             index_dir,
+            index_scratch: None,
             configs: Arc::default(),
             infos: Arc::default(),
             admissions: Arc::default(),

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3050,3 +3050,18 @@ fn an_extracted_event_is_visible_to_time_ranged_queries() {
         "a successfully written extracted event must be visible to a time-ranged query"
     );
 }
+
+#[test]
+fn scratch_engine_index_dir_dies_with_the_last_engine_clone() {
+    let engine = TemporalEngine::default();
+    let index_dir = engine.index_dir.clone();
+    assert!(index_dir.exists(), "a scratch engine must create its index dir");
+    let clone = engine.clone();
+    drop(engine);
+    assert!(index_dir.exists(), "a live engine clone must keep the scratch dir");
+    drop(clone);
+    assert!(
+        !index_dir.exists(),
+        "the last engine clone must remove the scratch index dir on drop"
+    );
+}

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -264,6 +264,9 @@ struct IndexLogInner {
     /// on process restart, so the first post-restart cycle may dump once -- harmless (a dump only
     /// materializes durable state that is already recoverable).
     last_dumped_len_by_shard: HashMap<ShardId, u64>,
+    // Set only by Default: the store owns its minted scratch directory, and the last
+    // clone's drop removes it. Never set for a caller-supplied root.
+    scratch: Option<std::sync::Arc<crate::scratch::ScratchDirGuard>>,
 }
 
 fn indexlog_enabled() -> bool {
@@ -392,6 +395,7 @@ impl LocalIndexLogStore {
                 stats: IndexLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
                 last_dumped_len_by_shard: HashMap::new(),
+                scratch: None,
             })),
             flush_gates: Arc::new(crate::flush_gate::FlushRegistry::default()),
         }
@@ -800,7 +804,14 @@ impl LocalIndexLogStore {
 
 impl Default for LocalIndexLogStore {
     fn default() -> Self {
-        Self::new(unique_temp_path("index-logs"))
+        let scratch = crate::scratch::owned_scratch_dir("index-logs");
+        let store = Self::new(scratch.path());
+        store
+            .inner
+            .lock()
+            .expect("index log lock poisoned")
+            .scratch = Some(scratch);
+        store
     }
 }
 
@@ -865,22 +876,21 @@ fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn unique_temp_path(kind: &str) -> PathBuf {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "temporalstore-rust-{kind}-{}-{nanos}-{counter}",
-        std::process::id()
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_store_scratch_dir_dies_with_the_last_clone() {
+        let store = LocalIndexLogStore::default();
+        let root = store.inner.lock().unwrap().root.clone();
+        assert!(root.exists(), "Default must create its scratch dir");
+        let clone = store.clone();
+        drop(store);
+        assert!(root.exists(), "a live clone must keep the scratch dir");
+        drop(clone);
+        assert!(!root.exists(), "the last clone's drop must remove the scratch dir");
+    }
 
     #[test]
     fn gc_before_sequence_rewrites_index_log_with_retained_tail() {

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -27,6 +27,7 @@ pub mod raft;
 pub mod readiness;
 pub mod rebalance;
 pub mod redis;
+mod scratch;
 pub mod sdk;
 pub mod shared_store;
 pub mod storage_backend;

--- a/crates/temporalstore-rust/src/scratch.rs
+++ b/crates/temporalstore-rust/src/scratch.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scratch directories: minting, ownership, and reclamation.
+//!
+//! # The leak this closes
+//!
+//! Every `Default` store constructor mints a unique directory under the system temp dir, and
+//! nothing ever removed one: not the store (dropping it left the directory behind), and not
+//! the next boot (the name is unique per process, so no later run ever reuses it). A box
+//! that builds engines often accumulates these without bound — tens of thousands were found
+//! on one shared machine.
+//!
+//! # Ownership
+//!
+//! A store built by `Default` OWNS its directory: it holds an [`ScratchDirGuard`] whose drop
+//! removes the tree. The stores are `Clone` with shared inner state, so the guard is held as
+//! an `Arc` inside that shared state — the directory lives exactly as long as the last
+//! clone. A store built on a caller-supplied directory never holds a guard, so a real data
+//! directory is never deleted.
+//!
+//! # Reclamation
+//!
+//! Drop cannot run on a killed process, so minting any scratch path also arms a
+//! once-per-process background sweep: the minted name embeds the owning process id, and the
+//! sweep removes `temporalstore-rust-*` directories whose owner is no longer alive. A live
+//! owner's directories are always kept, as is anything whose name does not parse.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Mint a unique path under the system temp dir. The name embeds the process id, which is
+/// what lets [`sweep_dead_scratch_dirs`] tell an abandoned directory (owner exited) from one
+/// a live process is still using. Minting also arms the once-per-process background sweep.
+pub(crate) fn unique_temp_path(kind: &str) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    arm_background_sweep();
+    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!(
+        "temporalstore-rust-{kind}-{}-{nanos}-{counter}",
+        std::process::id()
+    ))
+}
+
+/// A scratch directory the minting store owns: removed from disk when the guard drops.
+/// Held as an `Arc` inside the owning store's shared inner state, so the directory outlives
+/// every clone and dies with the last one.
+#[derive(Debug)]
+pub(crate) struct ScratchDirGuard {
+    path: PathBuf,
+}
+
+impl ScratchDirGuard {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Mint a scratch directory together with its owning guard.
+pub(crate) fn owned_scratch_dir(kind: &str) -> Arc<ScratchDirGuard> {
+    Arc::new(ScratchDirGuard {
+        path: unique_temp_path(kind),
+    })
+}
+
+/// TS_SCRATCH_SWEEP: reclaim scratch directories whose owning process is gone. Default ON;
+/// set to a falsey value to leave abandoned directories in place.
+fn sweep_enabled() -> bool {
+    !matches!(
+        std::env::var("TS_SCRATCH_SWEEP")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+fn arm_background_sweep() {
+    static ARMED: std::sync::Once = std::sync::Once::new();
+    ARMED.call_once(|| {
+        if !sweep_enabled() {
+            return;
+        }
+        std::thread::spawn(|| {
+            let report = sweep_dead_scratch_dirs(&std::env::temp_dir());
+            if report.removed > 0 || report.failed > 0 {
+                eprintln!(
+                    "temporalstore_scratch_sweep removed={} failed={} kept_live={}",
+                    report.removed, report.failed, report.kept_live
+                );
+            }
+        });
+    });
+}
+
+#[derive(Debug, Default)]
+struct SweepReport {
+    removed: u64,
+    failed: u64,
+    kept_live: u64,
+}
+
+/// Remove `temporalstore-rust-*` directories under `dir` whose embedded process id is no
+/// longer alive. Directories of live processes are kept; so is anything whose name does not
+/// parse, and everything on platforms where liveness cannot be checked.
+fn sweep_dead_scratch_dirs(dir: &Path) -> SweepReport {
+    let mut report = SweepReport::default();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return report;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(rest) = name.strip_prefix("temporalstore-rust-") else {
+            continue;
+        };
+        // Layout: {kind}-{pid}-{nanos}-{counter}. The kind may itself contain dashes
+        // ("index-logs"), so parse from the right.
+        let mut fields = rest.rsplitn(4, '-');
+        let (Some(_counter), Some(_nanos), Some(pid)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        let Ok(pid) = pid.parse::<u32>() else { continue };
+        if pid == std::process::id() {
+            report.kept_live += 1;
+            continue;
+        }
+        match process_is_alive(pid) {
+            Some(false) => {
+                if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    if std::fs::remove_dir_all(entry.path()).is_ok() {
+                        report.removed += 1;
+                    } else {
+                        report.failed += 1;
+                    }
+                }
+            }
+            // A live owner, or a platform where liveness cannot be checked: never guess
+            // about deleting.
+            Some(true) | None => report.kept_live += 1,
+        }
+    }
+    report
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_alive(pid: u32) -> Option<bool> {
+    Some(Path::new("/proc").join(pid.to_string()).exists())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_is_alive(_pid: u32) -> Option<bool> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_scratch_dir_survives_clones_and_dies_with_the_last() {
+        let guard = owned_scratch_dir("scratch-guard-test");
+        let path = guard.path().to_path_buf();
+        std::fs::create_dir_all(&path).expect("create scratch dir");
+        std::fs::write(path.join("probe"), b"x").expect("write probe");
+        let clone = Arc::clone(&guard);
+        drop(guard);
+        assert!(path.exists(), "a live clone must keep the directory");
+        drop(clone);
+        assert!(!path.exists(), "the last drop must remove the directory");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sweep_removes_dead_owners_and_keeps_live_ones() {
+        let base = tempfile::tempdir().expect("tempdir");
+        // pid_max caps real pids far below u32::MAX, so this owner can never be alive.
+        let dead = base.path().join("temporalstore-rust-pages-4294967295-1-2");
+        let live = base
+            .path()
+            .join(format!("temporalstore-rust-index-logs-{}-3-4", std::process::id()));
+        let unrelated = base.path().join("unrelated-dir");
+        for dir in [&dead, &live, &unrelated] {
+            std::fs::create_dir_all(dir).expect("create test dir");
+        }
+        let report = sweep_dead_scratch_dirs(base.path());
+        assert!(!dead.exists(), "a dead owner's directory must be reclaimed");
+        assert!(live.exists(), "this live process's directory must be kept");
+        assert!(unrelated.exists(), "unrelated names must never be touched");
+        assert_eq!(report.removed, 1);
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -508,6 +508,9 @@ pub type LocalWalStore = LocalWriteAheadLogStore;
 #[derive(Debug)]
 struct WriteAheadLogInner {
     root: PathBuf,
+    // Set only by Default: the store owns its minted scratch directory, and the last
+    // clone's drop removes it. Never set for a caller-supplied root.
+    scratch: Option<std::sync::Arc<crate::scratch::ScratchDirGuard>>,
     stats: WriteAheadLogStats,
     last_sequence_by_shard: HashMap<ShardId, u64>,
     // MANIFEST-CONFORMANCE / phase-1 flat-append cache (TS_PHASE1_FLAT). The WAL file byte length as
@@ -549,6 +552,7 @@ impl LocalWriteAheadLogStore {
         Self {
             inner: Arc::new(Mutex::new(WriteAheadLogInner {
                 root,
+                scratch: None,
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
                 verified_len_by_shard: HashMap::new(),
@@ -1447,7 +1451,14 @@ impl LocalWriteAheadLogStore {
 
 impl Default for LocalWriteAheadLogStore {
     fn default() -> Self {
-        Self::new(unique_temp_path("wals"))
+        let scratch = crate::scratch::owned_scratch_dir("wals");
+        let store = Self::new(scratch.path());
+        store
+            .inner
+            .lock()
+            .expect("write-ahead log lock poisoned")
+            .scratch = Some(scratch);
+        store
     }
 }
 
@@ -2457,23 +2468,22 @@ fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn unique_temp_path(kind: &str) -> PathBuf {
-    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let counter = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "temporalstore-rust-{kind}-{}-{nanos}-{counter}",
-        std::process::id()
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::Command;
+
+    #[test]
+    fn default_store_scratch_dir_dies_with_the_last_clone() {
+        let store = LocalWriteAheadLogStore::default();
+        let root = store.inner.lock().unwrap().root.clone();
+        assert!(root.exists(), "Default must create its scratch dir");
+        let clone = store.clone();
+        drop(store);
+        assert!(root.exists(), "a live clone must keep the scratch dir");
+        drop(clone);
+        assert!(!root.exists(), "the last clone's drop must remove the scratch dir");
+    }
 
     #[test]
     fn wal_interleaved_processes_refresh_sequence_from_disk() {


### PR DESCRIPTION
## What

Every `Default` store constructor mints a unique directory under the system temp dir (`temporalstore-rust-{kind}-{pid}-{nanos}-{counter}`), and nothing ever removed one: dropping the store left the directory behind, and no later boot reuses a per-process-unique name. About **200k such directories** had accumulated on one shared build machine, holding tens of gigabytes and contributing to disk-full build failures.

## Ownership

The stores are `Clone` with shared `Arc<Mutex<Inner>>` state, so ownership lives there: a Default-built `LocalBlockStore`, `LocalWriteAheadLogStore`, or `LocalIndexLogStore`, and a `TemporalEngine` that minted its own index dir, now hold a `ScratchDirGuard` in that shared state. The last clone's drop removes the directory tree. Constructors taking a caller-supplied directory never hold a guard, so a real data directory is never deleted.

## Reclamation

Drop cannot run on a killed process, so minting any scratch path also arms a once-per-process background sweep (`TS_SCRATCH_SWEEP`, default on): the minted name embeds the owning process id, and the sweep removes `temporalstore-rust-*` directories whose owner is no longer alive. Live owners are always kept, as is any name that does not parse, and everything on platforms where liveness cannot be checked. This also reclaims directories minted by other crates that use the same naming scheme.

The four duplicated `unique_temp_path` copies (block_store, wal, index_log, engine) collapse into the new `scratch` module.

## Verification

- Full lib suite, release, single-threaded: **1204 passed**; the 17 failures are the documented pre-existing set — 15 proxy socket tests and the raft TCP-transport test fail under box load and pass in isolation (re-verified: 60/60 and 1/1), and `jitter_backoff` is the known deterministic failure on main. None touch this change.
- New tests: last-clone removal for all four owners, caller-supplied-root preservation, and the sweep's keep/remove/ignore decisions.
- A manual run of the same sweep logic on the affected machine reclaimed ~200k dead directories.
