### PR TITLE
a locator list was rewritten whole on every add

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1474,6 +1474,58 @@ fn type_index_ready_key(record_hash_key: &str) -> String {
 /// A compact entry is always relative to the reader's own record log, which is the same thing the
 /// long shape's base check enforces: an entry under another base is not this log's business, and
 /// the writer leaves those in the long shape precisely because the compact one cannot say them.
+/// Every location a ref's locator holds, head chunk and continuations together.
+///
+/// A locator list longer than one chunk keeps its head under the ref's own field and continues in
+/// `"{ref}#1"`, `"{ref}#2"`, with the head naming how many follow. A reader that stops at the head
+/// sees a truncated list, and here that is not a slow answer but a wrong one: one of these callers
+/// decides which records a delete touches, so a missed chunk leaves records undeleted.
+fn locator_location_values(
+    engine: &TemporalEngine,
+    locator_key: &str,
+    id: &str,
+) -> Result<Vec<Value>, String> {
+    let mut out: Vec<Value> = Vec::new();
+    let raw = read_bytes(
+        engine,
+        Command::HashGet {
+            key: locator_key.to_string(),
+            field: id.to_string(),
+        },
+    )?;
+    if raw.is_empty() {
+        return Ok(out);
+    }
+    let Ok(decoded) = serde_json::from_str::<Value>(&raw) else {
+        return Ok(out);
+    };
+    if let Some(items) = decoded.get("locations").and_then(Value::as_array) {
+        out.extend(items.iter().cloned());
+    }
+    let chunks = decoded
+        .get("location_chunks")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    for index in 1..=chunks {
+        let chunk_raw = read_bytes(
+            engine,
+            Command::HashGet {
+                key: locator_key.to_string(),
+                field: format!("{id}#{index}"),
+            },
+        )?;
+        if chunk_raw.is_empty() {
+            continue;
+        }
+        if let Ok(chunk) = serde_json::from_str::<Value>(&chunk_raw) {
+            if let Some(items) = chunk.get("locations").and_then(Value::as_array) {
+                out.extend(items.iter().cloned());
+            }
+        }
+    }
+    Ok(out)
+}
+
 fn location_shard_and_field(location: &Value, record_hash_key: &str) -> Option<(String, String)> {
     if let Some(compact) = location.as_str() {
         let (shard, offset) = compact.split_once(':')?;
@@ -1788,30 +1840,13 @@ fn id_scoped_payloads(
         .unwrap_or(false);
     let mut positions: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for id in requested_ids {
-        let raw = read_bytes(
-            engine,
-            Command::HashGet {
-                key: locator_key.clone(),
-                field: id.clone(),
-            },
-        )?;
         let mut found = 0_usize;
-        if !raw.is_empty() {
-            if let Ok(decoded) = serde_json::from_str::<Value>(&raw) {
-                for location in decoded
-                    .get("locations")
-                    .and_then(Value::as_array)
-                    .map(|items| items.as_slice())
-                    .unwrap_or(&[])
-                {
-                    let Some((shard, field)) = location_shard_and_field(location, record_hash_key)
-                    else {
-                        continue;
-                    };
-                    positions.insert(format!("{shard}:{field}"));
-                    found += 1;
-                }
-            }
+        for location in locator_location_values(engine, &locator_key, id)? {
+            let Some((shard, field)) = location_shard_and_field(&location, record_hash_key) else {
+                continue;
+            };
+            positions.insert(format!("{shard}:{field}"));
+            found += 1;
         }
         if found == 0 {
             // An old store predating the side index, or an id that never existed. The walk is
@@ -2408,26 +2443,8 @@ fn located_fields_for_ids(
     }
     let mut by_shard: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for id in ids {
-        let raw = read_bytes(
-            engine,
-            Command::HashGet {
-                key: locator_key.clone(),
-                field: id.clone(),
-            },
-        )?;
-        if raw.is_empty() {
-            continue;
-        }
-        let Ok(decoded) = serde_json::from_str::<Value>(&raw) else {
-            continue;
-        };
-        for location in decoded
-            .get("locations")
-            .and_then(Value::as_array)
-            .map(|items| items.as_slice())
-            .unwrap_or(&[])
-        {
-            let Some((shard, field)) = location_shard_and_field(location, record_hash_key) else {
+        for location in locator_location_values(engine, &locator_key, id)? {
+            let Some((shard, field)) = location_shard_and_field(&location, record_hash_key) else {
                 continue;
             };
             let fields = by_shard.entry(shard).or_default();

--- a/tools/matrixark_temporal_direct_backend.py
+++ b/tools/matrixark_temporal_direct_backend.py
@@ -1167,17 +1167,14 @@ class _TemporalDirectBackendMixin:
             })
         for ref_hash, new_locations in locator_updates.items():
             field = str(ref_hash)
-            merged_locations = self._merge_ref_locations(existing_for(locator_key, field), new_locations)
-            entries.append(
-                {
-                    "key": locator_key,
-                    "field": field,
-                    "value": json.dumps(
-                        {"locations": compact_location_list(merged_locations, self._location_base())},
-                        separators=(",", ":"),
-                    ),
-                    "storage_route": route_by_hash_field.get((locator_key, field), {}),
-                }
+            entries.extend(
+                self._locator_entries_for_ref(
+                    locator_key,
+                    field,
+                    new_locations,
+                    existing_for,
+                    route_by_hash_field.get((locator_key, field), {}),
+                )
             )
         for (key, field), update in placement_updates.items():
             new_locations = update.get("locations", []) if isinstance(update, dict) else []
@@ -1278,6 +1275,99 @@ class _TemporalDirectBackendMixin:
     @staticmethod
     def _placement_chunk_field(field: str, index: int) -> str:
         return field if index == 0 else f"{field}#{index}"
+
+    # A ref's locator list is every record location carrying that ref, and it had exactly the
+    # problem the placement list had before chunking: held whole, each append re-read the list,
+    # added an entry, and wrote the whole thing back. O(list) bytes per add, O(list^2) over the
+    # life of a term. Measured by walking the page segments over 300 ingests, rows carrying only a
+    # `locations` field -- which is what a locator row is -- were **76.7 KB of the 77.6 KB** that
+    # every `locations` field cost per add. The placement rows beside them, already chunked, came
+    # to 0.4 KB.
+    #
+    # Same fix, same shape: the head field keeps its original name and contents, so a reader that
+    # knows nothing about chunks still finds locations there, overflow lives in "{ref}#1", "{ref}#2",
+    # and the head names how many follow.
+    LOCATOR_CHUNK_LOCATIONS = 32
+
+    @staticmethod
+    def _locator_chunk_field(field: str, index: int) -> str:
+        return field if index == 0 else f"{field}#{index}"
+
+    def _locator_entries_for_ref(
+        self,
+        key: str,
+        field: str,
+        new_locations: list[Json],
+        existing_for,
+        storage_route: Json,
+    ) -> list[Json]:
+        """Append `new_locations` to a ref's locator list, touching only the tail chunk."""
+        head_value = existing_for(key, field)
+        head_decoded: Json = {}
+        if head_value:
+            try:
+                decoded = json.loads(head_value)
+                if isinstance(decoded, dict):
+                    head_decoded = decoded
+            except Exception:
+                head_decoded = {}
+        head_locations = head_decoded.get("locations")
+        head_locations = head_locations if isinstance(head_locations, list) else []
+        try:
+            chunk_count = int(head_decoded.get("location_chunks") or 0)
+        except (TypeError, ValueError):
+            chunk_count = 0
+
+        tail_index = chunk_count if chunk_count else 0
+        if tail_index == 0 and len(head_locations) >= self.LOCATOR_CHUNK_LOCATIONS:
+            tail_index = 1
+        tail_field = self._locator_chunk_field(field, tail_index)
+        tail_value = head_value if tail_index == 0 else existing_for(key, tail_field)
+
+        merged_tail = self._merge_ref_locations(tail_value, new_locations)
+        # A tail that overflows starts the next chunk rather than growing without bound. A list
+        # already over the limit -- written before chunking -- is left where it is: rewriting it
+        # would cost exactly the O(list) write this exists to avoid.
+        if tail_index > 0 and len(merged_tail) > self.LOCATOR_CHUNK_LOCATIONS:
+            keep = self._merge_ref_locations(tail_value, [])
+            overflow = [item for item in merged_tail if item not in keep]
+            if overflow:
+                tail_index += 1
+                tail_field = self._locator_chunk_field(field, tail_index)
+                merged_tail = overflow
+        elif tail_index == 0 and len(merged_tail) > self.LOCATOR_CHUNK_LOCATIONS and head_locations:
+            overflow = [item for item in merged_tail if item not in head_locations]
+            if overflow:
+                tail_index = 1
+                tail_field = self._locator_chunk_field(field, tail_index)
+                merged_tail = overflow
+
+        base = self._location_base()
+        entries: list[Json] = []
+        if tail_index == 0:
+            payload: Json = {"locations": compact_location_list(merged_tail, base)}
+            if chunk_count:
+                payload["location_chunks"] = chunk_count
+            entries.append({"key": key, "field": field,
+                            "value": json.dumps(payload, separators=(",", ":")),
+                            "storage_route": storage_route})
+            return entries
+
+        entries.append({"key": key, "field": tail_field,
+                        "value": json.dumps(
+                            {"locations": compact_location_list(merged_tail, base)},
+                            separators=(",", ":")),
+                        "storage_route": storage_route})
+        # The head is rewritten only when the chunk count actually changes -- once per rollover,
+        # not once per add. That is the whole point: the common add touches one small tail.
+        if tail_index != chunk_count:
+            entries.append({"key": key, "field": field,
+                            "value": json.dumps(
+                                {"locations": compact_location_list(head_locations, base),
+                                 "location_chunks": tail_index},
+                                separators=(",", ":")),
+                            "storage_route": storage_route})
+        return entries
 
     def _placement_entries_for_node(
         self,

--- a/tools/matrixark_temporal_direct_read.py
+++ b/tools/matrixark_temporal_direct_read.py
@@ -731,6 +731,32 @@ class _TemporalDirectReadMixin:
             rows = batch_hget(entries)
         except Exception:
             return {"locations": [], "locator_rows": 0}
+        # A locator list longer than one chunk continues in sibling fields "{ref}#1", "{ref}#2".
+        # The head names how many follow. Not reading them drops locations silently, which reads
+        # as a memory that simply is not there -- so this follow-up is not an optimisation.
+        chunk_entries = []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict) or not row.get("value"):
+                continue
+            try:
+                decoded = json.loads(str(row.get("value")))
+            except Exception:
+                continue
+            if not isinstance(decoded, dict):
+                continue
+            try:
+                chunks = int(decoded.get("location_chunks") or 0)
+            except (TypeError, ValueError):
+                chunks = 0
+            for index in range(1, chunks + 1):
+                chunk_entries.append({"key": row.get("key"), "field": f"{row.get('field')}#{index}"})
+        if chunk_entries:
+            try:
+                extra = batch_hget(chunk_entries)
+                if isinstance(extra, list):
+                    rows = list(rows) + extra
+            except Exception:
+                pass
         locations: list[Json] = []
         resource_versions: set[str] = set()
         seen: set[tuple[str, str]] = set()


### PR DESCRIPTION
A ref's locator list holds every record location carrying that ref. Held as one value, each append
re-read the list, added an entry, and wrote the whole thing back: O(list) bytes per add, O(list²)
over the life of a term.

The placement list beside it was fixed this way some time ago. The locator was not, and it is the
larger of the two. Walking the page segments over 300 ingests, rows carrying only a `locations`
field -- which is exactly what a locator row is -- came to **76.7 KB of the 77.6 KB** that the
`locations` field cost per add. The already-chunked placement rows came to 0.4 KB.

Same fix, same shape: the head field keeps its original name and contents, so a reader that knows
nothing about chunks still finds locations there; overflow lives in `"{ref}#1"`, `"{ref}#2"`, and
the head names how many follow. The head is rewritten only when the chunk count changes -- once per
rollover, not once per add.

Measured, 300 adds into one subject:

```text
                      pages/add   durable/add   add p50   retrieve
whole-list             91.00 KB      118.87 KB   360 ms   [0, 12, 24]
chunked                71.05 KB       91.69 KB   367 ms   [0, 12, 24]
```

**22% off every page byte**, and the shape of the lists shows the mechanism rather than just the
outcome -- entries per stored row went from p50 46 / p90 185 / **max 370** to p50 16 / p90 29 /
**max 64**. The tail is bounded now, so the per-add cost stops tracking the length of the list.

Both readers follow the continuations, and that is not an optimisation: the proxy's
`located_fields_for_ids` decides which records a delete touches, so a reader that stopped at the
head would leave records undeleted while reporting success. `id_scoped_payloads` returns `None` and
falls back to a walk when it finds nothing, which is safe, but it would have been quietly wrong
about how much it had found.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, `cargo check --all-targets` clean,
retrieval returning the same items before and after.
