### PR TITLE
one engine served another engine's pages, for any key they both held

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -615,6 +615,18 @@ pub struct LocalBlockStore {
     inner: Arc<Mutex<BlockStoreInner>>,
 }
 
+impl LocalBlockStore {
+    /// Which store this is, as a value that can be compared and hashed.
+    ///
+    /// Clones of one store share their inner handle, so they answer the same; two engines --
+    /// which is what an embedded process runs several of -- never do. That distinction is the
+    /// only thing separating two engines that both serve shard 1 and both hold a key called
+    /// "user:1", so anything keyed per object has to include it.
+    pub fn store_id(&self) -> usize {
+        Arc::as_ptr(&self.inner) as *const u8 as usize
+    }
+}
+
 #[derive(Debug)]
 struct BlockStoreInner {
     root: PathBuf,

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -710,8 +710,14 @@ impl TemporalEngine {
                 // still equals apply order (reservation + byte-append stay under this lock).
                 // The reserve-only branch appends bytes without pages, so a write carrying
                 // pages must take the staged branch or they would be dropped on the floor.
+                // The reserve-only branch appends bytes and nothing else, so anything the
+                // record has to CARRY -- pages handed in, or the outcomes this write recorded --
+                // forces the staged branch or it would be dropped on the floor. Recording
+                // outcomes therefore costs the group-commit coalescing while the gate is on,
+                // which is one more reason the flip waits until the command comes out.
                 let concurrent_commit = sync
                     && carried_pages.is_empty()
+                    && !crate::wal::wal_outcome_items_enabled()
                     && (engine_concurrent_commit() || raft_apply_batch_active());
                 // Where each page this write stages ends up, so the index can carry it. Filled
                 // by the append below, which is the first moment the log id exists.
@@ -723,7 +729,7 @@ impl TemporalEngine {
                         .map(|record| Some(record.sequence))
                 } else {
                     self.wal_store
-                        .append_with_sync_staged(
+                        .append_with_outcomes(
                             request.shard_id,
                             command,
                             sync,
@@ -742,6 +748,11 @@ impl TemporalEngine {
                                 }
                                 std::mem::take(&mut carried_pages)
                             },
+                            if crate::wal::wal_outcome_items_enabled() {
+                                block_in_wal::take_outcomes()
+                            } else {
+                                Vec::new()
+                            },
                         )
                         .map(|(record, log_id)| {
                             // Point every page this record carries at the record, keyed on the
@@ -749,6 +760,7 @@ impl TemporalEngine {
                             // carries, so a read finds it by identity rather than by timing.
                             if block_in_wal::enabled() {
                                 block_in_wal::register_record(
+                                    &self.page_store,
                                     request.shard_id,
                                     &record.staged_pages,
                                     log_id,
@@ -3258,7 +3270,9 @@ fn read_page_bytes(
         // parses a log record.
         if block_in_wal::enabled() {
             if let Some(bytes) =
-                address.object_id.and_then(|object_id| block_in_wal::read_page(shard_id, object_id))
+                address
+                    .object_id
+                    .and_then(|object_id| block_in_wal::read_page(page_store, shard_id, object_id))
             {
                 let _ = cache.put(cache_key, bytes.clone());
                 return Some(bytes);

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -77,6 +77,7 @@ thread_local! {
 /// attach to an unrelated record.
 pub(super) fn begin_write() {
     STAGED.with(|staged| staged.borrow_mut().clear());
+    OUTCOMES.with(|outcomes| outcomes.borrow_mut().clear());
 }
 
 /// Put a page aside for the record this write is about to append.
@@ -87,6 +88,25 @@ pub(super) fn stage(object_id: u64, bytes: &[u8]) {
             bytes: bytes.to_vec(),
         })
     });
+}
+
+thread_local! {
+    /// Index outcomes produced by the write currently executing on this thread.
+    static OUTCOMES: RefCell<Vec<crate::wal::WalOutcomeItem>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// Put aside what this write DID: which object, and where its page now lives.
+///
+/// Staged for the same reason pages are -- the record does not exist yet, so there is nowhere
+/// to put it until the append.
+pub(super) fn stage_outcome(item: crate::wal::WalOutcomeItem) {
+    OUTCOMES.with(|outcomes| outcomes.borrow_mut().push(item));
+}
+
+/// Take what this write recorded doing, leaving nothing behind.
+pub(super) fn take_outcomes() -> Vec<crate::wal::WalOutcomeItem> {
+    OUTCOMES.with(|outcomes| std::mem::take(&mut *outcomes.borrow_mut()))
 }
 
 /// Take what this write staged, leaving nothing behind.
@@ -106,8 +126,15 @@ pub(super) fn take_staged() -> Vec<StagedPage> {
 /// sequence (see [`min_registered_sequence`]).
 type Registration = (LocalWriteAheadLogStore, u64, u64);
 
-fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<(ShardId, u64), Registration>>> = OnceLock::new();
+/// Keyed by the STORE as well as the shard and object.
+///
+/// An object id is derived from kind + key, not from who wrote it, and every embedded engine in
+/// a process serves shard 1. Keyed on (shard, object) alone, the last engine to write a key owned
+/// that key for the whole process and handed its own log to whoever asked next -- so one engine
+/// served another engine's bytes for any key they happened to share.
+fn registry() -> &'static Mutex<HashMap<(usize, ShardId, u64), Registration>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<(usize, ShardId, u64), Registration>>> =
+        OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -117,6 +144,7 @@ fn registry() -> &'static Mutex<HashMap<(ShardId, u64), Registration>> {
 /// A later write of the same object replaces its entry, so a registration always names the
 /// record holding the current page rather than a superseded one.
 pub(super) fn register_record(
+    block_store: &crate::block_store::LocalBlockStore,
     shard_id: ShardId,
     staged_pages: &[StagedPage],
     log_id: u64,
@@ -128,7 +156,10 @@ pub(super) fn register_record(
     }
     if let Ok(mut map) = registry().lock() {
         for page in staged_pages {
-            map.insert((shard_id, page.object_id), (store.clone(), log_id, sequence));
+            map.insert(
+                (block_store.store_id(), shard_id, page.object_id),
+                (store.clone(), log_id, sequence),
+            );
         }
     }
 }
@@ -139,6 +170,7 @@ pub(super) fn register_record(
 /// index. Same fact, different source, so it lands in the same table -- which is what lets the
 /// read path stay exactly as it was.
 pub(super) fn register_at(
+    block_store: &crate::block_store::LocalBlockStore,
     shard_id: ShardId,
     object_id: u64,
     log_id: u64,
@@ -146,7 +178,10 @@ pub(super) fn register_at(
     store: &LocalWriteAheadLogStore,
 ) {
     if let Ok(mut map) = registry().lock() {
-        map.insert((shard_id, object_id), (store.clone(), log_id, sequence));
+        map.insert(
+            (block_store.store_id(), shard_id, object_id),
+            (store.clone(), log_id, sequence),
+        );
     }
 }
 
@@ -159,21 +194,25 @@ pub(super) fn register_at(
 /// embedded engine serves shard 1, so without the filter one engine's registrations would pin
 /// every other engine's reclaim floor forever.
 pub(super) fn min_registered_sequence(
+    block_store: &crate::block_store::LocalBlockStore,
     shard_id: ShardId,
     store: &LocalWriteAheadLogStore,
 ) -> Option<u64> {
     let map = registry().lock().ok()?;
     map.iter()
-        .filter(|((shard, _), (reg_store, _, _))| *shard == shard_id && reg_store.same_log(store))
+        .filter(|((owner, shard, _), (reg_store, _, _))| {
+            *owner == block_store.store_id() && *shard == shard_id && reg_store.same_log(store)
+        })
         .map(|(_, (_, _, sequence))| *sequence)
         .min()
 }
 
 /// Forget a shard's registrations. Called when the shard unloads; a reload replays the WAL and
 /// re-derives whatever it needs.
-pub(super) fn clear_shard(shard_id: ShardId) {
+pub(super) fn clear_shard(block_store: &crate::block_store::LocalBlockStore, shard_id: ShardId) {
     if let Ok(mut map) = registry().lock() {
-        map.retain(|(shard, _), _| *shard != shard_id);
+        let owner = block_store.store_id();
+        map.retain(|(store_id, shard, _), _| !(*store_id == owner && *shard == shard_id));
     }
 }
 
@@ -182,8 +221,16 @@ pub(super) fn clear_shard(shard_id: ShardId) {
 /// `None` means the object was never registered, its record has been reclaimed, or the record
 /// does not carry that page -- in every case the caller falls through to the behaviour it had
 /// before, so this can only turn a miss into a hit.
-pub(super) fn read_page(shard_id: ShardId, object_id: u64) -> Option<Vec<u8>> {
-    let (store, log_id, _) = registry().lock().ok()?.get(&(shard_id, object_id))?.clone();
+pub(super) fn read_page(
+    block_store: &crate::block_store::LocalBlockStore,
+    shard_id: ShardId,
+    object_id: u64,
+) -> Option<Vec<u8>> {
+    let (store, log_id, _) = registry()
+        .lock()
+        .ok()?
+        .get(&(block_store.store_id(), shard_id, object_id))?
+        .clone();
     // One batch record carries many pages, and an ingest reads several of the fields its own
     // batch just wrote -- so the same record used to be pread and re-parsed once per page. WAL
     // records are immutable once written (append-only), so a small decoded-record LRU cannot go

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -388,6 +388,20 @@ impl TemporalEngine {
     /// re-appending to the WAL or re-persisting the index per record, then anchor and
     /// persist the reconstructed index once. Matches the WAL replay path,
     /// including its strict sequence-continuity check.
+    /// The address the index holds for a string key, so a test can compare it against what a
+    /// record claims the write did.
+    pub(super) fn string_page_address(
+        &self,
+        shard_id: ShardId,
+        key: &str,
+    ) -> Option<crate::block_store::BlockAddress> {
+        self.shards
+            .read()
+            .expect("engine lock poisoned")
+            .get(&shard_id)
+            .and_then(|shard| shard.strings.get(key).cloned())
+    }
+
     /// How many WAL-resident page locations this shard's index is carrying.
     ///
     /// The point of the map is that it is part of the index rather than process state, so a
@@ -416,6 +430,7 @@ impl TemporalEngine {
         };
         for (object_id, placement) in &shard.wal_resident_pages {
             super::block_in_wal::register_at(
+                &self.page_store,
                 shard_id,
                 *object_id,
                 placement.log_id,
@@ -652,7 +667,7 @@ impl TemporalEngine {
         hot_page_spill::clear_shard(request.shard_id);
         // Drop this shard's WAL-resident registrations too: they name records in a log this
         // engine no longer serves, and a reload re-derives them from the WAL anyway.
-        block_in_wal::clear_shard(request.shard_id);
+        block_in_wal::clear_shard(&self.page_store, request.shard_id);
         UnloadShardResponse {
             status: Status::ok(),
         }
@@ -852,6 +867,7 @@ mod batch_truncation_tests {
             command,
             metadata: Some(metadata),
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         }
     }
 

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -551,7 +551,7 @@ impl TemporalEngine {
         // (the write was acked off a synthetic address), so truncating it turns an acked write
         // into a MISSING read while the process is still serving.
         let wal_retention_floor =
-            super::block_in_wal::min_registered_sequence(shard_id, &self.wal_store);
+            super::block_in_wal::min_registered_sequence(&self.page_store, shard_id, &self.wal_store);
         match wal_retention_floor {
             Some(sequence) => self.wal_store.set_block_retention_floor(shard_id, sequence),
             None => self.wal_store.clear_block_retention_floor(shard_id),

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1127,6 +1127,20 @@ pub(super) fn upsert_bucket_index_page(
     let object_id = address
         .object_id
         .unwrap_or_else(|| stable_page_object_id(shard_id, kind, object_key, component.as_deref()));
+    // This IS the outcome: an object, its identity, and where its page ended up. Put it aside
+    // for the record, so replay has the option of installing it instead of re-running the
+    // command that produced it.
+    if crate::wal::wal_outcome_items_enabled() {
+        super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
+            kind: kind.to_string(),
+            object_key: object_key.to_string(),
+            component: component.clone(),
+            object_id,
+            routing_bucket,
+            address: address.clone(),
+            deleted: false,
+        });
+    }
     let entry = LivePageEntry {
         object_key: object_key.to_string(),
         kind: kind.to_string(),

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1511,6 +1511,7 @@ fn wal_replay_gap_refuses_load_like_dataloss() {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         })
         .unwrap();
     }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4064,6 +4064,253 @@ fn a_store_that_puts_no_pages_in_the_log_carries_no_locations() {
     assert_eq!(engine.wal_resident_page_count(1), 0);
 }
 
+/// A record can state what the write DID, and that statement has to match what the command
+/// actually produced.
+///
+/// This is the obligation that has to be discharged before replay can install outcomes instead
+/// of re-running commands. If an item disagreed with the index entry the command built, then
+/// switching replay over would silently rebuild a different shard.
+#[test]
+fn a_recorded_outcome_matches_the_index_entry_the_command_produced() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
+
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: "outcome-key".to_string(),
+                    value: b"outcome-value".to_vec(),
+                },
+            })
+            .status
+            .ok
+    );
+    std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap();
+    let record = records
+        .iter()
+        .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+        .find(|record| !record.outcomes.is_empty())
+        .expect("the record must state what the write did");
+
+    let item = record
+        .outcomes
+        .iter()
+        .find(|item| item.object_key == "outcome-key")
+        .expect("the object it touched must be named");
+    assert_eq!(item.kind, "string");
+    assert!(!item.deleted);
+    assert_eq!(item.object_id, item.address.object_id.unwrap_or_default());
+
+    // The claim has to equal what the index actually holds. This is the whole point.
+    let indexed = engine
+        .string_page_address(1, "outcome-key")
+        .expect("the index holds an address for the key");
+    assert_eq!(
+        item.address, indexed,
+        "the recorded outcome disagrees with the index entry the command built"
+    );
+}
+
+/// With the gate off a record carries no outcomes, so it is byte-identical to before.
+#[test]
+fn a_record_carries_no_outcomes_unless_asked() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    std::env::set_var("TS_WAL_OUTCOME_ITEMS", "0");
+    assert!(
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: "plain".to_string(),
+                    value: b"v".to_vec(),
+                },
+            })
+            .status
+            .ok
+    );
+    std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap();
+    assert!(
+        records
+            .iter()
+            .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+            .all(|record| record.outcomes.is_empty()),
+        "no record should carry outcomes with the gate off"
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Multiple engines in ONE process. The embedded path (the gateway proxy) does exactly this,
+// and every embedded engine serves shard 1 -- so anything keyed on (shard, object) alone is
+// shared between engines that have nothing to do with each other.
+// ---------------------------------------------------------------------------------------
+
+/// Two engines, same shard id, same object key: each must read back its OWN value.
+///
+/// The page resolver is a process-wide table keyed on (shard, object id), and a page's object
+/// id is derived from kind + key -- not from which engine wrote it. Two embedded engines
+/// therefore collide on every key they happen to share, and the only thing separating them is
+/// that a registration also remembers WHICH log it points into.
+#[test]
+fn two_engines_in_one_process_do_not_read_each_others_pages() {
+    let dir = tempfile::tempdir().unwrap();
+    let make = |name: &str| {
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join(format!("{name}-cache")),
+            dir.path().join(format!("{name}-pages")),
+            dir.path().join(format!("{name}-index")),
+        );
+        engine.load_shard(1);
+        engine.set_config(SetConfigRequest {
+            shard_id: 1,
+            config: Config {
+                version: 2,
+                async_storage: true,
+                ..Config::default()
+            },
+        });
+        engine
+    };
+
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    std::env::set_var("TS_HOT_PAGE_SPILL", "0");
+
+    let first = make("first");
+    let second = make("second");
+
+    // Same shard, same key, different values, different engines.
+    for (engine, value) in [(&first, b"from-first".to_vec()), (&second, b"from-second".to_vec())] {
+        assert!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: "shared-key".to_string(),
+                        value,
+                    },
+                })
+                .status
+                .ok
+        );
+    }
+
+    // Drop every cached copy so the read has to go through the resolver, which is the shared
+    // thing. If it resolved by (shard, object) alone, one engine would serve the other's bytes.
+    first.cache().invalidate_shard(1).unwrap();
+    second.cache().invalidate_shard(1).unwrap();
+
+    let read = |engine: &TemporalEngine| {
+        engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: "shared-key".to_string(),
+                },
+            })
+            .response
+    };
+    let first_read = read(&first);
+    let second_read = read(&second);
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+    std::env::remove_var("TS_HOT_PAGE_SPILL");
+
+    assert_eq!(
+        first_read,
+        CommandResponse::Bytes {
+            value: Some(b"from-first".to_vec())
+        },
+        "the first engine read the wrong engine's page"
+    );
+    assert_eq!(
+        second_read,
+        CommandResponse::Bytes {
+            value: Some(b"from-second".to_vec())
+        },
+        "the second engine read the wrong engine's page"
+    );
+}
+
+/// One engine's log-resident pages must not pin another engine's reclaim floor.
+///
+/// The retention floor is the lowest sequence any live registration still depends on. Computed
+/// across the whole process it would be pinned by every OTHER engine's writes forever, and a
+/// shard that had dumped everything would never be able to reclaim.
+#[test]
+fn one_engines_retention_floor_ignores_another_engines_registrations() {
+    let dir = tempfile::tempdir().unwrap();
+    let make = |name: &str| {
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join(format!("{name}-cache")),
+            dir.path().join(format!("{name}-pages")),
+            dir.path().join(format!("{name}-index")),
+        );
+        engine.load_shard(1);
+        engine.set_config(SetConfigRequest {
+            shard_id: 1,
+            config: Config {
+                version: 2,
+                async_storage: true,
+                ..Config::default()
+            },
+        });
+        engine
+    };
+
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    let busy = make("busy");
+    let quiet = make("quiet");
+
+    // The busy engine registers pages; the quiet one writes nothing at all.
+    for index in 0..8 {
+        assert!(
+            busy.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("busy-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            })
+            .status
+            .ok
+        );
+    }
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+
+    // The quiet engine's log has nothing registered against it, so nothing holds its floor.
+    assert_eq!(
+        quiet.write_ahead_log_store().block_retention_floor(1),
+        None,
+        "another engine's registrations pinned this engine's reclaim floor"
+    );
+}
+
 /// What waiting before a dump saves, and what the wait costs.
 ///
 /// A bucket is dumped, dirtied again by the very next write, and dumped again. Letting the log

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -211,6 +211,84 @@ pub struct WriteAheadLogRecord {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub staged_pages: Vec<StagedPage>,
+    /// What this write did, stated as results rather than as the operation that caused them.
+    ///
+    /// Called `outcomes` and not `items` on purpose: [`WriteAheadLogRecordMetadata`] already has
+    /// an `items` field describing the record's shape, and two different `items` on one record
+    /// would be read wrong by whoever came next.
+    ///
+    /// Empty and skipped unless [`wal_outcome_items_enabled`], so every record written without
+    /// it is byte-identical to before.
+    #[serde(
+        rename = "t",
+        alias = "outcomes",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub outcomes: Vec<WalOutcomeItem>,
+}
+
+/// TS_WAL_OUTCOME_ITEMS: also record what a write DID, beside the command that did it.
+///
+/// The log records commands, so replay re-executes them -- which reproduces state only if
+/// everything that influenced the original execution is reproduced too. That is why replay has
+/// to walk a config log to re-apply the eviction config effective at each record, and why it
+/// pins a replay clock so TTLs resolve against the leader's timestamp instead of the restart
+/// clock. Both are scar tissue from logging operations rather than results.
+///
+/// An outcome states the result instead: this object's page now lives at this address, or this
+/// object is gone. Replay can install that without running anything.
+///
+/// Default OFF while both are carried, because carrying both makes every record bigger and the
+/// payoff only arrives when replay switches to the outcomes and the command comes out. The flip
+/// belongs with that change, not before it.
+pub fn wal_outcome_items_enabled() -> bool {
+    matches!(
+        std::env::var("TS_WAL_OUTCOME_ITEMS")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn outcome_not_deleted(deleted: &bool) -> bool {
+    !*deleted
+}
+
+/// One index mutation a write produced, stated as a result.
+///
+/// Field for field this is the identity half of the log item being followed: the object it
+/// names, the kind/model it belongs to, its routing bucket, its object id, and where its page
+/// ended up. `deleted` covers the other outcome. Nothing here says which command ran, because
+/// replay does not need to know -- that is the entire point.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WalOutcomeItem {
+    #[serde(rename = "k", alias = "kind")]
+    pub kind: String,
+    #[serde(rename = "o", alias = "object_key")]
+    pub object_key: String,
+    #[serde(
+        rename = "c",
+        alias = "component",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub component: Option<String>,
+    #[serde(rename = "i", alias = "object_id")]
+    pub object_id: u64,
+    #[serde(rename = "b", alias = "routing_bucket")]
+    pub routing_bucket: u32,
+    #[serde(rename = "a", alias = "address")]
+    pub address: crate::block_store::BlockAddress,
+    #[serde(
+        rename = "d",
+        alias = "deleted",
+        default,
+        skip_serializing_if = "outcome_not_deleted"
+    )]
+    pub deleted: bool,
 }
 
 /// A page put aside during a write, to be carried in that write's log record.
@@ -663,7 +741,7 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
     ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
-        self.append_with_sync_inner(shard_id, command, sync, Vec::new())
+        self.append_with_sync_inner(shard_id, command, sync, Vec::new(), Vec::new())
     }
 
     /// Append, carrying pages this write produced, and report the log id it landed at.
@@ -677,7 +755,20 @@ impl LocalWriteAheadLogStore {
         sync: bool,
         staged_pages: Vec<StagedPage>,
     ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
-        self.append_with_sync_inner(shard_id, command, sync, staged_pages)
+        self.append_with_sync_inner(shard_id, command, sync, staged_pages, Vec::new())
+    }
+
+    /// [`append_with_sync_staged`](Self::append_with_sync_staged), also carrying what the write
+    /// DID -- see [`WalOutcomeItem`].
+    pub fn append_with_outcomes(
+        &self,
+        shard_id: ShardId,
+        command: Command,
+        sync: bool,
+        staged_pages: Vec<StagedPage>,
+        outcomes: Vec<WalOutcomeItem>,
+    ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
+        self.append_with_sync_inner(shard_id, command, sync, staged_pages, outcomes)
     }
 
     pub fn append_with_sync(
@@ -686,7 +777,7 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
-        self.append_with_sync_inner(shard_id, command, sync, Vec::new())
+        self.append_with_sync_inner(shard_id, command, sync, Vec::new(), Vec::new())
             .map(|(record, _)| record)
     }
 
@@ -696,6 +787,7 @@ impl LocalWriteAheadLogStore {
         command: Command,
         sync: bool,
         staged_pages: Vec<StagedPage>,
+        outcomes: Vec<WalOutcomeItem>,
     ) -> Result<(WriteAheadLogRecord, u64), WriteAheadLogError> {
         // In group-commit mode the durable barrier is deferred out of the append
         // critical section (below), so the byte-append records with sync=false and the
@@ -720,6 +812,7 @@ impl LocalWriteAheadLogStore {
                 metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
                 command,
                 staged_pages,
+                outcomes,
             };
             let report = append_record_locked(&mut inner, &rec, sync && !group, Some(on_disk_len))?;
             inner.stats.last_sequence = report.current_sequence;
@@ -787,6 +880,7 @@ impl LocalWriteAheadLogStore {
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
             command,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         // sync=false: write the bytes, defer the fdatasync to `commit_barrier`. Same as the
         // group branch of append_with_sync. `last_flushed_sequence` is NOT advanced here (the
@@ -883,6 +977,7 @@ impl LocalWriteAheadLogStore {
                     metadata: Some(metadata),
                     command,
                     staged_pages: Vec::new(),
+                    outcomes: Vec::new(),
                 };
                 // Buffer every record (sync=false); the single durability barrier below covers
                 // the whole batch. append_record_locked keeps last_flushed_sequence honest -- it
@@ -2910,6 +3005,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let mut raw = serde_json::to_vec(&make(1, "k1")).unwrap();
         raw.push(b'\n');
@@ -3099,6 +3195,7 @@ mod tests {
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
             command,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
 
         let first = store.append_replayed_record(replayed.clone()).unwrap();
@@ -3785,6 +3882,7 @@ mod tests {
                 object_id: 7,
                 bytes: page.clone(),
             }],
+            outcomes: Vec::new(),
         };
         let encoded = serde_json::to_vec(&record).unwrap();
         let overhead = encoded.len() as f64 / page.len() as f64;
@@ -3822,6 +3920,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let encoded = String::from_utf8(serde_json::to_vec(&record).unwrap()).unwrap();
         assert!(
@@ -4063,6 +4162,7 @@ mod tests {
                 batch_index: None,
             }),
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let encoded = serde_json::to_string(&record).unwrap();
         assert!(
@@ -4393,6 +4493,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let framed = crate::log_framing::encode_line(&encode_wal_payload(&record).unwrap());
         assert!(
@@ -4419,6 +4520,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let framed = crate::log_framing::encode_line(&encode_wal_payload(&record).unwrap());
         assert_eq!(decode_wal_line(&framed).unwrap(), record);
@@ -4437,6 +4539,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let payload = encode_wal_payload(&record).unwrap();
         assert!(
@@ -4458,6 +4561,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let payload = encode_wal_payload(&record).unwrap();
         assert_eq!(
@@ -4497,6 +4601,7 @@ mod tests {
             },
             metadata: None,
             staged_pages: Vec::new(),
+            outcomes: Vec::new(),
         };
         let mut payload = encode_wal_payload(&record).unwrap();
         payload.truncate(payload.len() - 40);

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -325,6 +325,7 @@ mod tests {
                     batch_index: None,
                 }),
                 staged_pages: Vec::new(),
+                outcomes: Vec::new(),
             };
             let today = crate::log_framing::encode_line(&serde_json::to_vec(&record).unwrap());
 
@@ -440,6 +441,7 @@ mod tests {
                     batch_index: None,
                 }),
                 staged_pages: Vec::new(),
+                outcomes: Vec::new(),
             };
             let framed = crate::log_framing::encode_line(&serde_json::to_vec(&record).unwrap());
             // base64 of n bytes is 4 characters per 3, rounded up to a multiple of 4.


### PR DESCRIPTION
one engine served another engine's pages, for any key they both held

Two engines in one process, both serving shard 1, both holding a key called "shared-key":
the first one reads back the second one's bytes. A test says so, and it fails the same way
on the commit before this one.

The page registry was keyed on (shard_id, object_id). An object id is derived from kind plus
key, not from who wrote it, and every embedded engine in a process serves shard 1 -- the
gateway proxy runs several. So the last engine to write a key owned that key for the whole
process, and handed its own log to whoever asked next.

What makes this a signature problem rather than an oversight: two of the three consumers
already defended against exactly this. min_registered_sequence filters on same_log, and the
decoded-record LRU filters on same_log. Only read_page did not -- and it could not, because
its signature (shard_id, object_id) never received the identity of whoever was asking.

LocalBlockStore is Arc-backed, so clones of one store answer the same and two engines never
do, and the read site was already being handed the block store it was reading from. So the
identity was in scope the whole time; nothing had asked for it. store_id() exposes it, the
registry key becomes (store_id, shard_id, object_id), and the five functions that touch the
registry take the store they mean. All five callers already had it.

No read path had to be threaded for this. read_page_bytes has taken the right object as an
argument since before the registry existed.

Also here, gated off: a record can now state what a write DID, not only what it was told to
do -- object key, kind, component, object id, routing bucket, the address its page landed at,
and a deleted flag. That is the identity half of the log item this design follows, whose own
item type carries no opcode at all.

Emitting it costs nothing extra to compute: upsert_bucket_index_page was already building
exactly that shape as LivePageEntry at every write site, and throwing it away. What it does
cost while the gate is on is the group-commit coalescing, because the reserve-only append
branch carries bytes and nothing else -- so anything the record must CARRY forces the staged
branch. Pages hit that same edge earlier; it is now two features deep and worth knowing about.

The gate stays off because carrying both a command and its outcomes makes every record bigger
for no gain. The payoff arrives when replay installs the outcomes and the command comes out,
which is also when the two scars of command-replay can go: the config-log walk that re-applies
the eviction config effective at each record, and the replay clock that resolves TTLs against
the leader's timestamp. Neither exists in a log that records results.

What this change buys now is the obligation discharged: a test asserting the recorded outcome
equals the index entry the command actually produced. If those ever disagree, switching replay
would silently rebuild a different shard.

Tests: two engines do not read each other's pages; one engine's registrations do not pin
another's reclaim floor; a recorded outcome matches the index entry; a record carries no

🤖 Generated with [Claude Code](https://claude.com/claude-code)
