### PR TITLE
A clamped shed rate is not a change

### DIFF
--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -320,6 +320,13 @@ impl SingleNodeMeta {
 
     pub(super) fn apply_put_proxy_group(&self, request: PutProxyGroupRequest) -> AckResponse {
         let mut state = self.inner.write().expect("meta lock poisoned");
+        // Clamped once, before anything compares or records it. What is stored
+        // has always been clamped; comparing the raw request against it meant a
+        // group asking for more than 100 never matched itself, so every re-put
+        // bumped config_version and told every attached proxy its config had
+        // changed. The change history had the same split, reporting a shed rate
+        // the group was not using.
+        let drop_percent = request.drop_percent.min(100);
         let existing = state.proxy_groups.get(&request.group).cloned();
         let config_version = match &existing {
             // Only a change proxies must act on bumps the version; re-putting an
@@ -327,7 +334,7 @@ impl SingleNodeMeta {
             Some(previous)
                 if previous.namespace == request.namespace
                     && previous.location == request.location
-                    && previous.drop_percent == request.drop_percent
+                    && previous.drop_percent == drop_percent
                     && previous.state == MetaEntityState::Normal =>
             {
                 previous.config_version
@@ -336,7 +343,7 @@ impl SingleNodeMeta {
             None => 1,
         };
         let info = ProxyGroupInfo {
-            drop_percent: request.drop_percent.min(100),
+            drop_percent,
             group: request.group.clone(),
             namespace: request.namespace,
             location: request.location,
@@ -351,7 +358,7 @@ impl SingleNodeMeta {
             format!("proxy_group:{}", request.group),
             format!(
                 "instance_num={},drop_percent={},config_version={config_version}",
-                request.instance_num, request.drop_percent
+                request.instance_num, drop_percent
             ),
         );
         AckResponse {
@@ -900,6 +907,82 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].namespace, "ns");
         assert_eq!(groups[0].instance_num, 3);
+    }
+
+    #[test]
+    fn a_clamped_drop_percent_still_counts_as_unchanged() {
+        // The stored value is clamped to 100; the comparison that decides
+        // "nothing changed" was made against the raw request. So a group asking
+        // for more than 100 never matched itself: every re-put bumped
+        // config_version, and every attached proxy saw config_changed on its
+        // next heartbeat, for as long as the group was re-applied.
+        let meta = SingleNodeMeta::default();
+        let put = || {
+            meta.put_proxy_group(PutProxyGroupRequest {
+                group: "orders".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                instance_num: 1,
+                drop_percent: 250,
+            })
+        };
+        assert!(put().status.ok);
+        let first = meta.list_proxy_groups().groups[0].clone();
+        assert_eq!(first.drop_percent, 100, "the stored value is clamped");
+
+        assert!(put().status.ok);
+        let second = meta.list_proxy_groups().groups[0].clone();
+        assert_eq!(
+            second.config_version, first.config_version,
+            "re-putting the same group moved config_version, so every attached \
+             proxy is told its config changed"
+        );
+
+        // And a real change still bumps it, so this does not just freeze the version.
+        assert!(meta
+            .put_proxy_group(PutProxyGroupRequest {
+                group: "orders".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                instance_num: 1,
+                drop_percent: 10,
+            })
+            .status
+            .ok);
+        let third = meta.list_proxy_groups().groups[0].clone();
+        assert!(
+            third.config_version > second.config_version,
+            "a genuine change stopped bumping config_version"
+        );
+        assert_eq!(third.drop_percent, 10);
+    }
+
+    #[test]
+    fn the_change_history_records_the_drop_percent_that_took_effect() {
+        // The event carried the requested value while the state carried the
+        // clamped one, so the history said 250 for a group shedding 100.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .put_proxy_group(PutProxyGroupRequest {
+                group: "orders".to_string(),
+                namespace: "ns".to_string(),
+                location: "rack-1".to_string(),
+                instance_num: 1,
+                drop_percent: 250,
+            })
+            .status
+            .ok);
+        let events = meta.topology_events(TopologyEventsRequest::default());
+        let put = events
+            .events
+            .iter()
+            .find(|event| event.kind == "put_proxy_group")
+            .expect("no put_proxy_group event");
+        assert!(
+            put.detail.contains("drop_percent=100"),
+            "the history reports a value the group is not using: {:?}",
+            put.detail
+        );
     }
 
     #[test]


### PR DESCRIPTION
put_proxy_group stores drop_percent clamped to 100, and decided whether
anything changed by comparing the raw request against the stored value.
So a group asking for more than 100 never matched itself:

    put(drop_percent: 250)  -> stored 100, config_version 1
    put(drop_percent: 250)  -> stored 100, config_version 2
    put(drop_percent: 250)  -> stored 100, config_version 3

The comment on that comparison says what it is for: "Only a change proxies
must act on bumps the version; re-putting an identical group leaves
attached proxies undisturbed." A re-put is how a control loop keeps a
group declared, so every round told every attached proxy its config had
changed, forever, over a value that never moved.

The change history had the same split. It recorded the requested number,
so it read drop_percent=250 for a group shedding 100 -- the one place an
operator would look to find out what the group is actually doing.

Clamp once, before anything compares or records it, so the comparison, the
stored value and the history all mean the same number.

Tests: re-putting an out-of-range group leaves config_version alone while a
genuine change still moves it, and the history reports the rate that took
effect. Both fail beforehand -- the first with "re-putting the same group
moved config_version", the second with drop_percent=250 recorded for a
group shedding 100.
