### PR TITLE
a deletion the engine made on its own reached one log and no other

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -1618,6 +1618,10 @@ impl DataNodeRuntime {
     /// [`SharedWalSink`]). Opt-in: with no sink attached the runtime behaves
     /// exactly as before.
     pub fn set_shared_wal_sink(&self, sink: Arc<dyn SharedWalSink>) {
+        // The engine emits deletions of its own -- eviction drops, expiry sweeps -- that never
+        // pass through this layer. Give it the same sink, or those deletions reach the local
+        // log alone and a successor replaying the shared log resurrects the keys.
+        self.inner.engine.set_maintenance_wal_mirror(Arc::clone(&sink));
         *self
             .inner
             .shared_wal_sink

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -122,9 +122,44 @@ pub struct TemporalEngine {
     /// `promote_scan_done` fast-skip holds it to a small constant once warm. Read by the phase-1
     /// aging test to prove the per-write O(n) reconcile scan is gone.
     promote_scans: Arc<std::sync::atomic::AtomicU64>,
+    /// Where to mirror writes this engine performs OUTSIDE the request path.
+    ///
+    /// Request-path writes are mirrored a layer up, by the data node, which sees each command
+    /// as it arrives. Maintenance never passes through there: eviction and the expiry sweep
+    /// append their own tombstones straight to the WAL. In shared mode those deletions therefore
+    /// reached the local log and no other, so a successor replaying the shared log never saw
+    /// them and the key came back -- the same failure the tombstone was introduced to fix, one
+    /// level up from where it was fixed.
+    maintenance_mirror: Arc<RwLock<Option<Arc<dyn crate::data_node::SharedWalSink>>>>,
 }
 
 impl TemporalEngine {
+    /// Mirror the deletions this engine emits on its own -- eviction drops, expiry sweeps --
+    /// to the same place request-path writes go.
+    ///
+    /// Opt-in. With nothing attached the engine behaves exactly as it did.
+    pub fn set_maintenance_wal_mirror(&self, sink: Arc<dyn crate::data_node::SharedWalSink>) {
+        *self
+            .maintenance_mirror
+            .write()
+            .expect("maintenance mirror lock poisoned") = Some(sink);
+    }
+
+    /// Hand a maintenance-generated command to the mirror, if one is attached.
+    ///
+    /// Called after the local append succeeds, so the mirror never learns of a deletion the
+    /// local log does not already hold.
+    pub(crate) fn mirror_maintenance_write(&self, shard_id: ShardId, command: &Command) {
+        let sink = self
+            .maintenance_mirror
+            .read()
+            .expect("maintenance mirror lock poisoned")
+            .clone();
+        if let Some(sink) = sink {
+            sink.record_write(shard_id, command);
+        }
+    }
+
     /// Set a shard's read and write rate limits, on a running engine.
     ///
     /// A rate of zero leaves that direction unlimited. Replacing a limit rebuilds the bucket, so

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -46,6 +46,7 @@ impl TemporalEngine {
             infos: Arc::default(),
             admissions: Arc::default(),
             promote_scans: Arc::default(),
+            maintenance_mirror: Arc::default(),
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
         }
     }

--- a/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
+++ b/crates/temporalstore-rust/src/engine/recovery_sweep_compact.rs
@@ -313,11 +313,15 @@ fn expiry_scan_budget(limit: usize) -> usize {
             // earlier SET/EXPIRE records.
             if !replaying_wal() {
                 for key in &expired_keys {
-                    let _ = self.wal_store.append_with_sync(
-                        request.shard_id,
-                        Command::CommonDelete { key: key.clone() },
-                        false,
-                    );
+                    let command = Command::CommonDelete { key: key.clone() };
+                    let appended = self
+                        .wal_store
+                        .append_with_sync(request.shard_id, command.clone(), false);
+                    // An expiry is a real deletion, so it has to reach every log that a
+                    // successor might replay -- not only this node's.
+                    if appended.is_ok() {
+                        self.mirror_maintenance_write(request.shard_id, &command);
+                    }
                 }
                 shard.applied_wal_sequence =
                     Some(self.wal_store.stats(request.shard_id).last_sequence);

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -1209,11 +1209,15 @@ impl TemporalEngine {
                     // engine's own tombstone discipline.)
                     if !replaying_wal() {
                         for key in &deleted_keys {
-                            let _ = self.wal_store.append_with_sync(
-                                shard_id,
-                                Command::CommonDelete { key: key.clone() },
-                                false,
-                            );
+                            let command = Command::CommonDelete { key: key.clone() };
+                            let appended =
+                                self.wal_store
+                                    .append_with_sync(shard_id, command.clone(), false);
+                            // Same reasoning as the expiry sweep: a drop that deletes is a
+                            // deletion, and it has to reach every log a successor may replay.
+                            if appended.is_ok() {
+                                self.mirror_maintenance_write(shard_id, &command);
+                            }
                         }
                         shard.applied_wal_sequence =
                             Some(self.wal_store.stats(shard_id).last_sequence);

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -2482,6 +2482,95 @@ fn string_setex_sets_value_and_ttl() {
     assert!(value > 0);
 }
 
+/// A sink that just remembers what it was told, so a test can ask whether a write reached it.
+#[derive(Debug, Default)]
+struct RecordingWalSink {
+    seen: std::sync::Mutex<Vec<(ShardId, Command)>>,
+}
+
+impl crate::data_node::SharedWalSink for RecordingWalSink {
+    fn record_write(&self, shard_id: ShardId, command: &Command) {
+        self.seen
+            .lock()
+            .expect("recording sink lock poisoned")
+            .push((shard_id, command.clone()));
+    }
+}
+
+/// An expiry deletion has to reach the mirror, not only this node's log.
+///
+/// Expiry appends its tombstone straight to the WAL, outside the request path, so nothing at
+/// the data-node layer ever sees it. In shared mode that meant the deletion reached the local
+/// log and no other: a successor replaying the shared log never observed it, reapplied the
+/// earlier write, and the key came back -- which is the very failure the tombstone was added
+/// to prevent, reappearing one level up.
+#[test]
+fn an_expiry_deletion_reaches_the_maintenance_mirror() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+
+    let sink = std::sync::Arc::new(RecordingWalSink::default());
+    engine.set_maintenance_wal_mirror(sink.clone());
+
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSetEx {
+                    key: "expire-me".to_string(),
+                    value: b"gone".to_vec(),
+                    ttl_ms: 1,
+                },
+            })
+            .status
+            .ok
+    );
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let report = engine.sweep_expired_records(1).unwrap();
+    assert_eq!(report.expired_records_removed, 1);
+
+    let seen = sink
+        .seen
+        .lock()
+        .expect("recording sink lock poisoned")
+        .clone();
+    assert_eq!(
+        seen,
+        vec![(
+            1u64,
+            Command::CommonDelete {
+                key: "expire-me".to_string()
+            }
+        )],
+        "the expiry tombstone must reach the mirror, not just the local log"
+    );
+}
+
+/// With no mirror attached the sweep behaves exactly as it did before one existed.
+#[test]
+fn an_expiry_sweep_without_a_mirror_is_unchanged() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSetEx {
+                    key: "expire-me".to_string(),
+                    value: b"gone".to_vec(),
+                    ttl_ms: 1,
+                },
+            })
+            .status
+            .ok
+    );
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let report = engine.sweep_expired_records(1).unwrap();
+    assert_eq!(report.expired_records_removed, 1);
+}
+
 #[test]
 fn expiry_sweep_removes_expired_records_without_lazy_read() {
     let engine = TemporalEngine::default();

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3746,6 +3746,216 @@ fn a_carried_page_is_what_reaches_the_log_record() {
     );
 }
 
