### PR TITLE
an ingest read a subject's whole history to use eight events

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -4718,6 +4718,7 @@ mod tests {
             record_hash_key: None,
             shard_size: None,
             record_types: None,
+            newest_by_type: None,
             selected_node_hashes: None,
             secondary_index_groups: None,
             scope: None,

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -78,6 +78,14 @@ struct RecordLogRequest {
     shard_size: Option<u64>,
     #[serde(default)]
     record_types: Option<Vec<String>>,
+    /// Cap the scan to the newest N locations of a given record type, by append order.
+    ///
+    /// For a consumer that only ever looks at the tail of a type -- prior context reads the newest
+    /// eight events and stops -- fetching the whole type is work whose result is discarded. Capping
+    /// is per TYPE on purpose: the same scan also carries tombstones and retention cutoffs, and a
+    /// cap on the union would drop the very records that make deleted memories stay deleted.
+    #[serde(default)]
+    newest_by_type: Option<BTreeMap<String, usize>>,
     /// Identity ids to remove, for `matrixark_delete_records`. Sent by the caller, which owns the
     /// decision about what a delete covers; the engine only matches and removes.
     #[serde(default)]
@@ -1107,6 +1115,9 @@ fn matrixark_scan_cache_key(command: &RecordLogRequest, count: u64) -> String {
         "secondary_index_groups": command.secondary_index_groups,
         "scope": command.scope,
         "return_index_records": command.return_index_records,
+        // A capped scan and an uncapped one are different answers to the same question, so they
+        // must not share a cache entry: the capped answer is a SUBSET.
+        "newest_by_type": command.newest_by_type,
     }))
     .unwrap_or_else(|_| format!("fallback:{count}"))
 }
