### PR TITLE
Metaserver admin surface can require a bearer token

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -7,8 +7,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use temporalstore_rust::http::{
-    get_json_with_options, json_response, parse_json, post_json_with_options, serve, HttpRequest,
-    HttpRequestOptions,
+    get_json_with_options, json_response, parse_json, post_json_with_options, serve,
+    serve_with_stream_handler, HttpRequest, HttpRequestOptions, RequestHead, StreamAction,
+    StreamTransfer,
 };
 use temporalstore_rust::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, AutoRebalanceOptions, ConvictionPolicy,
@@ -316,11 +317,69 @@ fn main() {
     } else {
         None
     };
+    // Admin-surface authentication: read once at startup, like every other
+    // security-relevant setting. Changing the variable on a running process
+    // deliberately does nothing.
+    let admin_token = temporalstore_rust::meta::admin_auth_token();
+    if admin_token.is_some() {
+        info!("metaserver admin token required (TS_META_ADMIN_TOKEN is set)");
+    }
     info!(%addr, "temporalstore metaserver listening");
-    if let Err(err) = serve(&addr, move |request| handle(&backend, &scheduler, request)) {
+    if let Err(err) = serve_with_stream_handler(
+        &addr,
+        move |head: &RequestHead, transfer: &mut StreamTransfer| {
+            admin_auth_gate(admin_token.as_deref(), head, transfer)
+        },
+        move |request| handle(&backend, &scheduler, request),
+    ) {
         error!(%err, "metaserver serve loop exited");
         std::process::exit(1);
     }
+}
+
+/// Routes served without a credential even when an admin token is required:
+/// the liveness/readiness probes and the metrics scrape. Load balancers and
+/// Prometheus cannot reasonably attach a bearer token, and none of these
+/// mutate or reveal tenant data.
+fn admin_auth_exempt(path: &str) -> bool {
+    matches!(
+        path,
+        "/health" | "/readiness" | "/metrics" | "/MasterService/Metrics"
+    )
+}
+
+/// Whether a request may proceed, given the required admin token (None = the
+/// surface is open, the previous behavior).
+fn admin_request_allowed(required: Option<&str>, head: &RequestHead) -> bool {
+    let Some(required) = required else { return true };
+    if admin_auth_exempt(&head.path) {
+        return true;
+    }
+    head.bearer_token.as_deref() == Some(required)
+}
+
+/// The head-stage gate in front of every route: a request that fails the token
+/// check is answered 401 before its body is read into memory, and the
+/// connection stays framed for keep-alive. Allowed requests fall through to
+/// the buffered handler untouched.
+fn admin_auth_gate(
+    required: Option<&str>,
+    head: &RequestHead,
+    transfer: &mut StreamTransfer,
+) -> StreamAction {
+    if admin_request_allowed(required, head) {
+        return StreamAction::Declined;
+    }
+    let body = serde_json::to_vec(&Status::error(
+        "unauthorized",
+        "missing or invalid admin token (TS_META_ADMIN_TOKEN)",
+    ))
+    .unwrap_or_default();
+    let _ = transfer.drain_body();
+    let _ = transfer.send_head(401, "application/json", body.len());
+    let _ = transfer.write_chunk(&body);
+    let _ = transfer.flush();
+    StreamAction::Handled
 }
 
 /// Which node an operation is about.
