### PR TITLE
A pushed config that changes only context routing is no longer answered "unchanged"

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3496,6 +3496,94 @@ mod tests {
         assert!(proxy_on.client_options_snapshot().refresh_route_on_backend_error);
         assert!(!proxy_off.client_options_snapshot().refresh_route_on_backend_error);
     }
+
+    #[test]
+    fn every_option_a_config_push_can_change_is_noticed() {
+        // Whether a pushed config is applied is decided by comparing its version to the
+        // running one. That version was hashed from a hand-listed subset of the options,
+        // and the list had fallen behind: `context_shard_count`, `context_first_shard_id`,
+        // `context_io_timeout_ms`, `service_registry_ttl_ms` and `listen_addr` were all
+        // missing, so a push that changed only one of them produced the same version and
+        // was answered "unchanged" -- telling the operator, in the report, that their
+        // change was a no-op.
+        //
+        // Rather than list the fields again here -- which is the mistake being fixed --
+        // this walks the serialized options and changes each one in turn, so a field
+        // added later is covered without anyone editing this test.
+        //
+        // The proxy is built from exactly this baseline. An earlier version of this test
+        // built it with a helper that overrode meta_addr, so every push differed in a
+        // field that IS hashed, every assertion passed, and the test proved nothing. The
+        // guard below is what catches that: if pushing the baseline back is treated as a
+        // change, the comparison is not being exercised at all.
+        let baseline = ProxyOptions {
+            config_version: 0,
+            meta_addr: "127.0.0.1:1".to_string(),
+            ..ProxyOptions::default()
+        };
+        let unchanged =
+            ProxyService::new(baseline.clone()).update_options_report(baseline.clone());
+        assert!(
+            !unchanged.applied,
+            "pushing an identical config must be a no-op, or the assertions below pass \
+             without testing anything (reason: {})",
+            unchanged.reason
+        );
+
+        let serde_json::Value::Object(fields) = serde_json::to_value(&baseline).unwrap() else {
+            panic!("options serialize as an object");
+        };
+
+        let mut checked = 0;
+        for (name, value) in fields {
+            // config_version IS the version, so changing it is not a content change.
+            if name == "config_version" {
+                continue;
+            }
+            let candidates: Vec<serde_json::Value> = match &value {
+                serde_json::Value::Bool(flag) => vec![serde_json::Value::Bool(!flag)],
+                serde_json::Value::Number(number) => {
+                    vec![serde_json::Value::from(number.as_u64().unwrap_or(0) + 1)]
+                }
+                serde_json::Value::String(text) => vec![
+                    serde_json::Value::from(format!("{text}-changed")),
+                    // enum-valued fields reject arbitrary text; offer real alternatives
+                    serde_json::Value::from("not_serving"),
+                    serde_json::Value::from("draining"),
+                ],
+                other => panic!("teach this test how to change {name} (it is {other})"),
+            };
+
+            let changed = candidates
+                .into_iter()
+                .filter_map(|candidate| {
+                    let serde_json::Value::Object(mut document) =
+                        serde_json::to_value(&baseline).unwrap()
+                    else {
+                        return None;
+                    };
+                    document.insert(name.clone(), candidate);
+                    serde_json::from_value::<ProxyOptions>(serde_json::Value::Object(document)).ok()
+                })
+                .find(|candidate| candidate != &baseline)
+                .unwrap_or_else(|| {
+                    panic!("could not produce a changed value for {name}; teach this test about it")
+                });
+
+            let proxy = ProxyService::new(baseline.clone());
+            let report = proxy.update_options_report(changed);
+            assert!(
+                report.applied,
+                "a config push changing {name} must be applied, not answered \"{}\"",
+                report.reason
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 20,
+            "expected to exercise every option; only walked {checked}"
+        );
+    }
     #[test]
     fn proxy_location_reaches_replica_selection() {
         // The proxy has always accepted a location, reported it to the metaserver and shown

--- a/crates/temporalstore-rust/src/proxy/config.rs
+++ b/crates/temporalstore-rust/src/proxy/config.rs
@@ -82,54 +82,29 @@ pub(super) fn proxy_config_version(options: &ProxyOptions) -> u64 {
     if options.config_version != 0 {
         return options.config_version;
     }
+    // Derived from the WHOLE options document, not from a hand-listed subset of it.
+    //
+    // Whether a pushed config is applied at all is decided by comparing this version to
+    // the running one. The list this used to hash left five fields out -- among them
+    // `context_shard_count` and `context_first_shard_id`, which decide where every
+    // tenant's context is routed -- so a push that changed only one of those hashed to
+    // the same number, and `update_options_report` answered "unchanged" and dropped it.
+    // The operator was told, in the report, that their change was a no-op.
+    //
+    // Hashing the document covers every field, including ones added after this was
+    // written, which a list cannot do: the list was already five fields behind when this
+    // was found, and nothing said so.
+    //
+    // `config_version` is removed first -- it is this function's answer, not an input.
+    let mut document = serde_json::to_value(options).unwrap_or(serde_json::Value::Null);
+    if let serde_json::Value::Object(fields) = &mut document {
+        fields.remove("config_version");
+    }
     let mut version = 1469598103934665603u64;
-    let view = ProxyConfigHashView {
-        meta_addr: &options.meta_addr,
-        proxy_addr: &options.proxy_addr,
-        namespace: &options.namespace,
-        location: &options.location,
-        binary_version: &options.binary_version,
-        route_cache_ttl_ms: options.route_cache_ttl_ms,
-        connect_timeout_ms: options.connect_timeout_ms,
-        io_timeout_ms: options.io_timeout_ms,
-        max_retries: options.max_retries,
-        refresh_route_on_backend_error: options.refresh_route_on_backend_error,
-        backend_continuous_failed_time_ms: options.backend_continuous_failed_time_ms,
-        ingestion_account: &options.ingestion_account,
-        enforce_ingestion_account: options.enforce_ingestion_account,
-        max_inflight_requests: options.max_inflight_requests,
-        max_inflight_write_requests: options.max_inflight_write_requests,
-        pin_primary_reads: options.pin_primary_reads,
-        heartbeat_timeout_ms: options.heartbeat_timeout_ms,
-        topology_check_interval_ms: options.topology_check_interval_ms,
-        auto_register_min_interval_ms: options.auto_register_min_interval_ms,
-    };
-    for byte in serde_json::to_vec(&view).unwrap_or_default() {
+    for byte in serde_json::to_vec(&document).unwrap_or_default() {
         version ^= byte as u64;
         version = version.wrapping_mul(1099511628211);
     }
     version
 }
 
-#[derive(Serialize)]
-struct ProxyConfigHashView<'a> {
-    meta_addr: &'a str,
-    proxy_addr: &'a str,
-    namespace: &'a str,
-    location: &'a str,
-    binary_version: &'a str,
-    route_cache_ttl_ms: u64,
-    connect_timeout_ms: u64,
-    io_timeout_ms: u64,
-    max_retries: usize,
-    refresh_route_on_backend_error: bool,
-    backend_continuous_failed_time_ms: u64,
-    ingestion_account: &'a str,
-    enforce_ingestion_account: bool,
-    max_inflight_requests: u64,
-    max_inflight_write_requests: u64,
-    pin_primary_reads: bool,
-    heartbeat_timeout_ms: u64,
-    topology_check_interval_ms: u64,
-    auto_register_min_interval_ms: u64,
-}


### PR DESCRIPTION
Whether POST /proxy/config is applied at all is decided by comparing the pushed
config's version to the running one. When an operator does not set a version
explicitly, it is hashed -- and it was hashed from a hand-written list of nineteen of
the twenty-seven options.

Five were missing:

  context_first_shard_id   context_shard_count   context_io_timeout_ms
  service_registry_ttl_ms  listen_addr

A push that changed only one of those hashed to the same number as the running
config, so the update was discarded and the operator was told, in the report they got
back, that nothing had changed. The first two decide which shard every tenant's
context is routed to, so there was no way to repartition context by pushing a config:
the request succeeded and did nothing.

Two other fields sit outside the hash and are fine: config_version is the answer
rather than an input, and serving_mode and drop_percent are compared separately.

The version is now derived from the whole options document with config_version
removed, and the hand-written list is deleted rather than extended. Extending it would
have been correct today and behind again by the next field added, which is what
happened here -- it was five behind, and nothing said so. The comment directly above
this code already made that argument about the merge path, which was rewritten to be
structural while the change detection was left as a list.

The test walks the serialized options and changes each field in turn, so a field added
later is covered without anyone editing the test. It opens by pushing the config back
unchanged and requiring that to be a no-op: an earlier version of this test built its
proxy through a helper that overrode meta_addr, so every push differed in a field that
was hashed, every assertion passed, and it proved nothing. That guard is what catches
it.