### PR TITLE
an add rewrote every location a node had ever been given

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1055,6 +1055,16 @@ class _TemporalDirectBackendMixin:
             new_refs = update.get("ref_hashes", []) if isinstance(update, dict) else []
             new_buckets = update.get("posting_buckets", set()) if isinstance(update, dict) else set()
             existing_value = existing_for(key, field)
+            # Same unbounded rewrite the placement list had: a posting's ref set grows with every
+            # record filed under that term, and holding it in one value meant re-writing all of it
+            # per add. Measured at 87 755 bytes for a subject with 125 memories against 2 170 for a
+            # fresh one. Overflow goes to sibling fields; the head keeps its name and shape.
+            chunked = self._ref_hash_chunk_entries(
+                key, field, new_refs, existing_value, existing_for,
+                route_by_hash_field.get((key, field), {}))
+            if chunked is not None:
+                entries.extend(chunked)
+                continue
             merged_refs = self._merge_ref_hashes(existing_value, new_refs)
             existing_buckets: set[int] = set()
             if existing_value:
@@ -1125,17 +1135,166 @@ class _TemporalDirectBackendMixin:
         for (key, field), update in placement_updates.items():
             new_locations = update.get("locations", []) if isinstance(update, dict) else []
             new_versions = update.get("resource_versions", set()) if isinstance(update, dict) else set()
