### PR TITLE
the trim is now a recorded fact, which is what lets replay stop reading config

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1158,13 +1158,14 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            while series.len() > feature_max_size {
-                if let Some(oldest) = series.keys().next().copied() {
-                    series.remove(&oldest);
-                } else {
-                    break;
-                }
-            }
+            mutated |= trim_timestamped_series(
+                shard_id,
+                "feature",
+                &key,
+                routing_bucket,
+                series,
+                feature_max_size,
+            );
             let live_addresses = series.values().cloned().collect::<Vec<_>>();
             sync_bucket_index_object_pages(
                 shard,
@@ -1225,14 +1226,14 @@ pub(crate) fn execute_on_shard(
                     }
                 }
             }
-            while series.len() > feature_max_size {
-                if let Some(oldest) = series.keys().next().copied() {
-                    series.remove(&oldest);
-                    mutated = true;
-                } else {
-                    break;
-                }
-            }
+            mutated |= trim_timestamped_series(
+                shard_id,
+                "feature",
+                &key,
+                routing_bucket,
+                series,
+                feature_max_size,
+            );
             let live_addresses = series.values().cloned().collect::<Vec<_>>();
             sync_bucket_index_object_pages(
                 shard,
@@ -1365,10 +1366,14 @@ pub(crate) fn execute_on_shard(
                 .range(crate::engine::timestamp_range_bounds(start_ms, end_ms))
                 .map(|(timestamp_ms, _)| *timestamp_ms)
                 .collect::<Vec<_>>();
-            for timestamp_ms in replaced {
-                series.remove(&timestamp_ms);
-                mutated = true;
-            }
+            mutated |= drop_timestamped_points(
+                shard_id,
+                "feature",
+                &key,
+                routing_bucket,
+                series,
+                &replaced,
+            );
             let points = sorted_feature_points(points);
             if let Ok(addresses) = append_timestamped_kv_pages(
                 cache,
@@ -1385,14 +1390,14 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            while series.len() > feature_max_size {
-                if let Some(oldest) = series.keys().next().copied() {
-                    series.remove(&oldest);
-                    mutated = true;
-                } else {
-                    break;
-                }
-            }
+            mutated |= trim_timestamped_series(
+                shard_id,
+                "feature",
+                &key,
+                routing_bucket,
+                series,
+                feature_max_size,
+            );
             let live_addresses = series.values().cloned().collect::<Vec<_>>();
             sync_bucket_index_object_pages(
                 shard,
@@ -1535,13 +1540,14 @@ pub(crate) fn execute_on_shard(
                     mutated = true;
                 }
             }
-            while series.len() > feature_max_size {
-                if let Some(oldest) = series.keys().next().copied() {
-                    series.remove(&oldest);
-                } else {
-                    break;
-                }
-            }
+            mutated |= trim_timestamped_series(
+                shard_id,
+                "feature",
+                &key,
+                routing_bucket,
+                series,
+                feature_max_size,
+            );
             let live_addresses = series.values().cloned().collect::<Vec<_>>();
             sync_bucket_index_object_pages(
                 shard,

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -421,6 +421,17 @@ impl TemporalEngine {
                 out.push_str(&format!("seen {key} member={member:?} at={at}\n"));
             }
         }
+        let mut features: Vec<_> = shard.features.iter().collect();
+        features.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, series) in features {
+            for (timestamp_ms, address) in series {
+                out.push_str(&format!(
+                    "feature {key} at={timestamp_ms} slab={} off={} len={}
+",
+                    address.page_slab_id, address.offset, address.length
+                ));
+            }
+        }
         let mut hashes: Vec<_> = shard.hashes.iter().collect();
         hashes.sort_by(|left, right| left.0.cmp(right.0));
         for (key, fields) in hashes {
@@ -655,6 +666,51 @@ impl TemporalEngine {
                     .entry(item.object_key.clone())
                     .or_default()
                     .insert(member, (biased, address));
+                true
+            }
+            // feature: the component is the point's timestamp. A trim and a replace both
+            // arrive here as a removal -- which is the whole reason replay can stop consulting
+            // the config that decided the trim.
+            "feature" => {
+                let Some(component) = item.component.clone() else {
+                    return false;
+                };
+                let Ok(timestamp_ms) = component.parse::<u64>() else {
+                    return false;
+                };
+                if item.deleted {
+                    if let Some(series) = shard.features.get_mut(&item.object_key) {
+                        series.remove(&timestamp_ms);
+                        if series.is_empty() {
+                            shard.features.remove(&item.object_key);
+                        }
+                    }
+                    super::mark_bucket_index_page_deleted(
+                        shard,
+                        shard_id,
+                        "feature",
+                        &item.object_key,
+                        Some(&component),
+                    );
+                    return true;
+                }
+                let Some(address) = item.address.clone() else {
+                    return false;
+                };
+                super::upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "feature",
+                    &item.object_key,
+                    Some(component),
+                    address.clone(),
+                    true,
+                );
+                shard
+                    .features
+                    .entry(item.object_key.clone())
+                    .or_default()
+                    .insert(timestamp_ms, address);
                 true
             }
             _ => false,

--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -86,6 +86,76 @@ fn stage_timestamped_outcomes(
     }
 }
 
+/// Record that a timestamped point is gone.
+///
+/// The insert above records where a point landed; without this its removal is invisible, and a
+/// shard rebuilt from records alone would keep points the shard itself has dropped.
+fn stage_timestamped_removal(shard_id: ShardId, kind: &str, key: &str, routing_bucket: u32, timestamp_ms: u64) {
+    if !crate::wal::wal_outcome_items_enabled() {
+        return;
+    }
+    let component = timestamp_ms.to_string();
+    super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
+        kind: kind.to_string(),
+        object_key: key.to_string(),
+        component: Some(component.clone()),
+        object_id: stable_page_object_id(shard_id, kind, key, Some(&component)),
+        routing_bucket,
+        address: None,
+        value: None,
+        ttl: None,
+        deleted: true,
+        meta: false,
+    });
+}
+
+/// Drop the named points from a series, recording each one.
+///
+/// Returns whether the series changed, so a caller can mark the shard dirty without repeating
+/// the test.
+pub(super) fn drop_timestamped_points(
+    shard_id: ShardId,
+    kind: &str,
+    key: &str,
+    routing_bucket: u32,
+    series: &mut BTreeMap<u64, BlockAddress>,
+    timestamps: &[u64],
+) -> bool {
+    let mut dropped = false;
+    for timestamp_ms in timestamps {
+        if series.remove(timestamp_ms).is_some() {
+            stage_timestamped_removal(shard_id, kind, key, routing_bucket, *timestamp_ms);
+            dropped = true;
+        }
+    }
+    dropped
+}
+
+/// Trim a series to its configured bound, oldest first, recording every point that went.
+///
+/// The bound lives in config rather than in the command, which is why replaying a command
+/// reproduces this trim only if the config effective at the time is reproduced with it. Recording
+/// the trimmed point instead states the result, and needs no config at all.
+pub(super) fn trim_timestamped_series(
+    shard_id: ShardId,
+    kind: &str,
+    key: &str,
+    routing_bucket: u32,
+    series: &mut BTreeMap<u64, BlockAddress>,
+    max_size: usize,
+) -> bool {
+    let mut trimmed = false;
+    while series.len() > max_size {
+        let Some(oldest) = series.keys().next().copied() else {
+            break;
+        };
+        series.remove(&oldest);
+        stage_timestamped_removal(shard_id, kind, key, routing_bucket, oldest);
+        trimmed = true;
+    }
+    trimmed
+}
+
 pub(super) fn append_timestamped_kv_pages(
     cache: &MultiLayerCache,
     block_store: &LocalBlockStore,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4489,6 +4489,21 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
     ran.load_shard(1);
     std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
 
+    // A bound tight enough that the workload below overflows it. Only this engine is told --
+    // which is the whole point: the shard rebuilt from records has to arrive at the same three
+    // points without ever learning what the bound was.
+    assert!(
+        ran.set_config(SetConfigRequest {
+            shard_id: 1,
+            config: Config {
+                version: 2,
+                feature_max_size: 3,
+                ..Config::default()
+            },
+        })
+        .ok
+    );
+
     // The kinds the apply path claims to handle so far.
     let workload = vec![
         Command::StringSet {
@@ -4554,6 +4569,28 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
         Command::CommonDelete {
             key: "eq-doomed".to_string(),
         },
+        // Five points into a series bounded at three. The two oldest are dropped by config the
+        // command never mentions -- so unless the trim itself is recorded, the rebuilt shard
+        // keeps points this one has thrown away.
+        Command::FeatureAppend {
+            key: "eq-feature".to_string(),
+            points: (0..5)
+                .map(|index| crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000 + index * 1_000,
+                    value: format!("point-{index}").into_bytes(),
+                })
+                .collect(),
+        },
+        // A replace drops a range and writes over it: removals and inserts in one command.
+        Command::FeatureReplace {
+            key: "eq-feature".to_string(),
+            start_ms: 1_787_270_073_000,
+            end_ms: 1_787_270_074_000,
+            points: vec![crate::types::FeaturePoint {
+                timestamp_ms: 1_787_270_073_500,
+                value: b"replacement".to_vec(),
+            }],
+        },
     ];
     for command in workload {
         let response = ran.execute(ExecuteRequest {
@@ -4562,6 +4599,26 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
         });
         assert!(response.status.ok, "workload write failed: {response:?}");
     }
+    // If this stops being true the trim is no longer under test and the gate has gone quiet.
+    // Five points, bounded to the newest three, then a replace drops two of those and writes one
+    // back: the oldest two must be gone by the trim, and the series must be down to two.
+    let ran_feature = ran
+        .index_shape_for_test(1)
+        .lines()
+        .filter(|line| line.starts_with("feature eq-feature "))
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ran_feature.len(),
+        2,
+        "the workload was supposed to leave a trimmed series, got {ran_feature:?}"
+    );
+    assert!(
+        !ran_feature
+            .iter()
+            .any(|line| line.contains("at=1787270070000") || line.contains("at=1787270071000")),
+        "the two oldest points should have been trimmed, got {ran_feature:?}"
+    );
 
     // Take the outcomes off the log, in the order they were written.
     let records = ran


