### PR TITLE
the whole suite is now the probe, and it found a durably-acked write that recovery lost

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -701,6 +701,24 @@ impl TemporalEngine {
             // async (or bulk backfill) -> buffered, no fsync (a fire-and-forget
             // commit). Page/index materialization stays deferred to dump.
             if write_command && !replaying_wal() {
+                // A write that changed the shard and recorded nothing cannot be replaced by its
+                // record. Off unless a sweep asks for it; when it is on, every existing test that
+                // writes anything becomes a probe for that property -- which covers far more of
+                // the mutating surface than a hand-listed fixture per command ever would.
+                if crate::wal::wal_outcome_items_enabled()
+                    && crate::wal::wal_outcome_strict()
+                    && block_in_wal::staged_outcome_count() == 0
+                {
+                    let rendered = format!("{command:?}");
+                    let label = rendered
+                        .split_once(' ')
+                        .map(|(head, _)| head.to_string())
+                        .unwrap_or(rendered);
+                    panic!(
+                        "TS_WAL_OUTCOME_STRICT: {label} changed shard {} and recorded nothing about what it did",
+                        request.shard_id
+                    );
+                }
                 let sync = !config.async_storage && !bulk_ingest_mode();
                 // Concurrent-commit path (gated, default OFF): for a synchronous write, only
                 // RESERVE the WAL sequence + append the bytes here (under the `shards` lock);

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -105,6 +105,11 @@ pub(super) fn stage_outcome(item: crate::wal::WalOutcomeItem) {
 }
 
 /// Take what this write recorded doing, leaving nothing behind.
+/// How many outcomes this write has staged so far, without consuming them.
+pub(super) fn staged_outcome_count() -> usize {
+    OUTCOMES.with(|outcomes| outcomes.borrow().len())
+}
+
 pub(super) fn take_outcomes() -> Vec<crate::wal::WalOutcomeItem> {
     OUTCOMES.with(|outcomes| std::mem::take(&mut *outcomes.borrow_mut()))
 }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -10,6 +10,38 @@ use super::*;
 /// The page path stages its outcome inside `upsert_bucket_index_page`, because that is where a
 /// page outcome is produced. These have no such moment, so they say it here.
 #[allow(clippy::too_many_arguments)]
+/// Record a page or a value that belongs to one COMPONENT of an object.
+///
+/// `stage_meta_outcome` states something about the object as a whole -- it is gone, its deadline
+/// is this. This states what one part of it became: which page backs it, or the bytes for state no
+/// page backs at all.
+#[allow(clippy::too_many_arguments)]
+fn stage_component_outcome(
+    shard_id: ShardId,
+    kind: &str,
+    object_key: &str,
+    component: Option<String>,
+    routing_bucket: u32,
+    address: Option<crate::block_store::BlockAddress>,
+    value: Option<Vec<u8>>,
+) {
+    if !crate::wal::wal_outcome_items_enabled() {
+        return;
+    }
+    super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
+        kind: kind.to_string(),
+        object_key: object_key.to_string(),
+        component: component.clone(),
+        object_id: stable_page_object_id(shard_id, kind, object_key, component.as_deref()),
+        routing_bucket,
+        address,
+        value,
+        ttl: None,
+        deleted: false,
+        meta: false,
+    });
+}
+
 fn stage_meta_outcome(
     shard_id: ShardId,
     kind: &str,
@@ -127,6 +159,16 @@ pub(crate) fn execute_on_shard(
                 }
                 if removed {
                     mutated = true;
+                    stage_meta_outcome(
+                        shard_id,
+                        "object",
+                        &key,
+                        start_routing_bucket,
+                        end_routing_bucket,
+                        None,
+                        None,
+                        false,
+                    );
                     invalidate_record_all(cache, shard_id, &key);
                 }
                 CommandResponse::Integer {
@@ -273,11 +315,36 @@ pub(crate) fn execute_on_shard(
                     );
                     shard.strings.insert(key.clone(), address);
                     if let Some(ttl_ms) = ttl_ms {
-                        shard
-                            .expires_at_ms
-                            .insert(key.clone(), resolve_now_ms().saturating_add(ttl_ms));
+                        let expires_at = resolve_now_ms().saturating_add(ttl_ms);
+                        shard.expires_at_ms.insert(key.clone(), expires_at);
+                        // A conditional write that refreshes a deadline records the refreshed
+                        // one. Recording only the page leaves a replay installing the value over
+                        // a LAPSED deadline from an earlier record, and the key reads as expired
+                        // even though the leader kept it alive.
+                        stage_meta_outcome(
+                            shard_id,
+                            "object",
+                            &key,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                            None,
+                            Some(expires_at),
+                            false,
+                        );
                     } else {
                         shard.expires_at_ms.remove(&key);
+                        // No deadline is equally a result. An object outcome carrying neither a
+                        // deadline nor a deletion says exactly that.
+                        stage_meta_outcome(
+                            shard_id,
+                            "object",
+                            &key,
+                            start_routing_bucket,
+                            end_routing_bucket,
+                            None,
+                            None,
+                            false,
+                        );
                     }
                     mutated = true;
                 }
@@ -1424,6 +1491,17 @@ pub(crate) fn execute_on_shard(
             CommandResponse::Empty
         }
         Command::FeatureDelete { key } => {
+            // A removal with no component: the whole series went, not one point.
+            stage_meta_outcome(
+                shard_id,
+                "feature",
+                &key,
+                start_routing_bucket,
+                end_routing_bucket,
+                None,
+                None,
+                true,
+            );
             mutated = shard.features.remove(&key).is_some();
             mutated |= mark_bucket_index_object_deleted(shard, &key);
             let _ = cache.invalidate_record(shard_id, "feature", &key);
@@ -1637,12 +1715,27 @@ pub(crate) fn execute_on_shard(
             amount,
         } => {
             remove_if_expired(shard, &key);
-            *shard
-                .control_state
-                .entry(key.clone())
-                .or_default()
-                .entry(timestamp_ms)
-                .or_default() += amount;
+            let resulting = {
+                let counter = shard
+                    .control_state
+                    .entry(key.clone())
+                    .or_default()
+                    .entry(timestamp_ms)
+                    .or_default();
+                *counter += amount;
+                *counter
+            };
+            // The RESULT, not the increment. An increment replayed twice counts twice; a count
+            // installed twice is the same count, which is what makes a record idempotent.
+            stage_component_outcome(
+                shard_id,
+                "control_counter",
+                &key,
+                Some(timestamp_ms.to_string()),
+                page_routing_bucket(&key, start_routing_bucket, end_routing_bucket),
+                None,
+                Some(resulting.to_le_bytes().to_vec()),
+            );
             persist_control_state_page(
                 cache,
                 page_store,
@@ -1710,11 +1803,29 @@ pub(crate) fn execute_on_shard(
                 .filter(|precision_ms| *precision_ms > 0)
                 .map(|precision_ms| timestamp_ms - timestamp_ms % precision_ms)
                 .unwrap_or(timestamp_ms);
+            stage_component_outcome(
+                shard_id,
+                "control_change",
+                &key,
+                Some(bucket_ms.to_string()),
+                page_routing_bucket(&key, start_routing_bucket, end_routing_bucket),
+                None,
+                Some(value.clone()),
+            );
             hll::record_change(shard, &key, bucket_ms, value);
             if let Some(ttl_ms) = ttl_ms {
-                shard
-                    .expires_at_ms
-                    .insert(key, resolve_now_ms().saturating_add(ttl_ms));
+                let expires_at = resolve_now_ms().saturating_add(ttl_ms);
+                shard.expires_at_ms.insert(key.clone(), expires_at);
+                stage_meta_outcome(
+                    shard_id,
+                    "object",
+                    &key,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                    None,
+                    Some(expires_at),
+                    false,
+                );
             }
             mutated = true;
             CommandResponse::Empty
@@ -2019,6 +2130,20 @@ pub(crate) fn execute_on_shard(
                 })
                 .unwrap_or(true);
             if should_store {
+                // The value that WON the comparison, so a replay installs the winner instead of
+                // re-running a comparison against whatever it happens to hold.
+                stage_component_outcome(
+                    shard_id,
+                    "control_selection",
+                    &key,
+                    Some(match selection_type {
+                        ControlStateSelectionType::First => "first".to_string(),
+                        ControlStateSelectionType::Last => "last".to_string(),
+                    }),
+                    page_routing_bucket(&key, start_routing_bucket, end_routing_bucket),
+                    None,
+                    Some(value.clone()),
+                );
                 shard.control_state_selection.insert(
                     key.clone(),
                     ControlStateSelectionValue {
@@ -2029,11 +2154,23 @@ pub(crate) fn execute_on_shard(
                 );
             }
             if ttl_ms > 0 {
-                shard
-                    .expires_at_ms
-                    .insert(key, resolve_now_ms().saturating_add(ttl_ms));
+                let expires_at = resolve_now_ms().saturating_add(ttl_ms);
+                shard.expires_at_ms.insert(key.clone(), expires_at);
+                stage_meta_outcome(
+                    shard_id,
+                    "object",
+                    &key,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                    None,
+                    Some(expires_at),
+                    false,
+                );
             }
-            mutated = true;
+            // A comparison this value LOST stored nothing and set no deadline, so it changed
+            // nothing. Reporting it as a mutation dirtied the shard and appended a record for a
+            // write that did not happen.
+            mutated = should_store || ttl_ms > 0;
             CommandResponse::Empty
         }
         Command::ControlStateSelectionQuery { key } => {
@@ -2246,6 +2383,15 @@ pub(crate) fn execute_on_shard(
                         Some(routing_bucket),
                         async_storage,
                     ) {
+                        stage_component_outcome(
+                            shard_id,
+                            "context_node",
+                            &object_key,
+                            Some(CONTEXT_NODE_FIELD.to_string()),
+                            routing_bucket,
+                            Some(address.clone()),
+                            None,
+                        );
                         shard
                             .hashes
                             .entry(object_key.clone())
@@ -2274,6 +2420,18 @@ pub(crate) fn execute_on_shard(
                 Some(routing_bucket),
                 async_storage,
             ) {
+                // Its own kind, deliberately: this writes a hash page and -- unlike HashSet --
+                // never registers it in the bucket index, so recording it as a "hash" would have
+                // a rebuild add an entry the write never made.
+                stage_component_outcome(
+                    shard_id,
+                    "context_node",
+                    &object_key,
+                    Some(CONTEXT_NODE_FIELD.to_string()),
+                    routing_bucket,
+                    Some(address.clone()),
+                    None,
+                );
                 shard
                     .hashes
                     .entry(object_key.clone())
@@ -2980,6 +3138,15 @@ pub(crate) fn execute_on_shard(
                 // insert() on the entity hash OVERWRITES: an entity has one current value, and
                 // its history is the separate context_entity_update_audit series. Keying this
                 // map by time instead would silently turn every upsert into an append.
+                stage_component_outcome(
+                    shard_id,
+                    "context_entity",
+                    &collection_key,
+                    Some(entity.entity_hash.to_string()),
+                    routing_bucket,
+                    Some(address.clone()),
+                    None,
+                );
                 shard
                     .context_entities
                     .entry(collection_key)

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -485,6 +485,54 @@ impl TemporalEngine {
         }
         // Every timestamped series renders the same way, so a kind that stops being installed
         // shows up as a missing line rather than as a map nobody compares.
+        let mut entities: Vec<_> = shard.context_entities.iter().collect();
+        entities.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, members) in entities {
+            for (entity_hash, address) in members {
+                out.push_str(&format!(
+                    "context_entity {key} id={entity_hash} slab={} off={} len={}
+",
+                    address.page_slab_id, address.offset, address.length
+                ));
+            }
+        }
+        let mut counter_pages: Vec<_> = shard.control_state_pages.iter().collect();
+        counter_pages.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, address) in counter_pages {
+            out.push_str(&format!(
+                "control_state_page {key} slab={} off={} len={}
+",
+                address.page_slab_id, address.offset, address.length
+            ));
+        }
+        let mut counters: Vec<_> = shard.control_state.iter().collect();
+        counters.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, series) in counters {
+            for (bucket_ms, total) in series {
+                out.push_str(&format!("control_counter {key} at={bucket_ms} total={total}
+"));
+            }
+        }
+        let mut selections: Vec<_> = shard.control_state_selection.iter().collect();
+        selections.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, selected) in selections {
+            out.push_str(&format!(
+                "control_selection {key} at={} value={:?}
+",
+                selected.occur_time_ms, selected.value
+            ));
+        }
+        let mut changes: Vec<_> = shard.control_state_changes.iter().collect();
+        changes.sort_by(|left, right| left.0.cmp(right.0));
+        for (key, buckets) in changes {
+            for (bucket_ms, members) in buckets {
+                out.push_str(&format!(
+                    "control_change {key} at={bucket_ms} members={}
+",
+                    members.len()
+                ));
+            }
+        }
         let mut event_keys: Vec<_> = shard.context_events.iter().collect();
         event_keys.sort_by(|left, right| left.0.cmp(right.0));
         for (key, entries) in event_keys {
@@ -602,8 +650,14 @@ impl TemporalEngine {
             // A deadline, already resolved by the write that set it -- so installing it needs
             // no clock, where re-running the command would resolve it against this one.
             "object" => {
+                // No deadline and no deletion means the deadline was CLEARED -- which a write
+                // that refreshes a value without a TTL does, and which has to be installable or
+                // a lapsed deadline from an earlier record outlives the write that removed it.
                 let Some(expires_at) = item.ttl else {
-                    return false;
+                    for record_key in super::associated_record_keys(&item.object_key) {
+                        shard.expires_at_ms.remove(&record_key);
+                    }
+                    return true;
                 };
                 for record_key in super::associated_record_keys(&item.object_key) {
                     if super::record_exists_exact(shard, &record_key) {
@@ -777,6 +831,17 @@ impl TemporalEngine {
             | "context_child"
             | "context_summary"
             | "context_compression" => {
+                // No component on a removal means the whole series went, not one point of it.
+                if item.deleted && item.component.is_none() {
+                    {
+                        let Some(series) = timestamped_series_mut(shard, &item.kind) else {
+                            return false;
+                        };
+                        series.remove(&item.object_key);
+                    }
+                    super::mark_bucket_index_object_deleted(shard, &item.object_key);
+                    return true;
+                }
                 let Some(component) = item.component.clone() else {
                     return false;
                 };
@@ -878,6 +943,115 @@ impl TemporalEngine {
                     &item.object_key,
                     live_addresses,
                     true,
+                );
+                true
+            }
+            // A context node's page. Its own kind because the write registers no bucket-index
+            // entry for it, unlike every other hash page -- so installing it as a "hash" would
+            // add an entry the write never made.
+            // An entity, under its node's collection. Like the node above, the write registers
+            // no bucket-index entry for it, so neither does this.
+            // The whole counter series, serialized to one page. The write registers it in the
+            // bucket index through the same upsert the string kind uses, so this does too.
+            "control_state" => {
+                let Some(address) = item.address.clone() else {
+                    return false;
+                };
+                super::upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "control_state",
+                    &item.object_key,
+                    None,
+                    address.clone(),
+                    true,
+                );
+                shard
+                    .control_state_pages
+                    .insert(item.object_key.clone(), address);
+                true
+            }
+            "context_entity" => {
+                let (Some(address), Some(component)) =
+                    (item.address.clone(), item.component.clone())
+                else {
+                    return false;
+                };
+                let Ok(entity_hash) = component.parse::<u64>() else {
+                    return false;
+                };
+                shard
+                    .context_entities
+                    .entry(item.object_key.clone())
+                    .or_default()
+                    .insert(entity_hash, address);
+                true
+            }
+            "context_node" => {
+                let (Some(address), Some(field)) = (item.address.clone(), item.component.clone())
+                else {
+                    return false;
+                };
+                shard
+                    .hashes
+                    .entry(item.object_key.clone())
+                    .or_default()
+                    .insert(field, address);
+                true
+            }
+            // The counter's RESULTING value at one bucket. Installing a result twice is the same
+            // result; replaying an increment twice is not, which is the whole reason the record
+            // carries the total rather than the delta.
+            "control_counter" => {
+                let (Some(bytes), Some(component)) = (item.value.as_ref(), item.component.clone())
+                else {
+                    return false;
+                };
+                let (Ok(bucket_ms), Ok(total)) = (
+                    component.parse::<u64>(),
+                    bytes.as_slice().try_into().map(i64::from_le_bytes),
+                ) else {
+                    return false;
+                };
+                shard
+                    .control_state
+                    .entry(item.object_key.clone())
+                    .or_default()
+                    .insert(bucket_ms, total);
+                true
+            }
+            // A distinct member. Installed through the write path's own producer so the exact-set
+            // and sketch representations are chosen the same way they were originally.
+            "control_change" => {
+                let (Some(value), Some(component)) = (item.value.clone(), item.component.clone())
+                else {
+                    return false;
+                };
+                let Ok(bucket_ms) = component.parse::<u64>() else {
+                    return false;
+                };
+                super::hll::record_change(shard, &item.object_key, bucket_ms, value);
+                true
+            }
+            // The value that won a first/last comparison. The winner is installed directly rather
+            // than re-comparing against whatever this shard happens to hold.
+            "control_selection" => {
+                let (Some(value), Some(component)) = (item.value.clone(), item.component.clone())
+                else {
+                    return false;
+                };
+                let selection_type = match component.as_str() {
+                    "first" => crate::types::ControlStateSelectionType::First,
+                    "last" => crate::types::ControlStateSelectionType::Last,
+                    _ => return false,
+                };
+                shard.control_state_selection.insert(
+                    item.object_key.clone(),
+                    super::state::ControlStateSelectionValue {
+                        occur_time_ms: item.ttl.unwrap_or_default(),
+                        value,
+                        selection_type,
+                    },
                 );
                 true
             }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5239,9 +5239,14 @@ fn a_cold_reload_rebuilds_the_shard_from_what_the_writes_recorded() {
 /// installing only what it recorded -- so a failure names the command rather than the workload.
 #[test]
 fn what_each_command_recorded_describes_everything_it_changed() {
-    let commands: Vec<(&str, Command)> = vec![
+    // (label, what must already exist, the command under test). A command that only fires
+    // against existing state -- a conditional write, a persist -- cannot be probed on an empty
+    // shard, and leaving it out is how StringSetConditional kept a real defect through four
+    // rounds of this.
+    let commands: Vec<(&str, Vec<Command>, Command)> = vec![
         (
             "StringSet",
+            Vec::new(),
             Command::StringSet {
                 key: "pc-string".to_string(),
                 value: b"v".to_vec(),
@@ -5249,6 +5254,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "StringSetEx",
+            Vec::new(),
             Command::StringSetEx {
                 key: "pc-setex".to_string(),
                 value: b"v".to_vec(),
@@ -5257,6 +5263,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "HashSet",
+            Vec::new(),
             Command::HashSet {
                 key: "pc-hash".to_string(),
                 field: "f".to_string(),
@@ -5265,6 +5272,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "HashIncrBy",
+            Vec::new(),
             Command::HashIncrBy {
                 key: "pc-hash".to_string(),
                 field: "counter".to_string(),
@@ -5273,6 +5281,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "SetAdd",
+            Vec::new(),
             Command::SetAdd {
                 key: "pc-set".to_string(),
                 member: b"m".to_vec(),
@@ -5280,6 +5289,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "ZSetAdd",
+            Vec::new(),
             Command::ZSetAdd {
                 key: "pc-zset".to_string(),
                 member: b"m".to_vec(),
@@ -5288,6 +5298,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "ListPush",
+            Vec::new(),
             Command::ListPush {
                 key: "pc-list".to_string(),
                 member: b"m".to_vec(),
@@ -5296,6 +5307,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "SeenCheck",
+            Vec::new(),
             Command::SeenCheck {
                 key: "pc-seen".to_string(),
                 member: b"m".to_vec(),
@@ -5304,6 +5316,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "BucketTake",
+            Vec::new(),
             Command::BucketTake {
                 key: "pc-bucket".to_string(),
                 tokens: 1.0,
@@ -5313,6 +5326,7 @@ fn what_each_command_recorded_describes_everything_it_changed() {
         ),
         (
             "FeatureAppend",
+            Vec::new(),
             Command::FeatureAppend {
                 key: "pc-feature".to_string(),
                 points: vec![crate::types::FeaturePoint {
@@ -5321,10 +5335,105 @@ fn what_each_command_recorded_describes_everything_it_changed() {
                 }],
             },
         ),
+        (
+            "StringSetConditional-refresh",
+            vec![Command::StringSetEx {
+                key: "pc-cond".to_string(),
+                value: b"v1".to_vec(),
+                ttl_ms: 120,
+            }],
+            Command::StringSetConditional {
+                key: "pc-cond".to_string(),
+                value: b"v2".to_vec(),
+                ttl_ms: Some(600_000),
+                condition: crate::types::StringSetCondition::IfExists,
+                return_old: false,
+            },
+        ),
+        (
+            "StringSetConditional-clears-deadline",
+            vec![Command::StringSetEx {
+                key: "pc-cond2".to_string(),
+                value: b"v1".to_vec(),
+                ttl_ms: 600_000,
+            }],
+            Command::StringSetConditional {
+                key: "pc-cond2".to_string(),
+                value: b"v2".to_vec(),
+                ttl_ms: None,
+                condition: crate::types::StringSetCondition::IfExists,
+                return_old: false,
+            },
+        ),
+        (
+            "CommonPersist",
+            vec![Command::StringSetEx {
+                key: "pc-persist".to_string(),
+                value: b"v".to_vec(),
+                ttl_ms: 600_000,
+            }],
+            Command::CommonPersist {
+                key: "pc-persist".to_string(),
+            },
+        ),
+        (
+            "CommonExpire",
+            vec![Command::StringSet {
+                key: "pc-expire".to_string(),
+                value: b"v".to_vec(),
+            }],
+            Command::CommonExpire {
+                key: "pc-expire".to_string(),
+                ttl_ms: 600_000,
+            },
+        ),
+        (
+            "FeatureDelete",
+            vec![Command::FeatureAppend {
+                key: "pc-featdel".to_string(),
+                points: vec![crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000,
+                    value: b"fv".to_vec(),
+                }],
+            }],
+            Command::FeatureDelete {
+                key: "pc-featdel".to_string(),
+            },
+        ),
+        (
+            "ControlStateIncrement",
+            Vec::new(),
+            Command::ControlStateIncrement {
+                key: "pc-ctr".to_string(),
+                timestamp_ms: 1_787_270_070_000,
+                amount: 5,
+            },
+        ),
+        (
+            "ContextUpsertNode",
+            Vec::new(),
+            Command::ContextUpsertNode {
+                tenant_hash: 41,
+                node: crate::types::ContextNode {
+                    node_hash: 9,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: "probe-node".to_string(),
+                    status: 1,
+                    last_event_time_ms: 1_787_270_070_000,
+                    raw_metadata_ref: String::new(),
+                    l0: String::new(),
+                    l1_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        ),
     ];
 
     let mut incomplete = Vec::new();
-    for (label, command) in commands {
+    for (label, prelude, command) in commands {
         let dir = tempfile::tempdir().unwrap();
         let ran = TemporalEngine::with_local_dirs(
             1024 * 1024,
@@ -5333,6 +5442,15 @@ fn what_each_command_recorded_describes_everything_it_changed() {
             dir.path().join("ran-index"),
         );
         ran.load_shard(1);
+        // The prelude runs with the gate OFF so the only outcomes on the log belong to the
+        // command under test, and the installed shard starts from the same prelude state.
+        for setup in &prelude {
+            let response = ran.execute(ExecuteRequest {
+                shard_id: 1,
+                command: setup.clone(),
+            });
+            assert!(response.status.ok, "{label}: prelude failed: {response:?}");
+        }
         std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
         let response = ran.execute(ExecuteRequest {
             shard_id: 1,
@@ -5358,6 +5476,13 @@ fn what_each_command_recorded_describes_everything_it_changed() {
             dir.path().join("inst-index"),
         );
         installed.load_shard(1);
+        for setup in &prelude {
+            let response = installed.execute(ExecuteRequest {
+                shard_id: 1,
+                command: setup.clone(),
+            });
+            assert!(response.status.ok, "{label}: prelude failed: {response:?}");
+        }
         for item in &outcomes {
             if !installed.apply_outcome_item(1, item) {
                 incomplete.push(format!("{label}: apply refused a {} outcome", item.kind));

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -227,6 +227,19 @@ pub struct WriteAheadLogRecord {
     )]
     pub outcomes: Vec<WalOutcomeItem>,
 }
+/// Whether a write that changed the shard but recorded NOTHING should fail loudly.
+///
+/// Opt-in, and nothing sets it outside a deliberate sweep. The point is leverage: enumerating the
+/// mutating command surface by hand and writing a fixture per command tests what the author
+/// remembered to list, while this turns every test that already writes anything into a probe for
+/// the same property. A command that mutates without recording is exactly the one whose records
+/// cannot replace it.
+pub fn wal_outcome_strict() -> bool {
+    std::env::var("TS_WAL_OUTCOME_STRICT")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 
 /// TS_WAL_OUTCOME_ITEMS: also record what a write DID, beside the command that did it.
 ///


### PR DESCRIPTION
the whole suite is now the probe, and it found a durably-acked write that recovery lost

Asking whether every command records what it did by listing the commands tests what the author
remembered to list. Both defects found before this one were things I had not thought to list. So
the engine now fails loudly, under a flag nothing sets by default, when a write changes a shard and
records nothing -- which turns all 1300 existing tests into a probe for that property.

It found EIGHT silent commands, and the count only settled after four rounds: ContextUpsertNode,
ContextSetNodeEmbedding, ContextUpsertEntity, ContextUpsertEntity's collection page,
ControlStateIncrement, ControlStateChangeAdd, ControlStateSelectionSet and FeatureDelete. Five, then
three, then zero -- a fail-fast probe unmasks, because fixing one silent write lets a test run on
into the next. The first number was never the real one.

Each fix records the RESULT rather than the operation. A counter records its resulting total, not
the increment: installing a total twice is the same total, replaying an increment twice is not. A
first/last selection records the value that WON, so recovery installs the winner instead of
re-running a comparison against whatever it holds. A distinct member installs through the write
path's own producer, so exact-set and sketch representations are chosen the way they originally
were.

Then the strict sweep went quiet and a REAL defect was still there, which is the part worth keeping.
A conditional write that refreshes a deadline recorded its page and not the refreshed deadline. It
records something, so the sweep is blind to it; the deadline was not in any gate's workload, so the
comparisons were blind too. Recovery installed the value over a LAPSED deadline from an earlier
record and the key read as expired -- a durably-acked write, silently gone, exactly the hole the
leader-clock test was written for years earlier.

So the per-command completeness probe grew a prelude and now covers seventeen commands including
both conditional branches. A command that only fires against existing state cannot be probed on an
empty shard, and leaving those out is precisely how this one survived four rounds of sweeping.

Two things fixed that are not about recording at all. A selection that LOST its comparison stored
nothing, set no deadline, and still reported a mutation -- dirtying the shard and appending a record
for a write that did not happen. And clearing a deadline is now a recordable result, because a write
that removes a TTL has to be able to say so.

Tests: strict sweep clean across the engine suite; per-command completeness green over seventeen;

🤖 Generated with [Claude Code](https://claude.com/claude-code)
