### PR TITLE
Reclaim the embedded engine index log and WAL after threshold catalog dumps

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -677,6 +677,7 @@ impl TemporalEngine {
                                     request.shard_id,
                                     &record.staged_pages,
                                     log_id,
+                                    record.sequence,
                                     &self.wal_store,
                                 );
                             }

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -94,19 +94,25 @@ pub(super) fn take_staged() -> Vec<StagedPage> {
     STAGED.with(|staged| std::mem::take(&mut *staged.borrow_mut()))
 }
 
-/// (shard, object id) -> the log holding that page, and where in it.
+/// (shard, object id) -> the log holding that page, where in it, and the WAL sequence of the
+/// record carrying it.
 ///
 /// The log handle is stored per entry rather than once per process: two engines in one process
 /// have separate logs, and a single shared handle would resolve one engine's addresses against
 /// the other's log -- reading the wrong bytes, silently.
-type Registration = (LocalWriteAheadLogStore, u64);
+///
+/// The sequence is what lets WAL reclaim coexist with these registrations: a registered page's
+/// only durable copy is its record, so reclaim must never truncate below the lowest registered
+/// sequence (see [`min_registered_sequence`]).
+type Registration = (LocalWriteAheadLogStore, u64, u64);
 
 fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
     static REGISTRY: OnceLock<Mutex<HashMap<(ShardId, u64), Registration>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Note that the pages in `record` live in the record at `log_id`.
+/// Note that the pages in `record` live in the record at `log_id`, carried by the WAL record
+/// at `sequence`.
 ///
 /// A later write of the same object replaces its entry, so a registration always names the
 /// record holding the current page rather than a superseded one.
