### PR TITLE
the served index gets a real binary payload, version-stamped so it cannot engage silently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1337,7 @@ dependencies = [
  "matrixraft",
  "prost",
  "protoc-bin-vendored",
+ "rmp-serde",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["database-implementations", "data-structures"]
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
+rmp-serde = "1.3"
 hex = "0.4"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1616,9 +1616,35 @@ fn serialize_index(shard: &ShardState) -> Vec<u8> {
 const INDEX_CONTAINER_MAGIC: &[u8] = b"TSIDX\x01";
 
 /// Payload codec ids inside the container. The whole point of the container is that this is an
-/// enumeration rather than a decision: a future protobuf or bincode payload is a new id whose
-/// decoder lands beside the existing ones, and every index written before it keeps loading.
+/// enumeration rather than a decision: each payload is an id whose decoder lands beside the
+/// others, and every index written before it keeps loading.
 const INDEX_CODEC_ZSTD_JSON: u8 = 1;
+/// The struct's own serde model in a binary encoding, then compressed.
+///
+/// Two decisions are baked in here, and measurement forced both.
+///
+/// NOT a hand-written protobuf schema. The served index IS a `ShardState` and has to round-trip
+/// one exactly. A schema mirroring its ~26 fields and their nested maps is a second definition of
+/// the same type, and the two drifting apart fails SILENTLY -- a field added here and forgotten
+/// there simply disappears from the durable image, and the loss surfaces as missing data after a
+/// reload. Riding the existing derives means a new field participates because it exists, not
+/// because someone remembered to add it in two places.
+///
+/// NOT a field-ORDER encoding either, which is what an earlier attempt at this used. These structs
+/// lean on `#[serde(skip_serializing_if)]` and `#[serde(default)]` -- `BlockAddress` alone skips
+/// six optional fields -- so the writer omits fields that a positional decoder still expects and
+/// the stream slides out of alignment. Tried directly here: the round-trip fails with "tag for
+/// enum is not valid, found 9". A self-describing encoding (field names, struct-as-map) keeps
+/// exactly the semantics JSON had, which is the only way those attributes stay honest.
+const INDEX_CODEC_ZSTD_MSGPACK: u8 = 2;
+
+/// Binary payloads carry the struct version they were written from, big-endian, right after the
+/// codec id. A name-free encoding read against a different struct does not fail, it MIS-READS --
+/// so the version is checked before a byte is decoded, and a mismatch is refused. This is also the
+/// trap that sank the previous attempt from the other end: the struct's own
+/// `index_format_version` field lives INSIDE the payload, so it cannot be consulted until after
+/// the decode it is supposed to guard, and a fresh shard carries 0 there regardless.
+const INDEX_BINARY_VERSION_BYTES: usize = 4;
 
 /// Compression level for the container payload. The served index is written whole, in the
 /// background, and read whole -- so this trades a little CPU on a path that is not the request
@@ -1632,6 +1658,40 @@ fn index_binary_container_enabled() -> bool {
     env_flag_on("TS_INDEX_BINARY")
 }
 
+/// TS_INDEX_CODEC: which payload to write when the container is on. `msgpack` (the default when
+/// the container is enabled) encodes the struct itself; `zstd-json` keeps the compressed-JSON
+/// payload, which any reader can still inspect with a decompressor and a JSON parser.
+fn index_container_codec() -> u8 {
+    match std::env::var("TS_INDEX_CODEC")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "zstd-json" | "json" => INDEX_CODEC_ZSTD_JSON,
+        _ => INDEX_CODEC_ZSTD_MSGPACK,
+    }
+}
+
+/// Encode a shard with the container's binary payload: the serde model as a binary map,
+/// compressed, behind the magic, the codec id and the struct version.
+fn encode_index_msgpack(shard: &ShardState) -> Option<Vec<u8>> {
+    // struct-as-MAP, not struct-as-array: the array form is positional, and positional is what
+    // mis-reads a struct that skipped an absent optional.
+    let mut encoded = Vec::new();
+    let mut serializer = rmp_serde::Serializer::new(&mut encoded).with_struct_map();
+    serde::Serialize::serialize(shard, &mut serializer).ok()?;
+    let payload = zstd::stream::encode_all(encoded.as_slice(), INDEX_ZSTD_LEVEL).ok()?;
+    let mut out = Vec::with_capacity(
+        payload.len() + INDEX_CONTAINER_MAGIC.len() + 1 + INDEX_BINARY_VERSION_BYTES,
+    );
+    out.extend_from_slice(INDEX_CONTAINER_MAGIC);
+    out.push(INDEX_CODEC_ZSTD_MSGPACK);
+    out.extend_from_slice(&SHARD_INDEX_FORMAT_VERSION.to_be_bytes());
+    out.extend_from_slice(&payload);
+    Some(out)
+}
+
 /// The single place the served index becomes bytes.
 ///
 /// The measured cost of raw JSON here is real: a 1 000-memory store carries a 74 MB index, and a
@@ -1639,6 +1699,13 @@ fn index_binary_container_enabled() -> bool {
 /// no schema mirrored by hand, no second definition to drift -- while cutting what is written and
 /// what must be read back at load.
 pub(super) fn encode_index_bytes(shard: &ShardState) -> Vec<u8> {
+    if index_binary_container_enabled() && index_container_codec() == INDEX_CODEC_ZSTD_MSGPACK {
+        // A binary payload only works from the struct itself, so the version-stamping path (which
+        // patches a `Value`) keeps to JSON; both still land inside the same container.
+        if let Some(encoded) = encode_index_msgpack(shard) {
+            return encoded;
+        }
+    }
     wrap_index_json(serde_json::to_vec(shard).expect("shard index should serialize"))
 }
 
@@ -1681,6 +1748,30 @@ pub(super) fn decode_index_bytes(bytes: &[u8]) -> Result<ShardState, String> {
             let json = zstd::stream::decode_all(payload)
                 .map_err(|error| format!("served index payload did not decompress: {error}"))?;
             serde_json::from_slice::<ShardState>(&json).map_err(|error| error.to_string())
+        }
+        INDEX_CODEC_ZSTD_MSGPACK => {
+            if payload.len() < INDEX_BINARY_VERSION_BYTES {
+                return Err("served index binary payload is truncated".to_string());
+            }
+            let (version_bytes, body) = payload.split_at(INDEX_BINARY_VERSION_BYTES);
+            let version = u32::from_be_bytes(
+                version_bytes
+                    .try_into()
+                    .map_err(|_| "served index version stamp is malformed".to_string())?,
+            );
+            // Checked BEFORE decoding, deliberately. This payload is addressed by field order, so
+            // decoding it against a different struct shape does not error, it produces a plausible
+            // and wrong `ShardState`. Refusing is treated like an absent index: the caller replays
+            // the WAL and the index-log deltas, which is slower and correct.
+            if version != SHARD_INDEX_FORMAT_VERSION {
+                return Err(format!(
+                    "served index was written from struct version {version}, this binary is {}",
+                    SHARD_INDEX_FORMAT_VERSION
+                ));
+            }
+            let decoded = zstd::stream::decode_all(body)
+                .map_err(|error| format!("served index payload did not decompress: {error}"))?;
+            rmp_serde::from_slice::<ShardState>(&decoded).map_err(|error| error.to_string())
         }
         other => Err(format!(
             "served index uses payload codec {other}, which this binary cannot read"

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3114,3 +3114,98 @@ fn served_index_container_round_trips_and_still_reads_plain_json() {
     let refused = decode_index_bytes(&future).expect_err("unknown codec must refuse");
     assert!(refused.contains("cannot read"), "unhelpful refusal: {refused}");
 }
+
+#[test]
+fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
+    use crate::engine::{decode_index_bytes, encode_index_bytes};
+
+    let mut shard = ShardState::default();
+    shard.index_format_version = crate::engine::SHARD_INDEX_FORMAT_VERSION;
+    for i in 0..64u64 {
+        shard.strings.insert(
+            format!("object-{i}"),
+            BlockAddress {
+                page_slab_id: i,
+                offset: i * 7,
+                length: i + 1,
+                page_id: Some(i),
+                object_id: Some(i * 3),
+                routing_bucket: Some((i % 8) as u32),
+                band_id: None,
+                generation: Some(i),
+                sha256: None,
+            },
+        );
+    }
+    shard.hashes.entry("hash-object".to_string()).or_default().insert(
+        "component".to_string(),
+        BlockAddress {
+            page_slab_id: 9,
+            offset: 1,
+            length: 2,
+            page_id: None,
+            object_id: None,
+            routing_bucket: None,
+            band_id: None,
+            generation: None,
+            sha256: None,
+        },
+    );
+    shard.applied_wal_sequence = Some(4242);
+
+    std::env::set_var("TS_INDEX_BINARY", "1");
+    std::env::set_var("TS_INDEX_CODEC", "msgpack");
+    let binary = encode_index_bytes(&shard);
+    std::env::remove_var("TS_INDEX_BINARY");
+    std::env::remove_var("TS_INDEX_CODEC");
+
+    assert!(binary.starts_with(b"TSIDX\x01"), "binary payload must ride the container");
+    assert_eq!(binary[6], 2, "payload codec id");
+
+    // Exact round-trip: the durable image has to come back as the same state, not merely a
+    // plausible one -- so compare the maps, not just that it decoded.
+    let decoded = decode_index_bytes(&binary).expect("binary index decodes");
+    assert_eq!(decoded.strings.len(), shard.strings.len());
+    for (key, address) in &shard.strings {
+        assert_eq!(decoded.strings.get(key), Some(address), "address changed for {key}");
+    }
+    assert_eq!(decoded.hashes, shard.hashes);
+    assert_eq!(decoded.applied_wal_sequence, shard.applied_wal_sequence);
+    assert_eq!(decoded.index_format_version, shard.index_format_version);
+
+    // The payload is addressed by field ORDER, so a struct of a different shape must be refused
+    // rather than decoded into something plausible and wrong. The version stamp sits outside the
+    // payload precisely so it can be checked before any of it is parsed.
+    let mut wrong_version = binary.clone();
+    wrong_version[7..11].copy_from_slice(&99u32.to_be_bytes());
+    let refused = decode_index_bytes(&wrong_version).expect_err("a foreign struct version refuses");
+    assert!(refused.contains("struct version"), "unhelpful refusal: {refused}");
+
+    // And every older on-disk shape still loads: plain JSON, and the compressed-JSON payload.
+    std::env::remove_var("TS_INDEX_BINARY");
+    let plain = encode_index_bytes(&shard);
+    assert_eq!(plain.first(), Some(&b'{'), "container off still writes JSON");
+    assert_eq!(
+        decode_index_bytes(&plain).expect("json decodes").strings.len(),
+        shard.strings.len()
+    );
+
+    std::env::set_var("TS_INDEX_BINARY", "1");
+    std::env::set_var("TS_INDEX_CODEC", "zstd-json");
+    let compressed_json = encode_index_bytes(&shard);
+    std::env::remove_var("TS_INDEX_BINARY");
+    std::env::remove_var("TS_INDEX_CODEC");
+    assert_eq!(compressed_json[6], 1, "zstd-json keeps codec id 1");
+    assert_eq!(
+        decode_index_bytes(&compressed_json).expect("zstd-json decodes").strings.len(),
+        shard.strings.len()
+    );
+
+    // The binary payload is the smaller one -- that is the whole point of adding it.
+    assert!(
+        binary.len() < plain.len(),
+        "binary {} not smaller than json {}",
+        binary.len(),
+        plain.len()
+    );
+}


### PR DESCRIPTION
The container landed earlier with one payload: the same JSON, compressed. This adds the encoding
itself as codec 2, and closes the two traps that sank the previous attempt at this.

**Trap one: the decoders.** Already fixed by the container -- one `encode_index_bytes`, one
`decode_index_bytes`, every site funnelled through them, and decoding SNIFFS, so plain JSON from
any older binary still loads.

**Trap two: a fresh shard carries struct version 0**, so an encoding keyed off the struct's own
version field never engages -- and worse, that field lives INSIDE the payload, where it cannot be
consulted until after the decode it is supposed to guard. So the version now rides the CONTAINER,
big-endian, right after the codec id, and is checked before a byte is parsed. A payload written
from a different struct shape is refused with a clear message, which the caller treats exactly like
an absent index: replay the WAL and the index-log deltas, slower and correct.

**A field-ORDER encoding cannot carry these structs, and this is worth recording.** Tried first,
directly: `bincode` round-trips these types with "tag for enum is not valid, found 9". The cause is
not bincode -- it is that `ShardState` and its nested types lean on `#[serde(skip_serializing_if)]`
and `#[serde(default)]` (`BlockAddress` alone skips six optional fields). A writer omits fields a
positional decoder still expects, and the stream slides out of alignment. The same objection rules
out a hand-written protobuf schema for a different reason: the schema would be a second definition
of a type that must round-trip exactly, and the two drifting apart fails silently -- a field added
here and forgotten there just disappears from the durable image. The payload is therefore
self-describing (field names, struct-as-map) and rides the existing derives, so a new field
participates because it exists rather than because someone remembered it in two places.

Measured. On a real 415-memory store's index:

    JSON                28 135 282 B
    zstd-JSON            3 380 291 B     8.3x
    binary payload       3 421 766 B     8.2x

On a uniform 200 000-entry index, where the shape is not dominated by highly compressible repeated
key strings:

    JSON            34.9 MB   encode  99.5 ms   decode 164.3 ms
    zstd-JSON        5.77 MB  encode 204.1 ms   decode 213.9 ms
    binary payload   4.89 MB  encode 144.5 ms   decode 197.3 ms

So: against raw JSON it is 7x smaller. Against compressed JSON the bytes are a WASH on a real index
-- compression already removes most of what a binary encoding would have saved -- and the win is
15% fewer bytes and 29% faster encoding on an index whose content does not compress as kindly. That
is a smaller result than "half the bytes", and it is what the measurement says.

Writing stays behind `TS_INDEX_BINARY`, default off, with `TS_INDEX_CODEC` choosing the payload
(binary by default when the container is on, `zstd-json` for a payload any reader can inspect with
a decompressor and a JSON parser). Reading is unconditional. The default stays off for the reason
observed while testing the container: once a store has written a container index and a dump has
reclaimed the logs behind it, a binary without the decoder cannot open that store at all.

Test pins all of it: exact round-trip on a populated shard (addresses compared, not just "it
decoded"), refusal on a foreign struct version, plain JSON still loading, compressed JSON still
loading, and the binary payload being the smaller one. Full lib suite 1 267 passed with one
inherited failure that reproduces on a pristine tree.