### PR TITLE
A metaserver that cannot serve now fails its readiness probe

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -35,7 +35,7 @@ use temporalstore_rust::rebalance::{
     TaskSchedulerSnapshot,
 };
 use temporalstore_rust::{
-    production_readiness_report, types::Status, DataNodeLifecycleReport,
+    types::Status, DataNodeLifecycleReport,
     DataNodeShardLifecycleState, LoadShardRequest, LoadShardResponse, SchedulerLifecycleToken,
     UnloadShardRequest, UnloadShardResponse,
 };
@@ -1460,7 +1460,8 @@ fn handle(
             metaserver_prometheus_metrics(meta, scheduler).into_bytes(),
         ),
         ("GET", "/readiness") => {
-            json_response(200, &production_readiness_report())
+            let (code, body) = meta.readiness();
+            json_response(code, &body)
         }
         ("GET", "/meta/info") => json_response(200, &backend_call!(meta, info)),
         ("GET", "/meta/stats") => json_response(200, &backend_call!(meta, stats)),
@@ -2330,6 +2331,53 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_metaserver_that_cannot_serve_fails_its_readiness_probe() {
+        // The probe answered 200 unconditionally, because it returned
+        // production_readiness_report() -- a static description of what the codebase
+        // supports, which takes no arguments and reads no live state. A metaserver that
+        // had lost quorum, or had only just started, said "ready" exactly as loudly as
+        // one serving normally, so a load balancer kept sending it traffic it could not
+        // answer. The verdict it needed already existed in validate_ready; nothing was
+        // asking for it.
+        let (code, body) = meta_readiness_response("raft", Err("no majority: 1/2".to_string()));
+        assert_eq!(
+            code, 503,
+            "a metaserver that cannot serve must fail the probe, not report 200"
+        );
+        assert!(!body.ready);
+        assert_eq!(body.backend, "raft");
+        assert!(
+            body.reason.contains("no majority"),
+            "the reason must be reported rather than left to be inferred from a bare 503: {:?}",
+            body.reason
+        );
+        assert!(!body.status.ok);
+        assert_eq!(body.status.code, "meta_not_ready");
+    }
+
+    #[test]
+    fn a_serving_metaserver_passes_its_readiness_probe() {
+        // The other half: this must not become a probe that always fails.
+        let (code, body) = meta_readiness_response("single", Ok(()));
+        assert_eq!(code, 200);
+        assert!(body.ready);
+        assert_eq!(body.backend, "single");
+        assert!(body.reason.is_empty());
+        assert!(body.status.ok);
+    }
+
+    #[test]
+    fn a_single_node_metaserver_is_ready_and_a_raft_one_answers_for_itself() {
+        // Wiring, not just the mapping: a single-node backend has no quorum to lose, so
+        // it is ready once it is up.
+        let backend = MetaBackend::Single(SingleNodeMeta::default());
+        let (code, body) = backend.readiness();
+        assert_eq!(code, 200);
+        assert!(body.ready);
+        assert_eq!(body.backend, "single");
+    }
     use tempfile::tempdir;
     use temporalstore_rust::data_node::DataNodeLifecycleSnapshot;
     use temporalstore_rust::http::HttpRequest;

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -44,6 +44,37 @@ impl MetaBackend {
         }
     }
 
