### PR TITLE
embedding metadata carried a routing blob thirteen times the size of the vector

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -637,6 +637,29 @@ INLINE_VECTOR_OWNER_BY_REF_TYPE = {
 }
 
 
+
+# `embedding_meta` is the embedding record copied wholesale minus a few keys, so it inherits
+# whatever the record happened to carry. Two of those are a routing blob:
+# `canonical_storage_route(storage_options)` is a pure function of the options beside it, and the
+# options are themselves already on the owning record.
+#
+# Measured by walking the page segments over 300 ingests: `embedding_meta.storage_route` cost
+# 3.93 KB per add and `embedding_meta.storage_options` 2.55 KB -- together 63% of everything
+# `embedding_meta` cost, and 13x the `vector` the metadata exists to describe (0.78 KB).
+#
+# Nothing reads either one. Every consumer of `embedding_meta` takes the source aggregates that
+# budgeting and recovery need; a search for a read of the nested route or options finds none. The
+# record's own top-level `storage_route` is kept and already slimmed to its placement half by
+# `slim_persisted_storage_route`, which is where a reader that wants placement looks.
+_EMBEDDING_META_SKIP = (
+    "record_type",
+    "ref_type",
+    "ref_hash",
+    "vector",
+    "storage_route",
+    "storage_options",
+)
+
 def fold_embedding_records(
     records: list[Json],
     resolve_owner=None,
@@ -698,7 +721,7 @@ def fold_embedding_records(
         meta = {
             key: value
             for key, value in record.items()
-            if key not in ("record_type", "ref_type", "ref_hash", "vector")
+            if key not in _EMBEDDING_META_SKIP
             and value not in (None, "", [], {})
         }
         if meta:


### PR DESCRIPTION
`embedding_meta` is the embedding record copied wholesale minus a few keys, so it inherits whatever
that record happened to carry. Two of the things it carried were a routing blob.

Measured by walking the page segments over 300 ingests:

```text
embedding_meta.storage_route      3.93 KB per add
embedding_meta.storage_options    2.55 KB per add
                                  ----
                                  6.48 KB per add   = 63% of everything embedding_meta cost
the `vector` it exists to describe 0.78 KB per add
```

Metadata about an embedding cost **thirteen times the embedding**.

Neither is read. Every consumer of `embedding_meta` takes the source aggregates that budgeting and
recovery need; searching for a read of the nested route or options finds none. And neither is
information: `canonical_storage_route(storage_options)` is a pure function of the options sitting
beside it, and the record's own top-level `storage_route` is kept -- already trimmed to its
placement half by `slim_persisted_storage_route`, which is where a reader that wants placement
looks. This applies the same judgement one level down, where the copy had been missed.

```text
                       embedding_meta   avg copy   durable/add
before                      10.31 KB     2 449 B      91.69 KB
after                        3.93 KB       905 B      89.47 KB
```

**62% off the field.** The durable figure moves by less than the field does, and that is worth
stating rather than hiding: pages are compressed, and a routing blob repeated across the records of
one bundle is close to free once a compressor has seen it. The logical saving is the honest measure
of what stopped being written; the disk saving is what a compressor could not already do.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, 7/7 attachment-policy tests (which
exercise the embedding fold directly), and retrieval returning the same items before and after.
