### PR TITLE
A table handle stopped routing by the shape it was opened with

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -961,6 +961,12 @@ pub struct TemporalStoreTable {
     namespace: String,
     table_name: String,
     shard_id: ShardId,
+    /// What this table looked like when the handle was opened.
+    ///
+    /// Only a fallback for `table_options()`, for the case where the client holds no
+    /// entry for this table. Everything else must go through `table_options()`, which
+    /// reads the copy the metaserver sync keeps current -- this one never changes, so
+    /// anything reading it directly is frozen at open time.
     options: TableOptions,
 }
 
@@ -1276,7 +1282,7 @@ impl TemporalStoreTable {
                     command: command.clone(),
                 },
                 force_primary,
-                self.http_options(),
+                self.http_options(&table_options),
                 Some(table_options.continuous_failed_time_ms),
                 table_options.replica_read_policy,
                 if table_options.preferred_location.is_empty() {
@@ -1338,7 +1344,12 @@ impl TemporalStoreTable {
                 responses: Vec::new(),
             });
         }
-        if self.options.shard_count > 1 {
+        // The LIVE shard count, not the one this handle was opened with. Read from the
+        // snapshot, a table that gained shards after the handle was created kept sending
+        // every command to the single shard the handle started on -- while
+        // `shard_id_for_command`, on this same handle, already knew which shard each key
+        // belonged to. The handle worked out the right answer and then declined to use it.
+        if table_options.shard_count > 1 {
             return self.batch_execute_grouped_by_shard(commands);
         }
         let request = BatchExecuteRequest {
@@ -1360,7 +1371,7 @@ impl TemporalStoreTable {
         let response = loop {
             let current = self.client.batch_execute_with_http(
                 request.clone(),
-                self.http_options(),
+                self.http_options(&table_options),
                 Some(table_options.continuous_failed_time_ms),
             )?;
             let decision = classify_retry_decision(
@@ -1473,17 +1484,22 @@ impl TemporalStoreTable {
         }
     }
 
-    fn http_options(&self) -> HttpRequestOptions {
+    /// Takes the table's options rather than reading them, so it cannot be called with
+    /// stale ones. It used to read `self.options` -- the copy this handle was opened
+    /// with -- and so kept sending the timeouts the table had when the handle was
+    /// created, for the whole life of the handle. `options()` meanwhile reported the
+    /// current ones, so the handle told you one timeout and used another.
+    fn http_options(&self, table_options: &TableOptions) -> HttpRequestOptions {
         HttpRequestOptions {
-            connect_timeout_ms: self.options.connect_timeout_ms,
-            io_timeout_ms: self.options.io_timeout_ms,
+            connect_timeout_ms: table_options.connect_timeout_ms,
+            io_timeout_ms: table_options.io_timeout_ms,
             max_retries: self.client.inner.options.max_retries,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn http_options_for_test(&self) -> HttpRequestOptions {
-        self.http_options()
+        self.http_options(&self.table_options())
     }
 
     /// Re-sync this table's topology because a request failed in a way that suggests the

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -534,6 +534,220 @@ fn a_topology_missing_a_primary_keeps_the_route_it_cannot_replace() {
 }
 
 #[test]
+fn a_tables_timeouts_reach_the_wire_after_they_change() {
+    // The table handle keeps a copy of the options it was opened with, and the client
+    // keeps the live ones, refreshed on every sync. Routing already reads the live
+    // copy; the request timeouts did not. So a table whose timeouts changed reported
+    // the new ones through `options()` while still putting the old ones on the wire,
+    // for the whole life of the handle.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    let io_ms = std::sync::Arc::new(AtomicU64::new(1111));
+    let connect_ms = std::sync::Arc::new(AtomicU64::new(2222));
+    let meta_addr = free_local_addr();
+    let meta_addr_for_listener = meta_addr.clone();
+    let io_for_server = io_ms.clone();
+    let connect_for_server = connect_ms.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => json_response(
+                    200,
+                    &TableTopologyResponse {
+                        status: Status::ok(),
+                        table: Some(crate::meta::TableMetaInfo {
+                            table_id: 1,
+                            namespace: "ns".to_string(),
+                            table_name: "tbl".to_string(),
+                            state: crate::meta::MetaEntityState::Normal,
+                            topology_version: 7,
+                            first_shard_id: 10,
+                            shard_count: 1,
+                            replica_count: 1,
+                            partition_version: 0,
+                            serving_options: crate::meta::TableServingOptions {
+                                io_timeout_ms: io_for_server.load(Ordering::Relaxed),
+                                connect_timeout_ms: connect_for_server.load(Ordering::Relaxed),
+                                ..crate::meta::TableServingOptions::default()
+                            },
+                        }),
+                        shards: Vec::new(),
+                        unchanged: false,
+                    },
+                ),
+                _ => json_response(404, &Status::error("not_found", "not found")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        meta_addr: Some(meta_addr),
+        ..ClientOptions::default()
+    });
+    let table = client.open_table_from_meta("ns", "tbl").unwrap();
+    assert_eq!(table.http_options_for_test().io_timeout_ms, 1111);
+    assert_eq!(table.http_options_for_test().connect_timeout_ms, 2222);
+
+    io_ms.store(3333, Ordering::Relaxed);
+    connect_ms.store(4444, Ordering::Relaxed);
+    client.sync_table_topology("ns", "tbl").unwrap();
+
+    assert_eq!(
+        table.options().io_timeout_ms,
+        3333,
+        "the handle reports the refreshed timeout"
+    );
+    assert_eq!(
+        table.http_options_for_test().io_timeout_ms,
+        3333,
+        "and must actually send it: reporting one timeout while using another is the bug"
+    );
+    assert_eq!(table.http_options_for_test().connect_timeout_ms, 4444);
+}
+
+#[test]
+fn a_batch_is_split_across_shards_the_table_gained_after_it_was_opened() {
+    // Whether a batch is grouped by shard was decided from the shard count the handle
+    // was opened with. A table that gains shards afterwards kept sending every command
+    // to the one shard the handle started on -- while `shard_id_for_key`, on the same
+    // handle, already knew the right shard for each key. The handle worked out the
+    // correct answer and then declined to use it.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
+    let shard_count = std::sync::Arc::new(AtomicU64::new(1));
+    let seen: std::sync::Arc<Mutex<Vec<ShardId>>> = std::sync::Arc::new(Mutex::new(Vec::new()));
+
+    let backend_addr = free_local_addr();
+    let backend_for_listener = backend_addr.clone();
+    let seen_for_server = seen.clone();
+    std::thread::spawn(move || {
+        serve(&backend_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/batch_execute") => {
+                    let req = parse_json::<BatchExecuteRequest>(&request.body).unwrap();
+                    seen_for_server.lock().unwrap().push(req.shard_id);
+                    json_response(
+                        200,
+                        &BatchExecuteResponse {
+                            status: Status::ok(),
+                            responses: req
+                                .commands
+                                .iter()
+                                .map(|_| ExecuteResponse {
+                                    status: Status::ok(),
+                                    response: CommandResponse::Empty,
+                                })
+                                .collect(),
+                        },
+                    )
+                }
+                _ => json_response(404, &Status::error("not_found", "not found")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&backend_addr);
+
+    let meta_addr = free_local_addr();
+    let meta_addr_for_listener = meta_addr.clone();
+    let count_for_server = shard_count.clone();
+    let backend_for_meta = backend_addr.clone();
+    std::thread::spawn(move || {
+        serve(&meta_addr_for_listener, move |request| {
+            match (request.method.as_str(), request.path.as_str()) {
+                ("POST", "/tables/topology") => {
+                    let count = count_for_server.load(Ordering::Relaxed);
+                    let shards = (0..count)
+                        .map(|offset| crate::meta::TableShard {
+                            shard_id: 10 + offset,
+                            start_bucket: offset * 4096,
+                            end_bucket: (offset + 1) * 4096 - 1,
+                            primary: Some(backend_for_meta.clone()),
+                            replicas: Vec::new(),
+                            primary_endpoint: None,
+                            replica_endpoints: Vec::new(),
+                        })
+                        .collect();
+                    json_response(
+                        200,
+                        &TableTopologyResponse {
+                            status: Status::ok(),
+                            table: Some(crate::meta::TableMetaInfo {
+                                table_id: 1,
+                                namespace: "ns".to_string(),
+                                table_name: "tbl".to_string(),
+                                state: crate::meta::MetaEntityState::Normal,
+                                topology_version: 7 + count,
+                                first_shard_id: 10,
+                                shard_count: count,
+                                replica_count: 1,
+                                partition_version: 0,
+                                serving_options: crate::meta::TableServingOptions::default(),
+                            }),
+                            shards,
+                            unchanged: false,
+                        },
+                    )
+                }
+                ("GET", path) if path.starts_with("/shards/") => {
+                    let shard_id: ShardId = path.trim_start_matches("/shards/").parse().unwrap();
+                    json_response(
+                        200,
+                        &GetShardResponse {
+                            status: Status::ok(),
+                            location: Some(ShardLocation {
+                                state: crate::meta::MetaEntityState::Normal,
+                                shard_id,
+                                server_addr: backend_for_meta.clone(),
+                                latest_snapshot: None,
+                            }),
+                        },
+                    )
+                }
+                _ => json_response(404, &Status::error("not_found", "not found")),
+            }
+        })
+        .unwrap();
+    });
+    wait_for_http(&meta_addr);
+
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        meta_addr: Some(meta_addr),
+        ..ClientOptions::default()
+    });
+    let table = client.open_table_from_meta("ns", "tbl").unwrap();
+    assert_eq!(table.options().shard_count, 1);
+
+    shard_count.store(4, Ordering::Relaxed);
+    client.sync_table_topology("ns", "tbl").unwrap();
+    assert_eq!(table.options().shard_count, 4);
+
+    let keys: Vec<String> = (0..40).map(|n| format!("key-{n}")).collect();
+    let want: std::collections::BTreeSet<ShardId> =
+        keys.iter().map(|key| table.shard_id_for_key(key)).collect();
+    assert!(
+        want.len() > 1,
+        "the test needs keys that land on different shards; got {want:?}"
+    );
+
+    seen.lock().unwrap().clear();
+    table
+        .batch_execute(
+            keys.iter()
+                .map(|key| Command::StringGet { key: key.clone() })
+                .collect(),
+        )
+        .unwrap();
+
+    let got: std::collections::BTreeSet<ShardId> = seen.lock().unwrap().iter().copied().collect();
+    assert_eq!(
+        got, want,
+        "each command must go to the shard its key routes to, not to the shard the handle was opened on"
+    );
+}
+
+#[test]
 fn a_table_that_asks_for_a_default_value_still_decides_it() {
     // A table set to shed nothing and to retry no writes, opened by a client that
     // sheds half its traffic and retries writes twice.


### PR DESCRIPTION
A table handle keeps two copies of the table's options: a snapshot from when it was
opened, and the client's copy, which every metaserver sync refreshes. Routing already
read the live copy. Two things still read the snapshot, and both are on the data path.

Whether a batch is split by shard was decided from the snapshot's shard count. So a
table that gained shards after a handle was opened kept sending every command in a
batch to the one shard the handle started on -- while `shard_id_for_command`, on that
same handle, already knew which shard each key belonged to. The handle worked out the
right answer and then declined to use it. In the test that now covers this, forty keys
belonging to shards 10 through 13 all went to shard 1: not merely the wrong shard, but
one outside the table's range entirely.

The request timeouts came from the snapshot too, so a table's io and connect timeouts
never reached the wire for any handle opened before they changed -- for the whole life
of that handle. `options()` reports the live values, so the handle would tell you one
timeout and use another.

Rather than correct the two reads, `http_options` now takes the options instead of
reading them: there is no way to call it with a stale copy. The grouping decision uses
the options already fetched a few lines above it. What remains of the snapshot is one
fallback inside `table_options()`, for when the client holds no entry for the table,
and the field now says that is all it is for.