### PR TITLE
an ordering index kept a second full copy of every event it ordered

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1353,9 +1353,22 @@ class _TemporalDirectBackendMixin:
             if record.get("event_id_hash") is None:
                 continue
             enriched = attach_context_event_time_key(record)
+            # Slim unless explicitly asked for the whole record. The `or parent_segment_hash`
+            # that used to be here made the common case the expensive one: a segment-parented
+            # event stored the ENTIRE event a second time, measured at 6 329 bytes of one add
+            # against 252 for the slim form. That is exactly what the payload helper's own
+            # docstring warns against -- "the full ContextEvent is already written to the serving
+            # record log ... avoids doubling hot write bytes for every event" -- and the other
+            # writer of this same index never had the exception, so the two disagreed about what
+            # the index is for.
+            #
+            # It is an ORDERING structure: the field is {timestamp:020d}:{event_hash}, so lexical
+            # order is chronological, and the slim payload carries what a reader needs to reach the
+            # canonical record (ref_hash, node_hash, scope_key, timestamp).
+            # MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD still restores the full copy.
             payload = (
                 json.dumps(enriched, sort_keys=True, separators=(",", ":"))
-                if full_payload or enriched.get("parent_segment_hash")
+                if full_payload
                 else self._context_event_time_index_payload(enriched)
             )
             entries.append(


### PR DESCRIPTION
`context_event_by_ingestion_time` exists to order events. Its key is the parent
(`...:context_event_by_ingestion_time:{parent_type}:{parent_hash}`) and its field is
`{timestamp_ms:020d}:{event_hash}` -- zero-padded, so lexical order IS chronological order and a
time window is a range scan. The value only has to be enough to reach the canonical record.

The payload helper says exactly that, in its own docstring: "The full ContextEvent is already
written to the serving record log ... Keeping raw text and extraction/debug fields out of this
index avoids doubling hot write bytes for every event."

Then the writer bypassed it for any event with a parent segment, which is the common case:

    segment-parented event, full copy   6 329 bytes
    the slim payload                      252 bytes

The other writer of this same index never had that exception -- it slims unless the environment
flag asks otherwise -- so the two disagreed about what the index is for. This makes them agree.
`MATRIXARK_CONTEXT_EVENT_TIME_INDEX_FULL_PAYLOAD` still restores the full copy.

The slim payload carries `ref_hash`, `node_hash`, `scope_key` and the timestamp, which is what a
reader needs to find the event it just ordered.

Measured on one add: total bytes written 158 176 -> 136 131, and the store grew 432 KB -> 380 KB.

Verified: strict mem0 conformance 22/22, ten mem0 unit suites, 36 proxy tests.