### PR TITLE
An async resource import reports done only once it has finished writing

### DIFF
--- a/tools/matrixark_local_adapter_dashboard.py
+++ b/tools/matrixark_local_adapter_dashboard.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
+    from tools.matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
+    from matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
 
 try:  # names owned by the parent module
     from tools.matrixark_mcp_local_adapter import (

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -543,6 +543,7 @@ class _LocalAdapterIngestMixin:
         resource_import_task_hash = 0
         resource_import_task_status = "not_applicable"
         resource_import_wait = True
+        held_import_completion: list[Json] = []
         resource_import_metrics: Json = {}
         resource_fact_event_hashes: list[int] = []
         resource_fact_entity_hashes: list[int] = []
@@ -1334,7 +1335,15 @@ class _LocalAdapterIngestMixin:
                 "summary_dirty_count": len(resource_dirty_hashes),
             }
             resource_import_task_status = "completed"
-            self.append(
+            # On the background worker this call still has writes ahead of it -- the hot path
+            # event batch and its index postings land after this point. Appending "completed"
+            # here publishes the one signal a caller polls for while a fifth of the task's
+            # records are still missing, and lets the caller tear the log down underneath the
+            # worker. Hold the marker and append it once the call has finished writing.
+            append_import_completion = (
+                held_import_completion.append if resource_import_background else self.append
+            )
+            append_import_completion(
                 {
                     "record_type": "resource_import_task",
                     "task_hash": resource_import_task_hash,
@@ -1699,6 +1708,8 @@ class _LocalAdapterIngestMixin:
                     threshold_messages=session_buffer_threshold,
                 )
             )
+        for held_record in held_import_completion:
+            self.append(held_record)
         return {
             "status": "accepted",
             "event_id_hash": event_id_hash,

--- a/tools/python_suite_baseline.json
+++ b/tools/python_suite_baseline.json
@@ -88,7 +88,6 @@
     "test_prometheus_renderer_covers_single_backend",
     "test_prompt_tokens_are_trimmed_from_the_decoded_output",
     "test_query_candidate_index_terms_match_core_source_lineage_terms",
-    "test_retrieval_audit_is_off_by_default",
     "test_retrieval_idle_preflush_reports_committed_memory_layers_and_selection_budget",
     "test_retrieval_prefilter_recovers_summary_from_compact_embedding_metadata",
     "test_retrieval_recovers_profile_layer_from_compact_embedding_metadata",

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -2988,55 +2988,62 @@ class _CodexPipelinePart5:
             event_log = Path(tmp_dir) / "matrixark-resource-queue.jsonl"
             adapter = MatrixArkLocalAdapter(event_log)
             server = MatrixArkMcpServer(adapter, line_json=True, access_mode="dev")
-            result = server.call_tool(
-                "matrixark_ingest",
-                {
-                    "kind": "resource",
-                    "raw_uri": "inline://resource-queue.md",
-                    "resource_type": "md",
-                    "wait": False,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": "# GPU Runbook\n\nAlice owns the GPU approval checklist. Finance review is required before purchase.",
-                        }
-                    ],
-                    "scope": {
-                        "account_id": "acct_queue",
-                        "tenant_id": "tenant_queue",
-                        "user_id": "user_queue",
-                        "session_id": "session_queue",
+            try:
+                result = server.call_tool(
+                    "matrixark_ingest",
+                    {
+                        "kind": "resource",
+                        "raw_uri": "inline://resource-queue.md",
+                        "resource_type": "md",
+                        "wait": False,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": "# GPU Runbook\n\nAlice owns the GPU approval checklist. Finance review is required before purchase.",
+                            }
+                        ],
+                        "scope": {
+                            "account_id": "acct_queue",
+                            "tenant_id": "tenant_queue",
+                            "user_id": "user_queue",
+                            "session_id": "session_queue",
+                        },
+                        "metadata": {"node_path": ["users", "user_queue", "resources", "runbooks"]},
                     },
-                    "metadata": {"node_path": ["users", "user_queue", "resources", "runbooks"]},
-                },
-            )
-            self.assertEqual("queued", result["status"])
-            task = result["resource_import_task"]
-            self.assertFalse(task["wait"])
-            self.assertTrue(task["worker_pool"]["bounded"])
-            self.assertEqual(1, task["worker_pool"]["worker_count"])
-            self.assertEqual(2, task["worker_pool"]["queue_max"])
+                )
+                self.assertEqual("queued", result["status"])
+                task = result["resource_import_task"]
+                self.assertFalse(task["wait"])
+                self.assertTrue(task["worker_pool"]["bounded"])
+                self.assertEqual(1, task["worker_pool"]["worker_count"])
+                self.assertEqual(2, task["worker_pool"]["queue_max"])
 
