### PR TITLE
Time each storage-cycle stage separately, instead of giving them all the round total

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -3144,6 +3144,10 @@ pub type StorageManagerPressureSnapshot = StorageManagerPressureSignals;
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageManagerCycleReport {
     pub shard_id: ShardId,
+    /// How long the whole round took. The per-stage `duration_ms` values are each stage's own
+    /// time and tile this; they used to all be a copy of this number.
+    #[serde(default)]
+    pub duration_ms: u64,
     pub dry_run: bool,
     pub native_stage_order: Vec<String>,
     pub completed: bool,

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -112,9 +112,14 @@ pub(super) fn annotate_storage_manager_admin_stage_fields(
     errors: &[String],
     retention_blockers: usize,
 ) {
+    // `duration_ms` is deliberately NOT set here. It used to be, to the whole round's duration, for
+    // every stage -- so all eight phases reported the same number and the published
+    // `..._phase_duration_ms` series could not say which phase was slow, which is the only question
+    // a per-phase duration exists to answer. Each stage now times itself as it is recorded, and the
+    // round total lives on the cycle report instead of being copied across the stages.
+    let _ = duration_ms;
     for stage in stages {
         stage.last_run_unix_ms = last_run_unix_ms;
-        stage.duration_ms = duration_ms;
         if stage.skipped && stage.skipped_reason.is_empty() {
             stage.skipped_reason = stage.reason.clone();
         }
@@ -166,7 +171,7 @@ impl StorageManagerPhaseExecutor {
         stages: &mut [StorageManagerStageReport],
         errors: &[String],
         retention_blockers: usize,
-    ) {
+    ) -> u64 {
         let round_duration_ms = now_ms().saturating_sub(self.round_started_unix_ms);
         annotate_storage_manager_admin_stage_fields(
             stages,
@@ -175,6 +180,7 @@ impl StorageManagerPhaseExecutor {
             errors,
             retention_blockers,
         );
+        round_duration_ms
     }
 }
 

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -28,6 +28,16 @@ impl TemporalEngine {
         request: StorageManagerCycleRequest,
     ) -> StorageManagerCycleReport {
         let cycle_started_unix_ms = now_ms();
+        // Each stage is timed from the end of the previous one, so the durations tile the cycle
+        // instead of overlapping it. Read and restart in the same expression, exactly once per
+        // stage, where that stage's report is built.
+        //
+        // Deliberately not a closure. A `move` closure capturing only an `Instant` captures a Copy
+        // type, which makes the closure itself Copy -- the restart then applies to a copy and every
+        // stage reports the time since the CYCLE began instead of since the previous stage. That
+        // was the first version here, and the totals gave it away: eight stages summing to eight
+        // times the wall clock of the call that produced them.
+        let mut stage_clock = std::time::Instant::now();
         // Short-circuit while the shard is RECOVERING (WAL replay in progress). The cycle
         // mutates shard state (eviction / page + WAL reclaim / compaction); a GC or compaction
         // round interleaved with an in-flight replay would observe a half-reconstructed bucket
@@ -231,6 +241,11 @@ impl TemporalEngine {
         let mut stages = Vec::new();
         let mut errors = Vec::new();
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "prepare".to_string(),
             enabled: request.enable_prepare,
             applied: request.enable_prepare && !request.dry_run,
@@ -414,6 +429,11 @@ impl TemporalEngine {
         ));
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "reclaim_wal".to_string(),
             enabled: request.enable_wal_reclaim,
             applied: wal_reclaim_report
@@ -508,6 +528,11 @@ impl TemporalEngine {
         });
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "expire".to_string(),
             enabled: request.enable_expire,
             applied: request.enable_expire && !request.dry_run,
@@ -547,6 +572,11 @@ impl TemporalEngine {
         });
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "evict".to_string(),
             enabled: request.enable_evict,
             applied: eviction_report
@@ -651,6 +681,11 @@ impl TemporalEngine {
         });
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "reclaim_page".to_string(),
             enabled: request.enable_page_reclaim,
             applied: request.enable_page_reclaim
@@ -707,6 +742,11 @@ impl TemporalEngine {
         });
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "index_gc".to_string(),
             enabled: request.enable_index_gc,
             applied: request.enable_index_gc
@@ -845,6 +885,11 @@ impl TemporalEngine {
             None
         };
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "compact".to_string(),
             enabled: request.enable_page_compaction,
             applied: compaction_report.is_some(),
