### PR TITLE
Shed the keys the rate names, not the batch that contains them

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -1329,19 +1329,77 @@ impl TemporalStoreTable {
             self.refresh_table_topology_before_write_if_due()?;
         }
         let table_options = self.table_options();
-        if let Some(command) = commands
+        // Shed by key, not by batch. `command_is_dropped` hashes the routing
+        // key, so the rate is per key -- but refusing the whole batch as soon
+        // as one key fell in the dropped range turned it into 1-(1-p)^n per
+        // batch. A 1% rate refused 63% of hundred-key batches, and 5% refused
+        // 99.5% of them, which is not a shed rate an operator can reason about.
+        //
+        // A shed key gets its own slot with its own status, beside the results
+        // of the keys that were not shed. That is the shape a batch already
+        // has: the grouped path fills a missing slot with a per-response error
+        // inside an otherwise-ok batch.
+        let shed: Vec<bool> = commands
             .iter()
-            .find(|command| command_is_dropped(command, table_options.drop_percent))
-        {
-            return Ok(BatchExecuteResponse {
-                status: Status::error(
-                    "traffic_dropped",
-                    format!(
-                        "batch command for key {:?} dropped by table drop_percent",
-                        command_key(command)
+            .map(|command| command_is_dropped(command, table_options.drop_percent))
+            .collect();
+        if shed.iter().any(|dropped| *dropped) {
+            let kept: Vec<Command> = commands
+                .iter()
+                .zip(shed.iter())
+                .filter(|(_, dropped)| !**dropped)
+                .map(|(command, _)| command.clone())
+                .collect();
+            // Nothing survived: the batch as a whole was shed, and it answers
+            // exactly as it always has. Only a batch with survivors changes,
+            // and only so the survivors are served.
+            if kept.is_empty() {
+                let first = commands
+                    .first()
+                    .and_then(command_key)
+                    .map(|key| key.to_string());
+                return Ok(BatchExecuteResponse {
+                    status: Status::error(
+                        "traffic_dropped",
+                        format!(
+                            "batch command for key {:?} dropped by table drop_percent",
+                            first
+                        ),
                     ),
-                ),
-                responses: Vec::new(),
+                    responses: Vec::new(),
+                });
+            }
+            let served = self.batch_execute(kept)?;
+            // A failure that stopped the batch is still the batch's failure.
+            if !served.status.ok {
+                return Ok(served);
+            }
+            let mut served = served.responses.into_iter();
+            let responses = shed
+                .iter()
+                .map(|dropped| {
+                    if *dropped {
+                        ExecuteResponse {
+                            status: Status::error(
+                                "traffic_dropped",
+                                "request dropped by table drop_percent",
+                            ),
+                            response: CommandResponse::Empty,
+                        }
+                    } else {
+                        served.next().unwrap_or_else(|| ExecuteResponse {
+                            status: Status::error(
+                                "missing_response",
+                                "batch response missing",
+                            ),
+                            response: CommandResponse::Empty,
+                        })
+                    }
+                })
+                .collect();
+            return Ok(BatchExecuteResponse {
+                status: Status::ok(),
+                responses,
             });
         }
         // The LIVE shard count, not the one this handle was opened with. Read from the

--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -400,3 +400,77 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod shed_shape {
+    use super::*;
+
+    /// How many of `batches` batches of `batch` keys contain at least one key
+    /// the rate sheds, and what share of individual keys it sheds.
+    fn shed_rates(percent: u8, batch: usize, batches: usize) -> (f64, f64) {
+        let mut batches_touched = 0usize;
+        let mut keys_shed = 0usize;
+        let mut keys_total = 0usize;
+        for b in 0..batches {
+            let commands: Vec<Command> = (0..batch)
+                .map(|i| Command::CommonExists {
+                    key: format!("tenant/{b}/key-{i}"),
+                })
+                .collect();
+            keys_total += commands.len();
+            let here = commands
+                .iter()
+                .filter(|command| command_is_dropped(command, percent))
+                .count();
+            keys_shed += here;
+            if here > 0 {
+                batches_touched += 1;
+            }
+        }
+        (
+            100.0 * keys_shed as f64 / keys_total as f64,
+            100.0 * batches_touched as f64 / batches as f64,
+        )
+    }
+
+    #[test]
+    fn the_rate_is_per_key_and_a_batch_multiplies_it() {
+        // Not a claim about the fix -- a claim about why one was needed. The
+        // rate really is per key, and the chance a batch contains at least one
+        // shed key climbs with its size. Refusing the batch on that basis is
+        // what turned 1% into most of the traffic.
+        let (keys, touched) = shed_rates(1, 100, 2_000);
+        assert!(
+            (0.5..2.0).contains(&keys),
+            "keys shed should track the rate, got {keys:.1}%"
+        );
+        assert!(
+            touched > 40.0,
+            "a hundred-key batch should usually contain a shed key at 1%, got {touched:.1}%"
+        );
+
+        // And at a rate an operator might actually pick for load shedding,
+        // nearly every large batch contains one.
+        let (_, touched) = shed_rates(5, 100, 2_000);
+        assert!(
+            touched > 90.0,
+            "at 5% nearly every hundred-key batch contains a shed key, got {touched:.1}%"
+        );
+    }
+
+    #[test]
+    fn a_single_key_is_shed_at_the_rate_it_was_given() {
+        for &percent in &[1u8, 10, 25] {
+            let (keys, batches) = shed_rates(percent, 1, 4_000);
+            assert!(
+                (keys - batches).abs() < f64::EPSILON,
+                "a batch of one is the key itself"
+            );
+            let expected = percent as f64;
+            assert!(
+                (keys - expected).abs() < 3.0,
+                "rate {percent} shed {keys:.1}% of keys"
+            );
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/client/tests/part2.rs
+++ b/crates/temporalstore-rust/src/client/tests/part2.rs
@@ -1355,6 +1355,73 @@ fn client_deployment_placement_routes_reads_to_local_secondary_and_writes_to_pri
 }
 
 #[test]
+fn a_partly_shed_batch_does_not_refuse_the_keys_it_kept() {
+    // drop_percent is a per-key rate, but the batch path refused the whole
+    // batch as soon as one key fell in the shed range, so the rate arrived as
+    // 1-(1-p)^n per batch: at 1%, 63% of hundred-key batches were refused; at
+    // 5%, 99.5%. The keys that were not shed never reached the network.
+    //
+    // The proxy address is unroutable, which is what makes the difference
+    // visible without standing a server up. A batch that is entirely shed
+    // never touches the network and answers traffic_dropped. A batch with
+    // survivors has to try to serve them, so it comes back as a connection
+    // failure instead -- that failure is the evidence the survivors were sent.
+    let client = TemporalStoreClient::with_options(ClientOptions {
+        proxy_addr: "127.0.0.1:1".to_string(),
+        ..ClientOptions::default()
+    });
+    let everything = client.open_table(
+        "ns",
+        "tbl",
+        TableOptions {
+            drop_percent: 100,
+            ..TableOptions::default()
+        },
+    );
+    let all_shed = everything
+        .batch_execute(
+            (0..40)
+                .map(|i| Command::StringGet {
+                    key: format!("key-{i}"),
+                })
+                .collect(),
+        )
+        .expect("a fully shed batch never reaches the network");
+    assert_eq!(all_shed.status.code, "traffic_dropped");
+    assert!(all_shed.responses.is_empty());
+    assert_eq!(client.stats().route_refreshes, 0);
+
+    let some = client.open_table(
+        "ns",
+        "tbl2",
+        TableOptions {
+            drop_percent: 50,
+            ..TableOptions::default()
+        },
+    );
+    let keys: Vec<Command> = (0..40)
+        .map(|i| Command::StringGet {
+            key: format!("key-{i}"),
+        })
+        .collect();
+    let shed_here = keys
+        .iter()
+        .filter(|command| crate::client::commands::command_is_dropped(command, 50))
+        .count();
+    assert!(
+        shed_here > 0 && shed_here < keys.len(),
+        "the test needs a batch that is partly shed; got {shed_here} of {}",
+        keys.len()
+    );
+    let result = some.batch_execute(keys);
+    assert!(
+        result.is_err(),
+        "the kept keys were never sent: a partly shed batch answered without \
+         touching the network, which is the whole-batch refusal this fixes"
+    );
+}
+
+#[test]
 fn client_table_drop_percent_rejects_sampled_requests_before_network() {
     let client = TemporalStoreClient::with_options(ClientOptions {
         proxy_addr: "127.0.0.1:1".to_string(),


### PR DESCRIPTION
drop_percent is a per-key rate: command_is_dropped hashes the routing key,
and the single-command path refuses exactly that key. The batch path
refused the entire batch as soon as any one key in it hashed into the shed
range, so the rate an operator set per key arrived as 1-(1-p)^n per batch.

Measured over 2000 batches per row:

    drop_percent   batch   keys shed   BATCHES refused
               1     100        1.0%             63.4%
               5     100        4.9%             99.5%
              10      50        9.9%             99.2%
              10     100        9.9%            100.0%

A 1% shed rate refused two thirds of hundred-key batches, and 5% refused
essentially all of them. The per-key rate was right the whole time; what
went out was every key that happened to share a batch with a shed one.

A shed key now gets its own slot with its own status, beside the results of
the keys that were kept. That is the shape a batch already has -- the
grouped path fills a missing slot with a per-response error inside an
otherwise-ok batch.

A batch with nothing left answers exactly as it did before, top-level
traffic_dropped and no responses, so the case that was already pinned by a
test keeps its contract. Only a batch with survivors changes, and only so
that the survivors are served.

Tests: a partly shed batch now reaches the network for the keys it kept,
which against an unroutable proxy is visible as a connection failure rather
than a refusal -- it fails on the unmodified code with "the kept keys were
never sent". Plus the shape itself: the rate is per key, and the chance a
batch contains a shed key climbs with its size.
