### PR TITLE
a fresh store gets the small index, not the one measurement rejected

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -1746,8 +1746,44 @@ const INDEX_ZSTD_LEVEL: i32 = 3;
 /// TS_INDEX_BINARY: write the served index in the binary container instead of raw JSON.
 /// Reading is unconditional and sniffed, so this flag only ever controls what is WRITTEN, and an
 /// index written either way loads in either setting.
+/// Does this look like a served index, in either of the two formats a reader may be handed?
+///
+/// A JSON index starts with `{`; a container starts with its magic. Callers that only need to
+/// know "these bytes are an index" -- rather than to decode one -- ask this instead of parsing.
+pub(crate) fn bytes_look_like_served_index(bytes: &[u8]) -> bool {
+    bytes.first() == Some(&b'{') || bytes.starts_with(INDEX_CONTAINER_MAGIC)
+}
+
+/// ON by default; `TS_INDEX_BINARY=0` is the escape hatch.
+///
+/// The container was built, measured and then left switched off, so every store written since has
+/// carried a plain-JSON served index. Measured at 300 adds into one subject, which is the shape
+/// that grows an index rather than merely touching it:
+///
+/// ```text
+///                    index      WAL    durable per memory   add p50
+///     JSON          19.9 MB  15.4 MB          227.0 KB      383.1 ms
+///     container      2.2 MB   2.3 MB          122.0 KB      367.8 ms
+/// ```
+///
+/// 46% less durable disk per memory. The WAL falls with it because index deltas ride the WAL, and
+/// page bytes do not move at all -- the data is unchanged, only the way the index is written.
+///
+/// A format default is a durability decision, not a size one, so the flip is gated on recovery
+/// rather than on the table above. Three cases, 120 memories each, comparing full retrieval
+/// snapshots across a restart:
+///
+///   * written by the container, reopened by it -- identical.
+///   * written as JSON, reopened with the container on -- identical, and the index on disk becomes
+///     a container, so an existing store upgrades in place with no migration step.
+///   * written by the container, reopened with the hatch pulled -- identical, and the index goes
+///     back to JSON. The flip is reversible in both directions, which is what makes it safe to
+///     make it the default rather than an opt-in.
+///
+/// A reader never has to be told which it is holding: JSON starts with `{`, a container with its
+/// magic, so both formats stay loadable whichever way this flag points.
 fn index_binary_container_enabled() -> bool {
-    env_flag_on("TS_INDEX_BINARY")
+    env_flag_default_on("TS_INDEX_BINARY")
 }
 
 /// TS_INDEX_CODEC: which payload to write when the container is on. `msgpack` (the default when

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3176,7 +3176,9 @@ fn served_index_container_round_trips_and_still_reads_plain_json() {
     );
 
     // Container OFF: raw JSON, and JSON is what an older binary would have written.
-    std::env::remove_var("TS_INDEX_BINARY");
+    // Say "0" rather than unsetting: unsetting selects the DEFAULT, which is the container,
+    // so an unset variable stopped meaning "off" the moment the default changed.
+    std::env::set_var("TS_INDEX_BINARY", "0");
     let plain = encode_index_bytes(&shard);
     assert_eq!(plain.first(), Some(&b'{'), "container off must write JSON");
     let decoded = decode_index_bytes(&plain).expect("json index decodes");
@@ -3271,7 +3273,9 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
     assert!(refused.contains("struct version"), "unhelpful refusal: {refused}");
 
     // And every older on-disk shape still loads: plain JSON, and the compressed-JSON payload.
