### PR TITLE
A table that asks for a default value now gets it

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1893,38 +1893,13 @@ struct MasterTableOptionsRequest {
 
 impl MasterTableOptionsRequest {
     fn serving_options(&self) -> temporalstore_rust::meta::TableServingOptions {
-        let mut options = temporalstore_rust::meta::TableServingOptions::default();
-        if let Some(pin_primary) = self.pin_primary {
-            options.pin_primary = pin_primary;
-        }
-        if let Some(replica_read_policy) = &self.replica_read_policy {
-            options.replica_read_policy = replica_read_policy.clone();
-        }
-        if let Some(preferred_location) = &self.preferred_location {
-            options.preferred_location = preferred_location.clone();
-        }
-        if let Some(drop_percent) = self.drop_percent {
-            options.drop_percent = drop_percent;
-        }
-        if let Some(max_read_retries) = self.max_read_retries {
-            options.max_read_retries = max_read_retries;
-        }
-        if let Some(max_write_retries) = self.max_write_retries {
-            options.max_write_retries = max_write_retries;
-        }
-        if let Some(retry_backoff_ms) = self.retry_backoff_ms {
-            options.retry_backoff_ms = retry_backoff_ms;
-        }
-        if let Some(continuous_failed_time_ms) = self.continuous_failed_time_ms {
-            options.continuous_failed_time_ms = continuous_failed_time_ms;
-        }
-        if let Some(io_timeout_ms) = self.io_timeout_ms {
-            options.io_timeout_ms = io_timeout_ms;
-        }
-        if let Some(connect_timeout_ms) = self.connect_timeout_ms {
-            options.connect_timeout_ms = connect_timeout_ms;
-        }
-        options
+        // Built through the patch rather than field by field, so a table created with
+        // an explicit setting is recorded as having set it. Rebuilding the merge here
+        // by hand meant the create path silently dropped that, and a table created
+        // asking for a default value -- `drop_percent: 0`, "never shed this table" --
+        // could not be told apart from one that had asked for nothing.
+        self.serving_options_patch()
+            .onto(temporalstore_rust::meta::TableServingOptions::default())
     }
 
     fn serving_options_patch(&self) -> temporalstore_rust::meta::TableServingOptionsPatch {

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -3,6 +3,7 @@
 
 //! TemporalStoreClient meta topology sync + route refresh/invalidation + reports, split from client.rs.
 use super::*;
+use crate::meta::TableServingField;
 
 impl TemporalStoreClient {
     pub fn sync_table_topology(
@@ -77,28 +78,29 @@ impl TemporalStoreClient {
                 .max(table.topology_version)
         };
         let serving_options = table.serving_options.clone();
-        let default_serving_options = crate::meta::TableServingOptions::default();
+        // Whether the table speaks for a field, or leaves it to this client's own
+        // option. Asking the table settles it; the alternative -- inferring it from
+        // "the value differs from the default" -- silently overrode any table that
+        // chose a default value on purpose, which is exactly what `drop_percent: 0`
+        // ("never shed this table") and `max_write_retries: 0` ("never retry a write
+        // here") are.
+        let table_decides = |field: TableServingField| serving_options.table_decides(field);
         let options = TableOptions {
             table_id: table.table_id,
-            io_timeout_ms: if serving_options.io_timeout_ms == default_serving_options.io_timeout_ms
-            {
-                self.inner.options.io_timeout_ms
-            } else {
+            io_timeout_ms: if table_decides(TableServingField::IoTimeoutMs) {
                 serving_options.io_timeout_ms
-            },
-            connect_timeout_ms: if serving_options.connect_timeout_ms
-                == default_serving_options.connect_timeout_ms
-            {
-                self.inner.options.connect_timeout_ms
             } else {
+                self.inner.options.io_timeout_ms
+            },
+            connect_timeout_ms: if table_decides(TableServingField::ConnectTimeoutMs) {
                 serving_options.connect_timeout_ms
-            },
-            continuous_failed_time_ms: if serving_options.continuous_failed_time_ms
-                == default_serving_options.continuous_failed_time_ms
-            {
-                TableOptions::default().continuous_failed_time_ms
             } else {
+                self.inner.options.connect_timeout_ms
+            },
+            continuous_failed_time_ms: if table_decides(TableServingField::ContinuousFailedTimeMs) {
                 serving_options.continuous_failed_time_ms
+            } else {
+                TableOptions::default().continuous_failed_time_ms
             },
             first_shard_id: table.first_shard_id,
             shard_count: table.shard_count,
@@ -107,36 +109,32 @@ impl TemporalStoreClient {
             replica_read_policy: replica_read_policy_from_meta(
                 &serving_options.replica_read_policy,
             ),
-            preferred_location: if serving_options.preferred_location.is_empty() {
-                self.inner.options.local_location.clone()
-            } else {
+            preferred_location: if table_decides(TableServingField::PreferredLocation)
+                && !serving_options.preferred_location.is_empty()
+            {
                 serving_options.preferred_location.clone()
-            },
-            drop_percent: if serving_options.drop_percent == default_serving_options.drop_percent {
-                self.inner.options.drop_percent.min(100)
             } else {
+                self.inner.options.local_location.clone()
+            },
+            drop_percent: if table_decides(TableServingField::DropPercent) {
                 serving_options.drop_percent.min(100)
-            },
-            max_read_retries: if serving_options.max_read_retries
-                == default_serving_options.max_read_retries
-            {
-                self.inner.options.max_read_retries
             } else {
+                self.inner.options.drop_percent.min(100)
+            },
+            max_read_retries: if table_decides(TableServingField::MaxReadRetries) {
                 serving_options.max_read_retries as usize
-            },
-            max_write_retries: if serving_options.max_write_retries
-                == default_serving_options.max_write_retries
-            {
-                self.inner.options.max_write_retries
             } else {
+                self.inner.options.max_read_retries
+            },
+            max_write_retries: if table_decides(TableServingField::MaxWriteRetries) {
                 serving_options.max_write_retries as usize
-            },
-            retry_backoff_ms: if serving_options.retry_backoff_ms
-                == default_serving_options.retry_backoff_ms
-            {
-                self.inner.options.retry_backoff_ms
             } else {
+                self.inner.options.max_write_retries
+            },
+            retry_backoff_ms: if table_decides(TableServingField::RetryBackoffMs) {
                 serving_options.retry_backoff_ms
+            } else {
+                self.inner.options.retry_backoff_ms
             },
             ..TableOptions::default()
         };

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -534,6 +534,116 @@ fn a_topology_missing_a_primary_keeps_the_route_it_cannot_replace() {
 }
 
 #[test]
+fn a_table_that_asks_for_a_default_value_still_decides_it() {
+    // A table set to shed nothing and to retry no writes, opened by a client that
+    // sheds half its traffic and retries writes twice.
+    //
+    // Both of the table's values equal the field's default. That used to be read as
+    // "the table said nothing", so the client's settings won: the table was shed at
+    // 50% and its writes were retried, which is the reverse of what it asked for.
+    // `drop_percent: 0` is the only way to say "never shed this table" and
+    // `max_write_retries: 0` the only way to say "never retry a write here", so the
+    // two settings whose whole purpose is to hold something back were the two that
+    // could not be expressed.
+    //
+    // max_read_retries is left unset here as the control: it must still come from
+    // the client, or the fix would just be "the table always wins".
+    let meta_addr = free_local_addr();
+    let meta_addr_for_listener = meta_addr.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => json_response(
+                    200,
+                    &TableTopologyResponse {
+                        status: Status::ok(),
+                        table: Some(crate::meta::TableMetaInfo {
+                            table_id: 1,
+                            namespace: "ns".to_string(),
+                            table_name: "tbl".to_string(),
+                            state: crate::meta::MetaEntityState::Normal,
+                            topology_version: 7,
+                            first_shard_id: 10,
+                            shard_count: 4,
+                            replica_count: 2,
+                            partition_version: 0,
+                            serving_options: crate::meta::TableServingOptions {
+                                drop_percent: 0,
+                                max_write_retries: 0,
+                                set_fields: ["drop_percent", "max_write_retries"]
+                                    .into_iter()
+                                    .map(str::to_string)
+                                    .collect(),
+                                ..crate::meta::TableServingOptions::default()
+                            },
+                        }),
+                        shards: Vec::new(),
+                        unchanged: false,
+                    },
+                ),
+                _ => json_response(404, &Status::error("not_found", "not found")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        meta_addr: Some(meta_addr.clone()),
+        drop_percent: 50,
+        max_write_retries: 2,
+        max_read_retries: 9,
+        ..ClientOptions::default()
+    });
+    let table = client.open_table_from_meta("ns", "tbl").unwrap();
+    let options = table.options();
+    assert_eq!(
+        options.drop_percent, 0,
+        "the table asked to shed nothing; the client's 50% must not override it"
+    );
+    assert_eq!(
+        options.max_write_retries, 0,
+        "the table asked for no write retries; the client's 2 must not override it"
+    );
+    assert_eq!(
+        options.max_read_retries, 9,
+        "a field the table never set must still come from the client"
+    );
+}
+
+#[test]
+fn a_table_record_written_before_set_fields_still_inherits_from_the_client() {
+    // The compatibility half. Records persisted before tables recorded which fields
+    // they set carry an empty set, and nothing can recover what was meant from the
+    // values alone. Those must keep behaving exactly as they did: a value equal to
+    // the default is read as unset and the client's own option is used.
+    let options = crate::meta::TableServingOptions::default();
+    assert!(options.set_fields.is_empty());
+    for field in [
+        crate::meta::TableServingField::DropPercent,
+        crate::meta::TableServingField::MaxWriteRetries,
+        crate::meta::TableServingField::MaxReadRetries,
+        crate::meta::TableServingField::IoTimeoutMs,
+        crate::meta::TableServingField::ConnectTimeoutMs,
+        crate::meta::TableServingField::RetryBackoffMs,
+        crate::meta::TableServingField::ContinuousFailedTimeMs,
+    ] {
+        assert!(
+            !options.table_decides(field),
+            "{} carries no record of being set, so the client must still decide it",
+            field.name()
+        );
+    }
+    // And a differing value is still read as set, which is all an older record ever
+    // had to go on.
+    let changed = crate::meta::TableServingOptions {
+        drop_percent: 23,
+        ..crate::meta::TableServingOptions::default()
+    };
+    assert!(changed.table_decides(crate::meta::TableServingField::DropPercent));
+}
+
+#[test]
 fn client_applies_metaserver_table_serving_options() {
     let meta_addr = free_local_addr();
     let meta_addr_for_listener = meta_addr.clone();
@@ -565,6 +675,7 @@ fn client_applies_metaserver_table_serving_options() {
                                 continuous_failed_time_ms: 19,
                                 io_timeout_ms: 321,
                                 connect_timeout_ms: 123,
+                                set_fields: Default::default(),
                             },
                         }),
                         shards: Vec::new(),
@@ -958,6 +1069,7 @@ fn client_deployment_placement_routes_reads_to_local_secondary_and_writes_to_pri
                                     continuous_failed_time_ms: 100,
                                     io_timeout_ms: 1_000,
                                     connect_timeout_ms: 1_000,
+                                    set_fields: Default::default(),
                                 },
                             }),
                             shards: vec![TableShard {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -625,6 +625,94 @@ pub struct TableServingOptions {
     pub io_timeout_ms: u64,
     #[serde(default = "default_table_connect_timeout_ms")]
     pub connect_timeout_ms: u64,
+    /// The fields this table set for itself, by name.
+    ///
+    /// Which fields a table has spoken for is not recoverable from the values: the
+    /// patch that carries them knows, and flattening it into this struct used to
+    /// throw that away. Records written before this field carry none, and are read
+    /// exactly as they were before -- see `table_decides`.
+    #[serde(default)]
+    pub set_fields: BTreeSet<String>,
+}
+
+/// A field of `TableServingOptions`, for naming one without spelling it.
+///
+/// The names go on the wire as plain strings, so a reader that meets a field it does
+/// not know simply carries it; but every name a caller can ask for comes from here,
+/// so a misspelling is a compile error rather than a silent "the table did not set
+/// this".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TableServingField {
+    PinPrimary,
+    ReplicaReadPolicy,
+    PreferredLocation,
+    DropPercent,
+    MaxReadRetries,
+    MaxWriteRetries,
+    RetryBackoffMs,
+    ContinuousFailedTimeMs,
+    IoTimeoutMs,
+    ConnectTimeoutMs,
+}
+
+impl TableServingField {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::PinPrimary => "pin_primary",
+            Self::ReplicaReadPolicy => "replica_read_policy",
+            Self::PreferredLocation => "preferred_location",
+            Self::DropPercent => "drop_percent",
+            Self::MaxReadRetries => "max_read_retries",
+            Self::MaxWriteRetries => "max_write_retries",
+            Self::RetryBackoffMs => "retry_backoff_ms",
+            Self::ContinuousFailedTimeMs => "continuous_failed_time_ms",
+            Self::IoTimeoutMs => "io_timeout_ms",
+            Self::ConnectTimeoutMs => "connect_timeout_ms",
+        }
+    }
+}
+
+impl TableServingOptions {
+    /// Whether this table means to decide `field` itself, rather than leaving it to
+    /// whatever the calling client was configured with.
+    ///
+    /// A table that set the field decides it. Records written before `set_fields`
+    /// existed say nothing about what was set, so for those the only signal left is
+    /// that the value differs from the default -- which is what every caller used to
+    /// rely on, and which cannot express a table deliberately choosing a default
+    /// value. `drop_percent: 0` means "never shed this table" and
+    /// `max_write_retries: 0` means "never retry a write here"; both equal the
+    /// default, so both were quietly replaced by the client's own setting. The two
+    /// options whose whole purpose is to hold something back were the two that could
+    /// not be said.
+    pub fn table_decides(&self, field: TableServingField) -> bool {
+        if self.set_fields.contains(field.name()) {
+            return true;
+        }
+        let defaults = Self::default();
+        match field {
+            TableServingField::PinPrimary => self.pin_primary != defaults.pin_primary,
+            TableServingField::ReplicaReadPolicy => {
+                self.replica_read_policy != defaults.replica_read_policy
+            }
+            TableServingField::PreferredLocation => {
+                self.preferred_location != defaults.preferred_location
+            }
+            TableServingField::DropPercent => self.drop_percent != defaults.drop_percent,
+            TableServingField::MaxReadRetries => self.max_read_retries != defaults.max_read_retries,
+            TableServingField::MaxWriteRetries => {
+                self.max_write_retries != defaults.max_write_retries
+            }
+            TableServingField::RetryBackoffMs => self.retry_backoff_ms != defaults.retry_backoff_ms,
+            TableServingField::ContinuousFailedTimeMs => {
+                self.continuous_failed_time_ms != defaults.continuous_failed_time_ms
+            }
+            TableServingField::IoTimeoutMs => self.io_timeout_ms != defaults.io_timeout_ms,
+            TableServingField::ConnectTimeoutMs => {
+                self.connect_timeout_ms != defaults.connect_timeout_ms
+            }
+        }
+    }
 }
 
 impl Default for TableServingOptions {
@@ -640,6 +728,7 @@ impl Default for TableServingOptions {
             continuous_failed_time_ms: default_continuous_failed_time_ms(),
             io_timeout_ms: default_table_io_timeout_ms(),
             connect_timeout_ms: default_table_connect_timeout_ms(),
+            set_fields: BTreeSet::new(),
         }
     }
 }
@@ -1653,41 +1742,69 @@ fn proxy_serving_mode_for_state(state: MetaEntityState) -> &'static str {
     }
 }
 
