### PR TITLE
Show the two per-shard backlogs the engine already acts on

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -143,6 +143,49 @@ impl TemporalEngine {
             .config_of(shard_id)
     }
 
+    /// How far behind the log each loaded shard's durable index is, in records.
+    ///
+    /// Records land in the log first and the index accounts for them afterwards; this is the
+    /// distance between. It explains two symptoms that otherwise look unrelated to each other: a
+    /// restart that takes much longer than usual, because everything past the index anchor is
+    /// replayed, and reclaim that frees nothing, because it will not pass that anchor.
+    ///
+    /// Every shard in one pass. Callers that already hold a read lock on the shard table must not
+    /// ask per shard: a second read on the same lock, with a writer queued between them, deadlocks.
+    pub fn shard_index_lags(&self) -> Vec<(ShardId, u64)> {
+        let applied: Vec<(ShardId, u64)> = {
+            let shards = self.shards.read().expect("engine lock poisoned");
+            shards
+                .iter()
+                .map(|(shard_id, shard)| (*shard_id, shard.applied_wal_sequence.unwrap_or(0)))
+                .collect()
+        };
+        applied
+            .into_iter()
+            .map(|(shard_id, applied)| {
+                let appended = self.wal_store.cached_last_sequence(shard_id);
+                (shard_id, appended.saturating_sub(applied))
+            })
+            .collect()
+    }
+
+    /// How many keys each loaded shard is holding an expiry deadline for.
+    ///
+    /// The sweep's own report says what it REMOVED, which looks equally healthy whether the backlog
+    /// behind it is draining or growing. This says which. The engine already decides how hard to
+    /// work from this number -- it becomes the expiry component of the storage cycle's pressure
+    /// signal -- so publishing it only makes visible what is already being acted on.
+    ///
+    /// Every shard in one pass, for the same reason as the trailing distance: a caller inside the
+    /// metrics loop already holds a read lock on the shard table.
+    pub fn shard_expiry_backlogs(&self) -> Vec<(ShardId, u64)> {
+        let shards = self.shards.read().expect("engine lock poisoned");
+        shards
+            .iter()
+            .map(|(shard_id, shard)| (*shard_id, shard.expires_at_ms.len() as u64))
+            .collect()
+    }
+
     /// What a shard's rate limit has allowed and refused, if it has one.
     ///
     /// Absent means the shard is not limited, which is different from a limit that has refused

