### PR TITLE
the dump manifest describes data that outlives the node, so publish it with the data

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1200,6 +1200,21 @@ fn restore_shared_index_before_load(
                 0
             }
         };
+    // Inherit the dump lineage along with the data. Without it this node treats every live
+    // generation as never dumped, which blocks WAL reclaim until it has re-dumped the whole
+    // shard itself. Advisory: the data is already restored and serving, so a lineage that
+    // cannot be read costs re-dumping, not correctness.
+    match runtime.block_on(replicator.restore_bucket_dump_manifests(shard_id, engine)) {
+        Ok(0) => {}
+        Ok(restored) => info!(
+            shard_id,
+            restored, "inherited bucket-dump manifests from shared storage"
+        ),
+        Err(err) => warn!(
+            shard_id, %err,
+            "could not restore bucket-dump manifests; this node will re-dump before it can reclaim"
+        ),
+    }
     Some(after_wal_index)
 }
 
@@ -1297,6 +1312,27 @@ fn publish_shard_checkpoint(
         }
         published += 1;
         last_wal_index = record.sequence;
+    }
+    // Send the dump lineage before the checkpoint manifest, so the checkpoint manifest is
+    // still the last object written and therefore still the commit point for a restore.
+    // Advisory on failure: the checkpoint alone is what a restore needs today, and failing
+    // the whole publish over the lineage would make this strictly worse than not having it.
+    match runtime.block_on(
+        replicator.publish_bucket_dump_manifests(
+            shard_id,
+            &engine.list_bucket_dump_manifests(shard_id),
+        ),
+    ) {
+        Ok(0) => {}
+        Ok(count) => info!(
+            shard_id,
+            manifests = count,
+            "published bucket-dump manifests to shared storage"
+        ),
+        Err(err) => warn!(
+            shard_id, %err,
+            "could not publish bucket-dump manifests; checkpoint still published without lineage"
+        ),
     }
     // Publish a real metadata+slab checkpoint at the current last-applied WAL index so
     // a future owner can lazily restore (index + slab addresses) and replay only the

--- a/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_manifest_methods.rs
@@ -248,6 +248,20 @@ impl TemporalEngine {
         list_bucket_dump_manifests_at(&self.index_dir, shard_id).unwrap_or_default()
     }
 
+    /// Land a manifest in this node's index dir durably, without installing it.
+    ///
+    /// This is deliberately NOT [`install_bucket_dump_manifest`](Self::install_bucket_dump_manifest):
+    /// installing rewrites shard state from the manifest, which is what a restore-onto-this-shard
+    /// wants. This one only records that the dump EXISTS, for a node inheriting a shard whose
+    /// data is already in shared storage -- the lineage arrives with the data, and whether to
+    /// install any of it stays a separate decision.
+    pub fn store_bucket_dump_manifest(
+        &self,
+        manifest: &BucketDumpManifest,
+    ) -> Result<(), std::io::Error> {
+        self.persist_bucket_dump_manifest(manifest)
+    }
+
     pub fn interrupted_bucket_dump_installs(&self, shard_id: ShardId) -> Vec<BucketDumpInstallMarker> {
         interrupted_bucket_dump_installs_at(&self.index_dir, shard_id).unwrap_or_default()
     }

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -1023,6 +1023,80 @@ where
         Ok(manifests)
     }
 
