### PR TITLE
a work queue kept every status it had ever had, in the record log

### DIFF
--- a/tools/matrixark_mcp_serving_records.py
+++ b/tools/matrixark_mcp_serving_records.py
@@ -382,6 +382,16 @@ def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
         summary_hash = record.get("summary_hash") or record.get("node_hash")
         if summary_type and summary_hash is not None:
             return ("context_summary", summary_type, summary_hash)
+    if record_type == "matrixark_async_pipeline_task":
+        # A queue entry's only meaningful state is its CURRENT status, and the drain already reads
+        # it that way: it folds the records down to the latest per task_hash and ignores the rest.
+        # Held in the append log, every status transition a task ever made was re-read on every
+        # ingest -- measured at 271 records and 998 KB for a single add, growing without bound. A
+        # latest-state identity collapses each task to one row AND keeps it out of the append log,
+        # which is where the re-reading came from.
+        task_hash = record.get("task_hash")
+        if task_hash is not None:
+            return ("matrixark_async_pipeline_task", task_hash)
     if record_type == "context_model_registry":
         model_kind = str(record.get("model_kind") or "embedding")
         model_ref = str(record.get("model_ref") or "")

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -404,12 +404,29 @@ class _TemporalDirectReadMixin:
         records = result.get("records")
         if not isinstance(records, list):
             return []
-        return [
+        found = [
             record
             for record in records
             if isinstance(record, dict)
             and record.get("record_type") == "matrixark_async_pipeline_task"
         ]
+        # Tasks written since they gained a latest-state identity live in that hash, NOT the append
+        # log the scan walks -- so the scan alone would stop seeing new tasks and the drain would
+        # quietly never fire. Tasks written before it are still in the log. Both are returned, and
+        # the drain's own last-write-wins fold over task_hash reconciles a task that appears in
+        # both. A store that predates the change keeps working; a fresh one stops paying for the
+        # log side entirely, because nothing writes there any more.
+        try:
+            latest_state = self._load_latest_context_state_records()
+        except Exception:  # noqa: BLE001 - a missing latest-state view is not a reason to drop
+            latest_state = []                     # the tasks the scan did find.
+        found.extend(
+            record
+            for record in latest_state
+            if isinstance(record, dict)
+            and record.get("record_type") == "matrixark_async_pipeline_task"
+        )
+        return found
 
     def _direct_record_load_lock(self) -> threading.RLock:
         with _DIRECT_RECORD_CACHE_LOCK:


### PR DESCRIPTION
Every ingest reads the async pipeline tasks to find idle-commit work that is due. The drain uses
them as a queue: it folds the records down to the LATEST status per task_hash and ignores the rest.
They were stored as an append log all the same, so every status transition a task ever made was
re-read on every ingest -- measured at 271 records and 998 KB for one add, and growing without
bound, because nothing ever removed a completed task.

A pipeline task now has a latest-state identity, keyed by task_hash. That is an existing mechanism
in this tree, and it does two things: each task collapses to one row, and records with such an
identity are kept OUT of the append log entirely. The drain reads both places -- the log, where a
store written before this change still has its tasks, and the latest-state hash, where new ones go
-- and its own last-write-wins fold reconciles a task appearing in both.

Measured, same binary, two 260-memory corpora built from empty:

    store size            109 MB  ->  102 MB     (6.4%)
    add after 260 builds  474.9 ms -> 455.5 ms   (4%)

Modest, and worth being plain about why: relocating the tasks stops the append log accumulating
them, but the drain still reads one row per task, so the read does not become free -- it stops
growing with a task's transition history rather than with the number of tasks. The fix that would
make it free is pruning a task when it reaches a terminal state, which this does not do; a queue
that never removes completed work is the underlying problem, and it deserves its own change.

Behaviour note: task history collapses to current state, so a view listing pipeline tasks shows
each task once rather than every transition. For a queue that is the more useful answer, and it is
already how the drain reads them.

Verified: the idle-commit candidate tests, strict mem0 conformance 22/22, ten mem0 unit suites, and
the python suite ratchet.