### PR TITLE
take the cache revision where evicting does not scan the whole tier

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -52,7 +52,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends clang libclang-dev cmake
 
       - name: Install Rust toolchain
-        run: rustup toolchain install 1.87.0 --profile minimal --no-self-update && rustup default 1.87.0
+        run: rustup toolchain install 1.88.0 --profile minimal --no-self-update && rustup default 1.88.0
 
       - name: Cache cargo registry and target
         uses: actions/cache@v4
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends clang libclang-dev cmake
 
       - name: Install Rust toolchain
-        run: rustup toolchain install 1.87.0 --profile minimal --no-self-update && rustup default 1.87.0
+        run: rustup toolchain install 1.88.0 --profile minimal --no-self-update && rustup default 1.88.0
 
       - name: Cache cargo registry and target
         uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,16 +126,14 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -228,7 +226,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -636,39 +633,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.19.0+11.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "4f45e86edad8e88efe97dbf384b4e48e1ff0f111eabf154c7b09d7a1e5fb573c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
+ "rustflags",
 ]
 
 [[package]]
@@ -721,7 +702,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "matrixcache"
 version = "0.1.0"
-source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=8bddbcd391592120680ce1019b004cd9b5c40935#8bddbcd391592120680ce1019b004cd9b5c40935"
+source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a#7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a"
 dependencies = [
  "rocksdb",
  "serde",
@@ -1150,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "d8d90add70d1d420ee487bce4a1449880a8d147451c6051b2ee5f8354553dcbf"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -1160,9 +1141,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustflags"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39e0e9135d7a7208ee80aa4e3e4b88f0f5ad7be92153ed70686c38a03db2e63"
 
 [[package]]
 name = "rustix"

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"
 matrixraft = { package = "matrixraft", git = "https://github.com/matrixarkai/MatrixRaft.git", rev = "a4334b37ba6592e7c7192f3eaa2afe087746ccc9" }
-matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "8bddbcd391592120680ce1019b004cd9b5c40935", features = ["rocksdb-ssd"] }
+matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a", features = ["rocksdb-ssd"] }
 temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
The cache dependency was pinned to a revision whose eviction weighs **every resident key** to choose
one victim, inside a loop that runs until the tier is under capacity. That cost is paid on almost
every write once the cache is full, and it grows with the number of resident entries.

It is not a theoretical cost. Walking a corpus up with a fixed subject, adds ran at 411 ms at 200
memories and then degraded to roughly **15 seconds each** a few hundred adds later. Sampling the
process settled where the time went without ambiguity -- 12 of 12 stacks identical, at 95% CPU:

```text
execute_record_log_request -> batch_execute -> execute_on_shard -> read_page_bytes
  -> MultiLayerCache::put -> put_memory -> evict_memory_to_capacity_since -> select_eviction_victim
```

Every page read was paying an eviction sweep. The upstream fix weighs a bounded window of
candidates in access order instead, with a whole-tier fallback when the window is entirely pinned:

```text
entries   groups weighed per eviction    ns/write
             before      after        before        after
  1024       1025.0      512.0       2436967       285566
  8192       8193.0      512.0      10409246       203738
```

Groups weighed is `entries + 1` before and flat at 512 after, so the per-write cost stops tracking
the size of the cache. Hit rate is identical to two decimals on both arms (82.37% / 81.99%), which
is the check that matters -- a cheaper selector that evicted better entries would read as a faster
cache that misses more.

This bumps only the pinned revision and the lock entry. Verified here by building the release proxy
against it and re-running the ingest ladder.