--- a/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
+++ b/crates/temporalstore-rust/src/engine/prometheus_metrics.rs
@@ -27,6 +27,10 @@ impl TemporalEngine {
         out.push_str("# TYPE temporalstore_page_store_zone_oldest_age_ms gauge\n");
         out.push_str("# HELP temporalstore_shard_rate_limit_total Commands allowed and refused by a rate limit. Absent for a shard with no limit, which is not the same as a limit that has refused nothing.\n");
         out.push_str("# TYPE temporalstore_shard_rate_limit_total counter\n");
+        out.push_str("# HELP temporalstore_shard_index_lag_records Records appended to the log that the durable index has not yet accounted for, by shard. High values mean a longer restart and reclaim that cannot advance.\n");
+        out.push_str("# TYPE temporalstore_shard_index_lag_records gauge\n");
+        out.push_str("# HELP temporalstore_shard_expiring_keys Keys holding an expiry deadline that the sweep has not yet removed, by shard. Rising means expiry is falling behind; the sweep's own counts look healthy either way.\n");
+        out.push_str("# TYPE temporalstore_shard_expiring_keys gauge\n");
         out.push_str(
             "# HELP temporalstore_wal_records_total Write-ahead log append records by shard.\n",
         );
@@ -75,6 +79,13 @@ impl TemporalEngine {
         out.push_str("# TYPE temporalstore_ingestion_stream_committed_sequence gauge\n");
         out.push_str("# HELP temporalstore_ingestion_flink_checkpoint_state Flink checkpoint state as a one-hot gauge.\n");
         out.push_str("# TYPE temporalstore_ingestion_flink_checkpoint_state gauge\n");
+        // Gathered for every shard before the loop below, which holds a read lock on the shard
+        // table: asking per shard inside it takes a second read on that lock, and a writer
+        // queued between the two deadlocks.
+        let index_lags: std::collections::HashMap<ShardId, u64> =
+            self.shard_index_lags().into_iter().collect();
+        let expiry_backlogs: std::collections::HashMap<ShardId, u64> =
+            self.shard_expiry_backlogs().into_iter().collect();
         for stats in self.loaded_shard_stats() {
             push_metric(
                 &mut out,
@@ -133,6 +144,22 @@ impl TemporalEngine {
             // Only for a shard that carries a limit. A shard with none has nothing to count, and
             // emitting zeros would say "this limit refused nothing" about a shard that has no
             // limit at all -- which is the one distinction an operator needs from this.
+            if let Some(waiting) = expiry_backlogs.get(&stats.shard_id) {
+                push_metric(
+                    &mut out,
+                    "temporalstore_shard_expiring_keys",
+                    &[("shard_id", stats.shard_id.to_string())],
+                    *waiting,
+                );
+            }
+            if let Some(lag) = index_lags.get(&stats.shard_id) {
+                push_metric(
+                    &mut out,
+                    "temporalstore_shard_index_lag_records",
+                    &[("shard_id", stats.shard_id.to_string())],
+                    *lag,
+                );
+            }
             if let Some(counters) = self.shard_quota_counters(stats.shard_id) {
                 for (kind, value) in [
                     ("read_allowed", counters.read_allowed),

--- a/crates/temporalstore-rust/src/engine/tests/quota.rs
+++ b/crates/temporalstore-rust/src/engine/tests/quota.rs
@@ -245,3 +245,86 @@ fn the_rate_limit_is_visible_in_the_metrics() {
     assert!(rendered.contains("kind=\"write_allowed\""));
     assert_eq!(engine.rate_limited_shards(), vec![1]);
 }
+
+/// How far the durable index trails the log is visible, and is zero when it has caught up.
+#[test]
+fn how_far_the_index_trails_the_log_is_visible() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    for index in 0..25 {
+        write(&engine, &format!("k{index}"));
+    }
+    let lags = engine.shard_index_lags();
+    let (shard_id, lag) = lags
+        .iter()
+        .find(|(shard_id, _)| *shard_id == 1)
+        .copied()
+        .expect("the loaded shard should report a distance");
+    assert_eq!(shard_id, 1);
+    assert_eq!(lag, 0, "a shard with nothing outstanding should report zero");
+    let rendered = engine.prometheus_metrics();
+    assert!(rendered.contains("# TYPE temporalstore_shard_index_lag_records gauge"));
+    assert!(
+        rendered.contains("temporalstore_shard_index_lag_records{shard_id=\"1\"}"),
+        "a loaded shard should report it: {rendered}"
+    );
+}
+
+/// Reporting it does not deadlock against the lock the metrics loop already holds.
+#[test]
+fn reporting_the_distance_does_not_deadlock_the_metrics_loop() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    for index in 0..10 {
+        write(&engine, &format!("k{index}"));
+    }
+    let writer = {
+        let engine = engine.clone();
+        std::thread::spawn(move || {
+            for index in 0..200 {
+                write(&engine, &format!("w{index}"));
+            }
+        })
+    };
+    for _ in 0..50 {
+        let _ = engine.prometheus_metrics();
+    }
+    writer.join().unwrap();
+}
+
+/// How many keys are waiting to expire is visible, and tracks what was actually set.
+#[test]
+fn how_many_keys_are_waiting_to_expire_is_visible() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = engine_at(dir.path());
+    let backlog_of = |engine: &TemporalEngine| -> u64 {
+        engine
+            .shard_expiry_backlogs()
+            .into_iter()
+            .find(|(shard_id, _)| *shard_id == 1)
+            .map(|(_, waiting)| waiting)
+            .expect("a loaded shard should report a backlog")
+    };
+    for index in 0..10 {
+        write(&engine, &format!("plain{index}"));
+    }
+    assert_eq!(backlog_of(&engine), 0, "keys without a deadline are not waiting");
+    for index in 0..7 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetEx {
+                key: format!("ttl{index}"),
+                value: b"v".to_vec(),
+                ttl_ms: 600_000,
+            },
+        });
+        assert!(response.status.ok, "{}", response.status.message);
+    }
+    assert_eq!(backlog_of(&engine), 7, "every key given a deadline should be counted");
+    let rendered = engine.prometheus_metrics();
+    assert!(rendered.contains("# TYPE temporalstore_shard_expiring_keys gauge"));
+    assert!(
+        rendered.contains("temporalstore_shard_expiring_keys{shard_id=\"1\"} 7"),
+        "the gauge should carry the count: {rendered}"
+    );
+}


### PR DESCRIPTION
Two per-shard backlog numbers the engine already acts on internally but never published. Both are
gathered in the same pass, for the same reason.

## How far the durable index trails the log

Records land in the log first and the index accounts for them afterwards. The distance between the
two explains two symptoms that otherwise look unrelated:

- **a restart that takes far longer than usual**, because everything past the index anchor is
  replayed;
- **reclaim that frees nothing**, because it will not pass that anchor.

Exposed as `temporalstore_shard_index_lag_records`.

## How many keys are waiting to expire

Nothing expiry-related was published at all — though `expires_at_ms.len()` already becomes the
expiry component of the storage cycle's pressure signal, so the engine decides how hard to work from
a figure nobody outside could see.

It answers what the sweep's own report cannot. That report says what it **removed**, which reads as
equally healthy whether the backlog behind it is draining or growing. This says which.

Exposed as `temporalstore_shard_expiring_keys`.

## The one thing that needed care

Both are gathered in **one pass each, before** the metrics loop — never per shard inside it. That
loop already holds a read lock on the shard table, and a second read on a std `RwLock`, with a
writer queued between the two, does not return.

There is a test that renders metrics repeatedly while another thread writes, which is the
arrangement that would expose it.

## Tests

24 pass. The expiry test asserts the **exact** gauge rather than its presence: zero when no key has
a deadline, then exactly seven once seven are given one. Deadlines are set far enough out that the
sweep cannot take them mid-test.

Both numbers are subtractions or lengths of things already in memory — no new bookkeeping.

## Stacked

Depends on #295 for the metrics-header and per-shard emission anchors, so its base is that branch
rather than `main`.

`cargo check --all-targets` clean.
