### PR TITLE
update reasons over the id's own records, not the whole store twice

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5613,8 +5613,14 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             new_text = args.get("content")
         if not isinstance(new_text, str) or not new_text.strip():
             raise MatrixArkError("update requires new content (data / text)")
+        # The id's own records, not the store's. An update reasons over exactly what a delete
+        # does -- the addressed event plus everything pointing at it -- and the same subset serves
+        # both the lookup here and the supersede closure below, so one id-scoped fetch replaces
+        # two full-store reads. The seam's contract is a SUPERSET of the id's live records, which
+        # is what both uses need; on an adapter without the index it still returns the whole store.
+        update_records = self.records_for_delete(memory_id)
         old: Json | None = None
-        for record in self.read_all():
+        for record in update_records:
             if str(record.get("record_type") or "") == "context_event" and str(record.get("event_id_hash")) == memory_id:
                 old = record
                 break
@@ -5661,7 +5667,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if memory_id_int is not None:
             # Sweep the superseded version's own embeddings / index postings so the old text can't leak
             # via retrieval after the update (same closure identity set as delete).
-            tombstone["closure_ref_ids"] = self._closure_ref_ids_for_event(self.read_all(), memory_id, memory_id_int)
+            tombstone["closure_ref_ids"] = self._closure_ref_ids_for_event(update_records, memory_id, memory_id_int)
             self._forget_persisted_event_members(memory_id)
             self._invalidate_event_member_index()
         self.append(tombstone)


### PR DESCRIPTION
An update is a supersede: ingest the new text, tombstone the old id. Finding the old record walked `read_all()` -- the whole store -- and computing the supersede closure walked it again. Update now reuses the id-scoped `records_for_delete` seam for both, since a delete reasons over exactly the same set (the event plus everything pointing at it) and that seam's contract is a superset of the id's live records.

Measured on one settled 400-memory store, base arm first: **update median 9 222 ms -> 2 062 ms (4.5x)**.

Strict mem0 conformance 22/22 (including update-supersede-then-retrieve), ten mem0 unit suites (132 tests) green, python suite ratchet green.