@@ -114,6 +120,7 @@ pub(super) fn register_record(
     shard_id: ShardId,
     staged_pages: &[StagedPage],
     log_id: u64,
+    sequence: u64,
     store: &LocalWriteAheadLogStore,
 ) {
     if staged_pages.is_empty() {
@@ -121,9 +128,28 @@ pub(super) fn register_record(
     }
     if let Ok(mut map) = registry().lock() {
         for page in staged_pages {
-            map.insert((shard_id, page.object_id), (store.clone(), log_id));
+            map.insert((shard_id, page.object_id), (store.clone(), log_id, sequence));
         }
     }
+}
+
+/// The lowest WAL sequence any of this shard's registrations IN THIS LOG still depends on, or
+/// `None` when nothing is registered. WAL reclaim uses this as the block-retention floor: a
+/// record at or above it may hold the only copy of a page the served index still points at, so
+/// truncating it would turn an acked write into a MISSING read.
+///
+/// Filtered by log identity, not just shard id: the registry is process-wide and every
+/// embedded engine serves shard 1, so without the filter one engine's registrations would pin
+/// every other engine's reclaim floor forever.
+pub(super) fn min_registered_sequence(
+    shard_id: ShardId,
+    store: &LocalWriteAheadLogStore,
+) -> Option<u64> {
+    let map = registry().lock().ok()?;
+    map.iter()
+        .filter(|((shard, _), (reg_store, _, _))| *shard == shard_id && reg_store.same_log(store))
+        .map(|(_, (_, _, sequence))| *sequence)
+        .min()
 }
 
 /// Forget a shard's registrations. Called when the shard unloads; a reload replays the WAL and
@@ -140,14 +166,57 @@ pub(super) fn clear_shard(shard_id: ShardId) {
 /// does not carry that page -- in every case the caller falls through to the behaviour it had
 /// before, so this can only turn a miss into a hit.
 pub(super) fn read_page(shard_id: ShardId, object_id: u64) -> Option<Vec<u8>> {
-    let (store, log_id) = registry().lock().ok()?.get(&(shard_id, object_id))?.clone();
-    // Ask for an upper bound; the read clamps to what the file holds.
-    let bytes = store.read_at_log_id(shard_id, log_id, 1 << 20).ok()??;
-    let line = bytes.split(|byte| *byte == 10u8).next()?;
-    let record = decode_wal_line(line).ok()?;
-    record
-        .staged_pages
+    let (store, log_id, _) = registry().lock().ok()?.get(&(shard_id, object_id))?.clone();
+    // One batch record carries many pages, and an ingest reads several of the fields its own
+    // batch just wrote -- so the same record used to be pread and re-parsed once per page. WAL
+    // records are immutable once written (append-only), so a small decoded-record LRU cannot go
+    // stale: a superseding write registers a NEWER log_id and old entries simply age out.
+    if let Ok(cache) = record_lru().lock() {
+        // Keyed by (log identity, shard, log id) -- a log id is a byte offset within ONE log,
+        // so the same number names unrelated records in different engines' logs.
+        if let Some((_, _, _, pages)) = cache
+            .iter()
+            .find(|(s, shard, l, _)| *shard == shard_id && *l == log_id && s.same_log(&store))
+        {
+            if let Some(page) = pages.iter().find(|page| page.object_id == object_id) {
+                return Some(page.bytes.clone());
+            }
+        }
+    }
+    // Adaptive pread: most records terminate well inside 128KB, so try that first and escalate
+    // only when the line does not end in the chunk -- a fixed 1MB upper bound makes every
+    // point read cost a megabyte of I/O.
+    let mut record = None;
+    for size in [128u64 << 10, 1 << 20, u64::MAX] {
+        let bytes = store.read_at_log_id(shard_id, log_id, size).ok()??;
+        let complete = bytes.contains(&10u8) || (bytes.len() as u64) < size;
+        if !complete {
+            continue;
+        }
+        let line = bytes.split(|byte| *byte == 10u8).next()?;
+        record = decode_wal_line(line).ok();
+        break;
+    }
+    let record = record?;
+    let pages = record.staged_pages;
+    if let Ok(mut cache) = record_lru().lock() {
+        if cache.len() >= 8 {
+            cache.remove(0);
+        }
+        cache.push((store.clone(), shard_id, log_id, pages.clone()));
+    }
+    pages
         .into_iter()
         .find(|page| page.object_id == object_id)
         .map(|page| page.bytes)
+}
+
+/// Decoded staged pages of recently read records, keyed by (log identity, shard, log id).
+/// Tiny on purpose: the working set is "the record(s) the current request's batch just wrote".
+/// Entries cannot go stale: WAL records are immutable, a superseding write registers a newer
+/// log id, and the post-dump WAL sweep never truncates a registered record (its floor).
+fn record_lru() -> &'static Mutex<Vec<(LocalWriteAheadLogStore, ShardId, u64, Vec<StagedPage>)>> {
+    static LRU: OnceLock<Mutex<Vec<(LocalWriteAheadLogStore, ShardId, u64, Vec<StagedPage>)>>> =
+        OnceLock::new();
+    LRU.get_or_init(|| Mutex::new(Vec::new()))
 }

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -416,14 +416,34 @@ impl TemporalEngine {
     /// watermark unadvanced, so the next cycle re-dumps rather than trusting a partial dump -- the
     /// catalog is never lost, only (harmlessly) re-materialized. Returns whether a dump completed.
     pub fn dump_index_catalog(&self, shard_id: ShardId) -> bool {
+        self.dump_index_catalog_anchored(shard_id).is_some()
+    }
+
+    /// [`dump_index_catalog`] returning the dump's coordinates on success: the WAL anchor the
+    /// durable base index reflects, and the index-log sequence its folded catalog anchor landed
+    /// at. Post-dump log reclaim needs both: everything the base reflects (WAL records at or
+    /// below the anchor, index-log records whose own anchor is at or below it) is redundant,
+    /// while the folded anchor record itself must survive.
+    pub(super) fn dump_index_catalog_anchored(&self, shard_id: ShardId) -> Option<(u64, u64)> {
         if !crate::index_log::index_catalog_fold_enabled() {
-            return false;
+            return None;
+        }
+        // A dump for a shard this engine does not serve is a no-op; check BEFORE the durability
+        // barrier so a background caller polling an unloaded shard does not pay (or issue) an
+        // fsync for nothing.
+        if !self
+            .shards
+            .read()
+            .expect("engine lock poisoned")
+            .contains_key(&shard_id)
+        {
+            return None;
         }
         // 1. Make deferred data pages + the band manifest + the WAL durable BEFORE materializing
         //    the dump, so nothing the anchor references is un-fsynced. Bail (without advancing the
         //    watermark) if the barrier fails; the next cycle retries.
         if self.page_store.sync_durable().is_err() || self.wal_store.flush(shard_id).is_err() {
-            return false;
+            return None;
         }
         // 2. Serialize + durably write the base served index (collapses the legacy per-write
         //    whole-index rewrite into this threshold dump). Also read the WAL anchor the index
@@ -435,14 +455,14 @@ impl TemporalEngine {
                     serialize_index(shard),
                     shard.applied_wal_sequence.unwrap_or(0),
                 ),
-                None => return false,
+                None => return None,
             }
         };
         if self
             .persist_index_bytes_durable(shard_id, &index_bytes)
             .is_err()
         {
-            return false;
+            return None;
         }
         // 3. Fold the band/zone catalog into a MetaItem anchor and append it durably to the
         //    index-log. This is this design's "dump the zone catalog into the index log" step:
@@ -457,25 +477,130 @@ impl TemporalEngine {
             zone_version,
             zones,
         };
-        if self
-            .index_log_store
-            .append_delta(
-                shard_id,
-                Vec::new(),
-                Vec::new(),
-                Some(anchor),
-                Some(meta),
-                false,
-                true,
-            )
-            .is_err()
-        {
-            return false;
-        }
+        let meta_sequence = match self.index_log_store.append_delta(
+            shard_id,
+            Vec::new(),
+            Vec::new(),
+            Some(anchor),
+            Some(meta),
+            false,
+            true,
+        ) {
+            Ok(sequence) => sequence,
+            Err(_) => return None,
+        };
         // 4. The base + folded anchor are durable; advance the dumped watermark so the undumped
         //    gap resets and the next threshold is measured from here.
         self.index_log_store.mark_catalog_dumped(shard_id);
-        true
+        Some((anchor, meta_sequence))
+    }
+
+    /// Embedded-path log maintenance: when the undumped index-log gap has crossed
+    /// `index_dump_wal_gap_bytes`, dump the catalog and then RECLAIM what the dump made
+    /// redundant. This is what keeps an engine with no background storage-manager cycle (the
+    /// gateway proxy embeds the engine directly; only the server/data-node run cycles) from
+    /// growing its WAL and index-log without bound: the dump durably captures everything at or
+    /// below its anchor, so the logs below it can go. No-op (returning `None`) with the fold
+    /// gate off, below the threshold, or when the dump could not complete.
+    pub fn maybe_dump_and_reclaim_index_logs(
+        &self,
+        shard_id: ShardId,
+    ) -> Option<super::reports::CatalogDumpReclaimReport> {
+        if !crate::index_log::index_catalog_fold_enabled() {
+            return None;
+        }
+        let gap = crate::storage_config::index_dump_wal_gap_bytes();
+        let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
+        if !crate::index_log::should_dump_index_catalog(undumped, gap) {
+            return None;
+        }
+        self.dump_and_reclaim_index_logs(shard_id)
+    }
+
+    /// Unconditional (past the threshold check) dump + reclaim. See
+    /// [`maybe_dump_and_reclaim_index_logs`](Self::maybe_dump_and_reclaim_index_logs).
+    pub fn dump_and_reclaim_index_logs(
+        &self,
+        shard_id: ShardId,
+    ) -> Option<super::reports::CatalogDumpReclaimReport> {
+        let (wal_anchor, meta_sequence) = self.dump_index_catalog_anchored(shard_id)?;
+        // Index-log first: drop every record the durable base already reflects (per-record WAL
+        // anchor at or below the dump's), keeping the folded catalog anchor and any delta a
+        // concurrent writer landed after the dump serialized.
+        let index_gc = self
+            .index_log_store
+            .gc_reflected_before_anchor(shard_id, wal_anchor, meta_sequence)
+            .ok();
+        // The sweep rewrote (shrank) the log file; re-mark the dumped watermark so the next
+        // threshold measures growth from the POST-reclaim length. Without this the gap signal
+        // would read `current - pre_reclaim_length`, saturating to zero until the file regrew
+        // past its old size -- silently suspending the cadence right after its first success.
+        self.index_log_store.mark_catalog_dumped(shard_id);
+        // Pin the WAL floor to the lowest sequence a live block-in-WAL registration still
+        // depends on: such a record holds the ONLY copy of a page the served index points at
+        // (the write was acked off a synthetic address), so truncating it turns an acked write
+        // into a MISSING read while the process is still serving.
+        let wal_retention_floor =
+            super::block_in_wal::min_registered_sequence(shard_id, &self.wal_store);
+        match wal_retention_floor {
+            Some(sequence) => self.wal_store.set_block_retention_floor(shard_id, sequence),
+            None => self.wal_store.clear_block_retention_floor(shard_id),
+        }
+        // WAL prefix below the anchor: the durable base reflects those records, replay-on-load
+        // starts above the anchor, and gc itself additionally retains the highest-sequence
+        // record (sequence continuity) and everything at or above the floor just set.
+        let wal_gc = self
+            .wal_store
+            .gc_before_sequence(shard_id, wal_anchor.saturating_add(1))
+            .ok();
+        Some(super::reports::CatalogDumpReclaimReport {
+            shard_id,
+            wal_anchor,
+            index_log_records_removed: index_gc
+                .as_ref()
+                .map(|report| report.records_removed)
+                .unwrap_or_default(),
+            index_log_bytes_before: index_gc
+                .as_ref()
+                .map(|report| report.bytes_before)
+                .unwrap_or_default(),
+            index_log_bytes_after: index_gc
+                .as_ref()
+                .map(|report| report.bytes_after)
+                .unwrap_or_default(),
+            wal_records_removed: wal_gc
+                .as_ref()
+                .map(|report| report.records_removed)
+                .unwrap_or_default(),
+            wal_bytes_before: wal_gc
+                .as_ref()
+                .map(|report| report.bytes_before)
+                .unwrap_or_default(),
+            wal_bytes_after: wal_gc
+                .as_ref()
+                .map(|report| report.bytes_after)
+                .unwrap_or_default(),
+            wal_retention_floor,
+        })
+    }
+
+    /// Test-only variant of `maybe_dump_and_reclaim_index_logs` taking an explicit gap, so a
+    /// test can drive the below-threshold (no-op) and above-threshold (dump + reclaim) branches
+    /// deterministically without mutating the process-wide gap env mid-test.
+    #[cfg(test)]
+    pub fn maybe_dump_and_reclaim_with_gap_for_test(
+        &self,
+        shard_id: ShardId,
+        gap_bytes: u64,
+    ) -> Option<super::reports::CatalogDumpReclaimReport> {
+        if !crate::index_log::index_catalog_fold_enabled() {
+            return None;
+        }
+        let undumped = self.index_log_store.undumped_len_since_dump(shard_id);
+        if !crate::index_log::should_dump_index_catalog(undumped, gap_bytes) {
+            return None;
+        }
+        self.dump_and_reclaim_index_logs(shard_id)
     }
 
     pub(super) fn persist_index_bytes(

--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -2694,6 +2694,28 @@ pub struct StorageIndexGcReport {
     pub skipped_reason: String,
 }
 
+/// What one threshold catalog dump reclaimed from the shard's logs (embedded path).
+///
+/// After [`dump_index_catalog`](crate::TemporalEngine::dump_index_catalog) durably
+/// materializes the base index at `wal_anchor` and folds the catalog anchor, everything the
+/// base reflects is redundant: index-log records whose own WAL anchor is at or below
+/// `wal_anchor`, and WAL records at or below it (clamped by the block-retention floor, which
+/// pins any record still holding the only copy of a served page).
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CatalogDumpReclaimReport {
+    pub shard_id: ShardId,
+    pub wal_anchor: u64,
+    pub index_log_records_removed: usize,
+    pub index_log_bytes_before: u64,
+    pub index_log_bytes_after: u64,
+    pub wal_records_removed: usize,
+    pub wal_bytes_before: u64,
+    pub wal_bytes_after: u64,
+    /// The block-retention floor in force during the WAL sweep (`None` = unconstrained): the
+    /// lowest WAL sequence a live block-in-WAL registration still depends on.
+    pub wal_retention_floor: Option<u64>,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StorageEvictionVictim {
     #[serde(rename = "routing_slot")]

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -2144,6 +2144,131 @@ fn manifest_fold_threshold_dump_fires_only_past_the_gap_and_folds_the_catalog() 
 }
 
 #[test]
+fn catalog_dump_reclaim_shrinks_both_logs_and_reload_stays_exact() {
+    // Embedded-path log reclaim: once a threshold dump durably captures the shard, the
+    // index-log records the base reflects and the WAL prefix below the anchor are redundant --
+    // reclaiming them must SHRINK both files on disk, keep the cadence alive (watermark
+    // measured from the post-reclaim length), and leave a reload byte-exact.
+    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine =
+        TemporalEngine::with_local_dirs(1 << 20, dir.path().join("cache-a"), &page_dir, &index_dir);
+    engine.load_shard(1);
+    for i in 0..60 {
+        write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
+    }
+    let report = engine
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1)
+        .expect("past the gap, the dump + reclaim must fire");
+    assert!(
+        report.index_log_bytes_after < report.index_log_bytes_before,
+        "the index log must shrink on disk after the dump ({} -> {})",
+        report.index_log_bytes_before,
+        report.index_log_bytes_after
+    );
+    assert!(
+        report.wal_bytes_after < report.wal_bytes_before,
+        "the WAL must shrink on disk after the dump ({} -> {})",
+        report.wal_bytes_before,
+        report.wal_bytes_after
+    );
+    assert!(report.index_log_records_removed > 0);
+    assert!(report.wal_records_removed > 0);
+    // The folded catalog anchor survives its own sweep -- it is the load-time catalog seed.
+    assert!(
+        engine
+            .index_log_store()
+            .latest_zone_catalog(1)
+            .unwrap()
+            .is_some(),
+        "the folded catalog anchor must survive the index-log sweep"
+    );
+    // The watermark was re-marked at the post-reclaim length: no immediate re-dump, and the
+    // cadence fires again once new writes regrow the gap (it must not wait for the file to
+    // regrow past its PRE-reclaim size).
+    assert!(engine.maybe_dump_and_reclaim_with_gap_for_test(1, u64::MAX).is_none());
+    for i in 60..70 {
+        write_string(&engine, &format!("key-{i}"), format!("val-{i}").as_bytes());
+    }
+    assert!(
+        engine.maybe_dump_and_reclaim_with_gap_for_test(1, 1).is_some(),
+        "the cadence must keep firing after a reclaim shrank the log"
+    );
+    drop(engine);
+    let restarted = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+    for i in 0..70 {
+        assert_eq!(
+            read_string(&restarted, &format!("key-{i}")),
+            Some(format!("val-{i}").into_bytes()),
+            "every acked key must survive reload after the logs were reclaimed"
+        );
+    }
+}
+
+#[test]
+fn catalog_dump_reclaim_pins_wal_records_holding_block_in_wal_pages() {
+    // An async write's page can live ONLY in its WAL record (served back through the
+    // block-in-WAL registration). A post-dump WAL sweep must pin its floor at the lowest
+    // registered sequence so that record survives, even when the dump anchor is far above it.
+    let _guard = FoldEnvGuard::set(&[("TS_INDEX_CATALOG_FOLD", "1")]);
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 20,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    // One async write first: its WAL record carries its staged page.
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        },
+    });
+    write_string(&engine, "async-key", b"async-value");
+    // Then a run of synchronous writes, which advance the dump anchor past the async record.
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 3,
+            async_storage: false,
+            ..Config::default()
+        },
+    });
+    for i in 0..40 {
+        write_string(&engine, &format!("sync-{i}"), format!("val-{i}").as_bytes());
+    }
+    let report = engine
+        .maybe_dump_and_reclaim_with_gap_for_test(1, 1)
+        .expect("dump + reclaim must fire");
+    let floor = report
+        .wal_retention_floor
+        .expect("the staged async page must register a WAL retention floor");
+    assert!(
+        floor <= report.wal_anchor,
+        "the floor ({floor}) pins a record below the dump anchor ({})",
+        report.wal_anchor
+    );
+    // The pinned record survived: the async value still reads back exactly.
+    assert_eq!(
+        read_string(&engine, "async-key"),
+        Some(b"async-value".to_vec()),
+        "the async write's page must survive the WAL sweep"
+    );
+}
+
+#[test]
 fn manifest_fold_reload_reconstructs_catalog_with_band_manifest_deleted() {
     // MANIFEST-CONFORMANCE FOLD round-trip: write, dump (folds the catalog), delete the band-manifest
     // file, reload -- every acked key must survive AND the band lifecycle must reconstruct from

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -312,21 +312,25 @@ fn indexlog_wal_only_sync() -> bool {
     )
 }
 
