### PR TITLE
a context event's record now names the entry it created, not just where its page landed

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -2334,7 +2334,7 @@ pub(crate) fn execute_on_shard(
                     page_routing_bucket(&object_key, start_routing_bucket, end_routing_bucket);
                 // The PAGE stays timestamp-keyed: pages pack by time, and the load path recovers
                 // the timeline key from the packed point. Only the index key changes.
-                if let Ok(addresses) = append_timestamped_kv_pages(
+                if let Ok(addresses) = append_timestamped_kv_pages_keyed(
                     cache,
                     page_store,
                     shard_id,
@@ -2346,6 +2346,7 @@ pub(crate) fn execute_on_shard(
                     }],
                     routing_bucket,
                     async_storage && !cold_storage,
+                    event_id_hash,
                 ) {
                     for (stored_timeline_key, address) in addresses {
                         series.insert(event_id_hash, address);
@@ -2410,7 +2411,7 @@ pub(crate) fn execute_on_shard(
                     start_routing_bucket,
                     end_routing_bucket,
                 );
-                if let Ok(addresses) = append_timestamped_kv_pages(
+                if let Ok(addresses) = append_timestamped_kv_pages_keyed(
                     cache,
                     page_store,
                     shard_id,
@@ -2422,6 +2423,7 @@ pub(crate) fn execute_on_shard(
                     }],
                     routing_bucket,
                     async_storage && !cold_storage,
+                    event_id_hash,
                 ) {
                     for (stored_timeline_key, address) in addresses {
                         event_series.insert(event_id_hash, address);

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -478,6 +478,29 @@ impl TemporalEngine {
         }
         // Every timestamped series renders the same way, so a kind that stops being installed
         // shows up as a missing line rather than as a map nobody compares.
+        let mut event_keys: Vec<_> = shard.context_events.iter().collect();
+        event_keys.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, entries) in event_keys {
+            for (event_id_hash, address) in entries {
+                out.push_str(&format!(
+                    "context_event {key} id={event_id_hash} slab={} off={} len={}
+",
+                    address.page_slab_id, address.offset, address.length
+                ));
+            }
+        }
+        // The time index is what every windowed read goes through, so a primary map that is
+        // right and a timeline that is empty must not compare equal.
+        let mut timeline_keys: Vec<_> = shard.context_event_timeline.iter().collect();
+        timeline_keys.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, entries) in timeline_keys {
+            for (timeline_key, event_id_hash) in entries {
+                out.push_str(&format!(
+                    "context_timeline {key} at={timeline_key} id={event_id_hash}
+"
+                ));
+            }
+        }
         for (kind, series) in [
             ("feature", &shard.features),
             ("context_index", &shard.context_indexes),
@@ -784,6 +807,67 @@ impl TemporalEngine {
                     shard,
                     shard_id,
                     &item.kind,
+                    &item.object_key,
+                    live_addresses,
+                    true,
+                );
+                true
+            }
+            // context_event: the page is timestamp-keyed but the index entry is keyed by the
+            // event id, so the component carries both -- sixteen hex digits of the timeline key,
+            // then sixteen of the id. Two maps have to move together: the primary, and the time
+            // index that every windowed read goes through. Installing only the primary leaves a
+            // shard whose events exist and whose time queries return nothing.
+            "context_event" => {
+                let Some(component) = item.component.clone() else {
+                    return false;
+                };
+                if component.len() != 32 {
+                    return false;
+                }
+                let (timeline_hex, id_hex) = component.split_at(16);
+                let (Ok(timeline_key), Ok(event_id_hash)) = (
+                    u64::from_str_radix(timeline_hex, 16),
+                    u64::from_str_radix(id_hex, 16),
+                ) else {
+                    return false;
+                };
+                if !item.deleted && item.address.is_none() {
+                    return false;
+                }
+                let live_addresses = {
+                    let events = shard.context_events.entry(item.object_key.clone()).or_default();
+                    match item.address.clone() {
+                        Some(address) if !item.deleted => {
+                            events.insert(event_id_hash, address);
+                        }
+                        _ => {
+                            events.remove(&event_id_hash);
+                        }
+                    }
+                    let live = events.values().cloned().collect::<Vec<_>>();
+                    let empty = events.is_empty();
+                    let timeline = shard
+                        .context_event_timeline
+                        .entry(item.object_key.clone())
+                        .or_default();
+                    if item.deleted {
+                        timeline.remove(&timeline_key);
+                    } else {
+                        timeline.insert(timeline_key, event_id_hash);
+                    }
+                    if timeline.is_empty() {
+                        shard.context_event_timeline.remove(&item.object_key);
+                    }
+                    if empty {
+                        shard.context_events.remove(&item.object_key);
+                    }
+                    live
+                };
+                super::sync_bucket_index_object_pages(
+                    shard,
+                    shard_id,
+                    "context_event",
                     &item.object_key,
                     live_addresses,
                     true,

--- a/crates/temporalstore-rust/src/engine/packed_pages.rs
+++ b/crates/temporalstore-rust/src/engine/packed_pages.rs
@@ -59,18 +59,32 @@ fn feature_point_encoded_len(point: &FeaturePoint) -> usize {
 /// pages -- feature series, sequences, control state, context events -- and each one having to
 /// remember to record the outcome is exactly how a kind ends up silently missing. The series is
 /// keyed by timestamp, so that is the component.
+/// How a recorded item names the entry a write created.
+///
+/// Most timestamped series are keyed by the stored timestamp, so the timestamp alone names the
+/// entry. A context event is not: its page is timestamp-keyed but its index entry is keyed by the
+/// event id, so the timestamp alone names nothing and the identity has to travel with it. Packing
+/// both is what list and zset already do with their own keys.
+pub(super) fn timestamped_component(stored_key: u64, identity: Option<u64>) -> String {
+    match identity {
+        Some(identity) => format!("{stored_key:016x}{identity:016x}"),
+        None => stored_key.to_string(),
+    }
+}
+
 fn stage_timestamped_outcomes(
     shard_id: ShardId,
     kind: &str,
     key: &str,
     routing_bucket: u32,
     refs: &[(u64, BlockAddress)],
+    identity: Option<u64>,
 ) {
     if refs.is_empty() || !crate::wal::wal_outcome_items_enabled() {
         return;
     }
     for (timestamp_ms, address) in refs {
-        let component = timestamp_ms.to_string();
+        let component = timestamped_component(*timestamp_ms, identity);
         super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
             kind: kind.to_string(),
             object_key: key.to_string(),
@@ -166,6 +180,60 @@ pub(super) fn append_timestamped_kv_pages(
     routing_bucket: u32,
     async_storage: bool,
 ) -> Result<Vec<(u64, BlockAddress)>, BlockStoreError> {
+    append_timestamped_kv_pages_inner(
+        cache,
+        block_store,
+        shard_id,
+        kind,
+        key,
+        points,
+        routing_bucket,
+        async_storage,
+        None,
+    )
+}
+
+/// Same, for a series whose index entry is keyed by something other than the stored timestamp.
+///
+/// The caller passes the key its map will actually use, so the recorded item can name the entry
+/// the write created. Without it a record states where a page landed and not what it became.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn append_timestamped_kv_pages_keyed(
+    cache: &MultiLayerCache,
+    block_store: &LocalBlockStore,
+    shard_id: ShardId,
+    kind: &str,
+    key: &str,
+    points: Vec<FeaturePoint>,
+    routing_bucket: u32,
+    async_storage: bool,
+    identity: u64,
+) -> Result<Vec<(u64, BlockAddress)>, BlockStoreError> {
+    append_timestamped_kv_pages_inner(
+        cache,
+        block_store,
+        shard_id,
+        kind,
+        key,
+        points,
+        routing_bucket,
+        async_storage,
+        Some(identity),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_timestamped_kv_pages_inner(
+    cache: &MultiLayerCache,
+    block_store: &LocalBlockStore,
+    shard_id: ShardId,
+    kind: &str,
+    key: &str,
+    points: Vec<FeaturePoint>,
+    routing_bucket: u32,
+    async_storage: bool,
+    identity: Option<u64>,
+) -> Result<Vec<(u64, BlockAddress)>, BlockStoreError> {
     let object_id = stable_page_object_id(shard_id, kind, key, None);
     let mut refs = Vec::new();
     let chunks = chunk_timestamped_kv_points(points);
@@ -194,7 +262,7 @@ pub(super) fn append_timestamped_kv_pages(
                     .map(|point| (point.timestamp_ms, address.clone())),
             );
         }
-        stage_timestamped_outcomes(shard_id, kind, key, routing_bucket, &refs);
+        stage_timestamped_outcomes(shard_id, kind, key, routing_bucket, &refs, identity);
         return Ok(refs);
     }
 
@@ -215,7 +283,7 @@ pub(super) fn append_timestamped_kv_pages(
                 .map(|point| (point.timestamp_ms, address.clone())),
         );
     }
-    stage_timestamped_outcomes(shard_id, kind, key, routing_bucket, &refs);
+    stage_timestamped_outcomes(shard_id, kind, key, routing_bucket, &refs, identity);
     Ok(refs)
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4581,6 +4581,40 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
                 })
                 .collect(),
         },
+        // The one kind whose index entry is NOT keyed by the stored timestamp: the page packs by
+        // time, the map keys by event id, and the time index maps one to the other. All three
+        // have to come back, which is why the record carries both keys.
+        Command::ContextWriteExtractedEvent {
+            tenant_hash: 41,
+            node_hash: 42,
+            event: crate::types::ContextEvent {
+                event_id_hash: 445,
+                event_time_ms: 1_787_270_075_000,
+                ingestion_time_ms: 1_787_270_075_000,
+                kind: 7,
+                event_type: 7,
+                actor_hash: 0,
+                status: 1,
+                valid_until_ms: 0,
+                confidence: 0.96,
+                importance: 0.88,
+                text: "an extracted event".to_string(),
+                source_ref: String::new(),
+                related_node_hashes: vec![42],
+                compact_attrs: Vec::new(),
+                vector: Vec::new(),
+            },
+            indexes: crate::types::ContextExtractedEventIndexes {
+                scope_hash: 3001,
+                entity_hashes: vec![501],
+                status_hash: 601,
+                source_hash: 701,
+                event_time_bucket_ms: 1_787_270_000_000,
+                disabled_indexes: Vec::new(),
+            },
+            first_write_only: false,
+            cold_storage: false,
+        },
         // The context maps are the same shape as a feature series -- stored key to page -- so
         // they are installed by the same arm. Which is exactly why they belong in here: one arm
         // covering six kinds is one place for five of them to go silently uninstalled.
@@ -4660,6 +4694,8 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
     // each kind is actually present before comparing anything.
     let ran_shape = ran.index_shape_for_test(1);
     for kind in [
+        "context_event",
+        "context_timeline",
         "context_index",
         "context_audit",
         "context_child",


### PR DESCRIPTION
a context event's record now names the entry it created, not just where its page landed

Every other timestamped series is keyed by the stored timestamp, so the timestamp alone names the
entry a write created. A context event is the exception: the page packs by time, the index keys by
event id, and a time index maps one to the other. The record carried the timeline key, which names
the page and nothing in the map -- so nothing could be installed from it.

The component now carries both keys, sixteen hex digits each, exactly as list and zset already pack
their own. The identity reaches the producer through a keyed sibling of it rather than a signature
change at fourteen call sites; the twelve that do not need it are untouched, and the two that do
name the event id where a reader can see it.

Three things come back or none do. The primary map, the time index, and the pages the bucket index
holds. Installing only the primary leaves a shard where every event exists and every windowed read
returns nothing -- which is not hypothetical: it is the exact shape of the rekey incident the
index format stamp exists to refuse.

So the gate renders the time index as its own lines, and the check for it is that removing the
timeline install -- leaving events landing perfectly -- turns the gate red on the missing line.
A shard whose events are all present is precisely the one that would otherwise pass.

The workload is also broader than it looks: one extracted-event write fans out into six index refs
of its own, so the entity, kind, time-bucket, source and status indexes are all installed and
compared without being written by hand.

Tests: equivalence green over sixteen kinds on the typed maps, the time index and the bucket index;

🤖 Generated with [Claude Code](https://claude.com/claude-code)
