### PR TITLE
the served index gets a versioned container, and stops being 64 MB of JSON

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1597,14 +1597,94 @@ pub(super) fn stamp_index_format_version(shard: &ShardState) -> serde_json::Valu
 /// bytes are identical either way.
 pub(super) fn serialize_index_stamped(shard: &mut ShardState) -> Vec<u8> {
     shard.index_format_version = SHARD_INDEX_FORMAT_VERSION;
-    serde_json::to_vec(shard).expect("shard index should serialize")
+    encode_index_bytes(shard)
 }
 
 fn serialize_index(shard: &ShardState) -> Vec<u8> {
     if shard.index_format_version == SHARD_INDEX_FORMAT_VERSION {
-        return serde_json::to_vec(shard).expect("shard index should serialize");
+        return encode_index_bytes(shard);
     }
-    serde_json::to_vec(&stamp_index_format_version(shard)).expect("shard index should serialize")
+    wrap_index_json(
+        serde_json::to_vec(&stamp_index_format_version(shard))
+            .expect("shard index should serialize"),
+    )
+}
+
+/// Container magic for a non-JSON served index. A JSON index starts with `{`, so a reader can
+/// tell the two apart from the first byte and never has to be told which it is holding.
+const INDEX_CONTAINER_MAGIC: &[u8] = b"TSIDX\x01";
+
+/// Payload codec ids inside the container. The whole point of the container is that this is an
+/// enumeration rather than a decision: a future protobuf or bincode payload is a new id whose
+/// decoder lands beside the existing ones, and every index written before it keeps loading.
+const INDEX_CODEC_ZSTD_JSON: u8 = 1;
+
+/// Compression level for the container payload. The served index is written whole, in the
+/// background, and read whole -- so this trades a little CPU on a path that is not the request
+/// path for a large cut in bytes written and bytes read at load.
+const INDEX_ZSTD_LEVEL: i32 = 3;
+
+/// TS_INDEX_BINARY: write the served index in the binary container instead of raw JSON.
+/// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
+/// index written either way loads in either setting.
+fn index_binary_container_enabled() -> bool {
+    env_flag_on("TS_INDEX_BINARY")
+}
+
+/// The single place the served index becomes bytes.
+///
+/// The measured cost of raw JSON here is real: a 1 000-memory store carries a 74 MB index, and a
+/// dump rewrites it whole. Compressing the same JSON keeps ONE representation of the struct --
+/// no schema mirrored by hand, no second definition to drift -- while cutting what is written and
+/// what must be read back at load.
+pub(super) fn encode_index_bytes(shard: &ShardState) -> Vec<u8> {
+    wrap_index_json(serde_json::to_vec(shard).expect("shard index should serialize"))
+}
+
+/// Put already-serialized index JSON into the container (or leave it as JSON when the container
+/// is off). Separate from `encode_index_bytes` because the version-stamping path serializes a
+/// patched `Value` rather than the struct, and both must produce the same on-disk shape.
+fn wrap_index_json(json: Vec<u8>) -> Vec<u8> {
+    if !index_binary_container_enabled() {
+        return json;
+    }
+    match zstd::stream::encode_all(json.as_slice(), INDEX_ZSTD_LEVEL) {
+        Ok(payload) => {
+            let mut out = Vec::with_capacity(payload.len() + INDEX_CONTAINER_MAGIC.len() + 1);
+            out.extend_from_slice(INDEX_CONTAINER_MAGIC);
+            out.push(INDEX_CODEC_ZSTD_JSON);
+            out.extend_from_slice(&payload);
+            out
+        }
+        // A compression failure must not cost the index: fall back to the bytes that always work.
+        Err(_) => json,
+    }
+}
+
+/// The single place served-index bytes become a `ShardState`, whatever wrote them.
+///
+/// Sniffs the container magic, so JSON written by any earlier binary keeps loading unchanged and
+/// a container written by a newer one is refused with a clear error rather than mis-parsed. Every
+/// decode site goes through here; the previous attempt at a binary index failed precisely because
+/// the decoders were scattered and could not move together.
+pub(super) fn decode_index_bytes(bytes: &[u8]) -> Result<ShardState, String> {
+    if !bytes.starts_with(INDEX_CONTAINER_MAGIC) {
+        return serde_json::from_slice::<ShardState>(bytes).map_err(|error| error.to_string());
+    }
+    let body = &bytes[INDEX_CONTAINER_MAGIC.len()..];
+    let (codec, payload) = body
+        .split_first()
+        .ok_or_else(|| "served index container is truncated".to_string())?;
+    match *codec {
+        INDEX_CODEC_ZSTD_JSON => {
+            let json = zstd::stream::decode_all(payload)
+                .map_err(|error| format!("served index payload did not decompress: {error}"))?;
+            serde_json::from_slice::<ShardState>(&json).map_err(|error| error.to_string())
+        }
+        other => Err(format!(
+            "served index uses payload codec {other}, which this binary cannot read"
+        )),
+    }
 }
 
 /// Collect the served-index delta items for exactly the object keys a single write

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -65,7 +65,7 @@ impl TemporalEngine {
             .export_index_bytes(shard_id)
             .map_err(|err| Status::error("slot_dump_failed", err.to_string()))?;
         let index_sha256 = sha256_hex_bytes(&index_bytes);
-        let dump_index_state = serde_json::from_slice::<ShardState>(&index_bytes)
+        let dump_index_state = crate::engine::decode_index_bytes(&index_bytes)
             .map_err(|err| Status::error("slot_dump_failed", err.to_string()))?;
         // The manifest's replay watermark MUST equal the WAL sequence the EMBEDDED index
         // actually reflects -- NOT the live WAL tail. Under MATRIXARK_BULK_INGEST the on-disk
@@ -562,7 +562,7 @@ impl TemporalEngine {
                 format!("slot dump references missing page segments: {missing:?}"),
             ));
         }
