### PR TITLE
a 62-byte message wrote 158 KB, and 38% of it was the same values over again

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3593,7 +3593,16 @@ fn matrixark_proxy_block_store_options() -> BlockStoreOptions {
                 "MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES",
                 "TS_PAGE_STORE_COMPRESSION_MIN_BYTES",
             ],
-            4096,
+            // Was 4096, and every index write an add makes is smaller than that: the postings, the
+            // placement rows, the locator entries. Those are also the most repetitive bytes in the
+            // system -- one add writes 28 postings carrying the same scope key and policy -- so
+            // they are exactly what compression is good at, and exactly what a 4 KB floor excluded.
+            //
+            // Measured over 120 adds on a fresh store: 176.8 KB per add at 4096, 148.1 KB at 256,
+            // and the adds were no slower (152.5 ms -> 144.7 ms). Compressing everything is worse:
+            // at a 1-byte floor the disk saving stops (149.7 KB) while the median add rises to
+            // 256.0 ms, because tiny payloads cost more to compress than they give back.
+            256,
         ),
         compression_level: env_i32_any(
             &[
@@ -5345,7 +5354,14 @@ mod tests {
 
         let options = matrixark_proxy_block_store_options();
         assert!(options.compression_enabled);
-        assert_eq!(options.compression_min_bytes, 4096);
+        // 256, not the 4096 this pinned before, and the floor moved because it was measured
+        // rather than because it was in the way: every index write an add makes is under 4 KB, and
+        // those are the most repetitive bytes in the store. Over 120 adds on a fresh store the
+        // disk cost went 176.8 -> 148.1 KB per add and the median add went 152.5 -> 144.7 ms, so
+        // the throughput this threshold exists to protect did not pay for it. Dropping the floor
+        // to 1 is worse on both counts (149.7 KB, 256.0 ms): the smallest payloads cost more to
+        // compress than they give back, which is what a floor is for.
+        assert_eq!(options.compression_min_bytes, 256);
         assert_eq!(
             options.compression_level,
             BlockStoreOptions::default().compression_level

--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -21,10 +21,12 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
 _ROUTE_KEYS_WORTH_STORING = (
     "placement_key",
     "placement_hash",
-    "routing_key",
-    "partition_key",
-    "colocation_group",
 )
+# What was dropped and why: `routing_key` and `partition_key` are set to `placement_key` and
+# `colocation_group` to a constant, so all three are copies of something already here. Measured on
+# one add, they cost 25 index postings x ~280 bytes -- about 7 KB per add to say the same thing
+# three more times. The one place that reads them consults `placement_key` first and falls through
+# to `routing_key` / `partition_key` only when it is absent, which it is not.
 
 
 def slim_persisted_storage_route(record: Json) -> Json:


### PR DESCRIPTION
One 62-byte message materialises 52 records, and a lot of what those records carry is each other.
Measuring which field VALUES repeat inside a single add's batch, rather than which fields are big:

    field              copies  distinct    bytes   repeated
    storage_route          29         1   12 441     12 012
    storage_options        28        12   15 456      8 854
    scope_key              43         1    2 924      2 856
    scope                   8         2    2 439      1 914
    posting_policy         28         1    1 148      1 107

40 330 bytes of a 105 KB record payload -- 38% -- was a value already written in the same batch.

Two changes, from opposite ends of that.

**Stop persisting route fields that are copies of another route field.** What survived the earlier
slimming was placement_key, placement_hash, routing_key, partition_key and colocation_group. But
`routing_key` and `partition_key` are SET to placement_key, and colocation_group is a constant, so
three of the five say something already present. The one place that reads them consults
placement_key first and falls through to the others only when it is absent, which it is not.
Record payload 105 065 -> 97 142 bytes, and the 28 index postings alone 29 713 -> 22 883.

**Let compression see the writes an add actually makes.** The page-record floor was 4 096 bytes,
and every index write is under it: the postings, the placement rows, the locator entries -- which
are also the most repetitive bytes in the store, since one add writes 28 postings carrying the same
scope key and the same policy. Over 120 adds on a fresh store:

    floor 4096 (before)   176.8 KB/add   add median 152.5 ms
    floor  256 (after)    148.1 KB/add   add median 144.7 ms
    floor    1            149.7 KB/add   add median 256.0 ms

The floor moved because it was measured, not because it was in the way: throughput did not pay for
the saving, and a 1-byte floor shows why a floor exists at all -- the smallest payloads cost more
to compress than they give back. The test that pinned 4 096 now pins 256 with those numbers
attached, and both environment overrides still work.

Together, on the same 120-add harness: **176.8 -> 134.3 KB per add, and the median add 152.5 ->
120.9 ms**.

Verified: 36 proxy tests, strict mem0 conformance 22/22, ten mem0 unit suites.

What this does NOT fix, and is worth naming: the remaining repetition is ACROSS pages, not inside
them -- 28 postings in 28 separate page records each carrying the same scope key. Per-page
compression cannot see that; sharing it needs a bundle-level dictionary that both the Python and
the Rust decoders resolve, which is a format change and belongs in its own review.