@@ -4786,5 +4845,89 @@ mod tests {
         let addr = listener.local_addr().unwrap().to_string();
         drop(listener);
         addr
+    }
+
+    fn head_with(path: &str, bearer_token: Option<&str>) -> RequestHead {
+        RequestHead {
+            method: "POST".to_string(),
+            path: path.to_string(),
+            content_length: 0,
+            keep_alive: false,
+            blob_peer_fetch_loop_guard: false,
+            bearer_token: bearer_token.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn without_a_configured_token_every_route_stays_open() {
+        assert!(admin_request_allowed(None, &head_with("/meta/mute", None)));
+        assert!(admin_request_allowed(None, &head_with("/servers/register", None)));
+        assert!(admin_request_allowed(None, &head_with("/health", None)));
+    }
+
+    #[test]
+    fn a_configured_token_gates_every_route_except_the_probes() {
+        let required = Some("s3cret");
+        // Probes stay open: a load balancer cannot attach a bearer token.
+        for probe in ["/health", "/readiness", "/metrics", "/MasterService/Metrics"] {
+            assert!(
+                admin_request_allowed(required, &head_with(probe, None)),
+                "{probe} must stay open"
+            );
+        }
+        // Everything else needs the exact token.
+        for route in ["/meta/mute", "/meta/raft/remove_node", "/meta/snapshot/restore", "/shards"] {
+            assert!(
+                !admin_request_allowed(required, &head_with(route, None)),
+                "{route} must be denied without a token"
+            );
+            assert!(
+                !admin_request_allowed(required, &head_with(route, Some("wrong"))),
+                "{route} must be denied with the wrong token"
+            );
+            assert!(
+                admin_request_allowed(required, &head_with(route, Some("s3cret"))),
+                "{route} must be allowed with the right token"
+            );
+        }
+    }
+
+    #[test]
+    fn the_serve_gate_answers_401_before_the_handler_and_still_serves_health() {
+        let addr = reserve_unused_loopback_addr();
+        let server_addr = addr.clone();
+        std::thread::spawn(move || {
+            let _ = serve_with_stream_handler(
+                &server_addr,
+                |head: &RequestHead, transfer: &mut StreamTransfer| {
+                    admin_auth_gate(Some("s3cret"), head, transfer)
+                },
+                |_request| json_response(200, &Status::ok()),
+            );
+        });
+        let options = HttpRequestOptions {
+            connect_timeout_ms: 1000,
+            io_timeout_ms: 1000,
+            max_retries: 10,
+        };
+        // The probe is served without a credential.
+        let health: Status =
+            get_json_with_options(&addr, "/health", options.clone()).expect("health while gated");
+        assert!(health.ok);
+        // A gated route without the token is refused at the head stage.
+        let denied = get_json_with_options::<Status>(&addr, "/meta/info", options.clone());
+        match denied {
+            Ok(status) => assert!(!status.ok, "an unauthenticated request must not reach the handler"),
+            Err(_) => {} // non-200 surfaces as an HttpError; either shape is a refusal
+        }
+        // The same route with the token reaches the handler.
+        let allowed: Status = temporalstore_rust::http::get_json_with_options_and_headers(
+            &addr,
+            "/meta/info",
+            "Authorization: Bearer s3cret\r\n",
+            options,
+        )
+        .expect("authorized request should reach the handler");
+        assert!(allowed.ok);
     }
 }

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -19,8 +19,9 @@ use temporalstore_rust::data_node::{DataNodeLifecycleSnapshot, DataNodeTopologyV
 use temporalstore_rust::engine::reports::{StorageManagerCycleReport, StorageManagerCycleRequest};
 use temporalstore_rust::engine::TemporalEngine;
 use temporalstore_rust::http::{
-    get_bytes_with_headers, json_response, parse_json, post_json, serve_with_stream_handler,
-    HttpRequest, HttpRequestOptions, StreamAction, StreamTransfer,
+    get_bytes_with_headers, json_response, parse_json, post_json,
+    post_json_with_options_and_headers, serve_with_stream_handler, HttpRequest,
+    HttpRequestOptions, StreamAction, StreamTransfer,
 };
 use std::io::Read as _;
 use temporalstore_rust::ingestion::{FlinkCheckpointStatus, IngestionBatchRequest};
@@ -328,7 +329,13 @@ fn main() {
             location,
             binary_version: binary_version.clone(),
         };
-        match post_json::<_, AckResponse>(&meta_addr, "/servers/register", &server_registration) {
+        match post_json_with_options_and_headers::<_, AckResponse>(
+            &meta_addr,
+            "/servers/register",
+            &server_registration,
+            &temporalstore_rust::meta::admin_auth_header(),
+            HttpRequestOptions::default(),
+        ) {
             Ok(response) if response.status.ok => {
                 info!(server = %advertised_addr, meta = %meta_addr, "registered server with metaserver");
             }
@@ -349,8 +356,13 @@ fn main() {
                 shard_id,
                 server_addr: advertised_addr.clone(),
             };
-            match post_json::<_, RegisterShardResponse>(&meta_addr, "/register_shard", &registration)
-            {
+            match post_json_with_options_and_headers::<_, RegisterShardResponse>(
+                &meta_addr,
+                "/register_shard",
+                &registration,
+                &temporalstore_rust::meta::admin_auth_header(),
+                HttpRequestOptions::default(),
+            ) {
                 Ok(response) if response.status.ok => {
                     info!(shard_id, meta = %meta_addr, "registered shard with metaserver");
                 }
@@ -2413,7 +2425,7 @@ fn validate_node_topology_from_meta(
     let mut fetched_tables = Vec::new();
     let mut fetch_errors = Vec::new();
     for table_name in &table_names {
-        let topology = post_json::<_, TableTopologyResponse>(
+        let topology = post_json_with_options_and_headers::<_, TableTopologyResponse>(
             meta_addr,
             "/tables/topology",
             &GetTableTopologyRequest {
@@ -2422,6 +2434,8 @@ fn validate_node_topology_from_meta(
                 table_name: table_name.clone(),
                 old_topology_version: 0,
             },
+            &temporalstore_rust::meta::admin_auth_header(),
+            HttpRequestOptions::default(),
         );
         match topology {
             Ok(topology) if topology.status.ok => {
@@ -2487,7 +2501,13 @@ fn send_heartbeat(
         shard_states: runtime.shard_serving_states(),
     };
     let response =
-        post_json::<_, ServerHeartbeatResponse>(meta_addr, "/servers/heartbeat", &request)
+        post_json_with_options_and_headers::<_, ServerHeartbeatResponse>(
+            meta_addr,
+            "/servers/heartbeat",
+            &request,
+            &temporalstore_rust::meta::admin_auth_header(),
+            HttpRequestOptions::default(),
+        )
             .unwrap_or_else(|err| ServerHeartbeatResponse {
                 status: Status::error("heartbeat_failed", err.to_string()),
                 forbid_auto_register: false,

--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::http::{
-    get_json, get_json_with_options, post_json, post_json_with_options, HttpError,
+    get_json, get_json_with_options, post_json, post_json_with_options,
+    post_json_with_options_and_headers, HttpError,
     HttpRequestOptions,
 };
 use crate::meta::GetShardResponse;

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -24,7 +24,7 @@ impl TemporalStoreClient {
             .meta_addr
             .as_ref()
             .ok_or_else(|| ClientError::Status("meta_addr is required".to_string()))?;
-        let topology: TableTopologyResponse = match post_json_with_options(
+        let topology: TableTopologyResponse = match post_json_with_options_and_headers(
             meta_addr,
             "/tables/topology",
             &GetTableTopologyRequest {
@@ -33,6 +33,7 @@ impl TemporalStoreClient {
                 table_name: table_name.clone(),
                 old_topology_version: self.last_synced_topology_version(&namespace, &table_name),
             },
+            &crate::meta::admin_auth_header(),
             self.inner.options.meta_sync_http_options(),
         ) {
             Ok(topology) => topology,
@@ -241,12 +242,13 @@ impl TemporalStoreClient {
 
     pub(super) fn current_meta_topology_version(&self) -> Option<u64> {
         let meta_addr = self.inner.options.meta_addr.as_ref()?;
-        let topology = post_json_with_options::<_, TopologyVersionReport>(
+        let topology = post_json_with_options_and_headers::<_, TopologyVersionReport>(
             meta_addr,
             "/meta/topology_version",
             &TopologyVersionRequest {
                 old_topology_version: 0,
             },
+            &crate::meta::admin_auth_header(),
             self.inner.options.meta_sync_http_options(),
         )
         .ok()?;
@@ -266,12 +268,13 @@ impl TemporalStoreClient {
             .meta_addr
             .as_ref()
             .ok_or_else(|| ClientError::Status("meta_addr is required".to_string()))?;
-        let topology: TopologyVersionReport = post_json_with_options(
+        let topology: TopologyVersionReport = post_json_with_options_and_headers(
             meta_addr,
             "/meta/topology_version",
             &TopologyVersionRequest {
                 old_topology_version,
             },
+            &crate::meta::admin_auth_header(),
             self.inner.options.meta_sync_http_options(),
         )?;
         if !topology.status.ok {
@@ -368,12 +371,13 @@ impl TemporalStoreClient {
             .meta_addr
             .as_ref()
             .ok_or_else(|| ClientError::Status("meta_addr is required".to_string()))?;
-        let topology: TopologyVersionReport = post_json_with_options(
+        let topology: TopologyVersionReport = post_json_with_options_and_headers(
             meta_addr,
             "/meta/topology_version",
             &TopologyVersionRequest {
                 old_topology_version,
             },
+            &crate::meta::admin_auth_header(),
             self.inner.options.meta_sync_http_options(),
         )?;
         if !topology.status.ok {

--- a/crates/temporalstore-rust/src/http.rs
+++ b/crates/temporalstore-rust/src/http.rs
@@ -86,6 +86,11 @@ pub struct RequestHead {
     /// other forever. Parsed generically here so the streaming blob handler can
     /// enforce the guard without re-reading the socket headers.
     pub blob_peer_fetch_loop_guard: bool,
+    /// The `Authorization: Bearer <token>` credential, when the request carried
+    /// one. Parsed generically here so a serving layer that requires a token
+    /// (the metaserver's admin surface) can enforce it at the head stage,
+    /// before any body byte is read.
+    pub bearer_token: Option<String>,
 }
 
 /// What a streaming handler did with a request.
@@ -356,7 +361,16 @@ pub fn get_json_with_options<Res: DeserializeOwned>(
     path: &str,
     options: HttpRequestOptions,
 ) -> Result<Res, HttpError> {
-    let raw = request_raw_with_options(addr, "GET", path, &[], "", options)?;
+    get_json_with_options_and_headers(addr, path, "", options)
+}
+
+pub fn get_json_with_options_and_headers<Res: DeserializeOwned>(
+    addr: &str,
+    path: &str,
+    extra_headers: &str,
+    options: HttpRequestOptions,
+) -> Result<Res, HttpError> {
+    let raw = request_raw_with_options(addr, "GET", path, &[], extra_headers, options)?;
     Ok(serde_json::from_slice(&raw)?)
 }
 
@@ -484,6 +498,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<RequestHead, HttpError> {
     let mut content_length = 0usize;
     let mut keep_alive = true;
     let mut blob_peer_fetch_loop_guard = false;
+    let mut bearer_token = None;
     for line in lines {
         if let Some((name, value)) = line.split_once(':') {
             if name.eq_ignore_ascii_case("content-length") {
@@ -494,6 +509,12 @@ fn parse_request_head(bytes: &[u8]) -> Result<RequestHead, HttpError> {
                 // A value of "0" marks the request as a peer-fetch hop: serve it
                 // local-only, never re-forward (loop guard).
                 blob_peer_fetch_loop_guard = value.trim() == "0";
+            } else if name.eq_ignore_ascii_case("authorization") {
+                let value = value.trim();
+                // The scheme name is case-insensitive; the token is not.
+                if value.len() > 7 && value[..7].eq_ignore_ascii_case("bearer ") {
+                    bearer_token = Some(value[7..].trim().to_string());
+                }
             }
         }
     }
@@ -503,6 +524,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<RequestHead, HttpError> {
         content_length,
         keep_alive,
         blob_peer_fetch_loop_guard,
+        bearer_token,
     })
 }
 
@@ -810,6 +832,31 @@ mod tests {
     use serde_json::Value;
     use std::net::TcpListener;
     use std::time::Instant;
+
+    #[test]
+    fn request_head_parses_a_bearer_token() {
+        let head = parse_request_head(
+            b"POST /meta/mute HTTP/1.1\r\nContent-Length: 2\r\nAuthorization: Bearer s3cret\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(head.bearer_token.as_deref(), Some("s3cret"));
+
+        // Header name and scheme are case-insensitive; the token itself is not.
+        let head = parse_request_head(
+            b"GET /health HTTP/1.1\r\nauthorization: bearer MiXeD\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(head.bearer_token.as_deref(), Some("MiXeD"));
+
+        // No credential, or a non-bearer scheme, parses as none.
+        let head = parse_request_head(b"GET /health HTTP/1.1\r\n\r\n").unwrap();
+        assert_eq!(head.bearer_token, None);
+        let head = parse_request_head(
+            b"GET /health HTTP/1.1\r\nAuthorization: Basic dXNlcg==\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(head.bearer_token, None);
+    }
 
     #[test]
     fn client_returns_after_content_length_without_waiting_for_close() {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -14,6 +14,29 @@ use serde::{Deserialize, Serialize};
 
 use crate::control::{ShardStatInfo, ShardCanonicalStorageStats};
 use crate::types::{ShardId, Status};
+
+/// TS_META_ADMIN_TOKEN: shared secret for the metaserver's HTTP surface.
+///
+/// When the metaserver starts with this set, every route except the liveness
+/// probes (`/health`, `/readiness`, `/metrics` and its alias) requires
+/// `Authorization: Bearer <token>`; when unset, the surface stays open, which
+/// is the previous behavior. The same variable is what the metaserver's
+/// clients (proxy, datanode, SDK topology sync) read to attach the credential,
+/// so one value configures a whole deployment.
+pub fn admin_auth_token() -> Option<String> {
+    std::env::var("TS_META_ADMIN_TOKEN")
+        .ok()
+        .filter(|token| !token.is_empty())
+}
+
+/// The ready-to-append header line for metaserver-bound requests, from
+/// TS_META_ADMIN_TOKEN. Empty when unset, so callers can attach it
+/// unconditionally.
+pub fn admin_auth_header() -> String {
+    admin_auth_token()
+        .map(|token| format!("Authorization: Bearer {token}\r\n"))
+        .unwrap_or_default()
+}
 mod partitioning;
 mod lifecycle;
 mod snapshot_ops;

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -39,7 +39,10 @@ use crate::client::{
     ClientStats, ClientTopologyCacheReport, ClientTopologyRefreshReport, ReplicaReadPolicy,
     RequestOptions, TableOptions, TemporalStoreClient,
 };
-use crate::http::{get_json_with_options, post_json_with_options, HttpRequest, HttpRequestOptions};
+use crate::http::{
+    get_json_with_options_and_headers, post_json_with_options_and_headers, HttpRequest,
+    HttpRequestOptions,
+};
 use crate::meta::GetShardResponse;
 use crate::meta::{
     AckResponse, ProxyHeartbeatRequest, ProxyHeartbeatResponse, RegisterProxyRequest,
@@ -1237,9 +1240,10 @@ impl ProxyService {
 
     fn get_shard(&self, shard_id: ShardId, count_error: bool) -> Result<GetShardResponse, Status> {
         let options = self.options();
-        get_json_with_options::<GetShardResponse>(
+        get_json_with_options_and_headers::<GetShardResponse>(
             &options.meta_addr,
             &format!("/shards/{shard_id}"),
+            &crate::meta::admin_auth_header(),
             options.http_options(),
         )
         .map_err(|err| {
@@ -1568,9 +1572,10 @@ impl ProxyService {
         if options.context_shard_count != 0 {
             return;
         }
-        let Ok(listed) = get_json_with_options::<crate::meta::ListShardsResponse>(
+        let Ok(listed) = get_json_with_options_and_headers::<crate::meta::ListShardsResponse>(
             &options.meta_addr,
             "/shards",
+            &crate::meta::admin_auth_header(),
             options.control_http_options(),
         ) else {
             return;

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -30,12 +30,13 @@ impl ProxyService {
         old_topology_version: u64,
     ) -> Result<TopologyVersionReport, Status> {
         let options = self.options();
-        post_json_with_options::<_, TopologyVersionReport>(
+        post_json_with_options_and_headers::<_, TopologyVersionReport>(
             &options.meta_addr,
             "/meta/topology_version",
             &TopologyVersionRequest {
                 old_topology_version,
             },
+            &crate::meta::admin_auth_header(),
             options.control_http_options(),
         )
         .map_err(|err| Status::error("topology_check_failed", err.to_string()))
@@ -55,10 +56,11 @@ impl ProxyService {
             config_version: proxy_config_version(&options),
             binary_version: options.binary_version.clone(),
         };
-        match post_json_with_options::<_, ProxyHeartbeatResponse>(
+        match post_json_with_options_and_headers::<_, ProxyHeartbeatResponse>(
             &options.meta_addr,
             "/proxies/heartbeat",
             &request,
+            &crate::meta::admin_auth_header(),
             options.control_http_options(),
         ) {
             Ok(response) if response.status.ok || response.status.code == "resource_frozen" => {
@@ -84,10 +86,11 @@ impl ProxyService {
                     return response;
                 }
                 if self.auto_register_proxy(&options).status.ok {
-                    let response = post_json_with_options::<_, ProxyHeartbeatResponse>(
+                    let response = post_json_with_options_and_headers::<_, ProxyHeartbeatResponse>(
                         &options.meta_addr,
                         "/proxies/heartbeat",
                         &request,
+                        &crate::meta::admin_auth_header(),
                         options.control_http_options(),
                     )
                     .unwrap_or_else(|err| ProxyHeartbeatResponse {
@@ -176,7 +179,7 @@ impl ProxyService {
             .write()
             .expect("proxy stats lock poisoned")
             .auto_register_total += 1;
-        let response = post_json_with_options::<_, AckResponse>(
+        let response = post_json_with_options_and_headers::<_, AckResponse>(
             &options.meta_addr,
             "/proxies/register",
             &RegisterProxyRequest {
@@ -186,6 +189,7 @@ impl ProxyService {
                 config_version: proxy_config_version(options),
                 binary_version: options.binary_version.clone(),
             },
+            &crate::meta::admin_auth_header(),
             options.control_http_options(),
         )
         .unwrap_or_else(|err| AckResponse {


### PR DESCRIPTION
## What

The metaserver served its **79 routes** — `/meta/mute`, `/meta/raft/remove_node`, `/meta/raft/transfer_leader`, `/meta/snapshot/restore` among them — to anyone who could reach the port. The raft *peer* transport can already require a token; the admin surface could not.

## Design

`TS_META_ADMIN_TOKEN`, read once at startup:

- **When set**, every route except the probes (`/health`, `/readiness`, `/metrics` + alias) requires `Authorization: Bearer <token>`. A request without it is answered **401 at the head stage, before its body is read into memory** — the gate runs in the HTTP layer's streaming pre-handler, so an unauthenticated 100MB POST costs a drain, not a buffer.
- **When unset**, the surface stays open — the previous behavior, so existing deployments change nothing until they opt in (mirrors how the raft transport token is opt-in).

The credential is parsed generically into `RequestHead` (same pattern as the blob peer-fetch loop guard), so the buffered handler and its 79 route arms are untouched.

Every metaserver client attaches the token from the same variable, so one value configures a whole deployment:
- datanode: `/servers/register`, `/register_shard`, `/servers/heartbeat`, `/tables/topology`
- proxy: shard routes, `/proxies/heartbeat`, `/proxies/register`, `/meta/topology_version`
- SDK topology sync: `/tables/topology`, `/meta/topology_version`

## Verification

- Metaserver bin suite: **29 passed, 0 failed**, including the new tests — open-when-unset, probes stay open under a token, exact-token match on gated routes, and an end-to-end over-TCP test proving 401 before the handler plus 200 with the credential.
- `parse_request_head` bearer parsing has its own tests (case-insensitivity of name/scheme, non-bearer schemes ignored).
- Full lib suite, release, single-threaded: **1223 passed**; the single failure is the documented pre-existing `jitter_backoff` failure on main, untouched by this change.
