### PR TITLE
RESP: PERSIST removes a timeout without touching the value

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -31,6 +31,7 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         Command::CommonDelete { key }
         | Command::CommonExpire { key, .. }
         | Command::CommonTtl { key }
+        | Command::CommonPersist { key }
         | Command::CommonExists { key }
         | Command::StringSet { key, .. }
         | Command::StringSetEx { key, .. }

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -38,6 +38,7 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         // Touches no object, so it holds no object keys.
         Command::LeaderEstablish => Vec::new(),
         Command::CommonDelete { key } => associated_record_keys(key),
+        Command::CommonPersist { key } => associated_record_keys(key),
         Command::CommonExpire { key, .. }
         | Command::StringSet { key, .. }
         | Command::StringSetEx { key, .. }
@@ -273,6 +274,7 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
         command,
         Command::CommonDelete { .. }
             | Command::CommonExpire { .. }
+            | Command::CommonPersist { .. }
             | Command::StringSet { .. }
             | Command::StringSetEx { .. }
             | Command::StringSetConditional { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -51,6 +51,31 @@ pub(crate) fn execute_on_shard(
             invalidate_record_all(cache, shard_id, &key);
             CommandResponse::Empty
         }
+        Command::CommonPersist { key } => {
+            // Expired-but-unswept is "missing" here, exactly as reads treat it: removing the
+            // sweep's pending work must not resurrect a value whose deadline already passed.
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                invalidate_record_all(cache, shard_id, &key);
+                CommandResponse::Integer { value: 0 }
+            } else {
+                let mut removed = false;
+                for record_key in associated_record_keys(&key) {
+                    if shard.expires_at_ms.remove(&record_key).is_some()
+                        && record_exists_exact(shard, &record_key)
+                    {
+                        removed = true;
+                    }
+                }
+                if removed {
+                    mutated = true;
+                    invalidate_record_all(cache, shard_id, &key);
+                }
+                CommandResponse::Integer {
+                    value: i64::from(removed),
+                }
+            }
+        }
         Command::CommonTtl { key } => {
             let expired = shard
                 .expires_at_ms

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -53,6 +53,7 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         Command::CommonDelete { key }
         | Command::CommonExpire { key, .. }
         | Command::CommonTtl { key }
+        | Command::CommonPersist { key }
         | Command::CommonExists { key }
         | Command::StringSet { key, .. }
         | Command::StringSetEx { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -466,6 +466,26 @@ mod tests {
             "EXPIRE on a missing key must return 0"
         );
         assert_eq!(run(&mut state, vec!["EXPIRE", "k", "100"]), RespValue::Integer(1));
+
+        // PERSIST removes the timeout without touching the value: 1 when a timeout came off,
+        // 0 for a key with none, 0 for a missing key -- and TTL reads -1 afterwards.
+        assert_eq!(run(&mut state, vec!["PERSIST", "k"]), RespValue::Integer(1));
+        assert_eq!(run(&mut state, vec!["TTL", "k"]), RespValue::Integer(-1));
+        assert_eq!(
+            run(&mut state, vec!["GET", "k"]),
+            RespValue::Bulk(Some(b"v".to_vec())),
+            "PERSIST must not disturb the value"
+        );
+        assert_eq!(
+            run(&mut state, vec!["PERSIST", "k"]),
+            RespValue::Integer(0),
+            "a key with no timeout answers 0"
+        );
+        assert_eq!(
+            run(&mut state, vec!["PERSIST", "missing"]),
+            RespValue::Integer(0),
+            "a missing key answers 0"
+        );
     }
 
     #[test]
@@ -865,6 +885,7 @@ mod tests {
             "MSET" => vec!["MSET", "advertised:mset", "v"],
             "MSETNX" => vec!["MSETNX", "advertised:msetnx", "v"],
             "PARTITION" => vec!["PARTITION", "INFO"],
+            "PERSIST" => vec!["PERSIST", "advertised:missing"],
             "PEXPIRE" => vec!["PEXPIRE", "advertised:missing", "10"],
             "PEXPIREAT" => vec!["PEXPIREAT", "advertised:missing", "4102444800000"],
             "PEXPIRETIME" => vec!["PEXPIRETIME", "advertised:missing"],

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -231,6 +231,11 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             flags: WRITE,
         },
         RedisCommandDescriptor {
+            name: "PERSIST",
+            arity: 2,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
             name: "PEXPIRETIME",
             arity: 2,
             flags: READ,

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -360,6 +360,13 @@ pub fn execute_redis_command_with_state(
         "PEXPIRE" if args.len() == 3 => expire_response(&args, 1, execute),
         "EXPIREAT" if args.len() == 3 => expire_at_response(&args, 1000, execute),
         "PEXPIREAT" if args.len() == 3 => expire_at_response(&args, 1, execute),
+        "PERSIST" if args.len() == 2 => match execute(Command::CommonPersist {
+            key: string_arg(&args[1]),
+        }) {
+            Ok(CommandResponse::Integer { value }) => RespValue::Integer(value),
+            Ok(_) => RespValue::Error("ERR invalid persist response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
         "EXPIRETIME" if args.len() == 2 => expire_time_response(&args[1], 1000, &mut execute),
         "PEXPIRETIME" if args.len() == 2 => expire_time_response(&args[1], 1, &mut execute),
         "TTL" if args.len() == 2 => match execute(Command::CommonTtl {

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1131,6 +1131,11 @@ pub enum Command {
     CommonTtl {
         key: String,
     },
+    /// Remove a key's expiry without touching its value: Redis PERSIST. Answers 1 when a
+    /// timeout was actually removed, 0 when the key is missing or already had none.
+    CommonPersist {
+        key: String,
+    },
     CommonExists {
         key: String,
     },


### PR DESCRIPTION
First slice of #244 item 1: the expiry surface had EXPIRE / PEXPIRE / TTL and variants but no way to walk a timeout back. CommonPersist removes the expiry for the key and its associated record keys, answering 1 only when a timeout actually came off a live record; missing, expired-but-unswept, and never-expiring keys answer 0, and an expired key is treated exactly as reads treat it. Write-classified, carried by both wire clients, advertised in the command table, conformance-tested (1/0 answers, TTL -1 read-back, value untouched). Redis lib suite 10/10; cargo check --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)