### PR TITLE
Recover the node-local matrixobject backend from a checkpoint, not all history

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1758,25 +1758,34 @@ fn wire_matrixobject_durability(
     };
 
     if !local_state_present && latest > 0 {
-        // TODO(S1 / checkpoint-recovery): this NODE-LOCAL matrixobject durability path still
-        // recovers via full WAL replay from seq 0 (O(all history)) and never publishes a
-        // checkpoint. The lazy checkpoint substrate now exists generically:
-        //   * `SharedStoreReplicator<O>::publish_checkpoint` / `restore_index_and_page_addresses`
-        //     are generic over `O: ObjectStore` (see shared_store.rs), and
-        //   * the NETWORKED path `wire_matrixobject_networked_durability` already does exactly the
-        //     target flow: restore index + lazy slab address map, replay only the WAL tail, and
-        //     publish a checkpoint on start.
-        // To close S1 for this backend: (a) publish a checkpoint on start when `local_state_present`
-        // (mirror wire_matrixobject_networked_durability's publish block), and (b) here, replace
-        // `replay_wal(shard_id, 0, ..)` with
-        //     `replicator.restore_index_and_page_addresses(shard_id, engine, &engine.block_store())`
-        // then `replay_wal(shard_id, manifest.checkpoint_wal_index, ..)`, falling back to a
-        // full replay only on `CheckpointNotFound`. `MatrixObjectObjectStore` implements
-        // `ObjectStore`, so a `SharedSlabSource` over it (analogous to `MatrixObjectSlabSource`)
-        // is all that the generic `restore_index_and_page_addresses_with` needs. Requires the
-        // `matrixobject` feature build (private crate) to land + test end-to-end, so it is
-        // deferred to a dedicated pass; recovery stays correct here today, just O(history).
-        match rt.block_on(replicator.replay_wal(shard_id, 0, engine)) {
+        // S1 checkpoint recovery: restore the served index plus a lazy slab address map from
+        // the latest checkpoint, then replay ONLY the WAL tail after it -- old pages are read
+        // out of the store on demand. A store with no checkpoint yet (or a failed restore)
+        // falls back to the full replay from 0: the old behavior, correct but O(history).
+        let after_wal_index = match rt.block_on(replicator.restore_index_and_page_addresses(
+            shard_id,
+            engine,
+            &engine.block_store(),
+        )) {
+            Ok(manifest) => {
+                println!(
+                    "restored shard {shard_id} index and lazy page addresses from matrixobject checkpoint {} (WAL tail from {})",
+                    manifest.checkpoint_id, manifest.checkpoint_wal_index
+                );
+                // Read the restored on-disk index into memory before the tail replay, which
+                // applies through the engine and needs a loaded shard.
+                engine.load_shard(shard_id);
+                manifest.checkpoint_wal_index
+            }
+            Err(temporalstore_rust::SharedStoreReplicationError::CheckpointNotFound(_)) => 0,
+            Err(err) => {
+                eprintln!(
+                    "matrixobject checkpoint restore failed for shard {shard_id} ({err}); replaying full WAL"
+                );
+                0
+            }
+        };
+        match rt.block_on(replicator.replay_wal(shard_id, after_wal_index, engine)) {
             Ok(report) => println!(
                 "recovered shard {shard_id} from matrixobject shared storage at {store_dir}: {} WAL entries replayed (through index {})",
                 report.applied, report.last_wal_index
@@ -1795,6 +1804,25 @@ fn wire_matrixobject_durability(
         println!(
             "matrixobject durability active for shard {shard_id} at {store_dir}; no shared WAL yet (fresh cluster)"
         );
+    }
+
+    // Publish this node's authoritative state as a checkpoint (index + slabs) at start, so a
+    // future fresh recovery replays only the tail instead of all history. Opt-out via env.
+    if local_state_present && env_bool("TS_MATRIXOBJECT_CHECKPOINT_ON_START", true) {
+        match rt.block_on(replicator.publish_checkpoint(
+            shard_id,
+            latest,
+            engine,
+            &engine.block_store(),
+        )) {
+            Ok(manifest) => println!(
+                "published matrixobject start checkpoint {} for shard {shard_id} at WAL index {}",
+                manifest.checkpoint_id, manifest.checkpoint_wal_index
+            ),
+            Err(err) => eprintln!(
+                "matrixobject start checkpoint publish failed for shard {shard_id}: {err}"
+            ),
+        }
     }
 
     let mode = SharedStoreStorageMode::from_sync_flag(sync_flush);

--- a/crates/temporalstore-rust/src/matrixobject_store.rs
+++ b/crates/temporalstore-rust/src/matrixobject_store.rs
@@ -100,6 +100,16 @@ impl MatrixObjectObjectStore {
         Arc::clone(&self.inner)
     }
 
+    /// Synchronous read of one object, for the lazy slab read-through: the store is a mutex
+    /// over in-process state, so nothing here would actually await.
+    pub fn get_blocking(&self, key: &str) -> Result<Bytes, ObjectStoreError> {
+        let inner = self.inner.lock().expect("matrixobject lock poisoned");
+        let object = inner
+            .get_object(&self.bucket, key)
+            .map_err(map_matrixobject_error)?;
+        Ok(Bytes::from(object.data))
+    }
+
     /// Force the durable snapshot to disk after a mutation.
     ///
     /// This is a no-op when the store has no `persistent_snapshot_path` (the

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -1882,6 +1882,73 @@ impl SharedStoreReplicator<MatrixObjectHttpStore> {
     }
 }
 
+/// Lazy read-through source for the NODE-LOCAL matrixobject backend
+/// ([`crate::matrixobject_store::MatrixObjectObjectStore`]): the same contract as
+/// [`MatrixObjectSlabSource`], resolved against the in-process store under its mutex
+/// instead of a networked GET, verifying the checkpoint checksum before the block
+/// store caches it.
+#[cfg(feature = "matrixobject")]
+#[derive(Debug)]
+pub struct MatrixObjectLocalSlabSource {
+    object_store: Arc<crate::matrixobject_store::MatrixObjectObjectStore>,
+    slabs: BTreeMap<u64, SharedSlabAddress>,
+}
+
+#[cfg(feature = "matrixobject")]
+impl SharedSlabSource for MatrixObjectLocalSlabSource {
+    fn fetch_slab(&self, page_slab_id: u64) -> Result<Option<Vec<u8>>, BlockStoreError> {
+        let Some(address) = self.slabs.get(&page_slab_id) else {
+            return Ok(None);
+        };
+        let bytes = self
+            .object_store
+            .get_blocking(&address.key)
+            .map_err(|err| {
+                BlockStoreError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    err.to_string(),
+                ))
+            })?
+            .to_vec();
+        // Conformance with restore_checkpoint: reject a corrupt shared slab before caching it.
+        let actual = sha256_hex(&bytes);
+        if bytes.len() as u64 != address.byte_size || actual != address.sha256 {
+            return Err(BlockStoreError::ChecksumMismatch {
+                page_slab_id,
+                offset: 0,
+                length: address.byte_size,
+                expected: address.sha256.clone(),
+                actual,
+            });
+        }
+        Ok(Some(bytes))
+    }
+}
+
+#[cfg(feature = "matrixobject")]
+impl SharedStoreReplicator<crate::matrixobject_store::MatrixObjectObjectStore> {
+    /// Conformance LAZY restore for the node-local matrixobject backend: install the
+    /// served INDEX and a per-slab shared address map WITHOUT installing any slab
+    /// bytes; old (pre-checkpoint) pages are read lazily out of the local store on the
+    /// first read that needs them. The same flow the shared-filesystem and networked
+    /// backends already run -- it is what lets this backend's recovery replay only the
+    /// WAL tail after a checkpoint instead of all history.
+    pub async fn restore_index_and_page_addresses(
+        &self,
+        shard_id: ShardId,
+        engine: &TemporalEngine,
+        block_store: &LocalBlockStore,
+    ) -> Result<SharedStoreCheckpointManifest, SharedStoreReplicationError> {
+        self.restore_index_and_page_addresses_with(shard_id, engine, block_store, |store, slabs| {
+            Arc::new(MatrixObjectLocalSlabSource {
+                object_store: store,
+                slabs,
+            }) as Arc<dyn SharedSlabSource>
+        })
+        .await
+    }
+}
+
 /// Build a per-entry [`SharedStoreWriteReport`] from an optional append receipt (JsonPerKey mode
 /// has no receipt; append-blob mode carries the byte range).
 fn write_report_from_receipt(
@@ -2832,6 +2899,90 @@ mod tests {
             CommandResponse::Bytes {
                 value: Some(b"keep-value".to_vec())
             }
+        );
+    }
+
+    #[cfg(feature = "matrixobject")]
+    #[tokio::test]
+    async fn matrixobject_local_lazy_restore_replays_only_wal_tail() {
+        // The node-local matrixobject backend recovers like every other shared backend:
+        // checkpoint index + lazy addresses, then ONLY the WAL tail -- not all history.
+        use crate::matrixobject_store::MatrixObjectObjectStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "before".to_string(),
+                value: b"snapshot-value".to_vec(),
+            },
+        });
+        let store = Arc::new(
+            MatrixObjectObjectStore::with_default_options("temporalstore-shared").unwrap(),
+        );
+        let replicator = SharedStoreReplicator::new("cluster-a", store);
+        let manifest = replicator
+            .publish_checkpoint(1, 1, &primary, &primary.block_store())
+            .await
+            .unwrap();
+        assert!(!manifest.page_slabs.is_empty());
+        replicator
+            .publish_wal_entry(SharedStoreWalEntry {
+                shard_id: 1,
+                wal_index: 2,
+                command: Command::StringSet {
+                    key: "after".to_string(),
+                    value: b"wal-value".to_vec(),
+                },
+            })
+            .await
+            .unwrap();
+
+        let follower = test_engine(dir.path(), "follower");
+        let restored = replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+            .unwrap();
+        assert_eq!(restored.checkpoint_wal_index, 1);
+        assert_eq!(follower.block_store().stats().shared_slab_fetches, 0);
+        follower.load_shard(1);
+        let report = replicator
+            .replay_wal(1, restored.checkpoint_wal_index, &follower)
+            .await
+            .unwrap();
+        assert_eq!(report.applied, 1, "only the tail entry replays");
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "after".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"wal-value".to_vec())
+            }
+        );
+        assert_eq!(
+            follower
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: "before".to_string()
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(b"snapshot-value".to_vec())
+            }
+        );
+        assert_eq!(
+            follower.block_store().stats().shared_slab_fetches,
+            1,
+            "the old key is served by exactly one on-demand slab fetch"
         );
     }
 


