### PR TITLE
An aging round counts what it dropped, not what it meant to drop

### DIFF
--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -522,13 +522,17 @@ impl SingleNodeMeta {
     /// every exported snapshot - forever.
     pub fn age_frozen_meta(&self, options: FreezeAgingOptions) -> FreezeAgingReport {
         let plan = self.plan_freeze_aging_now(options);
-        self.metrics.record_freeze_aging(&plan);
         if plan.is_empty() {
+            self.metrics.record_freeze_aging(&plan, &plan);
             return FreezeAgingReport {
                 status: Status::ok(),
                 plan,
             };
         }
+        // What the round actually got done, which stops matching the plan the
+        // moment a drop is refused: the round returns there and leaves the rest
+        // of the plan standing.
+        let mut applied = FreezeAgingPlan::default();
         // Routed through the ordinary state setters so the drop is recorded in
         // the mutation log, stamps `dropped_since_ms`, and emits the same
         // topology event an operator-driven drop would.
@@ -539,11 +543,13 @@ impl SingleNodeMeta {
                 reason: FreezeReason::Unspecified,
             });
             if !response.status.ok {
+                self.metrics.record_freeze_aging(&plan, &applied);
                 return FreezeAgingReport {
                     status: response.status,
                     plan,
                 };
             }
+            applied.proxies.push(addr.clone());
         }
         for key in &plan.tables {
             // `table_key` joins on '/', so the key must be split on the same
@@ -557,11 +563,13 @@ impl SingleNodeMeta {
                 table_name: table_name.to_string(),
             });
             if !response.status.ok {
+                self.metrics.record_freeze_aging(&plan, &applied);
                 return FreezeAgingReport {
                     status: response.status,
                     plan,
                 };
             }
