### PR TITLE
the batch write path pays a whole-store reconcile scan on every batch

### DIFF
--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -195,13 +195,35 @@ impl TemporalEngine {
             .as_ref()
             .map(|info| info.end_routing_bucket)
             .unwrap_or(u32::MAX);
-        if promote_model_maps_to_bucket_index_authority(
-            request.shard_id,
-            shard,
-            start_routing_bucket,
-            end_routing_bucket,
-        ) {
-            reconcile_secondary_views_from_bucket_index(&self.page_store, shard, None);
+        // Phase-1 flat-append fast-skip, the same one `execute_with_storage_override` applies to
+        // single commands. Without it the batch path pays the reconcile scan on EVERY batch, and
+        // that scan walks and CLONES every live model-map entry in the shard just to re-confirm
+        // that `bucket_index` -- which each mutating command already upserts before returning --
+        // is in sync. Measured on a 290 MB store, that made an ingest 1.65 s of pure proxy CPU
+        // against 0.15 s on a 26 MB one, and it was the single hottest frame in a stack profile
+        // of the write path. Every mem0 write arrives here, so the guarded path was the one that
+        // mattered and the unguarded one was the one being used.
+        //
+        // `promote_scan_done` is `#[serde(skip)]`, so a freshly loaded shard still pays exactly
+        // one full reconcile before the skip engages, and with the gate off the scan runs on
+        // every batch precisely as before.
+        if !(phase1_flat_enabled() && shard.promote_scan_done) {
+            self.promote_scans
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if promote_model_maps_to_bucket_index_authority(
+                request.shard_id,
+                shard,
+                start_routing_bucket,
+                end_routing_bucket,
+            ) {
+                reconcile_secondary_views_from_bucket_index(&self.page_store, shard, None);
+            }
+            // Latch only once the shard actually holds model-map state: `promote` returns false
+            // without establishing anything on an empty shard, so guarding on non-emptiness
+            // avoids latching before the first real write.
+            if phase1_flat_enabled() && shard_has_model_entries(shard) {
+                shard.promote_scan_done = true;
+            }
         }
         let mut mutated_any = false;
         let mut wal_commands = Vec::new();


### PR DESCRIPTION
The single-command path (`execute_with_storage_override`) already skips the per-command `promote_model_maps_to_bucket_index_authority` reconcile once a scan has confirmed `bucket_index` is in sync (TS_PHASE1_FLAT / `promote_scan_done`). `batch_execute` never got that skip — and every mem0 write goes through the batch path, so the guarded path was the unused one.

The scan walks and **clones every live model-map entry in the shard** to re-confirm what each mutating command already maintains (it upserts its page into `bucket_index` before returning). O(store) per batch, result "no change" every time.

Measured on one 296 MB store (1 158 memories), three ingests:

| | wall | proxy CPU |
|---|---|---|
| before | 5 003 ms | 4 950 ms |
| after | 538 ms | 360 ms |

The same three ingests against a 26 MB store cost 630 ms, so the store size was the whole cost. A stack profile of the write path found this frame in 21 of 23 samples. Across a corpus grown from empty, an ingest goes from 126 ms at 100 memories to 495 ms at 1 002 (was 228 ms -> 4 670 ms).

Safety is the single-command path's own argument: `promote_scan_done` is `#[serde(skip)]`, so a freshly loaded shard still pays one full reconcile before the skip engages, and it latches only once the shard holds model-map state. With the gate off, behaviour is unchanged.

Verified: a 1 158-memory store reads back byte-identical across a restart (subjects, memory count and a fixed subject's id digest all match) and a post-reload write lands; strict mem0 conformance 22/22; ten mem0 unit suites green; `cargo check --all-targets` clean. The two lib-suite reds are inherited — the storage-manager jitter/backoff test fails identically on pristine main, and the raft chunking test passes in isolation on both trees.