### PR TITLE
The readiness report says which transport this node is running

### DIFF
--- a/crates/temporalstore-rust/src/raft/readiness.rs
+++ b/crates/temporalstore-rust/src/raft/readiness.rs
@@ -42,6 +42,14 @@ pub struct RaftDistributedReadiness {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RaftTransportSecurityReadiness {
+    /// Which transport this process is actually configured for.
+    ///
+    /// The `*_present` flags below say what the build implements, which is the
+    /// same answer on every deployment. This one says what is running here, so
+    /// a reader can tell "we can do mTLS" from "this node is doing mTLS".
+    /// Defaults to plaintext, so its absence from a report is not a claim.
+    #[serde(default)]
+    pub configured_transport_mode: String,
     pub auth_token_validation_present: bool,
     pub mtls_cert_key_ca_validation_present: bool,
     pub authenticated_http_transport_present: bool,
@@ -356,6 +364,25 @@ pub fn raft_external_chaos_readiness() -> RaftExternalChaosReadiness {
 }
 
 pub fn raft_transport_security_readiness() -> RaftTransportSecurityReadiness {
+    // Read from the same place the transport itself reads, so the report cannot
+    // describe a configuration the process is not running.
+    raft_transport_security_readiness_for(
+        production_raft_security_from_env(String::new(), true)
+            .security
+            .mode,
+    )
+}
+
+/// The same report for a caller that already knows the configured mode, so it
+/// can be exercised without setting process-wide environment.
+pub fn raft_transport_security_readiness_for(
+    configured_mode: ProductionRaftSecurityMode,
+) -> RaftTransportSecurityReadiness {
+    let configured_transport_mode = match configured_mode {
+        ProductionRaftSecurityMode::Mtls => "mtls",
+        ProductionRaftSecurityMode::PlaintextForLocalChaos => "plaintext_for_local_chaos",
+    }
+    .to_string();
     let auth_token_validation_present = true;
     let mtls_cert_key_ca_validation_present = true;
     let authenticated_http_transport_present = true;
@@ -376,6 +403,7 @@ pub fn raft_transport_security_readiness() -> RaftTransportSecurityReadiness {
     };
 
     RaftTransportSecurityReadiness {
+        configured_transport_mode,
         auth_token_validation_present,
         mtls_cert_key_ca_validation_present,
         authenticated_http_transport_present,

--- a/crates/temporalstore-rust/src/raft/tests/part2.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part2.rs
@@ -1163,6 +1163,39 @@ fn raft_metaserver_membership_readiness_reports_real_scheduler_execution() {
 }
 
 #[test]
+fn the_report_says_which_transport_this_node_is_running() {
+    use crate::raft::{
+        production_raft_security_from_lookup, raft_transport_security_readiness_for,
+        ProductionRaftSecurityMode,
+    };
+
+    // The `*_present` flags describe the build, so they answer the same on
+    // every deployment -- including one running plaintext. Served at an
+    // unauthenticated /readiness on both the metaserver and the datanode, that
+    // left no way to tell "we can do mTLS" from "this node is doing mTLS".
+    let plaintext = raft_transport_security_readiness_for(
+        ProductionRaftSecurityMode::PlaintextForLocalChaos,
+    );
+    assert_eq!(plaintext.configured_transport_mode, "plaintext_for_local_chaos");
+    // The build-capability flags are unchanged by this: they still describe the
+    // build, and anything reading them keeps the answer it had.
+    assert!(plaintext.mtls_cert_key_ca_validation_present);
+
+    let mtls = raft_transport_security_readiness_for(ProductionRaftSecurityMode::Mtls);
+    assert_eq!(mtls.configured_transport_mode, "mtls");
+
+    // And the default deployment really is the plaintext one, so the two above
+    // are not hypothetical. Read through the lookup rather than the process
+    // environment so a test setting these cannot change the answer.
+    let configured = production_raft_security_from_lookup("token", true, |_| None);
+    assert_eq!(
+        configured.security.mode,
+        ProductionRaftSecurityMode::PlaintextForLocalChaos,
+        "the default transport stopped being plaintext; this test's premise needs revisiting"
+    );
+}
+
+#[test]
 fn raft_transport_security_readiness_covers_service_mtls() {
     let readiness = raft_transport_security_readiness();
     assert!(readiness.auth_token_validation_present);


### PR DESCRIPTION
GET /readiness is served by the metaserver and the datanode, and is exempt
from admin auth, so anyone who can reach the port can read it.

Its transport-security section reports five *_present flags that describe
what the build implements. They are constants, and the tests pin them that
way deliberately -- the build does implement all of it. Nothing in the
section says what THIS process is configured for. Measured on a default
deployment, with the environment stubbed so no other test could affect it:

    configured mode        = PlaintextForLocalChaos
    cert/key/ca configured = None / None / None
    readiness reports mtls_cert_key_ca_validation_present = true

The default transport is plaintext_for_local_chaos. So a node running
plaintext answers a security question with mtls..._present: true, and the
report offers nothing that would let a reader tell otherwise.

Report the configured mode alongside the flags, read from the same place
the transport itself reads. Every existing field keeps its meaning and its
value, so anything consuming them is unaffected; the report simply gains
the fact needed to tell "we can do mTLS" from "this node is doing mTLS".

Deliberately NOT changed: production_ready and missing are still derived
from the build flags, so they still read as always-ready. Making them
reflect configuration would change what a security endpoint reports for
every existing deployment -- it could break a dashboard, or make healthy
nodes look unready and block a rollout. That is a decision about what
/readiness means, not a bug fix.

Tests: the mode is reported for both configurations, the build flags are
asserted unchanged, and the premise -- that the default really is plaintext
-- is pinned so this does not quietly stop being true.
