### PR TITLE
A windowed seen-set model: check-and-mark for idempotency keys

### DIFF
--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -64,6 +64,8 @@ pub(super) fn command_key(command: &Command) -> Option<&str> {
         | Command::ZSetRank { key, .. }
         | Command::BucketTake { key, .. }
         | Command::BucketPeek { key, .. }
+        | Command::SeenCheck { key, .. }
+        | Command::SeenCard { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -24,6 +24,7 @@ mod packed_pages;
 mod product_model;
 mod set_index_serde;
 mod zset_index_serde;
+mod seen_index_serde;
 mod bucket_dump_manifest_methods;
 mod storage_lifecycle_methods;
 mod storage_manager_cycle;
@@ -2591,6 +2592,7 @@ fn delete_record_exact(shard: &mut ShardState, key: &str) -> bool {
     removed |= shard.lists.remove(key).is_some();
     removed |= shard.zsets.remove(key).is_some();
     removed |= shard.buckets.remove(key).is_some();
+    removed |= shard.seen.remove(key).is_some();
     if shard.features.remove(key).is_some() {
         removed = true;
         control_rollup::feature_forget(shard, key);
@@ -2940,6 +2942,8 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
         || shard.sets.contains_key(key)
         || shard.lists.contains_key(key)
         || shard.zsets.contains_key(key)
+        || shard.buckets.contains_key(key)
+        || shard.seen.contains_key(key)
         || shard.features.contains_key(key)
         || shard.control_state.contains_key(key)
         || shard.control_state_pages.contains_key(key)

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -65,6 +65,8 @@ pub(crate) fn command_object_keys(command: &Command) -> Vec<String> {
         | Command::ZSetRank { key, .. }
         | Command::BucketTake { key, .. }
         | Command::BucketPeek { key, .. }
+        | Command::SeenCheck { key, .. }
+        | Command::SeenCard { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureReplace { key, .. }
@@ -313,6 +315,7 @@ pub(crate) fn is_write_command(command: &Command) -> bool {
             | Command::ZSetIncrBy { .. }
             | Command::ZSetPop { .. }
             | Command::BucketTake { .. }
+            | Command::SeenCheck { .. }
             | Command::FeatureAppend { .. }
             | Command::FeatureAppendWithPolicy { .. }
             | Command::FeatureReplace { .. }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -658,6 +658,49 @@ pub(crate) fn execute_on_shard(
                 .collect();
             CommandResponse::Members { members }
         }
+        Command::SeenCheck {
+            key,
+            member,
+            window_ms,
+        } => {
+            let now = resolve_now_ms();
+            let floor = now.saturating_sub(window_ms);
+            let seen = shard.seen.entry(key).or_default();
+            // Bounded sweep from the time-ordered front: enough to keep pace with any
+            // sustained rate, never enough to stall a hot call on a huge backlog.
+            for _ in 0..128 {
+                match seen.by_time.first_key_value() {
+                    Some(((seen_at, _), ())) if *seen_at < floor => {
+                        let ((seen_at, expired), ()) =
+                            seen.by_time.pop_first().expect("front exists");
+                        if seen.by_member.get(&expired) == Some(&seen_at) {
+                            seen.by_member.remove(&expired);
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            let duplicate = seen
+                .by_member
+                .get(&member)
+                .is_some_and(|seen_at| *seen_at >= floor);
+            if !duplicate {
+                if let Some(previous) = seen.by_member.insert(member.clone(), now) {
+                    seen.by_time.remove(&(previous, member.clone()));
+                }
+                seen.by_time.insert((now, member), ());
+            }
+            mutated = true;
+            CommandResponse::Integer {
+                value: i64::from(duplicate),
+            }
+        }
+        Command::SeenCard { key } => CommandResponse::Integer {
+            value: shard
+                .seen
+                .get(&key)
+                .map_or(0, |seen| seen.by_member.len()) as i64,
+        },
         Command::BucketTake {
             key,
             tokens,

--- a/crates/temporalstore-rust/src/engine/seen_index_serde.rs
+++ b/crates/temporalstore-rust/src/engine/seen_index_serde.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::state::SeenSet;
+
+pub fn serialize<S>(value: &HashMap<String, SeenSet>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoded = value
+        .iter()
+        .map(|(key, seen)| {
+            (
+                key,
+                seen.by_member
+                    .iter()
+                    .map(|(member, seen_at)| (member, seen_at))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    encoded.serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, SeenSet>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let encoded = HashMap::<String, Vec<(Vec<u8>, u64)>>::deserialize(deserializer)?;
+    Ok(encoded
+        .into_iter()
+        .map(|(key, members)| {
+            let mut seen = SeenSet::default();
+            for (member, seen_at) in members {
+                seen.by_time.insert((seen_at, member.clone()), ());
+                seen.by_member.insert(member, seen_at);
+            }
+            (key, seen)
+        })
+        .collect())
+}

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -56,6 +56,13 @@ pub(super) struct ShardState {
     pub(super) hashes: HashMap<String, HashMap<String, BlockAddress>>,
     #[serde(default, with = "super::set_index_serde")]
     pub(super) sets: HashMap<String, BTreeMap<Vec<u8>, BlockAddress>>,
+    /// Windowed seen-sets backing idempotency keys: member -> when it was last seen, plus
+    /// the same entries time-ordered so expiry pops from the front in bounded steps. Like the
+    /// buckets, no pages back this state -- it persists with the shard index snapshot, and a
+    /// crash forgetting a window's worth of members re-admits a duplicate rather than
+    /// dropping a legitimate first ingest.
+    #[serde(default, with = "super::seen_index_serde")]
+    pub(super) seen: HashMap<String, SeenSet>,
     /// Token buckets: key -> (tokens remaining, last refill ms). Config rides each command,
     /// never the store -- the caller owns policy, which is exactly what a quota layer wants.
     /// No pages back this state: it persists only with the shard index snapshot, so a crash
@@ -507,4 +514,11 @@ pub(super) enum PackedFeaturePageDecode {
     Legacy,
     Packed(Vec<FeaturePoint>),
     Corrupt(String),
+}
+
+/// One windowed seen-set: both views hold exactly the same entries.
+#[derive(Debug, Clone, Default)]
+pub(super) struct SeenSet {
+    pub(super) by_member: BTreeMap<Vec<u8>, u64>,
+    pub(super) by_time: BTreeMap<(u64, Vec<u8>), ()>,
 }

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -86,6 +86,8 @@ fn proxy_command_key(command: &Command) -> Option<&str> {
         | Command::ZSetRank { key, .. }
         | Command::BucketTake { key, .. }
         | Command::BucketPeek { key, .. }
+        | Command::SeenCheck { key, .. }
+        | Command::SeenCard { key }
         | Command::FeatureAppend { key, .. }
         | Command::FeatureAppendWithPolicy { key, .. }
         | Command::FeatureQuery { key, .. }

--- a/crates/temporalstore-rust/src/redis.rs
+++ b/crates/temporalstore-rust/src/redis.rs
@@ -739,10 +739,65 @@ mod tests {
         assert_eq!("0", third[0], "the drained bucket must deny");
         assert!(third[2].parse::<u64>().expect("retry ms") > 0, "denied answers a retry-after");
 
-        // PEEK reports without consuming: two identical peeks.
+        // PEEK reports without consuming. The retry-after may drift by the milliseconds the
+        // wall clock moved between calls, so equality holds for the outcome and the level,
+        // and the retry-after only within a tolerance.
         let peek_one = fields(run(&mut state, vec!["BUCKETPEEK", "q", "1", "2", "0.001"]));
         let peek_two = fields(run(&mut state, vec!["BUCKETPEEK", "q", "1", "2", "0.001"]));
-        assert_eq!(peek_one, peek_two, "peek must not consume");
+        assert_eq!(peek_one[0], peek_two[0], "peek must not change the outcome");
+        assert_eq!(peek_one[1], peek_two[1], "peek must not consume");
+        let retry_one = peek_one[2].parse::<i64>().expect("retry ms");
+        let retry_two = peek_two[2].parse::<i64>().expect("retry ms");
+        assert!((retry_one - retry_two).abs() <= 50, "retry-after moved {retry_one} -> {retry_two}");
+    }
+
+    /// The windowed seen-set: first sight answers 0 and marks, a repeat inside the window
+    /// answers 1 without re-marking, the window expires entries, SEENCARD counts, and DEL
+    /// clears the whole set.
+    #[test]
+    fn seen_set_marks_dedupes_expires_and_clears() {
+        let engine = TemporalEngine::default();
+        engine.load_shard(1);
+        let mut state = RedisCommandState::default();
+        let mut run = |state: &mut RedisCommandState, args: Vec<&str>| {
+            execute_redis_command_with_state(
+                args.into_iter().map(|arg| arg.as_bytes().to_vec()).collect(),
+                1,
+                state,
+                &mut |command| {
+                    let response = engine.execute(crate::ExecuteRequest {
+                        shard_id: 1,
+                        command,
+                    });
+                    if response.status.ok {
+                        Ok(response.response)
+                    } else {
+                        Err(response.status.message)
+                    }
+                },
+            )
+        };
+
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "idem", "a", "60000"]), RespValue::Integer(0),
+            "first sight is not a duplicate");
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "idem", "a", "60000"]), RespValue::Integer(1),
+            "a repeat inside the window is");
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "idem", "b", "60000"]), RespValue::Integer(0));
+        assert_eq!(run(&mut state, vec!["SEENCARD", "idem"]), RespValue::Integer(2));
+
+        // A 1ms window expires across a 25ms sleep: the member reads as new again, and the
+        // bounded front-sweep has removed the stale entries from the count.
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "gone", "x", "1"]), RespValue::Integer(0));
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "gone", "x", "1"]), RespValue::Integer(0),
+            "an expired member is new again");
+        assert_eq!(run(&mut state, vec!["SEENCARD", "gone"]), RespValue::Integer(1),
+            "the sweep dropped the expired entry, keeping only the fresh mark");
+
+        assert_eq!(run(&mut state, vec!["DEL", "idem"]), RespValue::Integer(1));
+        assert_eq!(run(&mut state, vec!["SEENCARD", "idem"]), RespValue::Integer(0));
+        assert_eq!(run(&mut state, vec!["SEENCHECK", "idem", "a", "60000"]), RespValue::Integer(0),
+            "a cleared set forgets");
     }
 
     #[test]
@@ -1161,6 +1216,8 @@ mod tests {
             "RENAME" => vec!["RENAME", "advertised:missing", "advertised:renamed"],
             "RENAMENX" => vec!["RENAMENX", "advertised:missing", "advertised:renamed"],
             "SADD" => vec!["SADD", "advertised:set", "a"],
+            "SEENCARD" => vec!["SEENCARD", "advertised:seen"],
+            "SEENCHECK" => vec!["SEENCHECK", "advertised:seen", "m", "60000"],
             "SCARD" => vec!["SCARD", "advertised:set"],
             "SDIFF" => vec!["SDIFF", "advertised:set", "advertised:other"],
             "SCAN" => vec!["SCAN", "0"],

--- a/crates/temporalstore-rust/src/redis/command_table.rs
+++ b/crates/temporalstore-rust/src/redis/command_table.rs
@@ -311,6 +311,16 @@ pub(crate) fn redis_supported_commands() -> &'static [RedisCommandDescriptor] {
             flags: WRITE,
         },
         RedisCommandDescriptor {
+            name: "SEENCARD",
+            arity: 2,
+            flags: READ,
+        },
+        RedisCommandDescriptor {
+            name: "SEENCHECK",
+            arity: 4,
+            flags: WRITE,
+        },
+        RedisCommandDescriptor {
             name: "SADD",
             arity: -3,
             flags: WRITE,

--- a/crates/temporalstore-rust/src/redis/dispatch.rs
+++ b/crates/temporalstore-rust/src/redis/dispatch.rs
@@ -1414,6 +1414,26 @@ pub fn execute_redis_command_with_state(
                 Err(err) => RespValue::Error(format!("ERR {err}")),
             }
         }
+        "SEENCHECK" if args.len() == 4 => match parse_i64_arg(&args[3], "window_ms") {
+            Ok(window_ms) if window_ms >= 0 => match execute(Command::SeenCheck {
+                key: string_arg(&args[1]),
+                member: args[2].clone(),
+                window_ms: window_ms as u64,
+            }) {
+                Ok(CommandResponse::Integer { value }) => RespValue::Integer(value),
+                Ok(_) => RespValue::Error("ERR invalid seencheck response".to_string()),
+                Err(err) => RespValue::Error(format!("ERR {err}")),
+            },
+            Ok(_) => RespValue::Error("ERR window_ms must not be negative".to_string()),
+            Err(err) => RespValue::Error(err),
+        },
+        "SEENCARD" if args.len() == 2 => match execute(Command::SeenCard {
+            key: string_arg(&args[1]),
+        }) {
+            Ok(CommandResponse::Integer { value }) => RespValue::Integer(value),
+            Ok(_) => RespValue::Error("ERR invalid seencard response".to_string()),
+            Err(err) => RespValue::Error(format!("ERR {err}")),
+        },
         "BUCKETTAKE" | "BUCKETPEEK" if args.len() == 5 => {
             let parse = |raw: &[u8], name: &str| -> Result<f64, String> {
                 String::from_utf8_lossy(raw)

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1243,6 +1243,19 @@ pub enum Command {
         max_exclusive: bool,
         rev: bool,
     },
+    /// Atomic seen-within-window check-and-mark: answers 1 when the member was already seen
+    /// inside the window (a duplicate), else marks it and answers 0. Expired entries are
+    /// swept from the front in bounded steps on every call.
+    SeenCheck {
+        key: String,
+        #[serde(with = "crate::bytes_serde")]
+        member: Vec<u8>,
+        window_ms: u64,
+    },
+    /// How many members the set currently holds (expired-but-unswept included).
+    SeenCard {
+        key: String,
+    },
     /// Atomic take-with-refill on a token bucket: refill by elapsed time (capped at
     /// capacity), then take `tokens` if they fit. Answers three strings -- allowed ("1"/"0"),
     /// tokens remaining, and retry-after ms (0 when allowed).


### PR DESCRIPTION
Second of #245 remaining candidates (the dedup/seen-set): SEENCHECK is one atomic check-and-mark under the shard lock with a bounded front-sweep of expired entries; the window rides every command; crash forgets at most a window (re-admits a duplicate, never drops a first). SEENCARD counts.

Also found and fixed: the record-existence chain did not know the page-less state maps, so DEL/EXISTS answered 0 for bucket and seen keys — both maps are in the chain now, conformance-pinned. Redis lib suite 15/15; cargo check --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)