### PR DESCRIPTION
the trim is now a recorded fact, which is what lets replay stop reading config

A trim is decided by config the command never carries. That is why replay has to walk a config
log re-applying the bound effective at each record: re-running FeatureAppend reproduces the
append, but the trim it caused only reappears if the bound in force at the time reappears with
it. Recording the trimmed point instead states the result, and needs no config at all.

Four handlers each had their own copy of the trim loop, and a fifth site dropped a range for
FeatureReplace. All five now go through two producers next to the one that records the insert,
so the removal is recorded wherever it happens rather than wherever someone remembered to add it.
Two of the four copies also failed to mark the shard dirty after a trim -- reachable only when a
bound is lowered without a write following it -- which the shared producer fixes by returning
whether it changed anything.

Sequences needed nothing: they were folded into the feature map already, so they came over with
it.

The gate now proves the part that matters. It bounds the series to three on the engine that RUNS
the commands and tells the engine that REBUILDS from records nothing at all, then writes five
points and replaces a range across them. If the trim were unrecorded the rebuilt shard would keep
points the first one threw away -- so the assertion is not that the apply path accepted the
records, it is that a shard which never learned the bound arrives at the same two points.

That failure mode is not hypothetical, and I did not take the green on trust: with the recording
removed the gate fails and prints both shapes, the rebuilt one carrying the two trimmed points.
A guard for silent data divergence is worth exactly what it costs to make it fail on purpose.

Not covered, and next: context events. Their map is keyed by event id while the record carries
the timeline key, so the recorded item cannot name the entry it created. That is a schema
question -- the component has to carry both, the way zset already packs score and member -- not
another emission, which is why it is not in here.

Tests: part4 covers the trim and the replace; equivalence green over ten kinds; mutation of the

🤖 Generated with [Claude Code](https://claude.com/claude-code)
