### PR TITLE
the proxy deep-copied every record it had just parsed

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1433,14 +1433,20 @@ fn passes_secondary_groups(terms: &HashSet<String>, groups: &[Vec<String>]) -> b
 }
 
 fn decode_matrixark_payload(value: &str) -> Vec<Value> {
-    let Ok(decoded) = serde_json::from_str::<Value>(value) else {
+    let Ok(mut decoded) = serde_json::from_str::<Value>(value) else {
         return Vec::new();
     };
-    if let Some(bundle) = decoded.get("record_bundle").and_then(Value::as_array) {
-        return bundle
-            .iter()
-            .filter(|item| item.is_object())
-            .cloned()
+    // Take the bundle rather than copying it. `decoded` is ours -- it was just parsed here and
+    // nothing else can see it -- so cloning each record deep-copied every map and vector in it
+    // for no one. Sampling the proxy under sustained ingest put `BTreeMap::clone_subtree` and
+    // `Vec<Value>::clone` among the hottest frames; this is where they came from.
+    if let Some(bundle) = decoded
+        .get_mut("record_bundle")
+        .and_then(Value::as_array_mut)
+    {
+        return std::mem::take(bundle)
+            .into_iter()
+            .filter(Value::is_object)
             .collect();
     }
     if decoded.is_object() {


### PR DESCRIPTION
Sampling the proxy under sustained ingest put `BTreeMap::clone_subtree` and `Vec<Value>::clone`
among its hottest frames. They came from one line.

`decode_matrixark_payload` parses a payload into an owned `Value`, then took the records out of it
like this:

```rust
return bundle.iter().filter(|item| item.is_object()).cloned().collect();
```

`decoded` was parsed inside this function and nothing else can see it, so every one of those clones
deep-copied a map and its vectors for no one. Taking the array instead hands the same records back
with no copying at all.

Measured by alternating the two binaries across four runs, so machine drift cannot be mistaken for
the effect -- 120 warm-up adds then 100 measured, on a fresh store each round:

```text
   B1 275.3    A1 239.8    B2 282.0    A2 245.2      (add p50, ms)
   before mean 278.7        after mean 242.5
```

**13% off add latency.** The two before-arms sit within 6.7 ms of each other and the two after-arms
within 5.4 ms, against a 36 ms effect -- so this is not the noise band. An earlier two-arm attempt
at the same comparison was invalid and worth mentioning: `cp` onto the running binary failed with
"Text file busy" and both arms silently measured the same build. The swap is now a rename and is
gated on the binary's sha.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, `cargo check --all-targets` clean.
