### PR TITLE
A message wrapped across source lines keeps its indentation

### DIFF
--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -434,7 +434,9 @@ fn a_second_sync_asks_only_for_what_changed_and_keeps_its_routes() {
     assert_eq!(
         seen_version_calls.load(Ordering::SeqCst),
         version_calls_after_first,
-        "a sync that changed nothing should cost one round-trip, not two -- the cluster          topology version is only needed to stamp routes, and an unchanged reply installs none"
+        "a sync that changed nothing should cost one round-trip, not two -- the \
+         cluster topology version is only needed to stamp routes, and an \
+         unchanged reply installs none"
     );
 }
 

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -4527,8 +4527,17 @@ mod tests {
     #[test]
     fn growing_a_table_that_already_owns_shards_is_refused() {
         let meta = live_two_shard_table();
-        assert_eq!(grow_to(&meta, 4).code, "shards_registered");
+        let refused = grow_to(&meta, 4);
+        assert_eq!(refused.code, "shards_registered");
         assert_eq!(meta.list_tables().tables[0].shard_count, 2);
+        // An operator reads this one. A literal wrapped across source lines
+        // keeps the indentation of the continuation unless it is escaped, and
+        // this refusal was arriving with a run of spaces in the middle of it.
+        assert!(
+            !refused.message.contains("  "),
+            "the refusal reads with a run of spaces in it: {:?}",
+            refused.message
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/table_ops.rs
+++ b/crates/temporalstore-rust/src/meta/table_ops.rs
@@ -236,7 +236,9 @@ impl SingleNodeMeta {
                 return AckResponse {
                     status: Status::error(
                         "shards_registered",
-                        "shard_count cannot change once the table's shards are registered:                          the key range of every existing shard would move, and nothing                          redistributes the data that moved with it",
+                        "shard_count cannot change once the table's shards are registered: \
+                         the key range of every existing shard would move, and \
+                         nothing redistributes the data that moved with it",
                     ),
                 };
             }

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3711,7 +3711,8 @@ mod tests {
         });
         assert_eq!(
             status, 503,
-            "a drained proxy must fail its probe, or draining it does not take it out of              rotation"
+            "a drained proxy must fail its probe, or draining it does not take it \
+             out of rotation"
         );
         let parsed = parse_json::<ProxyReadinessResponse>(&body).expect("readiness body parses");
         assert!(!parsed.serving);
@@ -3861,7 +3862,8 @@ mod tests {
             });
             assert_eq!(
                 response.status.code, "proxy_traffic_dropped",
-                "attempt {attempt} on a refused key must be refused again -- the decision is                  per key, not per request"
+                "attempt {attempt} on a refused key must be refused again -- the decision \
+                 is per key, not per request"
             );
             assert!(
                 response.status.message.contains("will not succeed"),
@@ -5285,7 +5287,8 @@ mod tests {
         assert_eq!(
             hits.load(Ordering::SeqCst),
             1,
-            "a write that timed out must not be sent again -- the timeout says the datanode              stopped answering, not that it never received the write"
+            "a write that timed out must not be sent again -- the timeout says the datanode \
+             stopped answering, not that it never received the write"
         );
 
         // A read is a different matter: repeating it cannot change anything, so the

--- a/crates/temporalstore-rust/src/proxy/policy.rs
+++ b/crates/temporalstore-rust/src/proxy/policy.rs
@@ -68,8 +68,29 @@ fn proxy_dropped_status() -> Status {
     // dropped" -- invited exactly that retry loop.
     Status::error(
         "proxy_traffic_dropped",
-        "request refused for this key by proxy drop_percent; the same key is refused on every          attempt while drop_percent stands, so retrying it will not succeed",
+        "request refused for this key by proxy drop_percent; the same key is refused on \
+         every attempt while drop_percent stands, so retrying it will not succeed",
     )
+}
+
+#[cfg(test)]
+mod message_tests {
+    use super::*;
+
+    #[test]
+    fn the_refusal_a_caller_sees_reads_as_one_sentence() {
+        // This goes back over the wire to whoever made the request. A literal
+        // wrapped across source lines keeps the indentation of the continuation
+        // unless it is escaped, and this one was arriving with ten spaces in
+        // the middle of the sentence.
+        let status = proxy_dropped_status();
+        assert_eq!(status.code, "proxy_traffic_dropped");
+        assert!(
+            !status.message.contains("  "),
+            "the refusal reads with a run of spaces in it: {:?}",
+            status.message
+        );
+    }
 }
 
 pub(super) fn proxy_serving_mode_from_meta(value: &str) -> Option<ProxyServingMode> {

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4322,7 +4322,8 @@ mod tests {
         );
         assert!(
             surviving.iter().all(|survivor| *survivor < log_id),
-            "a record written after the crash took an address that still resolves to an earlier              one: new {log_id}, highest surviving {:?}",
+            "a record written after the crash took an address that still resolves to an \
+             earlier one: new {log_id}, highest surviving {:?}",
             surviving.iter().max()
         );
         set_wal_segment_bytes_for_test(None);


### PR DESCRIPTION
A Rust string literal that runs onto the next source line keeps the
continuation's leading whitespace unless the newline is escaped. Seven messages
in the crate were written that way, so each arrives with a run of ten to
twenty-five spaces in the middle of a sentence.

## The two that reach a caller

These are `Status::error` values, returned over the wire and rendered by
whatever displays `status.message`:

```
proxy_traffic_dropped
  "... the same key is refused on every          attempt while drop_percent stands ..."

shards_registered
  "... shards are registered:                          the key range of every existing shard ..."
```

The other five are assertion messages. They only surface when a test fails, but
they read the same way when they do.

## The change

Escape the newlines so each reads as one sentence. No wording changes — the
text a caller might match on is otherwise untouched, and no status code moves.

Found by sweeping the crate for a quoted literal containing a run of four or
more spaces between two lowercase letters; after the change that sweep returns
nothing.

## Tests

The two caller-visible messages now assert they carry no run of spaces.
Reintroducing the unescaped wrap fails the proxy one and prints the text back:

```
the refusal reads with a run of spaces in it: "request refused for this key by
proxy drop_percent; the same key is refused on every          attempt while ..."
```

`meta::` (291), `proxy::` (62), `client::` (31) and `wal::` (68) all pass.

## What this does not do

It fixes the seven that exist; it does not stop an eighth being written. A
repo-wide check would have to be a CI gate, and that is a cost decision for the
owner rather than something to add unasked.