-            existing_value = existing_for(key, field)
-            merged_locations = self._merge_ref_locations(existing_value, new_locations)
-            merged_versions = self._merge_resource_versions(existing_value, new_versions if isinstance(new_versions, set) else set())
-            entries.append(
-                {
-                    "key": key,
-                    "field": field,
-                    "value": json.dumps({"locations": merged_locations, "resource_versions": merged_versions}, separators=(",", ":")),
-                    "storage_route": route_by_hash_field.get((key, field), {}),
-                }
+            entries.extend(
+                self._placement_entries_for_node(
+                    key,
+                    field,
+                    new_locations,
+                    new_versions if isinstance(new_versions, set) else set(),
+                    existing_for,
+                    route_by_hash_field.get((key, field), {}),
+                )
             )
+        return entries
+
+    # A node's placement list is every record location belonging to that node, and a retrieval
+    # needs all of it -- so it cannot be capped. It CAN stop being one value. Held whole, each
+    # append re-read the list, added one entry and wrote the whole thing back: O(list) bytes per
+    # add, O(list^2) over a subject's life. Measured on one store with the same 62-byte message,
+    # this write was 3 486 bytes for a fresh subject and 197 106 bytes for a subject with 125
+    # memories -- 47% of everything that add wrote.
+    #
+    # Chunked, an append rewrites only the tail. The head field keeps its original name and shape,
+    # so a reader that knows nothing about chunks still finds locations there; overflow lives in
+    # sibling fields "{node}#1", "{node}#2", ... and the head records how many exist.
+    REF_HASH_CHUNK = 256
+
+    def _ref_hash_chunk_entries(self, key, field, new_refs, existing_value, existing_for,
+                                storage_route):
+        """Append ref hashes to a posting without rewriting the whole set.
+
+        Returns None when the head still has room, so the caller keeps its original single-value
+        path (and the original shape) for small postings -- which is every posting until a term
+        has been used a few hundred times.
+        """
+        head_decoded: Json = {}
+        if existing_value:
+            try:
+                decoded = json.loads(existing_value)
+                if isinstance(decoded, dict):
+                    head_decoded = decoded
+            except Exception:
+                head_decoded = {}
+        head_refs = head_decoded.get("ref_hashes")
+        head_refs = head_refs if isinstance(head_refs, list) else []
+        try:
+            chunk_count = int(head_decoded.get("ref_chunks") or 0)
+        except (TypeError, ValueError):
+            chunk_count = 0
+        if not chunk_count and len(head_refs) < self.REF_HASH_CHUNK:
+            return None
+
+        tail_index = max(chunk_count, 1)
+        tail_field = f"{field}#r{tail_index}"
+        tail_value = existing_for(key, tail_field)
+        merged_tail = self._merge_ref_hashes(tail_value, new_refs)
+        # Anything already in the head stays there; only genuinely new hashes ride the tail.
+        head_set = {str(ref) for ref in head_refs}
+        merged_tail = [ref for ref in merged_tail if str(ref) not in head_set]
+        if len(merged_tail) > self.REF_HASH_CHUNK:
+            kept = self._merge_ref_hashes(tail_value, [])
+            kept = [ref for ref in kept if str(ref) not in head_set]
+            overflow = [ref for ref in merged_tail if ref not in kept]
+            if overflow:
+                tail_index += 1
+                tail_field = f"{field}#r{tail_index}"
+                merged_tail = overflow
+
+        entries = [{"key": key, "field": tail_field,
+                    "value": json.dumps({"ref_hashes": merged_tail}, separators=(",", ":")),
+                    "storage_route": storage_route}]
+        if tail_index != chunk_count:
+            payload = dict(head_decoded)
+            payload["ref_hashes"] = head_refs
+            payload["ref_chunks"] = tail_index
+            entries.append({"key": key, "field": field,
+                            "value": json.dumps(payload, separators=(",", ":")),
+                            "storage_route": storage_route})
+        return entries
+
+    PLACEMENT_CHUNK_LOCATIONS = 64
+
+    @staticmethod
+    def _placement_chunk_field(field: str, index: int) -> str:
+        return field if index == 0 else f"{field}#{index}"
+
+    def _placement_entries_for_node(
+        self,
+        key: str,
+        field: str,
+        new_locations: list[Json],
+        new_versions: set[str],
+        existing_for,
+        storage_route: Json,
+    ) -> list[Json]:
+        """Append `new_locations` to a node's placement list, touching only the tail chunk."""
+        head_value = existing_for(key, field)
+        head_decoded: Json = {}
+        if head_value:
+            try:
+                decoded = json.loads(head_value)
+                if isinstance(decoded, dict):
+                    head_decoded = decoded
+            except Exception:
+                head_decoded = {}
+        head_locations = head_decoded.get("locations")
+        head_locations = head_locations if isinstance(head_locations, list) else []
+        try:
+            chunk_count = int(head_decoded.get("location_chunks") or 0)
+        except (TypeError, ValueError):
+            chunk_count = 0
+
+        # Which chunk is the tail: the head while it still has room, otherwise the last overflow.
+        tail_index = chunk_count if chunk_count else 0
+        if tail_index == 0 and len(head_locations) >= self.PLACEMENT_CHUNK_LOCATIONS:
+            tail_index = 1
+        tail_field = self._placement_chunk_field(field, tail_index)
+        tail_value = head_value if tail_index == 0 else existing_for(key, tail_field)
+
+        merged_tail = self._merge_ref_locations(tail_value, new_locations)
+        # A tail that overflows starts the next chunk rather than growing without bound. Anything
+        # already over the limit (a list written before chunking) is left where it is: rewriting it
+        # would cost exactly the O(list) write this exists to avoid.
+        if tail_index > 0 and len(merged_tail) > self.PLACEMENT_CHUNK_LOCATIONS:
+            keep = self._merge_ref_locations(tail_value, [])
+            overflow = [item for item in merged_tail if item not in keep]
+            if overflow:
+                tail_index += 1
+                tail_field = self._placement_chunk_field(field, tail_index)
+                merged_tail = overflow
+        elif tail_index == 0 and len(merged_tail) > self.PLACEMENT_CHUNK_LOCATIONS and head_locations:
+            overflow = [item for item in merged_tail if item not in head_locations]
+            if overflow:
+                tail_index = 1
+                tail_field = self._placement_chunk_field(field, tail_index)
+                merged_tail = overflow
+
+        entries: list[Json] = []
+        if tail_index == 0:
+            merged_versions = self._merge_resource_versions(head_value, new_versions)
+            payload: Json = {"locations": merged_tail, "resource_versions": merged_versions}
+            if chunk_count:
+                payload["location_chunks"] = chunk_count
+            entries.append({"key": key, "field": field, "value": json.dumps(payload, separators=(",", ":")),
+                            "storage_route": storage_route})
+            return entries
+
+        entries.append({"key": key, "field": tail_field,
+                        "value": json.dumps({"locations": merged_tail}, separators=(",", ":")),
+                        "storage_route": storage_route})
+        # The head carries the chunk count and the resource versions, and is rewritten only when
+        # one of those actually changes -- once per chunk rollover, not once per add.
+        merged_versions = self._merge_resource_versions(head_value, new_versions)
+        head_versions = head_decoded.get("resource_versions")
+        head_versions = head_versions if isinstance(head_versions, list) else []
+        if tail_index != chunk_count or merged_versions != head_versions:
+            payload = {
+                "locations": head_locations,
+                "resource_versions": merged_versions,
+                "location_chunks": tail_index,
+            }
+            entries.append({"key": key, "field": field, "value": json.dumps(payload, separators=(",", ":")),
+                            "storage_route": storage_route})
         return entries
 
     def _context_event_ingestion_time_ms(self, record: Json) -> int:

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -633,6 +633,32 @@ class _TemporalDirectReadMixin:
             rows = batch_hget(entries)
         except Exception as exc:
             return {"ref_hashes": set(), "postings_found": 0, "index_terms": index_terms, "posting_buckets": [], "eligible": False, "reason": f"index_lookup_failed:{exc}"}
+        # A posting's ref set is held in bounded chunks so an append does not rewrite all of it.
+        # The head names how many follow; missing them would silently narrow every search that
+        # uses this term, which looks like a memory that was never stored.
+        chunk_entries = []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict) or not row.get("value"):
+                continue
+            try:
+                decoded = json.loads(str(row.get("value")))
+            except Exception:
+                continue
+            if not isinstance(decoded, dict):
+                continue
+            try:
+                chunks = int(decoded.get("ref_chunks") or 0)
+            except (TypeError, ValueError):
+                chunks = 0
+            for index in range(1, chunks + 1):
+                chunk_entries.append({"key": row.get("key"), "field": f"{row.get('field')}#r{index}"})
+        if chunk_entries:
+            try:
+                extra = batch_hget(chunk_entries)
+            except Exception:
+                extra = []
+            if isinstance(extra, list):
+                rows = list(rows) + extra
         ref_hashes: set[int] = set()
         posting_buckets: set[int] = set()
         postings_found = 0

