### PR TITLE
A metric mapping entry describes the metric, not a class from elsewhere

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1778,7 +1778,7 @@ pub(super) fn proxy_metric_families_from(rendered: &str) -> Vec<String> {
 fn proxy_metrics_parity_mappings() -> Vec<ProxyMetricFamilyMapping> {
     vec![
         proxy_metric_mapping(
-            "common::metrics::CounterHolder proxy command/admission counters",
+            "proxy command/admission counters",
             "temporalstore_proxy_requests_total",
             vec!["kind"],
             "Proxy Requests And Admission",


### PR DESCRIPTION
The proxy's metric mapping table in proxy.rs describes, for each exported
Prometheus family, what it corresponds to on the older implementation's
side. Eight of its nine entries do that in plain words -- "proxy route
cache hit/miss/refresh counters", "proxy current route cache size".

The ninth quoted an internal class name from a codebase that is not this
one. That string is not a comment: it is a field in a report served over
HTTP, so the class name shipped in the response body to anyone who asked
for it.

Describe the metric the way the other eight do. The field name already
says which side it is describing, so nothing is lost, the meaning is
unchanged, and the existing test that pins this entry still holds.
