### PR TITLE
a large document was scanned once per entity it produced

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -16,6 +16,7 @@ import select
 import shutil
 import socket
 import subprocess
+import functools
 import hashlib
 import json
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -1753,31 +1754,52 @@ def extract_batch_entities(messages: list[Json], envelope: Json) -> list[Json]:
     return dedupe_entities(entities)
 
 
+_PATCH_CORRECTION_RE = re.compile(
+    r"\b(?:correction|correct|wrong|updated|changed)[:\s]+([^.;!?]+?)\s+(?:instead\s+of|not)\s+([^.;!?]+)",
+    flags=re.IGNORECASE,
+)
+_PATCH_PREFERENCE_RE = re.compile(
+    r"\b(?:prefer|prefers|favorite|likes?|loves?)\s+([^.;!?]+?)\s+(?:now|instead\s+of|not)\s+([^.;!?]+)",
+    flags=re.IGNORECASE,
+)
+_PATCH_NEGATIVE_RE = re.compile(
+    r"\b(?:never|avoid(?:s)?|do(?:es)?\s+not|don't|doesn't|cannot|can't|should\s+not|must\s+not)\s+([^.;!?]+)",
+    flags=re.IGNORECASE,
+)
+
+
+@functools.lru_cache(maxsize=4)
+def _whole_text_patch_scans(text: str):
+    """The three scans that read the WHOLE document, done once per document.
+
+    `infer_entity_field_patches` is called once per extracted entity, and each call used to run
+    these three searches across the entire text. The entity count grows with the document, so the
+    work grew as its square: a 256 KB markdown ingest spent ~33 seconds here, against ~1.2 s for a
+    JSON document of the same size that produced far fewer entities.
+
+    None of the three depend on the entity -- only on the text. Which patch is *kept* still depends
+    on `entity_type`, and that check is unchanged; this only stops recomputing the same three
+    answers. The cache is keyed on the text itself and holds four entries, which is enough for one
+    ingest to reuse its own document while never pinning more than a handful.
+    """
+    return (
+        _PATCH_CORRECTION_RE.search(text),
+        _PATCH_PREFERENCE_RE.search(text),
+        _PATCH_NEGATIVE_RE.search(text),
+    )
+
+
 def infer_entity_field_patches(entity_type: str, value: str, text: str) -> list[Json]:
     patches: list[Json] = []
-    correction = re.search(
-        r"\b(?:correction|correct|wrong|updated|changed)[:\s]+([^.;!?]+?)\s+(?:instead\s+of|not)\s+([^.;!?]+)",
-        text,
-        flags=re.IGNORECASE,
-    )
+    correction, preference, negative_preference = _whole_text_patch_scans(text)
     if correction:
         replace = clean_patch_value(correction.group(1))
         search = clean_patch_value(correction.group(2))
         patches.append(entity_patch(search, replace))
-    preference = re.search(
-        r"\b(?:prefer|prefers|favorite|likes?|loves?)\s+([^.;!?]+?)\s+(?:now|instead\s+of|not)\s+([^.;!?]+)",
-        text,
-        flags=re.IGNORECASE,
-    )
     if entity_type == "preference" and preference:
         replace = clean_patch_value(preference.group(1))
         search = clean_patch_value(preference.group(2))
         patches.append(entity_patch(search, replace))
-    negative_preference = re.search(
-        r"\b(?:never|avoid(?:s)?|do(?:es)?\s+not|don't|doesn't|cannot|can't|should\s+not|must\s+not)\s+([^.;!?]+)",
-        text,
-        flags=re.IGNORECASE,
-    )
     if entity_type == "preference" and negative_preference and not patches:
         patches.append(entity_patch("", "avoid " + clean_patch_value(negative_preference.group(1))))
     evolving_entity_types = {


### PR DESCRIPTION
Ingesting a 256 KB markdown document took **37.7 seconds**. A JSON document of the same size took
1.2. Sampling the process found it CPU-bound, on the GIL, in one stack every time:

```text
search (re.py:200)
infer_entity_field_patches (tools/matrixark_mcp_core.py)
extract_batch_entities (tools/matrixark_mcp_core.py)
one_pass_memory_extraction (tools/matrixark_mcp_core.py)
```

`infer_entity_field_patches` opens with three `re.search` calls **over the whole document**, and
`extract_batch_entities` calls it **once per extracted entity**. The entity count grows with the
document, so the work grows as its square. Markdown showed it and JSON did not because the same
byte count in prose yields far more entities than one long array does -- the shape of the input,
not its size, decided how many times the document was re-read.

None of the three scans depend on the entity. Only which patch is *kept* does, and that check is
untouched. They now run once per document, memoized on the text.

```text
             before        after
 md  16 KB    1 431 ms      567 ms
 md  64 KB    2 981 ms      484 ms
 md 256 KB   37 726 ms    2 949 ms      12.8x
```

The curve matters more than any single row: 4x the document used to cost 12.6x the time and now
costs about 6x, so this stops being the thing that decides whether a large file can be ingested at
all. JSON is unchanged at every size, which is the control -- it was never paying this cost.

The three patterns are also pre-compiled now. They were being recompiled through `re`'s internal
cache on every call, which is cheap per call and was not the problem, but there is no reason to
look them up hundreds of times per document.

Verified: the patch output is identical on correction, preference, negative-preference, no-match
and non-preference cases; two different documents still produce different patches and the same
document is stable across calls (the cache is keyed on the text and holds four entries); 22/22
strict mem0 conformance; 7/7 mem0 unit suites.
