### PR TITLE
Make a record that says nothing about where its payload lives decode as holding it inline

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -426,10 +426,21 @@ pub struct ContextResourceLifecycleRecord {
     pub payload_size_bytes: usize,
     #[serde(default)]
     pub max_inline_bytes: usize,
-    #[serde(default)]
+    /// Whether the payload is held in the record rather than in the object store.
+    ///
+    /// Defaulted explicitly rather than with a bare `#[serde(default)]`: on a bool that decodes an
+    /// ABSENT field to `false`, which here means "the payload is elsewhere" and sends a reader to
+    /// an `external_object_uri` that such a record does not carry. This type's own `Default` says
+    /// true, and decoding it should not disagree with constructing it.
+    #[serde(default = "inline_payload_default")]
     pub inline_payload: bool,
     #[serde(default)]
     pub external_object_uri: String,
+}
+
+/// A record with nothing said about where its payload lives holds it inline; see the field.
+fn inline_payload_default() -> bool {
+    true
 }
 
 impl Default for ContextResourceLifecycleRecord {

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2839,3 +2839,41 @@ fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
         "every node here carries its vector inline, so nothing may fall back to the rows"
     );
 }
+
+
+/// A lifecycle record that says nothing about where its payload lives must decode as holding it
+/// inline, which is what constructing one gives you.
+///
+/// `#[serde(default)]` on a bool decodes an absent field to `false`, and here false means "the
+/// payload is in the object store" -- so a record that simply did not mention it would send a
+/// reader to an `external_object_uri` it does not carry. The type's own `Default` says true, and
+/// decoding must not disagree with constructing.
+#[test]
+fn omitting_inline_payload_still_means_the_payload_is_held_inline() {
+    let mut body: serde_json::Value =
+        serde_json::to_value(ContextResourceLifecycleRecord::default()).unwrap();
+    let removed = body.as_object_mut().unwrap().remove("inline_payload");
+    assert!(removed.is_some(), "a serialised record should carry the field");
+
+    let silent: ContextResourceLifecycleRecord = serde_json::from_value(body).unwrap();
+    assert!(
+        silent.inline_payload,
+        "a record that does not mention where its payload lives decoded as pointing at the object \
+         store, and carries no uri to point with"
+    );
+    assert_eq!(
+        silent.inline_payload,
+        ContextResourceLifecycleRecord::default().inline_payload,
+        "an omitted field must decode to what the type's own default says"
+    );
+
+    // Saying it explicitly still works -- this is about what silence means.
+    let mut external: serde_json::Value =
+        serde_json::to_value(ContextResourceLifecycleRecord::default()).unwrap();
+    external
+        .as_object_mut()
+        .unwrap()
+        .insert("inline_payload".to_string(), serde_json::Value::Bool(false));
+    let stated: ContextResourceLifecycleRecord = serde_json::from_value(external).unwrap();
+    assert!(!stated.inline_payload);
+}


### PR DESCRIPTION
`#[serde(default)]` on a `bool` decodes an **absent** field to `false` — not to what the type's own
`Default` impl says. For `inline_payload`, `false` means *"the payload is in the object store"*, so
a record that simply never mentioned it decoded as pointing outward, and carried no
`external_object_uri` to point with. Constructing the same record in Rust gives `true`, because its
`Default` says so.

```rust
#[serde(default)]                                   // omitted -> false ("it's elsewhere")
pub inline_payload: bool,

ContextResourceLifecycleRecord::default().inline_payload   // true ("it's inline")
```

Decoding should not disagree with constructing. The field is now defaulted explicitly. Stating it
`false` still works — this is about what silence means, not about removing the choice.

## The audit behind it

Every bare `#[serde(default)]` bool in the crate was checked against its type's `Default`. Of
**149**, nineteen disagree.

**Eighteen are deliberately left alone.** They are readiness and tested flags on client and proxy
contract reports (`*_ready`, `*_tested`), where an absent field decoding to `false` means *"not
ready"* — the conservative answer, and the one to keep. Defaulting them `true` would let an omitted
field **claim readiness nobody stated**, which is strictly worse than the status quo. A mechanical
sweep over all nineteen would have introduced exactly that.

This one points the other way, and is the only one changed.

Two shapes are not this problem and were excluded: a **container**-level `#[serde(default)]` (it
fills from the struct's own `Default`, so the two agree by construction), and a derived `Default`
(both sides are `false`, so they agree).

## Validation

`cargo test --lib -- --test-threads=1`: context_workflow **32 passed, 0 failed**. The new test
removes only that field from a well-formed record, so it tests what silence means rather than
whether other fields happen to be optional; it fails without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
