### PR TITLE
a record location is a shard and an offset, and it took sixty-nine bytes

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1464,6 +1464,37 @@ fn type_index_ready_key(record_hash_key: &str) -> String {
 /// counters -- and only the record shards may feed the type index: an index-served scan fetches
 /// whatever the index names, and naming a non-record key would make it return rows the walk it
 /// replaces could never have seen.
+/// A stored location, in either shape, as `(shard, field)` within `record_hash_key`.
+///
+/// The long shape spells the whole thing out -- `{"key":"<base>:000003","field":"000...014"}` --
+/// and the compact shape is `"3:14"`, shard and offset in decimal. Measured over 300 ingests, the
+/// long shape was 87% of every byte written to a page, because the base is one deployment-wide
+/// string repeated in every entry and the offset is a twenty-digit rendering of a small number.
+///
+/// A compact entry is always relative to the reader's own record log, which is the same thing the
+/// long shape's base check enforces: an entry under another base is not this log's business, and
+/// the writer leaves those in the long shape precisely because the compact one cannot say them.
+fn location_shard_and_field(location: &Value, record_hash_key: &str) -> Option<(String, String)> {
+    if let Some(compact) = location.as_str() {
+        let (shard, offset) = compact.split_once(':')?;
+        let shard: u64 = shard.parse().ok()?;
+        let offset: u64 = offset.parse().ok()?;
+        return Some((format!("{shard:06}"), format!("{offset:020}")));
+    }
+    let key = location.get("key").and_then(Value::as_str).unwrap_or("");
+    let field = location.get("field").and_then(Value::as_str).unwrap_or("");
+    if key.is_empty() || field.is_empty() {
+        return None;
+    }
+    // Only locations in THIS record log: the locator is shared per prefix, and a location under
+    // another base must not leak into this scan.
+    let (base, shard) = record_shard_key_parts(key)?;
+    if base != record_hash_key {
+        return None;
+    }
+    Some((shard.to_string(), field.to_string()))
+}
+
 fn record_shard_key_parts(key: &str) -> Option<(&str, &str)> {
     let (base, shard) = key.rsplit_once(':')?;
     if shard.len() != 6 || !shard.bytes().all(|byte| byte.is_ascii_digit()) {
@@ -1773,19 +1804,10 @@ fn id_scoped_payloads(
                     .map(|items| items.as_slice())
                     .unwrap_or(&[])
                 {
-                    let key = location.get("key").and_then(Value::as_str).unwrap_or("");
-                    let field = location.get("field").and_then(Value::as_str).unwrap_or("");
-                    if key.is_empty() || field.is_empty() {
-                        continue;
-                    }
-                    // Only locations in THIS record log: the locator is shared per prefix, and a
-                    // location under another base must not leak into this scan.
-                    let Some((base, shard)) = record_shard_key_parts(key) else {
+                    let Some((shard, field)) = location_shard_and_field(location, record_hash_key)
+                    else {
                         continue;
                     };
-                    if base != record_hash_key {
-                        continue;
-                    }
                     positions.insert(format!("{shard}:{field}"));
                     found += 1;
                 }
@@ -2405,20 +2427,12 @@ fn located_fields_for_ids(
             .map(|items| items.as_slice())
             .unwrap_or(&[])
         {
-            let key = location.get("key").and_then(Value::as_str).unwrap_or("");
-            let field = location.get("field").and_then(Value::as_str).unwrap_or("");
-            if key.is_empty() || field.is_empty() {
-                continue;
-            }
-            let Some((base, shard)) = record_shard_key_parts(key) else {
+            let Some((shard, field)) = location_shard_and_field(location, record_hash_key) else {
                 continue;
             };
-            if base != record_hash_key {
-                continue;
-            }
-            let fields = by_shard.entry(shard.to_string()).or_default();
-            if !fields.iter().any(|existing| existing == field) {
-                fields.push(field.to_string());
+            let fields = by_shard.entry(shard).or_default();
+            if !fields.iter().any(|existing| existing == &field) {
+                fields.push(field);
             }
         }
     }

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -8,6 +8,19 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
+try:  # package path
+    from tools.matrixark_temporal_location_codec import (
+        compact_location,
+        compact_location_list,
+        expand_location,
+    )
+except ImportError:
+    from matrixark_temporal_location_codec import (
+        compact_location,
+        compact_location_list,
+        expand_location,
+    )
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     MatrixArkLocalAdapter,
@@ -872,6 +885,41 @@ class _TemporalDirectBackendMixin:
                 seen.add(ref_hash)
         return refs
 
+    def _location_base(self) -> str:
+        """The record log every compact location is relative to.
+
+        This is the RECORD log (`{storage_prefix}:records`), not the raw-ingestion log. They are
+        different keys, and using the wrong one is silent: every entry simply fails the prefix
+        test and stays in the long form, so the encoding looks live and saves nothing.
+        """
+        base = str(getattr(self, "_record_hash_key", "") or "")
+        if base:
+            return base
+        prefix = str(getattr(self, "_storage_prefix", "") or "")
+        return ("%s:records" % prefix) if prefix else ""
+
+    def _location_token(self, location: Json) -> Json | None:
+        """One location in the form it will be STORED in, or None if it is not a location.
+
+        The merge used to expand every stored entry into `{"key", "field"}` and the writer then
+        compacted every one of them straight back -- two string formats per entry, on a list that
+        runs to four figures per ingest. Nothing in between needed the long form: the callers
+        serialize the result, count it, or compare entries to each other. So the merge now works
+        in the stored form throughout, and the compact string doubles as its own dedupe key.
+        """
+        if isinstance(location, str):
+            return location or None
+        if isinstance(location, dict):
+            key = str(location.get("key") or "")
+            field = str(location.get("field") or "")
+            if not key or not field:
+                return None
+            compact = compact_location(key, field, self._location_base())
+            if isinstance(compact, str):
+                return compact
+            return (key, field)
+        return None
+
     def _merge_ref_locations(self, existing_value: str, new_locations: list[Json]) -> list[Json]:
         locations: list[Json] = []
         resource_versions: set[str] = set()
@@ -883,21 +931,17 @@ class _TemporalDirectBackendMixin:
                 decoded = {}
             raw_locations = decoded.get("locations", []) if isinstance(decoded, dict) else []
             for location in raw_locations if isinstance(raw_locations, list) else []:
-                if not isinstance(location, dict):
+                token = self._location_token(location)
+                if token is None or token in seen:
                     continue
-                key = str(location.get("key") or "")
-                field = str(location.get("field") or "")
-                if not key or not field or (key, field) in seen:
-                    continue
-                locations.append({"key": key, "field": field})
-                seen.add((key, field))
+                locations.append(token)
+                seen.add(token)
         for location in new_locations:
-            key = str(location.get("key") or "")
-            field = str(location.get("field") or "")
-            if not key or not field or (key, field) in seen:
+            token = self._location_token(location)
+            if token is None or token in seen:
                 continue
-            locations.append({"key": key, "field": field})
-            seen.add((key, field))
+            locations.append(token)
+            seen.add(token)
         return locations
 
     def _merge_resource_versions(self, existing_value: str, new_versions: set[str]) -> list[str]:
@@ -1128,7 +1172,10 @@ class _TemporalDirectBackendMixin:
                 {
                     "key": locator_key,
                     "field": field,
-                    "value": json.dumps({"locations": merged_locations}, separators=(",", ":")),
+                    "value": json.dumps(
+                        {"locations": compact_location_list(merged_locations, self._location_base())},
+                        separators=(",", ":"),
+                    ),
                     "storage_route": route_by_hash_field.get((locator_key, field), {}),
                 }
             )
@@ -1286,7 +1333,10 @@ class _TemporalDirectBackendMixin:
         entries: list[Json] = []
         if tail_index == 0:
             merged_versions = self._merge_resource_versions(head_value, new_versions)
-            payload: Json = {"locations": merged_tail, "resource_versions": merged_versions}
+            payload: Json = {
+                "locations": compact_location_list(merged_tail, self._location_base()),
+                "resource_versions": merged_versions,
+            }
             if chunk_count:
                 payload["location_chunks"] = chunk_count
             entries.append({"key": key, "field": field, "value": json.dumps(payload, separators=(",", ":")),
@@ -1294,7 +1344,10 @@ class _TemporalDirectBackendMixin:
             return entries
 
         entries.append({"key": key, "field": tail_field,
-                        "value": json.dumps({"locations": merged_tail}, separators=(",", ":")),
+                        "value": json.dumps(
+                            {"locations": compact_location_list(merged_tail, self._location_base())},
+                            separators=(",", ":"),
+                        ),
                         "storage_route": storage_route})
         # The head carries the chunk count and the resource versions, and is rewritten only when
         # one of those actually changes -- once per chunk rollover, not once per add.

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -8,6 +8,11 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
+try:  # package path
+    from tools.matrixark_temporal_location_codec import compact_location_list, expand_location
+except ImportError:
+    from matrixark_temporal_location_codec import compact_location_list, expand_location
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     RETRIEVAL_HOT_RECORD_TYPES,
@@ -747,12 +752,13 @@ class _TemporalDirectReadMixin:
             if not isinstance(raw_locations, list):
                 continue
             locator_rows += 1
+            scan_base = str(getattr(self, "_record_hash_key", "") or "")
             for location in raw_locations:
-                if not isinstance(location, dict):
+                expanded = expand_location(location, scan_base)
+                if expanded is None:
                     continue
-                key = str(location.get("key") or "")
-                field = str(location.get("field") or "")
-                if not key or not field or (key, field) in seen:
+                key, field = expanded
+                if (key, field) in seen:
                     continue
                 locations.append({"key": key, "field": field})
                 seen.add((key, field))

--- a/tools/matrixark_temporal_direct_retrieve.py
+++ b/tools/matrixark_temporal_direct_retrieve.py
@@ -8,6 +8,11 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
+try:  # package path
+    from tools.matrixark_temporal_location_codec import compact_location_list, expand_location
+except ImportError:
+    from matrixark_temporal_location_codec import compact_location_list, expand_location
+
 try:  # names owned by the parent module
     from tools.matrixark_mcp_temporal_adapters import (
     RETRIEVAL_HOT_RECORD_TYPES,
@@ -106,12 +111,13 @@ class _TemporalDirectRetrieveMixin:
             if not isinstance(raw_locations, list):
                 continue
             locator_rows += 1
+            scan_base = str(getattr(self, "_record_hash_key", "") or "")
             for location in raw_locations:
-                if not isinstance(location, dict):
+                expanded = expand_location(location, scan_base)
+                if expanded is None:
                     continue
-                key = str(location.get("key") or "")
-                field = str(location.get("field") or "")
-                if not key or not field or (key, field) in seen:
+                key, field = expanded
+                if (key, field) in seen:
                     continue
                 locations.append({"key": key, "field": field})
                 seen.add((key, field))

--- a/tools/matrixark_temporal_location_codec.py
+++ b/tools/matrixark_temporal_location_codec.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A record location is a shard and an offset. Storing it took 69 bytes.
+
+A placement or locator row lists where records live, as
+``{"key": "matrixark:mcp:records:000003", "field": "00000000000000000014"}``. Measured over 300
+ingests, that list was **87% of every byte written to a page**: 1,132 entries per add at 69 bytes
+each, and across 339,660 entries the ``key`` took just **nine** distinct values, because the base
+is one deployment-wide string and the shard is a number that fits in three digits.
+
+So 41% of those bytes re-spelled a constant, 29% were a twenty-digit zero-padded rendering of a
+number usually under five digits, and 30% were JSON punctuation around them.
+
+The compact form is ``"3:14"`` -- shard and offset, in decimal, in one string. About six bytes
+where there were sixty-nine.
+
+Two decisions are load-bearing:
+
+* **Shard and offset are both written out**, rather than the single global sequence they can be
+  packed into. The sequence form needs the reader to know ``shard_size`` to unpack it, which makes
+  every stored location depend on a constant staying the same forever -- change it and old
+  locations silently decode to the wrong records. This form needs no shared constant.
+* **A location whose base is not the reader's own record log stays a dict.** Readers already skip
+  foreign bases; compacting one would assert something the form cannot express.
+
+Decoding accepts both shapes, so a store written before this reads unchanged, and
+``MATRIXARK_COMPACT_LOCATIONS=0`` returns the writer to the long form without touching readers.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+SHARD_DIGITS = 6
+FIELD_DIGITS = 20
+
+
+def compact_locations_enabled() -> bool:
+    """ON by default; ``MATRIXARK_COMPACT_LOCATIONS=0`` is the escape hatch."""
+    return os.environ.get("MATRIXARK_COMPACT_LOCATIONS", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def compact_location(key: str, field: str, base: str) -> Any:
+    """``(key, field)`` as ``"shard:offset"`` when it belongs to ``base``, else the dict as-is."""
+    original = {"key": key, "field": field}
+    if not compact_locations_enabled() or not base:
+        return original
+    if not key.startswith(base + ":"):
+        return original
+    shard = key[len(base) + 1 :]
+    if len(shard) != SHARD_DIGITS or not shard.isdigit():
+        return original
+    if len(field) != FIELD_DIGITS or not field.isdigit():
+        return original
+    return "%d:%d" % (int(shard), int(field))
+
+
+def compact_location_list(locations: list, base: str) -> list:
+    """Compact every entry that can be, leaving the rest exactly as they are."""
+    out = []
+    for entry in locations or []:
+        if isinstance(entry, dict):
+            key = str(entry.get("key") or "")
+            field = str(entry.get("field") or "")
+            if key and field:
+                out.append(compact_location(key, field, base))
+                continue
+        elif isinstance(entry, tuple) and len(entry) == 2:
+            # The merge's token for a location it could not compact -- a foreign base. It has to
+            # go back out as the long form, which is the only shape that can express it.
+            out.append({"key": str(entry[0]), "field": str(entry[1])})
+            continue
+        out.append(entry)
+    return out
+
+
+def expand_location(entry: Any, base: str) -> tuple[str, str] | None:
+    """Any stored location shape -> ``(key, field)``, or ``None`` if it is neither."""
+    if isinstance(entry, str):
+        shard, _, offset = entry.partition(":")
+        if not shard.isdigit() or not offset.isdigit() or not base:
+            return None
+        return (
+            "%s:%0*d" % (base, SHARD_DIGITS, int(shard)),
+            "%0*d" % (FIELD_DIGITS, int(offset)),
+        )
+    if isinstance(entry, dict):
+        key = str(entry.get("key") or "")
+        field = str(entry.get("field") or "")
+        if not key or not field:
+            return None
+        return key, field
+    return None


### PR DESCRIPTION
A placement or locator row lists where records live. Each entry looked like this:

```json
{"key":"matrixark:mcp:records:000003","field":"00000000000000000014"}
```

Measured over 300 ingests by walking the page segments: **1,132 such entries per add**, 69 bytes
each. Across 339,660 entries the `key` took **nine** distinct values, because the base is one
deployment-wide string and the shard is a number under three digits. So 41% of those bytes
re-spelled a constant, 29% were a twenty-digit rendering of a number usually under five digits, and
30% was JSON punctuation around them.

The compact form is `"3:14"` -- shard and offset, in decimal. Six bytes where there were
sixty-nine.

Measured, 300 adds into one subject, both arms in one run:

```text
                    pages/add    add p50    retrieve
long form            102.74 KB   443.4 ms   [0, 12, 24]
compact               91.00 KB   359.5 ms   [0, 12, 24]
```

**11.4% off every page byte and 19% off add latency.** The latency is not a side effect: the merge
used to expand every stored entry into a dict and the writer compacted every one of them straight
back, so a four-figure list was formatted twice per ingest for nothing. The merge now dedupes in
the stored form, and the compact string doubles as its own dedupe key -- which is less work than
the code did *before* this change.

The disk saving is smaller than the byte counts suggest, and that is worth saying plainly: pages
are compressed, and a repeated 28-character string is exactly what a compressor eats. The logical
payload falls by far more than the stored bytes do.

Two decisions are load-bearing:

* **Shard and offset are both written out**, not the single sequence they pack into. The packed
  form needs the reader to know `shard_size` to unpack it, so every stored location would depend on
  that constant never changing -- change it and old locations decode to the *wrong records*, and
  nothing would say so. This form needs no shared constant.
* **A location whose base is not the reader's own record log stays a dict.** Readers already skip
  foreign bases; compacting one would assert something the form cannot express.

Decoding accepts both shapes, so an existing store reads unchanged, and
`MATRIXARK_COMPACT_LOCATIONS=0` returns the writer to the long form.

The proxy's two locator readers learned the compact form in the same change. That is not optional:
one of them drives the delete path, and a reader that skipped an entry it did not recognise would
silently leave records undeleted.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, `cargo check --all-targets` clean,
and retrieval returning the same items on both arms.
