### PR TITLE
Tell people how to contribute: add CONTRIBUTING and a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, as its code of conduct. The full text is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+to the project maintainers by opening an issue or contacting them privately. All
+complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to TemporalStore
+
+Thanks for your interest in improving TemporalStore. Issues, discussion and pull
+requests are all welcome, from anyone.
+
+## Ground rules
+
+- **Durability rules are not negotiable to make a test pass.** A write is never
+  acknowledged before its bytes are durable. If a change moves an `fsync`, it must
+  say which barrier still covers the acknowledgement and why.
+- **A record's format is a durable contract.** Anything written to disk outlives the
+  process that wrote it, so a format change must either be backward compatible
+  (a marker or version the reader can detect) or refuse the old shape explicitly and
+  fall back to a path that rebuilds. Never make an older file decode into the right
+  shape with the wrong contents.
+- **Recovery must be provable, not plausible.** If you change replay, compaction or
+  a checkpoint, add a test that restarts through the real on-disk artifacts and reads
+  every value back.
+
+## Making a change land well
+
+State what the change fixes and how you know. The most useful pull requests here
+follow the same shape:
+
+1. **A test that fails first.** Write the test against the current behavior, watch it
+   fail, and say what it printed. A test written after the fix proves much less.
+2. **A measurement, if the claim is about cost.** "Faster" is hard to review;
+   "42 ms of encode moved off the shard write lock" is not. Say what you measured, on
+   what corpus, and on what hardware — a loaded shared machine can invent a 3x
+   difference that is not there.
+3. **The blast radius.** Which callers, which formats, which recovery paths. Grep is
+   cheap; a durable format converted at four of its thirteen call sites is not.
+
+## Development
+
+```bash
+cargo build --all-targets
+cargo test --lib -p temporalstore-rust
+cargo fmt --all
+cargo clippy --all-targets
+```
+
+Some suites are large. When iterating, filter to the area you touched
+(`cargo test --lib -p temporalstore-rust -- raft::`), but run the broader suite before
+opening the pull request — several subsystems share the engine, and a change to
+compaction can surface in the dump or reload tests.
+
+Tests run in parallel and share the machine. A test that pins a process-global (an
+environment flag, a fixed port) can fail for reasons that have nothing to do with your
+change; re-run the failure on its own before assuming it is yours.
+
+## Reporting a problem
+
+An issue is most actionable with the workload that produced it, what you expected,
+what happened, and anything the node logged. Data-loss and durability reports are
+prioritized above everything else.


### PR DESCRIPTION
MatrixCache and MatrixRaft both carry these; TemporalStore did not — so the repository people are most likely to arrive at was the one with no answer to "how do I propose a change here?"

The contributing guide is specific to this codebase rather than generic: durability rules are not negotiable to make a test pass, a record format is a durable contract that must stay readable or refuse itself explicitly, and recovery changes need a test that restarts through the real on-disk artifacts. It asks for the two things that make a change reviewable here — a test that fails *before* the fix, and a measurement when the claim is about cost — and notes that suites share the machine, so a parallel-run failure should be re-run alone before being blamed on the change.

The code of conduct is the Contributor Covenant 2.1, matching the sibling repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)