### PR TITLE
recovery now installs what a write recorded, and a SETEX key stopped losing its deadline

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -125,6 +125,13 @@ pub struct TemporalEngine {
     /// `promote_scan_done` fast-skip holds it to a small constant once warm. Read by the phase-1
     /// aging test to prove the per-write O(n) reconcile scan is gone.
     promote_scans: Arc<std::sync::atomic::AtomicU64>,
+    /// Diagnostics: how many recorded outcomes this engine has INSTALLED during WAL replay.
+    ///
+    /// Recovery falls back to re-executing a record's command when it carries no outcomes, so a
+    /// restart test comparing shard shapes passes either way and proves nothing about which path
+    /// ran. This makes the claim checkable: a test can require that recovery installed what the
+    /// writes recorded rather than quietly replaying commands again.
+    replay_installs: Arc<std::sync::atomic::AtomicU64>,
     /// Where to mirror writes this engine performs OUTSIDE the request path.
     ///
     /// Request-path writes are mirrored a layer up, by the data node, which sees each command

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -210,9 +210,22 @@ pub(crate) fn execute_on_shard(
                     true,
                 );
                 shard.strings.insert(key.clone(), address);
-                shard
-                    .expires_at_ms
-                    .insert(key.clone(), resolve_now_ms().saturating_add(ttl_ms));
+                let expires_at = resolve_now_ms().saturating_add(ttl_ms);
+                shard.expires_at_ms.insert(key.clone(), expires_at);
+                // This write sets a value AND a deadline. Recording only the page passes a probe
+                // that asks whether the record said anything, and produces a recovered key that
+                // never expires -- so the deadline is recorded too, already resolved, exactly as
+                // CommonExpire records its own.
+                stage_meta_outcome(
+                    shard_id,
+                    "object",
+                    &key,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                    None,
+                    Some(expires_at),
+                    false,
+                );
                 mutated = true;
             }
             invalidate_cache_key(cache, CacheKey::string(shard_id, &key), async_storage);

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -66,9 +66,16 @@ impl TemporalEngine {
             infos: Arc::default(),
             admissions: Arc::default(),
             promote_scans: Arc::default(),
+            replay_installs: Arc::default(),
             maintenance_mirror: Arc::default(),
             quotas: Arc::new(RwLock::new(crate::engine::quota::QuotaTable::default())),
         }
