### PR TITLE
Bound what a follower holds in memory, and stop serializing the index twice

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1588,7 +1588,22 @@ pub(super) fn stamp_index_format_version(shard: &ShardState) -> serde_json::Valu
     value
 }
 
+/// Serialize a shard whose stamp is already current, straight to bytes.
+///
+/// The stamping path builds an entire intermediate `serde_json::Value` tree of the whole index
+/// before encoding it -- serializing a multi-megabyte structure twice, once into a tree of
+/// allocations and once into bytes, on every snapshot. A shard whose version field is already
+/// correct needs none of that; one whose field is stale still takes the stamping path, so the
+/// bytes are identical either way.
+pub(super) fn serialize_index_stamped(shard: &mut ShardState) -> Vec<u8> {
+    shard.index_format_version = SHARD_INDEX_FORMAT_VERSION;
+    serde_json::to_vec(shard).expect("shard index should serialize")
+}
+
 fn serialize_index(shard: &ShardState) -> Vec<u8> {
+    if shard.index_format_version == SHARD_INDEX_FORMAT_VERSION {
+        return serde_json::to_vec(shard).expect("shard index should serialize");
+    }
     serde_json::to_vec(&stamp_index_format_version(shard)).expect("shard index should serialize")
 }
 

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -322,7 +322,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);
             }
-            let index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
+            let index_bytes = Ok::<_, serde_json::Error>(super::serialize_index_stamped(shard))
                 .map_err(|err| Status::error("expire_sweep_failed", err.to_string()))?;
             self.persist_index_bytes(request.shard_id, &index_bytes)
                 .map_err(|err| Status::error("expire_sweep_failed", err.to_string()))?;
@@ -581,7 +581,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                     ),
                 )
             })?;
-            let partial_index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
+            let partial_index_bytes = Ok::<_, serde_json::Error>(super::serialize_index_stamped(shard))
                 .map_err(|serialize| Status::error("page_compaction_failed", serialize.to_string()))?;
             self.persist_index_bytes(shard_id, &partial_index_bytes)
                 .map_err(|persist| Status::error("page_compaction_failed", persist.to_string()))?;
@@ -637,7 +637,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 ),
             )
         })?;
-        let index_bytes = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard))
+        let index_bytes = Ok::<_, serde_json::Error>(super::serialize_index_stamped(shard))
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
         self.persist_index_bytes(shard_id, &index_bytes)
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1204,7 +1204,7 @@ impl TemporalEngine {
                         shard.applied_wal_sequence =
                             Some(self.wal_store.stats(shard_id).last_sequence);
                     }
