### PR TITLE
Ingest coalesces its pending-event cluster into one durable batch

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -293,6 +293,7 @@ class _LocalAdapterIngestMixin:
                 pending_memory_layer = candidate_memory_layer_name(pending_event_record)
                 if pending_memory_layer:
                     pending_event_record["memory_layer"] = pending_memory_layer
+                self._begin_append_coalescing()
                 self.append(pending_event_record)
                 pending_embedding_record = compact_context_embedding_record(
                     {
@@ -361,6 +362,7 @@ class _LocalAdapterIngestMixin:
                         "updated_at_ms": envelope["ingestion_time_ms"],
                     }
                 )
+            self._flush_append_coalescing()
             pending_events = self.pending_session_events(envelope["scope"])
             pending_event_count = len(pending_events)
             pending_message_count = session_event_message_count(pending_events)

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4259,7 +4259,49 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def _apply_serving_dedup(self, records: list[Json]) -> list[Json]:
         return self._coalesce_summary_dirty(self._filter_duplicate_model_registry(records))
 
+    @property
+    def _append_coalesce_tls(self) -> threading.local:
+        tls = getattr(self, "_append_coalesce_tls_obj", None)
+        if tls is None:
+            tls = threading.local()
+            self._append_coalesce_tls_obj = tls
+        return tls
+
+    def _begin_append_coalescing(self) -> None:
+        """Buffer this THREAD's subsequent append() calls until flush.
+
+        For a run of consecutive appends with no interleaved read, one append_many is
+        semantically identical (same records, same order, same batch pipeline) and costs one
+        durable engine batch instead of one per record. Thread-local on purpose: the adapter is
+        shared across request threads, and one request's buffer must never receive another's
+        records. The caller owns the flush point (before its first read) and the abort on
+        failure (so a reused pool thread cannot inherit an active buffer).
+        """
+        tls = self._append_coalesce_tls
+        tls.buffer = []
+        tls.active = True
+
+    def _flush_append_coalescing(self) -> None:
+        tls = self._append_coalesce_tls
+        if not getattr(tls, "active", False):
+            return
+        tls.active = False
+        buffered = tls.buffer
+        tls.buffer = []
+        if buffered:
+            self.append_many(buffered)
+
+    def _abort_append_coalescing(self) -> None:
+        """Drop this thread's buffered records without writing (failed-request cleanup)."""
+        tls = self._append_coalesce_tls
+        tls.active = False
+        tls.buffer = []
+
     def append(self, record: Json) -> None:
+        tls = getattr(self, "_append_coalesce_tls_obj", None)
+        if tls is not None and getattr(tls, "active", False):
+            tls.buffer.append(record)
+            return
         records = self._apply_serving_dedup(
             self._stamp_ingest_fields(materialize_serving_record_batch([record]))
         )


### PR DESCRIPTION
One single-message ingest issued 14 separate durable append batches (~120 engine round trips). The consecutive pending-event cluster now lands as one append_many via a thread-local coalescing seam (flush before the first read; abort-on-exception). Measured warm: 120 -> 42 round trips, 18.2s -> 5.0s, appends 14 -> 5. Strict 22/22; shadow gauntlet 0/9; suites baseline-identical.