### PR TITLE
Count what a shard's rate limit allows and refuses

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -143,6 +143,25 @@ impl TemporalEngine {
             .config_of(shard_id)
     }
 
+    /// What a shard's rate limit has allowed and refused, if it has one.
+    ///
+    /// Absent means the shard is not limited, which is different from a limit that has refused
+    /// nothing -- and the difference is the one an operator actually wants.
+    pub fn shard_quota_counters(&self, shard_id: ShardId) -> Option<quota::QuotaCounters> {
+        self.quotas
+            .read()
+            .expect("quota lock poisoned")
+            .counters_of(shard_id)
+    }
+
+    /// Every shard carrying a rate limit, for reporting.
+    pub fn rate_limited_shards(&self) -> Vec<ShardId> {
+        self.quotas
+            .read()
+            .expect("quota lock poisoned")
+            .limited_shards()
+    }
+
     /// Take one token for `kind`. True when the command may proceed.
     ///
     /// The overwhelmingly common case is a shard with no limit, and that case must not pay for

--- a/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
+++ b/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
@@ -25,6 +25,8 @@ impl TemporalEngine {
         out.push_str("# TYPE temporalstore_page_store_zone_oldest_unix_ms gauge\n");
         out.push_str("# HELP temporalstore_page_store_zone_oldest_age_ms Oldest page-store zone age by shard and lifecycle scope.\n");
         out.push_str("# TYPE temporalstore_page_store_zone_oldest_age_ms gauge\n");
+        out.push_str("# HELP temporalstore_shard_rate_limit_total Commands allowed and refused by a rate limit. Absent for a shard with no limit, which is not the same as a limit that has refused nothing.\n");
+        out.push_str("# TYPE temporalstore_shard_rate_limit_total counter\n");
         out.push_str(
             "# HELP temporalstore_wal_records_total Write-ahead log append records by shard.\n",
         );
@@ -128,6 +130,27 @@ impl TemporalEngine {
                 ],
                 stats.control_state_records as u64,
             );
+            // Only for a shard that carries a limit. A shard with none has nothing to count, and
+            // emitting zeros would say "this limit refused nothing" about a shard that has no
+            // limit at all -- which is the one distinction an operator needs from this.
+            if let Some(counters) = self.shard_quota_counters(stats.shard_id) {
+                for (kind, value) in [
+                    ("read_allowed", counters.read_allowed),
+                    ("read_refused", counters.read_refused),
+                    ("write_allowed", counters.write_allowed),
+                    ("write_refused", counters.write_refused),
+                ] {
+                    push_metric(
+                        &mut out,
+                        "temporalstore_shard_rate_limit_total",
+                        &[
+                            ("shard_id", stats.shard_id.to_string()),
+                            ("kind", kind.into()),
+                        ],
+                        value,
+                    );
+                }
+            }
             for (kind, value) in [
                 ("memory_hits", stats.cache.memory_hits),
                 ("disk_hits", stats.cache.disk_hits),

--- a/crates/temporalstore-rust/src/engine/quota.rs
+++ b/crates/temporalstore-rust/src/engine/quota.rs
@@ -140,11 +140,26 @@ impl ShardQuotaConfig {
     }
 }
 
+/// What a shard's limit has allowed and refused.
+///
+/// Both halves, not just refusals: a refusal count with no denominator says nothing about whether
+/// the limit is close or miles away. Only shards that HAVE a limit carry these -- an unlimited
+/// shard has nothing to count, and keeping it that way is what lets the fast path stay on a read
+/// lock.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QuotaCounters {
+    pub read_allowed: u64,
+    pub read_refused: u64,
+    pub write_allowed: u64,
+    pub write_refused: u64,
+}
+
 /// The buckets for one shard.
 #[derive(Debug)]
 pub(crate) struct ShardQuota {
     read: Option<TokenBucket>,
     write: Option<TokenBucket>,
+    counters: QuotaCounters,
 }
 
 impl ShardQuota {
@@ -154,7 +169,12 @@ impl ShardQuota {
                 .then(|| TokenBucket::new(config.read_qps, config.read_burst)),
             write: (config.write_qps > 0)
                 .then(|| TokenBucket::new(config.write_qps, config.write_burst)),
+            counters: QuotaCounters::default(),
         }
+    }
+
+    pub(crate) fn counters(&self) -> QuotaCounters {
+        self.counters
     }
 
     /// Take one token for `kind`. An unlimited direction always succeeds.
