### PR TITLE
A proxy group needs a name on the raft path too

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1460,6 +1460,50 @@ impl SingleNodeMeta {
     /// mute: the mutation log then holds only creations that were accepted, so
     /// replay does not have to re-decide against a reserved set that has since
     /// changed.
+    /// Why this change must not be admitted, judged against current state.
+    ///
+    /// These guards lived only in the public methods. `apply_mutation` dispatches
+    /// straight to the `apply_*` functions, so the raft propose path went around
+    /// every one of them: a reserved namespace could be created, and a namespace
+    /// could be dropped out from under a table that was still live, stranding it.
+    ///
+    /// Judged before proposing and never while applying. Replay has to reapply
+    /// what was already accepted -- a name reserved today must not invalidate a
+    /// namespace legitimately created before it.
+    pub(crate) fn admission_refusal(&self, mutation: &MetaMutation) -> Option<Status> {
+        match mutation {
+            MetaMutation::AddNamespace(request) => {
+                self.reserved_name_refusal(&request.namespace, None)
+            }
+            MetaMutation::AddTable(request) => {
+                self.reserved_name_refusal(&request.namespace, Some(&request.table_name))
+            }
+            MetaMutation::SetNamespaceState(request, MetaEntityState::Dropped) => {
+                self.namespace_not_empty_refusal(&request.namespace)
+            }
+            _ => None,
+        }
+    }
+
+    /// Refuses dropping a namespace that still holds a table which is not itself
+    /// dropped, so dropping a namespace cannot strand one.
+    fn namespace_not_empty_refusal(&self, namespace: &str) -> Option<Status> {
+        let state = self.inner.read().expect("meta lock poisoned");
+        state
+            .tables
+            .values()
+            .any(|table| {
+                table.info.namespace == namespace
+                    && table.info.state != MetaEntityState::Dropped
+            })
+            .then(|| {
+                Status::error(
+                    "namespace_not_empty",
+                    "namespace still holds a table that is not dropped",
+                )
+            })
+    }
+
     fn reserved_name_refusal(&self, namespace: &str, table: Option<&str>) -> Option<Status> {
         let state = self.inner.read().expect("meta lock poisoned");
         if state.reserved_names.namespaces.contains(namespace) {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -915,6 +915,20 @@ pub struct MetaPreflightReport {
     pub degraded_reasons: Vec<String>,
 }
 
+impl MetaMutation {
+    /// Whether this change may still be made while metadata change is muted.
+    ///
+    /// Only the lever itself and the retention purge. The lever, because muting
+    /// must not be a one-way door -- refusing it would leave no way back. The
+    /// purge, because the single-node path has always allowed it: its one
+    /// caller is the retention loop, which the mute stops separately, and the
+    /// two backends have to agree on what the mute means rather than each
+    /// inventing an answer.
+    pub(crate) fn allowed_while_muted(&self) -> bool {
+        matches!(self, Self::SetMetaChangeMuted(_) | Self::PurgeMeta(_))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", content = "request", rename_all = "snake_case")]
 pub enum MetaMutation {
@@ -1394,13 +1408,17 @@ impl SingleNodeMeta {
 
     /// The refusal every guarded entry point returns while muted, or `None` when
     /// metadata change is flowing normally.
+    /// The refusal a muted metaserver answers with, so both backends phrase it
+    /// identically.
+    pub(crate) fn muted_status() -> Status {
+        Status::error(
+            "meta_change_muted",
+            "metadata change is muted; resume it before making changes",
+        )
+    }
+
     fn meta_change_refusal(&self) -> Option<Status> {
-        self.is_meta_change_muted().then(|| {
-            Status::error(
-                "meta_change_muted",
-                "metadata change is muted; resume it before making changes",
-            )
-        })
+        self.is_meta_change_muted().then(Self::muted_status)
     }
 
     /// The names currently held back from creation.

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1481,8 +1481,24 @@ impl SingleNodeMeta {
             MetaMutation::SetNamespaceState(request, MetaEntityState::Dropped) => {
                 self.namespace_not_empty_refusal(&request.namespace)
             }
+            MetaMutation::PutProxyGroup(request) => Self::proxy_group_name_refusal(request),
             _ => None,
         }
+    }
+
+    /// Refuses a proxy group that names neither itself nor a namespace.
+    ///
+    /// The group name is the key it is stored under, and an empty one is also
+    /// the value an unattached proxy carries -- so a nameless group is indexed
+    /// by "no group at all" and reads as though every idle proxy belongs to it.
+    /// The public method has always refused this; the propose path dispatched
+    /// straight to `apply_put_proxy_group`, which does not check, and committed
+    /// it into replicated metadata.
+    ///
+    /// Takes no lock: it judges the request alone, not the state around it.
+    fn proxy_group_name_refusal(request: &PutProxyGroupRequest) -> Option<Status> {
+        (request.group.is_empty() || request.namespace.is_empty())
+            .then(|| Status::error("bad_request", "group and namespace are required"))
     }
 
     /// Refuses dropping a namespace that still holds a table which is not itself

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -286,10 +286,12 @@ impl SingleNodeMeta {
         if let Some(status) = self.meta_change_refusal() {
             return AckResponse { status };
         }
-        if request.group.is_empty() || request.namespace.is_empty() {
-            return AckResponse {
-                status: Status::error("bad_request", "group and namespace are required"),
-            };
+        // Through the same judgement the propose path uses, so the two
+        // cannot drift apart again.
+        if let Some(status) =
+            self.admission_refusal(&MetaMutation::PutProxyGroup(request.clone()))
+        {
+            return AckResponse { status };
         }
         self.record_mutation(MetaMutation::PutProxyGroup(request.clone()));
         self.apply_put_proxy_group(request)

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -469,20 +469,11 @@ impl SingleNodeMeta {
                     status: Status::error("not_modified", "namespace state is unchanged"),
                 };
             }
-            if next == MetaEntityState::Dropped {
-                let live = state.tables.values().any(|table| {
-                    table.info.namespace == request.namespace
-                        && table.info.state != MetaEntityState::Dropped
-                });
-                if live {
-                    return AckResponse {
-                        status: Status::error(
-                            "namespace_not_empty",
-                            "namespace still holds a table that is not dropped",
-                        ),
-                    };
-                }
-            }
+        }
+        if let Some(status) =
+            self.admission_refusal(&MetaMutation::SetNamespaceState(request.clone(), next))
+        {
+            return AckResponse { status };
         }
         self.record_mutation(MetaMutation::SetNamespaceState(request.clone(), next));
         self.apply_set_namespace_state(request, next)

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -573,16 +573,27 @@ impl MetaRaftCluster {
                 return SingleNodeMeta::muted_status();
             }
         }
+        // The same guards the public methods apply. `apply_mutation` dispatches
+        // straight to the `apply_*` functions, so without this the propose path
+        // goes around every one of them.
+        if let Some(Some(status)) =
+            self.with_readable_meta(|meta| meta.admission_refusal(&mutation))
+        {
+            return status;
+        }
         self.propose_mutation(mutation)
             .unwrap_or_else(|err| Status::error("raft_error", err.to_string()))
     }
 
-    /// Whether the readable replica reports metadata change as muted.
+    /// Ask the readable replica a question without copying it.
     ///
     /// Deliberately not `read_meta()`: that clones the entire metadata state,
-    /// and this runs on every mutation. `None` means no replica could answer,
-    /// which is not the same as "not muted".
-    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+    /// and everything here runs on every mutation. `None` means no replica could
+    /// answer, which is not the same as an answer of "no".
+    pub(super) fn with_readable_meta<T>(
+        &self,
+        ask: impl FnOnce(&SingleNodeMeta) -> T,
+    ) -> Option<T> {
         let inner = self.inner.read().expect("meta raft lock poisoned");
         let leader_commit_index = inner.nodes.get(&inner.leader_id)?.commit_index;
         inner
@@ -590,7 +601,11 @@ impl MetaRaftCluster {
             .values()
             .filter(|node| node.alive && node.commit_index >= leader_commit_index)
             .min_by_key(|node| node.id)
-            .map(|node| node.meta.is_meta_change_muted())
+            .map(|node| ask(&node.meta))
+    }
+
+    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+        self.with_readable_meta(SingleNodeMeta::is_meta_change_muted)
     }
 
     pub(super) fn read_meta(&self) -> Result<SingleNodeMeta, Status> {

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -557,8 +557,40 @@ impl MetaRaftCluster {
     }
 
     pub(super) fn mutation_status(&self, mutation: MetaMutation) -> Status {
+        // The mute is the incident lever: while it is set, the metaserver is
+        // meant to refuse every recorded metadata mutation. That check lived
+        // only in SingleNodeMeta's public methods, and this path proposes
+        // straight past them -- so on a raft-backed metaserver, which is what a
+        // real deployment runs, setting the mute changed nothing at all.
+        //
+        // Checked before proposing rather than while applying: replay has to
+        // reapply what was already accepted, including changes recorded before
+        // the mute was set.
+        if !mutation.allowed_while_muted() {
+            // An unreadable cluster is left to propose and fail on its own
+            // terms. Refusing here would turn "cannot tell" into "muted".
+            if self.peek_meta_change_muted() == Some(true) {
+                return SingleNodeMeta::muted_status();
+            }
+        }
         self.propose_mutation(mutation)
             .unwrap_or_else(|err| Status::error("raft_error", err.to_string()))
+    }
+
+    /// Whether the readable replica reports metadata change as muted.
+    ///
+    /// Deliberately not `read_meta()`: that clones the entire metadata state,
+    /// and this runs on every mutation. `None` means no replica could answer,
+    /// which is not the same as "not muted".
+    pub(super) fn peek_meta_change_muted(&self) -> Option<bool> {
+        let inner = self.inner.read().expect("meta raft lock poisoned");
+        let leader_commit_index = inner.nodes.get(&inner.leader_id)?.commit_index;
+        inner
+            .nodes
+            .values()
+            .filter(|node| node.alive && node.commit_index >= leader_commit_index)
+            .min_by_key(|node| node.id)
+            .map(|node| node.meta.is_meta_change_muted())
     }
 
     pub(super) fn read_meta(&self) -> Result<SingleNodeMeta, Status> {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1044,6 +1044,91 @@ fn muting_metadata_change_refuses_changes_on_the_raft_path_too() {
     );
 }
 
+fn table_in(meta: &MetaRaftCluster, namespace: &str, table_name: &str) -> Status {
+    meta.add_table(AddTableRequest {
+        namespace: namespace.to_string(),
+        table_name: table_name.to_string(),
+        first_shard_id: 500,
+        shard_count: 1,
+        replica_count: 1,
+        partition_version: 0,
+        serving_options: crate::meta::TableServingOptions::default(),
+    })
+    .status
+}
+
+#[test]
+fn a_reserved_name_cannot_be_taken_on_the_raft_path() {
+    // Reserved names exist to hold a name back from creation. The check lived
+    // in the public method, and the raft path proposes past it, so on a
+    // raft-backed metaserver the reservation held nothing back at all.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    let mut reserved = crate::meta::ReservedNames::default();
+    reserved.namespaces.insert("system".to_string());
+    reserved.tables.insert("internal".to_string());
+    assert!(meta.set_reserved_names(reserved).status.ok);
+
+    let taken = meta.add_namespace(AddNamespaceRequest {
+        namespace: "system".to_string(),
+    });
+    assert!(!taken.status.ok, "a reserved namespace was created anyway");
+    assert_eq!(taken.status.code, "name_reserved");
+
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok);
+    let table = table_in(&meta, "tenant", "internal");
+    assert!(!table.ok, "a reserved table name was created anyway");
+    assert_eq!(table.code, "name_reserved");
+
+    // And an unreserved name is still allowed, so the guard is not a blanket no.
+    assert!(table_in(&meta, "tenant", "orders").ok);
+}
+
+#[test]
+fn dropping_a_namespace_cannot_strand_a_live_table_on_the_raft_path() {
+    // The single-node path refuses this precisely so a drop cannot leave tables
+    // behind in a namespace that no longer exists. The raft path did not.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta
+        .add_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok);
+    assert!(table_in(&meta, "tenant", "orders").ok);
+
+    let stranding = meta.drop_namespace(AddNamespaceRequest {
+        namespace: "tenant".to_string(),
+    });
+    assert!(
+        !stranding.status.ok,
+        "a namespace was dropped out from under a live table"
+    );
+    assert_eq!(stranding.status.code, "namespace_not_empty");
+
+    // Once the table is gone the namespace can be dropped, or the guard would
+    // make a namespace undroppable rather than merely safe to drop.
+    assert!(meta
+        .delete_table(DeleteTableRequest {
+            namespace: "tenant".to_string(),
+            table_name: "orders".to_string(),
+        })
+        .status
+        .ok);
+    assert!(
+        meta.drop_namespace(AddNamespaceRequest {
+            namespace: "tenant".to_string()
+        })
+        .status
+        .ok,
+        "an empty namespace could not be dropped"
+    );
+}
+
 #[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -7,6 +7,51 @@ use super::*;
 use super::helpers::*;
 
 #[test]
+fn a_proxy_group_needs_a_name_on_the_raft_path_too() {
+    use crate::meta::{PutProxyGroupRequest, SingleNodeMeta};
+
+    // put_proxy_group validates in the public method, and the propose path
+    // dispatches straight to apply_put_proxy_group, which does not. So a raft
+    // metaserver committed a group with no name and no namespace into
+    // replicated metadata, where the single-node one answered bad_request.
+    //
+    // Judged before proposing, never while applying: replay has to reapply what
+    // was already accepted.
+    let empty = || PutProxyGroupRequest {
+        group: String::new(),
+        namespace: String::new(),
+        location: "rack-1".to_string(),
+        instance_num: 1,
+    };
+
+    let single = SingleNodeMeta::default();
+    let single_ack = single.put_proxy_group(empty());
+    assert_eq!(single_ack.status.code, "bad_request");
+    assert!(single.list_proxy_groups().groups.is_empty());
+
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    let raft_ack = meta.put_proxy_group(empty());
+    assert_eq!(
+        raft_ack.status.code, "bad_request",
+        "the raft path accepted a proxy group with no name"
+    );
+    assert!(
+        meta.list_proxy_groups().groups.is_empty(),
+        "a nameless proxy group reached replicated metadata"
+    );
+
+    // A named group still goes through, so the guard is not simply refusing.
+    let good = meta.put_proxy_group(PutProxyGroupRequest {
+        group: "orders".to_string(),
+        namespace: "ns".to_string(),
+        location: "rack-1".to_string(),
+        instance_num: 1,
+    });
+    assert!(good.status.ok, "a valid group was refused: {good:?}");
+    assert_eq!(meta.list_proxy_groups().groups.len(), 1);
+}
+
+#[test]
 fn add_node_after_leader_snapshot_installs_snapshot_and_tail() {
     let cluster = RaftCluster::new_single_shard_with_config(
         1,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -1014,6 +1014,37 @@ fn metaserver_raft_mutation_api_rejects_without_majority() {
 }
 
 #[test]
+fn muting_metadata_change_refuses_changes_on_the_raft_path_too() {
+    // The mute is the incident lever: while it is set the metaserver is meant
+    // to refuse every recorded metadata mutation. That check lived only in
+    // SingleNodeMeta's public methods, and the raft backend proposes straight
+    // past them -- so on a raft-backed metaserver, which is what a real
+    // deployment runs, setting the mute changed nothing.
+    let meta = MetaRaftCluster::new([10, 11, 12]);
+    assert!(meta.set_meta_change_muted(true).status.ok);
+
+    let muted = meta.add_namespace(AddNamespaceRequest {
+        namespace: "during-an-incident".to_string(),
+    });
+    assert!(
+        !muted.status.ok,
+        "the cluster was muted and the change went through anyway"
+    );
+    assert_eq!(muted.status.code, "meta_change_muted");
+
+    // And the lever has to be releasable, or muting would be a one-way door.
+    assert!(meta.set_meta_change_muted(false).status.ok);
+    assert!(
+        meta.add_namespace(AddNamespaceRequest {
+            namespace: "after-the-incident".to_string(),
+        })
+        .status
+        .ok,
+        "unmuting did not restore metadata change"
+    );
+}
+
+#[test]
 fn metaserver_raft_can_read_from_any_live_committed_replica() {
     let meta = MetaRaftCluster::new([10, 11, 12]);
     meta.propose(MetaCommand::PutShardLocation(ShardLocation {


### PR DESCRIPTION
`put_proxy_group` refuses a group that names neither itself nor a namespace.
That check lived only in the public method, and the propose path dispatches
straight to `apply_put_proxy_group`, which does not check.

## Measured

The same request, both backends:

```
single-node -> ok=false code=bad_request groups=0
raft        -> ok=true  code=ok          groups=1
               group name="" namespace="" location="rack-1"
```

A nameless group is committed into replicated metadata by the raft path and
refused outright by the single-node one.

## Why it does not simply sit there harmlessly

The group name is the key it is stored under, and an empty name is also the
value an unattached proxy carries. So the group is indexed by "no group at
all", and calibration counts every idle proxy as already belonging to it. I
expected that to churn — plan an attach every round, forever — and measured it
instead: three rounds, `attach=[] detach=[] shortfalls=0`. It does not churn.
It does something quieter: the phantom group reads as permanently satisfied by
proxies that are actually idle, so nothing ever reports it and nothing ever
cleans it up. It then survives snapshot and replay, because by that point it is
legitimately committed history.

## The change

Judge it in `admission_refusal`, alongside the other pre-propose checks, and
let the public method go through that same judgement so the two cannot drift
apart again. Before proposing and never while applying — replay has to reapply
what was already accepted, which is why this does not go in `apply_*`.

The check takes no lock: it judges the request alone, not the state around it.

## Test

The raft path now answers `bad_request` and stores nothing, matching the
single-node path, and a properly named group still goes through so the guard
is not simply refusing everything. It fails before the change with `the raft
path accepted a proxy group with no name`.

Full `meta::` (290) and `raft::` (219) suites pass.

## Base

Stacked on #231, which introduced `admission_refusal`. **Merge #231 first.**

It targets `main` rather than #231's branch on purpose: `rust-ci` and
`oss-readiness` declare `pull_request: branches: [main, rust-main]`, and for
`pull_request` that filters the *base*. A pull request aimed anywhere else is
never compiled and its tests never run, while still reporting `CLEAN`.
Targeting `main` means this diff also carries #231's commit and CI builds the
two together, which is the state that will land; once #231 merges this reduces
to its own commit.
