### PR TITLE
Upsert index-log deltas: an append logs the pages it wrote, not the store

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -505,6 +505,7 @@ impl TemporalEngine {
             // Capture this write's touched keys for the O(delta) index-log append below
             // (the command is moved into the WAL append before we reach that point).
             let delta_command_keys = object_keys.clone();
+            let upsert_components = command_upsert_components(&command);
             if object_keys.is_empty() {
                 rebuild_bucket_page_ownership(
                     request.shard_id,
@@ -681,12 +682,27 @@ impl TemporalEngine {
                 // stream. The whole base index is NOT rewritten per write (that O(store) path
                 // is gone); the base is materialized at compaction/unload, the funnel serves
                 // the live in-memory shard between them, and cold reload folds base + deltas.
-                let items = collect_command_index_items(
-                    shard,
-                    &delta_command_keys,
-                    start_routing_bucket,
-                    end_routing_bucket,
-                );
+                let (items, upsert_record) = match &upsert_components {
+                    Some(components) => (
+                        collect_upsert_index_items(
+                            shard,
+                            request.shard_id,
+                            components,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                        ),
+                        true,
+                    ),
+                    None => (
+                        collect_command_index_items(
+                            shard,
+                            &delta_command_keys,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                        ),
+                        false,
+                    ),
+                };
                 let key_states = capture_key_states(shard, &delta_command_keys);
                 // `durable` fsyncs the delta record before returning. Deferred on the raft
                 // apply path (raft log is the durability source) and, under the single-barrier
@@ -703,6 +719,7 @@ impl TemporalEngine {
                     key_states,
                     shard.applied_wal_sequence,
                     None,
+                    upsert_record,
                     index_log_durable,
                 );
             }
@@ -1514,6 +1531,91 @@ fn serialize_index(shard: &ShardState) -> Vec<u8> {
 /// touched key. Deleted pages ride as `deleted` tombstones so a fold applies the removal.
 /// Empty when the command has no object keys (e.g. a context rebuild command); the caller
 /// still appends the record so the index-log sequence advances per write.
+/// The (kind, object_key, component) writes a command performs when -- and only when -- every
+/// one of them lands through the page-upsert path (one new page per component, predecessor
+/// replaced). `None` = the command's write shape is not a pure upsert (deletes, features,
+/// rewrites), and the caller must fall back to the whole-object snapshot record.
+fn command_upsert_components(
+    command: &Command,
+) -> Option<Vec<(&'static str, String, Option<String>)>> {
+    match command {
+        Command::HashSet { key, field, .. } => {
+            Some(vec![("hash", key.clone(), Some(field.clone()))])
+        }
+        Command::HashMultiSet { key, entries } => Some(
+            entries
+                .iter()
+                .map(|(field, _)| ("hash", key.clone(), Some(field.clone())))
+                .collect(),
+        ),
+        Command::HashIncrBy { key, field, .. } => {
+            Some(vec![("hash", key.clone(), Some(field.clone()))])
+        }
+        Command::StringSet { key, .. } => Some(vec![("string", key.clone(), None)]),
+        _ => None,
+    }
+}
+
+/// Build the exact index items for an upsert record from post-apply shard state: each written
+/// component's address is read back from the map the write just updated, so the logged page is
+/// precisely the one a reload must serve. A component absent from the map (its append failed)
+/// is skipped -- it produced no page to pin.
+fn collect_upsert_index_items(
+    shard: &ShardState,
+    shard_id: ShardId,
+    components: &[(&'static str, String, Option<String>)],
+    start_routing_bucket: u32,
+    end_routing_bucket: u32,
+) -> Vec<crate::index_log::IndexItem> {
+    let mut items = Vec::with_capacity(components.len());
+    for (kind, object_key, component) in components {
+        let address = match (*kind, component) {
+            ("hash", Some(field)) => shard
+                .hashes
+                .get(object_key)
+                .and_then(|fields| fields.get(field))
+                .cloned(),
+            ("string", None) => shard.strings.get(object_key).cloned(),
+            _ => None,
+        };
+        let Some(address) = address else { continue };
+        let routing_bucket = address
+            .routing_bucket
+            .unwrap_or_else(|| {
+                page_routing_bucket(object_key, start_routing_bucket, end_routing_bucket)
+            });
+        let object_id = address.object_id.unwrap_or_else(|| {
+            stable_page_object_id(shard_id, kind, object_key, component.as_deref())
+        });
+        let page_ref_key = format!(
+            "{}:{}:{}:{}:{}:{}:{}:{}",
+            kind,
+            object_key,
+            component.as_deref().unwrap_or(""),
+            address.page_slab_id,
+            address.offset,
+            address.length,
+            address.page_id.unwrap_or_default(),
+            address.generation.unwrap_or_default()
+        );
+        items.push(crate::index_log::IndexItem {
+            kind: crate::index_log::IndexItemKind::Page,
+            routing_bucket,
+            page_ref_key,
+            object_key: object_key.clone(),
+            model_id: (*kind).to_string(),
+            component: component.clone(),
+            object_id,
+            page_id: address.page_id.unwrap_or(0),
+            size: address.length,
+            in_log: address.page_id.is_none(),
+            deleted: false,
+            address: Some(address),
+        });
+    }
+    items
+}
+
 fn collect_command_index_items(
     shard: &ShardState,
     command_keys: &[String],
@@ -1689,8 +1791,24 @@ fn fold_delta_page_items(
     bucket_index: &mut CoreIndex,
     covered_keys: &BTreeSet<String>,
     items: &[crate::index_log::IndexItem],
+    upsert: bool,
 ) {
-    if !covered_keys.is_empty() {
+    if upsert {
+        // Upsert record: each item replaces exactly its (kind, object, component) predecessor,
+        // the same replacement the write path performed in memory. The predecessor lives in the
+        // same routing bucket (the bucket derives from the object key), so the removal scans one
+        // bucket per item and the covered-key wipe below stays untouched for snapshot records.
+        for item in items {
+            let Some(bucket) = bucket_index.bucket_map.get_mut(&item.routing_bucket) else {
+                continue;
+            };
+            bucket.page_index.retain(|_, page| {
+                !(page.model_id == item.model_id
+                    && page.object_key == item.object_key
+                    && page.component == item.component)
+            });
+        }
+    } else if !covered_keys.is_empty() {
         for bucket in bucket_index.bucket_map.values_mut() {
             bucket
                 .page_index

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -297,7 +297,7 @@ impl TemporalEngine {
                 continue;
             }
             let covered = delta_record_covered_keys(record);
-            fold_delta_page_items(&mut shard.bucket_index, &covered, &record.items);
+            fold_delta_page_items(&mut shard.bucket_index, &covered, &record.items, record.upsert);
             apply_key_states(shard, &record.key_states);
             max_anchor = max_anchor.max(record_anchor);
             applied = true;
@@ -465,6 +465,7 @@ impl TemporalEngine {
                 Vec::new(),
                 Some(anchor),
                 Some(meta),
+                false,
                 true,
             )
             .is_err()

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -208,6 +208,10 @@ impl TemporalEngine {
         // Accumulate the object keys every mutating command in the batch touched, for the
         // single O(delta) index-log append below (delta path). Empty when the flag is off.
         let mut delta_command_keys: Vec<String> = Vec::new();
+        // Some(components) while every mutating command in the batch is a pure page-upsert;
+        // one non-upsert write downgrades the whole record to snapshot semantics.
+        let mut batch_upsert_components: Option<Vec<(&'static str, String, Option<String>)>> =
+            Some(Vec::new());
         for command in request.commands {
             let write_command = is_write_command(&command);
             if readonly && write_command {
@@ -285,6 +289,13 @@ impl TemporalEngine {
                 mutated_any = true;
                 let object_keys = command_object_keys(&command_for_post_write);
                 delta_command_keys.extend(object_keys.iter().cloned());
+                match (
+                    &mut batch_upsert_components,
+                    command_upsert_components(&command_for_post_write),
+                ) {
+                    (Some(collected), Some(components)) => collected.extend(components),
+                    (state, _) => *state = None,
+                }
                 if object_keys.is_empty() {
                     rebuild_bucket_page_ownership(
                         request.shard_id,
@@ -374,12 +385,27 @@ impl TemporalEngine {
                 // Append the pages this batch changed (O(delta)) to the index-log (advances
                 // the sequence + populates the delta stream). The whole-index base rewrite is
                 // deferred to the next compaction point (see the single-command execute path).
-                let items = collect_command_index_items(
-                    shard,
-                    &delta_command_keys,
-                    start_routing_bucket,
-                    end_routing_bucket,
-                );
+                let (items, upsert_record) = match &batch_upsert_components {
+                    Some(components) => (
+                        collect_upsert_index_items(
+                            shard,
+                            request.shard_id,
+                            components,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                        ),
+                        true,
+                    ),
+                    None => (
+                        collect_command_index_items(
+                            shard,
+                            &delta_command_keys,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                        ),
+                        false,
+                    ),
+                };
                 let key_states = capture_key_states(shard, &delta_command_keys);
                 let _ = self.index_log_store.append_delta(
                     request.shard_id,
@@ -387,6 +413,7 @@ impl TemporalEngine {
                     key_states,
                     shard.applied_wal_sequence,
                     None,
+                    upsert_record,
                     // Non-blocking on the raft apply path (raft log is the durability source).
                     !raft_applying(),
                 );

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -186,6 +186,15 @@ pub struct IndexDeltaRecord {
     /// pages the deltas already pin at their original addresses).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub applied_wal_sequence: Option<u64>,
+    /// When true, this record's items are the exact pages the write produced: replay replaces
+    /// each item's (kind, object, component) predecessor and inserts, WITHOUT the covered-key
+    /// wipe -- mirroring the write path's upsert_bucket_index_page. When false (the default,
+    /// and every record written before this field existed), the record snapshots each covered
+    /// object's whole page set and replay wipes-then-restores. The snapshot shape is what made
+    /// every append O(store): a batch touching the grow-with-the-store index hashes logged
+    /// every page of each of them, every time.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub upsert: bool,
     /// Opaque per-touched-key state blobs (one JSON object per key) carrying the
     /// authoritative post-write value of the maps that are NOT reconstructable from a
     /// single page-index entry -- packed timestamped series (feature membership survives
@@ -522,6 +531,7 @@ impl LocalIndexLogStore {
         key_states: Vec<serde_json::Value>,
         applied_wal_sequence: Option<u64>,
         meta: Option<MetaItem>,
+        upsert: bool,
         durable: bool,
     ) -> Result<u64, IndexLogError> {
         if bulk_ingest_mode() || !indexlog_enabled() {
@@ -545,6 +555,7 @@ impl LocalIndexLogStore {
             meta,
             applied_wal_sequence,
             key_states,
+            upsert,
         };
         // Frame the delta record with a length + SHA-256 digest (crate::log_framing) so a
         // value-preserving bit-flip (e.g. a flipped `deleted` flag or page address) in this
@@ -974,11 +985,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         let seq1 = store
-            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
+            .append_delta(7, vec![page_item(1, "a", false)], Vec::new(), None, None, false, true)
             .unwrap();
         assert_eq!(seq1, 1);
         let seq2 = store
-            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None, true)
+            .append_delta(7, vec![page_item(1, "b", false)], Vec::new(), None, None, false, true)
             .unwrap();
         assert_eq!(seq2, 2);
         // The two single-item deltas together are far smaller than a whole-index blob
@@ -1016,10 +1027,10 @@ mod tests {
         // A legacy whole-index record and a delta record share the log file.
         store.append_json(9, b"{\"value\":1}").unwrap();
         let anchor_seq = store
-            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
+            .append_delta(9, vec![page_item(1, "a", false)], Vec::new(), None, None, false, true)
             .unwrap();
         store
-            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None, true)
+            .append_delta(9, vec![page_item(1, "b", false)], Vec::new(), None, None, false, true)
             .unwrap();
         // Only delta records are returned; the whole-index line is ignored.
         let all = store.read_delta_records(9, 0).unwrap();
@@ -1035,7 +1046,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalIndexLogStore::new(dir.path());
         store
-            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None, true)
+            .append_delta(3, vec![page_item(1, "a", false)], Vec::new(), None, None, false, true)
             .unwrap();
         let meta = MetaItem {
             version: 1,
@@ -1043,7 +1054,7 @@ mod tests {
             timestamp_ms: 100,
             ..MetaItem::default()
         };
-        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta), true).unwrap();
+        store.append_delta(3, Vec::new(), Vec::new(), None, Some(meta), false, true).unwrap();
         let records = store.read_delta_records(3, 0).unwrap();
         assert_eq!(records.len(), 2);
         assert_eq!(records[1].meta.as_ref().unwrap().start_wal_sequence, 42);
@@ -1087,7 +1098,7 @@ mod tests {
         let store = LocalIndexLogStore::new(dir.path());
         for key in ["a", "b", "c"] {
             store
-                .append_delta(5, vec![page_item(1, key, false)], Vec::new(), Some(1), None, true)
+                .append_delta(5, vec![page_item(1, key, false)], Vec::new(), Some(1), None, false, true)
                 .unwrap();
         }
         drop(store);
@@ -1129,6 +1140,7 @@ mod tests {
                     Vec::new(),
                     Some(index as u64 + 1),
                     None,
+                    false,
                     true,
                 )
                 .unwrap();
@@ -1218,7 +1230,7 @@ mod tests {
             ],
         };
         store
-            .append_delta(4, Vec::new(), Vec::new(), Some(5), Some(meta.clone()), true)
+            .append_delta(4, Vec::new(), Vec::new(), Some(5), Some(meta.clone()), false, true)
             .unwrap();
         // A reopen reads the folded catalog back exactly, and latest_zone_catalog finds it.
         let reopened = LocalIndexLogStore::new(dir.path());
@@ -1268,14 +1280,14 @@ mod tests {
             }],
         };
         store
-            .append_delta(6, Vec::new(), Vec::new(), Some(1), Some(older), true)
+            .append_delta(6, Vec::new(), Vec::new(), Some(1), Some(older), false, true)
             .unwrap();
         // An anchor with no zones between them must not shadow the folded catalog.
         store
-            .append_delta(6, Vec::new(), Vec::new(), Some(5), Some(MetaItem::default()), true)
+            .append_delta(6, Vec::new(), Vec::new(), Some(5), Some(MetaItem::default()), false, true)
             .unwrap();
         store
-            .append_delta(6, Vec::new(), Vec::new(), Some(9), Some(newer.clone()), true)
+            .append_delta(6, Vec::new(), Vec::new(), Some(9), Some(newer.clone()), false, true)
             .unwrap();
         assert_eq!(store.latest_zone_catalog(6).unwrap().unwrap(), newer);
     }
@@ -1384,6 +1396,7 @@ mod tests {
                                 Vec::new(),
                                 None,
                                 None,
+                                false,
                                 true,
                             )
                             .unwrap();


### PR DESCRIPTION
At 100K records the index log hit 57GB because delta records snapshot every touched object's whole page set while appends touch the grow-with-the-store index hashes -- linear adds, quadratic log, recovery in hours. Upsert records list exactly the written pages; replay replaces each item's (kind,object,component) predecessor, mirroring the in-memory write path; other write shapes and all pre-existing records keep snapshot semantics. Evidence: index-log bytes/ingest flat (~106KB) over 400 live ingests; SIGKILL crash proof exact; lib 1212/1 known flake.