### PR TITLE
Renew the leader lease when sender heartbeats confirm quorum contact

### DIFF
--- a/crates/temporalstore-rust/src/raft/follower_pipeline.rs
+++ b/crates/temporalstore-rust/src/raft/follower_pipeline.rs
@@ -246,6 +246,26 @@ impl RaftCluster {
         }
     }
 
+    /// Renew the leader lease after the timer loop confirmed quorum contact through the
+    /// senders. The fan-out's own heartbeat round renews the lease as acks come back, but
+    /// sender heartbeats fold their acks into the commit advance, which renews only when a
+    /// commit actually moves -- so an IDLE leader's lease decayed, and the first propose
+    /// after any gap longer than the lease bounced off `leader_lease_valid` until something
+    /// committed. On hardware that surfaced as ~400 ms per propose on every cadence slower
+    /// than the lease window, while busy cells never saw it.
+    pub(crate) fn renew_leader_lease_after_quorum_contact(&self) {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let leader_id = inner.leader_id;
+        let is_leader = inner
+            .nodes
+            .get(&leader_id)
+            .map(|node| node.alive && node.role == RaftRole::Leader)
+            .unwrap_or(false);
+        if is_leader {
+            inner.renew_leader_lease();
+        }
+    }
+
     /// Peers that answered within `window_ms`, for check-quorum. The leader counts itself.
     pub(crate) fn pipeline_reached_within(&self, window_ms: u64) -> usize {
         self.follower_pipeline

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -470,6 +470,10 @@ impl ProductionRaftRuntime {
                                 }
                             } else {
                                 quorum_misses = 0;
+                                // Quorum contact within the window is exactly what the lease
+                                // certifies; without this an idle leader's lease decays and
+                                // the next propose stalls on it (see the method's comment).
+                                cluster.renew_leader_lease_after_quorum_contact();
                             }
                             last_heartbeat = InstantCompat::now();
                             let _ = cluster.tick_election();

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1464,3 +1464,40 @@ fn serialized_pipeline_fallback_holds_the_invariant() {
     );
     assert_eq!(accepted, 16, "every propose should commit through the serialized fallback");
 }
+
+/// An idle leader's lease decays between proposes; the timer's quorum-contact renewal is
+/// what keeps the NEXT propose from bouncing off `leader_lease_valid`. Without the renewal
+/// this test fails with NoMajority/LeaderUnavailable on the post-idle propose.
+#[test]
+fn idle_leader_lease_renews_on_quorum_contact() {
+    let _pipeline = super::part4::EnvFlagGuard::set("TS_RAFT_FOLLOWER_PIPELINE");
+    let dir = tempfile::tempdir().unwrap();
+    let config = RaftConfig {
+        lease_duration_ms: 50,
+        ..RaftConfig::default()
+    };
+    let cluster = RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], config).unwrap();
+    let transport = cluster.clone();
+    cluster
+        .propose_distributed(
+            Command::StringSet {
+                key: "warm".to_string(),
+                value: b"v".to_vec(),
+            },
+            &transport,
+        )
+        .unwrap();
+    // Idle past the lease: the propose gate would now reject on leader_lease_valid.
+    cluster.advance_time_ms(200);
+    // The timer loop's quorum-contact renewal (senders answered within the window).
+    cluster.renew_leader_lease_after_quorum_contact();
+    cluster
+        .propose_distributed(
+            Command::StringSet {
+                key: "after-idle".to_string(),
+                value: b"v2".to_vec(),
+            },
+            &transport,
+        )
+        .expect("a renewed lease must admit the post-idle propose");
+}


### PR DESCRIPTION
## What this does

Fixes the ~400 ms-per-propose stall that hit the pipeline's slow-cadence cells on hardware.

The fan-out's heartbeat round renews the leader lease as acks come back. Sender heartbeats fold their acks into the commit advance instead — which renews only when a commit actually moves. So an **idle** leader's lease decayed, and the first propose after any lull longer than the lease bounced off `leader_lease_valid` until something committed. Any workload whose per-writer propose spacing exceeds the lease window collapses into that retry pacing: exactly the single-writer cell (403 ms p50) and the 1 KB cell (383 ms p50) of the last window, while the busy cells never saw it because their own commits kept the lease fresh.

The timer loop's check-quorum block already computes quorum contact through the senders every heartbeat tick; when quorum is reached it now renews the lease — which is precisely what the lease certifies.

## Proven by

A test that warms a pipelined cluster, idles past a 50 ms lease, applies the quorum-contact renewal, and requires the post-idle propose to be admitted. Plus both pipeline invariant tests unchanged and green; pipeline-on raft suite 224 with the one failure being the known fixed-port collision (passes isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
