### PR TITLE
the shared log carried commands only, and a command cannot rebuild a derived page

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1301,6 +1301,11 @@ fn publish_shard_checkpoint(
             shard_id,
             wal_index: record.sequence,
             command: record.command,
+            // The local record already carries whatever pages this write produced, and a
+            // page can be derived state that the command alone cannot rebuild. Mirroring
+            // the command without them would publish a history a successor could not
+            // finish replaying.
+            staged_pages: record.staged_pages,
         };
         if let Err(err) = runtime.block_on(replicator.publish_wal_entry(entry)) {
             return PublishShardCheckpointResponse {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -229,11 +229,29 @@ impl TemporalEngine {
     }
 
     pub fn execute(&self, request: ExecuteRequest) -> ExecuteResponse {
-        self.execute_with_storage_override(request, None)
+        self.execute_with_storage_override(request, None, Vec::new())
+    }
+
+    /// Apply `request`, attaching `pages` to its log record instead of whatever this node
+    /// would derive for it.
+    ///
+    /// For replaying a write that was already acked somewhere else. A page can be derived
+    /// state -- a serialized counter series, a hash map -- and re-executing the command that
+    /// produced it reconstructs it only from a state this node may no longer have. When the
+    /// original bytes travelled with the command, they are the truth, and re-deriving would
+    /// quietly substitute a reconstruction for what was actually acknowledged.
+    ///
+    /// An empty `pages` is exactly [`execute`](Self::execute).
+    pub fn execute_with_carried_pages(
+        &self,
+        request: ExecuteRequest,
+        pages: Vec<crate::wal::StagedPage>,
+    ) -> ExecuteResponse {
+        self.execute_with_storage_override(request, None, pages)
     }
 
     pub fn execute_durable(&self, request: ExecuteRequest) -> ExecuteResponse {
-        self.execute_with_storage_override(request, Some(false))
+        self.execute_with_storage_override(request, Some(false), Vec::new())
     }
 
     /// Apply a committed raft entry to the state machine, durably (fsync'd WAL) but with a
@@ -244,7 +262,7 @@ impl TemporalEngine {
     /// tail is safe -- raft-log replay on restart re-applies and rebuilds the served index.
     pub fn execute_raft_apply(&self, request: ExecuteRequest) -> ExecuteResponse {
         let _guard = RaftApplyGuard::enter();
-        self.execute_with_storage_override(request, Some(false))
+        self.execute_with_storage_override(request, Some(false), Vec::new())
     }
 
     /// Apply a batch of committed raft entries to the state machine. Under
@@ -269,7 +287,7 @@ impl TemporalEngine {
         let batch_guard = RaftApplyBatchGuard::enter();
         let mut responses = Vec::with_capacity(requests.len());
         for request in requests {
-            responses.push(self.execute_with_storage_override(request, Some(false)));
+            responses.push(self.execute_with_storage_override(request, Some(false), Vec::new()));
         }
         let barrier = batch_guard.take_barrier();
         drop(batch_guard);
@@ -302,10 +320,10 @@ impl TemporalEngine {
         };
         match replication_mode {
             EventReplicationMode::SyncStorage => {
-                self.execute_with_storage_override(request, Some(false))
+                self.execute_with_storage_override(request, Some(false), Vec::new())
             }
             EventReplicationMode::AsyncStorage => {
-                self.execute_with_storage_override(request, Some(true))
+                self.execute_with_storage_override(request, Some(true), Vec::new())
             }
             EventReplicationMode::Raft | EventReplicationMode::Inherit => self.execute(request),
         }
@@ -342,6 +360,7 @@ impl TemporalEngine {
         &self,
         request: ExecuteRequest,
         async_storage_override: Option<bool>,
+        mut carried_pages: Vec<crate::wal::StagedPage>,
     ) -> ExecuteResponse {
         // Charged before anything else, including the read-only fast path -- a read served without
         // taking the shard lock still costs the shard, and a limit the cheapest reads slip past is
@@ -651,8 +670,11 @@ impl TemporalEngine {
                 // WAL sequence here; the single coalesced fdatasync is issued once for the whole
                 // batch in `execute_raft_apply_batch` (see `raft_apply_batch_active`). WAL order
                 // still equals apply order (reservation + byte-append stay under this lock).
-                let concurrent_commit =
-                    sync && (engine_concurrent_commit() || raft_apply_batch_active());
+                // The reserve-only branch appends bytes without pages, so a write carrying
+                // pages must take the staged branch or they would be dropped on the floor.
+                let concurrent_commit = sync
+                    && carried_pages.is_empty()
+                    && (engine_concurrent_commit() || raft_apply_batch_active());
                 let append_result = if concurrent_commit {
                     self.wal_store
                         .append_for_group_commit(request.shard_id, command)
@@ -663,10 +685,20 @@ impl TemporalEngine {
                             request.shard_id,
                             command,
                             sync,
-                            if block_in_wal::enabled() {
-                                block_in_wal::take_staged()
+                            if carried_pages.is_empty() {
+                                if block_in_wal::enabled() {
+                                    block_in_wal::take_staged()
+                                } else {
+                                    Vec::new()
+                                }
                             } else {
-                                Vec::new()
+                                // The caller handed us the pages the original write produced.
+                                // Drop whatever this execute re-derived rather than letting a
+                                // reconstruction win over the bytes that were acked.
+                                if block_in_wal::enabled() {
+                                    let _ = block_in_wal::take_staged();
+                                }
+                                std::mem::take(&mut carried_pages)
                             },
                         )
                         .map(|(record, log_id)| {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3689,6 +3689,63 @@ fn an_evicted_derived_page_is_served_from_its_wal_record() {
 }
 
 
+/// A write handed its pages must log THOSE pages, not the ones it would have derived.
+///
+/// This is what lets a replayed write reproduce the bytes that were acked somewhere else
+/// rather than this node's reconstruction of them.
+#[test]
+fn a_carried_page_is_what_reaches_the_log_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        },
+    });
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+
+    let carried = vec![crate::wal::StagedPage {
+        object_id: 4242,
+        bytes: b"pages-from-somewhere-else".to_vec(),
+    }];
+    let write = engine.execute_with_carried_pages(
+        ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: "carried".to_string(),
+                field: "f".to_string(),
+                value: b"local-derivation".to_vec(),
+            },
+        },
+        carried.clone(),
+    );
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+    assert!(write.status.ok, "the write must be acked: {write:?}");
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap();
+    let logged = records
+        .iter()
+        .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+        .find(|record| !record.staged_pages.is_empty())
+        .expect("the record must carry pages");
+    assert_eq!(
+        logged.staged_pages, carried,
+        "the carried pages belong on the record, not this node's re-derivation"
+    );
+}
+
 /// What waiting before a dump saves, and what the wait costs.
 ///
 /// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -91,6 +91,19 @@ pub struct SharedStoreWalEntry {
     #[serde(rename = "wal_index")]
     pub wal_index: u64,
     pub command: Command,
+    /// The pages this write produced, carried beside the command that produced them.
+    ///
+    /// A command is not always enough to rebuild what it wrote. A page can be DERIVED state --
+    /// a serialized counter series, a hash map -- and re-executing the command that bumped it
+    /// reconstructs it only if every earlier write is also replayed, in order, from a state
+    /// that still exists. Locally that is what the engine WAL record carries, for exactly this
+    /// reason; a shared log that carried commands alone could hand a successor a shard it could
+    /// not finish rebuilding.
+    ///
+    /// Empty for the overwhelming majority of writes, and `serde(default)` so an entry written
+    /// before this field existed still loads.
+    #[serde(default)]
+    pub staged_pages: Vec<crate::wal::StagedPage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -358,6 +371,14 @@ impl<O> Clone for SharedStoreReplicator<O> {
 }
 
 #[derive(Clone, PartialEq, Message)]
+struct SharedStoreStagedPageProto {
+    #[prost(uint64, tag = "1")]
+    object_id: u64,
+    #[prost(bytes = "vec", tag = "2")]
+    bytes: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
 struct SharedStoreWalFrameProto {
     #[prost(uint64, tag = "1")]
     shard_id: u64,
@@ -371,6 +392,10 @@ struct SharedStoreWalFrameProto {
     command_sha256: String,
     #[prost(uint32, tag = "6")]
     command_encoding: u32,
+    /// Tag 7, added after the fact: an older reader ignores it and an older writer leaves it
+    /// empty, so both directions stay readable across the change.
+    #[prost(message, repeated, tag = "7")]
+    staged_pages: Vec<SharedStoreStagedPageProto>,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -1190,10 +1215,17 @@ where
             if wal_index <= after_wal_index {
                 continue;
             }
-            let response = engine.execute(ExecuteRequest {
-                shard_id,
-                command: entry.command,
-            });
+            // Hand the replayed write the pages the ORIGINAL write produced. Re-executing the
+            // command would otherwise substitute this node's reconstruction for the bytes that
+            // were actually acked -- identical for a plain value, and not necessarily so for
+            // derived state.
+            let response = engine.execute_with_carried_pages(
+                ExecuteRequest {
+                    shard_id,
+                    command: entry.command,
+                },
+                entry.staged_pages,
+            );
             if !response.status.ok {
                 return Err(SharedStoreReplicationError::ApplyFailed {
                     wal_index,
@@ -1242,10 +1274,17 @@ where
                     actual: wal_index,
                 });
             }
-            let response = engine.execute(ExecuteRequest {
-                shard_id,
-                command: entry.command,
-            });
+            // Hand the replayed write the pages the ORIGINAL write produced. Re-executing the
+            // command would otherwise substitute this node's reconstruction for the bytes that
+            // were actually acked -- identical for a plain value, and not necessarily so for
+            // derived state.
+            let response = engine.execute_with_carried_pages(
+                ExecuteRequest {
+                    shard_id,
+                    command: entry.command,
+                },
+                entry.staged_pages,
+            );
             if !response.status.ok {
                 return Err(SharedStoreReplicationError::ApplyFailed {
                     wal_index,
@@ -2110,7 +2149,9 @@ where
             shard_id,
             wal_index,
             command,
-        };
+        
+                        staged_pages: Vec::new(),
+                    };
         match self.mode {
             SharedStoreStorageMode::Sync if self.group_commit => {
                 self.group_commit_write(entry).await
@@ -2390,6 +2431,14 @@ fn encode_wal_proto_frame(
         command_sha256: sha256_hex(&command_payload),
         command_payload,
         command_encoding,
+        staged_pages: entry
+            .staged_pages
+            .iter()
+            .map(|page| SharedStoreStagedPageProto {
+                object_id: page.object_id,
+                bytes: page.bytes.clone(),
+            })
+            .collect(),
     };
     let mut encoded = frame.encode_to_vec();
     let mut out = Vec::with_capacity(4 + encoded.len());
@@ -2470,6 +2519,14 @@ fn decode_wal_proto_frame_exact(
         shard_id: frame.shard_id,
         wal_index: frame.wal_index,
         command,
+        staged_pages: frame
+            .staged_pages
+            .into_iter()
+            .map(|page| crate::wal::StagedPage {
+                object_id: page.object_id,
+                bytes: page.bytes,
+            })
+            .collect(),
     })
 }
 
@@ -2767,7 +2824,9 @@ mod tests {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -2987,7 +3046,9 @@ mod tests {
                 command: Command::CommonDelete {
                     key: "gone".to_string(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -3076,7 +3137,9 @@ mod tests {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -3160,7 +3223,9 @@ mod tests {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -3427,7 +3492,9 @@ mod tests {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -3530,7 +3597,9 @@ mod tests {
                         key: key.to_string(),
                         value: key.as_bytes().to_vec(),
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
         }
@@ -3585,7 +3654,9 @@ mod tests {
                         key: key.to_string(),
                         value,
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
         }
@@ -3833,7 +3904,9 @@ mod tests {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -3949,7 +4022,9 @@ mod tests {
                         key: key.to_string(),
                         value: key.as_bytes().to_vec(),
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
         }
@@ -4004,7 +4079,9 @@ mod tests {
                         key: key.to_string(),
                         value,
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
         }
@@ -4034,6 +4111,70 @@ mod tests {
                 value: Some(b"1".to_vec())
             }
         );
+    }
+
+    #[tokio::test]
+    async fn a_published_entry_keeps_the_pages_its_write_produced() {
+        // A command is not always enough to rebuild what it wrote. If the shared log drops the
+        // pages, a successor replays the command and reconstructs derived state from whatever
+        // it happens to have -- which is not necessarily the bytes that were acked.
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, replicator) = test_shared_store(dir.path());
+
+        let entry = SharedStoreWalEntry {
+            shard_id: 1,
+            wal_index: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+            staged_pages: vec![crate::wal::StagedPage {
+                object_id: 77,
+                bytes: b"derived-page-bytes".to_vec(),
+            }],
+        };
+        replicator.publish_wal_entry(entry.clone()).await.unwrap();
+
+        let loaded = replicator.load_wal_entries(1).await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        let round_tripped = loaded.values().next().expect("one entry");
+        assert_eq!(
+            round_tripped.staged_pages, entry.staged_pages,
+            "the pages must survive the trip, not just the command"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_entry_written_before_pages_existed_still_loads() {
+        // `staged_pages` is serde(default), so a WAL object published by an older writer -- one
+        // that never had the field -- must still deserialize rather than failing the whole
+        // replay of a shard's history.
+        // Build the legacy shape from a real entry rather than by hand, so this tests the
+        // actual serialized form instead of a guess at it: serialize, drop the field an older
+        // writer never emitted, and load what remains.
+        let entry = SharedStoreWalEntry {
+            shard_id: 1,
+            wal_index: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+            },
+            staged_pages: Vec::new(),
+        };
+        let mut legacy = serde_json::to_value(&entry).unwrap();
+        legacy
+            .as_object_mut()
+            .expect("entry serializes to an object")
+            .remove("staged_pages");
+        assert!(
+            legacy.get("staged_pages").is_none(),
+            "the field must actually be gone for this to test anything"
+        );
+
+        let loaded: SharedStoreWalEntry = serde_json::from_value(legacy)
+            .expect("an entry without the field must still load");
+        assert!(loaded.staged_pages.is_empty());
+        assert_eq!(loaded.command, entry.command);
     }
 
     #[tokio::test]
@@ -4240,7 +4381,9 @@ mod tests {
                     key: "gap".to_string(),
                     value: b"v".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -4627,7 +4770,9 @@ mod tests {
                     key: "k".to_string(),
                     value: b"v".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
 
@@ -4677,7 +4822,9 @@ mod tests {
                     key: "retry".to_string(),
                     value: b"ok".to_vec(),
                 },
-            })
+            
+                                   staged_pages: Vec::new(),
+                               })
             .await
             .unwrap();
     }
@@ -4733,7 +4880,9 @@ mod tests {
                         key: format!("k{wal_index}"),
                         value: vec![wal_index as u8],
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
         }
@@ -4800,7 +4949,9 @@ mod tests {
                         key: key.to_string(),
                         value,
                     },
-                })
+                
+                                       staged_pages: Vec::new(),
+                                   })
                 .await
                 .unwrap();
             append_receipts.push(receipt.expect("protobuf append blob should return offsets"));


### PR DESCRIPTION
the shared log carried commands only, and a command cannot rebuild a derived page

SharedStoreWalEntry was { shard_id, wal_index, command }. Replay re-executed the command
and let this node derive the page again.

That works for a plain value and does not work for derived state. A page can be a
serialized counter series or a hash map -- state the command MUTATES rather than states.
Re-executing reconstructs it only from a state the replaying node still has, in order,
from the beginning. The local engine record already carries the page bytes for exactly
this reason: block_in_wal exists because under async_storage a written page's only durable
copy IS its log record. The shared log was carrying the strictly weaker thing, so a
successor could be handed a history it could not finish replaying.

The entry now carries the pages beside the command that produced them:

- serde(default) on the field, so an object published before it existed still loads. That
  is tested by taking a real entry, deleting the field from its serialized form, and
  loading what remains -- not by hand-writing a guess at the old shape, which is how the
  first version of that test managed to fail against its own format.
- protobuf tag 7, a repeated message. An older reader ignores it, an older writer leaves
  it empty, so both directions stay readable.
- the publish path fills it from the local record, which already had the pages.
- replay hands them to the write through execute_with_carried_pages, so the record written
  on the successor carries what the original produced rather than this node's
  reconstruction of it.

execute_with_carried_pages threads the pages explicitly rather than through a thread-local:
a carried page that leaked into the next command's record would be a silent wrong-data bug,
and a parameter cannot leak. Two details that would otherwise lose them: the reserve-only
concurrent-commit branch appends bytes WITHOUT pages, so a write carrying pages is forced
onto the staged branch; and when pages are carried, whatever this execute re-derived is
taken and dropped rather than left to be preferred over the bytes that were acked.

Local and raft are unchanged. Neither uses SharedStoreWalEntry, the new parameter is
Vec::new() at all six existing call sites, and an empty carry is byte-identical to the
previous path.

Tests: pages survive publish and load; an entry without the field still loads; a carried

🤖 Generated with [Claude Code](https://claude.com/claude-code)
