### PR TITLE
six timestamped kinds install through one arm, because five of them were about to be forgotten

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -9,6 +9,26 @@ impl Default for TemporalEngine {
     }
 }
 
+/// The series a timestamped kind lives in.
+///
+/// Kept as one place so the apply path and anything else that has to go from a recorded kind to
+/// the map it belongs in cannot disagree about the answer.
+fn timestamped_series_mut<'a>(
+    shard: &'a mut super::state::ShardState,
+    kind: &str,
+) -> Option<&'a mut std::collections::HashMap<String, std::collections::BTreeMap<u64, crate::block_store::BlockAddress>>>
+{
+    Some(match kind {
+        "feature" => &mut shard.features,
+        "context_index" => &mut shard.context_indexes,
+        "context_audit" => &mut shard.context_audits,
+        "context_child" => &mut shard.context_children,
+        "context_summary" => &mut shard.context_summaries,
+        "context_compression" => &mut shard.context_compressions,
+        _ => return None,
+    })
+}
+
 impl TemporalEngine {
     pub fn new(cache: MultiLayerCache) -> Self {
         Self::with_cache_and_block_store(cache, LocalBlockStore::default())
@@ -421,15 +441,26 @@ impl TemporalEngine {
                 out.push_str(&format!("seen {key} member={member:?} at={at}\n"));
             }
         }
-        let mut features: Vec<_> = shard.features.iter().collect();
-        features.sort_by(|left, right| left.0.cmp(right.0));
-        for (key, series) in features {
-            for (timestamp_ms, address) in series {
-                out.push_str(&format!(
-                    "feature {key} at={timestamp_ms} slab={} off={} len={}
+        // Every timestamped series renders the same way, so a kind that stops being installed
+        // shows up as a missing line rather than as a map nobody compares.
+        for (kind, series) in [
+            ("feature", &shard.features),
+            ("context_index", &shard.context_indexes),
+            ("context_audit", &shard.context_audits),
+            ("context_child", &shard.context_children),
+            ("context_summary", &shard.context_summaries),
+            ("context_compression", &shard.context_compressions),
+        ] {
+            let mut keys: Vec<_> = series.iter().collect();
+            keys.sort_by(|left, right| left.0.cmp(right.0));
+            for (key, entries) in keys {
+                for (stored_key, address) in entries {
+                    out.push_str(&format!(
+                        "{kind} {key} at={stored_key} slab={} off={} len={}
 ",
-                    address.page_slab_id, address.offset, address.length
-                ));
+                        address.page_slab_id, address.offset, address.length
+                    ));
+                }
             }
         }
         let mut hashes: Vec<_> = shard.hashes.iter().collect();
@@ -668,27 +699,41 @@ impl TemporalEngine {
                     .insert(member, (biased, address));
                 true
             }
-            // feature: the component is the point's timestamp. A trim and a replace both
-            // arrive here as a removal -- which is the whole reason replay can stop consulting
-            // the config that decided the trim.
-            "feature" => {
+            // Every timestamped series is the same shape: stored key -> page, with the key in
+            // the component. One arm covers all of them, so a new kind is a line in the map
+            // below rather than another branch that can be forgotten here.
+            //
+            // For a feature the key is the point's timestamp, and a trim or a replace arrives
+            // as a removal -- which is the whole reason replay can stop consulting the config
+            // that decided the trim.
+            "feature"
+            | "context_index"
+            | "context_audit"
+            | "context_child"
+            | "context_summary"
+            | "context_compression" => {
                 let Some(component) = item.component.clone() else {
                     return false;
                 };
-                let Ok(timestamp_ms) = component.parse::<u64>() else {
+                let Ok(stored_key) = component.parse::<u64>() else {
                     return false;
                 };
                 if item.deleted {
-                    if let Some(series) = shard.features.get_mut(&item.object_key) {
-                        series.remove(&timestamp_ms);
-                        if series.is_empty() {
-                            shard.features.remove(&item.object_key);
+                    {
+                        let Some(series) = timestamped_series_mut(shard, &item.kind) else {
+                            return false;
+                        };
+                        if let Some(entries) = series.get_mut(&item.object_key) {
+                            entries.remove(&stored_key);
+                            if entries.is_empty() {
+                                series.remove(&item.object_key);
+                            }
                         }
                     }
                     super::mark_bucket_index_page_deleted(
                         shard,
                         shard_id,
-                        "feature",
+                        &item.kind,
                         &item.object_key,
                         Some(&component),
                     );
@@ -697,20 +742,24 @@ impl TemporalEngine {
                 let Some(address) = item.address.clone() else {
                     return false;
                 };
+                {
+                    let Some(series) = timestamped_series_mut(shard, &item.kind) else {
+                        return false;
+                    };
+                    series
+                        .entry(item.object_key.clone())
+                        .or_default()
+                        .insert(stored_key, address.clone());
+                }
                 super::upsert_bucket_index_page(
                     shard,
                     shard_id,
-                    "feature",
+                    &item.kind,
                     &item.object_key,
                     Some(component),
-                    address.clone(),
+                    address,
                     true,
                 );
-                shard
-                    .features
-                    .entry(item.object_key.clone())
-                    .or_default()
-                    .insert(timestamp_ms, address);
                 true
             }
             _ => false,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4581,6 +4581,63 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
                 })
                 .collect(),
         },
+        // The context maps are the same shape as a feature series -- stored key to page -- so
+        // they are installed by the same arm. Which is exactly why they belong in here: one arm
+        // covering six kinds is one place for five of them to go silently uninstalled.
+        Command::ContextWriteIndexRef {
+            tenant_hash: 41,
+            index_name: "actor".to_string(),
+            index_value_hash: 77,
+            scope_hash: 3,
+            event_time_ms: 1_787_270_070_000,
+            index_ref: crate::types::ContextIndexRef {
+                primary_node_hash: 9,
+                primary_event_time_ms: 1_787_270_070_000,
+                event_id_hash: 1234,
+            },
+        },
+        Command::ContextWritePackAudit {
+            tenant_hash: 41,
+            audit: crate::types::ContextPackAudit {
+                query_id: "q-1".to_string(),
+                session_hash: 5,
+                request_time_ms: 1_787_270_071_000,
+                query_hash: 6,
+                max_prompt_tokens: 100,
+                selected_tokens: 40,
+                selected_refs: Vec::new(),
+                blocked_refs: Vec::new(),
+            },
+        },
+        Command::ContextUpsertChildRef {
+            tenant_hash: 41,
+            child_ref: crate::types::ContextChildRef {
+                parent_hash: 9,
+                child_hash: 10,
+                updated_at_ms: 1_787_270_072_000,
+            },
+        },
+        Command::ContextUpsertSummary {
+            tenant_hash: 41,
+            summary: crate::types::ContextSummary {
+                node_hash: 9,
+                level: 1,
+                text: "a summary".to_string(),
+                valid_from_ms: 1_787_270_073_000,
+                vector: Vec::new(),
+            },
+        },
+        Command::ContextWriteCompressionEvent {
+            tenant_hash: 41,
+            event: crate::types::ContextCompressionEvent {
+                compression_id_hash: 21,
+                node_hash: 9,
+                source_start_ms: 1_787_270_070_000,
+                source_end_ms: 1_787_270_073_000,
+                compressed_time_ms: 1_787_270_074_000,
+                summary: "compressed".to_string(),
+            },
+        },
         // A replace drops a range and writes over it: removals and inserts in one command.
         Command::FeatureReplace {
             key: "eq-feature".to_string(),
@@ -4599,6 +4656,22 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
         });
         assert!(response.status.ok, "workload write failed: {response:?}");
     }
+    // Two empty maps compare equal, so a workload that quietly wrote nothing would pass. Assert
+    // each kind is actually present before comparing anything.
+    let ran_shape = ran.index_shape_for_test(1);
+    for kind in [
+        "context_index",
+        "context_audit",
+        "context_child",
+        "context_summary",
+        "context_compression",
+    ] {
+        assert!(
+            ran_shape.lines().any(|line| line.starts_with(&format!("{kind} "))),
+            "the workload wrote no {kind}, so installing it proves nothing"
+        );
+    }
+
     // If this stops being true the trim is no longer under test and the gate has gone quiet.
     // Five points, bounded to the newest three, then a replace drops two of those and writes one
     // back: the oldest two must be gone by the trim, and the series must be down to two.


### PR DESCRIPTION
six timestamped kinds install through one arm, because five of them were about to be forgotten

The context maps are the same shape as a feature series: stored key to page, with the key in the
recorded component. They were being RECORDED already -- the producer that writes timestamped pages
covers them -- and none of them were being installed, so a shard rebuilt from records would come
back missing every index ref, audit, child ref, summary and compression event it ever wrote.

Nothing about that would have failed. The maps would simply be empty, reads over them would return
nothing, and the shard would look fine.

So the arm is now written once for the shape rather than once per kind. A small router maps a
recorded kind to the series it belongs in, and adding a kind is a line in that router instead of
another branch beside five near-identical ones -- which is the form of the mistake that put five
kinds in this position to begin with.

The renderer the gate compares with got the same treatment: it walks the same list, so a kind that
stops being installed shows up as a missing line rather than as a map nobody thought to compare.

Two things the gate now does that it did not before. It asserts each kind is actually PRESENT in
the shard the commands built before comparing anything, because two empty maps compare equal and a
workload that quietly wrote nothing would otherwise pass. And it was made to fail on purpose:
dropping one kind from the router turns it red naming that kind, which is the evidence that the
five additions are covered rather than merely present.

Context events are still out, and they are a different problem, not a bigger one. Their map is
keyed by event id while the record carries the timeline key, so the recorded item cannot name the
entry it created. The component has to carry both, the way zset already packs score and member,
and the identity has to reach the producer that writes the page -- a schema change, so it is its
own change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