+// ---------------------------------------------------------------------------------------
+// Interleavings: the shard does not hold still between a decision and the act it authorizes.
+//
+// Most of this suite is sequential -- set up, act, assert -- and that shape found none of the
+// concurrency-adjacent defects in the reclaim sweep. These exercise the seam this codebase
+// actually has: plan and apply are separate calls, so anything that happens in between is a
+// real interleaving, reproducible without threads or timing.
+// ---------------------------------------------------------------------------------------
+
+/// A write that lands between planning a reclaim and applying it must survive.
+///
+/// The plan is computed, handed back -- over an RPC, or through a cycle stage -- and applied
+/// later. The shard keeps taking writes the whole time. A plan authorizes dropping what the
+/// durable index could replace WHEN IT WAS MADE, and a record that did not exist then was
+/// never covered by that proof.
+#[test]
+fn a_reclaim_plan_does_not_authorize_dropping_writes_that_landed_after_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "before".to_string(),
+            value: b"v1".to_vec(),
+        },
+    });
+    engine.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+
+    let plan = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+
+    // The interleaving: a write lands after the plan was made, before it is applied.
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: "after".to_string(),
+                    value: b"v2".to_vec(),
+                },
+            })
+            .status
+            .ok
+    );
+    let after_sequence = engine.write_ahead_log_store().stats(1).last_sequence;
+
+    let _report = engine.apply_storage_wal_reclaim(plan);
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap();
+    let highest = records
+        .iter()
+        .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+        .map(|record| record.sequence)
+        .max()
+        .unwrap_or(0);
+    assert!(
+        highest >= after_sequence,
+        "the later write's record was reclaimed by a plan made before it existed \
+         (highest kept {highest}, the write was at {after_sequence})"
+    );
+    assert_eq!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: "after".to_string()
+                },
+            })
+            .response,
+        CommandResponse::Bytes {
+            value: Some(b"v2".to_vec())
+        },
+        "and it must still read back"
+    );
+}
+
+/// A dump taken between planning a manifest prune and applying it must not be pruned.
+///
+/// The prune decides which manifests are redundant. A dump that completes after that decision
+/// is the freshest thing the shard has, and pruning it would throw away the only manifest
+/// covering the current generation.
+#[test]
+fn a_manifest_created_after_a_prune_plan_is_not_pruned_by_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "k".to_string(),
+            value: b"v1".to_vec(),
+        },
+    });
+    engine.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "k".to_string(),
+            value: b"v2".to_vec(),
+        },
+    });
+    engine.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+
+    let _plan = engine.bucket_dump_manifest_prune_plan(1);
+
+    // The interleaving: a third dump completes after the prune was planned.
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "k".to_string(),
+            value: b"v3".to_vec(),
+        },
+    });
+    let newest = engine.create_bucket_dump_manifest(1, Vec::new()).unwrap();
+
+    let _report = engine.apply_bucket_dump_manifest_prune(1);
+
+    let remaining = engine.list_bucket_dump_manifests(1);
+    assert!(
+        remaining
+            .iter()
+            .any(|manifest| manifest.manifest_id == newest.manifest_id),
+        "the dump taken after the prune was planned is the freshest manifest and must survive; \
+         remaining: {:?}",
+        remaining
+            .iter()
+            .map(|manifest| &manifest.manifest_id)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The same page must still read back after the shard is RELOADED.
+///
+/// Registrations are live-path state: they are dropped when a shard unloads, and the standing
+/// claim is that reload replays the WAL and re-derives every page. That only holds if replay
+/// revisits the record carrying the page -- and replay starts ABOVE the persisted watermark,
+/// which this very write advanced past its own record. If nothing rebuilds the mapping, the
+/// served index is left pointing at a synthetic address naming no file, and an acked write
+/// reads back as MISSING after a restart: exactly the hole staging was added to close,
+/// reopened by a reload.
+#[test]
+fn a_block_in_wal_page_still_reads_back_after_a_shard_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.set_config(SetConfigRequest {
+        shard_id: 1,
+        config: Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        },
+    });
+
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+
+    let key = "reload-block-key";
+    let value = b"reload-block-value".to_vec();
+    let write = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: key.to_string(),
+            value: value.clone(),
+        },
+    });
+    assert!(write.status.ok, "the write must be acked: {write:?}");
+
+    // Drop every cached copy, then take the shard down and bring it back. This is the restart,
+    // and it is what clears the registrations.
+    engine.cache().invalidate_shard(1).unwrap();
+    engine.unload_shard(1);
+    engine.load_shard(1);
+
+    let read = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: key.to_string(),
+        },
+    });
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+    std::env::remove_var("TS_HOT_PAGE_SPILL");
+
+    assert_eq!(
+        read.response,
+        CommandResponse::Bytes {
+            value: Some(value)
+        },
+        "an acked write must not read back as missing after a reload"
+    );
+}
+
 /// What waiting before a dump saves, and what the wait costs.
 ///
 /// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log


