### PR TITLE
Serve the WAL status report from the cursor instead of re-reading every segment

### DIFF
--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -1138,11 +1138,33 @@ impl LocalRaftWal {
         Ok(())
     }
 
+    /// Bytes and index bounds this node's segments hold.
+    ///
+    /// Served from the in-memory cursor when one is live. Deriving it from disk means READING
+    /// AND PARSING EVERY SEGMENT IN FULL -- `node_segments` calls `inspect_segment_sequences`,
+    /// which reads each file end to end to find its sequence bounds. That is fine as a cold
+    /// rebuild, and it is not fine on the admin status endpoint, which is a plain HTTP GET:
+    /// anything polling it made the node re-read its whole log every time, and one cheap
+    /// request forced megabytes of disk read and record parsing.
+    ///
+    /// The cursor already carries the per-segment info this report returns, kept current by
+    /// every append, so the live path costs a lock and a clone. The disk scan stays as the
+    /// fallback for a node whose cursor has not been seeded yet.
     pub fn segment_report(
         &self,
         shard_id: ShardId,
         node_id: RaftNodeId,
     ) -> io::Result<RaftWalSegmentReport> {
+        {
+            let cursors = self.cursors.lock().expect("raft wal cursor lock poisoned");
+            if let Some(cursor) = cursors.get(&(shard_id, node_id)) {
+                let mut report = Self::segment_report_from_segments(&cursor.segments);
+                report.released_segment_count = cursor.released_segment_count;
+                report.last_fsync_elapsed_ms = cursor.last_fsync_elapsed_ms;
+                report.slow_fsync_backpressure_observed = cursor.slow_fsync_backpressure_observed;
+                return Ok(report);
+            }
+        }
         let segments = self.node_segments(shard_id, node_id)?;
         let runtime_state = self.read_segment_runtime_state(shard_id, node_id);
         let first_retained_log_index = segments

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1774,3 +1774,47 @@ fn a_deployed_followers_in_memory_log_is_bounded_as_the_corpus_grows() {
          growing with the corpus, not with the state"
     );
 }
+
+/// The WAL status report must be identical whether it is served from the live cursor or
+/// rebuilt from disk.
+///
+/// Rebuilding it reads and parses EVERY segment end to end, and it is reachable over a plain
+/// HTTP GET (`/raft/control/matrixraft_runtime_admin`), so anything polling that endpoint made
+/// the node re-read its whole log each time. The cursor already carries the same per-segment
+/// info, so the live path serves it -- and this test fails if the two ever disagree.
+#[test]
+fn the_segment_report_matches_whether_it_is_cached_or_scanned() {
+    let dir = tempfile::tempdir().unwrap();
+    let cluster =
+        RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], RaftConfig::default())
+            .unwrap();
+    cluster.set_local_node_id(1);
+    let transport = cluster.clone();
+    for i in 0..30u32 {
+        cluster
+            .propose_distributed(
+                Command::StringSet {
+                    key: format!("seg-{i:03}"),
+                    value: vec![(i % 251) as u8; 128],
+                },
+                &transport,
+            )
+            .unwrap();
+    }
+
+    let wal = LocalRaftWal::new(dir.path());
+    // A freshly built handle has no cursor, so this is the disk-scanning path.
+    let scanned = wal.segment_report(1, 1).unwrap();
+    // Seeding a cursor makes the next call take the cached path.
+    let _ = wal.recover_node_segmented(1, 1);
+    let cached = wal.segment_report(1, 1).unwrap();
+
+    assert_eq!(
+        cached.segments, scanned.segments,
+        "the cached report must describe exactly the segments the scan finds"
+    );
+    assert_eq!(cached.active_segment_id, scanned.active_segment_id);
+    assert_eq!(cached.first_retained_log_index, scanned.first_retained_log_index);
+    assert_eq!(cached.last_retained_log_index, scanned.last_retained_log_index);
+    assert!(!cached.segments.is_empty(), "the node should have segments");
+}


### PR DESCRIPTION
## What this does

The WAL status report is served from the in-memory cursor instead of re-reading the log.

Deriving it from disk means reading and parsing **every segment end to end** — `node_segments` calls `inspect_segment_sequences`, which reads each file in full just to find its sequence bounds. That is correct for a cold rebuild. It is not correct for the admin status report, which is reachable over a plain HTTP GET (`/raft/control/matrixraft_runtime_admin`): anything polling that endpoint made the node re-read its **entire log** every time, and one cheap request forced megabytes of disk read and record parsing.

The cursor already carries the per-segment info the report returns, kept current by every append, so the live path now costs a lock and a clone. The disk scan remains the fallback for a node whose cursor has not been seeded yet — the case it was written for.

## Why it's safe

The two paths must agree or the endpoint starts lying. A new test builds a node, reads the report through the scanning path and again through the cursor, and requires the segment list, the active segment id, and both retained log-index bounds to match.

## Validation

Raft suite 229; the one failure is the known fixed-port collision that passes isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
