### PR TITLE
Weigh the log, not the state, when deciding to compact

### DIFF
--- a/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_snapshot.rs
@@ -711,7 +711,7 @@ impl RaftCluster {
             let applied_log_bytes = inner
                 .wal
                 .as_ref()
-                .map(|wal| wal.node_disk_bytes(inner.shard_id, node_id))
+                .map(|wal| wal.node_log_bytes_after(inner.shard_id, node_id, last_snapshot_index))
                 .unwrap_or(0)
                 .max(logical);
             let limit = inner.config.max_applied_log_bytes;
@@ -795,7 +795,7 @@ impl RaftCluster {
                     inner
                         .wal
                         .as_ref()
-                        .map(|wal| wal.node_disk_bytes(inner.shard_id, node_id))
+                        .map(|wal| wal.node_log_bytes_after(inner.shard_id, node_id, last_snapshot_index))
                 })
                 .unwrap_or(0)
                 .max(logical_log_bytes);

--- a/crates/temporalstore-rust/src/raft/local_wal.rs
+++ b/crates/temporalstore-rust/src/raft/local_wal.rs
@@ -1086,25 +1086,70 @@ impl LocalRaftWal {
     // Retained for the legacy on-disk prune path; the segmented append hot path now
     // prunes in-memory via the cursor to stay O(1).
     #[allow(dead_code)]
-    /// Bytes this node's log actually occupies on disk: every segment plus any externalized
-    /// state image. Metadata only -- no segment is opened or scanned, so this is cheap enough
-    /// for the periodic compaction check to consult on every tick.
+    /// Bytes of LOG this node holds on disk -- the segments, and nothing else.
     ///
-    /// The compaction threshold exists to bound THIS number. Judging it by the logical size of
-    /// the commands instead understates it by the log's whole encoding overhead: on a 30k-write
-    /// corpus the commands were 5 MB while the segments held 36 MB, so an 8 MB bound did not
-    /// fire until the disk was already past 50 MB.
-    pub fn node_disk_bytes(&self, shard_id: ShardId, node_id: RaftNodeId) -> u64 {
+    /// This is what the compaction threshold bounds, and it is deliberately not the directory's
+    /// total size. An externalized state image lives beside the segments, and compaction cannot
+    /// reclaim it: compaction is what WRITES it. Counting it made the threshold permanently
+    /// satisfied on any shard whose state outgrew the bound, so every check with a single new
+    /// entry rebuilt the entire image to reclaim a few kilobytes of log -- measured at 223 KB
+    /// weighed against a 4 KB bound, one small write after a compaction.
+    ///
+    /// Judging it by the logical size of the commands instead is the opposite error, and
+    /// understates it by the log's whole encoding overhead: on a 30k-write corpus the commands
+    /// were 5 MB while the segments held 36 MB. The segments are the honest measure.
+    ///
+    /// Metadata only -- no segment is opened or scanned, so the periodic check can consult it
+    /// on every tick.
+    /// Bytes of log a compaction at `snapshot_index` could still be carrying -- the segments
+    /// holding entries ABOVE that marker.
+    ///
+    /// This is what the compaction threshold should weigh, and neither of the simpler measures
+    /// is right. Total directory size counts the externalized state image, which compaction
+    /// writes rather than reclaims, so a shard whose state outgrew the bound compacted on every
+    /// check forever. Total SEGMENT size is closer but still counts the predecessor segment that
+    /// rotation deliberately keeps so a torn tail has somewhere to recover from -- a segment
+    /// entirely below the marker, which the next compaction supersedes rather than shrinks.
+    /// Weighing either one makes the trigger fire for bytes it cannot do anything about.
+    ///
+    /// Served from the cursor, which already carries each segment's index bounds, so this stays
+    /// a lock and some arithmetic. Without a cursor it falls back to the whole-segment total,
+    /// which is the conservative direction: it can only compact sooner, never later.
+    pub fn node_log_bytes_after(
+        &self,
+        shard_id: ShardId,
+        node_id: RaftNodeId,
+        snapshot_index: u64,
+    ) -> u64 {
+        {
+            let cursors = self.cursors.lock().expect("raft wal cursor lock poisoned");
+            if let Some(cursor) = cursors.get(&(shard_id, node_id)) {
+                return cursor
+                    .segments
+                    .iter()
+                    .filter(|segment| {
+                        // `last_log_index == 0` means the segment carries no entry bounds
+                        // (an empty or read-index-only segment); count it, since nothing
+                        // proves it superseded.
+                        segment.last_log_index == 0 || segment.last_log_index > snapshot_index
+                    })
+                    .map(|segment| segment.bytes)
+                    .sum();
+            }
+        }
+        self.node_log_bytes(shard_id, node_id)
+    }
+
+    pub fn node_log_bytes(&self, shard_id: ShardId, node_id: RaftNodeId) -> u64 {
         let dir = self.node_segment_dir(shard_id, node_id);
         let mut total = 0u64;
         if let Ok(entries) = fs::read_dir(&dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let is_log = matches!(
-                    path.extension().and_then(|ext| ext.to_str()),
-                    Some("wal") | Some("bin")
-                );
-                if !is_log {
+                // Segments only. An `image-*.bin` in this directory is state, not log.
+                let is_segment =
+                    path.extension().and_then(|ext| ext.to_str()) == Some("wal");
+                if !is_segment {
                     continue;
                 }
                 if let Ok(metadata) = entry.metadata() {

--- a/crates/temporalstore-rust/src/raft/tests/part5.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part5.rs
@@ -1818,3 +1818,68 @@ fn the_segment_report_matches_whether_it_is_cached_or_scanned() {
     assert_eq!(cached.last_retained_log_index, scanned.last_retained_log_index);
     assert!(!cached.segments.is_empty(), "the node should have segments");
 }
+
+/// Compaction must be driven by how much LOG there is, not by how big the state is.
+///
+/// The threshold measures what the log occupies on disk so the bound means something. But the
+/// externalized state image sits in that same directory, and it is not log -- compaction cannot
+/// reclaim it, it REPLACES it. Counting it means that once a shard's state grows past the
+/// threshold, the trigger is permanently satisfied: every check with any new entry rebuilds the
+/// whole image to reclaim a few kilobytes of log. On a large shard that is a full state rebuild
+/// every check, forever.
+#[test]
+fn compaction_does_not_rebuild_the_image_for_a_log_that_is_already_small() {
+    let _image = super::part4::EnvFlagGuard::set("TS_RAFT_SNAPSHOT_STATE_IMAGE");
+    let dir = tempfile::tempdir().unwrap();
+    let cluster = RaftCluster::new_single_shard_with_wal(
+        dir.path(),
+        1,
+        [1, 2, 3],
+        RaftConfig {
+            // Chosen so the STATE image exceeds it while the post-compaction log does not:
+            // that is the exact band where counting the image made the trigger fire forever.
+            // (Below one base record the threshold is degenerate -- a single base always
+            // exceeds it -- so this is deliberately a realistic size, not the smallest one.)
+            max_applied_log_bytes: 64 * 1024,
+            max_retained_log_bytes: 0,
+            ..RaftConfig::default()
+        },
+    )
+    .unwrap();
+    cluster.set_local_node_id(1);
+    let transport = cluster.clone();
+    for i in 0..150u32 {
+        cluster
+            .propose_distributed(
+                Command::StringSet {
+                    key: format!("thrash-{i:04}"),
+                    value: vec![(i % 251) as u8; 256],
+                },
+                &transport,
+            )
+            .unwrap();
+    }
+
+    // First compaction: legitimate, the log really has outgrown the bound.
+    let first = cluster.maybe_trigger_snapshot().unwrap();
+    assert!(first.triggered, "the log should compact once: {}", first.reason);
+
+    // The image now exceeds the threshold on its own. One more small write must NOT be enough
+    // to justify rebuilding the entire state again.
+    cluster
+        .propose_distributed(
+            Command::StringSet {
+                key: "one-more".to_string(),
+                value: b"small".to_vec(),
+            },
+            &transport,
+        )
+        .unwrap();
+    let second = cluster.maybe_trigger_snapshot().unwrap();
+    assert!(
+        !second.triggered,
+        "a single small write must not rebuild the whole state image \
+         (reason: {}, measured {} bytes against a {} byte bound)",
+        second.reason, second.applied_log_bytes, second.max_applied_log_bytes
+    );
+}


### PR DESCRIPTION
## What this does

The compaction threshold measures what the node's log occupies on disk. The externalized **state image** lives in that same directory — and it is not log. Compaction does not reclaim it; compaction is what *writes* it.

Counting it meant that once a shard's state grew past the threshold, **the trigger was permanently satisfied**: every periodic check that saw any new applied entry rebuilt the entire state image to reclaim a few kilobytes of log. On a large shard that is a full state rebuild every check, forever.

Measured on unmodified main: one small write after a compaction weighed **223,311 bytes against a 4,096 byte bound**.

Counting all *segment* bytes is closer but still wrong — rotation deliberately keeps one predecessor segment so a torn tail has somewhere to recover from, and that segment sits entirely below the snapshot marker, so the next compaction supersedes it rather than shrinking it.

The trigger now weighs only the segments holding entries **above the marker** — the part a compaction can still be carrying. It's served from the cursor, which already knows each segment's index bounds, so it stays a lock and some arithmetic; with no cursor it falls back to the whole-segment total, which errs toward compacting sooner rather than later.

**Same corpus: 223,311 measured bytes → 5,610.**

## Proven by

A test that compacts once legitimately, writes a single small record, and requires the next check *not* to rebuild the state. It fails on unmodified main with the numbers above.

## Validation

- Raft suite: **231 passed, 0 failed**.
- Engine, WAL, index-log and shared-store suites: 356 passed, 1 failed — that one (`async_hot_page_survives_memory_eviction_via_spill`) passes isolated both on this branch and on unmodified main, so it's a parallel-run flake, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