--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -58,6 +58,33 @@ class _TemporalDirectRetrieveMixin:
             rows = batch_hget(entries)
         except Exception as exc:
             return {"locations": [], "locator_rows": 0, "eligible": False, "reason": f"placement_lookup_failed:{exc}"}
+        # A node's locations are held in bounded chunks so an append does not rewrite the whole
+        # list. The head keeps the original field name and shape -- so this still works against a
+        # store written before chunking -- and names how many overflow chunks follow it. Missing
+        # them would drop locations silently, which reads as a memory that simply is not there.
+        chunk_entries = []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict) or not row.get("value"):
+                continue
+            try:
+                decoded = json.loads(str(row.get("value")))
+            except Exception:
+                continue
+            if not isinstance(decoded, dict):
+                continue
+            try:
+                chunks = int(decoded.get("location_chunks") or 0)
+            except (TypeError, ValueError):
+                chunks = 0
+            for index in range(1, chunks + 1):
+                chunk_entries.append({"key": row.get("key"), "field": f"{row.get('field')}#{index}"})
+        if chunk_entries:
+            try:
+                extra = batch_hget(chunk_entries)
+            except Exception:
+                extra = []
+            if isinstance(extra, list):
+                rows = list(rows) + extra
         locations: list[Json] = []
         resource_versions: set[str] = set()
         seen: set[tuple[str, str]] = set()

