### PR TITLE
every record carried a copy of routing it did not need

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -15,6 +15,47 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import Json, compact_latest_context_state_records, stable_hash
 
 
+# Keys of `storage_route` that are NOT recoverable from `storage_options`: where this record was
+# placed. Everything else `canonical_storage_route` produces is a pure function of the options,
+# which are stored on the record already.
+_ROUTE_KEYS_WORTH_STORING = (
+    "placement_key",
+    "placement_hash",
+    "routing_key",
+    "partition_key",
+    "colocation_group",
+)
+
+
+def slim_persisted_storage_route(record: Json) -> Json:
+    """Persist the placement half of `storage_route`, not the derived half.
+
+    `canonical_storage_route(storage_options)` is a pure function producing ~25 fields, and a copy
+    of its output was written onto every record. Measured on one add of a 62-byte message: 51
+    copies, 41 477 bytes, and only THREE distinct values -- one ~1 KB blob repeated onto 29 index
+    postings. That was 35% of everything the record payload carried.
+
+    What survives here is what nothing can recompute: the placement fields, which readers do use
+    (index enrichment falls back to `storage_route.placement_key` when the top-level one is
+    missing). The derived fields are dropped because they are already implied by the record's own
+    `storage_options`; a consumer that wants them calls `canonical_storage_route` on those.
+    """
+    if not isinstance(record, dict):
+        return record
+    route = record.get("storage_route")
+    if not isinstance(route, dict) or not route:
+        return record
+    kept = {key: route[key] for key in _ROUTE_KEYS_WORTH_STORING if key in route}
+    if len(kept) == len(route):
+        return record
+    slim = dict(record)
+    if kept:
+        slim["storage_route"] = kept
+    else:
+        slim.pop("storage_route", None)
+    return slim
+
+
 def materialize_appended_records_locked(
     target: Any,
     *,
@@ -113,7 +154,8 @@ def append_many_materialized(target: Any, records: list[Json], *, allow_queue: b
         for bundle in target._record_bundles(records):
             record_key, record_id = target._record_location(sequence)
             payload_value: Json
-            payload_value = bundle[0] if len(bundle) == 1 else {"record_bundle": bundle}
+            slim = [slim_persisted_storage_route(record) for record in bundle]
+            payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
             payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))
             entries.append(
                 {

--- a/tools/matrixark_temporal_direct_write.py
+++ b/tools/matrixark_temporal_direct_write.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     from matrixark_mcp_local_adapter import fold_embedding_records
 
+try:
+    from tools.matrixark_mcp_temporal_append import slim_persisted_storage_route
+except ImportError:
+    from matrixark_mcp_temporal_append import slim_persisted_storage_route
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     TEMPORAL_COMPRESSED_OLD_RECORD_TYPES,
@@ -323,7 +328,8 @@ class _TemporalDirectWriteMixin:
             for bundle in self._record_bundles(records):
                 record_key, record_id = self._record_location(sequence)
                 payload_value: Json
-                payload_value = bundle[0] if len(bundle) == 1 else {"record_bundle": bundle}
+                slim = [slim_persisted_storage_route(record) for record in bundle]
+                payload_value = slim[0] if len(slim) == 1 else {"record_bundle": slim}
                 payload = json.dumps(payload_value, sort_keys=True, separators=(",", ":"))
                 entries.append({"key": record_key, "field": record_id, "value": payload, "storage_route": self._storage_route_for_bundle(bundle)})
                 located_bundles.append((bundle, record_key, record_id))


### PR DESCRIPTION
`canonical_storage_route(storage_options)` is a pure function: give it a record's storage options
and it returns about twenty-five fields describing how the write is routed. A copy of that output
was then written onto every record.

Measured on one add of a 62-byte message: 51 copies, 41 477 bytes, and only THREE distinct values
-- one roughly 1 KB blob repeated onto 29 index postings. That was 35% of everything the record
payload carried, and the options it is derived from are stored on the record anyway.

Only the placement half is not recomputable: placement_key, placement_hash, routing_key,
partition_key, colocation_group -- where this record was put. Those are kept, because readers do
use them (index enrichment falls back to `storage_route.placement_key` when the top-level field is
absent). The derived half is no longer persisted; a consumer that wants it calls
`canonical_storage_route` on the record's own options, which is where it came from.

Same add, after:

    storage_route copies      51 -> 29
    storage_route bytes   41 477 -> 12 441
    record payload       128 001 -> 98 578      (23%)

Verified: strict mem0 conformance 22/22 and ten mem0 unit suites green.

Worth stating plainly about what this does NOT fix: on-disk size per memory is roughly unchanged,
because one 62-byte memory materialises about 52 records -- event, node, entity, segment,
summaries, 28 index postings, embeddings, audits -- and the storage layer writes each of them to
the WAL, the pages and the index log. Shrinking that further is a question about what an ingest
materialises, not about duplicated bytes, and it needs its own design.