### PR TITLE
RESP: sorted sets, one component per member so order recovers from the index

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -53,6 +53,12 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ListPop { key, .. }
         | Command::ListRange { key, .. }
         | Command::ListLen { key }
+        | Command::ZSetAdd { key, .. }
+        | Command::ZSetScore { key, .. }
+        | Command::ZSetRemove { key, .. }
+        | Command::ZSetCard { key }
+        | Command::ZSetRange { key, .. }
+        | Command::ZSetRangeByScore { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -23,6 +23,7 @@ mod object_manager;
 mod packed_pages;
 mod product_model;
 mod set_index_serde;
+mod zset_index_serde;
 mod bucket_dump_manifest_methods;
 mod storage_lifecycle_methods;
 mod storage_manager_cycle;
@@ -2488,6 +2489,7 @@ fn delete_record_exact(shard: &mut ShardState, key: &str) -> bool {
     removed |= shard.hashes.remove(key).is_some();
     removed |= shard.sets.remove(key).is_some();
     removed |= shard.lists.remove(key).is_some();
+    removed |= shard.zsets.remove(key).is_some();
     if shard.features.remove(key).is_some() {
         removed = true;
         control_rollup::feature_forget(shard, key);
@@ -2653,6 +2655,9 @@ fn collect_live_page_slab_ids(shard: &ShardState) -> BTreeSet<u64> {
     }
     for elements in shard.lists.values() {
         ids.extend(elements.values().map(|address| address.page_slab_id));
+    }
+    for members in shard.zsets.values() {
+        ids.extend(members.values().map(|(_, address)| address.page_slab_id));
     }
     for series in shard.features.values() {
         ids.extend(series.values().map(|address| address.page_slab_id));
@@ -2833,6 +2838,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
         || shard.hashes.contains_key(key)
         || shard.sets.contains_key(key)
         || shard.lists.contains_key(key)
+        || shard.zsets.contains_key(key)
         || shard.features.contains_key(key)
         || shard.control_state.contains_key(key)
         || shard.control_state_pages.contains_key(key)
@@ -2854,6 +2860,7 @@ fn storage_model_kinds() -> &'static [&'static str] {
         "hash",
         "set",
         "list",
+        "zset",
         "feature",
         "sequence",
         "control_state",
@@ -3016,6 +3023,7 @@ fn object_manager_stats(
             + shard.hashes.len()
             + shard.sets.len()
             + shard.lists.len()
+            + shard.zsets.len()
             + shard.features.len()
             + shard.control_state.len()
             + shard.control_state_changes.len()
@@ -3033,6 +3041,7 @@ fn object_manager_stats(
             + shard.hashes.values().map(HashMap::len).sum::<usize>()
             + shard.sets.values().map(BTreeMap::len).sum::<usize>()
             + shard.lists.values().map(BTreeMap::len).sum::<usize>()
+            + shard.zsets.values().map(BTreeMap::len).sum::<usize>()
             + shard.features.values().map(BTreeMap::len).sum::<usize>()
             + shard.context_nodes.len()
             + shard
@@ -3103,6 +3112,7 @@ fn object_manager_stats(
         + shard.hashes.len()
         + shard.sets.len()
         + shard.lists.len()
+        + shard.zsets.len()
         + shard.features.len()
         + shard.control_state.len()
         + shard.context_nodes.len()
@@ -3117,6 +3127,7 @@ fn object_manager_stats(
         + shard.hashes.values().map(HashMap::len).sum::<usize>()
         + shard.sets.values().map(BTreeMap::len).sum::<usize>()
         + shard.lists.values().map(BTreeMap::len).sum::<usize>()
+        + shard.zsets.values().map(BTreeMap::len).sum::<usize>()
         + shard.features.values().map(BTreeMap::len).sum::<usize>()
         + shard.context_nodes.len()
         + shard

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -54,6 +54,12 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ListPop { key, .. }
         | Command::ListRange { key, .. }
         | Command::ListLen { key }
+        | Command::ZSetAdd { key, .. }
+        | Command::ZSetScore { key, .. }
+        | Command::ZSetRemove { key, .. }
+        | Command::ZSetCard { key }
+        | Command::ZSetRange { key, .. }
+        | Command::ZSetRangeByScore { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureReplace { key, .. }
@@ -267,6 +273,8 @@ pub(super) fn command_updates_bucket_index_directly(command: &Command) -> bool {
             | Command::SetRemove { .. }
             | Command::ListPush { .. }
             | Command::ListPop { .. }
+            | Command::ZSetAdd { .. }
+            | Command::ZSetRemove { .. }
             | Command::ControlStateIncrement { .. }
             | Command::ControlStateIncrementWithOptions { .. }
             | Command::ControlStateSet { .. }
@@ -293,6 +301,8 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::SetRemove { .. }
             | Command::ListPush { .. }
             | Command::ListPop { .. }
+            | Command::ZSetAdd { .. }
+            | Command::ZSetRemove { .. }
             | Command::FeatureAppend { .. }
             | Command::FeatureAppendWithPolicy { .. }
             | Command::FeatureReplace { .. }

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -83,6 +83,8 @@ pub(super) fn model_compaction_policy_reports(
             "set"
         } else if shard.lists.contains_key(key) {
             "list"
+        } else if shard.zsets.contains_key(key) {
+            "zset"
         } else if shard.features.contains_key(key) {
             "feature"
         } else if shard.control_state_pages.contains_key(key) {
@@ -298,6 +300,16 @@ pub(super) fn compaction_model_layout_reports(
             .hashes
             .values()
             .flat_map(|fields| fields.values().cloned()),
+        &slab_page_counts,
+        None,
+    ));
+    reports.push(compaction_layout_from_addresses(
+        "zset",
+        shard.zsets.len(),
+        shard
+            .zsets
+            .values()
+            .flat_map(|members| members.values().map(|(_, address)| address.clone())),
         &slab_page_counts,
         None,
     ));

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -491,6 +491,173 @@ pub(crate) fn execute_on_shard(
             let _ = cache.invalidate_record(shard_id, "set", &key);
             CommandResponse::Empty
         }
+        Command::ZSetAdd { key, member, score } => {
+            remove_if_expired(shard, &key);
+            let biased = zset_score_bits(score);
+            let existed = shard
+                .zsets
+                .get(&key)
+                .and_then(|members| members.get(&member))
+                .map(|(old_biased, _)| *old_biased);
+            if existed == Some(biased) {
+                // Same score: nothing to rewrite, and the answer is still "not new".
+                return ExecuteOutcome {
+                    response: CommandResponse::Integer { value: 0 },
+                    mutated,
+                };
+            }
+            if let Some(old_biased) = existed {
+                let old_component = zset_component(old_biased, &member);
+                mark_bucket_index_page_deleted(shard, "zset", &key, Some(&old_component));
+            }
+            let component = zset_component(biased, &member);
+            let object_id = stable_page_object_id(shard_id, "zset", &key, Some(&component));
+            let routing_bucket =
+                page_routing_bucket(&key, start_routing_bucket, end_routing_bucket);
+            if let Ok(address) = append_value(
+                cache,
+                page_store,
+                shard_id,
+                &member,
+                Some(object_id),
+                Some(routing_bucket),
+                async_storage,
+            ) {
+                upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "zset",
+                    &key,
+                    Some(component.clone()),
+                    address.clone(),
+                    true,
+                );
+                shard
+                    .zsets
+                    .entry(key.clone())
+                    .or_default()
+                    .insert(member.clone(), (biased, address));
+                mutated = true;
+            }
+            let _ = cache.invalidate_record(shard_id, "zset", &key);
+            CommandResponse::Integer {
+                value: i64::from(existed.is_none()),
+            }
+        }
+        Command::ZSetScore { key, member } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "zset", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Bytes { value: None },
+                    mutated,
+                };
+            }
+            CommandResponse::Bytes {
+                value: shard
+                    .zsets
+                    .get(&key)
+                    .and_then(|members| members.get(&member))
+                    .map(|(biased, _)| zset_score_string(*biased).into_bytes()),
+            }
+        }
+        Command::ZSetRemove { key, member } => {
+            let removed = shard
+                .zsets
+                .get_mut(&key)
+                .and_then(|members| members.remove(&member));
+            match removed {
+                None => CommandResponse::Integer { value: 0 },
+                Some((biased, _)) => {
+                    mutated = true;
+                    let component = zset_component(biased, &member);
+                    mark_bucket_index_page_deleted(shard, "zset", &key, Some(&component));
+                    if shard.zsets.get(&key).is_some_and(BTreeMap::is_empty) {
+                        shard.zsets.remove(&key);
+                    }
+                    let _ = cache.invalidate_record(shard_id, "zset", &key);
+                    CommandResponse::Integer { value: 1 }
+                }
+            }
+        }
+        Command::ZSetCard { key } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "zset", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Integer { value: 0 },
+                    mutated,
+                };
+            }
+            CommandResponse::Integer {
+                value: shard.zsets.get(&key).map_or(0, BTreeMap::len) as i64,
+            }
+        }
+        Command::ZSetRange {
+            key,
+            start,
+            stop,
+            rev,
+        } => {
+            remove_if_expired(shard, &key);
+            let mut ordered = zset_ordered_members(shard, &key);
+            if rev {
+                ordered.reverse();
+            }
+            let length = ordered.len() as i64;
+            let resolve = |index: i64| if index < 0 { length + index } else { index };
+            let from = resolve(start).max(0);
+            let to = resolve(stop).min(length - 1);
+            let members = if from > to || length == 0 {
+                Vec::new()
+            } else {
+                ordered[from as usize..=to as usize]
+                    .iter()
+                    .flat_map(|(member, biased)| {
+                        [member.clone(), zset_score_string(*biased).into_bytes()]
+                    })
+                    .collect()
+            };
+            CommandResponse::Members { members }
+        }
+        Command::ZSetRangeByScore {
+            key,
+            min,
+            max,
+            min_exclusive,
+            max_exclusive,
+            rev,
+        } => {
+            remove_if_expired(shard, &key);
+            let min_bits = zset_score_bits(min);
+            let max_bits = zset_score_bits(max);
+            let mut ordered: Vec<(Vec<u8>, u64)> = zset_ordered_members(shard, &key)
+                .into_iter()
+                .filter(|(_, biased)| {
+                    let above = if min_exclusive {
+                        *biased > min_bits
+                    } else {
+                        *biased >= min_bits
+                    };
+                    let below = if max_exclusive {
+                        *biased < max_bits
+                    } else {
+                        *biased <= max_bits
+                    };
+                    above && below
+                })
+                .collect();
+            if rev {
+                ordered.reverse();
+            }
+            let members = ordered
+                .into_iter()
+                .flat_map(|(member, biased)| {
+                    [member, zset_score_string(biased).into_bytes()]
+                })
+                .collect();
+            CommandResponse::Members { members }
+        }
         Command::ListPush { key, member, left } => {
             remove_if_expired(shard, &key);
             let seq = {
@@ -2923,4 +3090,52 @@ pub(crate) fn execute_on_shard(
         }
     };
     ExecuteOutcome { response, mutated }
+}
+
+/// IEEE-754 total-order bias: flip everything for negatives, set the sign for positives, so
+/// unsigned comparison of the bits is numeric comparison of the floats.
+pub(super) fn zset_score_bits(score: f64) -> u64 {
+    let bits = score.to_bits();
+    if bits & (1 << 63) != 0 {
+        !bits
+    } else {
+        bits | (1 << 63)
+    }
+}
+
+pub(super) fn zset_score_from_bits(biased: u64) -> f64 {
+    if biased & (1 << 63) != 0 {
+        f64::from_bits(biased & !(1 << 63))
+    } else {
+        f64::from_bits(!biased)
+    }
+}
+
+pub(super) fn zset_score_string(biased: u64) -> String {
+    let score = zset_score_from_bits(biased);
+    if score == score.trunc() && score.abs() < 1e17 {
+        format!("{}", score as i64)
+    } else {
+        format!("{score}")
+    }
+}
+
+/// The persisted component: score bits then member, so lexical order is (score, member) order.
+pub(super) fn zset_component(biased: u64, member: &[u8]) -> String {
+    format!("{biased:016x}{}", hex::encode(member))
+}
+
+fn zset_ordered_members(shard: &ShardState, key: &str) -> Vec<(Vec<u8>, u64)> {
+    let mut ordered: Vec<(Vec<u8>, u64)> = shard
+        .zsets
+        .get(key)
+        .map(|members| {
+            members
+                .iter()
+                .map(|(member, (biased, _))| (member.clone(), *biased))
+                .collect()
+        })
+        .unwrap_or_default();
+    ordered.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    ordered
 }

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -559,6 +559,8 @@ impl TemporalEngine {
             let set_records = state.sets.len();
             let list_records = state.lists.len();
             let _ = list_records;
+            let zset_records = state.zsets.len();
+            let _ = zset_records;
             let feature_records = state.features.len();
             let sequence_records = state.sequences.len();
             let control_state_records =

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -426,6 +426,16 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 &mut rewrite_stats,
             )?;
         }
+        for members in shard.zsets.values_mut() {
+            compact_page_addresses(
+                &self.page_store,
+                &self.cache,
+                shard_id,
+                "zset",
+                members.values_mut().map(|entry| &mut entry.1),
+                &mut rewrite_stats,
+            )?;
+        }
         for elements in shard.lists.values_mut() {
             compact_page_addresses(
                 &self.page_store,

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -56,6 +56,12 @@ pub(super) struct ShardState {
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,
     #[serde(default, with = "super::set_index_serde")]
     pub(super) sets: HashMap<String, BTreeMap<Vec<u8>, BlockAddress>>,
+    /// Sorted sets: member -> (total-order score bits, element page). The score-ordered view
+    /// is derived per query -- V1 accepts the per-range sort; the upgrade path is a second
+    /// in-memory map rebuilt at load, never a second persisted structure (the index component
+    /// already encodes score-then-member, so recovery has the order for free).
+    #[serde(default, with = "super::zset_index_serde")]
+    pub(super) zsets: HashMap<String, BTreeMap<Vec<u8>, (u64, BlockAddress)>>,
     /// Redis-style lists: element pages keyed by a signed sequence -- left pushes walk the
     /// low end down, right pushes walk the high end up, so both ends are O(log n) and the
     /// BTree's order IS the list's order.

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -943,6 +943,7 @@ pub(super) fn shard_has_model_entries(shard: &ShardState) -> bool {
         || !shard.hashes.is_empty()
         || !shard.sets.is_empty()
         || !shard.lists.is_empty()
+        || !shard.zsets.is_empty()
         || !shard.features.is_empty()
         || !shard.control_state_pages.is_empty()
         || !shard.context_nodes.is_empty()
@@ -966,6 +967,16 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
     for (key, fields) in &shard.hashes {
         entries.extend(fields.iter().map(|(field, address)| {
             live_page_entry(key.clone(), "hash", Some(field.clone()), address.clone())
+        }));
+    }
+    for (key, members) in &shard.zsets {
+        entries.extend(members.iter().map(|(member, (biased, address))| {
+            live_page_entry(
+                key.clone(),
+                "zset",
+                Some(format!("{biased:016x}{}", hex::encode(member))),
+                address.clone(),
+            )
         }));
     }
     for (key, elements) in &shard.lists {
@@ -1600,6 +1611,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut saw_hashes = false;
     let mut saw_sets = false;
     let mut saw_lists = false;
+    let mut saw_zsets = false;
     let mut saw_features = false;
     let mut saw_control_state = false;
     let mut saw_context_events = false;
@@ -1614,6 +1626,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut hashes = HashMap::<String, HashMap<String, BlockAddress>>::new();
     let mut sets = HashMap::<String, BTreeMap<Vec<u8>, BlockAddress>>::new();
     let mut lists = HashMap::<String, BTreeMap<i64, BlockAddress>>::new();
+    let mut zsets = HashMap::<String, BTreeMap<Vec<u8>, (u64, BlockAddress)>>::new();
     let mut features = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
     let mut control_state = HashMap::<String, BTreeMap<u64, i64>>::new();
     let mut control_state_pages = HashMap::new();
@@ -1649,6 +1662,22 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
                 sets.entry(entry.object_key)
                     .or_default()
                     .insert(member, entry.address);
+            }
+            "zset" => {
+                saw_zsets = true;
+                if let Some(component) = entry.component.as_deref() {
+                    if component.len() > 16 {
+                        if let (Ok(biased), Ok(member)) = (
+                            u64::from_str_radix(&component[..16], 16),
+                            hex::decode(&component[16..]),
+                        ) {
+                            zsets
+                                .entry(entry.object_key)
+                                .or_default()
+                                .insert(member, (biased, entry.address));
+                        }
+                    }
+                }
             }
             "list" => {
                 saw_lists = true;
@@ -1796,6 +1825,9 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     }
     if saw_lists {
         shard.lists = lists;
+    }
+    if saw_zsets {
+        shard.zsets = zsets;
     }
     if saw_sets {
         shard.sets = sets;

--- a/crates/temporalstore-rust/src/engine/zset_index_serde.rs
+++ b/crates/temporalstore-rust/src/engine/zset_index_serde.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::block_store::BlockAddress;
+
+pub fn serialize<S>(
+    value: &HashMap<String, BTreeMap<Vec<u8>, (u64, BlockAddress)>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoded = value
+        .iter()
+        .map(|(key, members)| {
+            (
+                key,
+                members
+                    .iter()
+                    .map(|(member, entry)| (member, entry))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    encoded.serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, BTreeMap<Vec<u8>, (u64, BlockAddress)>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let encoded =
+        HashMap::<String, Vec<(Vec<u8>, (u64, BlockAddress))>>::deserialize(deserializer)?;
+    Ok(encoded
+        .into_iter()
+        .map(|(key, members)| (key, members.into_iter().collect()))
+        .collect())
+}

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -75,6 +75,12 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ListPop { key, .. }
         | Command::ListRange { key, .. }
         | Command::ListLen { key }
+        | Command::ZSetAdd { key, .. }
+        | Command::ZSetScore { key, .. }
+        | Command::ZSetRemove { key, .. }
+        | Command::ZSetCard { key }
+        | Command::ZSetRange { key, .. }
+        | Command::ZSetRangeByScore { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -561,6 +561,82 @@ mod tests {
         assert_eq!(run(&mut state, vec!["LPOP", "l"]), RespValue::Bulk(Some(b"z".to_vec())));
     }
 
+    /// Sorted sets behave like the native ones: ZADD answers only NEW members, a re-score
+    /// moves ordering without growing the set, ranges walk (score, member) order with
+    /// negative indices and WITHSCORES, score windows honor -inf/+inf and the exclusive
+    /// paren, and TYPE says zset.
+    #[test]
+    fn sorted_set_commands_match_native() {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let mut state = RedisCommandState::default();
+        let mut run = |state: &mut RedisCommandState, args: Vec<&str>| {
+            execute_redis_command_with_state(
+                args.into_iter().map(|arg| arg.as_bytes().to_vec()).collect(),
+                1,
+                state,
+                &mut |command| {
+                    let response = engine.execute(crate::ExecuteRequest {
+                        shard_id: 1,
+                        command,
+                    });
+                    if response.status.ok {
+                        Ok(response.response)
+                    } else {
+                        Err(response.status.message)
+                    }
+                },
+            )
+        };
+        let bulk = |text: &str| RespValue::Bulk(Some(text.as_bytes().to_vec()));
+
+        assert_eq!(run(&mut state, vec!["ZADD", "z", "2", "b", "1", "a"]), RespValue::Integer(2));
+        assert_eq!(run(&mut state, vec!["ZADD", "z", "3", "c", "5", "a"]), RespValue::Integer(1),
+            "re-scoring a is not an add");
+        assert_eq!(run(&mut state, vec!["ZCARD", "z"]), RespValue::Integer(3));
+        assert_eq!(run(&mut state, vec!["ZSCORE", "z", "a"]), bulk("5"));
+        assert_eq!(run(&mut state, vec!["ZSCORE", "z", "missing"]), RespValue::Bulk(None));
+        assert_eq!(run(&mut state, vec!["TYPE", "z"]), RespValue::SimpleString("zset".to_string()));
+
+        assert_eq!(
+            run(&mut state, vec!["ZRANGE", "z", "0", "-1"]),
+            RespValue::Array(vec![bulk("b"), bulk("c"), bulk("a")]),
+            "order follows the moved score"
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZRANGE", "z", "0", "1", "WITHSCORES"]),
+            RespValue::Array(vec![bulk("b"), bulk("2"), bulk("c"), bulk("3")]),
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZREVRANGE", "z", "0", "0"]),
+            RespValue::Array(vec![bulk("a")]),
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZRANGEBYSCORE", "z", "-inf", "+inf"]),
+            RespValue::Array(vec![bulk("b"), bulk("c"), bulk("a")]),
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZRANGEBYSCORE", "z", "(2", "5"]),
+            RespValue::Array(vec![bulk("c"), bulk("a")]),
+            "the paren excludes the bound"
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZREVRANGEBYSCORE", "z", "+inf", "3", "WITHSCORES"]),
+            RespValue::Array(vec![bulk("a"), bulk("5"), bulk("c"), bulk("3")]),
+            "rev-by-score takes (max, min) and answers descending"
+        );
+
+        assert_eq!(run(&mut state, vec!["ZREM", "z", "b", "missing"]), RespValue::Integer(1));
+        assert_eq!(run(&mut state, vec!["ZCARD", "z"]), RespValue::Integer(2));
+
+        // Negative scores order below positives (the sign-flip bias at work).
+        assert_eq!(run(&mut state, vec!["ZADD", "z", "-1.5", "n"]), RespValue::Integer(1));
+        assert_eq!(
+            run(&mut state, vec!["ZRANGE", "z", "0", "0", "WITHSCORES"]),
+            RespValue::Array(vec![bulk("n"), bulk("-1.5")]),
+        );
+    }
+
     #[test]
     fn set_zero_expiry_match_native() {
         let engine = TemporalEngine::default();
@@ -998,6 +1074,14 @@ mod tests {
             "TTL" => vec!["TTL", "advertised:missing"],
             "TOUCH" => vec!["TOUCH", "advertised:missing"],
             "TYPE" => vec!["TYPE", "advertised:missing"],
+            "ZADD" => vec!["ZADD", "advertised:zset", "1", "m"],
+            "ZCARD" => vec!["ZCARD", "advertised:zset"],
+            "ZRANGE" => vec!["ZRANGE", "advertised:zset", "0", "-1"],
+            "ZRANGEBYSCORE" => vec!["ZRANGEBYSCORE", "advertised:zset", "-inf", "+inf"],
+            "ZREM" => vec!["ZREM", "advertised:zset", "m"],
+            "ZREVRANGE" => vec!["ZREVRANGE", "advertised:zset", "0", "-1"],
+            "ZREVRANGEBYSCORE" => vec!["ZREVRANGEBYSCORE", "advertised:zset", "+inf", "-inf"],
+            "ZSCORE" => vec!["ZSCORE", "advertised:zset", "m"],
             "UNLINK" => vec!["UNLINK", "advertised:missing"],
             other => panic!("missing sample command for {other}"),
         }

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -425,5 +425,45 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             arity: -2,
             flags: WRITE,
         },
-    ]
+
+        RedisCommandDescriptor {
+            name: "ZADD",
+            arity: -4,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "ZCARD",
+            arity: 2,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZRANGE",
+            arity: -4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZRANGEBYSCORE",
+            arity: -4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZREM",
+            arity: -3,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "ZREVRANGE",
+            arity: -4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZREVRANGEBYSCORE",
+            arity: -4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZSCORE",
+            arity: 3,
+            flags: READ,
+        },    ]
 }

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -686,6 +686,136 @@ pub fn execute_redis_command_with_state(
             }
             RespValue::Integer(removed)
         }
+        "ZADD" if args.len() >= 4 && args.len() % 2 == 0 => {
+            let key = string_arg(&args[1]);
+            let mut pairs = Vec::new();
+            for chunk in args[2..].chunks(2) {
+                match parse_score_arg(&chunk[0]) {
+                    Ok((score, false, false)) => pairs.push((score, chunk[1].clone())),
+                    Ok(_) => {
+                        return RespValue::Error(
+                            "ERR min and max cannot be exclusive here".to_string(),
+                        )
+                    }
+                    Err(err) => return RespValue::Error(err),
+                }
+            }
+            let mut added = 0;
+            for (score, member) in pairs {
+                match execute(Command::ZSetAdd {
+                    key: key.clone(),
+                    member,
+                    score,
+                }) {
+                    Ok(CommandResponse::Integer { value }) => added += value,
+                    Ok(_) => return RespValue::Error("ERR invalid zadd response".to_string()),
+                    Err(err) => return RespValue::Error(format!("ERR {err}")),
+                }
+            }
+            state.keyspace.insert(key);
+            RespValue::Integer(added)
+        }
+        "ZSCORE" if args.len() == 3 => match execute(Command::ZSetScore {
+            key: string_arg(&args[1]),
+            member: args[2].clone(),
+        }) {
+            Ok(CommandResponse::Bytes { value }) => RespValue::Bulk(value),
+            Ok(_) => RespValue::Error("ERR invalid zscore response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
+        "ZREM" if args.len() >= 3 => {
+            let key = string_arg(&args[1]);
+            let mut removed = 0;
+            for member in args.iter().skip(2) {
+                match execute(Command::ZSetRemove {
+                    key: key.clone(),
+                    member: member.clone(),
+                }) {
+                    Ok(CommandResponse::Integer { value }) => removed += value,
+                    Ok(_) => return RespValue::Error("ERR invalid zrem response".to_string()),
+                    Err(err) => return RespValue::Error(format!("ERR {err}")),
+                }
+            }
+            RespValue::Integer(removed)
+        }
+        "ZCARD" if args.len() == 2 => match execute(Command::ZSetCard {
+            key: string_arg(&args[1]),
+        }) {
+            Ok(CommandResponse::Integer { value }) => RespValue::Integer(value),
+            Ok(_) => RespValue::Error("ERR invalid zcard response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
+        "ZRANGE" | "ZREVRANGE" if args.len() == 4 || args.len() == 5 || args.len() == 6 => {
+            let mut rev = command == "ZREVRANGE";
+            let mut withscores = false;
+            for flag in args.iter().skip(4) {
+                match string_arg(flag).to_ascii_uppercase().as_str() {
+                    "WITHSCORES" => withscores = true,
+                    "REV" if command == "ZRANGE" => rev = true,
+                    other => {
+                        return RespValue::Error(format!("ERR syntax error near {other}"))
+                    }
+                }
+            }
+            match (
+                parse_i64_arg(&args[2], "start"),
+                parse_i64_arg(&args[3], "stop"),
+            ) {
+                (Ok(start), Ok(stop)) => match execute(Command::ZSetRange {
+                    key: string_arg(&args[1]),
+                    start,
+                    stop,
+                    rev,
+                }) {
+                    Ok(CommandResponse::Members { members }) => {
+                        interleaved_members_response(members, withscores)
+                    }
+                    Ok(_) => RespValue::Error("ERR invalid zrange response".to_string()),
+                    Err(err) => RespValue::Error(format!("ERR {err}")),
+                },
+                (Err(err), _) | (_, Err(err)) => RespValue::Error(err),
+            }
+        }
+        "ZRANGEBYSCORE" | "ZREVRANGEBYSCORE" if args.len() == 4 || args.len() == 5 => {
+            let rev = command == "ZREVRANGEBYSCORE";
+            let withscores = match args.get(4) {
+                None => false,
+                Some(flag) if string_arg(flag).eq_ignore_ascii_case("WITHSCORES") => true,
+                Some(other) => {
+                    return RespValue::Error(format!(
+                        "ERR syntax error near {}",
+                        string_arg(other)
+                    ))
+                }
+            };
+            // ZREVRANGEBYSCORE takes (max, min); the engine always takes (min, max).
+            let (low_raw, high_raw) = if rev {
+                (&args[3], &args[2])
+            } else {
+                (&args[2], &args[3])
+            };
+            match (parse_score_arg(low_raw), parse_score_arg(high_raw)) {
+                (Ok((min, min_exclusive, _)), Ok((max, max_exclusive, _))) => {
+                    match execute(Command::ZSetRangeByScore {
+                        key: string_arg(&args[1]),
+                        min,
+                        max,
+                        min_exclusive,
+                        max_exclusive,
+                        rev,
+                    }) {
+                        Ok(CommandResponse::Members { members }) => {
+                            interleaved_members_response(members, withscores)
+                        }
+                        Ok(_) => {
+                            RespValue::Error("ERR invalid zrangebyscore response".to_string())
+                        }
+                        Err(err) => RespValue::Error(format!("ERR {err}")),
+                    }
+                }
+                (Err(err), _) | (_, Err(err)) => RespValue::Error(err),
+            }
+        }
         "LPUSH" | "RPUSH" if args.len() >= 3 => {
             let key = string_arg(&args[1]);
             let left = command == "LPUSH";
@@ -1521,4 +1651,39 @@ pub fn execute_redis_command_with_state(
         }
         _ => RespValue::Error(format!("ERR unsupported command or arity: {command}")),
     }
+}
+
+/// Score syntax: plain float, -inf/+inf/inf, or a leading paren for an exclusive bound.
+/// Answers (score, exclusive, was_infinite).
+fn parse_score_arg(raw: &[u8]) -> Result<(f64, bool, bool), String> {
+    let text = String::from_utf8_lossy(raw);
+    let (body, exclusive) = match text.strip_prefix('(') {
+        Some(rest) => (rest, true),
+        None => (text.as_ref(), false),
+    };
+    match body.to_ascii_lowercase().as_str() {
+        "-inf" => return Ok((f64::NEG_INFINITY, exclusive, true)),
+        "inf" | "+inf" => return Ok((f64::INFINITY, exclusive, true)),
+        _ => {}
+    }
+    body.parse::<f64>()
+        .map(|score| (score, exclusive, false))
+        .map_err(|_| "ERR min or max is not a float".to_string())
+}
+
+/// Engine z-range answers ride interleaved [member, score, member, score, ...]; the verb
+/// decides whether the scores stay in the reply.
+fn interleaved_members_response(members: Vec<Vec<u8>>, withscores: bool) -> RespValue {
+    let values = members
+        .chunks(2)
+        .flat_map(|pair| {
+            if withscores {
+                pair.to_vec()
+            } else {
+                pair.first().cloned().into_iter().collect()
+            }
+        })
+        .map(|value| RespValue::Bulk(Some(value)))
+        .collect();
+    RespValue::Array(values)
 }

--- a/crates/temporalstore-rust/src/redis/keyspace_commands.rs
+++ b/crates/temporalstore-rust/src/redis/keyspace_commands.rs
@@ -164,6 +164,14 @@ pub(super) fn redis_type_response(
         Ok(_) => return RespValue::Error("ERR invalid type hash response".to_string()),
         Err(err) => return RespValue::Error(format!("ERR {err}")),
     }
+    match execute(Command::ZSetCard { key: key.clone() }) {
+        Ok(CommandResponse::Integer { value }) if value > 0 => {
+            return RespValue::SimpleString("zset".to_string());
+        }
+        Ok(CommandResponse::Integer { .. }) => {}
+        Ok(_) => return RespValue::Error("ERR invalid type zset response".to_string()),
+        Err(err) => return RespValue::Error(format!("ERR {err}")),
+    }
     match execute(Command::ListLen { key: key.clone() }) {
         Ok(CommandResponse::Integer { value }) if value > 0 => {
             return RespValue::SimpleString("list".to_string());

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1204,6 +1204,45 @@ pub enum Command {
         #[serde(with = "crate::bytes_serde")]
         member: Vec<u8>,
     },
+    /// Upsert one member with a score. Answers 1 for a new member, 0 for a re-score.
+    ZSetAdd {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+        score: f64,
+    },
+    /// The member's score as its shortest string form, or nil when absent.
+    ZSetScore {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+    },
+    ZSetRemove {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+    },
+    ZSetCard {
+        key: String,
+    },
+    /// Index range in (score, member) order, Redis semantics (negatives from the tail).
+    /// Answers interleaved member/score-string pairs.
+    ZSetRange {
+        key: String,
+        start: i64,
+        stop: i64,
+        rev: bool,
+    },
+    /// Score-window range; exclusive flags implement the leading-paren syntax. Answers
+    /// interleaved member/score-string pairs.
+    ZSetRangeByScore {
+        key: String,
+        min: f64,
+        max: f64,
+        min_exclusive: bool,
+        max_exclusive: bool,
+        rev: bool,
+    },
     /// Push one element onto a list end (left = head). Answers the new length.
     ListPush {
         key: String,

--- a/crates/temporalstore-rust/tests/zset_recovery.rs
+++ b/crates/temporalstore-rust/tests/zset_recovery.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! A sorted set's scores and order must survive a restart -- re-scores included.
+//!
+//! Each member's page is named in the bucket index by a component encoding (score, member), and
+//! a re-score marks the OLD component deleted before publishing the new one. Recovery rebuilds
+//! the map purely from live components, so a restart must see the moved score exactly once,
+//! never the stale one -- that is the failure this pins: if the delete-then-insert ever loses
+//! its delete, the member comes back twice at two scores.
+
+use std::path::PathBuf;
+
+use temporalstore_rust::{Command, CommandResponse, ExecuteRequest, TemporalEngine};
+
+const SHARD_ID: u64 = 1;
+const CACHE_BYTES: usize = 4096;
+
+fn unique_root(name: &str) -> PathBuf {
+    let pid = std::process::id();
+    let mut root = std::env::temp_dir();
+    root.push(format!("ts-zset-recovery-{name}-{pid}"));
+    root
+}
+
+fn new_engine(root: &PathBuf) -> TemporalEngine {
+    for sub in ["cache", "pages", "indexes"] {
+        std::fs::create_dir_all(root.join(sub)).expect("create engine dir");
+    }
+    let engine = TemporalEngine::with_local_dirs(
+        CACHE_BYTES,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    );
+    engine.load_shard(SHARD_ID);
+    engine
+}
+
+fn run(engine: &TemporalEngine, command: Command) -> CommandResponse {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: SHARD_ID,
+        command,
+    });
+    assert!(response.status.ok, "command failed: {:?}", response.status);
+    response.response
+}
+
+fn zadd(engine: &TemporalEngine, member: &str, score: f64) {
+    run(
+        engine,
+        Command::ZSetAdd {
+            key: "board".to_string(),
+            member: member.as_bytes().to_vec(),
+            score,
+        },
+    );
+}
+
+fn full_range(engine: &TemporalEngine) -> Vec<String> {
+    match run(
+        engine,
+        Command::ZSetRange {
+            key: "board".to_string(),
+            start: 0,
+            stop: -1,
+            rev: false,
+        },
+    ) {
+        CommandResponse::Members { members } => members
+            .into_iter()
+            .map(|member| String::from_utf8(member).expect("utf8"))
+            .collect(),
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn scores_and_order_survive_restart_including_a_rescore() {
+    let root = unique_root("order");
+    let _ = std::fs::remove_dir_all(&root);
+
+    {
+        let engine = new_engine(&root);
+        zadd(&engine, "alice", 10.0);
+        zadd(&engine, "bob", 20.0);
+        zadd(&engine, "carol", -3.5);
+        // The re-score that must not fork: alice moves past bob.
+        zadd(&engine, "alice", 30.0);
+        assert_eq!(
+            vec!["carol", "-3.5", "bob", "20", "alice", "30"],
+            full_range(&engine)
+        );
+    }
+
+    {
+        let engine = new_engine(&root);
+        assert_eq!(
+            vec!["carol", "-3.5", "bob", "20", "alice", "30"],
+            full_range(&engine),
+            "recovery must see the moved score exactly once -- a duplicated member here means \
+             the re-score's delete was lost"
+        );
+        match run(
+            &engine,
+            Command::ZSetCard {
+                key: "board".to_string(),
+            },
+        ) {
+            CommandResponse::Integer { value } => assert_eq!(3, value),
+            other => panic!("unexpected response: {other:?}"),
+        }
+        match run(
+            &engine,
+            Command::ZSetRemove {
+                key: "board".to_string(),
+                member: b"bob".to_vec(),
+            },
+        ) {
+            CommandResponse::Integer { value } => assert_eq!(1, value),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    {
+        let engine = new_engine(&root);
+        assert_eq!(
+            vec!["carol", "-3.5", "alice", "30"],
+            full_range(&engine),
+            "a removed member must not resurrect on restart"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Third slice of #244 — item 4, per the design posted on the issue.

Each member is one page whose bucket-index component encodes total-order score bits (IEEE sign-flip bias) then the member, so lexical order is (score, member) order and recovery rebuilds the whole map from live components alone. A re-score is delete-then-insert on the index — the restart test pins that the moved score comes back exactly once (a lost delete would fork the member into two scores). One in-memory map (member → score bits + page); the ordered view derives per query as a stated V1 cost.

RESP: ZADD (multi pairs, answers only new members), ZSCORE, ZREM, ZCARD, ZRANGE/ZREVRANGE (REV, WITHSCORES), ZRANGEBYSCORE/ZREVRANGEBYSCORE (-inf/+inf, exclusive paren), TYPE answers zset. Redis lib suite 12/12; zset restart test 1/1; cargo check --all-targets clean.

Remaining on item 4 after this: ZRANK-family order statistics (an honest walk first, counts in scan stats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)