+    }
+
+    /// How many recorded outcomes recovery has installed (see `replay_installs`).
+    pub(crate) fn replay_installs_for_test(&self) -> u64 {
+        self.replay_installs
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Total per-execute promote reconcile scans this engine has run (see `promote_scans`).
@@ -1029,6 +1036,34 @@ impl TemporalEngine {
                     .expect("config lock poisoned")
                     .insert(shard_id, config_log[config_cursor].config.clone());
                 config_cursor += 1;
+            }
+            // A record that says what its write DID is installed, not re-executed. Re-executing
+            // reproduces state only if everything that influenced the original execution is
+            // reproduced with it -- which is why the two lines below this exist at all.
+            //
+            // The fallback is not a nicety. A record carrying no outcomes is replayed as a
+            // command exactly as before, so a kind that records nothing recovers correctly
+            // instead of silently recovering as nothing. The command cannot be dropped from the
+            // record until no accepted write can produce an empty one.
+            if !record.outcomes.is_empty() {
+                for item in &record.outcomes {
+                    if !self.apply_outcome_item(shard_id, item) {
+                        return Err(Status::error(
+                            "wal_replay_outcome_refused",
+                            format!(
+                                "WAL replay could not install a recorded {} outcome at sequence {}; refusing load rather than serving a shard missing it",
+                                item.kind, record.sequence
+                            ),
+                        ));
+                    }
+                }
+                self.replay_installs.fetch_add(
+                    record.outcomes.len() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                replayed_through = record.sequence;
+                expected = expected.saturating_add(1);
+                continue;
             }
             // Resolve TTL deadlines / event times against the LEADER's timestamp
             // captured when this record was written, not the (later) restart clock, so

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5094,3 +5094,294 @@ fn the_storage_cycle_records_how_long_its_stages_take() {
     // Deliberately NOT asserting some stage exceeds zero -- a quick cycle rounds every stage to
     // zero milliseconds, and that assertion would fail on a fast machine for no reason.
 }
+
+/// A COLD RELOAD, not a synthetic apply loop: a fresh engine rebuilds the shard from disk.
+///
+/// The equivalence gate feeds recorded outcomes to an engine by hand, which proves the apply path
+/// understands them. It does not prove RECOVERY uses them -- replay could ignore every outcome and
+/// re-execute every command and that gate would stay green.
+///
+/// Neither does comparing shard shapes across a restart, which is worth stating because the first
+/// version of this test did exactly that and passed while recovery installed NOTHING: unloading a
+/// shard flushes its index, so the reload had no tail left to replay and never entered the path
+/// under test. The install counter is what caught it, and asserting on it is what keeps this test
+/// honest -- so the engine is dropped without unloading, the way a crash leaves it.
+#[test]
+fn a_cold_reload_rebuilds_the_shard_from_what_the_writes_recorded() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    let pages = dir.path().join("pages");
+    let indexes = dir.path().join("indexes");
+
+    let workload = vec![
+        Command::StringSet {
+            key: "rs-a".to_string(),
+            value: b"alpha".to_vec(),
+        },
+        Command::StringSetEx {
+            key: "rs-ttl".to_string(),
+            value: b"expiring".to_vec(),
+            ttl_ms: 600_000,
+        },
+        Command::HashSet {
+            key: "rs-hash".to_string(),
+            field: "f".to_string(),
+            value: b"hv".to_vec(),
+        },
+        Command::SetAdd {
+            key: "rs-set".to_string(),
+            member: b"m".to_vec(),
+        },
+        Command::ZSetAdd {
+            key: "rs-zset".to_string(),
+            member: b"zm".to_vec(),
+            score: 3.5,
+        },
+        Command::ListPush {
+            key: "rs-list".to_string(),
+            member: b"lm".to_vec(),
+            left: true,
+        },
+        Command::SeenCheck {
+            key: "rs-seen".to_string(),
+            member: b"m".to_vec(),
+            window_ms: 600_000,
+        },
+        Command::BucketTake {
+            key: "rs-bucket".to_string(),
+            tokens: 2.0,
+            capacity: 10.0,
+            refill_per_sec: 1.0,
+        },
+        Command::FeatureAppend {
+            key: "rs-feature".to_string(),
+            points: (0..3)
+                .map(|index| crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000 + index * 1_000,
+                    value: format!("p{index}").into_bytes(),
+                })
+                .collect(),
+        },
+    ];
+
+    let (before, before_index, recorded) = {
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            cache.clone(),
+            pages.clone(),
+            indexes.clone(),
+        );
+        engine.load_shard(1);
+        std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
+        for command in workload {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command,
+            });
+            assert!(response.status.ok, "workload write failed: {response:?}");
+        }
+        std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+        let shape = engine.index_shape_for_test(1);
+        assert!(
+            shape.contains("string rs-a") && shape.contains("feature rs-feature"),
+            "the workload did not build the shard it was supposed to: {shape}"
+        );
+        let records = engine
+            .write_ahead_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .unwrap();
+        let recorded = records
+            .iter()
+            .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+            .filter(|record| !record.outcomes.is_empty())
+            .count();
+        assert!(
+            recorded >= 8,
+            "expected the workload to leave records carrying outcomes, got {recorded}"
+        );
+        (shape, engine.bucket_index_shape_for_test(1), recorded)
+        // dropped WITHOUT unload: the index is not flushed, so the tail must be replayed.
+    };
+
+    // The gate stays OFF for the reload. Recording is what it gates; a record that already says
+    // what it did is installed on its own evidence.
+    let recovered = TemporalEngine::with_local_dirs(1024 * 1024, cache, pages, indexes);
+    recovered.load_shard(1);
+
+    // The shapes below would match even if recovery ignored every outcome and re-executed the
+    // commands, so assert WHICH path ran before asserting the result.
+    let installed = recovered.replay_installs_for_test();
+    assert!(
+        installed >= recorded as u64,
+        "recovery installed {installed} outcomes for {recorded} records that carried them, so it          fell back to replaying commands and this test proves nothing"
+    );
+
+    assert_eq!(
+        recovered.index_shape_for_test(1),
+        before,
+        "a cold reload did not rebuild the shard the writes described"
+    );
+    assert_eq!(
+        recovered.bucket_index_shape_for_test(1),
+        before_index,
+        "a cold reload rebuilt the maps but not the index"
+    );
+}
+
+/// PER COMMAND: does what a write recorded describe EVERYTHING it changed, or just something?
+///
+/// The coverage probe asks whether a record said anything at all, which is a much weaker question
+/// than it looks. StringSetEx writes a value and a deadline; recording only the value passes the
+/// probe, passes the equivalence gate as long as no deadline is in the workload, and produces a
+/// recovered key that never expires. That defect was real and this is the test that names it.
+///
+/// Each command runs alone against a fresh pair of shards -- one built by running it, one built by
+/// installing only what it recorded -- so a failure names the command rather than the workload.
+#[test]
+fn what_each_command_recorded_describes_everything_it_changed() {
+    let commands: Vec<(&str, Command)> = vec![
+        (
+            "StringSet",
+            Command::StringSet {
+                key: "pc-string".to_string(),
+                value: b"v".to_vec(),
+            },
+        ),
+        (
+            "StringSetEx",
+            Command::StringSetEx {
+                key: "pc-setex".to_string(),
+                value: b"v".to_vec(),
+                ttl_ms: 600_000,
+            },
+        ),
+        (
+            "HashSet",
+            Command::HashSet {
+                key: "pc-hash".to_string(),
+                field: "f".to_string(),
+                value: b"v".to_vec(),
+            },
+        ),
+        (
+            "HashIncrBy",
+            Command::HashIncrBy {
+                key: "pc-hash".to_string(),
+                field: "counter".to_string(),
+                increment: 3,
+            },
+        ),
+        (
+            "SetAdd",
+            Command::SetAdd {
+                key: "pc-set".to_string(),
+                member: b"m".to_vec(),
+            },
+        ),
+        (
+            "ZSetAdd",
+            Command::ZSetAdd {
+                key: "pc-zset".to_string(),
+                member: b"m".to_vec(),
+                score: 1.5,
+            },
+        ),
+        (
+            "ListPush",
+            Command::ListPush {
+                key: "pc-list".to_string(),
+                member: b"m".to_vec(),
+                left: true,
+            },
+        ),
+        (
+            "SeenCheck",
+            Command::SeenCheck {
+                key: "pc-seen".to_string(),
+                member: b"m".to_vec(),
+                window_ms: 600_000,
+            },
+        ),
+        (
+            "BucketTake",
+            Command::BucketTake {
+                key: "pc-bucket".to_string(),
+                tokens: 1.0,
+                capacity: 10.0,
+                refill_per_sec: 1.0,
+            },
+        ),
+        (
+            "FeatureAppend",
+            Command::FeatureAppend {
+                key: "pc-feature".to_string(),
+                points: vec![crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000,
+                    value: b"fv".to_vec(),
+                }],
+            },
+        ),
+    ];
+
+    let mut incomplete = Vec::new();
+    for (label, command) in commands {
+        let dir = tempfile::tempdir().unwrap();
+        let ran = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("ran-cache"),
+            dir.path().join("ran-pages"),
+            dir.path().join("ran-index"),
+        );
+        ran.load_shard(1);
+        std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
+        let response = ran.execute(ExecuteRequest {
+            shard_id: 1,
+            command,
+        });
+        std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+        if !response.status.ok {
+            continue;
+        }
+        let outcomes = ran
+            .write_ahead_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .unwrap()
+            .iter()
+            .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+            .flat_map(|record| record.outcomes)
+            .collect::<Vec<_>>();
+
+        let installed = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("inst-cache"),
+            dir.path().join("inst-pages"),
+            dir.path().join("inst-index"),
+        );
+        installed.load_shard(1);
+        for item in &outcomes {
+            if !installed.apply_outcome_item(1, item) {
+                incomplete.push(format!("{label}: apply refused a {} outcome", item.kind));
+            }
+        }
+        let expected = ran.index_shape_for_test(1);
+        let actual = installed.index_shape_for_test(1);
+        if expected != actual {
+            let missing = expected
+                .lines()
+                .filter(|line| !actual.lines().any(|other| other == *line))
+                .collect::<Vec<_>>();
+            let extra = actual
+                .lines()
+                .filter(|line| !expected.lines().any(|other| other == *line))
+                .collect::<Vec<_>>();
+            incomplete.push(format!(
+                "{label}: recorded outcomes do not describe everything it changed -- missing {missing:?}, extra {extra:?}"
+            ));
+        }
+    }
+
+    assert!(
+        incomplete.is_empty(),
+        "these commands recorded SOMETHING but not EVERYTHING, so a recovered shard would be          quietly wrong rather than obviously broken: {incomplete:#?}"
+    );
+}


