### PR TITLE
size the page cache from the machine: writes were not linear in corpus, they were cache misses

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -14,6 +14,7 @@ use std::env;
 use std::hash::{Hash, Hasher};
 use std::io::{self, BufRead, Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
@@ -3291,6 +3292,64 @@ fn clear_engine_cache() {
     }
 }
 
+/// Page-cache capacity already handed out across every engine this process has opened.
+static ENGINE_CACHE_GRANTED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// MemTotal in bytes, or None where /proc is not available.
+fn system_memory_bytes() -> Option<usize> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in text.lines() {
+        let rest = match line.strip_prefix("MemTotal:") {
+            Some(rest) => rest,
+            None => continue,
+        };
+        let kilobytes: usize = rest.trim().trim_end_matches("kB").trim().parse().ok()?;
+        return kilobytes.checked_mul(1024);
+    }
+    None
+}
+
+/// Page-cache capacity for a newly opened engine.
+///
+/// The old fixed 128 MiB default is smaller than the working set of any store past a few hundred
+/// megabytes, and every page read that misses it pays a second-layer read AND a cache fill. That
+/// is what made writes look linear in corpus size. Measured on one 260 MB store, the same ingest
+/// took 3 291 ms at 128 MiB, 1 157 ms at 384 MiB and 902 ms at 1 GiB, while that ingest against a
+/// 20 MB store took 173 ms -- so the "linear growth" was mostly the working set crossing a fixed
+/// cache, not the corpus. A 24 GiB machine now lands each engine at the 512 MiB per-engine
+/// ceiling.
+///
+/// This is a CAPACITY, not an allocation: a cache that may hold a gigabyte still holds only what
+/// has actually been read, so a small store costs no more than it did before. What the capacity
+/// does set is a ceiling, so the number is derived from the machine and bounded twice -- per
+/// engine, and across every engine this process opens, since one proxy can serve many namespaces
+/// and N independent caches at the per-engine size would be N times the intended footprint.
+/// `MATRIXARK_RUST_PROXY_CACHE_BYTES` still overrides this absolutely, per engine, for
+/// deployments that know their own working set.
+fn default_engine_cache_bytes() -> usize {
+    const FLOOR: usize = 128 * 1024 * 1024;
+    const PER_ENGINE_CEILING: usize = 512 * 1024 * 1024;
+    const PROCESS_FLOOR: usize = 512 * 1024 * 1024;
+    const PROCESS_CEILING: usize = 4096 * 1024 * 1024;
+
+    let memory = match system_memory_bytes() {
+        Some(memory) => memory,
+        None => return FLOOR,
+    };
+    // Per engine, not per process: one proxy opens a separate engine per record-log prefix, so a
+    // generous per-engine number spent entirely on the first one starves the rest. A share each
+    // beats everything for one.
+    let want = (memory / 16).clamp(FLOOR, PER_ENGINE_CEILING);
+    let process_ceiling = (memory / 4).clamp(PROCESS_FLOOR, PROCESS_CEILING);
+    // First come, first served against the process budget: an engine opened once the budget is
+    // spent falls back to the floor rather than pushing the process past its ceiling.
+    let granted = ENGINE_CACHE_GRANTED_BYTES.load(Ordering::Relaxed);
+    let remaining = process_ceiling.saturating_sub(granted);
+    let grant = if remaining >= want { want } else { FLOOR };
+    ENGINE_CACHE_GRANTED_BYTES.fetch_add(grant, Ordering::Relaxed);
+    grant
+}
+
 fn open_engine(request: &RecordLogRequest) -> Result<TemporalEngine, String> {
     let root = record_log_root(request);
     {
@@ -3311,7 +3370,17 @@ fn open_engine(request: &RecordLogRequest) -> Result<TemporalEngine, String> {
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
-        .unwrap_or(128 * 1024 * 1024);
+        .unwrap_or_else(default_engine_cache_bytes);
+    eprintln!(
+        "engine page cache: {} MiB for {} ({})",
+        cache_bytes / (1024 * 1024),
+        root.display(),
+        if env::var("MATRIXARK_RUST_PROXY_CACHE_BYTES").is_ok() {
+            "MATRIXARK_RUST_PROXY_CACHE_BYTES"
+        } else {
+            "default, derived from system memory"
+        }
+    );
     let engine = TemporalEngine::with_local_dirs_and_block_store_options(
         cache_bytes,
         root.join("cache"),

--- a/docs/ENTERPRISE_INGESTION_RETRIEVAL_PERF.md
+++ b/docs/ENTERPRISE_INGESTION_RETRIEVAL_PERF.md
@@ -161,8 +161,12 @@ For ingest-heavy enterprise workloads (metadata KV + large attachments):
   = true) so the primary write path is non-blocking; large attachments to the MatrixObject
   blob store via the `append_blob` extent path.
 - **Concurrency**: ~1.5-2 writer threads per core, spread across multiple client instances
-  (independent lock domains). Cache: default `MATRIXARK_RUST_PROXY_CACHE_BYTES` (128 MiB) was
-  sufficient; raise for larger hot sets.
+  (independent lock domains). Cache: the page-cache default is now
+  derived from system memory (a sixteenth per engine, 128 MiB floor, 512 MiB ceiling,
+  bounded across a process at a quarter of memory) rather than a fixed 128 MiB. A cache
+  smaller than the working set is what makes writes look linear in corpus size: on one
+  260 MB store the same ingest took 3 291 ms at 128 MiB, 1 157 ms at 384 MiB and 902 ms at
+  1 GiB. `MATRIXARK_RUST_PROXY_CACHE_BYTES` still overrides it per engine.
 - **Sizing**: expect ~5,000 concurrent ops/s and ~4,700 ingest ops/s per 8-core box at these
   latencies; scale out horizontally beyond that (single-box throughput plateaus ~5,300 ops/s
   by 16 cores until the connection-per-request and per-client-lock limits are addressed).


### PR DESCRIPTION
Reads are flat in corpus size; writes were not. A fresh subject with five memories cost 146 ms to add on a 20 MB store and 2 513 ms on a 260 MB one, so the cost tracked the STORE, not the subject.

Tracing one ingest: 1.9 s of a 2.5 s add inside `batch_hget`, ~100 ms per field on 2.9 KB of arguments. The proxy already issues one HashMultiGet per key and the engine lookup is two map hits -- the time was in `read_page_bytes` missing a page cache smaller than the working set, paying a second-layer read and a cache fill per page.

Same 260 MB store, capacity is the only variable:

| page cache | add |
|---|---|
| 128 MiB (old default) | 3 291 ms |
| 384 MiB | 1 157 ms |
| 1 GiB | 902 ms |
| *(the same ingest on a 20 MB store)* | *173 ms* |

The default is now a sixteenth of system memory per engine (floor 128 MiB, ceiling 512 MiB), with the total across all engines a process opens bounded at a quarter of memory -- one proxy opens an engine per record-log prefix, so spending a generous per-engine number on the first starves the rest. `MATRIXARK_RUST_PROXY_CACHE_BYTES` still overrides per engine.

Capacity, not allocation: proxy RSS on a 20 MB store measured 102 MB under the new default, so small deployments pay nothing. Each engine now logs the capacity it received and whether it came from the env var or the machine.