-        let mut restored = serde_json::from_slice::<ShardState>(&manifest.index_bytes)
+        let mut restored = crate::engine::decode_index_bytes(&manifest.index_bytes)
             .map_err(|err| Status::error("slot_dump_invalid_index", err.to_string()))?;
         // `hashes` is `skip_serializing`, so a freshly deserialized index never carries it.
         // Without this the model-maps lifecycle below sees no hash objects while the
@@ -760,7 +760,7 @@ impl TemporalEngine {
         let mut unreadable_page_bytes = 0u64;
         let mut restored_index = None;
         if !manifest.index_bytes.is_empty() && missing_page_slab_ids.is_empty() {
-            if let Ok(restored) = serde_json::from_slice::<ShardState>(&manifest.index_bytes) {
+            if let Ok(restored) = crate::engine::decode_index_bytes(&manifest.index_bytes) {
                 let manifest_buckets = manifest.bucket_ids.iter().copied().collect::<BTreeSet<_>>();
                 for entry in collect_live_page_entries(&restored) {
                     let routing_bucket = entry.address.routing_bucket.unwrap_or_else(|| {
@@ -1263,7 +1263,7 @@ impl TemporalEngine {
                 ),
             ));
         }
-        let mut restored = serde_json::from_slice::<ShardState>(&manifest.index_bytes)
+        let mut restored = crate::engine::decode_index_bytes(&manifest.index_bytes)
             .map_err(|err| Status::error("slot_dump_invalid_index", err.to_string()))?;
         // Rebuild the unserialized model maps from the durable bucket index BEFORE rebuilding
         // ownership. `rebuild_bucket_page_ownership` clears the bucket map and repopulates it

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -175,7 +175,7 @@ impl TemporalEngine {
                     // which refuses to install a manifest older than the delta-advanced index-log
                     // sequence -- cannot block trusting the durable checkpoint over the un-synced
                     // delta.
-                    match serde_json::from_slice::<ShardState>(&manifest.index_bytes) {
+                    match crate::engine::decode_index_bytes(&manifest.index_bytes) {
                         Ok(mut restored) => {
                             rebuild_bucket_page_ownership(
                                 request.shard_id,

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -181,7 +181,7 @@ impl TemporalEngine {
         // first compaction leaves no base -- start empty and rebuild from the index-log
         // deltas below.
         let mut shard = match read {
-            Ok(bytes) => match serde_json::from_slice::<ShardState>(&bytes) {
+            Ok(bytes) => match crate::engine::decode_index_bytes(&bytes) {
                 Ok(shard) => {
                     // Refuse an index written in an older on-disk shape. A stale index decodes
                     // CLEANLY -- the types are unchanged -- while a field's meaning has moved

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -611,7 +611,7 @@ impl TemporalEngine {
         for summary in &bucket_summaries {
             let matching_manifest = manifests.iter().rev().find(|manifest| {
                 let Ok(manifest_state) =
-                    serde_json::from_slice::<ShardState>(&manifest.index_bytes)
+                    crate::engine::decode_index_bytes(&manifest.index_bytes)
                 else {
                     return false;
                 };

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3065,3 +3065,52 @@ fn scratch_engine_index_dir_dies_with_the_last_engine_clone() {
         "the last engine clone must remove the scratch index dir on drop"
     );
 }
+
+#[test]
+fn served_index_container_round_trips_and_still_reads_plain_json() {
+    use crate::engine::{decode_index_bytes, encode_index_bytes};
+
+    let mut shard = ShardState::default();
+    shard.strings.insert(
+        "container-probe".to_string(),
+        BlockAddress {
+            page_slab_id: 7,
+            offset: 11,
+            length: 13,
+            page_id: None,
+            object_id: None,
+            routing_bucket: None,
+            band_id: None,
+            generation: None,
+            sha256: None,
+        },
+    );
+
+    // Container OFF: raw JSON, and JSON is what an older binary would have written.
+    std::env::remove_var("TS_INDEX_BINARY");
+    let plain = encode_index_bytes(&shard);
+    assert_eq!(plain.first(), Some(&b'{'), "container off must write JSON");
+    let decoded = decode_index_bytes(&plain).expect("json index decodes");
+    assert!(decoded.strings.contains_key("container-probe"));
+
+    // Container ON: a magic-prefixed payload that decodes back to the same state...
+    std::env::set_var("TS_INDEX_BINARY", "1");
+    let wrapped = encode_index_bytes(&shard);
+    std::env::remove_var("TS_INDEX_BINARY");
+    assert!(wrapped.starts_with(b"TSIDX\x01"), "container on must write the container");
+    assert_ne!(wrapped.first(), Some(&b'{'));
+    let decoded = decode_index_bytes(&wrapped).expect("container index decodes");
+    assert!(decoded.strings.contains_key("container-probe"));
+
+    // ...and reading is unconditional: a container decodes with the flag off, which is what
+    // makes the write flag safe to turn on and off independently of any reader.
+    let decoded_again = decode_index_bytes(&wrapped).expect("container decodes with flag off");
+    assert!(decoded_again.strings.contains_key("container-probe"));
+
+    // An unknown payload codec must be refused, never guessed at: a mis-parsed index serves
+    // wrong data with no error anywhere, which is the failure mode this container exists to stop.
+    let mut future = wrapped.clone();
+    future[6] = 0xEE;
+    let refused = decode_index_bytes(&future).expect_err("unknown codec must refuse");
+    assert!(refused.contains("cannot read"), "unhelpful refusal: {refused}");
+}


### PR DESCRIPTION
The served index (`shard-{id}.index.json`) is the engine's map of what lives where: it is written
whole at every catalog dump and read whole at load. On a 1 000-memory store it had grown to 64 MB
of raw JSON -- 58.9 MB of it the bucket/page index, 14.9 MB the hash object map.

The obstacle to changing that has never been the encoding, it has been the decoders: seven call
sites parsed those bytes independently with `serde_json::from_slice::<ShardState>`, so no format
could move without all of them moving in the same step. An earlier attempt at a binary index was
reverted for exactly this.

So this adds the piece that was missing: one funnel.

- `encode_index_bytes` is now the only place the index becomes bytes, and `decode_index_bytes`
  the only place bytes become a `ShardState`. All seven decode sites route through it.
- Bytes carry a container header (`TSIDX\x01` + a payload codec id). Decoding SNIFFS: an index
  written as plain JSON by any earlier binary still loads unchanged, because JSON starts with `{`
  and the container does not. An unknown codec id is REFUSED with a clear message rather than
  guessed at -- a mis-parsed index serves wrong data with no error anywhere.
- The first payload codec compresses the same JSON with zstd, which is already a dependency. That
  keeps ONE representation of the struct: no schema mirrored by hand, nothing to drift. The
  container is what makes a different payload (protobuf, bincode) a new id whose decoder lands
  beside this one, rather than another all-at-once rewrite.

Measured on one 250 MB store:

    index on disk    64 MB  ->  8 MB
    header           {"inde  ->  TSIDX\x01

Writing the container is behind `TS_INDEX_BINARY` and DEFAULT OFF. Reading is unconditional, so
the flag only ever controls what is written and an index written either way loads either way.
The default stays off deliberately: a binary that cannot decode the container treats it as an
absent base and rebuilds from the WAL and index-log, which is correct but depends on those logs
still retaining enough -- and a dump reclaims them. Flipping the default is therefore a
follow-up, once every reader is deployed.

Verified: an existing 998-memory store with a JSON index on disk read correctly with the flag on;
after a dump rewrote the base into the container the store reloaded with the same subject count,
the same memory count and an unchanged id digest for a fixed subject. Unit test pins all four
directions (JSON in, container in, container decoded with the flag off, unknown codec refused).
Full lib suite 1 258 passed with one inherited failure that reproduces on a pristine tree.
Observed while testing, and the reason the default stays off: once a store has written a
container index and a dump has reclaimed the logs behind it, a binary without the decoder cannot
open that store AT ALL -- it treats the base as absent, finds nothing left to replay, and refuses
the load (HTTP 500 on every request). Data is intact and the same store reads normally under a
binary that has the decoder, confirmed at 11 subjects / 1 032 memories. So the flip is only safe
once every reader is deployed, which is exactly what a separate follow-up is for.
