### PR TITLE
Serve a loading or refused store honestly, and turn upsert index-log delta records on by default

### DIFF
--- a/crates/temporalstore-rust/src/bin/upsert_reload_harness.rs
+++ b/crates/temporalstore-rust/src/bin/upsert_reload_harness.rs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scale reload-equality harness for the upsert index-log delta records
+//! (TS_INDEXLOG_UPSERT_DELTAS). Builds a store the way a batch-committing ingest does --
+//! thousands of hash batches (HashMultiSet + StringSet only, so every batch emits ONE
+//! upsert delta record), a durably-logged shard config (config-log present), threshold
+//! dumps part-way through (anchored base + durable pages), and an abrupt abort in place
+//! of a clean shutdown -- then reloads and asserts the SERVED view equals the view every
+//! acked write implies. Each phase runs in its own process so the caller controls the
+//! recovery-mode environment per phase.
+//!
+//! Modes:
+//!   build         --root R --batches N
+//!                   generation 1: write batches 0..N (each ack'd), threshold-dump at
+//!                   N/3 and 2N/3, then abort.
+//!   extend        --root R --batches N --extend M
+//!                   generation 2: load (recovers gen 1), VERIFY the gen-1 view, write
+//!                   batches N..N+M on top, then abort.
+//!   verify        --root R --batches T
+//!                   load (recovers everything) and assert the served view equals the
+//!                   final view of batches 0..T; print a JSON report; exit nonzero on
+//!                   any missing/mismatched/extra entry.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use temporalstore_rust::{
+    BatchExecuteRequest, Command, CommandResponse, Config, ExecuteRequest, SetConfigRequest,
+    TemporalEngine,
+};
+
+const USERS: u64 = 120;
+const KEYS_PER_USER: u64 = 3;
+const FIELDS_PER_KEY: u64 = 40;
+const SETS_PER_BATCH: u64 = 8;
+const ENTRIES_PER_SET: u64 = 3;
+
+fn hash_key(user: u64, slot: u64) -> String {
+    format!("harness:mem:{user}:{slot}")
+}
+
+fn placement_key(user: u64) -> String {
+    format!("harness:placement:{user}")
+}
+
+fn field_name(index: u64) -> String {
+    format!("f{index:04}")
+}
+
+fn value_of(user: u64, slot: u64, field: u64, batch: u64) -> Vec<u8> {
+    // Batch-stamped payload so a stale generation of an overwritten field cannot pass,
+    // padded so thousands of batches produce a store that dwarfs the cache.
+    format!(
+        "val-u{user}-s{slot}-f{field}-b{batch}-{}",
+        "x".repeat(140)
+    )
+    .into_bytes()
+}
+
+fn placement_value(user: u64, batch: u64) -> Vec<u8> {
+    format!("placement-u{user}-b{batch}-{}", "y".repeat(60)).into_bytes()
+}
+
+/// The commands batch `b` writes. Every command carries upsert components, so the whole
+/// batch emits a single upsert delta record (the shape the scale ingest produced).
+fn batch_commands(b: u64) -> Vec<Command> {
+    let user = b % USERS;
+    let mut commands = Vec::new();
+    for s in 0..SETS_PER_BATCH {
+        let slot = (b / USERS + s) % KEYS_PER_USER;
+        let entries = (0..ENTRIES_PER_SET)
+            .map(|e| {
+                let field = (b * SETS_PER_BATCH * ENTRIES_PER_SET + s * ENTRIES_PER_SET + e)
+                    % FIELDS_PER_KEY;
+                (field_name(field), value_of(user, slot, field, b))
+            })
+            .collect();
+        commands.push(Command::HashMultiSet {
+            key: hash_key(user, slot),
+            entries,
+        });
+    }
+    commands.push(Command::StringSet {
+        key: placement_key(user),
+        value: placement_value(user, b),
+    });
+    commands
+}
+
+/// The exact served view batches 0..total imply: last write per (key, field) wins.
+fn expected_view(
+    total: u64,
+) -> (
+    BTreeMap<String, BTreeMap<String, Vec<u8>>>,
+    BTreeMap<String, Vec<u8>>,
+) {
+    let mut hashes: BTreeMap<String, BTreeMap<String, Vec<u8>>> = BTreeMap::new();
+    let mut strings: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for b in 0..total {
+        for command in batch_commands(b) {
+            match command {
+                Command::HashMultiSet { key, entries } => {
+                    let map = hashes.entry(key).or_default();
+                    for (field, value) in entries {
+                        map.insert(field, value);
+                    }
+                }
+                Command::StringSet { key, value } => {
+                    strings.insert(key, value);
+                }
+                _ => unreachable!("harness batches hold only upsert-component commands"),
+            }
+        }
+    }
+    (hashes, strings)
+}
+
+fn open_engine(root: &Path) -> TemporalEngine {
+    TemporalEngine::with_local_dirs(
+        1 << 20,
+        root.join("cache"),
+        root.join("pages"),
+        root.join("indexes"),
+    )
+}
+
+fn write_batches(engine: &TemporalEngine, from: u64, to: u64, dump_at: &[u64]) {
+    for b in from..to {
+        let response = engine.batch_execute(BatchExecuteRequest {
+            shard_id: 1,
+            commands: batch_commands(b),
+        });
+        assert!(
+            response.status.ok,
+            "batch {b} not acked: {}",
+            response.status.message
+        );
+        for (i, r) in response.responses.iter().enumerate() {
+            assert!(r.status.ok, "batch {b} command {i}: {}", r.status.message);
+        }
+        if dump_at.contains(&b) {
+            // Background threshold dump: fsync pages + persist the anchored base index,
+            // the checkpoint base-only fold recovery starts from.
+            engine.flush_shard_index(1);
+        }
+    }
+}
+
+fn verify_view(engine: &TemporalEngine, total: u64) -> bool {
+    let (expected_hashes, expected_strings) = expected_view(total);
+    let mut missing = 0u64;
+    let mut mismatched = 0u64;
+    let mut extra = 0u64;
+    let mut fields_ok = 0u64;
+    for (key, expected_fields) in &expected_hashes {
+        let served: BTreeMap<String, Vec<u8>> = match engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashGetAll { key: key.clone() },
+            })
+            .response
+        {
+            CommandResponse::HashEntries { entries } => entries.into_iter().collect(),
+            _ => BTreeMap::new(),
+        };
+        for (field, expected_value) in expected_fields {
+            match served.get(field) {
+                None => missing += 1,
+                Some(value) if value != expected_value => mismatched += 1,
+                Some(_) => fields_ok += 1,
+            }
+        }
+        extra += served.len() as u64 - served.keys().filter(|f| expected_fields.contains_key(*f)).count() as u64;
+    }
+    let mut strings_ok = 0u64;
+    for (key, expected_value) in &expected_strings {
+        match engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet { key: key.clone() },
+            })
+            .response
+        {
+            CommandResponse::Bytes { value: Some(value) } if &value == expected_value => {
+                strings_ok += 1
+            }
+            CommandResponse::Bytes { value: Some(_) } => mismatched += 1,
+            _ => missing += 1,
+        }
+    }
+    let ok = missing == 0 && mismatched == 0 && extra == 0;
+    println!(
+        "{{\"ok\":{ok},\"missing\":{missing},\"mismatched\":{mismatched},\"extra\":{extra},\"fields_ok\":{fields_ok},\"strings_ok\":{strings_ok},\"expected_keys\":{}}}",
+        expected_hashes.len()
+    );
+    ok
+}
+
+fn arg(name: &str) -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
+fn main() {
+    let mode = arg("--mode").expect("--mode");
+    let root = PathBuf::from(arg("--root").expect("--root"));
+    let batches: u64 = arg("--batches").expect("--batches").parse().unwrap();
+    match mode.as_str() {
+        "build" => {
+            let engine = open_engine(&root);
+            engine.load_shard(1);
+            // Durably log the shard config so the config-log is present on reload, the
+            // way the production stores that hit the defect all had it.
+            let mut config = Config::default();
+            config.version = 2;
+            let status = engine.set_config(SetConfigRequest {
+                shard_id: 1,
+                config,
+            });
+            assert!(status.ok, "set_config: {}", status.message);
+            write_batches(&engine, 0, batches, &[batches / 3, 2 * batches / 3]);
+            assert!(verify_view(&engine, batches), "pre-crash view already wrong");
+            // Abrupt loss (the production restarts were SIGKILL-grade), never a clean
+            // unload: recovery must reconstruct from the durable artifacts alone.
+            std::process::abort();
+        }
+        "extend" => {
+            let extend: u64 = arg("--extend").expect("--extend").parse().unwrap();
+            let engine = open_engine(&root);
+            engine.load_shard(1);
+            assert!(
+                verify_view(&engine, batches),
+                "generation-1 view wrong after first reload"
+            );
+            write_batches(&engine, batches, batches + extend, &[]);
+            assert!(
+                verify_view(&engine, batches + extend),
+                "generation-2 view wrong before crash"
+            );
+            std::process::abort();
+        }
+        "verify" => {
+            let engine = open_engine(&root);
+            engine.load_shard(1);
+            let ok = verify_view(&engine, batches);
+            std::process::exit(if ok { 0 } else { 1 });
+        }
+        other => panic!("unknown mode {other}"),
+    }
+}

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1617,17 +1617,21 @@ fn serialize_index(shard: &ShardState) -> Vec<u8> {
 /// one of them lands through the page-upsert path (one new page per component, predecessor
 /// replaced). `None` = the command's write shape is not a pure upsert (deletes, features,
 /// rewrites), and the caller must fall back to the whole-object snapshot record.
-/// Emission gate for upsert delta records. OFF by default. A multi-restart scale store
-/// reconstructed EMPTY through base-only fold recovery (config-log present -> no WAL replay)
-/// while full WAL replay of the same store served everything -- the fold of a large log holding
-/// these records is the suspect, and small-store SIGKILL proofs do not cover it. Until a
-/// scale reload-equality test pins the fold, new writes emit snapshot records.
+/// Emission gate for upsert delta records. ON by default; TS_INDEXLOG_UPSERT_DELTAS=0 is the
+/// escape hatch. The gate was OFF while a multi-restart scale store that reconstructed EMPTY
+/// on reload was attributed to the fold of a large upsert-record log. The scale
+/// reload-equality suite (tests/upsert_reload_equality.rs: thousands of batch-committed
+/// upsert records, config-log present, threshold dumps, SIGKILL restarts across two
+/// generations, verified under BOTH recovery modes) plus an engine-level reload of the
+/// preserved damaged store under every mode/artifact combination showed the fold reconstructs
+/// the full served view; the observed emptiness came from the serving layer answering
+/// vacuously (a discarded shard-load failure served as an empty store) and is fixed there.
 fn upsert_deltas_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
         std::env::var("TS_INDEXLOG_UPSERT_DELTAS")
-            .map(|value| matches!(value.trim(), "1" | "true" | "yes" | "on"))
-            .unwrap_or(false)
+            .map(|value| !matches!(value.trim(), "0" | "false" | "no" | "off"))
+            .unwrap_or(true)
     })
 }
 