-            task_hash = task["task_hash"]
-            deadline = time.time() + 5.0
-            records: list[dict] = []
-            while time.time() < deadline:
-                records = adapter.read_all()
-                if any(
-                    record.get("record_type") == "resource_import_task"
-                    and record.get("task_hash") == task_hash
-                    and record.get("status") == "completed"
-                    for record in records
-                ):
-                    break
-                time.sleep(0.05)
-            else:
-                self.fail("background resource import did not complete")
+                task_hash = task["task_hash"]
+                deadline = time.time() + 5.0
+                records: list[dict] = []
+                while time.time() < deadline:
+                    records = adapter.read_all()
+                    if any(
+                        record.get("record_type") == "resource_import_task"
+                        and record.get("task_hash") == task_hash
+                        and record.get("status") == "completed"
+                        for record in records
+                    ):
+                        break
+                    time.sleep(0.05)
+                else:
+                    self.fail("background resource import did not complete")
 
-            self.assertTrue(any(record.get("record_type") == "resource_chunk" for record in records))
-            # Folded: the vectors live on the owners (chunks and summaries carry them).
-            self.assertTrue(any(record.get("vector") for record in records))
-            self.assertTrue(any(record.get("record_type") == "context_summary" for record in records))
+                self.assertTrue(any(record.get("record_type") == "resource_chunk" for record in records))
+                # Folded: the vectors live on the owners (chunks and summaries carry them).
+                self.assertTrue(any(record.get("vector") for record in records))
+                self.assertTrue(any(record.get("record_type") == "context_summary" for record in records))
+            finally:
+                # The import runs on a worker thread that keeps writing into this directory --
+                # the event log and the read-cache sidecars each append maintains -- until the
+                # task is drained. Without this the temp dir is torn down underneath the worker,
+                # which re-creates the log it just deleted and fails cleanup with ENOTEMPTY.
+                server.close(timeout_s=10.0)
 
     def test_tenant_shared_resource_and_skill_live_outside_session_and_retrieve_with_quota(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
The python suite ratchet has been failing intermittently on `main` itself — runs 32811328686 (05:03Z) and 32801456690 (02:27Z) both failed with no PR involved — which intermittently blocks unrelated pull requests. It also failed #263, which touches two Rust files and cannot reach a python import test.

The named test was `test_async_resource_import_uses_bounded_worker_queue`. Three separate problems sat behind it.

### The async import reported itself done before it had finished writing

`_ingest_impl` published the `resource_import_task` record with `status: "completed"` and `progress: {percent: 100}` from the middle of the call, then carried on writing — the hot path event batch and its index postings land after that point. Measured on the queue test: **38–39 of the task's 49 records existed when the marker appeared, on every run**, all 10–11 late records being `context_index` postings.

That marker is the only signal a caller has that an async import is done, so anything polling it — including this test — could read the import while its index postings were still landing. The marker now goes out as the call's last write. Only the background path defers it; a synchronous import is unchanged. After the change the marker means all 49 records are present, 12 runs out of 12.

### The background worker's error path could not run

`_run_background_resource_import` falls back to `_mcp_debug_log(...)` when it cannot record a failed import. `matrixark_local_adapter_dashboard.py` never imports that name — a star import skips underscore names, which is precisely why the sibling module imports it explicitly with a comment saying so. A background import that failed **and** then failed to record the failure raised `NameError` inside the worker thread instead of logging anything. Now imported.

### The test tore its temp directory down under a live worker

This was the actual flake. `rmtree` unlinked the event log, the worker's next `append` re-created it (`open("a")` creates), and cleanup died with `OSError: [Errno 39] Directory not empty`. Every one of the 15 observed failures was this, never an assertion. The test now drains through `server.close(timeout_s=10.0)` in a `finally`, matching the convention the rest of the suite already follows.

The last sliver is not fixable by ordering: `append()` writes its read-cache sidecars *after* the record itself, so the final append is observable before it is finished. Draining is the only correct answer, which is what `close()` is for.

### Rates

Single test, in isolation, subprocess per run:

| | before | after |
|---|---|---|
| idle box | 45 pass / 15 fail of 60 | 60 / 0 of 60 |
| 6 background spinners | — | 150 / 0 of 150 |
| box at load 24 | — | 200 / 0 of 200 |

One failure in ~490 post-fix runs, at load 24, was a different mode — the completed marker visible while the polled snapshot lacked `resource_chunk`, i.e. the read path, not the teardown race. Not reproduced in 200 in-process runs or in the last 200 subprocess runs. Noted, not addressed here.

### Whole suite

Full `unittest discover` on this branch vs. pristine `main`, same box: 131 failing names each. Two names differ, one in each direction, and both are pre-existing flakes rather than anything this change did — `test_http_json_portal_facade_calls_live_mcp_admin_routes` fails 1 in 12 on `main` in isolation and 0 in 12 here.

### Baseline

Banked `test_retrieval_audit_is_off_by_default`, which #280 fixed and which every run since has printed under "fixed since the baseline". Confirmed against the runner rather than re-recorded here: runs where nothing flakes print `failing now: 124   baseline: 125`, so 124 is the stable set. A local `--record` would have been wrong — this box reports 131, and the runner's baseline is the one that gates merges.
