### PR TITLE
RESP: native lists, ordered by construction and rebuilt from the index alone

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -49,6 +49,10 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::SetAdd { key, .. }
         | Command::SetMembers { key }
         | Command::SetRemove { key, .. }
+        | Command::ListPush { key, .. }
+        | Command::ListPop { key, .. }
+        | Command::ListRange { key, .. }
+        | Command::ListLen { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2290,6 +2290,7 @@ fn delete_record_exact(shard: &mut ShardState, key: &str) -> bool {
     removed |= shard.strings.remove(key).is_some();
     removed |= shard.hashes.remove(key).is_some();
     removed |= shard.sets.remove(key).is_some();
+    removed |= shard.lists.remove(key).is_some();
     if shard.features.remove(key).is_some() {
         removed = true;
         control_rollup::feature_forget(shard, key);
@@ -2452,6 +2453,9 @@ fn collect_live_page_slab_ids(shard: &ShardState) -> BTreeSet<u64> {
     }
     for members in shard.sets.values() {
         ids.extend(members.values().map(|address| address.page_slab_id));
+    }
+    for elements in shard.lists.values() {
+        ids.extend(elements.values().map(|address| address.page_slab_id));
     }
     for series in shard.features.values() {
         ids.extend(series.values().map(|address| address.page_slab_id));
@@ -2631,6 +2635,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
         || shard.strings.contains_key(key)
         || shard.hashes.contains_key(key)
         || shard.sets.contains_key(key)
+        || shard.lists.contains_key(key)
         || shard.features.contains_key(key)
         || shard.control_state.contains_key(key)
         || shard.control_state_pages.contains_key(key)
@@ -2651,6 +2656,7 @@ fn storage_model_kinds() -> &'static [&'static str] {
         "string",
         "hash",
         "set",
+        "list",
         "feature",
         "sequence",
         "control_state",
@@ -2812,6 +2818,7 @@ fn object_manager_stats(
         let secondary_object_count = shard.strings.len()
             + shard.hashes.len()
             + shard.sets.len()
+            + shard.lists.len()
             + shard.features.len()
             + shard.control_state.len()
             + shard.control_state_changes.len()
@@ -2828,6 +2835,7 @@ fn object_manager_stats(
         let secondary_page_ref_count = shard.strings.len()
             + shard.hashes.values().map(HashMap::len).sum::<usize>()
             + shard.sets.values().map(BTreeMap::len).sum::<usize>()
+            + shard.lists.values().map(BTreeMap::len).sum::<usize>()
             + shard.features.values().map(BTreeMap::len).sum::<usize>()
             + shard.context_nodes.len()
             + shard
@@ -2897,6 +2905,7 @@ fn object_manager_stats(
     let object_count = shard.strings.len()
         + shard.hashes.len()
         + shard.sets.len()
+        + shard.lists.len()
         + shard.features.len()
         + shard.control_state.len()
         + shard.context_nodes.len()
@@ -2910,6 +2919,7 @@ fn object_manager_stats(
     let page_ref_count = shard.strings.len()
         + shard.hashes.values().map(HashMap::len).sum::<usize>()
         + shard.sets.values().map(BTreeMap::len).sum::<usize>()
+        + shard.lists.values().map(BTreeMap::len).sum::<usize>()
         + shard.features.values().map(BTreeMap::len).sum::<usize>()
         + shard.context_nodes.len()
         + shard

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -50,6 +50,10 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::HashDelete { key, .. }
         | Command::SetAdd { key, .. }
         | Command::SetRemove { key, .. }
+        | Command::ListPush { key, .. }
+        | Command::ListPop { key, .. }
+        | Command::ListRange { key, .. }
+        | Command::ListLen { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureReplace { key, .. }
@@ -261,6 +265,8 @@ pub(super) fn command_updates_bucket_index_directly(command: &Command) -> bool {
             | Command::HashDelete { .. }
             | Command::SetAdd { .. }
             | Command::SetRemove { .. }
+            | Command::ListPush { .. }
+            | Command::ListPop { .. }
             | Command::ControlStateIncrement { .. }
             | Command::ControlStateIncrementWithOptions { .. }
             | Command::ControlStateSet { .. }
@@ -285,6 +291,8 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::HashDelete { .. }
             | Command::SetAdd { .. }
             | Command::SetRemove { .. }
+            | Command::ListPush { .. }
+            | Command::ListPop { .. }
             | Command::FeatureAppend { .. }
             | Command::FeatureAppendWithPolicy { .. }
             | Command::FeatureReplace { .. }

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -81,6 +81,8 @@ pub(super) fn model_compaction_policy_reports(
             "hash"
         } else if shard.sets.contains_key(key) {
             "set"
+        } else if shard.lists.contains_key(key) {
+            "list"
         } else if shard.features.contains_key(key) {
             "feature"
         } else if shard.control_state_pages.contains_key(key) {
@@ -296,6 +298,16 @@ pub(super) fn compaction_model_layout_reports(
             .hashes
             .values()
             .flat_map(|fields| fields.values().cloned()),
+        &slab_page_counts,
+        None,
+    ));
+    reports.push(compaction_layout_from_addresses(
+        "list",
+        shard.lists.len(),
+        shard
+            .lists
+            .values()
+            .flat_map(|elements| elements.values().cloned()),
         &slab_page_counts,
         None,
     ));

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -491,6 +491,134 @@ pub(crate) fn execute_on_shard(
             let _ = cache.invalidate_record(shard_id, "set", &key);
             CommandResponse::Empty
         }
+        Command::ListPush { key, member, left } => {
+            remove_if_expired(shard, &key);
+            let seq = {
+                let list = shard.lists.entry(key.clone()).or_default();
+                if left {
+                    list.keys().next().copied().map_or(0, |first| first - 1)
+                } else {
+                    list.keys().next_back().copied().map_or(0, |last| last + 1)
+                }
+            };
+            // Two's-complement bias makes the hex component sort lexically in list order,
+            // which is what lets recovery and range reads walk the bucket index directly.
+            let component = format!("{:016x}", (seq as u64).wrapping_sub(i64::MIN as u64));
+            let object_id = stable_page_object_id(shard_id, "list", &key, Some(&component));
+            let routing_bucket =
+                page_routing_bucket(&key, start_routing_bucket, end_routing_bucket);
+            if let Ok(address) = append_value(
+                cache,
+                page_store,
+                shard_id,
+                &member,
+                Some(object_id),
+                Some(routing_bucket),
+                async_storage,
+            ) {
+                upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "list",
+                    &key,
+                    Some(component.clone()),
+                    address.clone(),
+                    true,
+                );
+                shard
+                    .lists
+                    .entry(key.clone())
+                    .or_default()
+                    .insert(seq, address);
+                mutated = true;
+            }
+            let _ = cache.invalidate_record(shard_id, "list", &key);
+            let length = shard.lists.get(&key).map_or(0, BTreeMap::len) as i64;
+            CommandResponse::Integer { value: length }
+        }
+        Command::ListPop { key, left } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "list", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Bytes { value: None },
+                    mutated,
+                };
+            }
+            let popped = shard.lists.get_mut(&key).and_then(|list| {
+                let seq = if left {
+                    list.keys().next().copied()
+                } else {
+                    list.keys().next_back().copied()
+                }?;
+                list.remove(&seq).map(|address| (seq, address))
+            });
+            match popped {
+                None => CommandResponse::Bytes { value: None },
+                Some((seq, address)) => {
+                    let component =
+                        format!("{:016x}", (seq as u64).wrapping_sub(i64::MIN as u64));
+                    mutated = true;
+                    mark_bucket_index_page_deleted(shard, "list", &key, Some(&component));
+                    if shard.lists.get(&key).is_some_and(BTreeMap::is_empty) {
+                        shard.lists.remove(&key);
+                    }
+                    let _ = cache.invalidate_record(shard_id, "list", &key);
+                    CommandResponse::Bytes {
+                        value: read_page_bytes(cache, page_store, shard_id, &address),
+                    }
+                }
+            }
+        }
+        Command::ListRange { key, start, stop } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "list", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Members {
+                        members: Vec::new(),
+                    },
+                    mutated,
+                };
+            }
+            let addresses: Vec<BlockAddress> = shard
+                .lists
+                .get(&key)
+                .map(|list| list.values().cloned().collect())
+                .unwrap_or_default();
+            let length = addresses.len() as i64;
+            let resolve = |index: i64| -> i64 {
+                if index < 0 {
+                    length + index
+                } else {
+                    index
+                }
+            };
+            let from = resolve(start).max(0);
+            let to = resolve(stop).min(length - 1);
+            let members = if from > to || length == 0 {
+                Vec::new()
+            } else {
+                addresses[from as usize..=to as usize]
+                    .iter()
+                    .filter_map(|address| read_page_bytes(cache, page_store, shard_id, address))
+                    .collect()
+            };
+            CommandResponse::Members { members }
+        }
+        Command::ListLen { key } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "list", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Integer { value: 0 },
+                    mutated,
+                };
+            }
+            CommandResponse::Integer {
+                value: shard.lists.get(&key).map_or(0, BTreeMap::len) as i64,
+            }
+        }
         Command::SetMembers { key } => {
             if remove_if_expired(shard, &key) {
                 mutated = true;

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -556,6 +556,8 @@ impl TemporalEngine {
             let string_records = state.strings.len();
             let hash_records = state.hashes.len();
             let set_records = state.sets.len();
+            let list_records = state.lists.len();
+            let _ = list_records;
             let feature_records = state.features.len();
             let sequence_records = state.sequences.len();
             let control_state_records =

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -426,6 +426,16 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 &mut rewrite_stats,
             )?;
         }
+        for elements in shard.lists.values_mut() {
+            compact_page_addresses(
+                &self.page_store,
+                &self.cache,
+                shard_id,
+                "list",
+                elements.values_mut(),
+                &mut rewrite_stats,
+            )?;
+        }
         for members in shard.sets.values_mut() {
             compact_page_addresses(
                 &self.page_store,

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -56,6 +56,11 @@ pub(super) struct ShardState {
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,
     #[serde(default, with = "super::set_index_serde")]
     pub(super) sets: HashMap<String, BTreeMap<Vec<u8>, BlockAddress>>,
+    /// Redis-style lists: element pages keyed by a signed sequence -- left pushes walk the
+    /// low end down, right pushes walk the high end up, so both ends are O(log n) and the
+    /// BTree's order IS the list's order.
+    #[serde(default)]
+    pub(super) lists: HashMap<String, BTreeMap<i64, BlockAddress>>,
     pub(super) features: HashMap<String, BTreeMap<u64, BlockAddress>>,
     // Sequence data is now stored in `features` (thin-layer fold: Sequence is Feature
     // with a typed row codec over identical timestamped-KV storage). This field is

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -936,6 +936,7 @@ pub(super) fn shard_has_model_entries(shard: &ShardState) -> bool {
     !shard.strings.is_empty()
         || !shard.hashes.is_empty()
         || !shard.sets.is_empty()
+        || !shard.lists.is_empty()
         || !shard.features.is_empty()
         || !shard.control_state_pages.is_empty()
         || !shard.context_nodes.is_empty()
@@ -959,6 +960,16 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
     for (key, fields) in &shard.hashes {
         entries.extend(fields.iter().map(|(field, address)| {
             live_page_entry(key.clone(), "hash", Some(field.clone()), address.clone())
+        }));
+    }
+    for (key, elements) in &shard.lists {
+        entries.extend(elements.iter().map(|(seq, address)| {
+            live_page_entry(
+                key.clone(),
+                "list",
+                Some(format!("{:016x}", (*seq as u64).wrapping_sub(i64::MIN as u64))),
+                address.clone(),
+            )
         }));
     }
     for (key, members) in &shard.sets {
@@ -1582,6 +1593,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut saw_strings = false;
     let mut saw_hashes = false;
     let mut saw_sets = false;
+    let mut saw_lists = false;
     let mut saw_features = false;
     let mut saw_control_state = false;
     let mut saw_context_events = false;
@@ -1595,6 +1607,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut strings = HashMap::new();
     let mut hashes = HashMap::<String, HashMap<String, BlockAddress>>::new();
     let mut sets = HashMap::<String, BTreeMap<Vec<u8>, BlockAddress>>::new();
+    let mut lists = HashMap::<String, BTreeMap<i64, BlockAddress>>::new();
     let mut features = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut control_state = HashMap::<String, BTreeMap<u64, i64>>::new();
     let mut control_state_pages = HashMap::new();
@@ -1630,6 +1643,19 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
                 sets.entry(entry.object_key)
                     .or_default()
                     .insert(member, entry.address);
+            }
+            "list" => {
+                saw_lists = true;
+                let seq = entry
+                    .component
+                    .as_deref()
+                    .and_then(|component| u64::from_str_radix(component, 16).ok())
+                    .map(|biased| biased.wrapping_add(i64::MIN as u64) as i64)
+                    .unwrap_or_default();
+                lists
+                    .entry(entry.object_key)
+                    .or_default()
+                    .insert(seq, entry.address);
             }
             "feature" => {
                 saw_features = true;
@@ -1761,6 +1787,9 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     }
     if saw_hashes {
         shard.hashes = hashes;
+    }
+    if saw_lists {
+        shard.lists = lists;
     }
     if saw_sets {
         shard.sets = sets;

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -71,6 +71,10 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::SetAdd { key, .. }
         | Command::SetMembers { key }
         | Command::SetRemove { key, .. }
+        | Command::ListPush { key, .. }
+        | Command::ListPop { key, .. }
+        | Command::ListRange { key, .. }
+        | Command::ListLen { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -488,6 +488,79 @@ mod tests {
         );
     }
 
+    /// Lists behave like the native ones: push answers the growing length, order is
+    /// head-to-tail with LPUSH walking the head, pops drain the chosen end, negative LRANGE
+    /// indices count from the tail, and TYPE says "list".
+    #[test]
+    fn list_commands_match_native() {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let mut state = RedisCommandState::default();
+        let mut run = |state: &mut RedisCommandState, args: Vec<&str>| {
+            execute_redis_command_with_state(
+                args.into_iter().map(|arg| arg.as_bytes().to_vec()).collect(),
+                1,
+                state,
+                &mut |command| {
+                    let response = engine.execute(crate::ExecuteRequest {
+                        shard_id: 1,
+                        command,
+                    });
+                    if response.status.ok {
+                        Ok(response.response)
+                    } else {
+                        Err(response.status.message)
+                    }
+                },
+            )
+        };
+
+        assert_eq!(run(&mut state, vec!["RPUSH", "l", "b"]), RespValue::Integer(1));
+        assert_eq!(run(&mut state, vec!["RPUSH", "l", "c", "d"]), RespValue::Integer(3));
+        assert_eq!(run(&mut state, vec!["LPUSH", "l", "a"]), RespValue::Integer(4));
+        assert_eq!(run(&mut state, vec!["LLEN", "l"]), RespValue::Integer(4));
+        assert_eq!(run(&mut state, vec!["TYPE", "l"]), RespValue::SimpleString("list".to_string()));
+
+        let full = RespValue::Array(vec![
+            RespValue::Bulk(Some(b"a".to_vec())),
+            RespValue::Bulk(Some(b"b".to_vec())),
+            RespValue::Bulk(Some(b"c".to_vec())),
+            RespValue::Bulk(Some(b"d".to_vec())),
+        ]);
+        assert_eq!(run(&mut state, vec!["LRANGE", "l", "0", "-1"]), full);
+        assert_eq!(
+            run(&mut state, vec!["LRANGE", "l", "-2", "-1"]),
+            RespValue::Array(vec![
+                RespValue::Bulk(Some(b"c".to_vec())),
+                RespValue::Bulk(Some(b"d".to_vec())),
+            ]),
+            "negative indices count from the tail"
+        );
+        assert_eq!(
+            run(&mut state, vec!["LRANGE", "l", "5", "9"]),
+            RespValue::Array(Vec::new()),
+            "an out-of-window range answers empty, never an error"
+        );
+
+        assert_eq!(run(&mut state, vec!["LPOP", "l"]), RespValue::Bulk(Some(b"a".to_vec())));
+        assert_eq!(run(&mut state, vec!["RPOP", "l"]), RespValue::Bulk(Some(b"d".to_vec())));
+        assert_eq!(
+            run(&mut state, vec!["LPOP", "l", "5"]),
+            RespValue::Array(vec![
+                RespValue::Bulk(Some(b"b".to_vec())),
+                RespValue::Bulk(Some(b"c".to_vec())),
+            ]),
+            "a COUNT larger than the list drains it and answers what there was"
+        );
+        assert_eq!(run(&mut state, vec!["LPOP", "l"]), RespValue::Bulk(None));
+        assert_eq!(run(&mut state, vec!["LLEN", "l"]), RespValue::Integer(0));
+        assert_eq!(run(&mut state, vec!["LLEN", "missing"]), RespValue::Integer(0));
+
+        // Interleaved pushes after a drain keep working -- the sequence space is not consumed.
+        assert_eq!(run(&mut state, vec!["LPUSH", "l", "z"]), RespValue::Integer(1));
+        assert_eq!(run(&mut state, vec!["LPOP", "l"]), RespValue::Bulk(Some(b"z".to_vec())));
+    }
+
     #[test]
     fn set_zero_expiry_match_native() {
         let engine = TemporalEngine::default();
@@ -881,6 +954,12 @@ mod tests {
             "INFO" => vec!["INFO"],
             "INCRBYFLOAT" => vec!["INCRBYFLOAT", "advertised:float", "1.5"],
             "KEYS" => vec!["KEYS", "*"],
+            "LLEN" => vec!["LLEN", "advertised:list"],
+            "LPOP" => vec!["LPOP", "advertised:list"],
+            "LPUSH" => vec!["LPUSH", "advertised:list", "v"],
+            "LRANGE" => vec!["LRANGE", "advertised:list", "0", "-1"],
+            "RPOP" => vec!["RPOP", "advertised:list"],
+            "RPUSH" => vec!["RPUSH", "advertised:list", "v"],
             "MGET" => vec!["MGET", "advertised:missing"],
             "MSET" => vec!["MSET", "advertised:mset", "v"],
             "MSETNX" => vec!["MSETNX", "advertised:msetnx", "v"],

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -196,6 +196,26 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             flags: WRITE,
         },
         RedisCommandDescriptor {
+            name: "LLEN",
+            arity: 2,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "LPOP",
+            arity: -2,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "LPUSH",
+            arity: -3,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "LRANGE",
+            arity: 4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
             name: "MGET",
             arity: -2,
             flags: READ,
@@ -268,6 +288,16 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
         RedisCommandDescriptor {
             name: "RENAMENX",
             arity: 3,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "RPOP",
+            arity: -2,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "RPUSH",
+            arity: -3,
             flags: WRITE,
         },
         RedisCommandDescriptor {

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -686,6 +686,93 @@ pub fn execute_redis_command_with_state(
             }
             RespValue::Integer(removed)
         }
+        "LPUSH" | "RPUSH" if args.len() >= 3 => {
+            let key = string_arg(&args[1]);
+            let left = command == "LPUSH";
+            let mut length = 0;
+            for member in args.iter().skip(2) {
+                match execute(Command::ListPush {
+                    key: key.clone(),
+                    member: member.clone(),
+                    left,
+                }) {
+                    Ok(CommandResponse::Integer { value }) => length = value,
+                    Ok(_) => return RespValue::Error("ERR invalid lpush response".to_string()),
+                    Err(err) => return RespValue::Error(format!("ERR {err}")),
+                }
+            }
+            state.keyspace.insert(key);
+            RespValue::Integer(length)
+        }
+        "LPOP" | "RPOP" if args.len() == 2 || args.len() == 3 => {
+            let key = string_arg(&args[1]);
+            let left = command == "LPOP";
+            // Optional COUNT arg: answers an array (possibly empty) instead of a bulk/nil.
+            let count = if args.len() == 3 {
+                match parse_i64_arg(&args[2], "count") {
+                    Ok(count) if count >= 0 => Some(count),
+                    Ok(_) => return RespValue::Error("ERR value is out of range, must be positive".to_string()),
+                    Err(err) => return RespValue::Error(err),
+                }
+            } else {
+                None
+            };
+            let mut popped = Vec::new();
+            let want = count.unwrap_or(1);
+            for _ in 0..want {
+                match execute(Command::ListPop {
+                    key: key.clone(),
+                    left,
+                }) {
+                    Ok(CommandResponse::Bytes { value: Some(value) }) => popped.push(value),
+                    Ok(CommandResponse::Bytes { value: None }) => break,
+                    Ok(_) => return RespValue::Error("ERR invalid lpop response".to_string()),
+                    Err(err) => return RespValue::Error(format!("ERR {err}")),
+                }
+            }
+            match count {
+                None => match popped.pop() {
+                    Some(value) => RespValue::Bulk(Some(value)),
+                    None => RespValue::Bulk(None),
+                },
+                Some(_) if popped.is_empty() => RespValue::Bulk(None),
+                Some(_) => RespValue::Array(
+                    popped
+                        .into_iter()
+                        .map(|value| RespValue::Bulk(Some(value)))
+                        .collect(),
+                ),
+            }
+        }
+        "LRANGE" if args.len() == 4 => {
+            match (
+                parse_i64_arg(&args[2], "start"),
+                parse_i64_arg(&args[3], "stop"),
+            ) {
+                (Ok(start), Ok(stop)) => match execute(Command::ListRange {
+                    key: string_arg(&args[1]),
+                    start,
+                    stop,
+                }) {
+                    Ok(CommandResponse::Members { members }) => RespValue::Array(
+                        members
+                            .into_iter()
+                            .map(|member| RespValue::Bulk(Some(member)))
+                            .collect(),
+                    ),
+                    Ok(_) => return RespValue::Error("ERR invalid lrange response".to_string()),
+                    Err(err) => return RespValue::Error(format!("ERR {err}")),
+                },
+                (Err(err), _) | (_, Err(err)) => RespValue::Error(err),
+            }
+        }
+        "LLEN" if args.len() == 2 => match execute(Command::ListLen {
+            key: string_arg(&args[1]),
+        }) {
+            Ok(CommandResponse::Integer { value }) => RespValue::Integer(value),
+            Ok(_) => RespValue::Error("ERR invalid llen response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
         "SADD" if args.len() >= 3 => {
             let key = string_arg(&args[1]);
             let mut existing = match execute(Command::SetMembers { key: key.clone() }) {

--- a/crates/temporalstore-rust/src/redis/keyspace_commands.rs
+++ b/crates/temporalstore-rust/src/redis/keyspace_commands.rs
@@ -164,6 +164,14 @@ pub(super) fn redis_type_response(
         Ok(_) => return RespValue::Error("ERR invalid type hash response".to_string()),
         Err(err) => return RespValue::Error(format!("ERR {err}")),
     }
+    match execute(Command::ListLen { key: key.clone() }) {
+        Ok(CommandResponse::Integer { value }) if value > 0 => {
+            return RespValue::SimpleString("list".to_string());
+        }
+        Ok(CommandResponse::Integer { .. }) => {}
+        Ok(_) => return RespValue::Error("ERR invalid type list response".to_string()),
+        Err(err) => return RespValue::Error(format!("ERR {err}")),
+    }
     match execute(Command::SetMembers { key }) {
         Ok(CommandResponse::Members { members }) if !members.is_empty() => {
             RespValue::SimpleString("set".to_string())

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1204,6 +1204,27 @@ pub enum Command {
         #[serde(with = "crate::bytes_serde")]
         member: Vec<u8>,
     },
+    /// Push one element onto a list end (left = head). Answers the new length.
+    ListPush {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+        left: bool,
+    },
+    /// Pop one element off a list end. Answers the element, or nil for an empty/missing list.
+    ListPop {
+        key: String,
+        left: bool,
+    },
+    /// Inclusive range with Redis index semantics (negatives count from the tail).
+    ListRange {
+        key: String,
+        start: i64,
+        stop: i64,
+    },
+    ListLen {
+        key: String,
+    },
     SetMembers {
         key: String,
     },

--- a/crates/temporalstore-rust/tests/list_recovery.rs
+++ b/crates/temporalstore-rust/tests/list_recovery.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! A list's order must survive a restart.
+//!
+//! Elements are pages named by a sortable sequence component in the bucket index, so recovery
+//! rebuilds the in-memory list purely from the index -- including elements pushed on the LEFT,
+//! whose sequences are negative. This drives pushes on both ends, reopens the engine from disk,
+//! and requires the exact order back; then proves pops persist too (a popped element must not
+//! resurrect on the next restart).
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let pid = std::process::id();
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-list-recovery-{name}-{pid}"));
+    root
+}
+
+fn new_engine(root: &PathBuf) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    engine.load_shard(SHARD_ID);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command,
+    });
+    assert!(response.status.ok, "command failed: {:?}", response.status);
+    response.response
+}
+
+fn push(engine: &TemporalEngine, member: &str, left: bool) {
+    run(
+        engine,
+        Command::ListPush {
+            key: "jobs".to_string(),
+            member: member.as_bytes().to_vec(),
+            left,
+        },
+    );
+}
+
+fn range(engine: &TemporalEngine) -> Vec<String> {
+    match run(
+        engine,
+        Command::ListRange {
+            key: "jobs".to_string(),
+            start: 0,
+            stop: -1,
+        },
+    ) {
+        CommandResponse::Members { members } => members
+            .into_iter()
+            .map(|member| String::from_utf8(member).expect("utf8"))
+            .collect(),
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn list_order_survives_restart_and_pops_stay_popped() {
+    let root = unique_root("order");
+    let _ = std::fs::remove_dir_all(&root);
+
+    {
+        let engine = new_engine(&root);
+        push(&engine, "c", false);
+        push(&engine, "b", true);
+        push(&engine, "d", false);
+        push(&engine, "a", true);
+        assert_eq!(vec!["a", "b", "c", "d"], range(&engine));
+    }
+
+    {
+        let engine = new_engine(&root);
+        assert_eq!(
+            vec!["a", "b", "c", "d"],
+            range(&engine),
+            "order must come back from the index alone, negative sequences included"
+        );
+        match run(
+            &engine,
+            Command::ListPop {
+                key: "jobs".to_string(),
+                left: true,
+            },
+        ) {
+            CommandResponse::Bytes { value } => assert_eq!(Some(b"a".to_vec()), value),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    {
+        let engine = new_engine(&root);
+        assert_eq!(
+            vec!["b", "c", "d"],
+            range(&engine),
+            "a popped element must not resurrect on restart"
+        );
+        match run(
+            &engine,
+            Command::ListLen {
+                key: "jobs".to_string(),
+            },
+        ) {
+            CommandResponse::Integer { value } => assert_eq!(3, value),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Second slice of #244 item 3 (the remaining half): a native engine list family plus the RESP verbs over it.

Each element is a page whose bucket-index component is its signed sequence in a biased hex encoding, so lexical component order IS list order — left pushes walk the low end down, right pushes the high end up, both ends O(log n), and recovery rebuilds the list purely from the index, negative sequences included. The family rides every maintenance path the sets ride: delete, expiry, eviction id enumeration, compaction layout + post-compaction address fixups, live-entry export, model kinds, object/page-ref counts.

Over RESP: LPUSH/RPUSH (variadic), LPOP/RPOP (optional COUNT: array answers, nil on empty), LRANGE (negatives from the tail, out-of-window answers empty), LLEN, and TYPE says list — all advertised in the command table with the dispatch-path cross-check.

Tests: RESP conformance (push lengths, head/tail order, COUNT drain, nil sentinels, TYPE) and a restart integration test proving order survives reopen and popped elements do not resurrect. Redis lib suite 11/11; cargo check --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)