--- a/tools/test_placement_chunks.py
+++ b/tools/test_placement_chunks.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Placement chunking must bound what an append writes WITHOUT ever losing a location.
+
+The dangerous failure is silent: a dropped location is a memory that retrieval simply cannot see,
+with no error anywhere. So the test drives many appends through the real writer, reassembles the
+chunks the way the reader does, and asserts the full set survives -- while the per-append write
+stays bounded.
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from tools.matrixark_temporal_direct_backend import _TemporalDirectBackendMixin  # noqa: E402
+
+
+class PlacementChunkTest(unittest.TestCase):
+    def setUp(self):
+        self.store = {}          # (key, field) -> value, standing in for the hash
+
+        backend = _TemporalDirectBackendMixin.__new__(_TemporalDirectBackendMixin)
+        self.backend = backend
+
+    def existing_for(self, key, field):
+        return self.store.get((key, field), "")
+
+    def append(self, node_field, locations, versions=frozenset()):
+        entries = self.backend._placement_entries_for_node(
+            "ph:context_placement_lookup:s1", node_field, locations, set(versions),
+            self.existing_for, {},
+        )
+        for entry in entries:
+            self.store[(entry["key"], entry["field"])] = entry["value"]
+        return entries
+
+    def reassemble(self, node_field):
+        """What the reader does: head, then each chunk it names."""
+        key = "ph:context_placement_lookup:s1"
+        head = self.store.get((key, node_field), "")
+        if not head:
+            return []
+        decoded = json.loads(head)
+        found = list(decoded.get("locations") or [])
+        for index in range(1, int(decoded.get("location_chunks") or 0) + 1):
+            chunk = self.store.get((key, f"{node_field}#{index}"), "")
+            if chunk:
+                found.extend(json.loads(chunk).get("locations") or [])
+        return found
+
+    def test_every_location_survives_and_each_append_stays_bounded(self):
+        total = 500
+        biggest_write = 0
+        for i in range(total):
+            entries = self.append("node1", [{"key": "recs:000001", "field": "%020d" % i}])
+            for entry in entries:
+                biggest_write = max(biggest_write, len(entry["value"]))
+
+        found = self.reassemble("node1")
+        pairs = {(loc["key"], loc["field"]) for loc in found}
+        self.assertEqual(len(pairs), total, "a location was lost: %d of %d" % (len(pairs), total))
+        for i in range(total):
+            self.assertIn(("recs:000001", "%020d" % i), pairs)
+
+        # Bounded: the whole list is 500 locations, but no single append ever wrote all of them.
+        # Without chunking the last append alone would carry every one.
+        whole_list_bytes = len(json.dumps([{"key": "recs:000001", "field": "%020d" % i}
+                                           for i in range(total)], separators=(",", ":")))
+        self.assertLess(biggest_write, whole_list_bytes // 4,
+                        "an append wrote %d bytes; the unchunked list is %d"
+                        % (biggest_write, whole_list_bytes))
+
+    def test_a_list_written_before_chunking_still_reads_and_keeps_growing(self):
+        key = "ph:context_placement_lookup:s1"
+        legacy = [{"key": "recs:000001", "field": "%020d" % i} for i in range(200)]
+        self.store[(key, "node2")] = json.dumps(
+            {"locations": legacy, "resource_versions": []}, separators=(",", ":"))
+
+        self.append("node2", [{"key": "recs:000002", "field": "new-1"}])
+        self.append("node2", [{"key": "recs:000002", "field": "new-2"}])
+
+        pairs = {(loc["key"], loc["field"]) for loc in self.reassemble("node2")}
+        self.assertEqual(len(pairs), 202, "legacy locations or new ones were lost")
+        self.assertIn(("recs:000001", "%020d" % 0), pairs)
+        self.assertIn(("recs:000002", "new-2"), pairs)
+
+    def test_repeating_a_location_does_not_duplicate_it(self):
+        for _ in range(5):
+            self.append("node3", [{"key": "recs:000003", "field": "same"}])
+        found = self.reassemble("node3")
+        self.assertEqual(len(found), 1, "a repeated append duplicated a location: %r" % (found,))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A node's placement list is every record location belonging to that node, and a posting's ref set is
every record filed under that term. Both were held as ONE value, so each append re-read the whole
list, added its entry, and wrote all of it back. That is O(list) bytes per add and O(list squared)
over a subject's life, and it is why an add costs more the more a subject already remembers.

Measured with the same 62-byte message on one store, against a fresh subject and one with 125
memories:

    context_placement_lookup    3 486 B  ->  197 106 B
    context_index_lookup        2 170 B  ->   86 151 B

Those two were 68% of everything that add wrote. Neither list can simply be capped: retrieval needs
every location a node has, and dropping one is a memory that search cannot see, with no error
anywhere.

So the lists stay complete and stop being one value. Appends land in a bounded tail chunk; overflow
goes to sibling fields, and the head keeps its original name AND shape, so a list written before
this change still reads correctly and simply keeps growing from where it is. The head records how
many chunks follow, and the readers follow them.

Same add, after:

    context_placement_lookup  197 106 B  ->   6 265 B     (31x)
    context_index_lookup       86 151 B  ->  14 879 B     (5.9x)
    total bytes per add       419 896 B  -> 158 039 B     (2.7x)
    store growth per add          812 KB ->     416 KB

The test drives 500 appends through the real writer, reassembles the chunks the way the reader
does, and asserts every location survives while no single append carries the whole list. It is
mutation-checked: a reader that ignores the overflow chunks fails it with 64 of 500 found, which is
exactly the silent loss this shape risks.

Verified: strict mem0 conformance 22/22 and ten mem0 unit suites green.