-                    if let Ok(index_bytes) = serde_json::to_vec_pretty(&super::stamp_index_format_version(shard)) {
+                    if let Ok(index_bytes) = Ok::<_, serde_json::Error>(super::serialize_index_stamped(shard)) {
                         let _ = self.persist_index_bytes(shard_id, &index_bytes);
                         let _ = self.index_log_store.append_json(shard_id, &index_bytes);
                     }

--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -658,7 +658,119 @@ impl RaftCluster {
         inner.config.max_applied_log_bytes = bytes;
     }
 
+    /// Entries this node is holding IN MEMORY. The log is trimmed only when a snapshot is
+    /// installed, so this is what a node's residency actually costs.
+    pub fn in_memory_log_entries(&self, node_id: RaftNodeId) -> usize {
+        self.inner
+            .read()
+            .expect("raft cluster lock poisoned")
+            .nodes
+            .get(&node_id)
+            .map(|node| node.log.len())
+            .unwrap_or(0)
+    }
+
+    /// Compact the log THIS process's own node is holding, when that node is a follower.
+    ///
+    /// The leader's compaction trims the leader. In-process that trims everyone, because one
+    /// process owns every node -- but a deployed follower is a separate process that learns
+    /// only by RPC, and a follower that stays CAUGHT UP never falls behind the leader's
+    /// retained range, so it is never sent a snapshot and nothing ever trims it. Its log then
+    /// grows with the corpus instead of with the state, in memory and in its own WAL record
+    /// alike. Measured: a caught-up follower held every one of 400 entries.
+    ///
+    /// A follower compacts to its APPLIED index and no further: those entries are committed and
+    /// already in its state machine, so nothing that could still be truncated by a conflict is
+    /// discarded. The snapshot it installs carries the marker that keeps `prev_log_index` /
+    /// `prev_log_term` answerable across the trim, exactly as a leader-sent snapshot would.
+    fn maybe_compact_local_follower(&self) -> Result<Option<RaftSnapshotTriggerReport>, RaftError> {
+        let (node_id, shard_id, watermark, engine, applied_log_bytes, limit, report_base) = {
+            let inner = self.inner.read().expect("raft cluster lock poisoned");
+            let Some(node_id) = inner.local_node_id else {
+                // The in-process model: the leader's compaction already trims every node.
+                return Ok(None);
+            };
+            if node_id == inner.leader_id {
+                return Ok(None);
+            }
+            if !inner.config.can_trigger_snapshot {
+                return Ok(None);
+            }
+            let Some(node) = inner.nodes.get(&node_id) else {
+                return Ok(None);
+            };
+            let last_snapshot_index = node
+                .installed_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.last_included_index)
+                .unwrap_or_default();
+            if node.applied_index <= last_snapshot_index {
+                return Ok(None);
+            }
+            let logical = raft_log_bytes_after(&node.log, last_snapshot_index);
+            let applied_log_bytes = inner
+                .wal
+                .as_ref()
+                .map(|wal| wal.node_disk_bytes(inner.shard_id, node_id))
+                .unwrap_or(0)
+                .max(logical);
+            let limit = inner.config.max_applied_log_bytes;
+            if applied_log_bytes < limit {
+                return Ok(None);
+            }
+            (
+                node_id,
+                inner.shard_id,
+                node.applied_index,
+                node.engine.clone(),
+                applied_log_bytes,
+                limit,
+                (inner.leader_id, node.applied_index, last_snapshot_index),
+            )
+        };
+
+        // Built off the cluster lock, then confirmed by watermark -- the same discipline the
+        // leader's image build uses.
+        let Some(image) = build_state_image(&engine, shard_id) else {
+            return Ok(None);
+        };
+        let mut inner = self.inner.write().expect("raft cluster lock poisoned");
+        let Some(node) = inner.nodes.get_mut(&node_id) else {
+            return Ok(None);
+        };
+        if node.applied_index != watermark {
+            // Something applied while the image was building; the next tick tries again.
+            return Ok(None);
+        }
+        let last_included_term = node_term_at_log_or_snapshot_index(node, watermark)
+            .unwrap_or(node.current_term);
+        let snapshot = RaftSnapshot {
+            shard_id,
+            last_included_term,
+            last_included_index: watermark,
+            external_snapshot_ref: None,
+            entries: Vec::new(),
+            state_image: Some(image),
+            state_image_externalized: false,
+        };
+        install_snapshot_state(node, snapshot);
+        inner.persist_configured_wal()?;
+        Ok(Some(RaftSnapshotTriggerReport {
+            triggered: true,
+            reason: "follower_applied_log_bytes_threshold".to_string(),
+            leader_id: report_base.0,
+            applied_index: report_base.1,
+            last_snapshot_index: report_base.2,
+            applied_log_bytes,
+            max_applied_log_bytes: limit,
+        }))
+    }
+
     pub fn maybe_trigger_snapshot(&self) -> Result<RaftSnapshotTriggerReport, RaftError> {
+        // A deployed follower compacts its own log; only the leader runs the check below.
+        if let Some(report) = self.maybe_compact_local_follower()? {
+            return Ok(report);
+        }
         let (should_trigger, report) = {
             let inner = self.inner.read().expect("raft cluster lock poisoned");
             let leader = inner

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1709,3 +1709,68 @@ fn walkdir_images(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     out.sort();
     out
 }
+
+/// A DEPLOYED follower's in-memory log must be bounded as the corpus grows.
+///
+/// The log is trimmed only when a snapshot is installed, and the compaction check refuses to
+/// run on anything but the leader. In-process that is harmless -- one process owns every node,
+/// so the leader's compaction trims the peers' state too. A deployed follower is a separate
+/// process that learns only by RPC, and a follower that stays CAUGHT UP never falls behind the
+/// leader's retained range, so it is never sent a snapshot and nothing ever trims it. Its
+/// residency then grows with the corpus instead of with the state.
+#[test]
+fn a_deployed_followers_in_memory_log_is_bounded_as_the_corpus_grows() {
+    let dir = tempfile::tempdir().unwrap();
+    let follower = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig {
+            max_applied_log_bytes: 4096,
+            max_retained_log_bytes: 0,
+            ..RaftConfig::default()
+        },
+    )
+    .unwrap();
+    // This process owns node 2, and node 2 is a follower: the deployed shape.
+    follower.set_local_node_id(2);
+
+    let total = 400u64;
+    for index in 1..=total {
+        let entry = RaftLogEntry {
+            term: 1,
+            index,
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("mem-{index:04}"),
+                value: vec![(index % 251) as u8; 128],
+            },
+        };
+        let response = follower
+            .receive_append_entries(AppendEntriesRequest {
+                rpc: None,
+                shard_id: 1,
+                term: 1,
+                leader_id: 1,
+                target_id: 2,
+                prev_log_index: index - 1,
+                prev_log_term: if index == 1 { 0 } else { 1 },
+                entries: vec![entry],
+                // The leader commits as it goes, so everything here is applied.
+                leader_commit: index,
+            })
+            .unwrap();
+        assert!(response.success, "append {index} should be accepted");
+        // The periodic check the timer loop runs on every node, follower included.
+        if index % 50 == 0 {
+            let _ = follower.maybe_trigger_snapshot();
+        }
+    }
+
+    let held = follower.in_memory_log_entries(2);
+    assert!(
+        held < (total / 2) as usize,
+        "a caught-up deployed follower held {held} of {total} entries in memory -- its log is \
+         growing with the corpus, not with the state"
+    );
+}