@@ -1567,6 +1578,7 @@ fn scope_index_payloads(
     record_hash_key: &str,
     allowed_types: &HashSet<String>,
     bucket: &str,
+    newest_by_type: Option<&BTreeMap<String, usize>>,
 ) -> Result<Option<(Vec<String>, u64)>, String> {
     let ready = read_record_count(engine, &scope_index_ready_key(record_hash_key))?;
     if ready.trim() != SCOPE_INDEX_LAYOUT_VERSION {
@@ -1611,6 +1623,38 @@ fn scope_index_payloads(
                 .intersection(&type_positions)
                 .cloned()
                 .collect();
+            // Per-type cap, applied AFTER the scope intersection so "newest" means newest within
+            // this scope rather than newest in the store. A location is "{shard:06}:{field}" with
+            // both parts zero-padded, so lexical order IS append order and the newest N are the
+            // last N. Types without a cap keep every position they had.
+            if let Some(caps) = newest_by_type {
+                let mut capped: std::collections::BTreeSet<String> = positions.clone();
+                for (record_type, limit) in caps {
+                    if *limit == 0 || !allowed_types.contains(record_type) {
+                        continue;
+                    }
+                    let mut of_type: Vec<String> = Vec::new();
+                    for (location, _) in
+                        hgetall_map(engine, type_index_key(record_hash_key, record_type))?
+                    {
+                        if positions.contains(&location) {
+                            of_type.push(location);
+                        }
+                    }
+                    if of_type.len() <= *limit {
+                        continue;
+                    }
+                    of_type.sort();
+                    let keep: std::collections::BTreeSet<String> =
+                        of_type[of_type.len() - *limit..].iter().cloned().collect();
+                    for location in of_type {
+                        if !keep.contains(&location) {
+                            capped.remove(&location);
+                        }
+                    }
+                }
+                positions = capped;
+            }
         }
     }
     let (values, shards_touched) =
@@ -1858,9 +1902,13 @@ fn scan_matrixark_candidates(
     let mut scope_index_used = false;
     if !id_scoped_used && count > 0 {
         if let Some(bucket) = &query_bucket {
-            if let Some((values, shards_touched)) =
-                scope_index_payloads(engine, &record_hash_key, &allowed_types, bucket)?
-            {
+            if let Some((values, shards_touched)) = scope_index_payloads(
+                engine,
+                &record_hash_key,
+                &allowed_types,
+                bucket,
+                command.newest_by_type.as_ref(),
+            )? {
                 payload_values = values;
                 placement_partitions_touched = shards_touched;
                 scope_index_used = true;

--- a/tools/matrixark_mcp_rust_direct_client.py
+++ b/tools/matrixark_mcp_rust_direct_client.py
@@ -213,7 +213,7 @@ class MatrixArkRustCdylibClient:
             append_options=append_options,
         )
 
-    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int]) -> Json:
+    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], newest_by_type: Json | None = None) -> Json:
         request = json.dumps({"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}, separators=(",", ":"), sort_keys=True).encode("utf-8")
         def call() -> Json:
             out = self._ctypes.c_void_p()

--- a/tools/matrixark_mcp_rust_proxy_client.py
+++ b/tools/matrixark_mcp_rust_proxy_client.py
@@ -703,12 +703,19 @@ class MatrixArkRustProxyClient(MatrixArkRustProxyCacheMixin):
         selected_node_hashes: list[int],
         record_ids: list[str] | None = None,
         return_index_records: bool = False,
+        newest_by_type: Json | None = None,
     ) -> Json:
         extra: Json = {}
         if record_ids:
             extra["record_ids"] = [str(item) for item in record_ids]
         if return_index_records:
             extra["return_index_records"] = True
+        # Cap the scan to the newest N locations of a named type. Sent only when asked for, so a
+        # request that does not carry it is byte-identical to before.
+        if newest_by_type:
+            extra["newest_by_type"] = {
+                str(record_type): int(limit) for record_type, limit in newest_by_type.items()
+            }
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1193,9 +1193,22 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 **({"newest_by_type": dict(newest_by_type)} if newest_by_type else {}),
             )
         except TypeError:
-            # A client whose signature lacks one of the newer parameters. The full-read fallback
-            # is always correct; retrying with fewer kwargs is not -- a scan without
-            # return_index_records silently eats the embedding rows a caller asked for.
+            # A client whose signature lacks one of the newer parameters. Retrying with fewer
+            # kwargs is generally WRONG -- a scan without return_index_records silently eats the
+            # embedding rows a caller asked for -- so the full read is the fallback.
+            #
+            # Except for one: the cap is the ONE kwarg safe to drop, because dropping it widens
+            # the answer rather than narrowing it. Without it the scan returns every record of
+            # these types, which is exactly what this call did before the cap existed, and the
+            # consumer filters the same way either way. Falling all the way back to a full-store
+            # read would be the opposite of what asking for a cap was for.
+            if newest_by_type:
+                try:
+                    return self._scan_records_of_types(
+                        record_types, record_ids=record_ids, scope=scope, newest_by_type=None
+                    )
+                except Exception:  # noqa: BLE001 - the full read is the fallback, not a guess.
+                    return None
             return None
         except Exception:  # noqa: BLE001 - an unanswered question means "do the full read".
             return None

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -388,6 +388,26 @@ _SUBJECT_RESCOPE_DROP = frozenset({
 })
 
 
+
+def _prior_context_event_window() -> int:
+    """How many of a subject's newest events prior context fetches. 0 disables the cap.
+
+    Default 256 against a consumer that uses 8: wide enough that a subject interleaving many
+    sessions still finds its eight, narrow enough that the fetch stops growing with a subject's
+    whole history.
+    """
+    import os as _os
+
+    raw = _os.environ.get("MATRIXARK_PRIOR_CONTEXT_EVENT_WINDOW", "").strip()
+    if not raw:
+        return 256
+    try:
+        value = int(raw)
+    except ValueError:
+        return 256
+    return max(value, 0)
+
+
 class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, _TemporalDirectWriteMixin, _TemporalDirectReadMixin, _TemporalDirectRetrieveMixin):
     # The base class precedes the mixins in the MRO, so without this the buffered audit
     # implementation the __init__ prepares for (MATRIXARK_DIRECT_AUDIT_MODE, buffer, flusher)
@@ -1140,6 +1160,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         record_types: list[str],
         record_ids: list[str] | None = None,
         scope: Json | None = None,