-fn apply_serving_options_patch(
-    mut options: TableServingOptions,
-    patch: &TableServingOptionsPatch,
-) -> TableServingOptions {
+impl TableServingOptionsPatch {
+    /// Apply this patch onto `base`, recording which fields it set.
+    ///
+    /// This is the only place the merge is written. It used to exist twice -- once
+    /// here and once in the metaserver's create handler, which rebuilt the same
+    /// field-by-field merge by hand and, having no reason to, did not carry over
+    /// which fields the caller had actually sent. That is how a table created with
+    /// an explicit setting arrived carrying no record of it.
+    pub fn onto(&self, base: TableServingOptions) -> TableServingOptions {
+        let patch = self;
+        let mut options = base;
+    let set = |field: TableServingField, options: &mut TableServingOptions| {
+        options.set_fields.insert(field.name().to_string());
+    };
     if let Some(pin_primary) = patch.pin_primary {
         options.pin_primary = pin_primary;
+        set(TableServingField::PinPrimary, &mut options);
     }
     if let Some(replica_read_policy) = &patch.replica_read_policy {
         options.replica_read_policy = replica_read_policy.clone();
+        set(TableServingField::ReplicaReadPolicy, &mut options);
     }
     if let Some(preferred_location) = &patch.preferred_location {
         options.preferred_location = preferred_location.clone();
+        set(TableServingField::PreferredLocation, &mut options);
     }
     if let Some(drop_percent) = patch.drop_percent {
         options.drop_percent = drop_percent;
+        set(TableServingField::DropPercent, &mut options);
     }
     if let Some(max_read_retries) = patch.max_read_retries {
         options.max_read_retries = max_read_retries;
+        set(TableServingField::MaxReadRetries, &mut options);
     }
     if let Some(max_write_retries) = patch.max_write_retries {
         options.max_write_retries = max_write_retries;
+        set(TableServingField::MaxWriteRetries, &mut options);
     }
     if let Some(retry_backoff_ms) = patch.retry_backoff_ms {
         options.retry_backoff_ms = retry_backoff_ms;
+        set(TableServingField::RetryBackoffMs, &mut options);
     }
     if let Some(continuous_failed_time_ms) = patch.continuous_failed_time_ms {
         options.continuous_failed_time_ms = continuous_failed_time_ms;
+        set(TableServingField::ContinuousFailedTimeMs, &mut options);
     }
     if let Some(io_timeout_ms) = patch.io_timeout_ms {
         options.io_timeout_ms = io_timeout_ms;
+        set(TableServingField::IoTimeoutMs, &mut options);
     }
     if let Some(connect_timeout_ms) = patch.connect_timeout_ms {
         options.connect_timeout_ms = connect_timeout_ms;
+        set(TableServingField::ConnectTimeoutMs, &mut options);
     }
     options
+    }
+}
+
+fn apply_serving_options_patch(
+    options: TableServingOptions,
+    patch: &TableServingOptionsPatch,
+) -> TableServingOptions {
+    patch.onto(options)
 }
 
 fn now_ms() -> u64 {
@@ -5313,6 +5430,81 @@ mod tests {
     }
 
     #[test]
+    fn setting_a_serving_option_to_its_default_value_is_a_real_change() {
+        // "Never shed this table" is spelled drop_percent: 0, and 0 is also the
+        // default. An update carrying it used to compare equal to what the table
+        // already had, so the metaserver answered not_modified and did nothing --
+        // the operator was told plainly that nothing had changed, while the table
+        // went on inheriting whatever shedding its clients were configured with.
+        //
+        // The table now records that it set the field, so this is a change: it says
+        // something the table was not saying before.
+        let meta = SingleNodeMeta::default();
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "tbl".to_string(),
+            first_shard_id: 100,
+            shard_count: 2,
+            replica_count: 1,
+            partition_version: 0,
+            serving_options: crate::meta::TableServingOptions::default(),
+        });
+        let created = meta.list_tables().tables[0].clone();
+        assert_eq!(created.serving_options.drop_percent, 0);
+        assert!(
+            !created
+                .serving_options
+                .table_decides(TableServingField::DropPercent),
+            "a table that never spoke for drop_percent must leave it to the client"
+        );
+
+        let updated = meta.update_table(UpdateTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "tbl".to_string(),
+            shard_count: None,
+            replica_count: None,
+            first_shard_id: None,
+            partition_version: None,
+            serving_options: Some(TableServingOptionsPatch {
+                drop_percent: Some(0),
+                ..TableServingOptionsPatch::default()
+            }),
+        });
+        assert!(
+            updated.status.ok,
+            "asking to shed nothing must be accepted, not answered not_modified: {updated:?}"
+        );
+
+        let table = meta.list_tables().tables[0].clone();
+        assert_eq!(table.serving_options.drop_percent, 0);
+        assert!(
+            table
+                .serving_options
+                .table_decides(TableServingField::DropPercent),
+            "the table has now spoken for drop_percent and must decide it"
+        );
+        assert!(
+            table.topology_version > created.topology_version,
+            "clients only pick this up if the topology version moves"
+        );
+
+        // Saying the same thing twice really is unchanged.
+        let again = meta.update_table(UpdateTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "tbl".to_string(),
+            shard_count: None,
+            replica_count: None,
+            first_shard_id: None,
+            partition_version: None,
+            serving_options: Some(TableServingOptionsPatch {
+                drop_percent: Some(0),
+                ..TableServingOptionsPatch::default()
+            }),
+        });
+        assert_eq!(again.status.code, "not_modified");
+    }
+
+    #[test]
     fn metaserver_update_table_expands_topology_and_guards_unsafe_changes() {
         let meta = SingleNodeMeta::default();
         meta.add_table(AddTableRequest {
@@ -5426,6 +5618,7 @@ mod tests {
                     continuous_failed_time_ms: 22,
                     io_timeout_ms: 333,
                     connect_timeout_ms: 444,
+                    set_fields: Default::default(),
                 },
             })
             .status

--- a/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
+++ b/crates/temporalstore-rust/tests/unified_temporalstore_corpus.rs
@@ -2710,6 +2710,7 @@ fn verify_client_deployment_placement_routing() {
                                 continuous_failed_time_ms: 100,
                                 io_timeout_ms: 1_000,
                                 connect_timeout_ms: 1_000,
+                                set_fields: Default::default(),
                             },
                         }),
                         shards: vec![TableShard {


### PR DESCRIPTION
Table serving options are overlaid on the client's own options one field at a time,
and which of the two wins was decided by asking whether the table's value differed
from that field's default. A value equal to the default was read as "the table said
nothing", so the client's setting was used instead.

That cannot express a table that chose a default value deliberately, and two of the
ten fields are only meaningful when it does:

  drop_percent: 0       -- never shed this table
  max_write_retries: 0  -- never retry a write here

Both equal the default. So a table configured to shed nothing, opened by a client
shedding half its traffic, was shed at half its traffic; and a table configured to
retry no writes, opened by a client that retries twice, retried twice. The two
settings whose whole purpose is to hold something back were the two that could not be
said, and the failure was silent -- the table reported the options it had been given,
and the client used different ones.

The information existed and was thrown away: the patch that carries these options is
per-field optional, so the metaserver knows exactly which fields a caller set, and
then flattened them into a struct that does not. Tables now record the fields they
set, and the overlay asks that instead of guessing from the values.

Records written before this carry no such record, and nothing can recover intent from
their values alone, so they keep the old reading exactly: a value equal to the default
is treated as unset. That is a compatibility path, not a second policy -- it applies
only where the real answer was never stored.

Field names are reachable only through an enum, so a misspelling is a compile error
rather than a quiet "the table did not set this".

The sharpest form of it was on the write path. Because the stored options compared
equal, an operator asking a fresh table to shed nothing was answered "not_modified":
told in as many words that nothing had changed, while the table went on inheriting
whatever its clients were configured with. That request is now a real change, because
it says something the table was not saying before; repeating it is still not_modified.