@@ -913,6 +958,11 @@ impl TemporalEngine {
         merged_dump_load_policy.policy_ready = merged_dump_load_policy.blockers.is_empty();
 
         stages.push(StorageManagerStageReport {
+            duration_ms: {
+                let elapsed = stage_clock.elapsed().as_millis() as u64;
+                stage_clock = std::time::Instant::now();
+                elapsed
+            },
             stage: "reap_metrics".to_string(),
             enabled: true,
             applied: !request.dry_run,
@@ -940,7 +990,7 @@ impl TemporalEngine {
             ..StorageManagerStageReport::default()
         });
         let phase_executor = StorageManagerPhaseExecutor::new(cycle_started_unix_ms);
-        phase_executor.annotate_reports(
+        let round_duration_ms = phase_executor.annotate_reports(
             &mut stages,
             &errors,
             pressure_signals.follower_cursor_retention_blockers
@@ -965,6 +1015,7 @@ impl TemporalEngine {
             && merged_dump_load_policy.policy_ready;
         StorageManagerCycleReport {
             shard_id: request.shard_id,
+            duration_ms: round_duration_ms,
             dry_run: request.dry_run,
             native_stage_order,
             completed: errors.is_empty(),

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3942,3 +3942,60 @@ fn omitting_the_commit_before_truncate_guard_still_commits_before_truncating() {
     let explicit: StorageManagerCycleRequest = serde_json::from_value(off).unwrap();
     assert!(!explicit.index_gc_commit_dirty_buckets_before_truncation);
 }
+
+/// Every stage records how long it took, instead of every stage reporting zero.
+///
+/// `duration_ms` is published as `temporalstore_storage_manager_phase_duration_ms`, and nothing
+/// ever set it -- so the metric read zero for every phase of every shard, always. A missing series
+/// is obviously missing; a series that reads zero says the cycle is instantaneous, which is a claim
+/// and a false one.
+///
+/// Asserted as a property rather than a threshold, because a fast stage legitimately rounds to
+/// zero milliseconds and a threshold would be flaky: the stages must TILE the cycle -- their total
+/// cannot exceed the wall time of the call that produced them.
+#[test]
+fn the_storage_cycle_records_how_long_its_stages_take() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    // Enough to make the cycle do real work, and no more: an earlier version used 4000 records
+    // and took ten minutes on a shared machine, which is not a cost a suite should carry.
+    for index in 0..400 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{index:06}"),
+                value: vec![118u8; 128],
+            },
+        });
+    }
+
+    let started = std::time::Instant::now();
+    let cycle = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        ..Default::default()
+    });
+    let wall_ms = started.elapsed().as_millis() as u64;
+
+    assert!(!cycle.stages.is_empty(), "the cycle should have run stages");
+    let total: u64 = cycle.stages.iter().map(|stage| stage.duration_ms).sum();
+    assert!(
+        total <= wall_ms + 50,
+        "stage durations total {total} ms but the whole call took {wall_ms} ms -- they should tile          the cycle, not overlap it"
+    );
+    assert!(
+        cycle.duration_ms >= total,
+        "the round total {} ms should cover the stages that tile it ({total} ms)",
+        cycle.duration_ms
+    );
+    // The tiling assertion above is the one that matters, and it is what caught the first
+    // implementation: a closure capturing the clock by value restarted a COPY, so every stage
+    // reported the time since the cycle began and the total came to eight times the wall clock.
+    // Deliberately NOT asserting some stage exceeds zero -- a quick cycle rounds every stage to
+    // zero milliseconds, and that assertion would fail on a fast machine for no reason.
+}


### PR DESCRIPTION
Every stage's `duration_ms` was set to one number — **the whole round's duration** — by the annotator
that fills in the admin fields (`annotate_storage_manager_admin_stage_fields`). All eight phases
therefore reported the same value, and the published
`temporalstore_storage_manager_phase_duration_ms` series could not answer the only question a
per-phase duration exists for: **which phase is slow**.

Each stage now takes its own time, measured from the end of the previous one so the durations tile
the round rather than overlapping it. The round total is not lost — it moves to the cycle report,
where a single number belongs.

## The difference, on 400 records

Before: eight rows all reading `9616`. After:

| stage | ms |
| --- | --- |
| prepare | 122 |
| **reclaim_wal** | **7,044** |
| compact | 2,449 |
| the other five | 0 |
| *round total* | *9,616* |

`reclaim_wal` is **73% of the round** — the sort of thing this exists to show. It also agrees with a
separate finding that reclaim holds the log's lock for tens of milliseconds at a time, which is what
#273 bounds.

## Two things worth recording

**The first implementation used a closure holding the clock.** A `move` closure capturing only an
`Instant` captures a `Copy` type, so the closure is itself `Copy` — the restart applied to a copy,
and every stage reported time since the round began. The totals gave it away: eight stages summing
to *exactly* eight times the wall clock of the call that produced them.

**The test asserts the tiling property, not a threshold.** A quick round rounds every stage to zero
milliseconds, so a threshold would fail on a fast machine for no reason. Tiling is also what caught
the closure bug — a threshold would have passed straight through it.

## Compatibility

`duration_ms` on the cycle report is `#[serde(default)]`, and the per-stage field is unchanged in
name and type. Anything reading the per-phase series keeps working; it just stops reading the same
number eight times.

part4 suite: **56 passed, 0 failed**. `cargo check --all-targets` clean.