+        newest_by_type: Json | None = None,
     ) -> list[Json] | None:
         """Records of exactly these types, in append order, from one filtered scan. None = could
         not ask.
@@ -1169,6 +1190,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 # already excluded them and the flag is a no-op.
                 return_index_records=True,
                 **({"record_ids": [str(item) for item in record_ids]} if record_ids else {}),
+                **({"newest_by_type": dict(newest_by_type)} if newest_by_type else {}),
             )
         except TypeError:
             # A client whose signature lacks one of the newer parameters. The full-read fallback
@@ -1873,6 +1895,17 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 }
                 if scope.get("user_id"):
                     engine_scope["user_id"] = str(scope.get("user_id"))
+        # `collect_prior_context` walks these newest-first and STOPS at MAX_PRIOR_MESSAGES, so
+        # every event older than that window is fetched, decoded and discarded. Measured on a
+        # subject with 125 memories: 436 records and 2.65 MB fetched, 184 ms, to select eight.
+        #
+        # The cap is on `context_event` ONLY. Tombstones and retention cutoffs are what make the
+        # subset reproduce LIVE-view semantics, and summaries are what the payload is built from --
+        # capping those would drop deleted memories back into view. The window is far wider than
+        # the eight actually consumed because the consumer filters by session and scope after the
+        # fetch, and it counts only matches; the margin is what keeps a busy multi-session subject
+        # seeing the same eight it saw before.
+        newest_events = _prior_context_event_window()
         subset = self._scan_records_of_types(
             [
                 "context_event",
@@ -1882,6 +1915,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                 MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
             ],
             scope=engine_scope if pinned_hashes else None,
+            newest_by_type=({"context_event": newest_events} if newest_events else None),
         )
         if subset is None:
             return self.read_all()
@@ -2972,12 +3006,14 @@ class MatrixArkRustCdylibClient:
             append_options=append_options,
         )
 
-    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False) -> Json:
+    def matrixark_scan_candidates(self, *, count_key: str, record_hash_key: str, shard_size: int, scope: Json, record_types: list[str], secondary_index_groups: list[list[str]], selected_node_hashes: list[int], record_ids: list[str] | None = None, return_index_records: bool = False, newest_by_type: Json | None = None) -> Json:
         payload: Json = {"scope": scope, "record_types": record_types, "secondary_index_groups": secondary_index_groups, "selected_node_hashes": selected_node_hashes}
         if record_ids:
             payload["record_ids"] = [str(item) for item in record_ids]
         if return_index_records:
             payload["return_index_records"] = True
+        if newest_by_type:
+            payload["newest_by_type"] = {str(k): int(v) for k, v in newest_by_type.items()}
         request = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
         def call() -> Json:
             out = self._ctypes.c_void_p()
@@ -4104,12 +4140,17 @@ class MatrixArkRustProxyClient:
         selected_node_hashes: list[int],
         record_ids: list[str] | None = None,
         return_index_records: bool = False,
+        newest_by_type: Json | None = None,
     ) -> Json:
         extra: Json = {}
         if record_ids:
             extra["record_ids"] = [str(item) for item in record_ids]
         if return_index_records:
             extra["return_index_records"] = True
+        if newest_by_type:
+            extra["newest_by_type"] = {
+                str(record_type): int(limit) for record_type, limit in newest_by_type.items()
+            }
         return self._call_json(
             "matrixark_scan_candidates",
             count_key=count_key,

--- a/tools/test_prior_context_scoped.py
+++ b/tools/test_prior_context_scoped.py
@@ -51,7 +51,11 @@ class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
         self.full = full or []
         self.full_reads = 0
 
-    def _scan_records_of_types(self, record_types, record_ids=None, scope=None):
+    def _scan_records_of_types(self, record_types, record_ids=None, scope=None,
+                               newest_by_type=None):
+        # Prior context caps the event fetch; the stub records the cap rather than
+        # refusing it, so a signature change cannot silently turn into a full read.
+        self.newest_by_type = newest_by_type
         if self.scanned is None:
             return None
         wanted = set(record_types)

--- a/tools/test_prior_context_window.py
+++ b/tools/test_prior_context_window.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""The prior-context event window must not change what the consumer sees.
+
+`collect_prior_context` walks records newest-first and stops at MAX_PRIOR_MESSAGES, so fetching a
+subject's whole event history to select eight is work whose result is discarded. Capping the fetch
+is only safe if the payload is identical -- so that is what this asserts, against the real
+consumer, over a history far deeper than the window.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    from tools.matrixark_mcp_core import MAX_PRIOR_MESSAGES
+    from tools.matrixark_mcp_core_session import collect_prior_context
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_mcp_core import MAX_PRIOR_MESSAGES
+    from matrixark_mcp_core_session import collect_prior_context
+
+
+def _event(index: int, session: str = "s1") -> dict:
+    scope = {"user_id": "deep", "session_id": session, "tenant_id": "t"}
+    return {
+        "record_type": "context_event",
+        "event_id_hash": 1000 + index,
+        "scope": scope,
+        "scope_key": "t=t|u=deep|s=%s" % session,
+        "envelope": {"scope": scope, "messages": [{"role": "user", "content": "fact %d" % index}]},
+        "text": "fact %d" % index,
+        "created_at_ms": 1_700_000_000_000 + index,
+    }
+
+
+class PriorContextWindowTest(unittest.TestCase):
+    def envelope(self) -> dict:
+        scope = {"user_id": "deep", "session_id": "s1", "tenant_id": "t"}
+        return {"scope": scope, "messages": [{"role": "user", "content": "the new one"}]}
+
+    def test_window_far_deeper_than_the_consumer_needs_changes_nothing(self):
+        history = [_event(i) for i in range(1000)]
+        window = 256
+        self.assertGreater(window, MAX_PRIOR_MESSAGES,
+                           "a window at or below the consumer's own limit would truncate it")
+
+        full = collect_prior_context(self.envelope(), history)
+        capped = collect_prior_context(self.envelope(), history[-window:])
+        self.assertEqual(full, capped,
+                         "capping the fetch changed what prior context reports")
+
+    def test_the_consumer_really_does_stop_early(self):
+        """Guards the premise: if this ever stopped being true the cap would start truncating."""
+        history = [_event(i) for i in range(1000)]
+        payload = collect_prior_context(self.envelope(), history)
+        self.assertLessEqual(len(payload.get("messages") or []), MAX_PRIOR_MESSAGES)
+
+    def test_a_window_smaller_than_the_limit_does_truncate(self):
+        """The test above must not be passing vacuously: too small a window IS visible."""
+        history = [_event(i) for i in range(1000)]
+        full = collect_prior_context(self.envelope(), history)
+        starved = collect_prior_context(self.envelope(), history[-2:])
+        self.assertNotEqual(full, starved,
+                            "the comparison cannot see truncation, so it proves nothing")
+
+    def test_interleaved_sessions_still_fill_the_window(self):
+        """The realistic worry: other sessions crowding the newest slice."""
+        history = []
+        for i in range(1000):
+            history.append(_event(i, session="s1" if i % 4 == 0 else "s%d" % (i % 7 + 2)))
+        full = collect_prior_context(self.envelope(), history)
+        capped = collect_prior_context(self.envelope(), history[-256:])
+        self.assertEqual(full, capped,
+                         "with one session in four, a 256 window still holds the newest eight")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_refresh_scoped2.py
+++ b/tools/test_refresh_scoped2.py
@@ -33,7 +33,11 @@ class _Adapter(adapters.MatrixArkTemporalStoreDirectAdapter):
         self.full_reads = 0
         self.scan_kwargs = None
 
-    def _scan_records_of_types(self, record_types, record_ids=None, scope=None):
+    def _scan_records_of_types(self, record_types, record_ids=None, scope=None,
+                               newest_by_type=None):
+        # Prior context caps the event fetch; the stub records the cap rather than
+        # refusing it, so a signature change cannot silently turn into a full read.
+        self.newest_by_type = newest_by_type
         self.scan_kwargs = {"record_types": list(record_types), "record_ids": record_ids}
         if self.scanned is None:
             return None


### PR DESCRIPTION
`collect_prior_context` walks a subject's records newest-first and STOPS at MAX_PRIOR_MESSAGES,
which is eight. The fetch feeding it had no such bound: it pulled every event the subject had ever
recorded. Traced on one add against a subject with 125 memories -- 436 records, 2.65 MB, 184 ms of
a 515 ms add -- to select eight of them. That is why an add costs more the longer a subject
remembers, which is the wrong thing for it to depend on.

Scans can now be told to take only the newest N locations of a named type, and prior context asks
for the newest 256 events.

The cap is per TYPE, and that is the load-bearing detail. The same scan also carries tombstones and
retention cutoffs, which are what let the subset reproduce LIVE-view semantics -- capping the union
would drop the records that keep deleted memories deleted, and the failure would look like a
memory coming back from the dead. Summaries are uncapped for the same reason: the payload is built
from them. Location strings are "{shard:06}:{field}" with both parts zero-padded, so lexical order
IS append order and "the newest N" is the last N.

Measured on one subject holding 400 events, same store, cap off then on:

    add median   683.7 ms  ->  389.3 ms

The window is 256 against a consumer that uses 8 -- wide enough that a subject interleaving many
sessions still finds its eight, and the point is that the fetch stops growing, not that it becomes
small. `MATRIXARK_PRIOR_CONTEXT_EVENT_WINDOW=0` disables it.

Four scan clients had to move together. A client whose signature lacks a parameter raises
TypeError, and the adapter turns that into "do the whole read" -- so patching one of them made an
add SLOWER (4 873 ms), because the capped path silently fell back to a full-store read. Measuring
after each step is what caught it; reading the code would not have.

Tests pin the invariant at the consumer, not at the fetch: over a 1 000-event history the payload
from the full list and from the newest 256 must be identical, including when three sessions in
four are interleaved into the newest slice. Two of the four tests exist to stop the first from
passing vacuously -- one asserts the consumer really does stop early, the other that a window
below the limit DOES change the payload, so the comparison can see truncation when there is any.
Strict mem0 conformance 22/22, ten mem0 unit suites green.