+    /// This metaserver's answer to a readiness probe, and the HTTP status that goes
+    /// with it.
+    ///
+    /// `/readiness` used to return `production_readiness_report()` with a hardcoded 200.
+    /// That report takes no arguments and reads no live state -- it describes what the
+    /// codebase supports, not what this process can do, and its own test asserts that it
+    /// is never `production_ready`. So the probe answered 200 from the first instant of
+    /// startup and could not answer anything else, which defeats the one thing a
+    /// readiness probe is for: a metaserver that cannot serve still had traffic sent to
+    /// it.
+    ///
+    /// The signal was already here. A raft-backed metaserver that has lost quorum cannot
+    /// serve metadata, and `validate_ready` already says so -- it was just never wired to
+    /// the probe. A single-node backend has no quorum to lose, so it is ready once it is
+    /// up.
+    ///
+    /// Deliberately NOT used here: `MetaPreflightReport.degraded_reasons`. Those describe
+    /// the CLUSTER (frozen servers, frozen proxies), so one frozen datanode would fail
+    /// this probe on every metaserver at once and pull the whole control plane out of
+    /// service exactly when it is needed.
+    fn readiness(&self) -> (u16, MetaReadinessResponse) {
+        let (backend, ready) = match self {
+            Self::Single(_) => ("single", Ok(())),
+            Self::Raft(runtime) => (
+                "raft",
+                runtime.validate_ready().map_err(|err| err.to_string()),
+            ),
+        };
+        meta_readiness_response(backend, ready)
+    }
+
     fn raft_ready(&self) -> Status {
         match self {
             Self::Single(_) => Status::error("raft_disabled", "meta raft is disabled"),
@@ -262,5 +293,48 @@ impl MetaBackend {
                 },
             },
         }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct MetaReadinessResponse {
+    status: Status,
+    /// Whether this metaserver can serve metadata right now.
+    ready: bool,
+    /// Which backend answered: "single" or "raft".
+    backend: String,
+    /// Why it is not ready, empty when it is. Reported rather than left to be
+    /// inferred from a bare 503.
+    reason: String,
+}
+
+/// Map a backend's own verdict to a readiness answer.
+///
+/// Split out from `MetaBackend::readiness` so both outcomes are testable without
+/// standing up a raft cluster: the interesting half is that a not-ready metaserver
+/// answers 503 rather than 200.
+fn meta_readiness_response(
+    backend: &str,
+    ready: Result<(), String>,
+) -> (u16, MetaReadinessResponse) {
+    match ready {
+        Ok(()) => (
+            200,
+            MetaReadinessResponse {
+                status: Status::ok(),
+                ready: true,
+                backend: backend.to_string(),
+                reason: String::new(),
+            },
+        ),
+        Err(reason) => (
+            503,
+            MetaReadinessResponse {
+                status: Status::error("meta_not_ready", reason.clone()),
+                ready: false,
+                backend: backend.to_string(),
+                reason,
+            },
+        ),
     }
 }


### PR DESCRIPTION
GET /readiness returned production_readiness_report() with a hardcoded 200. That
report takes no arguments and reads no live state: it describes what the codebase
supports, not what this process can do, and its own test asserts it is never
production_ready. So the probe answered 200 from the first instant of startup and
could not answer anything else -- which defeats the single thing a readiness probe is
for. A metaserver that had lost quorum was kept in service and sent traffic it could
not answer.

The verdict already existed. validate_ready reports whether a raft-backed metaserver
still has a majority, and a metaserver without one cannot serve metadata; it was
simply never wired to the probe. A single-node backend has no quorum to lose, so it is
ready once it is up. The response says which backend answered and, when it is not
ready, why -- rather than leaving that to be inferred from a bare 503.

Deliberately not used: MetaPreflightReport.degraded_reasons. Those describe the
cluster, not this node -- frozen servers, frozen proxies -- so one frozen datanode
would fail this probe on every metaserver at once and pull the whole control plane out
of service exactly when it is needed most. That is a worse failure than the one being
fixed.

The mapping from verdict to HTTP status is a free function so both outcomes are
testable without standing up a raft cluster. The half that matters is that a not-ready
metaserver answers 503; the other test pins that a serving one still answers 200, so
this cannot quietly become a probe that always fails.

The datanode probe has the same shape and is NOT changed here. Its own preflight
report is node-local, but it is not safe to key a probe on: two of its degraded
reasons are cumulative counters that latch on the first rejected or timed-out request
and never clear, and another follows the metaserver heartbeat, so a metaserver blip
would fail readiness on every datanode at once. Choosing what unready means for a
datanode needs a decision, not a guess.