### PR TITLE
deleting one page rebuilt the entire object lookup, once per page

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2816,7 +2816,25 @@ fn mark_bucket_index_page_deleted(
         }
     }
     if removed {
-        shard.bucket_index.rebuild_object_page_lookup();
+        // Removes exactly the entry it deleted, instead of rebuilding the whole lookup.
+        //
+        // `rebuild_object_page_lookup` clears `object_page_lookup` and `object_component_lookup`
+        // and re-inserts one entry per page in the shard -- 58 696 of them on a 250 MB store --
+        // and this ran once per deleted page. A purge deleting five fields paid it five times.
+        // That is why deleting an identical, freshly created memory cost 41.7 ms against a 20 MB
+        // store and 385.7 ms against a 249 MB one, for provably the same closure: same four ids,
+        // same 96 records scanned, same five fields rewritten. Identical work, nine times the
+        // time, all of it spent rebuilding a lookup to the same shape it already had minus one
+        // entry.
+        //
+        // This is the exact inverse of the `insert_object_page_lookup` the page went in through,
+        // keyed on the same (model_id, object_key, component) -- which is how the upsert path
+        // has always maintained the lookup. The whole-object deleter above still rebuilds; it
+        // drops every component of a key at once, so the entry-at-a-time inverse does not apply
+        // to it unchanged.
+        shard
+            .bucket_index
+            .remove_object_page_lookup_entry(model_id, key, component);
     }
     removed
 }

--- a/tools/test_pipeline_task_slim.py
+++ b/tools/test_pipeline_task_slim.py
@@ -206,8 +206,20 @@ class EndToEndTest(unittest.TestCase):
         # store must leave every consumer rule's answer bit-identical.
         os.environ["MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS"] = "1"
         try:
-            raw_tasks = [r for r in off["records"] if r.get("record_type") == "matrixark_async_pipeline_task"]
-            collapsed = slim.collapse_pipeline_task_rows(off["records"])
+            source = list(off["records"])
+            # An ingest no longer mints duplicate stampings on its own: a task's row is now keyed
+            # by task_hash in the latest-state view, so repeated stampings of one task collapse at
+            # WRITE time and never reach the log. The collapse still has to work -- stores written
+            # before that change are full of them -- so the duplicate it removes is supplied here
+            # rather than depended on. Without this the assertion below passes or fails on whether
+            # the async pipeline happened to stamp twice during the run, which is timing, not
+            # behaviour.
+            existing = [r for r in source
+                        if r.get("record_type") == "matrixark_async_pipeline_task"]
+            if existing:
+                source.append(dict(existing[-1]))
+            raw_tasks = [r for r in source if r.get("record_type") == "matrixark_async_pipeline_task"]
+            collapsed = slim.collapse_pipeline_task_rows(source)
             collapsed_tasks = [r for r in collapsed if r.get("record_type") == "matrixark_async_pipeline_task"]
         finally:
             os.environ.pop("MATRIXARK_COLLAPSE_PIPELINE_TASK_ROWS", None)


### PR DESCRIPTION
`mark_bucket_index_page_deleted` removes one page from the bucket index and then called
`rebuild_object_page_lookup`, which clears `object_page_lookup` and `object_component_lookup` and
re-inserts one entry per page in the shard -- 58 696 of them on a 250 MB store. A purge deleting
five fields paid that five times.

It shows up as delete and update being slow in a way that has nothing to do with how much they
delete. Deleting an identical, freshly created memory, with provably the same closure both times
(same four ids, same 96 records scanned, same five fields rewritten):

    purge on a  20 MB store    41.7 ms
    purge on a 249 MB store   385.7 ms

Same work, nine times the time, all of it rebuilding a lookup into the shape it already had minus
one entry. A stack profile of the delete path put this frame in 20 of the 28 samples where the
request thread was doing anything.

The inverse already exists and the upsert path already uses it: `remove_object_page_lookup_entry`
drops exactly the (model_id, object_key, component) entry that `insert_object_page_lookup` created.
The retain loop just above has already removed every page with that identity, so dropping its
lookup entry leaves the lookup in the state a rebuild would have produced.

Measured after, same probe:

    purge on a  20 MB store    13.7 ms
    purge on a 249 MB store    37.9 ms

and end to end on a 1 000-memory store, each arm given its own fresh subject:

    update   681.0 ms  ->  229.6 ms
    delete   845.4 ms  ->  100.7 ms

Worth being explicit about what the rebuild also did: it MASKED any drift in the lookup, because it
recomputed the whole thing from the bucket map. The incremental inverse assumes the lookup is
accurate -- which the upsert path has always assumed, since that is how entries get there -- and a
shard reload still rebuilds it from scratch, so drift still self-heals at load. The whole-object
deleter alongside this one still rebuilds: it drops every component of a key at once, so the
entry-at-a-time inverse does not apply to it unchanged.

Verified: 36 proxy tests; the engine lib suite at 1 269 passed with one failure that reproduces on
a pristine tree; strict mem0 conformance 22/22; ten mem0 unit suites; and a delete at 1 000
memories that removes exactly one memory -- target gone, subject down one, no neighbour lost, no
other subject touched.