-    std::env::remove_var("TS_INDEX_BINARY");
+    // "0" rather than unset -- unset now selects the container, which is not what is under
+    // test here.
+    std::env::set_var("TS_INDEX_BINARY", "0");
     let plain = encode_index_bytes(&shard);
     assert_eq!(plain.first(), Some(&b'{'), "container off still writes JSON");
     assert_eq!(

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -191,8 +191,14 @@ fn control_api_reads_and_scans_index_log_stream() {
     // which is the complete, current ShardState in both the whole-index (base-file) and the
     // delta (live-in-memory) paths -- the index-log itself is a per-write log, not the
     // authoritative complete image.
-    let served: serde_json::Value =
-        serde_json::from_slice(&engine.export_index_bytes(1).unwrap()).unwrap();
+    // The served index is written in whichever format the container gate selects, so decode it
+    // through the funnel a reader uses and assert over the STATE. Reading the bytes as JSON was an
+    // assumption about the encoding, not about the thing being tested.
+    let served: serde_json::Value = serde_json::to_value(
+        crate::engine::decode_index_bytes(&engine.export_index_bytes(1).unwrap())
+            .expect("served index decodes"),
+    )
+    .expect("shard state re-serializes for assertion");
     // `hashes` is deliberately NOT serialized (`skip_serializing`): it is rebuildable from
     // the durable bucket index on load, and duplicating those page references in every
     // checkpoint is what made large context backfills tens of MB heavier. Assert the hash
@@ -2161,11 +2167,15 @@ fn recovery_reconciles_model_views_from_bucket_index_authority() {
     );
     engine.unload_shard(1);
 
+    // Empty the string map and put it back through the same encoder that wrote it. Injecting the
+    // fault as JSON text quietly required the index to BE JSON, which is not what this test is
+    // about -- it is about recovery rebuilding the strings from the bucket index.
     let index_path = index_dir.join("shard-1.index.json");
-    let mut json: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(&index_path).expect("index file")).unwrap();
-    json["strings"] = serde_json::json!({});
-    std::fs::write(&index_path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+    let mut damaged =
+        crate::engine::decode_index_bytes(&std::fs::read(&index_path).expect("index file"))
+            .expect("served index decodes");
+    damaged.strings.clear();
+    std::fs::write(&index_path, crate::engine::encode_index_bytes(&damaged)).unwrap();
 
     let recovered = TemporalEngine::with_local_dirs(1024, &cache_dir, &page_dir, &index_dir);
     recovered.load_shard(1);

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -2091,14 +2091,16 @@ fn bucket_dump_manifest_rejects_object_lifecycle_mismatch() {
 
     let mut reused_owner = manifest.clone();
     {
-        let mut restored = serde_json::from_slice::<ShardState>(&reused_owner.index_bytes)
+        // A manifest carries the index in the format it was written in; decode and re-encode it
+        // through the funnel rather than assuming JSON on either side.
+        let mut restored = crate::engine::decode_index_bytes(&reused_owner.index_bytes)
             .expect("manifest index should decode");
         let address = restored
             .strings
             .get_mut("lifecycle")
             .expect("manifest string address");
         address.object_id = Some(address.object_id.unwrap_or_default().wrapping_add(1));
-        reused_owner.index_bytes = serde_json::to_vec(&restored).unwrap();
+        reused_owner.index_bytes = crate::engine::encode_index_bytes(&restored);
         reused_owner.index_sha256 = sha256_hex_bytes(&reused_owner.index_bytes);
         reused_owner.dump_generation_id = bucket_dump_generation_id(&reused_owner);
         reused_owner.checksum = bucket_dump_manifest_checksum(&reused_owner).unwrap();

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -482,7 +482,16 @@ impl LocalIndexLogStore {
         if bulk_ingest_mode() || !indexlog_enabled() {
             return Ok(0);
         }
-        debug_assert!(serde_json::from_slice::<serde_json::Value>(index_bytes).is_ok());
+        // This once asserted the bytes parse as JSON, from when this appender spliced the whole
+        // index into the record. It no longer does -- it writes a digest and a length, and never
+        // looks inside -- so the JSON demand was a precondition that outlived its reason, and it
+        // fires the moment the index is written in its binary container. Assert what this code
+        // actually needs: that it was handed an index at all, in either format a reader accepts.
+        debug_assert!(
+            crate::engine::bytes_look_like_served_index(index_bytes),
+            "index-log anchor was handed {} bytes that are not a served index in any known format",
+            index_bytes.len()
+        );
         let mut inner = self.inner.lock().expect("index log lock poisoned");
         fs::create_dir_all(&inner.root)?;
         let last_sequence = match inner.last_sequence_by_shard.get(&shard_id).copied() {


### PR DESCRIPTION
The binary index container has been in the tree, tested, and switched **off**, so every store ever
written carries a plain-JSON served index. This makes it what a fresh store gets;
`TS_INDEX_BINARY=0` is the hatch.

Measured at 300 adds into one subject -- the shape that grows an index rather than merely touching
it -- both arms in one run:

```text
                  pages     index       WAL   index log   durable/memory   add p50
JSON             30.8 MB   19.9 MB   15.4 MB     2.0 MB       227.0 KB     383.1 ms
container        30.8 MB    2.2 MB    2.3 MB     1.2 MB       122.0 KB     367.8 ms
```

**46% less durable disk per memory.** The index is 8.9x smaller and the WAL 6.7x smaller, because
index deltas ride the WAL and shrink with it. Page bytes do not move at all, which is the check
that matters: the data is unchanged, only the way the index is written. Latency is flat inside the
noise. At fifty thousand records that is about 6.1 GB instead of 11.4 GB.

A format default is a durability decision, not a size one, so it is gated on recovery rather than
on that table. Three cases, 120 memories each, comparing full retrieval snapshots across a restart:

* written by the container, reopened by it -- identical.
* written as JSON, reopened with the container on -- identical, and the file on disk becomes a
  container. An existing store upgrades in place with no migration step.
* written by the container, reopened with the hatch pulled -- identical, and the file goes back to
  JSON. **Reversible in both directions**, which is what makes this a default rather than a
  one-way door.

Nothing in the write path had to change, because no reader parses these bytes as JSON: every
production path hashes them, measures them, installs them or exports them, and the one function
that does parse (`append_json`) has no production callers.

### What the rest of this change is

Turning it on surfaced five places that said "JSON" where they meant "the served index". They are
worth reading as the actual content of this PR, because each was a latent assumption:

* `index_log.rs::append_index_bytes` asserted its input parses as JSON. That was a precondition
  from when the appender **embedded** the index; it now writes a digest and a length and never
  looks inside. Replaced with a check for what it actually needs -- that it was handed a served
  index in either format. This one is a live bug independent of the default: anyone setting
  `TS_INDEX_BINARY=1` on a debug build hits it today. It accounted for 18 of the 27 initial
  failures.
* Two round-trip tests expressed "container off" as *unsetting* the variable. That is only the
  same thing while the default is off. They now say `"0"`.
* Two fault-injection tests damaged an index by rewriting it as JSON text, and one decoded a dump
  manifest's index the same way. They now decode, damage, and re-encode through the same funnel a
  reader uses, so they test recovery rather than an encoding.

### Verified

`cargo check --all-targets` clean. `cargo test --lib`: **1328 passed, 4 failed** -- and all four
are already failing on pristine `main` (two live-embedding context tests, a
`jitter_backoff` runtime test, a WAL group-commit test); each passes in isolation on both
branches, so they are parallel-execution flakes, not consequences of this change. Main's own
baseline is six, so this branch fails fewer tests than the branch point.

One test worth calling out because it changed behavior and then stopped:
`distributed_raft_chunks_large_sequence_add_under_default_entry_limit` failed in the first full
run and passes in isolation and in every run since -- smaller index bytes do change how a large
sequence chunks under the entry limit, so it was checked rather than waved through.
