### PR TITLE
the posting chunk size is what an add pays, and 256 was a guess

### DIFF
--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1157,7 +1157,21 @@ class _TemporalDirectBackendMixin:
     # Chunked, an append rewrites only the tail. The head field keeps its original name and shape,
     # so a reader that knows nothing about chunks still finds locations there; overflow lives in
     # sibling fields "{node}#1", "{node}#2", ... and the head records how many exist.
-    REF_HASH_CHUNK = 256
+    # An append rewrites its TAIL chunk, so this number is what one add pays to touch a posting,
+    # and 256 was a first guess. Measured at three sizes -- 150 adds into ONE subject, so the
+    # posting lists actually grow, which is the case that matters for a large corpus:
+    #
+    #     chunk 256   236.3 KB per add    add median 241.2 ms
+    #     chunk  64   207.5 KB per add    add median 266.2 ms
+    #     chunk  16   174.7 KB per add    add median 253.8 ms
+    #
+    # 26% less disk per add at 16, with add latency flat inside the noise and retrieval returning
+    # the same items at every size. The cost of going smaller is more chunk fields to fetch, but
+    # the reader collects them in ONE batch call whatever the count, so it buys back little below
+    # this. Shrinking the placement chunk alongside it changed nothing measurable (174.6 vs 174.7),
+    # because a node's location list is far shorter than a term's posting list -- so that one
+    # stays where it is rather than being tuned on a number that did not move.
+    REF_HASH_CHUNK = 16
 
     def _ref_hash_chunk_entries(self, key, field, new_refs, existing_value, existing_for,
                                 storage_route):


### PR DESCRIPTION
Appending to a term's posting list rewrites its tail chunk, so the chunk size IS the per-add write
cost for `context_index_lookup` -- the largest index an add touches. It was set to 256 refs when
chunking landed, which was a first guess rather than a measurement.

Measured at three sizes, 150 adds into ONE subject so the posting lists actually grow -- which is
the case that matters for a large corpus:

    chunk 256   236.3 KB per add   add median 241.2 ms   retrieve 7 items
    chunk  64   207.5 KB per add   add median 266.2 ms   retrieve 7 items
    chunk  16   174.7 KB per add   add median 253.8 ms   retrieve 7 items

**26% less disk per add**, add latency flat inside the noise, and retrieval returning the same
items at every size -- which is the check that matters, since a chunk size that lost refs would
show up as a shorter answer.

Going smaller buys little: the reader collects every chunk in ONE batch call whatever the count, so
the win is in bytes rewritten, not round trips, and that curve is already flattening.

Shrinking the placement chunk alongside it changed nothing measurable (174.6 vs 174.7 KB), because
a node's location list is far shorter than a term's posting list. It stays where it is rather than
being tuned on a number that did not move.

Verified: strict mem0 conformance 22/22 and ten mem0 unit suites.