+            applied.tables.push(key.clone());
         }
         for addr in &plan.servers {
             let response = self.drop_server(StateChangeRequest {
@@ -570,12 +578,15 @@ impl SingleNodeMeta {
                 reason: FreezeReason::Unspecified,
             });
             if !response.status.ok {
+                self.metrics.record_freeze_aging(&plan, &applied);
                 return FreezeAgingReport {
                     status: response.status,
                     plan,
                 };
             }
+            applied.servers.push(addr.clone());
         }
+        self.metrics.record_freeze_aging(&plan, &applied);
         FreezeAgingReport {
             status: Status::ok(),
             plan,
@@ -973,6 +984,72 @@ mod tests {
         assert_eq!(purged.plan.servers, vec!["node-a"]);
         assert!(meta.list_servers().servers.is_empty());
         assert!(meta.export_snapshot().servers.is_empty());
+    }
+
+    #[test]
+    fn a_round_that_stops_early_does_not_count_what_it_did_not_drop() {
+        // `temporalstore_meta_freeze_aged_total` is documented as "Frozen
+        // resources aged into the dropped state", but it was incremented from
+        // the plan before the round ran. A round returns on the first drop that
+        // fails and leaves the rest of the plan untouched, so the counter
+        // claimed resources had reached Dropped that are still sitting there
+        // frozen -- and a counter is exactly what an operator would trust to
+        // tell them aging is keeping up.
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.register_proxy(RegisterProxyRequest {
+            proxy_addr: "p1".to_string(),
+            namespace: String::new(),
+            location: "rack-1".to_string(),
+            config_version: 0,
+            binary_version: "v1".to_string(),
+        });
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let frozen = meta.freeze_stale_resources(0);
+        assert_eq!(frozen.frozen_servers, vec!["node-a"]);
+        assert_eq!(frozen.frozen_proxies, vec!["p1"]);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        // Muting metadata change refuses every drop the round attempts, so it
+        // stops on the first one. The background loop checks the mute before a
+        // round, but a round is many drops and the mute can land inside one.
+        assert!(meta.set_meta_change_muted(true).status.ok);
+
+        let report = meta.age_frozen_meta(aging(FreezeAgingOptions {
+            server_freeze_ms: 1,
+            proxy_freeze_ms: 1,
+            ..FreezeAgingOptions::default()
+        }));
+        assert!(
+            !report.status.ok,
+            "the round should have been refused: {report:?}"
+        );
+        assert_eq!(
+            meta.list_servers().servers[0].state,
+            MetaEntityState::Frozen,
+            "nothing was dropped, so the server is still frozen"
+        );
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_freeze_aged_total{kind=\"proxy\"} 0"),
+            "counted a proxy the round never dropped:\n{exported}"
+        );
+        assert!(
+            exported.contains("temporalstore_meta_freeze_aged_total{kind=\"server\"} 0"),
+            "counted a server the round never dropped:\n{exported}"
+        );
+        // The round still happened, and the cap it hit is still the plan's.
+        assert!(
+            exported.contains("temporalstore_meta_detector_rounds_total{subsystem=\"freeze_aging\"} 1"),
+            "the round itself stopped being counted:\n{exported}"
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/shard_check.rs
+++ b/crates/temporalstore-rust/src/meta/shard_check.rs
@@ -425,6 +425,45 @@ impl SingleNodeMeta {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_server_the_check_skipped_is_not_reported_as_consistent() {
+        // The check skips a server that has never reported shard states -- it
+        // `continue`s, so that server's shards are never examined. Without this
+        // reported, `diverged 0` means either "nothing diverged" or "the servers
+        // that mattered were never looked at", and nothing tells them apart.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
+                server_addr: "quiet".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+
+        let mut checker = ShardChecker::new(ShardCheckOptions::default());
+        let (report, _) = meta.check_shard_divergence(&mut checker);
+        assert!(report.diverged.is_empty());
+        assert_eq!(report.skipped_without_shard_reports.len(), 1, "{report:?}");
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains(
+                "temporalstore_meta_divergence_skipped{reason=\"no_shard_reports\"} 1"
+            ),
+            "a server the check never examined was not reported:\n{exported}"
+        );
+        // And the clean reason stays at zero, so the two are distinguishable.
+        assert!(
+            exported
+                .contains("temporalstore_meta_divergence_skipped{reason=\"reboot_grace\"} 0"),
+            "{exported}"
+        );
+    }
+
     use super::*;
 
     fn owners(pairs: &[(ShardId, &str)]) -> BTreeMap<ShardId, String> {

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -153,16 +153,24 @@ impl SubsystemMetrics {
     }
 
     /// Record one freeze-aging round.
-    pub fn record_freeze_aging(&self, plan: &FreezeAgingPlan) {
+    /// Record one aging round: `plan` is what it set out to do, `applied` is
+    /// what it actually dropped.
+    ///
+    /// They are the same only when the round ran to the end. A drop that is
+    /// refused returns from the round with the rest of the plan untouched, and
+    /// counting the plan there reports resources as aged into the dropped state
+    /// while they are still sitting in the metadata, frozen. The cap still comes
+    /// from the plan: what a round held back is a fact about planning it.
+    pub fn record_freeze_aging(&self, plan: &FreezeAgingPlan, applied: &FreezeAgingPlan) {
         self.with(|state| {
             *state
                 .rounds_total
                 .entry("freeze_aging".to_string())
                 .or_default() += 1;
             for (kind, count) in [
-                ("server", plan.servers.len()),
-                ("proxy", plan.proxies.len()),
-                ("table", plan.tables.len()),
+                ("server", applied.servers.len()),
+                ("proxy", applied.proxies.len()),
+                ("table", applied.tables.len()),
             ] {
                 *state.aged_total.entry(kind.to_string()).or_default() += count as u64;
             }
@@ -619,12 +627,14 @@ mod tests {
             blocked_servers: vec!["s2".to_string()],
             capped: 3,
         });
-        metrics.record_freeze_aging(&FreezeAgingPlan {
+        let aged = FreezeAgingPlan {
             servers: vec!["s3".to_string()],
             proxies: Vec::new(),
             tables: Vec::new(),
             capped: 0,
-        });
+        };
+        // A round that ran to the end: what it applied is what it planned.
+        metrics.record_freeze_aging(&aged, &aged);
 
         let rendered = metrics.prometheus();
         assert_eq!(

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -61,6 +61,8 @@ struct SubsystemMetricsState {
     divergence_rate_limited: u64,
     retention_blocked_servers: u64,
     retention_capped: u64,
+    freeze_aging_capped: u64,
+    divergence_skipped: BTreeMap<String, u64>,
 }
 
 /// Shared recorder for background-subsystem outcomes.
@@ -115,6 +117,18 @@ impl SubsystemMetrics {
             state.diverged_now = report.diverged.len() as u64;
             state.settling_now = report.settling.len() as u64;
             state.divergence_rate_limited = report.rate_limited as u64;
+            // Servers the check declined to look at. Without these, a reported
+            // zero means either "nothing diverged" or "the servers that mattered
+            // were never examined", and an operator cannot tell which. A server
+            // that has never reported shard states is skipped outright.
+            for (reason, servers) in [
+                ("reboot_grace", &report.skipped_in_reboot_grace),
+                ("no_shard_reports", &report.skipped_without_shard_reports),
+            ] {
+                state
+                    .divergence_skipped
+                    .insert(reason.to_string(), servers.len() as u64);
+            }
         });
     }
 
@@ -152,6 +166,10 @@ impl SubsystemMetrics {
             ] {
                 *state.aged_total.entry(kind.to_string()).or_default() += count as u64;
             }
+            // Retention reports the work its per-round cap held back; freeze
+            // aging has the same field and was not reporting it, so a round
+            // doing less than it wanted looked like a round with less to do.
+            state.freeze_aging_capped = plan.capped as u64;
         });
     }
 
@@ -369,6 +387,24 @@ fn render(state: &SubsystemMetricsState) -> String {
         state.retention_blocked_servers,
     );
 
+    out.push_str("# HELP temporalstore_meta_freeze_aging_capped Freeze-aging work the per-round cap held back last round.\n");
+    out.push_str("# TYPE temporalstore_meta_freeze_aging_capped gauge\n");
+    push(
+        &mut out,
+        "temporalstore_meta_freeze_aging_capped",
+        &[],
+        state.freeze_aging_capped,
+    );
+    out.push_str("# HELP temporalstore_meta_divergence_skipped Servers the divergence check did not examine last round.\n");
+    out.push_str("# TYPE temporalstore_meta_divergence_skipped gauge\n");
+    for (reason, value) in &state.divergence_skipped {
+        push(
+            &mut out,
+            "temporalstore_meta_divergence_skipped",
+            &[("reason", reason)],
+            *value,
+        );
+    }
     out.push_str("# HELP temporalstore_meta_retention_capped Purges the per-round cap held back last round.\n");
     out.push_str("# TYPE temporalstore_meta_retention_capped gauge\n");
     push(


### PR DESCRIPTION
`temporalstore_meta_freeze_aged_total` is documented as *"Frozen resources aged
into the dropped state"*. It was incremented from the plan, before the round
dropped any of it.

## Why that is wrong

`age_frozen_meta` stops at the first drop that is refused and returns, leaving
the rest of the plan standing:

```rust
let response = self.drop_proxy(...);
if !response.status.ok {
    return FreezeAgingReport { status: response.status, plan };
}
```

Everything the round had not reached was already counted as dropped. The
counter then reports that aging is keeping up while frozen resources pile up in
the metadata -- and a counter is exactly what an operator would trust to tell
them otherwise.

Two ordinary ways in:

- **Metadata change is muted mid-round.** The background loop checks the mute
  before starting a round, but a round is many drops and every drop goes
  through `set_proxy_state` / `set_server_state`, which refuse while muted.
- **A table is deleted between planning and applying**, so `delete_table`
  answers `table_not_found`.

## The change

Record what the round applied rather than what it planned. The cap still comes
from the plan -- what a round held back is a fact about planning it -- and the
round itself is still counted whether or not it ran to the end.

## Test

Freeze a server and a proxy, mute metadata change, then run a round. It is
refused on the first drop, the server is still `Frozen`, and:

- `temporalstore_meta_freeze_aged_total{kind="proxy"}` is `0`
- `temporalstore_meta_freeze_aged_total{kind="server"}` is `0`
- `temporalstore_meta_detector_rounds_total{subsystem="freeze_aging"}` is `1`

On the unmodified code it fails with `counted a proxy the round never dropped`.

## Base

Stacked on #276, which owns the current shape of `record_freeze_aging` (it
added the cap reporting). **Merge #276 first.**

It targets `main` rather than #276's branch on purpose: `rust-ci` and
`oss-readiness` both declare `pull_request: branches: [main, rust-main]`, and
for `pull_request` that filters the *base*. A pull request aimed at any other
branch therefore gets only auto-approve, SPDX and gitleaks -- it is never
compiled and its tests are never run, while still reporting `CLEAN`. Targeting
`main` means the diff here also carries #276's commit, and CI builds the two
together, which is the state that will actually land. Once #276 merges, this
diff reduces to its own commit on its own.