### PR DESCRIPTION
## What this does

Closes the last O(history) recovery path: the **node-local matrixobject backend** now recovers from a checkpoint plus the WAL tail, the way the shared-filesystem and networked backends already do.

Before: a fresh node on this backend replayed the full shared WAL from sequence zero, and nothing ever published a checkpoint — so recovery cost grew with all history, forever. Now: restore the served index plus a lazy per-slab address map from the latest checkpoint, replay **only the WAL tail** after it, and read old pages out of the store **on demand** — the first read that needs one fetches it, checksum-verified, at most once. A store with no checkpoint yet falls back to the full replay (the old behavior: correct, just O(history)).

The missing pieces were mechanical:

- the store type gained a synchronous read (it is a mutex over in-process state — nothing there ever actually awaited),
- a lazy slab read-through source over it, mirroring the networked one,
- the restore entry point the other two backends already had,
- and on the server: recovery tries the checkpoint first, and a node that starts with local state present **publishes a checkpoint** of its authoritative state (opt-out `TS_MATRIXOBJECT_CHECKPOINT_ON_START=0`), so the *next* fresh recovery has a checkpoint to start from.

## How it's proven

A gated end-to-end test publishes a checkpoint and one tail entry, restores into a fresh engine, and asserts: the tail replay applied exactly one record, both the checkpointed and the tail key serve correctly, and the pre-checkpoint key cost exactly **one** on-demand slab fetch (nothing eager).

## Validation

- With the enterprise store crate linked locally: gated tests pass; the datanode bin compiles with the wiring.
- Default build unchanged and clean; the committed manifest and lockfile carry no private-crate entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
