### PR TITLE
RESP: the rest of the sorted-set surface

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -59,6 +59,9 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ZSetCard { key }
         | Command::ZSetRange { key, .. }
         | Command::ZSetRangeByScore { key, .. }
+        | Command::ZSetIncrBy { key, .. }
+        | Command::ZSetPop { key, .. }
+        | Command::ZSetRank { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -60,6 +60,9 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ZSetCard { key }
         | Command::ZSetRange { key, .. }
         | Command::ZSetRangeByScore { key, .. }
+        | Command::ZSetIncrBy { key, .. }
+        | Command::ZSetPop { key, .. }
+        | Command::ZSetRank { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureReplace { key, .. }
@@ -275,6 +278,8 @@ pub(super) fn command_updates_bucket_index_directly(command: &Command) -> bool {
             | Command::ListPop { .. }
             | Command::ZSetAdd { .. }
             | Command::ZSetRemove { .. }
+            | Command::ZSetIncrBy { .. }
+            | Command::ZSetPop { .. }
             | Command::ControlStateIncrement { .. }
             | Command::ControlStateIncrementWithOptions { .. }
             | Command::ControlStateSet { .. }
@@ -303,6 +308,8 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ListPop { .. }
             | Command::ZSetAdd { .. }
             | Command::ZSetRemove { .. }
+            | Command::ZSetIncrBy { .. }
+            | Command::ZSetPop { .. }
             | Command::FeatureAppend { .. }
             | Command::FeatureAppendWithPolicy { .. }
             | Command::FeatureReplace { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -658,6 +658,123 @@ pub(crate) fn execute_on_shard(
                 .collect();
             CommandResponse::Members { members }
         }
+        Command::ZSetIncrBy {
+            key,
+            member,
+            increment,
+        } => {
+            remove_if_expired(shard, &key);
+            let old = shard
+                .zsets
+                .get(&key)
+                .and_then(|members| members.get(&member))
+                .map(|(biased, _)| *biased);
+            let score = old.map_or(0.0, zset_score_from_bits) + increment;
+            let biased = zset_score_bits(score);
+            if let Some(old_biased) = old {
+                let old_component = zset_component(old_biased, &member);
+                mark_bucket_index_page_deleted(shard, "zset", &key, Some(&old_component));
+            }
+            let component = zset_component(biased, &member);
+            let object_id = stable_page_object_id(shard_id, "zset", &key, Some(&component));
+            let routing_bucket =
+                page_routing_bucket(&key, start_routing_bucket, end_routing_bucket);
+            if let Ok(address) = append_value(
+                cache,
+                page_store,
+                shard_id,
+                &member,
+                Some(object_id),
+                Some(routing_bucket),
+                async_storage,
+            ) {
+                shard
+                    .zsets
+                    .entry(key.clone())
+                    .or_default()
+                    .insert(member.clone(), (biased, address.clone()));
+                upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "zset",
+                    &key,
+                    Some(component),
+                    address,
+                    true,
+                );
+                mutated = true;
+            }
+            let _ = cache.invalidate_record(shard_id, "zset", &key);
+            CommandResponse::Bytes {
+                value: Some(zset_score_string(biased).into_bytes()),
+            }
+        }
+        Command::ZSetPop { key, min, count } => {
+            if remove_if_expired(shard, &key) {
+                mutated = true;
+                let _ = cache.invalidate_record(shard_id, "zset", &key);
+                return ExecuteOutcome {
+                    response: CommandResponse::Members {
+                        members: Vec::new(),
+                    },
+                    mutated,
+                };
+            }
+            let mut ordered = zset_ordered_members(shard, &key);
+            if !min {
+                ordered.reverse();
+            }
+            ordered.truncate(count as usize);
+            let mut members = Vec::new();
+            for (member, biased) in ordered {
+                let component = zset_component(biased, &member);
+                mark_bucket_index_page_deleted(shard, "zset", &key, Some(&component));
+                if let Some(entries) = shard.zsets.get_mut(&key) {
+                    entries.remove(&member);
+                }
+                mutated = true;
+                members.push(member);
+                members.push(zset_score_string(biased).into_bytes());
+            }
+            if shard.zsets.get(&key).is_some_and(BTreeMap::is_empty) {
+                shard.zsets.remove(&key);
+            }
+            if mutated {
+                let _ = cache.invalidate_record(shard_id, "zset", &key);
+            }
+            CommandResponse::Members { members }
+        }
+        Command::ZSetRank { key, member, rev } => {
+            remove_if_expired(shard, &key);
+            let target = shard
+                .zsets
+                .get(&key)
+                .and_then(|members| members.get(&member))
+                .map(|(biased, _)| (*biased, member.clone()));
+            CommandResponse::Bytes {
+                value: target.map(|(biased, member)| {
+                    let before = shard
+                        .zsets
+                        .get(&key)
+                        .map(|members| {
+                            members
+                                .iter()
+                                .filter(|(other, (other_biased, _))| {
+                                    let other_key = (*other_biased, (*other).clone());
+                                    let target_key = (biased, member.clone());
+                                    if rev {
+                                        other_key > target_key
+                                    } else {
+                                        other_key < target_key
+                                    }
+                                })
+                                .count()
+                        })
+                        .unwrap_or(0);
+                    before.to_string().into_bytes()
+                }),
+            }
+        }
         Command::ListPush { key, member, left } => {
             remove_if_expired(shard, &key);
             let seq = {

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -81,6 +81,9 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ZSetCard { key }
         | Command::ZSetRange { key, .. }
         | Command::ZSetRangeByScore { key, .. }
+        | Command::ZSetIncrBy { key, .. }
+        | Command::ZSetPop { key, .. }
+        | Command::ZSetRank { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -637,6 +637,61 @@ mod tests {
         );
     }
 
+    /// The rest of the sorted-set surface: ZINCRBY creates-then-moves atomically, ZCOUNT
+    /// honors the window syntax, ZPOPMIN/ZPOPMAX drain in order with scores attached, and
+    /// ZRANK/ZREVRANK answer positions or nil.
+    #[test]
+    fn sorted_set_completion_commands_match_native() {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let mut state = RedisCommandState::default();
+        let mut run = |state: &mut RedisCommandState, args: Vec<&str>| {
+            execute_redis_command_with_state(
+                args.into_iter().map(|arg| arg.as_bytes().to_vec()).collect(),
+                1,
+                state,
+                &mut |command| {
+                    let response = engine.execute(crate::ExecuteRequest {
+                        shard_id: 1,
+                        command,
+                    });
+                    if response.status.ok {
+                        Ok(response.response)
+                    } else {
+                        Err(response.status.message)
+                    }
+                },
+            )
+        };
+        let bulk = |text: &str| RespValue::Bulk(Some(text.as_bytes().to_vec()));
+
+        // ZINCRBY on a missing member starts from 0; on a present one it moves the score.
+        assert_eq!(run(&mut state, vec!["ZINCRBY", "z", "3", "a"]), bulk("3"));
+        assert_eq!(run(&mut state, vec!["ZINCRBY", "z", "-1.5", "a"]), bulk("1.5"));
+        assert_eq!(run(&mut state, vec!["ZCARD", "z"]), RespValue::Integer(1));
+
+        assert_eq!(run(&mut state, vec!["ZADD", "z", "5", "b", "7", "c"]), RespValue::Integer(2));
+        assert_eq!(run(&mut state, vec!["ZCOUNT", "z", "-inf", "+inf"]), RespValue::Integer(3));
+        assert_eq!(run(&mut state, vec!["ZCOUNT", "z", "(1.5", "5"]), RespValue::Integer(1),
+            "the paren excludes a's exact score");
+
+        assert_eq!(run(&mut state, vec!["ZRANK", "z", "a"]), RespValue::Integer(0));
+        assert_eq!(run(&mut state, vec!["ZREVRANK", "z", "a"]), RespValue::Integer(2));
+        assert_eq!(run(&mut state, vec!["ZRANK", "z", "missing"]), RespValue::Bulk(None));
+
+        assert_eq!(
+            run(&mut state, vec!["ZPOPMIN", "z"]),
+            RespValue::Array(vec![bulk("a"), bulk("1.5")]),
+        );
+        assert_eq!(
+            run(&mut state, vec!["ZPOPMAX", "z", "5"]),
+            RespValue::Array(vec![bulk("c"), bulk("7"), bulk("b"), bulk("5")]),
+            "a COUNT larger than the set drains it high-to-low"
+        );
+        assert_eq!(run(&mut state, vec!["ZCARD", "z"]), RespValue::Integer(0));
+        assert_eq!(run(&mut state, vec!["ZPOPMIN", "z"]), RespValue::Array(Vec::new()));
+    }
+
     #[test]
     fn set_zero_expiry_match_native() {
         let engine = TemporalEngine::default();
@@ -1076,6 +1131,12 @@ mod tests {
             "TYPE" => vec!["TYPE", "advertised:missing"],
             "ZADD" => vec!["ZADD", "advertised:zset", "1", "m"],
             "ZCARD" => vec!["ZCARD", "advertised:zset"],
+            "ZCOUNT" => vec!["ZCOUNT", "advertised:zset", "-inf", "+inf"],
+            "ZINCRBY" => vec!["ZINCRBY", "advertised:zset", "1", "m"],
+            "ZPOPMAX" => vec!["ZPOPMAX", "advertised:zset"],
+            "ZPOPMIN" => vec!["ZPOPMIN", "advertised:zset"],
+            "ZRANK" => vec!["ZRANK", "advertised:zset", "m"],
+            "ZREVRANK" => vec!["ZREVRANK", "advertised:zset", "m"],
             "ZRANGE" => vec!["ZRANGE", "advertised:zset", "0", "-1"],
             "ZRANGEBYSCORE" => vec!["ZRANGEBYSCORE", "advertised:zset", "-inf", "+inf"],
             "ZREM" => vec!["ZREM", "advertised:zset", "m"],

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -432,6 +432,36 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             flags: WRITE,
         },
         RedisCommandDescriptor {
+            name: "ZCOUNT",
+            arity: 4,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZINCRBY",
+            arity: 4,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "ZPOPMAX",
+            arity: -2,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "ZPOPMIN",
+            arity: -2,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
+            name: "ZRANK",
+            arity: 3,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "ZREVRANK",
+            arity: 3,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
             name: "ZCARD",
             arity: 2,
             flags: READ,

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -816,6 +816,83 @@ pub fn execute_redis_command_with_state(
                 (Err(err), _) | (_, Err(err)) => RespValue::Error(err),
             }
         }
+        "ZINCRBY" if args.len() == 4 => match parse_score_arg(&args[2]) {
+            Ok((increment, false, _)) => match execute(Command::ZSetIncrBy {
+                key: string_arg(&args[1]),
+                member: args[3].clone(),
+                increment,
+            }) {
+                Ok(CommandResponse::Bytes { value }) => RespValue::Bulk(value),
+                Ok(_) => RespValue::Error("ERR invalid zincrby response".to_string()),
+                Err(err) => RespValue::Error(format!("ERR {err}")),
+            },
+            Ok(_) => RespValue::Error("ERR increment cannot be exclusive".to_string()),
+            Err(err) => RespValue::Error(err),
+        },
+        "ZCOUNT" if args.len() == 4 => {
+            match (parse_score_arg(&args[2]), parse_score_arg(&args[3])) {
+                (Ok((min, min_exclusive, _)), Ok((max, max_exclusive, _))) => {
+                    match execute(Command::ZSetRangeByScore {
+                        key: string_arg(&args[1]),
+                        min,
+                        max,
+                        min_exclusive,
+                        max_exclusive,
+                        rev: false,
+                    }) {
+                        Ok(CommandResponse::Members { members }) => {
+                            RespValue::Integer((members.len() / 2) as i64)
+                        }
+                        Ok(_) => RespValue::Error("ERR invalid zcount response".to_string()),
+                        Err(err) => RespValue::Error(format!("ERR {err}")),
+                    }
+                }
+                (Err(err), _) | (_, Err(err)) => RespValue::Error(err),
+            }
+        }
+        "ZPOPMIN" | "ZPOPMAX" if args.len() == 2 || args.len() == 3 => {
+            let count = match args.get(2) {
+                None => 1,
+                Some(raw) => match parse_i64_arg(raw, "count") {
+                    Ok(count) if count >= 0 => count as u64,
+                    Ok(_) => {
+                        return RespValue::Error(
+                            "ERR value is out of range, must be positive".to_string(),
+                        )
+                    }
+                    Err(err) => return RespValue::Error(err),
+                },
+            };
+            match execute(Command::ZSetPop {
+                key: string_arg(&args[1]),
+                min: command == "ZPOPMIN",
+                count,
+            }) {
+                Ok(CommandResponse::Members { members }) => RespValue::Array(
+                    members
+                        .into_iter()
+                        .map(|value| RespValue::Bulk(Some(value)))
+                        .collect(),
+                ),
+                Ok(_) => RespValue::Error("ERR invalid zpop response".to_string()),
+                Err(err) => RespValue::Error(format!("ERR {err}")),
+            }
+        }
+        "ZRANK" | "ZREVRANK" if args.len() == 3 => match execute(Command::ZSetRank {
+            key: string_arg(&args[1]),
+            member: args[2].clone(),
+            rev: command == "ZREVRANK",
+        }) {
+            Ok(CommandResponse::Bytes { value: Some(rank) }) => {
+                match String::from_utf8_lossy(&rank).parse::<i64>() {
+                    Ok(rank) => RespValue::Integer(rank),
+                    Err(_) => RespValue::Error("ERR invalid zrank response".to_string()),
+                }
+            }
+            Ok(CommandResponse::Bytes { value: None }) => RespValue::Bulk(None),
+            Ok(_) => RespValue::Error("ERR invalid zrank response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
         "LPUSH" | "RPUSH" if args.len() >= 3 => {
             let key = string_arg(&args[1]);
             let left = command == "LPUSH";

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1243,6 +1243,29 @@ pub enum Command {
         max_exclusive: bool,
         rev: bool,
     },
+    /// Add to a member's score (0 when absent), atomically under the shard lock.
+    /// Answers the new score as its shortest string form.
+    ZSetIncrBy {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+        increment: f64,
+    },
+    /// Pop up to `count` members off the low (min) or high end, in order.
+    /// Answers interleaved member/score-string pairs.
+    ZSetPop {
+        key: String,
+        min: bool,
+        count: u64,
+    },
+    /// The member's 0-based position in (score, member) order, tail-based when rev.
+    /// Answers the rank as a decimal string, or nil for a missing member.
+    ZSetRank {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+        rev: bool,
+    },
     /// Push one element onto a list end (left = head). Answers the new length.
     ListPush {
         key: String,


### PR DESCRIPTION
Final slice of #244 item 4: ZINCRBY (engine-atomic create-then-move), ZPOPMIN/ZPOPMAX (ordered drain with COUNT, same delete-then-insert as the re-score), ZRANK/ZREVRANK (honest walk, nil for missing), ZCOUNT (rides the score-window range, which never reads a page). Redis lib suite 13/13; cargo check --all-targets clean.

With this, every item of the issue except the explicitly-excluded MULTI/Lua is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)