### PR TITLE
Bound compaction on the log's disk footprint, not on the size of its commands

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -651,6 +651,13 @@ impl RaftCluster {
         }))
     }
 
+    /// Test hook: retune the compaction threshold on a live cluster.
+    #[cfg(test)]
+    pub(crate) fn set_max_applied_log_bytes_for_test(&self, bytes: u64) {
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        inner.config.max_applied_log_bytes = bytes;
+    }
+
     pub fn maybe_trigger_snapshot(&self) -> Result<RaftSnapshotTriggerReport, RaftError> {
         let (should_trigger, report) = {
             let inner = self.inner.read().expect("raft cluster lock poisoned");
@@ -664,7 +671,22 @@ impl RaftCluster {
                 .as_ref()
                 .map(|snapshot| snapshot.last_included_index)
                 .unwrap_or_default();
-            let applied_log_bytes = raft_log_bytes_after(&leader.log, last_snapshot_index);
+            // What the threshold is meant to bound is the log ON DISK, so judge it by that
+            // when this node keeps one. The logical command bytes understate the footprint by
+            // the entire encoding overhead -- measured at 7x on a 30k-write corpus, which is
+            // the difference between an 8 MB bound firing at 8 MB and firing at 56 MB. The
+            // in-process model (no WAL) keeps the logical measure, which is all it has.
+            let logical_log_bytes = raft_log_bytes_after(&leader.log, last_snapshot_index);
+            let applied_log_bytes = inner
+                .local_node_id
+                .and_then(|node_id| {
+                    inner
+                        .wal
+                        .as_ref()
+                        .map(|wal| wal.node_disk_bytes(inner.shard_id, node_id))
+                })
+                .unwrap_or(0)
+                .max(logical_log_bytes);
             let mut report = RaftSnapshotTriggerReport {
                 triggered: false,
                 reason: "below_threshold".to_string(),

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -1085,6 +1085,39 @@ impl LocalRaftWal {
     // Retained for the legacy on-disk prune path; the segmented append hot path now
     // prunes in-memory via the cursor to stay O(1).
     #[allow(dead_code)]
+    /// Bytes this node's log actually occupies on disk: every segment plus any externalized
+    /// state image. Metadata only -- no segment is opened or scanned, so this is cheap enough
+    /// for the periodic compaction check to consult on every tick.
+    ///
+    /// The compaction threshold exists to bound THIS number. Judging it by the logical size of
+    /// the commands instead understates it by the log's whole encoding overhead: on a 30k-write
+    /// corpus the commands were 5 MB while the segments held 36 MB, so an 8 MB bound did not
+    /// fire until the disk was already past 50 MB.
+    pub fn node_disk_bytes(&self, shard_id: ShardId, node_id: RaftNodeId) -> u64 {
+        let dir = self.node_segment_dir(shard_id, node_id);
+        let mut total = 0u64;
+        if let Ok(entries) = fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let is_log = matches!(
+                    path.extension().and_then(|ext| ext.to_str()),
+                    Some("wal") | Some("bin")
+                );
+                if !is_log {
+                    continue;
+                }
+                if let Ok(metadata) = entry.metadata() {
+                    total = total.saturating_add(metadata.len());
+                }
+            }
+        }
+        // The pre-segment single-file layout, for a node that has not rolled yet.
+        if let Ok(metadata) = fs::metadata(self.node_path(shard_id, node_id)) {
+            total = total.saturating_add(metadata.len());
+        }
+        total
+    }
+
     pub(super) fn prune_node_segments(
         &self,
         shard_id: ShardId,

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1548,3 +1548,60 @@ fn lagging_follower_beyond_the_window_still_catches_up() {
         "the probed follower must converge to the leader commit ({leader_commit})"
     );
 }
+
+/// The compaction threshold bounds the log ON DISK, so it must be judged by the disk footprint.
+///
+/// Judging it by the logical size of the commands understates the footprint by the whole
+/// encoding overhead: on a 30,000-write corpus the commands were 5 MB while the segments held
+/// 36 MB, so an 8 MB bound never fired and the log grew without limit. This test writes a
+/// corpus whose ON-DISK size passes a threshold its COMMAND bytes do not, and requires the
+/// trigger to fire.
+#[test]
+fn compaction_threshold_is_judged_on_the_logs_disk_footprint() {
+    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig {
+            // Never hold compaction for a lagging peer in this test: it is the byte accounting
+            // under test, not the retention policy.
+            max_retained_log_bytes: 0,
+            ..RaftConfig::default()
+        },
+    )
+    .unwrap();
+    cluster.set_local_node_id(1);
+    let transport = cluster.clone();
+    for i in 0..120u32 {
+        cluster
+            .propose_distributed(
+                Command::StringSet {
+                    key: format!("disk-{i:04}"),
+                    value: vec![(i % 251) as u8; 96],
+                },
+                &transport,
+            )
+            .unwrap();
+    }
+
+    let logical: u64 = 120 * 96;
+    let report = cluster.maybe_trigger_snapshot().unwrap();
+    assert!(
+        report.applied_log_bytes > logical,
+        "the trigger must judge the on-disk footprint ({}), not just the command bytes ({logical})",
+        report.applied_log_bytes
+    );
+
+    // A threshold ABOVE the command bytes but BELOW the disk footprint must fire: that band is
+    // exactly where an unbounded log used to live.
+    let between = (logical + report.applied_log_bytes) / 2;
+    cluster.set_max_applied_log_bytes_for_test(between);
+    let fired = cluster.maybe_trigger_snapshot().unwrap();
+    assert!(
+        fired.triggered,
+        "a threshold inside the encoding overhead must compact (reason: {}, bytes: {}, limit: {between})",
+        fired.reason, fired.applied_log_bytes
+    );
+}


### PR DESCRIPTION
## What this does

Makes the compaction threshold measure the thing it is meant to bound.

A 30,000-write corpus audit found the log growing without limit under an 8 MB bound: **32 MB on disk, zero state images ever written**, no compaction ever attempted. The threshold was never crossed — because it was compared against the wrong number.

`max_applied_log_bytes` exists to bound what the log occupies **on disk**: that is what a compaction reclaims and what a restart replays. The trigger measured the **logical size of the commands** since the last snapshot instead, which understates the footprint by the entire encoding overhead — on that corpus, 5 MB of commands against 36 MB of segments, a 7× mismatch. An 8 MB bound therefore did not fire until the disk was past 50 MB, and a slower-growing workload never fired at all.

The trigger now judges the physical footprint whenever the node keeps a log of its own: every segment plus any externalized state image, **by file metadata only** — nothing is opened or scanned, so the periodic check stays cheap. The in-process model has no log on disk and keeps the logical measure, which is all it has. Whichever is larger wins, so no configuration compacts *less* often than before.

## Proven by

A test that writes a corpus whose on-disk footprint passes a threshold its command bytes do not, then requires the trigger to fire in that band — exactly the band where an unbounded log used to live. The existing bounds, restart-through-image, and catch-up tests are unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
