### PR TITLE
A token-bucket model: atomic take-with-refill, config rides the command

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -62,6 +62,8 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ZSetIncrBy { key, .. }
         | Command::ZSetPop { key, .. }
         | Command::ZSetRank { key, .. }
+        | Command::BucketTake { key, .. }
+        | Command::BucketPeek { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2510,6 +2510,7 @@ fn delete_record_exact(shard: &mut ShardState, key: &str) -> bool {
     removed |= shard.sets.remove(key).is_some();
     removed |= shard.lists.remove(key).is_some();
     removed |= shard.zsets.remove(key).is_some();
+    removed |= shard.buckets.remove(key).is_some();
     if shard.features.remove(key).is_some() {
         removed = true;
         control_rollup::feature_forget(shard, key);

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -63,6 +63,8 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ZSetIncrBy { key, .. }
         | Command::ZSetPop { key, .. }
         | Command::ZSetRank { key, .. }
+        | Command::BucketTake { key, .. }
+        | Command::BucketPeek { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureReplace { key, .. }
@@ -310,6 +312,7 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ZSetRemove { .. }
             | Command::ZSetIncrBy { .. }
             | Command::ZSetPop { .. }
+            | Command::BucketTake { .. }
             | Command::FeatureAppend { .. }
             | Command::FeatureAppendWithPolicy { .. }
             | Command::FeatureReplace { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -658,6 +658,36 @@ pub(crate) fn execute_on_shard(
                 .collect();
             CommandResponse::Members { members }
         }
+        Command::BucketTake {
+            key,
+            tokens,
+            capacity,
+            refill_per_sec,
+        } => {
+            let now = resolve_now_ms();
+            let current = shard.buckets.get(&key).copied();
+            let (allowed, remaining, retry_after_ms, next) =
+                bucket_take(current, now, tokens, capacity, refill_per_sec);
+            shard.buckets.insert(key, next);
+            mutated = true;
+            CommandResponse::Members {
+                members: bucket_answer(allowed, remaining, retry_after_ms),
+            }
+        }
+        Command::BucketPeek {
+            key,
+            tokens,
+            capacity,
+            refill_per_sec,
+        } => {
+            let now = resolve_now_ms();
+            let current = shard.buckets.get(&key).copied();
+            let (allowed, remaining, retry_after_ms, _) =
+                bucket_take(current, now, tokens, capacity, refill_per_sec);
+            CommandResponse::Members {
+                members: bucket_answer(allowed, remaining, retry_after_ms),
+            }
+        }
         Command::ZSetIncrBy {
             key,
             member,
@@ -3255,4 +3285,49 @@ fn zset_ordered_members(shard: &ShardState, key: &str) -> Vec<(Vec<u8>, u64)> {
         .unwrap_or_default();
     ordered.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
     ordered
+}
+
+/// The whole token-bucket model in one pure function, so its arithmetic is testable with
+/// explicit clocks: refill by elapsed time at `refill_per_sec` (capped at capacity, and a
+/// clock that moved backwards refills nothing), then take if it fits. Answers
+/// (allowed, remaining AFTER the outcome, retry-after ms, state to store). An absent bucket
+/// starts full.
+pub(super) fn bucket_take(
+    current: Option<(f64, u64)>,
+    now_ms: u64,
+    tokens: f64,
+    capacity: f64,
+    refill_per_sec: f64,
+) -> (bool, f64, u64, (f64, u64)) {
+    let tokens = tokens.max(0.0);
+    let capacity = capacity.max(0.0);
+    let refill_per_sec = refill_per_sec.max(0.0);
+    let filled = match current {
+        None => capacity,
+        Some((had, last_ms)) => {
+            let elapsed_ms = now_ms.saturating_sub(last_ms);
+            (had + refill_per_sec * (elapsed_ms as f64 / 1000.0)).min(capacity)
+        }
+    };
+    if tokens <= filled {
+        let remaining = filled - tokens;
+        (true, remaining, 0, (remaining, now_ms))
+    } else {
+        let shortfall = tokens - filled;
+        let retry_after_ms = if refill_per_sec > 0.0 && tokens <= capacity {
+            (shortfall / refill_per_sec * 1000.0).ceil() as u64
+        } else {
+            // A take larger than capacity can never succeed; answer the sentinel.
+            u64::MAX
+        };
+        (false, filled, retry_after_ms, (filled, now_ms))
+    }
+}
+
+fn bucket_answer(allowed: bool, remaining: f64, retry_after_ms: u64) -> Vec<Vec<u8>> {
+    vec![
+        if allowed { b"1".to_vec() } else { b"0".to_vec() },
+        format!("{remaining:.3}").into_bytes(),
+        retry_after_ms.to_string().into_bytes(),
+    ]
 }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -56,6 +56,14 @@ pub(super) struct ShardState {
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,
     #[serde(default, with = "super::set_index_serde")]
     pub(super) sets: HashMap<String, BTreeMap<Vec<u8>, BlockAddress>>,
+    /// Token buckets: key -> (tokens remaining, last refill ms). Config rides each command,
+    /// never the store -- the caller owns policy, which is exactly what a quota layer wants.
+    /// No pages back this state: it persists only with the shard index snapshot, so a crash
+    /// refills every bucket to capacity. That direction is deliberate and documented -- a
+    /// limiter that briefly over-admits after a crash beats one that starves recovered
+    /// tenants on stale counts.
+    #[serde(default)]
+    pub(super) buckets: HashMap<String, (f64, u64)>,
     /// Sorted sets: member -> (total-order score bits, element page). The score-ordered view
     /// is derived per query -- V1 accepts the per-range sort; the upgrade path is a second
     /// in-memory map rebuilt at load, never a second persisted structure (the index component

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -84,3 +84,46 @@ mod quota;
 mod upsert_deltas;
 mod part3;
 mod part4;
+
+
+/// The token-bucket arithmetic with explicit clocks -- the whole model is this pure function,
+/// so this is the whole model under test: start full, drain to deny with an honest
+/// retry-after, refill by elapsed time capped at capacity, tolerate a backwards clock, and
+/// name the impossible take.
+#[test]
+fn bucket_take_arithmetic_with_explicit_clocks() {
+    use crate::engine::execute_on_shard::bucket_take;
+
+    // An absent bucket starts full: 10 capacity, take 3 -> 7 left.
+    let (allowed, remaining, retry, state) = bucket_take(None, 1_000, 3.0, 10.0, 1.0);
+    assert!(allowed);
+    assert_eq!(7.0, remaining);
+    assert_eq!(0, retry);
+    assert_eq!((7.0, 1_000), state);
+
+    // Drain past the level: denied, retry-after is the shortfall at the refill rate.
+    let (allowed, remaining, retry, state) = bucket_take(Some(state), 1_000, 9.0, 10.0, 1.0);
+    assert!(!allowed);
+    assert_eq!(7.0, remaining, "a denied take consumes nothing");
+    assert_eq!(2_000, retry, "2 tokens short at 1 token/sec");
+
+    // 5 seconds later the refill covers it: 7 + 5 = 12, capped at 10, take 9 -> 1.
+    let (allowed, remaining, _, state) = bucket_take(Some(state), 6_000, 9.0, 10.0, 1.0);
+    assert!(allowed);
+    assert_eq!(1.0, remaining);
+
+    // A clock that moved backwards refills nothing and never panics.
+    let (allowed, remaining, _, _) = bucket_take(Some(state), 5_000, 0.5, 10.0, 1.0);
+    assert!(allowed);
+    assert_eq!(0.5, remaining);
+
+    // A take larger than capacity can never succeed: the sentinel says so.
+    let (allowed, _, retry, _) = bucket_take(None, 1_000, 20.0, 10.0, 1.0);
+    assert!(!allowed);
+    assert_eq!(u64::MAX, retry);
+
+    // Zero refill rate: a denied take also answers the sentinel rather than dividing by zero.
+    let (allowed, _, retry, _) = bucket_take(Some((0.0, 1_000)), 2_000, 1.0, 10.0, 0.0);
+    assert!(!allowed);
+    assert_eq!(u64::MAX, retry);
+}

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -84,6 +84,8 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ZSetIncrBy { key, .. }
         | Command::ZSetPop { key, .. }
         | Command::ZSetRank { key, .. }
+        | Command::BucketTake { key, .. }
+        | Command::BucketPeek { key, .. }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -692,6 +692,59 @@ mod tests {
         assert_eq!(run(&mut state, vec!["ZPOPMIN", "z"]), RespValue::Array(Vec::new()));
     }
 
+    /// The token-bucket verbs over RESP: TAKE admits until the bucket runs dry and then
+    /// answers denied with a retry-after, PEEK answers the same shape without consuming.
+    #[test]
+    fn bucket_verbs_admit_then_deny_with_retry_after() {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let mut state = RedisCommandState::default();
+        let mut run = |state: &mut RedisCommandState, args: Vec<&str>| {
+            execute_redis_command_with_state(
+                args.into_iter().map(|arg| arg.as_bytes().to_vec()).collect(),
+                1,
+                state,
+                &mut |command| {
+                    let response = engine.execute(crate::ExecuteRequest {
+                        shard_id: 1,
+                        command,
+                    });
+                    if response.status.ok {
+                        Ok(response.response)
+                    } else {
+                        Err(response.status.message)
+                    }
+                },
+            )
+        };
+        let fields = |value: RespValue| -> Vec<String> {
+            match value {
+                RespValue::Array(items) => items
+                    .into_iter()
+                    .map(|item| match item {
+                        RespValue::Bulk(Some(bytes)) => String::from_utf8(bytes).expect("utf8"),
+                        other => panic!("unexpected item: {other:?}"),
+                    })
+                    .collect(),
+                other => panic!("unexpected response: {other:?}"),
+            }
+        };
+
+        // Capacity 2, no refill within the test: two takes admit, the third denies.
+        let first = fields(run(&mut state, vec!["BUCKETTAKE", "q", "1", "2", "0.001"]));
+        assert_eq!("1", first[0]);
+        let second = fields(run(&mut state, vec!["BUCKETTAKE", "q", "1", "2", "0.001"]));
+        assert_eq!("1", second[0]);
+        let third = fields(run(&mut state, vec!["BUCKETTAKE", "q", "1", "2", "0.001"]));
+        assert_eq!("0", third[0], "the drained bucket must deny");
+        assert!(third[2].parse::<u64>().expect("retry ms") > 0, "denied answers a retry-after");
+
+        // PEEK reports without consuming: two identical peeks.
+        let peek_one = fields(run(&mut state, vec!["BUCKETPEEK", "q", "1", "2", "0.001"]));
+        let peek_two = fields(run(&mut state, vec!["BUCKETPEEK", "q", "1", "2", "0.001"]));
+        assert_eq!(peek_one, peek_two, "peek must not consume");
+    }
+
     #[test]
     fn set_zero_expiry_match_native() {
         let engine = TemporalEngine::default();
@@ -1052,6 +1105,8 @@ mod tests {
             "BGSAVE" => vec!["BGSAVE"],
             "COMMAND" => vec!["COMMAND", "COUNT"],
             "CONFIG" => vec!["CONFIG", "GET", "maxmemory"],
+            "BUCKETPEEK" => vec!["BUCKETPEEK", "advertised:bucket", "1", "10", "1"],
+            "BUCKETTAKE" => vec!["BUCKETTAKE", "advertised:bucket", "1", "10", "1"],
             "COPY" => vec!["COPY", "advertised:missing", "advertised:copy"],
             "DBSIZE" => vec!["DBSIZE"],
             "DEL" => vec!["DEL", "advertised:missing"],

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -36,6 +36,16 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             flags: ADMIN,
         },
         RedisCommandDescriptor {
+            name: "BUCKETPEEK",
+            arity: 5,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "BUCKETTAKE",
+            arity: 5,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
             name: "COPY",
             arity: -3,
             flags: WRITE,

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -1414,6 +1414,50 @@ pub fn execute_redis_command_with_state(
                 Err(err) => RespValue::Error(format!("ERR {err}")),
             }
         }
+        "BUCKETTAKE" | "BUCKETPEEK" if args.len() == 5 => {
+            let parse = |raw: &[u8], name: &str| -> Result<f64, String> {
+                String::from_utf8_lossy(raw)
+                    .parse::<f64>()
+                    .map_err(|_| format!("ERR {name} is not a float"))
+            };
+            match (
+                parse(&args[2], "tokens"),
+                parse(&args[3], "capacity"),
+                parse(&args[4], "refill_per_sec"),
+            ) {
+                (Ok(tokens), Ok(capacity), Ok(refill_per_sec)) => {
+                    let key = string_arg(&args[1]);
+                    let command_value = if command == "BUCKETTAKE" {
+                        Command::BucketTake {
+                            key,
+                            tokens,
+                            capacity,
+                            refill_per_sec,
+                        }
+                    } else {
+                        Command::BucketPeek {
+                            key,
+                            tokens,
+                            capacity,
+                            refill_per_sec,
+                        }
+                    };
+                    match execute(command_value) {
+                        Ok(CommandResponse::Members { members }) => RespValue::Array(
+                            members
+                                .into_iter()
+                                .map(|value| RespValue::Bulk(Some(value)))
+                                .collect(),
+                        ),
+                        Ok(_) => RespValue::Error("ERR invalid bucket response".to_string()),
+                        Err(err) => RespValue::Error(format!("ERR {err}")),
+                    }
+                }
+                (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => {
+                    RespValue::Error(err)
+                }
+            }
+        }
         "CONTROLSTATEINCR" if args.len() == 4 => {
             let timestamp_ms = match parse_u64(&args[2], "timestamp_ms") {
                 Ok(value) => value,

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1243,6 +1243,22 @@ pub enum Command {
         max_exclusive: bool,
         rev: bool,
     },
+    /// Atomic take-with-refill on a token bucket: refill by elapsed time (capped at
+    /// capacity), then take `tokens` if they fit. Answers three strings -- allowed ("1"/"0"),
+    /// tokens remaining, and retry-after ms (0 when allowed).
+    BucketTake {
+        key: String,
+        tokens: f64,
+        capacity: f64,
+        refill_per_sec: f64,
+    },
+    /// The same arithmetic without taking: what a take of `tokens` WOULD answer.
+    BucketPeek {
+        key: String,
+        tokens: f64,
+        capacity: f64,
+        refill_per_sec: f64,
+    },
     /// Add to a member's score (0 when absent), atomically under the shard lock.
     /// Answers the new score as its shortest string form.
     ZSetIncrBy {


### PR DESCRIPTION
First of #245 suggested models (the rate limiter), and the server-side primitive #243 quota work needs.

One pure function is the whole model — refill by elapsed time at the given rate capped at capacity, take if it fits — run atomically under the shard lock. Config rides every command (the caller owns policy). State is one map entry per bucket, persisted with the shard index snapshot: a crash refills buckets to capacity, the deliberate direction. Replay stays deterministic via the replay clock, the same stance expiry takes.

BucketTake answers allowed / remaining / retry-after-ms (impossible takes answer the max sentinel instead of dividing by zero); BucketPeek answers without consuming. Over RESP: BUCKETTAKE / BUCKETPEEK. Arithmetic pinned with explicit clocks (backwards clock included); RESP test pins admit-until-deny and peek-never-consumes. Redis lib suite 14/14; cargo check --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)