### PR DESCRIPTION
## What this does

Two costs that grew with the **corpus** instead of with the **state**.

### A deployed follower never trimmed its log

The in-memory log is trimmed only when a snapshot is installed, and the compaction check refuses to run on anything but the leader. In-process that is harmless — one process owns every node, so the leader's compaction trims the peers' state too. **A deployed follower is a separate process that learns only by RPC**, and a follower that stays *caught up* never falls behind the leader's retained range, so it is never sent a snapshot and nothing ever trims it.

Measured by a probe in the deployed shape: a caught-up follower held **every one of 400 entries** — in memory and in its own log record alike.

A follower now compacts its own log on the same periodic check, **to its applied index and no further**: those entries are committed and already in its state machine, so nothing a conflict could still truncate is discarded. The image is built off the cluster lock and confirmed by watermark — the same discipline the leader's build uses — and the snapshot it installs carries the marker that keeps `prev_log_index` / `prev_log_term` answerable across the trim.

### The served index was serialized twice

Writing the index built an entire intermediate JSON value tree of the whole structure before encoding it: a multi-megabyte index serialized once into a tree of allocations and again into bytes, on **every** snapshot. Four of the five write sites also **pretty-printed** it — whitespace and newlines, in a file nothing reads as text. A shard whose version stamp is already current now serializes straight to compact bytes; a stale one still takes the old path, so the output is identical either way.

## Validation

- The follower-residency probe fails on the previous behavior with `held 400 of 400 entries` and passes now.
- Raft suites: 228 in both sender modes; the one failure is the known fixed-port collision that passes isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
