### PR TITLE
Delete works from the id's own records; users() pins only where it pays

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -2285,6 +2285,70 @@ fn record_addressable_ids(record: &Value) -> Vec<String> {
 /// Mirrors `forget_scope_records` -- same shard walk, same survivor rewrite, same single durable
 /// batch that also clears the scan/hgetall caches so a later retrieve cannot re-serve a removed
 /// record from cache. Only the predicate differs: identity ids instead of a scope.
+/// The `(shard, field)` locations the ref locator holds for `ids`, or `None` when the locator
+/// cannot be trusted to be complete for this store.
+///
+/// Completeness is the whole question: visiting only located fields is correct exactly when the
+/// locator saw every record this store ever wrote, which is what the `provenance_from_start`
+/// marker attests (it is stamped by the batch that writes the store's first record). Without it
+/// the caller must walk, because a missed field would leave a deleted record physically present.
+fn located_fields_for_ids(
+    engine: &TemporalEngine,
+    record_hash_key: &str,
+    ids: &[String],
+) -> Result<Option<BTreeMap<String, Vec<String>>>, String> {
+    let Some(prefix) = record_hash_key.strip_suffix(":records") else {
+        return Ok(None);
+    };
+    let locator_key = format!("{prefix}:context_ref_locator");
+    let covered = hgetall_map(engine, format!("{locator_key}_meta"))?
+        .get("provenance_from_start")
+        .map(|value| value.trim() == "1")
+        .unwrap_or(false);
+    if !covered {
+        return Ok(None);
+    }
+    let mut by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for id in ids {
+        let raw = read_bytes(
+            engine,
+            Command::HashGet {
+                key: locator_key.clone(),
+                field: id.clone(),
+            },
+        )?;
+        if raw.is_empty() {
+            continue;
+        }
+        let Ok(decoded) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        for location in decoded
+            .get("locations")
+            .and_then(Value::as_array)
+            .map(|items| items.as_slice())
+            .unwrap_or(&[])
+        {
+            let key = location.get("key").and_then(Value::as_str).unwrap_or("");
+            let field = location.get("field").and_then(Value::as_str).unwrap_or("");
+            if key.is_empty() || field.is_empty() {
+                continue;
+            }
+            let Some((base, shard)) = record_shard_key_parts(key) else {
+                continue;
+            };
+            if base != record_hash_key {
+                continue;
+            }
+            let fields = by_shard.entry(shard.to_string()).or_default();
+            if !fields.iter().any(|existing| existing == field) {
+                fields.push(field.to_string());
+            }
+        }
+    }
+    Ok(Some(by_shard))
+}
+
 fn delete_records_by_ids(
     engine: &TemporalEngine,
     record_hash_key: &str,
@@ -2309,10 +2373,31 @@ fn delete_records_by_ids(
     }
     let max_shard = (count - 1) / shard_size;
     let mut commands = Vec::new();
-    for shard in 0..=max_shard {
+    // Which fields could hold these ids? The locator answers directly on a store it covers
+    // completely; otherwise every shard has to be read.
+    let located = located_fields_for_ids(engine, record_hash_key, ids)?;
+    let visit: Vec<(String, Vec<String>)> = match &located {
+        Some(by_shard) => by_shard
+            .iter()
+            .map(|(shard, fields)| (shard.clone(), fields.clone()))
+            .collect(),
+        None => (0..=max_shard)
+            .map(|shard| (format!("{shard:06}"), Vec::new()))
+            .collect(),
+    };
+    for (shard, only_fields) in visit {
         stats.shards_scanned += 1;
-        let key = format!("{}:{:06}", record_hash_key, shard);
-        for (field, value) in hgetall_map(engine, key.clone())? {
+        let key = format!("{}:{}", record_hash_key, shard);
+        let shard_map = hgetall_map(engine, key.clone())?;
+        let entries: Vec<(String, String)> = if only_fields.is_empty() {
+            shard_map.into_iter().collect()
+        } else {
+            only_fields
+                .into_iter()
+                .filter_map(|field| shard_map.get(&field).map(|value| (field, value.clone())))
+                .collect()
+        };
+        for (field, value) in entries {
             let records = decode_matrixark_payload(&value);
             if records.is_empty() {
                 // Undecodable / non-record field (e.g. a counter): never touch it.
@@ -2342,14 +2427,14 @@ fn delete_records_by_ids(
                 for record_type in payload_record_types(&value) {
                     commands.push(Command::HashDelete {
                         key: type_index_key(record_hash_key, &record_type),
-                        field: format!("{shard:06}:{field}"),
+                        field: format!("{shard}:{field}"),
                     });
                 }
                 for record in decode_matrixark_payload(&value) {
                     for bucket in record_scope_buckets(&record) {
                         commands.push(Command::HashDelete {
                             key: scope_index_key(record_hash_key, &bucket),
-                            field: format!("{shard:06}:{field}"),
+                            field: format!("{shard}:{field}"),
                         });
                     }
                 }

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5045,6 +5045,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             result["purge"] = purge
         return result
 
+    def records_for_delete(self, memory_id: str) -> list[Json]:
+        """The live records a delete reasons over: the event and everything pointing at it.
+
+        Base implementation: the whole store. delete's own predicates run over whatever this
+        returns, so an override only has to produce a SUPERSET of the id's live records --
+        missing one would leave a derivative pointing at a deleted source.
+        """
+        return self.read_all()
+
     def delete_memory(self, args: Json, hook: Json | None = None) -> Json:
         """Delete a single memory by id/hash (mem0 ``delete``), with provenance-closure cascade.
 
@@ -5064,7 +5073,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         memory_id = str(args.get("memory_id") or args.get("id") or "").strip()
         if not memory_id:
             raise MatrixArkError("delete requires a memory_id")
-        records = self.read_all()
+        records = self.records_for_delete(memory_id)
         try:
             memory_id_int: int | None = int(memory_id)
         except (TypeError, ValueError):

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1085,10 +1085,15 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                         continue
                     counts[name] += 1
 
-            # Every subject resolved to a non-zero tenant AND user hash, which is exactly the
-            # condition a pinned subject view needs, so each subject is counted from its own
-            # records instead of from one pass over the whole store.
-            pinned = all(
+            # Two conditions, and both matter. Every subject must resolve to a non-zero tenant
+            # AND user hash, which is what a pinned view needs to engage; and this adapter must
+            # actually have the engine scan API, because without it a "pinned" view degrades to a
+            # full read and per-subject counting becomes one full read PER SUBJECT -- strictly
+            # worse than the single pass it replaced.
+            scanner_available = callable(
+                getattr(getattr(self, "_client", None), "matrixark_scan_candidates", None)
+            )
+            pinned = scanner_available and all(
                 tenant_by_user.get(user_hash) and user_hash
                 for user_hash in name_by_user
             )
@@ -1546,6 +1551,120 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                         log.write("CLEAN %d records\n" % len(got))
                 except OSError:
                     pass
+            return full
+        return live_subset
+
+    def records_for_delete(self, memory_id: str) -> list[Json]:
+        """The id's live records from the same two-round id-scoped fetch get(id) uses.
+
+        Wider type set than get(id): index postings are included because the closure must see
+        multi-source derivatives to demote them rather than remove them. Gated on the locator
+        coverage marker; without it the full read stands, since a derivative the locator never
+        saw would silently keep pointing at a deleted source.
+        """
+        import os as _os
+
+        if not self._locator_covers_pointed_ids():
+            return self.read_all()
+        try:
+            from tools.matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from tools.matrixark_mcp_serving_records import compact_latest_context_state_records
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import (
+                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+                MEMORY_TOMBSTONE_RECORD_TYPE,
+                compact_and_apply_tombstones,
+                filter_live_memory_records,
+            )
+            from matrixark_mcp_serving_records import compact_latest_context_state_records
+
+        kept_types = [
+            "context_event",
+            "context_entity",
+            "context_summary",
+            "context_summary_dirty",
+            "context_segment",
+            "context_index",
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        ]
+        linked = self._scan_records_of_types(kept_types, record_ids=[str(memory_id)])
+        if linked is None:
+            return self.read_all()
+        identity_ids = {str(memory_id)}
+        for record in linked:
+            for field in ("entity_hash", "summary_hash", "segment_hash", "event_id_hash"):
+                value = record.get(field)
+                if value not in (None, "", 0):
+                    identity_ids.add(str(value))
+        subset = (
+            linked
+            if len(identity_ids) <= 1
+            else self._scan_records_of_types(kept_types, record_ids=sorted(identity_ids))
+        )
+        if subset is None:
+            return self.read_all()
+        try:
+            latest_state = self._load_latest_context_state_records()
+        except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+            return self.read_all()
+        folded = compact_latest_context_state_records(list(subset) + list(latest_state))
+        live_subset = filter_live_memory_records(compact_and_apply_tombstones(folded))
+
+        shadow = _os.environ.get("MATRIXARK_DELETE_SHADOW_COMPARE", "").strip()
+        if shadow not in {"", "0", "false", "no", "off"}:
+            full = self.read_all()
+            log_path = _os.environ.get("MATRIXARK_DELETE_SHADOW_LOG",
+                                       "/tmp/matrixark_delete_shadow.log")
+
+            def decisions(records: list[Json]) -> tuple:
+                """What delete actually decides from these records: is this a source event, and
+                which derivatives are single-source (removed) versus multi-source (demoted)."""
+                try:
+                    from tools.matrixark_mcp_local_adapter import (
+                        _record_derivative_identity_ids,
+                        _record_provenance_source_ids,
+                        _safe_int,
+                    )
+                except ModuleNotFoundError:
+                    from matrixark_mcp_local_adapter import (
+                        _record_derivative_identity_ids,
+                        _record_provenance_source_ids,
+                        _safe_int,
+                    )
+                mid_int = _safe_int(str(memory_id))
+                is_source = any(
+                    str(r.get("record_type") or "") == "context_event"
+                    and str(r.get("event_id_hash")) == str(memory_id)
+                    for r in records
+                )
+                single, multi = set(), set()
+                for record in records:
+                    provenance = _record_provenance_source_ids(record)
+                    if provenance is None or mid_int not in provenance:
+                        continue
+                    ids = _record_derivative_identity_ids(record)
+                    if provenance == {mid_int}:
+                        single |= set(ids)
+                    else:
+                        multi |= set(ids)
+                return (is_source, tuple(sorted(map(str, single))), tuple(sorted(map(str, multi))))
+
+            expected, got = decisions(full), decisions(live_subset)
+            try:
+                with open(log_path, "a", encoding="utf-8") as log:
+                    if expected != got:
+                        log.write("MISMATCH id=%s full=%r subset=%r\n" % (memory_id, expected, got))
+                    else:
+                        log.write("CLEAN id=%s source=%s single=%d multi=%d\n"
+                                  % (memory_id, expected[0], len(expected[1]), len(expected[2])))
+            except OSError:
+                pass
             return full
         return live_subset
 


### PR DESCRIPTION
Ports the delete work and the users() gate from private main. delete walked every shard to find the fields carrying an id (866 ms at 61 memories, 2816 ms at 205, 7141 ms at 509; update pays it twice) and then re-read the whole live view to compute the closure; both now work from the locator's located fields and a two-round id-scoped fetch (round two fetches every version in append order, since derivatives are last-writer-wins), with index postings included so multi-source derivatives are demoted rather than removed. Gated on the provenance_from_start marker; reclamation and per-field behaviour unchanged. users() counts per subject only when the engine scan API is present — the fix for the two ratchet reds on the one-read contract. Validated: delete shadow 0/3 closure comparisons, delete exact by count and id across a restart, subject-count suite green.