-/// MANIFEST-CONFORMANCE FOLD gate (default OFF, byte-identical when off). When on, the band/zone
+/// MANIFEST-CONFORMANCE FOLD gate (default ON, opt-out). When on, the band/zone
 /// catalog is folded into the index-log anchor at a threshold dump
 /// and the per-write band-manifest file stops being the
 /// catalog's source of truth (it is reconstructed on load from the durable pages + the folded
 /// anchor). Off, none of that fold code runs: no `zones` are ever captured (so anchor records
-/// serialize identically), and recovery/persistence take the existing paths unchanged. Ships
-/// dark; flips on after the crash-recovery suite is green.
+/// serialize identically), and recovery/persistence take the existing paths unchanged.
+///
+/// Shipped dark originally (the flip once broke proxy tests); the full lib + proxy suites are
+/// green with it on since the upsert-delta and single-barrier work landed, and the threshold
+/// dump is what lets the embedded (proxy) engine reclaim its index-log and WAL at all -- so it
+/// now defaults on. Set `TS_INDEX_CATALOG_FOLD=0` to restore the previous behaviour.
 pub fn index_catalog_fold_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_INDEX_CATALOG_FOLD")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -804,6 +808,97 @@ impl LocalIndexLogStore {
         })
     }
 
+    /// Remove every record a completed catalog dump has made redundant, deciding retention per
+    /// record on CONTENT rather than on log position alone.
+    ///
+    /// A dump durably materializes the base served index at WAL anchor `wal_anchor` and then
+    /// appends its folded catalog anchor, which lands at index-log sequence `meta_sequence`.
+    /// Everything the base reflects -- records whose own WAL anchor is at or below `wal_anchor`
+    /// -- is redundant on load (the fold skips them), so it goes. Two kinds of record sit below
+    /// `meta_sequence` yet must SURVIVE:
+    ///
+    /// - a delta a concurrent writer appended between the dump's serialization and its anchor
+    ///   append: its WAL anchor is above `wal_anchor`, so the base does not reflect it, and
+    ///   removing it would lose an eviction/removal that lives only in the delta stream;
+    /// - nothing else -- a legacy whole-index line carries no anchor and is read by no load
+    ///   path, so it is treated as reflected and removed.
+    ///
+    /// The folded catalog anchor itself is at `meta_sequence`, above the removal window, so the
+    /// load-time catalog seed always survives. Position (`sequence < meta_sequence`) still
+    /// bounds the sweep so a record appended AFTER the dump with a stale-looking anchor is never
+    /// touched.
+    pub fn gc_reflected_before_anchor(
+        &self,
+        shard_id: ShardId,
+        wal_anchor: u64,
+        meta_sequence: u64,
+    ) -> Result<IndexLogGcReport, IndexLogError> {
+        #[derive(serde::Deserialize)]
+        struct AnchorProbe {
+            sequence: u64,
+            #[serde(default)]
+            applied_wal_sequence: Option<u64>,
+        }
+        let inner = self.inner.lock().expect("index log lock poisoned");
+        fs::create_dir_all(&inner.root)?;
+        let path = index_log_path(&inner.root, shard_id);
+        if !path.exists() {
+            return Ok(IndexLogGcReport {
+                shard_id,
+                retain_from_sequence: meta_sequence,
+                ..IndexLogGcReport::default()
+            });
+        }
+
+        let bytes_before = path.metadata()?.len();
+        let _ = last_sequence_at(&inner.root, shard_id)?;
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+        let mut records_before = 0usize;
+        let mut retained = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            records_before += 1;
+            // Decode verifies the integrity envelope; the retained raw payload is re-framed on
+            // write-out below, so a retained delta record keeps its exact on-disk bytes.
+            let payload = crate::log_framing::decode_line(line.as_bytes())?;
+            let probe: AnchorProbe = serde_json::from_slice(payload)?;
+            let reflected = probe.applied_wal_sequence.unwrap_or(0) <= wal_anchor;
+            if probe.sequence >= meta_sequence || !reflected {
+                retained.push(payload.to_vec());
+            }
+        }
+
+        let temp_path = path.with_extension("jsonl.tmp");
+        {
+            let mut temp = File::create(&temp_path)?;
+            for payload in &retained {
+                temp.write_all(&crate::log_framing::encode_line(payload))?;
+            }
+            temp.flush()?;
+            crate::durability_metrics::record_barrier("engine_index_log_gc");
+            temp.sync_all()?;
+        }
+        fs::rename(&temp_path, &path)?;
+        sync_parent_dir(&path)?;
+        let bytes_after = path.metadata()?.len();
+        Ok(IndexLogGcReport {
+            shard_id,
+            retain_from_sequence: meta_sequence,
+            max_entries_per_round: 0,
+            records_before,
+            records_after: retained.len(),
+            records_removed: records_before.saturating_sub(retained.len()),
+            removable_records_before_budget: records_before.saturating_sub(retained.len()),
+            budget_exhausted: false,
+            bytes_before,
+            bytes_after,
+        })
+    }
+
     pub fn stats(&self, shard_id: ShardId) -> IndexLogStats {
         let inner = self.inner.lock().expect("index log lock poisoned");
         IndexLogStats {
@@ -1058,6 +1153,57 @@ mod tests {
         let records = store.read_delta_records(3, 0).unwrap();
         assert_eq!(records.len(), 2);
         assert_eq!(records[1].meta.as_ref().unwrap().start_wal_sequence, 42);
+    }
+
+    #[test]
+    fn gc_reflected_before_anchor_keeps_unreflected_deltas_and_the_catalog_anchor() {
+        // Content-based post-dump sweep: records whose WAL anchor the durable base already
+        // reflects go; a delta a concurrent writer landed with a HIGHER anchor survives even
+        // though it sits below the catalog anchor in the log, and the anchor record itself
+        // (the load-time catalog seed) survives its own sweep.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalIndexLogStore::new(dir.path());
+        // seq 1: legacy whole-index line (no anchor; read by no load path -> reflected).
+        store.append_json(7, b"{\"value\":1}").unwrap();
+        // seq 2: delta reflected by the dump (WAL anchor 2 <= dump anchor 2).
+        store
+            .append_delta(7, vec![page_item(1, "covered", false)], Vec::new(), Some(2), None, false, true)
+            .unwrap();
+        // seq 3: concurrent delta landed after the dump serialized (WAL anchor 5 > 2).
+        store
+            .append_delta(7, vec![page_item(1, "racing", false)], Vec::new(), Some(5), None, false, true)
+            .unwrap();
+        // seq 4: the dump's folded catalog anchor.
+        let meta = MetaItem {
+            version: 1,
+            start_wal_sequence: 2,
+            timestamp_ms: 100,
+            ..MetaItem::default()
+        };
+        let meta_sequence = store
+            .append_delta(7, Vec::new(), Vec::new(), Some(2), Some(meta), false, true)
+            .unwrap();
+
+        let report = store.gc_reflected_before_anchor(7, 2, meta_sequence).unwrap();
+        assert_eq!(report.records_before, 4);
+        assert_eq!(report.records_removed, 2, "the whole-index line and the covered delta go");
+        assert!(report.bytes_after < report.bytes_before);
+
+        let survivors = store.read_delta_records(7, 0).unwrap();
+        assert_eq!(survivors.len(), 2);
+        assert_eq!(
+            survivors[0].items[0].page_ref_key, "racing",
+            "the unreflected concurrent delta must survive the sweep"
+        );
+        assert!(
+            survivors[1].meta.is_some(),
+            "the folded catalog anchor must survive the sweep"
+        );
+        // Sequence continuity: the next append lands above the anchor record.
+        let next = store
+            .append_delta(7, vec![page_item(1, "later", false)], Vec::new(), Some(6), None, false, true)
+            .unwrap();
+        assert_eq!(next, meta_sequence + 1);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3225,6 +3225,40 @@ fn open_engine(request: &RecordLogRequest) -> Result<TemporalEngine, String> {
             ..Config::default()
         },
     });
+    // Embedded log maintenance: the proxy engine runs no storage-manager cycle (only the
+    // server/data-node do), so without this its WAL and index-log grow without bound -- a
+    // 100K-record ingest left a multi-GB index log that nothing ever truncated. Poll the
+    // threshold-dump cadence in the background: when the undumped index-log gap crosses
+    // `TS_INDEX_DUMP_WAL_GAP_BYTES`, dump the catalog and reclaim the log prefixes the dump
+    // made redundant. The poll itself is one file-length stat per interval; the dump/reclaim
+    // runs off the request path so no client write pays for the base-index materialization.
+    // No-op (thread not spawned) with the fold gate off or the interval set to 0.
+    let reclaim_interval_ms = env::var("MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(1000);
+    if temporalstore_rust::index_log::index_catalog_fold_enabled() && reclaim_interval_ms > 0 {
+        let reclaim_engine = engine.clone();
+        let reclaim_root = root.clone();
+        std::thread::spawn(move || loop {
+            std::thread::sleep(std::time::Duration::from_millis(reclaim_interval_ms));
+            if let Some(report) = reclaim_engine.maybe_dump_and_reclaim_index_logs(DEFAULT_SHARD_ID)
+            {
+                eprintln!(
+                    "matrixark_rust_proxy_log_reclaim root={} wal_anchor={} index_log_bytes={}->{} ({} records removed) wal_bytes={}->{} ({} records removed) floor={:?}",
+                    reclaim_root.display(),
+                    report.wal_anchor,
+                    report.index_log_bytes_before,
+                    report.index_log_bytes_after,
+                    report.index_log_records_removed,
+                    report.wal_bytes_before,
+                    report.wal_bytes_after,
+                    report.wal_records_removed,
+                    report.wal_retention_floor,
+                );
+            }
+        });
+    }
     let mut cache = engine_cache()
         .lock()
         .map_err(|_| "record-log engine cache lock poisoned".to_string())?;

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1122,6 +1122,14 @@ impl LocalWriteAheadLogStore {
     /// Set this to the dump watermark and advance it as blocks are dumped into bands. Until a
     /// shard registers a floor its GC is unconstrained, so this is inert for callers that do not
     /// put blocks in the WAL.
+    /// Whether two handles address the SAME underlying log (clones of one store). Registrations
+    /// keyed only by (shard, object) conflate engines -- every embedded engine in a process
+    /// serves shard 1 -- so consumers that aggregate across a registry must filter by the log
+    /// identity the registration actually points at.
+    pub fn same_log(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     pub fn set_block_retention_floor(&self, shard_id: ShardId, sequence: u64) {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         inner.block_retention_floor_by_shard.insert(shard_id, sequence);


### PR DESCRIPTION
## Problem

The gateway proxy embeds the engine directly and runs no background storage-manager cycle (only the server and data node do), so nothing ever truncated its index log or write-ahead log. Every write appended forever: a 100K-record ingest left a 57GB index log that outlived every record in it. The upsert-delta work made per-entry appends flat-sized, but the files still only grew.

## Change

After a threshold catalog dump durably materializes the base served index at a WAL anchor, everything the base reflects is redundant — so reclaim it:

- **Index log**: swept by CONTENT, not position. A record goes only when its own recorded WAL anchor is at or below the dump's anchor. A delta a concurrent writer lands between the dump's serialization and its anchor append survives (its anchor is higher), and the folded catalog anchor the next load seeds from always survives.
- **WAL**: the prefix at or below the anchor is truncated, clamped by a block-retention floor pinned at the lowest WAL sequence a live block-in-WAL registration still depends on — a record holding the only copy of a page the served index points at is never removed. Registrations now carry their record's sequence, and the floor is computed per log identity: the registry is process-wide and every embedded engine serves shard 1, so without the identity filter one engine's registrations would pin every other engine's floor forever.
- The dumped watermark is re-marked after the sweep so the next threshold measures growth from the post-reclaim length (otherwise the cadence silently suspends until the file regrows past its old size).

The proxy polls the cadence per engine in a background thread (`MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS`, default 1000ms, 0 disables); the poll is one file-length stat, and the dump/reclaim runs off the request path.

`TS_INDEX_CATALOG_FOLD` now defaults **on** (opt-out with `0`): the flip that once broke proxy tests is clean against the current tree — full lib suite and both proxy bin suites are green with it enabled — and the threshold dump is what makes embedded reclaim possible at all.

Hot-page point reads also stop paying a fixed 1MB pread and a re-parse per page (measured 40–73ms per read at 45K records): an adaptive read (128KB, escalating only when the record's line does not terminate in the chunk) plus a small decoded-record cache keyed by (log identity, shard, log id). WAL records are immutable and a superseding write registers a newer log id, so the cache cannot go stale; the sweep never truncates a registered record, so it cannot dangle.

## Proof

- New tests: content-based index-log sweep (keeps racing deltas + the catalog anchor, drops covered records), dump+reclaim shrinking both files with an exact reload afterwards, and the floor pinning a WAL record that holds an async write's only page copy.
- Full lib suite (`--lib --test-threads=1`) and both proxy bin suites green.
- Live gateway A/B (results in comments below): on-disk bytes shrink after dumps while SIGKILL recovery keeps every acked memory.