@@ -163,10 +183,17 @@ impl ShardQuota {
             QuotaKind::Read => self.read.as_mut(),
             QuotaKind::Write => self.write.as_mut(),
         };
-        match bucket {
+        let allowed = match bucket {
             Some(bucket) => bucket.try_consume(1),
             None => true,
+        };
+        match (kind, allowed) {
+            (QuotaKind::Read, true) => self.counters.read_allowed += 1,
+            (QuotaKind::Read, false) => self.counters.read_refused += 1,
+            (QuotaKind::Write, true) => self.counters.write_allowed += 1,
+            (QuotaKind::Write, false) => self.counters.write_refused += 1,
         }
+        allowed
     }
 
     pub(crate) fn limit_of(&self, kind: QuotaKind) -> Option<(u64, u64)> {
@@ -191,7 +218,17 @@ impl QuotaTable {
     /// new one.
     pub(crate) fn set(&mut self, shard_id: ShardId, config: ShardQuotaConfig) {
         self.configured.insert(shard_id, config);
-        self.by_shard.insert(shard_id, ShardQuota::new(config));
+        // The bucket is rebuilt, but the counters are carried across: they record what this shard
+        // has done, not what this bucket has done, and resetting them on every reconfiguration
+        // would erase the history right when someone is watching it to decide the new number.
+        let carried = self
+            .by_shard
+            .get(&shard_id)
+            .map(|quota| quota.counters())
+            .unwrap_or_default();
+        let mut quota = ShardQuota::new(config);
+        quota.counters = carried;
+        self.by_shard.insert(shard_id, quota);
     }
 
     pub(crate) fn config_of(&self, shard_id: ShardId) -> Option<ShardQuotaConfig> {
@@ -225,6 +262,18 @@ impl QuotaTable {
         self.by_shard.contains_key(&shard_id)
     }
 
+    /// What this shard's limit has allowed and refused, if it has one.
+    pub(crate) fn counters_of(&self, shard_id: ShardId) -> Option<QuotaCounters> {
+        self.by_shard.get(&shard_id).map(|quota| quota.counters())
+    }
+
+    /// Every shard that carries a limit, for reporting.
+    pub(crate) fn limited_shards(&self) -> Vec<ShardId> {
+        let mut shards: Vec<ShardId> = self.by_shard.keys().copied().collect();
+        shards.sort_unstable();
+        shards
+    }
+
     pub(crate) fn limit_of(&self, shard_id: ShardId, kind: QuotaKind) -> Option<(u64, u64)> {
         self.by_shard
             .get(&shard_id)
@@ -235,6 +284,74 @@ impl QuotaTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn what_the_limit_allowed_and_refused_is_counted() {
+        let mut quota = ShardQuota::new(ShardQuotaConfig {
+            write_qps: 10,
+            write_burst: 3,
+            ..Default::default()
+        });
+        let mut allowed = 0;
+        for _ in 0..20 {
+            if quota.try_consume(QuotaKind::Write) {
+                allowed += 1;
+            }
+        }
+        let counters = quota.counters();
+        assert_eq!(counters.write_allowed, allowed);
+        assert_eq!(counters.write_refused, 20 - allowed);
+        assert!(counters.write_refused > 0, "the limit should have refused some");
+        assert_eq!(counters.read_allowed, 0, "reads were never asked for");
+    }
+
+    #[test]
+    fn an_unlimited_direction_still_counts_what_it_allowed() {
+        // The denominator matters: without it a refusal count says nothing about how close the
+        // limit is.
+        let mut quota = ShardQuota::new(ShardQuotaConfig {
+            write_qps: 1,
+            write_burst: 1,
+            ..Default::default()
+        });
+        for _ in 0..5 {
+            quota.try_consume(QuotaKind::Read);
+        }
+        assert_eq!(quota.counters().read_allowed, 5);
+        assert_eq!(quota.counters().read_refused, 0);
+    }
+
+    #[test]
+    fn changing_a_limit_keeps_what_the_shard_has_already_done() {
+        let mut table = QuotaTable::default();
+        table.set(
+            1,
+            ShardQuotaConfig {
+                write_qps: 1,
+                write_burst: 1,
+                ..Default::default()
+            },
+        );
+        for _ in 0..10 {
+            table.try_consume(1, QuotaKind::Write, ShardQuotaConfig::default());
+        }
+        let before = table.counters_of(1).unwrap();
+        assert!(before.write_refused > 0);
+
+        table.set(
+            1,
+            ShardQuotaConfig {
+                write_qps: 1_000,
+                write_burst: 1_000,
+                ..Default::default()
+            },
+        );
+        let after = table.counters_of(1).unwrap();
+        assert_eq!(
+            after.write_refused, before.write_refused,
+            "reconfiguring erased the history someone would be watching to pick the new number"
+        );
+    }
 
     #[test]
     fn a_rate_of_zero_never_refuses() {

--- a/crates/temporalstore-rust/src/engine/tests/quota.rs
+++ b/crates/temporalstore-rust/src/engine/tests/quota.rs
@@ -199,3 +199,49 @@ fn a_replicated_apply_is_never_refused_by_the_limit() {
     });
     assert!(found.status.ok || found.status.code == "quota_exhausted");
 }
+
+/// A limited shard reports what it allowed and refused; an unlimited one reports nothing.
+///
+/// The absence matters as much as the numbers: zeros for an unlimited shard would read as "this
+/// limit refused nothing", which is a different statement from "this shard has no limit".
+#[test]
+fn the_rate_limit_is_visible_in_the_metrics() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+
+    // With no limit, the shard reports no counters at all.
+    for index in 0..20 {
+        write(&engine, &format!("free{index}"));
+    }
+    assert!(engine.shard_quota_counters(1).is_none());
+    assert!(!engine
+        .prometheus_metrics()
+        .contains("temporalstore_shard_rate_limit_total{shard_id=\"1\""));
+
+    engine.set_shard_quota(
+        1,
+        ShardQuotaConfig {
+            write_qps: 5,
+            write_burst: 2,
+            ..Default::default()
+        },
+    );
+    for index in 0..40 {
+        write(&engine, &format!("k{index}"));
+    }
+
+    let counters = engine.shard_quota_counters(1).expect("the shard is limited");
+    assert!(counters.write_refused > 0, "the limit should have refused some");
+    assert!(counters.write_allowed > 0, "and allowed some");
+    assert_eq!(
+        counters.write_allowed + counters.write_refused,
+        40,
+        "every command should be counted on one side or the other"
+    );
+
+    let rendered = engine.prometheus_metrics();
+    assert!(rendered.contains("# TYPE temporalstore_shard_rate_limit_total counter"));
+    assert!(rendered.contains("kind=\"write_refused\""), "{rendered}");
+    assert!(rendered.contains("kind=\"write_allowed\""));
+    assert_eq!(engine.rate_limited_shards(), vec![1]);
+}


### PR DESCRIPTION
The rate limit refuses commands and **nothing counted the refusals**, so there was no way to tell
from outside whether a limit was biting, set too tight, or doing nothing at all. A limit that cannot
be observed cannot be tuned.

Exposed as `temporalstore_shard_rate_limit_total`, by shard and kind, beside the counters that
already exist for cache admission.

## Three decisions worth naming

**Both halves are counted, not just refusals.** A refusal count with no denominator says nothing
about whether the limit is close or miles away.

**A shard with no limit reports nothing, not zeros.** Zeros would read as *"this limit refused
nothing"*, which is a different statement from *"this shard has no limit"* — and that distinction is
the one an operator actually needs.

**The counters live inside the per-shard buckets**, which exist only for shards that have a limit.
That keeps the fast path exactly as it was: an unlimited shard still settles under a read lock and
never touches the table, which is the whole reason that path is cheap. Counting every allowed
command centrally would have quietly undone it.

## Reconfiguring keeps the history

Changing a limit carries the counters across rather than resetting them. They record what the
*shard* has done, not what the current *bucket* has done — and clearing them on reconfiguration
would erase the history right when someone is watching it to choose the new number. There is a test
for that specifically.

## Verification

- 21 quota tests, including one that asserts every command lands on one side or the other
  (`write_allowed + write_refused == 40`), that the metric renders with both kinds, and that an
  unlimited shard emits **no** rate-limit series at all;
- engine suite **231 passed, 0 failed**;
- `cargo check --all-targets` clean.