### PR DESCRIPTION
recovery now installs what a write recorded, and a SETEX key stopped losing its deadline

Replay re-executed every record's command. It now installs the record's outcomes instead when it
has them, and falls back to the command when it does not -- which is not a nicety: a record that
recorded nothing must recover as what it was, not as nothing. The command cannot leave the record
until no accepted write can produce an empty one.

Three tests, and the order they were written in is the finding.

The FIRST version compared shard shapes across a restart and passed. It was worthless. Unloading a
shard flushes its index, so the reload had no tail left to replay and never entered the path under
test -- recovery installed ZERO outcomes and the shapes matched because the commands had been
replayed exactly as before. A shape comparison cannot tell you which path produced the shape.

So the engine now counts what recovery installs, the way it already counts promote scans, and the
test asserts on that count BEFORE asserting on the shape. It also drops the engine without
unloading, the way a crash leaves it. That version failed immediately, and what it caught is the
second finding.

A SETEX key came back from a cold reload with its value and NO DEADLINE. It never expires. The
write sets two things and recorded one, and every gate was blind to it: the coverage probe asks
whether a record said ANYTHING, the equivalence gate compares a workload that had no deadline in
it, and neither notices a record that is half right.

Hence the third test, which asks the stronger question per command: run one command, install only
what it recorded, and diff the shards. A failure names the command and the missing line rather than
the workload. Run across ten commands it named exactly one -- StringSetEx, missing
`expires pc-setex` -- and the other nine were already complete. That is the question that actually
licenses dropping the command from the record, and "did it say anything" never was.

The fix is one emission beside the deadline it sets, already resolved, exactly as CommonExpire
records its own.

Tests: per-command completeness green over ten; cold reload asserts recovery installed what the

🤖 Generated with [Claude Code](https://claude.com/claude-code)
