### PR TITLE
"is this block in the log" was asked two different ways, in seven places

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -61,6 +61,9 @@ mod state;
 
 use self::admin_report::*;
 use self::constants::*;
+// Re-exported so `wal_record::is_wal_resident` can answer for this sentinel too, rather than
+// every site comparing against it by hand.
+pub(crate) use self::constants::HOT_PAGE_SLAB_ID;
 use self::execute_on_shard::execute_on_shard;
 use self::context::*;
 use self::packed_pages::*;
@@ -3184,7 +3187,7 @@ fn read_page_bytes(
     // the redirect and read the durable copy. On a genuine miss (never spilled, or spill failed)
     // this falls through to the normal read below, which returns None -- the WAL still holds the
     // value and a reload replays it.
-    if address.page_slab_id == HOT_PAGE_SLAB_ID {
+    if crate::wal_record::is_wal_resident(address.page_slab_id) {
         if let Some(real_address) = hot_page_spill::lookup_spilled(shard_id, address.offset) {
             if let Ok(bytes) = page_store.read(&real_address) {
                 let _ = cache.put(cache_key, bytes.clone());

--- a/crates/temporalstore-rust/src/engine/constants.rs
+++ b/crates/temporalstore-rust/src/engine/constants.rs
@@ -30,5 +30,10 @@ pub(super) const CONTEXT_MAX_REF_BYTES: usize = 4096;
 pub(super) const CONTEXT_MAX_EVENT_TEXT_BYTES: usize = 64 * 1024;
 pub(super) const CONTEXT_MAX_COMPACT_ATTRS_BYTES: usize = 8 * 1024;
 pub(super) const CONTEXT_NODE_FIELD: &str = "meta";
-pub(super) const HOT_PAGE_SLAB_ID: u64 = u64::MAX;
+/// Sentinel slab id for a block that lives in the log rather than a slab file, as the live
+/// write path mints it: the address's `offset` is a counter, not a position.
+///
+/// `pub(crate)` so [`crate::wal_record::is_wal_resident`] can answer for both sentinels in one
+/// place rather than each site comparing by hand.
+pub(crate) const HOT_PAGE_SLAB_ID: u64 = u64::MAX;
 pub(super) static HOT_PAGE_OFFSET: AtomicU64 = AtomicU64::new(1);

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1419,7 +1419,7 @@ pub(super) fn object_still_has_hot_page(shard: &ShardState, object_key: &str) ->
     shard
         .strings
         .get(object_key)
-        .map(|address| address.page_slab_id == HOT_PAGE_SLAB_ID)
+        .map(|address| crate::wal_record::is_wal_resident(address.page_slab_id))
         .unwrap_or(false)
         || shard
             .hashes
@@ -1427,7 +1427,7 @@ pub(super) fn object_still_has_hot_page(shard: &ShardState, object_key: &str) ->
             .map(|fields| {
                 fields
                     .values()
-                    .any(|address| address.page_slab_id == HOT_PAGE_SLAB_ID)
+                    .any(|address| crate::wal_record::is_wal_resident(address.page_slab_id))
             })
             .unwrap_or(false)
 }

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -535,7 +535,7 @@ impl TemporalEngine {
                 let mut publish_targets = shard
                     .strings
                     .iter()
-                    .filter(|(_, address)| address.page_slab_id == HOT_PAGE_SLAB_ID)
+                    .filter(|(_, address)| crate::wal_record::is_wal_resident(address.page_slab_id))
                     .map(|(key, address)| {
                         (PublishTarget::String { key: key.clone() }, address.clone())
                     })
@@ -546,7 +546,7 @@ impl TemporalEngine {
                         .iter()
                         .flat_map(|(key, fields)| {
                             fields.iter().filter_map(move |(field, address)| {
-                                (address.page_slab_id == HOT_PAGE_SLAB_ID).then(|| {
+                                crate::wal_record::is_wal_resident(address.page_slab_id).then(|| {
                                     (
                                         PublishTarget::Hash {
                                             key: key.clone(),
@@ -564,7 +564,7 @@ impl TemporalEngine {
                 let mut publish_targets = Vec::new();
                 for key in &selected_keys {
                     if let Some(address) = shard.strings.get(key) {
-                        if address.page_slab_id == HOT_PAGE_SLAB_ID {
+                        if crate::wal_record::is_wal_resident(address.page_slab_id) {
                             publish_targets.push((
                                 PublishTarget::String { key: key.clone() },
                                 address.clone(),
@@ -573,7 +573,7 @@ impl TemporalEngine {
                     }
                     if let Some(fields) = shard.hashes.get(key) {
                         publish_targets.extend(fields.iter().filter_map(|(field, address)| {
-                            (address.page_slab_id == HOT_PAGE_SLAB_ID).then(|| {
+                            crate::wal_record::is_wal_resident(address.page_slab_id).then(|| {
                                 (
                                     PublishTarget::Hash {
                                         key: key.clone(),

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -120,9 +120,20 @@ pub fn block_address_from_item(log_id: u64, log_size: u64, item: &WalItem) -> Bl
 /// widening it or adding a parallel flag.
 pub const WAL_LOG_SLAB_ID: u64 = u64::MAX - 1;
 
-/// Whether an address resolves inside the WAL.
+/// Whether an address resolves inside the WAL rather than in a slab file.
+///
+/// Two sentinels answer to this, because the idea got invented twice. [`WAL_LOG_SLAB_ID`] is
+/// the ported one, where the address carries the log id of the record holding the block, so a
+/// read seeks straight to it and the mapping survives a restart because it lives in the served
+/// index. `HOT_PAGE_SLAB_ID` is what the live write path mints today: a counter rather than a
+/// position, which is why resolving it needs a process-local registry and why that mapping is
+/// gone after a reload.
+///
+/// They ask the same question -- is this block in the log? -- so it gets one answer here
+/// instead of an open-coded comparison at each site. The sites are then already asking the
+/// right question on the day the write path starts minting positions instead of counters.
 pub fn is_wal_resident(page_slab_id: u64) -> bool {
-    page_slab_id == WAL_LOG_SLAB_ID
+    page_slab_id == WAL_LOG_SLAB_ID || page_slab_id == crate::engine::HOT_PAGE_SLAB_ID
 }
 
 #[cfg(test)]


### PR DESCRIPTION
"is this block in the log" was asked two different ways, in seven places

There are two sentinel slab ids for the same idea. WAL_LOG_SLAB_ID, in wal_record.rs, is the
ported one: the address carries the log id of the record holding the block, so a read seeks
straight to it and the mapping survives a restart because it lives in the served index.
HOT_PAGE_SLAB_ID is the one the live write path mints, in append_value: the offset is a
counter from an AtomicU64 rather than a position, which is exactly why resolving it needs a
process-local registry and why that registry is empty after a reload.

Seven sites compared against the live sentinel by hand. is_wal_resident answers for both
instead, and the sites ask it. Nothing mints WAL_LOG_SLAB_ID yet, so this changes no
behaviour today -- it removes the second copy of the concept, and it means the read sites are
already asking the right question on the day the write path starts minting positions.

That day is the actual structural work, and it is worth writing down what it costs, because
the obvious implementation is wrong.

The address cannot be known while a command executes: append_value builds the BlockAddress
during execution, and the record it will live in has not been appended, so it has no offset.
Staging is what resolves this -- items accumulate during execution and the offset is written
back into every staged block descriptor at commit. Writing that back by searching shard state
for the object would cost a scan of every address map per write, which is the per-write O(n)
this engine has already had to remove twice. So the write-back needs staging to record a
locator for the descriptor it created, not just the object id. That is a change to how
append_value's result reaches shard state, and it is the piece that turns the registry from
the source of truth into a cache -- and closes the restart hole structurally rather than by
adding another side table.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
