### PR TITLE
the reap stage reported itself executed and collected nothing

### DIFF
--- a/crates/temporalstore-rust/src/data_node.rs
+++ b/crates/temporalstore-rust/src/data_node.rs
@@ -996,6 +996,24 @@ pub struct StorageManagerPressureDecision {
     pub skip_reason: Option<String>,
 }
 
+/// What a metrics reap actually collected.
+///
+/// The stage used to push the string "reap_metrics" onto the executed list and stop there, so a
+/// cycle reported the stage as having run while nothing was gathered and nothing published. The
+/// WAL's own counters are the clearest example of the cost: they are incremented on every append
+/// and barrier and were never read by anything outside the module that owns them.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageMetricsReapReport {
+    /// Durability barriers taken, by the call site that took them.
+    #[serde(default)]
+    pub durability_barriers: std::collections::BTreeMap<String, u64>,
+    #[serde(default)]
+    pub durability_barriers_total: u64,
+    /// This shard's write-ahead log counters at the moment of the reap.
+    #[serde(default)]
+    pub wal: crate::wal::WriteAheadLogStats,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StorageManagerLoopReport {
     pub shard_id: ShardId,
@@ -1009,6 +1027,10 @@ pub struct StorageManagerLoopReport {
     pub lifecycle_report: Option<StorageLifecycleReport>,
     #[serde(default)]
     pub expired_records_removed: usize,
+    /// Present when the reap stage ran. `None` means it was disabled, not that it found
+    /// nothing -- a reap that gathers nothing still reports zeros.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics_reap: Option<StorageMetricsReapReport>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction_report: Option<CompactionResponse>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -562,7 +562,23 @@ impl DataNodeRuntime {
             (!options.enable_index_gc).then(|| "reclaim_index_disabled".to_string()),
         ));
 
-        if options.enable_metrics_reap {
+        // Gather what the stage has always claimed to gather. Deliberately a snapshot and not
+        // a reset: `durability_metrics` documents its counters as process-wide and monotonic,
+        // and tests reset them to isolate a measurement window -- a background cycle clearing
+        // them would pull the floor out from under anyone diffing two points in time.
+        let metrics_reap = options.enable_metrics_reap.then(|| {
+            let durability_barriers: std::collections::BTreeMap<String, u64> =
+                crate::durability_metrics::snapshot()
+                    .into_iter()
+                    .map(|(site, count)| (site.to_string(), count))
+                    .collect();
+            StorageMetricsReapReport {
+                durability_barriers_total: durability_barriers.values().copied().sum(),
+                durability_barriers,
+                wal: self.inner.engine.write_ahead_log_store().stats(shard_id),
+            }
+        });
+        if metrics_reap.is_some() {
             executed_stages.push("reap_metrics".to_string());
         } else {
             skipped_stages.push("reap_metrics_disabled".to_string());
@@ -603,6 +619,7 @@ impl DataNodeRuntime {
             lifecycle_plan,
             lifecycle_report,
             expired_records_removed,
+            metrics_reap,
             compaction_report,
             gc_report,
             status,

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -1964,6 +1964,85 @@ fn runtime_rejects_background_work_when_background_queue_is_full() {
 
 // shared-corpus: storage_matrixraft_dump_load_atomicity storage_matrixraft_cache_refill_pressure
 #[test]
+/// A stage that reports itself as executed has to have executed something.
+///
+/// The reap used to push "reap_metrics" onto the executed list and stop there, so a cycle said
+/// the stage ran while nothing was gathered and nothing published. The WAL counters are the
+/// clearest case: incremented on every append and barrier, and read by nothing outside the
+/// module that owns them.
+#[test]
+fn a_metrics_reap_collects_the_counters_it_says_it_did() {
+    let engine = TemporalEngine::default();
+    engine.load_shard(1);
+    let runtime = DataNodeRuntime::new(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 1,
+            max_queue_depth: 8,
+            max_background_queue_depth: 8,
+        },
+    );
+    for key in ["reap-a", "reap-b", "reap-c"] {
+        assert!(
+            runtime
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: key.to_string(),
+                        value: b"v".to_vec(),
+                    },
+                })
+                .status
+                .ok
+        );
+    }
+
+    let report = runtime.run_storage_manager_once(
+        1,
+        StorageManagerOptions {
+            enable_metrics_reap: true,
+            ..StorageManagerOptions::default()
+        },
+    );
+    assert!(
+        report
+            .executed_stages
+            .iter()
+            .any(|stage| stage == "reap_metrics"),
+        "the stage should report itself executed: {:?}",
+        report.executed_stages
+    );
+    let reaped = report
+        .metrics_reap
+        .expect("the stage ran, so the report carries what it read");
+    assert!(
+        reaped.wal.last_sequence >= 3,
+        "the WAL counters have to be THIS shard's, and three writes went in: {reaped:?}"
+    );
+    assert_eq!(
+        reaped.durability_barriers_total,
+        reaped.durability_barriers.values().copied().sum::<u64>(),
+        "the total has to be the sum of what was attributed"
+    );
+
+    // Disabled: nothing collected, and the cycle says which it was.
+    let off = runtime.run_storage_manager_once(
+        1,
+        StorageManagerOptions {
+            enable_metrics_reap: false,
+            ..StorageManagerOptions::default()
+        },
+    );
+    assert!(off.metrics_reap.is_none());
+    assert!(
+        off.skipped_stages
+            .iter()
+            .any(|stage| stage == "reap_metrics_disabled"),
+        "{:?}",
+        off.skipped_stages
+    );
+}
+
 fn storage_manager_cycle_runs_as_bounded_background_data_node_task() {
     let dir = tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(


### PR DESCRIPTION
the reap stage reported itself executed and collected nothing

enable_metrics_reap pushed the string "reap_metrics" onto the executed-stages list and did
nothing else. A cycle therefore reported the stage as having run while nothing was gathered
and nothing published -- worse than a stage that is merely absent, because the report says
otherwise.

The WAL counters are the clearest case of what that cost. WriteAheadLogStats is incremented
on every append, flush and barrier, and outside wal.rs nothing reads it: not the shard report,
not the cycle, not any endpoint. The same is true of the per-site durability barrier counters,
which exist precisely because attributing barriers by reading the code produced confident
wrong answers here more than once.

The stage now collects both and puts them on the loop report: the barrier counts by call site,
their total, and this shard's WAL counters at the moment of the reap.

Deliberately a snapshot and NOT a reset. durability_metrics documents its counters as
process-wide and monotonic, and tests reset them to isolate a measurement window -- a
background cycle clearing them would pull the floor out from under anyone diffing two points
in time. Consumers difference two reaps; the reap itself destroys nothing.

metrics_reap is None when the stage is disabled, and Some with zeros when it ran and found
nothing, so "did not run" and "ran, nothing to report" stay distinguishable.

Tests: with the stage on, the report carries this shard's WAL sequence and a barrier total

🤖 Generated with [Claude Code](https://claude.com/claude-code)
