### PR TITLE
Restore the test build on main: two struct literals were missing fields

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2797,6 +2797,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         assert!(
             meta.put_proxy_group(PutProxyGroupRequest {
+                drop_percent: 0,
                 group: "front".to_string(),
                 namespace: "tenant".to_string(),
                 location: String::new(),
@@ -2927,6 +2928,7 @@ mod tests {
         // This pins the fact those messages now assert, so a future change that
         // gives raft one of these capabilities has to update the text as well.
         let runtime = ProductionMetaRaftRuntime::start(ProductionMetaRaftRuntimeOptions {
+            forbid_self_clearing_conviction: false,
             snapshot_check_interval_ms: 0,
             engine: ProductionRaftEngineKind::TemporalRaft,
             local_node_id: 1,

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -18,6 +18,7 @@ fn a_proxy_group_needs_a_name_on_the_raft_path_too() {
     // Judged before proposing, never while applying: replay has to reapply what
     // was already accepted.
     let empty = || PutProxyGroupRequest {
+        drop_percent: 0,
         group: String::new(),
         namespace: String::new(),
         location: "rack-1".to_string(),
@@ -42,6 +43,7 @@ fn a_proxy_group_needs_a_name_on_the_raft_path_too() {
 
     // A named group still goes through, so the guard is not simply refusing.
     let good = meta.put_proxy_group(PutProxyGroupRequest {
+        drop_percent: 0,
         group: "orders".to_string(),
         namespace: "ns".to_string(),
         location: "rack-1".to_string(),


### PR DESCRIPTION
## What this does

Restores `cargo check --all-targets` on main. Two fields were added to shared structs without updating the literals that build them in test and binary code, so **the public tree did not compile for anyone running the tests**:

- `PutProxyGroupRequest::drop_percent` (added with proxy load shedding) — missing in two `raft/tests/part4.rs` literals and one in `bin/metaserver.rs`. Set to `0`, which the field's own documentation defines as "never shed this table" — the behavior those call sites had before the field existed.
- `ProductionMetaRaftRuntimeOptions::forbid_self_clearing_conviction` — missing in one `bin/metaserver.rs` literal. Set to `false`, preserving the prior behavior.

The library itself always compiled; only the test and binary targets were broken, which is why it went unnoticed — but it means nobody could run the suite from a fresh clone.

No behavior changes: every value chosen is the pre-existing default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