+    /// Publish this shard's bucket-dump manifests to the object store.
+    ///
+    /// A dump manifest is the durable reclaim watermark plus the recovery index for the data it
+    /// covers. In shared mode that data outlives the node -- it is in the object store -- but
+    /// the manifest describing it was only ever written to the node's local index dir, so
+    /// losing the node lost the lineage for data that was still perfectly present. A manifest
+    /// should be as durable as the data it describes; this is the half that was missing.
+    ///
+    /// Deliberately not on the write path. Manifests are produced at dump cadence, so this is
+    /// one put per manifest at checkpoint time and nothing at all in the steady state -- unlike
+    /// the WAL, which is the per-write barrier and stays node-local for exactly that reason.
+    pub async fn publish_bucket_dump_manifests(
+        &self,
+        shard_id: ShardId,
+        manifests: &[crate::BucketDumpManifest],
+    ) -> Result<usize, SharedStoreReplicationError> {
+        let mut published = 0usize;
+        for manifest in manifests {
+            if manifest.shard_id != shard_id {
+                continue;
+            }
+            self.object_store
+                .put(
+                    &self.bucket_dump_manifest_key(shard_id, &manifest.manifest_id),
+                    Bytes::from(serde_json::to_vec_pretty(manifest)?),
+                )
+                .await?;
+            published += 1;
+        }
+        Ok(published)
+    }
+
+    /// Land every published bucket-dump manifest for this shard in the local index dir.
+    ///
+    /// The counterpart to [`publish_bucket_dump_manifests`](Self::publish_bucket_dump_manifests):
+    /// a node taking over a shard inherits the dump lineage along with the data, instead of
+    /// starting blind and treating every live generation as never dumped -- which is what
+    /// blocks WAL reclaim until this node has dumped everything again itself.
+    ///
+    /// A manifest already present locally is left alone. A local manifest is at least as
+    /// current as a published one, and rewriting it would churn the very file that authorizes
+    /// WAL reclaim.
+    pub async fn restore_bucket_dump_manifests(
+        &self,
+        shard_id: ShardId,
+        engine: &TemporalEngine,
+    ) -> Result<usize, SharedStoreReplicationError> {
+        let existing: std::collections::BTreeSet<String> = engine
+            .list_bucket_dump_manifests(shard_id)
+            .into_iter()
+            .map(|manifest| manifest.manifest_id)
+            .collect();
+        let mut restored = 0usize;
+        for key in self
+            .object_store
+            .list(&self.bucket_dump_prefix(shard_id))
+            .await?
+        {
+            if !key.ends_with(".json") {
+                continue;
+            }
+            let manifest: crate::BucketDumpManifest =
+                serde_json::from_slice(&self.object_store.get(&key).await?)?;
+            // A manifest filed under another shard's prefix, or one this node already has,
+            // is not ours to write.
+            if manifest.shard_id != shard_id || existing.contains(&manifest.manifest_id) {
+                continue;
+            }
+            engine.store_bucket_dump_manifest(&manifest)?;
+            restored += 1;
+        }
+        Ok(restored)
+    }
+
     pub async fn restore_checkpoint(
         &self,
         manifest: &SharedStoreCheckpointManifest,
@@ -1467,6 +1541,14 @@ where
 
     fn checkpoints_prefix(&self, shard_id: ShardId) -> String {
         format!("{}checkpoints/", self.shard_prefix(shard_id))
+    }
+
+    fn bucket_dump_prefix(&self, shard_id: ShardId) -> String {
+        format!("{}slot_dumps/", self.shard_prefix(shard_id))
+    }
+
+    fn bucket_dump_manifest_key(&self, shard_id: ShardId, manifest_id: &str) -> String {
+        format!("{}{manifest_id}.json", self.bucket_dump_prefix(shard_id))
     }
 
     fn checkpoint_prefix(&self, shard_id: ShardId, checkpoint_id: &str) -> String {
@@ -3894,6 +3976,84 @@ mod tests {
                 value: Some(b"1".to_vec())
             }
         );
+    }
+
+    #[tokio::test]
+    async fn bucket_dump_manifests_travel_with_the_data_to_a_new_owner() {
+        // In shared mode the data outlives the node, but the manifest describing it was only
+        // ever written to that node's local index dir. Losing the node lost the lineage for
+        // data that was still perfectly present -- the next owner could not tell what had
+        // already been dumped, so it had to treat every live generation as undumped.
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, replicator) = test_shared_store(dir.path());
+
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        let dumped = primary.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+
+        let published = replicator
+            .publish_bucket_dump_manifests(1, &primary.list_bucket_dump_manifests(1))
+            .await
+            .unwrap();
+        assert_eq!(published, 1);
+
+        // A different node: its own index dir, and no local lineage whatsoever.
+        let successor = test_engine(dir.path(), "successor");
+        successor.load_shard(1);
+        assert!(successor.list_bucket_dump_manifests(1).is_empty());
+
+        let restored = replicator
+            .restore_bucket_dump_manifests(1, &successor)
+            .await
+            .unwrap();
+        assert_eq!(restored, 1);
+
+        let inherited = successor.list_bucket_dump_manifests(1);
+        assert_eq!(inherited.len(), 1);
+        assert_eq!(inherited[0].manifest_id, dumped.manifest_id);
+        assert_eq!(
+            inherited[0].wal_sequence, dumped.wal_sequence,
+            "the reclaim watermark has to survive the move, not merely the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn restoring_bucket_dump_manifests_leaves_a_local_one_alone() {
+        // A local manifest is at least as current as a published one, and it is the file that
+        // authorizes WAL reclaim. Rewriting it on every restore would churn exactly the wrong
+        // thing, so a manifest this node already has is skipped rather than overwritten.
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, replicator) = test_shared_store(dir.path());
+
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+        primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+        });
+        primary.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+        replicator
+            .publish_bucket_dump_manifests(1, &primary.list_bucket_dump_manifests(1))
+            .await
+            .unwrap();
+
+        // Restoring onto the very node that produced them writes nothing.
+        let restored = replicator
+            .restore_bucket_dump_manifests(1, &primary)
+            .await
+            .unwrap();
+        assert_eq!(restored, 0);
+        assert_eq!(primary.list_bucket_dump_manifests(1).len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
A bucket-dump manifest is the durable reclaim watermark plus the recovery index for the buckets it covers. It was only ever written to the node's local index dir — `bucket_dump_manifest_path(index_dir, …)` — in **every** storage mode.

### Why that is wrong in exactly one mode

| mode | data lives | manifest lived | same fate? |
|---|---|---|---|
| local | local disk | local index dir | ✅ |
| raft | the replicated group | local index dir | ✅ |
| shared | the object store — **outlives the node** | local index dir | ❌ |

In shared mode the data survives the node and the artifact describing it does not. A node taking over the shard inherits the data and none of the lineage, so it treats every live generation as never dumped — which is precisely the condition that blocks WAL reclaim until it has re-dumped the whole shard itself.

### The change

Publish the manifests alongside the checkpoint; pull them back on restore. A manifest should be as durable as the data it describes, and this is the half that was missing.

**Deliberately not on the write path.** Manifests are produced at dump cadence, so this is one put per manifest at checkpoint time and nothing at all in the steady state. The WAL stays node-local for the opposite reason: it is the per-write barrier, a remote round trip per write would dominate it, and it legitimately describes writes that are not in shared storage yet.

**Ordering.** Dump manifests go out *before* the checkpoint manifest, so the checkpoint manifest remains the last object written and therefore still the commit point for a restore.

**Failure posture — advisory in both directions.** On publish, the checkpoint alone is what a restore needs today, so failing the whole publish over the lineage would make this strictly worse than not having it. On restore, the data is already back and serving, so unreadable lineage costs re-dumping, not correctness. Both log.

**Idempotence.** A manifest already present locally is skipped, not overwritten — a local manifest is at least as current as a published one, and it is the file that authorizes WAL reclaim.

`store_bucket_dump_manifest` is deliberately *not* `install_bucket_dump_manifest`: installing rewrites shard state from the manifest, which restore-onto-this-shard wants. This one only records that the dump exists, leaving whether to install any of it a separate decision.

### Tests

- manifests travel to a new owner with the reclaim watermark intact, not just the file
- restoring onto the node that produced them writes nothing

`shared_store` **30/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
