### PR TITLE
get-by-id stops reading the whole store: the locator learns provenance links

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1594,13 +1594,28 @@ fn record_id_linked(record: &Value, ids: &HashSet<String>) -> bool {
     {
         return true;
     }
-    for field in ["target_memory_id", "superseded_by"] {
+    for field in ["target_memory_id", "superseded_by", "source_event_hash"] {
         match record.get(field) {
             Some(Value::String(text)) if ids.contains(text.as_str()) => return true,
             Some(Value::Number(number)) if ids.contains(number.to_string().as_str()) => {
                 return true
             }
             _ => {}
+        }
+    }
+    // Provenance arrays: a derivative points at its sources through these, without carrying
+    // them as addressable ids -- exactly the records a get-by-id must return alongside the event.
+    for field in ["source_event_ids", "source_refs"] {
+        if let Some(Value::Array(items)) = record.get(field) {
+            for item in items {
+                match item {
+                    Value::String(text) if ids.contains(text.as_str()) => return true,
+                    Value::Number(number) if ids.contains(number.to_string().as_str()) => {
+                        return true
+                    }
+                    _ => {}
+                }
+            }
         }
     }
     false
@@ -1626,6 +1641,18 @@ fn id_scoped_payloads(
         return Ok(None);
     };
     let locator_key = format!("{prefix}:context_ref_locator");
+    // A store whose locator was fed pointed ids (provenance + targets) from its FIRST append
+    // marks itself; on such stores the locator alone answers "records about these ids", and the
+    // type-index compose below -- which would fetch every record of each requested type -- is
+    // skipped. Unmarked (pre-existing) stores keep the composed behavior unchanged.
+    let locator_covers_pointed_ids = hgetall_map(engine, format!("{locator_key}_meta"))
+        .ok()
+        .map(|meta| {
+            meta.get("provenance_from_start")
+                .map(|value| value.trim() == "1")
+                .unwrap_or(false)
+        })
+        .unwrap_or(false);
     let mut positions: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for id in requested_ids {
         let raw = read_bytes(
@@ -1668,12 +1695,14 @@ fn id_scoped_payloads(
             return Ok(None);
         }
     }
-    for record_type in allowed_types {
-        if record_type == "context_event" {
-            continue;
-        }
-        for (location, _) in hgetall_map(engine, type_index_key(record_hash_key, record_type))? {
-            positions.insert(location);
+    if !locator_covers_pointed_ids {
+        for record_type in allowed_types {
+            if record_type == "context_event" {
+                continue;
+            }
+            for (location, _) in hgetall_map(engine, type_index_key(record_hash_key, record_type))? {
+                positions.insert(location);
+            }
         }
     }
     let (values, shards_touched) =

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5526,6 +5526,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         purge = self.purge_tombstones(force=True)
         return {"reset": True, "tenant_hash": tenant_hash, "removed_count": removed, "purge": purge}
 
+    def records_for_get_memory(self, memory_id: str) -> list[Json]:
+        """The live records get_memory filters for one id. Base implementation: the whole store.
+
+        get_memory's own matching (id equality and the provenance check) runs over whatever this
+        returns, so an override only has to produce a SUPERSET of the id's live records -- being
+        slow is recoverable, answering {found: false} for a live memory is not.
+        """
+        return self.read_all()
+
     def get_memory(self, args: Json) -> Json:
         """Fetch a single memory by id (mem0 ``get``). Returns the live ``context_event`` for
         ``memory_id`` projected to ``{id, memory, text, metadata, ...}`` plus the derived records
@@ -5537,7 +5546,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         memory_id_int = _safe_int(memory_id)
         event: Json | None = None
         derived: list[Json] = []
-        for record in self.read_all():
+        for record in self.records_for_get_memory(memory_id):
             record_type = str(record.get("record_type") or "")
             if record_type == "context_event" and str(record.get("event_id_hash")) == memory_id:
                 event = record

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1531,6 +1531,141 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return full
         return live_subset
 
+    def _locator_covers_pointed_ids(self) -> bool:
+        """True once the store's locator has indexed pointed ids since its FIRST append.
+
+        Sticky per process: the marker is stamped at store birth and never unset, so one positive
+        read is authoritative for the store's lifetime.
+        """
+        if getattr(self, "_locator_pointed_marker", False):
+            return True
+        try:
+            rows = self._client.scan_hash(
+                f"{self._storage_prefix}:context_ref_locator_meta").get("records") or []
+        except Exception:  # noqa: BLE001
+            return False
+        covered = any(
+            str(row.get("field")) == "provenance_from_start" and str(row.get("value")).strip() == "1"
+            for row in rows if isinstance(row, dict)
+        )
+        if covered:
+            self._locator_pointed_marker = True
+        return covered
+
+    def records_for_get_memory(self, memory_id: str) -> list[Json]:
+        """One id's live view from an id-scoped scan, on stores whose locator can answer it.
+
+        Engages ONLY when the provenance_from_start marker attests that pointed-id indexing was
+        active for every record this store ever held -- on any other store the locator cannot
+        enumerate the id's derivatives, and the id-scoped read would silently drop them (the
+        failure the shadow harness caught on the first attempt). The subset runs the SAME chain
+        as the full read -- latest-state fold, tombstone sweep, expiry filter -- so a deleted
+        memory still answers {found: false}.
+        """
+        import os as _os
+
+        if not self._locator_covers_pointed_ids():
+            return self.read_all()
+        try:
+            from tools.matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from tools.matrixark_mcp_serving_records import compact_latest_context_state_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from matrixark_mcp_serving_records import compact_latest_context_state_records
+
+        kept_types = [
+            "context_event",
+            "context_entity",
+            "context_summary",
+            "context_summary_dirty",
+            "context_segment",
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        ]
+        # Round 1 discovers WHICH derivative identities this memory is involved with.
+        linked = self._scan_records_of_types(kept_types, record_ids=[str(memory_id)])
+        if linked is None:
+            return self.read_all()
+        # Round 2 fetches every VERSION of those identities. Derivatives are last-writer-wins by
+        # identity, so a subset holding only the versions that still LINK to this id would let a
+        # superseded copy win compaction and resurface -- the shadow caught exactly that. One
+        # scan (not a union of two) so the records come back in append order, which is what
+        # last-writer-wins needs to pick the same winner the full read picks.
+        identity_ids = {str(memory_id)}
+        for record in linked:
+            for field in ("entity_hash", "summary_hash", "segment_hash", "event_id_hash"):
+                value = record.get(field)
+                if value not in (None, "", 0):
+                    identity_ids.add(str(value))
+        subset = (
+            linked
+            if len(identity_ids) <= 1
+            else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
+        )
+        if subset is None:
+            return self.read_all()
+        try:
+            latest_state = self._load_latest_context_state_records()
+        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+            return self.read_all()
+        folded = compact_latest_context_state_records(list(subset) + list(latest_state))
+        live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
+
+        shadow = _os.environ.get("MATRIXARK_GETMEM_SHADOW_COMPARE", "").strip()
+        if shadow not in {"", "0", "false", "no", "off"}:
+            full = self.read_all()
+            log_path = _os.environ.get("MATRIXARK_GETMEM_SHADOW_LOG",
+                                       "/tmp/matrixark_getmem_shadow.log")
+
+            def project(records: list[Json]) -> tuple:
+                try:
+                    from tools.matrixark_mcp_local_adapter import (
+                        _record_provenance_source_ids,
+                        _safe_int,
+                    )
+                except ModuleNotFoundError:
+                    from matrixark_mcp_local_adapter import (
+                        _record_provenance_source_ids,
+                        _safe_int,
+                    )
+                mid_int = _safe_int(str(memory_id))
+                event_seen = None
+                derived = []
+                for record in records:
+                    rtype = str(record.get("record_type") or "")
+                    if rtype == "context_event" and str(record.get("event_id_hash")) == str(memory_id):
+                        event_seen = str(record.get("event_id_hash"))
+                        continue
+                    if mid_int is not None:
+                        prov = _record_provenance_source_ids(record)
+                        if prov is not None and mid_int in prov:
+                            derived.append((rtype, str(record.get("entity_hash")),
+                                            str(record.get("summary_hash"))))
+                return (event_seen, sorted(derived))
+
+            expected, got = project(full), project(live_subset)
+            try:
+                with open(log_path, "a", encoding="utf-8") as log:
+                    if expected != got:
+                        log.write("MISMATCH id=%s full=%r subset=%r\n"
+                                  % (memory_id, expected, got))
+                    else:
+                        log.write("CLEAN id=%s derived=%d\n" % (memory_id, len(expected[1])))
+            except OSError:
+                pass
+            return full
+        return live_subset
+
     def raw_records_for_history(self, memory_id: str | None = None) -> list[Json]:
         """History's records from a three-type scan instead of a raw read of the whole log.
 

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -938,6 +938,33 @@ class _TemporalDirectBackendMixin:
             return ""
         return str(value or "")
 
+    @staticmethod
+    def record_pointed_ref_ids(record: Json) -> list[int]:
+        """The ids a record points AT without carrying: provenance sources and tombstone/feedback
+        targets. Filed into the locator so one id lookup finds the records ABOUT an id, not just
+        the records carrying it."""
+        values: list = []
+        source_ids = record.get("source_event_ids")
+        if isinstance(source_ids, list):
+            values.extend(source_ids)
+        source_refs = record.get("source_refs")
+        if isinstance(source_refs, list):
+            values.extend(source_refs)
+        for field in ("source_event_hash", "target_memory_id", "superseded_by"):
+            if record.get(field) is not None:
+                values.append(record.get(field))
+        out: list[int] = []
+        seen: set[int] = set()
+        for value in values:
+            try:
+                ref = int(value)
+            except (TypeError, ValueError):
+                continue
+            if ref and ref not in seen:
+                seen.add(ref)
+                out.append(ref)
+        return out
+
     def _native_side_index_entries_for_bundles(self, bundles: list[tuple[list[Json], str, str]]) -> list[Json]:
         """Build sidecar lookup rows so retrieval can avoid broad record scans.
 
@@ -973,6 +1000,10 @@ class _TemporalDirectBackendMixin:
                         if route:
                             route_by_hash_field.setdefault(placement_key, route)
                 for ref_hash in context_index_ref_hashes(record):
+                    locator_updates.setdefault(ref_hash, []).append(location)
+                    if route:
+                        route_by_hash_field.setdefault((self._context_ref_locator_key(), str(ref_hash)), route)
+                for ref_hash in self.record_pointed_ref_ids(record):
                     locator_updates.setdefault(ref_hash, []).append(location)
                     if route:
                         route_by_hash_field.setdefault((self._context_ref_locator_key(), str(ref_hash)), route)
@@ -1047,6 +1078,27 @@ class _TemporalDirectBackendMixin:
                 }
             )
         locator_key = self._context_ref_locator_key()
+        # Store birth: the batch placing the very first record (shard 000000, field 000000) also
+        # stamps the coverage marker, so readers can trust that pointed-id indexing was active
+        # for every record this store has ever held. Idempotent; existing stores never gain it.
+        def _is_birth_location(record_key: str, record_id: str) -> bool:
+            # Shard 0, field 0 -- the store's very first append. Field ids are zero-padded to a
+            # width that differs from the shard width, so compare numerically, not by literal.
+            if not record_key.endswith(":000000"):
+                return False
+            try:
+                return int(record_id) == 0
+            except (TypeError, ValueError):
+                return False
+
+        if any(_is_birth_location(record_key, record_id)
+               for _, record_key, record_id in bundles):
+            entries.append({
+                "key": locator_key + "_meta",
+                "field": "provenance_from_start",
+                "value": "1",
+                "storage_route": {},
+            })
         for ref_hash, new_locations in locator_updates.items():
             field = str(ref_hash)
             merged_locations = self._merge_ref_locations(existing_for(locator_key, field), new_locations)


### PR DESCRIPTION
The ref locator now indexes the ids a record points AT (provenance sources, tombstone/feedback targets) as well as those it carries, so one lookup finds an event plus its derivatives. Engine id filtering matches provenance fields; on stores marked provenance_from_start (stamped at store birth) the id-scoped compose skips the dense type-index pass. Two-round fetch keeps last-writer-wins compaction honest (round 1 discovers identities, round 2 fetches every version in append order) — the shadow caught the single-round version returning EXTRA derivatives. Evidence: same-store A/B on 1.7 GB, get(id) 2007 ms -> 7.4 ms with identical answers; shadow 0 mismatches / 9 compares; strict 22/22; proxy bin suite 35/0.