--- a/crates/temporalstore-rust/src/engine/tests.rs
+++ b/crates/temporalstore-rust/src/engine/tests.rs
@@ -81,5 +81,6 @@ mod phase1_flat;
 mod part1;
 mod part2;
 mod quota;
+mod upsert_deltas;
 mod part3;
 mod part4;

--- a/crates/temporalstore-rust/src/engine/tests/upsert_deltas.rs
+++ b/crates/temporalstore-rust/src/engine/tests/upsert_deltas.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Reload-equality coverage for the upsert index-log delta records
+//! (TS_INDEXLOG_UPSERT_DELTAS): the served view reconstructed through base-only fold
+//! recovery must equal the pre-reload view at scale.
+#![allow(clippy::all)]
+use super::*;
+
+/// Forensic probe against a preserved on-disk store (not a regression test): point
+/// PROBE_DIR at a store prefix (holding cache/ pages/ indexes/), load shard 1 through
+/// the normal lifecycle, and print what the served view holds.
+#[test]
+#[ignore]
+fn evidence_store_probe() {
+    let dir = std::env::var("PROBE_DIR").expect("set PROBE_DIR to a store prefix");
+    let engine = TemporalEngine::with_local_dirs(
+        1 << 30,
+        format!("{dir}/cache"),
+        format!("{dir}/pages"),
+        format!("{dir}/indexes"),
+    );
+    let started = std::time::Instant::now();
+    let response = engine.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    println!(
+        "load: ok={} msg={} elapsed={:?}",
+        response.status.ok, response.status.message, started.elapsed()
+    );
+    let shards = engine.shards.read().unwrap();
+    if let Some(shard) = shards.get(&1) {
+        let pages: usize = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .map(|bucket| bucket.page_index.len())
+            .sum();
+        let live_pages: usize = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .map(|bucket| bucket.page_index.values().filter(|p| !p.deleted).count())
+            .sum();
+        println!(
+            "served: hashes={} strings={} features={} context_nodes={} buckets={} pages={} live_pages={} anchor={:?}",
+            shard.hashes.len(),
+            shard.strings.len(),
+            shard.features.len(),
+            shard.context_nodes.len(),
+            shard.bucket_index.bucket_map.len(),
+            pages,
+            live_pages,
+            shard.applied_wal_sequence,
+        );
+    } else {
+        println!("served: shard 1 absent");
+    }
+}

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3212,7 +3212,31 @@ fn open_engine(request: &RecordLogRequest) -> Result<TemporalEngine, String> {
     if defaulted_nonblocking_warm {
         env::set_var("MATRIXARK_EAGER_CACHE_WARM_ON_LOAD", "0");
     }
-    engine.load_shard(DEFAULT_SHARD_ID);
+    // A shard load can be REFUSED (corrupt delta stream, WAL hole, replay failure) or can
+    // genuinely fail partway. `load_shard` discards that answer, and the engine below is
+    // cached -- so a refused load used to become a healthy-looking server whose every op
+    // returns shard_not_loaded, which upstream layers can mistake for an empty store. That
+    // is precisely how a damaged-at-scale store served vacuous empties on every reload.
+    // Refuse to open instead: the error names the cause, nothing is cached, and the next
+    // request retries the load rather than inheriting a permanently-empty engine.
+    let load = engine.load_shard_with(temporalstore_rust::LoadShardRequest {
+        shard_id: DEFAULT_SHARD_ID,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    if !load.status.ok && load.status.code != "already_exists" {
+        return Err(format!(
+            "shard load refused for record-log root {}: {}: {}",
+            root.display(),
+            load.status.code,
+            load.status.message
+        ));
+    }
     let async_cache_warm = !matches!(
         env::var("MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD")
             .unwrap_or_else(|_| "1".to_string())
@@ -4510,6 +4534,58 @@ mod tests {
         format!(
             r#"{{"record_type":"context_event","event_id_hash":{event_id},"text":"{text}","scope_key":"t={tenant}|u={user}|s=1|","access_scope":{{"tenant_hash":{tenant},"user_hash":{user},"scope_key":"t={tenant}|u={user}|s=1|"}}}}"#
         )
+    }
+
+    /// A store whose shard load is REFUSED (here: a corrupt WAL record with no base to hide
+    /// behind) must refuse to open -- not hand back a cached engine whose every op answers
+    /// shard_not_loaded. Upstream layers read that steady error stream as an empty store, which
+    /// is exactly how a damaged-at-scale store served vacuous empties on every reload while its
+    /// records sat durably on disk. The refusal must also not be cached: each open retries the
+    /// load, so repairing the artifacts heals the next request.
+    #[test]
+    fn a_refused_shard_load_refuses_open_instead_of_serving_empty() {
+        let _guard = env_guard();
+        let dir = tempdir().expect("tempdir");
+        env::set_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT", dir.path());
+        clear_engine_cache();
+        clear_matrixark_scan_cache();
+
+        let probe = request("get_string");
+        let root = record_log_root(&probe);
+        {
+            let engine = open_engine(&probe).expect("fresh store opens");
+            let mut put = request("put_string");
+            put.key = "k1".to_string();
+            put.value = "v1".to_string();
+            execute_record_log_request(&engine, put, root.clone()).expect("write lands");
+        }
+        // Crash-and-damage: the process is gone (drop the cache's engine), the durable base is
+        // absent (none was materialized), and a WAL record is corrupt -- so the reload must
+        // replay the WAL and must refuse when it cannot.
+        clear_engine_cache();
+        let wal_path = root.join("indexes").join("wals").join("shard-1.wal.jsonl");
+        let contents = std::fs::read(&wal_path).expect("wal exists");
+        let mut damaged = b"GARBAGE-NOT-A-FRAMED-RECORD".to_vec();
+        damaged.push(b'\n');
+        damaged.extend_from_slice(&contents);
+        std::fs::write(&wal_path, damaged).expect("corrupt wal");
+        let base_path = root.join("indexes").join("shard-1.index.json");
+        let _ = std::fs::remove_file(&base_path);
+
+        let refused = open_engine(&probe);
+        let error = refused.expect_err("a refused load must refuse the open");
+        assert!(
+            error.contains("shard load refused"),
+            "the refusal must name the cause, got: {error}"
+        );
+        assert!(
+            !engine_cache()
+                .lock()
+                .expect("engine cache lock")
+                .contains_key(&root),
+            "a refused load must not cache an engine; the next open must retry the load"
+        );
+        env::remove_var("MATRIXARK_TEMPORALSTORE_RUST_ROOT");
     }
 
     /// The blob ops are the python surface's road to the embedded engine's attachment tier:

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -108,6 +108,15 @@ struct RecordLogRequest {
     /// Minimum age before an unreferenced blob is eligible for the sweep.
     #[serde(default)]
     blob_min_age_ms: Option<u64>,
+    /// Client-chosen correlation id, echoed verbatim on the response. The serve loop answers
+    /// requests strictly in order on one stdout, so a client that abandons a slow request (its
+    /// own timeout) and keeps the process alive would otherwise read the ABANDONED request's
+    /// late response as the answer to its next request -- every later reply shifted one back,
+    /// silently serving the wrong data (observed as one scope's scan answered with another
+    /// scope's records). The echo lets the client discard late responses instead of
+    /// mis-attributing them.
+    #[serde(default)]
+    client_request_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -359,6 +368,9 @@ struct RecordLogResponse {
     error_code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     retryable: Option<bool>,
+    /// The request's correlation id, echoed verbatim (see RecordLogRequest::client_request_id).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_request_id: Option<String>,
     #[serde(flatten)]
     extra: BTreeMap<String, Value>,
 }
@@ -436,6 +448,7 @@ fn response_from_result(
             error: String::new(),
             error_code: String::new(),
             retryable: None,
+            client_request_id: None,
             extra: output.extra,
         },
         Err((op, error)) => {
@@ -460,6 +473,7 @@ fn response_from_result(
                 error,
                 error_code,
                 retryable: Some(retryable),
+                client_request_id: None,
                 extra: BTreeMap::new(),
             }
         }
@@ -554,6 +568,13 @@ fn serve() -> i32 {
         }
         let started = Instant::now();
         let request: Result<RecordLogRequest, _> = serde_json::from_str(&line);
+        // Captured before the request moves into its handler; echoed on EVERY response line
+        // (including shutdown), so the client can match responses to requests and discard the
+        // late answer of a request it abandoned instead of shifting every later reply back one.
+        let client_request_id = request
+            .as_ref()
+            .ok()
+            .and_then(|request| request.client_request_id.clone());
         let result = match request {
             Ok(request) if request.op == "shutdown" => {
                 let cached_clients = cached_engine_count();
@@ -568,6 +589,7 @@ fn serve() -> i32 {
                     Ok(("shutdown".to_string(), output)),
                     started.elapsed().as_millis(),
                 );
+                response.client_request_id = client_request_id;
                 let _ = writeln!(stdout, "{}", serialize_response_with_metrics(&mut response));
                 let _ = stdout.flush();
                 return 0;
@@ -599,6 +621,7 @@ fn serve() -> i32 {
         };
         let elapsed_ms = started.elapsed().as_millis();
         let mut response = response_from_result(result, elapsed_ms);
+        response.client_request_id = client_request_id;
         let response_json = serialize_response_with_metrics(&mut response);
         command_count += 1;
         let observed_elapsed_ms = response.elapsed_ms.unwrap_or(elapsed_ms);
@@ -4453,6 +4476,7 @@ mod tests {
             blob_length: None,
             blob_referenced_hashes: None,
             blob_min_age_ms: None,
+            client_request_id: None,
         }
     }
 

--- a/crates/temporalstore-rust/tests/upsert_reload_equality.rs
+++ b/crates/temporalstore-rust/tests/upsert_reload_equality.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Scale reload-equality for upsert index-log delta records (TS_INDEXLOG_UPSERT_DELTAS).
+//!
+//! A ~45K-record production store built through batch-committing ingest reconstructed
+//! EMPTY on reload while the small-store proofs passed, so this drives the same shape at
+//! a scale the unit tests never reach: thousands of hash batches (every batch emits one
+//! upsert delta record), a durably-logged config (config-log present), threshold dumps
+//! mid-stream, SIGKILL-grade restarts between generations, and reload-equality asserted
+//! over the full served view -- under BOTH recovery modes (default base-only + WAL
+//! replay, and the TS_WAL_LEGACY_RECOVERY delta-fold path that the flat-log format needs
+//! at scale). Every phase runs in its own subprocess so the upsert-emission gate and the
+//! recovery-mode env never leak into the rest of the suite.
+
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_upsert_reload_harness")
+}
+
+const GEN1_BATCHES: u64 = 2600;
+const GEN2_BATCHES: u64 = 400;
+
+fn run(mode: &str, root: &Path, batches: u64, extend: Option<u64>, legacy_recovery: bool) -> (bool, String) {
+    let mut cmd = Command::new(bin());
+    cmd.args([
+        "--mode",
+        mode,
+        "--root",
+        root.to_str().unwrap(),
+        "--batches",
+        &batches.to_string(),
+    ]);
+    if let Some(extend) = extend {
+        cmd.args(["--extend", &extend.to_string()]);
+    }
+    // The emission gate under test: every phase runs with upsert delta records ON.
+    cmd.env("TS_INDEXLOG_UPSERT_DELTAS", "1");
+    if legacy_recovery {
+        cmd.env("TS_WAL_LEGACY_RECOVERY", "1");
+    }
+    let out = cmd.output().expect("harness should run");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    (
+        out.status.success(),
+        format!("stdout={stdout} stderr={stderr}"),
+    )
+}
+
+fn copy_dir(from: &Path, to: &Path) {
+    std::fs::create_dir_all(to).unwrap();
+    for entry in std::fs::read_dir(from).unwrap() {
+        let entry = entry.unwrap();
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+#[test]
+fn upsert_delta_store_reloads_to_the_view_it_acked() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("store");
+    std::fs::create_dir_all(&root).unwrap();
+
+    // Generation 1: thousands of upsert batches, threshold dumps, then abort.
+    let (ok, log) = run("build", &root, GEN1_BATCHES, None, false);
+    assert!(!ok, "build must end in the simulated crash, not exit cleanly: {log}");
+    assert!(
+        log.contains("\"ok\":true"),
+        "generation-1 pre-crash view must verify before the crash counts: {log}"
+    );
+
+    // Generation 2: reload (verifies gen 1 inside), extend, abort. This is where the
+    // production stores lived: upsert records interleaved across restart generations.
+    let (ok, log) = run("extend", &root, GEN1_BATCHES, Some(GEN2_BATCHES), false);
+    assert!(!ok, "extend must end in the simulated crash: {log}");
+    assert!(
+        log.contains("\"ok\":true"),
+        "reload equality failed inside the extend generation: {log}"
+    );
+
+    // Freeze the crashed store so each recovery mode folds the same artifacts.
+    let fold_root = dir.path().join("store-fold");
+    copy_dir(&root, &fold_root);
+
+    // Default recovery: base-only checkpoint + WAL tail replay.
+    let (ok, log) = run("verify", &root, GEN1_BATCHES + GEN2_BATCHES, None, false);
+    assert!(
+        ok,
+        "default (base + WAL replay) recovery lost acked writes: {log}"
+    );
+
+    // Delta-fold recovery: base + upsert-record fold, no WAL re-execution. This is the
+    // path the flat-log format relies on at scale.
+    let (ok, log) = run("verify", &fold_root, GEN1_BATCHES + GEN2_BATCHES, None, true);
+    assert!(
+        ok,
+        "delta-fold recovery of the upsert record stream lost acked writes: {log}"
+    );
+}

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -122,6 +122,12 @@ def is_retryable_temporalstore_error(error: Any) -> bool:
         "connection reset",
         "temporarily unavailable",
         "server is busy",
+        # The engine's load-window statuses: a shard that has not loaded yet, or is mid
+        # WAL-replay ("shard_not_loaded: shard is recovering"), answers again once the load
+        # completes. Treating these as terminal made callers give up -- or worse, serve the
+        # store as empty -- during exactly the window a retry would have covered.
+        "not loaded",
+        "recovering",
     )
     return any(fragment in text for fragment in retryable_fragments)
 

--- a/tools/matrixark_mcp_errors.py
+++ b/tools/matrixark_mcp_errors.py
@@ -27,5 +27,11 @@ def is_retryable_temporalstore_error(error: Any) -> bool:
         "connection reset",
         "temporarily unavailable",
         "server is busy",
+        # The engine's load-window statuses: a shard that has not loaded yet, or is mid
+        # WAL-replay ("shard_not_loaded: shard is recovering"), answers again once the load
+        # completes. Treating these as terminal made callers give up -- or worse, serve the
+        # store as empty -- during exactly the window a retry would have covered.
+        "not loaded",
+        "recovering",
     )
     return any(fragment in text for fragment in retryable_fragments)

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -181,7 +181,13 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             self._lane_cursors[group] = index + 1
         return group, lanes[index]
 
-    def _read_json_line(self, proc: subprocess.Popen[str], op: str, lane: Json | None = None) -> Json:
+    def _read_json_line(
+        self,
+        proc: subprocess.Popen[str],
+        op: str,
+        lane: Json | None = None,
+        expected_request_id: str | None = None,
+    ) -> Json:
         assert proc.stdout is not None
         deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
         while time.monotonic() < deadline:
@@ -201,9 +207,19 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             if not line.strip().startswith("{"):
                 continue
             try:
-                return json.loads(line)
+                parsed = json.loads(line)
             except json.JSONDecodeError as exc:
                 raise MatrixArkError(f"Rust TemporalStore {op} returned invalid JSON: {line[:200]!r}") from exc
+            # The proxy answers strictly in order on one stdout, so the late response of a
+            # request some earlier caller abandoned (its own timeout) would otherwise be read
+            # as THIS request's answer -- and every later reply shifts one back, silently
+            # serving the wrong data. Discard responses tagged for a different request; an
+            # untagged response (older proxy binary) is accepted unchanged.
+            if expected_request_id is not None:
+                stale_id = parsed.get("client_request_id")
+                if stale_id is not None and stale_id != expected_request_id:
+                    continue
+            return parsed
         raise MatrixArkError(
             f"Rust TemporalStore {op} timed out waiting for response from {self.cli_path} "
             f"after {max(2.0, self.request_timeout_ms / 1000.0 + 2.0):.1f}s"
@@ -239,6 +255,12 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
             with lock:
                 proc = self._ensure_lane_proc(lane)
                 assert proc.stdin is not None
+                # Tag the request so the reader can discard the late responses of requests a
+                # previous caller abandoned on this lane (see _read_json_line).
+                request_id = f"{id(lane)}-{time.monotonic_ns()}"
+                lane_command = dict(command)
+                lane_command["client_request_id"] = request_id
+                payload = json.dumps(lane_command, separators=(",", ":")) + "\n"
                 try:
                     proc.stdin.write(payload)
                     proc.stdin.flush()
@@ -253,7 +275,7 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
                     if stderr:
                         detail += f": {stderr[-1000:]}"
                     raise MatrixArkError(detail) from exc
-                response = self._read_json_line(proc, op, lane)
+                response = self._read_json_line(proc, op, lane, expected_request_id=request_id)
         except Exception:
             elapsed_ms = (time.perf_counter() - started) * 1000.0
             self._record_call_metrics(op, kwargs, None, elapsed_ms, failed=True, lane=group, wait_ms=wait_ms)

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3141,7 +3141,13 @@ class MatrixArkRustProxyClient:
             self._lane_cursors[group] = index + 1
         return group, lanes[index]
 
-    def _read_json_line(self, proc: subprocess.Popen[str], op: str, lane: Json | None = None) -> Json:
+    def _read_json_line(
+        self,
+        proc: subprocess.Popen[str],
+        op: str,
+        lane: Json | None = None,
+        expected_request_id: str | None = None,
+    ) -> Json:
         assert proc.stdout is not None
         deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
         while time.monotonic() < deadline:
@@ -3160,9 +3166,21 @@ class MatrixArkRustProxyClient:
             if not line.strip().startswith("{"):
                 continue
             try:
-                return json.loads(line)
+                parsed = json.loads(line)
             except json.JSONDecodeError as exc:
                 raise MatrixArkError(f"Rust TemporalStore {op} returned invalid JSON: {line[:200]!r}") from exc
+            # The proxy answers strictly in order on one stdout. A request abandoned by ITS OWN
+            # timeout still gets its response line later -- and without correlation the next
+            # caller on this lane would read that stale line as its answer, shifting every
+            # later reply one back and serving the wrong data (one scope's scan was observed
+            # answered with another scope's records). Discard any response tagged for a
+            # different request; a response with no tag (older proxy binary) is accepted
+            # unchanged.
+            if expected_request_id is not None:
+                stale_id = parsed.get("client_request_id")
+                if stale_id is not None and stale_id != expected_request_id:
+                    continue
+            return parsed
         raise MatrixArkError(
             f"Rust TemporalStore {op} timed out waiting for response from {self.cli_path} "
             f"after {max(2.0, self.request_timeout_ms / 1000.0 + 2.0):.1f}s"
@@ -3213,6 +3231,14 @@ class MatrixArkRustProxyClient:
             with lock:
                 proc = self._ensure_lane_proc(lane)
                 assert proc.stdin is not None
+                # Tag the request so the reader can discard the late responses of requests a
+                # previous caller abandoned on this lane (see _read_json_line). Tagged into the
+                # LANE payload only: the daemon-socket path opens a connection per request and
+                # cannot desync.
+                request_id = f"{id(lane)}-{time.monotonic_ns()}"
+                lane_command = dict(command)
+                lane_command["client_request_id"] = request_id
+                payload = json.dumps(lane_command, separators=(",", ":")) + "\n"
                 try:
                     proc.stdin.write(payload)
                     proc.stdin.flush()
@@ -3227,7 +3253,7 @@ class MatrixArkRustProxyClient:
                     if stderr:
                         detail += f": {stderr[-1000:]}"
                     raise MatrixArkError(detail) from exc
-                response = self._read_json_line(proc, op, lane)
+                response = self._read_json_line(proc, op, lane, expected_request_id=request_id)
         except Exception:
             elapsed_ms = (time.perf_counter() - started) * 1000.0
             self._record_call_metrics(op, kwargs, None, elapsed_ms, failed=True, lane=group, wait_ms=wait_ms)

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -402,9 +402,16 @@ class _TemporalDirectBackendMixin:
                     time.sleep(max(0.05, BACKEND_READINESS_BACKOFF_MS / 1000.0))
 
     def _get_index(self) -> list[str]:
+        # A backend that cannot answer right now (shard loading / not loaded, timeout,
+        # connection refused) must stay a question: swallowing it into [] served a populated
+        # store as vacuously empty for as long as the load took -- and let a write path
+        # compute its append position from a lie. An absent index key on a reachable backend
+        # is the real "no index yet" and still answers [].
         try:
             raw = self._client.get_string(self._index_key)
-        except Exception:
+        except Exception as exc:
+            if is_retryable_temporalstore_error(exc):
+                raise
             return []
         if not raw:
             return []
@@ -417,9 +424,14 @@ class _TemporalDirectBackendMixin:
         return [str(item) for item in value]
 
     def _get_count(self) -> int:
+        # Same contract as _get_index: only an ABSENT count key on a reachable backend is
+        # count 0. A retryable failure raises so readers surface a retryable error instead
+        # of an empty-but-successful view, and writers never derive positions from 0.
         try:
             raw = self._client.get_string(self._count_key)
-        except Exception:
+        except Exception as exc:
+            if is_retryable_temporalstore_error(exc):
+                raise
             return 0
         if not raw:
             return 0

--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -342,6 +342,10 @@ class _TemporalDirectRetrieveMixin:
         return result
 
     def _load_records_by_count(self, count: int) -> list[Json]:
+        # Same contract as _get_count: a backend that cannot answer right now (shard still
+        # loading, timeout) must raise, never shrink the result. The count said the records
+        # exist; silently dropping the ones a loading shard could not serve returned an
+        # EMPTY-but-successful view of a populated store for the whole load window.
         records = []
         self._last_read_all_native_shard_scan = False
         scan_records = self._load_records_by_native_shard_scan(count)
@@ -356,7 +360,9 @@ class _TemporalDirectRetrieveMixin:
                 entries.append({"key": record_key, "field": record_id})
             try:
                 read_records = batch_hget(entries)
-            except Exception:
+            except Exception as exc:
+                if is_retryable_temporalstore_error(exc):
+                    raise
                 read_records = []
             for item in read_records:
                 if not isinstance(item, dict):
@@ -375,7 +381,9 @@ class _TemporalDirectRetrieveMixin:
             record_key, record_id = self._record_location(sequence)
             try:
                 payload = self._client.hget(record_key, record_id)
-            except Exception:
+            except Exception as exc:
+                if is_retryable_temporalstore_error(exc):
+                    raise
                 continue
             if not payload:
                 continue
@@ -396,7 +404,9 @@ class _TemporalDirectRetrieveMixin:
             key = f"{self._record_hash_key}:{shard:06d}"
             try:
                 response = scanner(key)
-            except Exception:
+            except Exception as exc:
+                if is_retryable_temporalstore_error(exc):
+                    raise
                 return None
             rows = response.get("records") if isinstance(response, dict) else None
             if not isinstance(rows, list):
@@ -431,11 +441,14 @@ class _TemporalDirectRetrieveMixin:
         return f"{self._record_hash_key}:{shard:06d}", f"{offset:020d}"
 
     def _load_records(self, index: list[str]) -> list[Json]:
+        # Legacy index-mode read: same must-not-lie contract as _load_records_by_count.
         records = []
         for record_id in index:
             try:
                 payload = self._client.hget(self._record_hash_key, record_id)
-            except Exception:
+            except Exception as exc:
+                if is_retryable_temporalstore_error(exc):
+                    raise
                 continue
             if not payload:
                 continue

--- a/tools/test_backend_unavailable_reads.py
+++ b/tools/test_backend_unavailable_reads.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A backend that cannot answer yet must never serve as an empty store.
+
+A populated store whose shard was still loading (or whose load had been refused) answered
+every read as a clean empty -- ``_get_count`` swallowed the backend error into 0 and
+``_get_index`` into [], so ``get_all`` returned ``{"memories": [], "count": 0}`` with a 200
+while thousands of records sat durably on disk. Worse, a write path that derives its append
+position from the count would derive it from the lie. These tests pin the corrected
+contract: a RETRYABLE backend failure (shard not loaded / recovering / timeout) raises; only
+an ABSENT key on a reachable backend is an authoritative zero. They also pin the retry
+classifier knowing the engine's load-window statuses.
+"""
+import unittest
+
+try:
+    from tools import matrixark_mcp_temporal_adapters as adapters
+    from tools.matrixark_mcp_errors import MatrixArkError, is_retryable_temporalstore_error
+except ImportError:  # run from tools/ dir
+    import matrixark_mcp_temporal_adapters as adapters
+    from matrixark_mcp_errors import MatrixArkError, is_retryable_temporalstore_error
+
+
+class _LoadingClient:
+    """A client whose shard is mid-load: every read fails with the engine's status."""
+
+    def get_string(self, key):
+        raise MatrixArkError(
+            "Rust TemporalStore get_string failed: shard_not_loaded: "
+            "shard is not loaded on this server"
+        )
+
+
+class _BrokenClient:
+    """A client failing with a NON-retryable error: best-effort answers stay best-effort."""
+
+    def get_string(self, key):
+        raise MatrixArkError("stored value is not UTF-8: invalid byte")
+
+
+class _EmptyStoreClient:
+    """A reachable backend with no count/index keys: the real empty store."""
+
+    def get_string(self, key):
+        return ""
+
+
+class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
+    def __init__(self, client):
+        self._client = client
+        self._count_key = "p:record_count"
+        self._index_key = "p:record_index"
+
+
+class BackendUnavailableReadTests(unittest.TestCase):
+    def test_count_raises_while_the_shard_loads(self):
+        with self.assertRaises(MatrixArkError):
+            _Adapter(_LoadingClient())._get_count()
+
+    def test_index_raises_while_the_shard_loads(self):
+        with self.assertRaises(MatrixArkError):
+            _Adapter(_LoadingClient())._get_index()
+
+    def test_non_retryable_failures_keep_the_best_effort_answer(self):
+        self.assertEqual(0, _Adapter(_BrokenClient())._get_count())
+        self.assertEqual([], _Adapter(_BrokenClient())._get_index())
+
+    def test_an_absent_key_on_a_reachable_backend_is_zero(self):
+        self.assertEqual(0, _Adapter(_EmptyStoreClient())._get_count())
+        self.assertEqual([], _Adapter(_EmptyStoreClient())._get_index())
+
+
+class LoadWindowRetryClassificationTests(unittest.TestCase):
+    def test_not_loaded_is_retryable(self):
+        self.assertTrue(is_retryable_temporalstore_error(
+            "shard_not_loaded: shard is not loaded on this server"))
+
+    def test_recovering_is_retryable(self):
+        self.assertTrue(is_retryable_temporalstore_error(
+            "shard_not_loaded: shard is recovering (WAL replay in progress)"))
+
+    def test_plain_data_errors_stay_terminal(self):
+        self.assertFalse(is_retryable_temporalstore_error("stored value is not UTF-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_backend_unavailable_reads.py
+++ b/tools/test_backend_unavailable_reads.py
@@ -84,5 +84,51 @@ class LoadWindowRetryClassificationTests(unittest.TestCase):
         self.assertFalse(is_retryable_temporalstore_error("stored value is not UTF-8"))
 
 
+class _StreamProc:
+    """A lane process whose stdout already holds the given response lines."""
+
+    def __init__(self, lines):
+        import os
+        read_fd, write_fd = os.pipe()
+        self.stdout = os.fdopen(read_fd, "r")
+        with os.fdopen(write_fd, "w") as writer:
+            for line in lines:
+                writer.write(line + "\n")
+
+    def poll(self):
+        return None
+
+
+def _lane_reader():
+    reader = object.__new__(adapters.MatrixArkRustProxyClient)
+    reader.request_timeout_ms = 2000
+    reader.cli_path = "matrixark_rust_proxy"
+    return reader
+
+
+class LaneResponseCorrelationTests(unittest.TestCase):
+    """The proxy answers strictly in order on one stdout, so the late response of a request an
+    earlier caller abandoned (its own timeout) sits first in the stream. Without correlation the
+    next caller reads it as ITS answer and every later reply shifts one back -- observed live as
+    one scope's scan answered with another scope's records. The reader must discard responses
+    tagged for a different request and accept untagged ones (older proxy binaries)."""
+
+    def test_a_stale_tagged_response_is_discarded(self):
+        import json as _json
+        stale = _json.dumps({"ok": True, "value": "stale", "client_request_id": "abandoned-1"})
+        mine = _json.dumps({"ok": True, "value": "mine", "client_request_id": "current-2"})
+        proc = _StreamProc([stale, mine])
+        response = _lane_reader()._read_json_line(proc, "get_string", None,
+                                                  expected_request_id="current-2")
+        self.assertEqual("mine", response.get("value"))
+
+    def test_an_untagged_response_still_answers(self):
+        import json as _json
+        proc = _StreamProc([_json.dumps({"ok": True, "value": "legacy"})])
+        response = _lane_reader()._read_json_line(proc, "get_string", None,
+                                                  expected_request_id="current-9")
+        self.assertEqual("legacy", response.get("value"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_prior_context_scoped.py
+++ b/tools/test_prior_context_scoped.py
@@ -51,7 +51,7 @@ class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
         self.full = full or []
         self.full_reads = 0
 
-    def _scan_records_of_types(self, record_types):
+    def _scan_records_of_types(self, record_types, record_ids=None, scope=None):
         if self.scanned is None:
             return None
         wanted = set(record_types)

--- a/tools/test_refresh_scoped2.py
+++ b/tools/test_refresh_scoped2.py
@@ -33,7 +33,7 @@ class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
         self.full_reads = 0
         self.scan_kwargs = None
 
-    def _scan_records_of_types(self, record_types, record_ids=None):
+    def _scan_records_of_types(self, record_types, record_ids=None, scope=None):
         self.scan_kwargs = {"record_types": list(record_types), "record_ids": record_ids}
         if self.scanned is None:
             return None


### PR DESCRIPTION
## What this fixes

A ~45K-record store (456MB) built through batch-committing ingest with upsert index-log
delta records on served `{"memories": [], "count": 0}` with clean 200s on every reload,
while all of its records sat durably on disk. The fold of its 97MB upsert-record log was
the suspect, and the emission gate shipped dark pending a scale reload-equality test.

Loading the preserved damaged store directly through the engine (every recovery mode ×
every artifact combination: base present/sidelined, config-log present/sidelined, default
and TS_WAL_LEGACY_RECOVERY=1, all 8 store prefixes) reconstructs the FULL served view every
time — including a 9.4s fold of the whole 97MB upsert log with no base at all. The fold was
never the defect. The emptiness came from the serving layers, three defects deep:

1. **Lane response desync (the core mechanism).** The proxy lane protocol answers requests
   strictly in order on one stdout. A request abandoned by its own client timeout still
   gets its response line later, so the next caller on that lane read the abandoned
   request's answer as its own — and every later reply shifted one back. On a store whose
   first open outlives the client timeout this poisons the lane on every restart: reads
   flap between full, wrong-scope, and empty (one scope's scan was observed answered with
   another scope's records). Small stores load inside the timeout, which is why the
   small-store proofs never caught it.
2. **Vacuous-empty swallows.** `_get_count`/`_get_index` swallowed any backend failure into
   `0`/`[]`, and the by-count/by-index record loads silently dropped every record a loading
   shard could not serve — turning "the backend cannot answer yet" into an authoritative
   empty store (and letting a write path derive its append position from the same lie).
3. **Discarded load refusals.** The proxy cached an engine whose `load_shard` result was
   ignored, so a genuinely refused load (corrupt WAL, replay hole) became a healthy-looking
   server whose every op fails fast with `shard_not_loaded` — which the swallows above
   turned into an empty store, permanently.

## The changes

- Requests carry a `client_request_id` the proxy echoes on every response line; the lane
  readers discard responses tagged for a different request (untagged responses from older
  binaries are accepted unchanged).
- `_get_count` / `_get_index` / the record loads raise on retryable backend failures and
  answer empty only for an absent key on a reachable backend. The retry classifiers learn
  the load-window statuses ("not loaded", "recovering").
- `open_engine` refuses to open a root whose shard load was refused, names the cause, and
  caches nothing, so the next request retries the load.
- Upsert index-log delta records default ON (`TS_INDEXLOG_UPSERT_DELTAS=0` is the escape
  hatch), carrying the scale reload-equality proof the gate asked for:
  `tests/upsert_reload_equality.rs` + a harness bin drive 3,000 batch-committed upsert
  batches (each batch emits one upsert record), a durably-logged config, threshold dumps
  mid-stream, and SIGKILL restarts across two generations, then assert the served view
  equals the acked view under BOTH recovery modes (default base + WAL tail replay, and the
  delta-fold path the flat-log format relies on at scale). An ignored `evidence_store_probe`
  test loads any on-disk store prefix through the normal lifecycle and reports what it
  serves — the tool used for the damaged-store matrix above.

## Verification

- `tests/upsert_reload_equality.rs`: green under both recovery modes (607s, release).
- Full `--lib` suite with the new default: 1233 passed; 3 shared-box flakes pass when rerun
  serially; 1 failure (`storage_manager_runtime_supports_stop_pause_resume_...`) also fails
  on the unmodified parent build, i.e. pre-existing and unrelated.
- `--bin matrixark_rust_proxy`: 36/36 including the new refusal test (which fails without
  the open_engine fix).
- Recovery integration suites (`delta_served_index`, `wal_single_barrier_recovery`,
  `delta_index_log_gc`, `delta_index_cost`, `list_recovery`): all green.
- Python: `tools/test_backend_unavailable_reads.py` 9/9 — the swallow/classifier tests fail
  4-of-7 on the pre-fix tree; the lane-correlation tests pin stale-response discard.
- Live gateway proof on the REAL damaged store (fresh copy, bases sidelined so the first
  open replays the full 57K-record WAL ≈ 35s, default 20s client timeouts, config-log
  present): before the fix, 149 consecutive `{"count": 0}` 200s and wrong-scope flapping,
  indefinitely; after the fix, one honest `backend_timeout` during the load window, then
  the exact count (50) on every read, indefinitely — zero vacuous empties.
- Live multi-generation reload proof (gateway level, 3 generations incl. SIGKILL): exact
  counts, upserts on by default.
- Fresh store built by this branch's binary (upsert records + batch commit via the gateway;
  the host killed the ingest gateway partway, so the durable set is what reached the engine),
  then cold-restarted twice on default timeouts: one honest backend error during each load
  window, then exact per-user counts, identical across both restarts (fully-ingested users
  serve 50/50; users whose tail sends were only 202-accepted into the killed gateway's
  in-memory pipeline serve exactly what the engine committed, stably) — no vacuous empties
  anywhere.
