### PR TITLE
Stop re-parsing the whole served index on every index-log append

### DIFF
--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -328,7 +328,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 .map_err(|err| Status::error("expire_sweep_failed", err.to_string()))?;
             let _ = self
                 .index_log_store
-                .append_json(request.shard_id, &index_bytes);
+                .append_index_bytes(request.shard_id, &index_bytes);
         }
         Ok(ShardExpirySweepReport {
             shard_id: request.shard_id,
@@ -585,7 +585,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
                 .map_err(|serialize| Status::error("page_compaction_failed", serialize.to_string()))?;
             self.persist_index_bytes(shard_id, &partial_index_bytes)
                 .map_err(|persist| Status::error("page_compaction_failed", persist.to_string()))?;
-            let _ = self.index_log_store.append_json(shard_id, &partial_index_bytes);
+            let _ = self.index_log_store.append_index_bytes(shard_id, &partial_index_bytes);
             return Err(err);
         }
 
@@ -641,7 +641,7 @@ fn expiry_scan_budget(limit: usize) -> usize {
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
         self.persist_index_bytes(shard_id, &index_bytes)
             .map_err(|err| Status::error("page_compaction_failed", err.to_string()))?;
-        let _ = self.index_log_store.append_json(shard_id, &index_bytes);
+        let _ = self.index_log_store.append_index_bytes(shard_id, &index_bytes);
         let rewritten_object_pages = rewrite_stats.rewritten_page_refs;
         let bucket_layout_transition_count =
             bucket_layout_transition_count_after.saturating_sub(bucket_layout_transition_count_before);

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1206,7 +1206,7 @@ impl TemporalEngine {
                     }
                     if let Ok(index_bytes) = Ok::<_, serde_json::Error>(super::serialize_index_stamped(shard)) {
                         let _ = self.persist_index_bytes(shard_id, &index_bytes);
-                        let _ = self.index_log_store.append_json(shard_id, &index_bytes);
+                        let _ = self.index_log_store.append_index_bytes(shard_id, &index_bytes);
                     }
                 }
             }

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -414,6 +414,14 @@ impl LocalIndexLogStore {
         }
     }
 
+    /// Append an index record, PARSING the bytes into a value first.
+    ///
+    /// Prefer [`append_index_bytes`](Self::append_index_bytes), which splices the already
+    /// serialized bytes into the record instead. This one parses the whole index into a
+    /// `serde_json::Value` and then re-encodes it, so a multi-megabyte index is walked twice
+    /// more per append -- measured at 2.31 MB for a 2,000-key shard. It remains for callers
+    /// that genuinely need the parsed record back; every engine caller writes an index it has
+    /// just serialized and discards the result, so they all take the splicing path.
     pub fn append_json(
         &self,
         shard_id: ShardId,
@@ -984,6 +992,31 @@ fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    /// The splicing appender and the parsing one must produce the SAME record bytes.
+    ///
+    /// The engine's index-log appends were routed to the splicing path to stop re-parsing and
+    /// re-encoding a multi-megabyte index on every append. That is only safe while the two
+    /// produce identical bytes, which holds because `IndexLogRecord` declares its fields in
+    /// exactly the order the splice writes them. This test fails if either side drifts.
+    #[test]
+    fn both_appenders_write_the_same_record_bytes() {
+        let spliced_dir = tempfile::tempdir().unwrap();
+        let parsed_dir = tempfile::tempdir().unwrap();
+        let spliced = LocalIndexLogStore::new(spliced_dir.path());
+        let parsed = LocalIndexLogStore::new(parsed_dir.path());
+        let index = br#"{"index_format_version":3,"strings":{"a":{"page_slab_id":1}}}"#;
+
+        spliced.append_index_bytes(11, index).unwrap();
+        parsed.append_json(11, index).unwrap();
+
+        let spliced_bytes = std::fs::read(index_log_path(spliced_dir.path(), 11)).unwrap();
+        let parsed_bytes = std::fs::read(index_log_path(parsed_dir.path(), 11)).unwrap();
+        assert_eq!(
+            spliced_bytes, parsed_bytes,
+            "the splicing appender must write exactly what the parsing one writes"
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## What this does

The index log has two appenders:

- `append_index_bytes` **splices** the already-serialized index bytes into the record. Its own comment says it exists "to avoid re-parsing/re-encoding the whole index".
- `append_json` **parses** those bytes into a `serde_json::Value` and re-encodes the result.

Exactly **one of five callers** used the splicing one.

The other four are the engine's own index-log appends — at compaction, at partial sweep, at recovery-sweep completion, and in the lifecycle flush. Every one of them hands over an index it has *just serialized* and then discards the record it gets back, so each was walking a multi-megabyte structure two extra times to build a value nobody reads. Measured on a scaled corpus, that index is **2.31 MB for a 2,000-key shard**.

All four now take the splicing path. The parsing appender stays for callers that genuinely need the parsed record back, and now documents which to prefer and why.

## Why it's safe

The swap only holds while both appenders write identical bytes — which is true because `IndexLogRecord` declares its fields in exactly the order the splice writes them (`shard_id`, `sequence`, `index`). A new test appends the same index through both appenders and requires the two log files to match **byte for byte**, so it fails if either side drifts.

## Validation

79 tests across the index-log, index-format, reload, recovery-sweep, storage-lifecycle and dump suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
