### PR TITLE
Proxy binary: read option defaults from the options, not from repeated literals

### DIFF
--- a/crates/temporalstore-rust/src/bin/proxy.rs
+++ b/crates/temporalstore-rust/src/bin/proxy.rs
@@ -11,38 +11,60 @@ fn main() {
         .or_else(|_| std::env::var("TS_PROXY_ADDR"))
         .unwrap_or_else(|_| "127.0.0.1:17000".to_string());
     let meta_addr = std::env::var("TS_META_ADDR").unwrap_or_else(|_| "127.0.0.1:17001".to_string());
+    // Every environment fallback below reads its default from here rather than repeating a
+    // literal. Repeating them meant the binary could disagree with the option's declared
+    // default and nothing would say so: context_shard_count was declared 0, meaning "follow
+    // the cluster", while this file passed 1 -- so the deployed proxy always looked explicitly
+    // configured and the cluster-following it was given never ran. Tests did not catch it
+    // because they build ProxyOptions directly and get the real default.
+    let defaults = ProxyOptions::default();
     let options = ProxyOptions {
         meta_addr,
         proxy_addr: std::env::var("TS_PROXY_ADVERTISED_ADDR").unwrap_or_else(|_| addr.clone()),
         listen_addr: addr.clone(),
-        config_version: env_u64("TS_PROXY_CONFIG_VERSION", 0),
+        config_version: env_u64("TS_PROXY_CONFIG_VERSION", defaults.config_version),
         namespace: std::env::var("TS_PROXY_NAMESPACE").unwrap_or_default(),
         location: std::env::var("TS_PROXY_LOCATION").unwrap_or_default(),
         binary_version: std::env::var("TS_PROXY_BINARY_VERSION")
             .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string()),
-        route_cache_ttl_ms: env_u64("TS_PROXY_ROUTE_CACHE_TTL_MS", 1_000),
-        connect_timeout_ms: env_u64("TS_PROXY_CONNECT_TIMEOUT_MS", 200),
-        io_timeout_ms: env_u64("TS_PROXY_IO_TIMEOUT_MS", 200),
-        max_retries: env_usize("TS_PROXY_MAX_RETRIES", 0),
-        refresh_route_on_backend_error: env_bool("TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR", true),
+        route_cache_ttl_ms: env_u64("TS_PROXY_ROUTE_CACHE_TTL_MS", defaults.route_cache_ttl_ms),
+        connect_timeout_ms: env_u64("TS_PROXY_CONNECT_TIMEOUT_MS", defaults.connect_timeout_ms),
+        io_timeout_ms: env_u64("TS_PROXY_IO_TIMEOUT_MS", defaults.io_timeout_ms),
+        max_retries: env_usize("TS_PROXY_MAX_RETRIES", defaults.max_retries),
+        refresh_route_on_backend_error: env_bool(
+            "TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR",
+            defaults.refresh_route_on_backend_error,
+        ),
         backend_continuous_failed_time_ms: env_u64(
             "TS_PROXY_BACKEND_CONTINUOUS_FAILED_TIME_MS",
-            10_000,
+            defaults.backend_continuous_failed_time_ms,
         ),
-        service_registry_ttl_ms: env_u64("TS_PROXY_SERVICE_REGISTRY_TTL_MS", 30_000),
-        serving_mode: env_serving_mode("TS_PROXY_SERVING_MODE", ProxyServingMode::Serving),
-        drop_percent: env_u8("TS_PROXY_DROP_PERCENT", 0),
+        service_registry_ttl_ms: env_u64("TS_PROXY_SERVICE_REGISTRY_TTL_MS", defaults.service_registry_ttl_ms),
+        serving_mode: env_serving_mode("TS_PROXY_SERVING_MODE", defaults.serving_mode),
+        drop_percent: env_u8("TS_PROXY_DROP_PERCENT", defaults.drop_percent),
         ingestion_account: std::env::var("TS_PROXY_INGESTION_ACCOUNT").unwrap_or_default(),
-        enforce_ingestion_account: env_bool("TS_PROXY_ENFORCE_INGESTION_ACCOUNT", false),
-        max_inflight_requests: env_u64("TS_PROXY_MAX_INFLIGHT_REQUESTS", 0),
-        max_inflight_write_requests: env_u64("TS_PROXY_MAX_INFLIGHT_WRITE_REQUESTS", 0),
-        pin_primary_reads: env_bool("TS_PROXY_PIN_PRIMARY_READS", true),
-        heartbeat_timeout_ms: env_u64("TS_PROXY_HEARTBEAT_TIMEOUT_MS", 5_000),
-        topology_check_interval_ms: env_u64("TS_PROXY_TOPOLOGY_CHECK_INTERVAL_MS", 50),
-        auto_register_min_interval_ms: env_u64("TS_PROXY_AUTO_REGISTER_MIN_INTERVAL_MS", 60_000),
-        context_first_shard_id: env_u64("TS_PROXY_CONTEXT_FIRST_SHARD", 1),
-        context_shard_count: env_u64("TS_PROXY_CONTEXT_SHARD_COUNT", 1),
-        context_io_timeout_ms: env_u64("TS_PROXY_CONTEXT_IO_TIMEOUT_MS", 30_000),
+        enforce_ingestion_account: env_bool(
+            "TS_PROXY_ENFORCE_INGESTION_ACCOUNT",
+            defaults.enforce_ingestion_account,
+        ),
+        max_inflight_requests: env_u64("TS_PROXY_MAX_INFLIGHT_REQUESTS", defaults.max_inflight_requests),
+        max_inflight_write_requests: env_u64(
+            "TS_PROXY_MAX_INFLIGHT_WRITE_REQUESTS",
+            defaults.max_inflight_write_requests,
+        ),
+        pin_primary_reads: env_bool("TS_PROXY_PIN_PRIMARY_READS", defaults.pin_primary_reads),
+        heartbeat_timeout_ms: env_u64("TS_PROXY_HEARTBEAT_TIMEOUT_MS", defaults.heartbeat_timeout_ms),
+        topology_check_interval_ms: env_u64(
+            "TS_PROXY_TOPOLOGY_CHECK_INTERVAL_MS",
+            defaults.topology_check_interval_ms,
+        ),
+        auto_register_min_interval_ms: env_u64(
+            "TS_PROXY_AUTO_REGISTER_MIN_INTERVAL_MS",
+            defaults.auto_register_min_interval_ms,
+        ),
+        context_first_shard_id: env_u64("TS_PROXY_CONTEXT_FIRST_SHARD", defaults.context_first_shard_id),
+        context_shard_count: env_u64("TS_PROXY_CONTEXT_SHARD_COUNT", defaults.context_shard_count),
+        context_io_timeout_ms: env_u64("TS_PROXY_CONTEXT_IO_TIMEOUT_MS", defaults.context_io_timeout_ms),
     };
     let proxy = ProxyService::new(options);
     let heartbeat_interval_ms = env_u64("TS_PROXY_HEARTBEAT_INTERVAL_MS", 10_000);


### PR DESCRIPTION
The proxy binary set seventeen options from the environment, each with its own
fallback written as a literal. Those literals are meant to match the defaults
declared on the options themselves, and there was nothing keeping them in step.

They had already come apart. context_shard_count is declared 0, which means "spread
context over the cluster's shards". The binary passed 1. So a deployed proxy always
looked as though an operator had explicitly asked for one shard, the cluster-
following it had been given never ran, and every tenant's context still landed on
the first shard -- the exact behaviour that change was made to end.

Nothing failed. The tests build the options directly and get the real default, so
they exercised the intended behaviour while the shipped binary did something else.
That is the shape worth naming: a default that is correct everywhere except in the
process that actually runs.

Each fallback now reads the declared default, so the two cannot disagree. Setting
the environment variable still wins, unchanged.

The one literal left is the heartbeat interval, which is not an option field -- it
is a local passed to the heartbeat loop, and it has no declared default to track.