### PR DESCRIPTION
a deletion the engine made on its own reached one log and no other

SharedWalSink is reached only through mirror_write / mirror_writes, and those are called
from four request-path sites. Two paths append to the WAL outside that: eviction, when a
drop deletes keys, and the expiry sweep. Both write a CommonDelete straight to wal_store.

In shared mode those deletions therefore landed in the local log and nowhere else. A
successor replaying the shared log never observed them, reapplied the earlier write, and
the key came back.

That is the same failure the tombstone was introduced to prevent, one level up from where
it was fixed. The comment above the eviction append says so directly: emitting no WAL
tombstone left the deletion invisible to followers and let the key resurrect on reload.
The tombstone fixed the local log and the shared log kept the bug.

The engine now carries an optional maintenance mirror. It is set alongside the data node's
own sink, so attaching one attaches both, and it is consulted only after the local append
succeeds -- the mirror never learns of a deletion the local log does not already hold. With
nothing attached the engine behaves exactly as before, which is what the second test pins.

Also here, three tests of a shape this suite was missing.

Almost everything in it is sequential -- set up, act, assert -- and that shape found none of
the concurrency-adjacent defects in this sweep. These use the seam the code actually has:
plan and apply are separate calls, so whatever happens between them is a real interleaving,
reproducible without threads or timing.

- a write that lands between planning a reclaim and applying it must survive. A plan
  authorizes dropping what the durable index could replace WHEN IT WAS MADE; a record that
  did not exist then was never covered by that proof.
- a dump taken between planning a manifest prune and applying it must not be pruned by it.
- and the block-in-WAL reload case, which is a restart interleaved with un-dumped pages.
  That last one passes on main: it documents behaviour rather than fixing it. It is here
  because the property is load-bearing and nothing was pinning it.

Tests: part1 expiry mirror + no-mirror control, part4 59/0 including both interleavings,
engine 239/0, data-node 46/1 (the jitter_backoff timeout, failing identically without this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
