### PR TITLE
every ingest re-asked whether an idle deadline had passed

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -26,6 +26,14 @@ except ImportError:
 )
 
 
+def _idle_drain_min_interval_ms() -> int:
+    """How long a quiet session may go unchecked for a due idle commit (default 1s, 0 disables)."""
+    try:
+        return max(0, int(os.environ.get("MATRIXARK_IDLE_DRAIN_MIN_INTERVAL_MS", "1000")))
+    except (TypeError, ValueError):
+        return 1000
+
+
 class _LocalAdapterRetrievalMixin:
     def reload_context_hot_state_from_disk(self, *, scope: Json | None = None) -> Json:
         """Rebuild process-local serving state from the durable JSONL record log."""
@@ -715,6 +723,24 @@ class _LocalAdapterRetrievalMixin:
 
     def drain_due_idle_session_commits(self, *, scope: Json, args: Json, hook: Json | None) -> Json:
         now = now_ms()
+        # This runs on EVERY ingest and its only question is whether a scheduled idle deadline has
+        # passed. Answering it costs a typed scan: measured on a 200-memory store, the scan the
+        # drain issues was 53.7 ms of a 270 ms add, one of three scans that together were 61% of
+        # the whole call. Re-asking it a few milliseconds after the last "no" cannot produce a
+        # different answer -- an idle timeout is measured in seconds.
+        #
+        # So after a pass that finds nothing due, this session's key is quiet until the interval
+        # elapses. A deadline that falls inside that window fires up to one interval late, against
+        # an idle timeout orders of magnitude longer. A pass that DOES drain something sets no
+        # gate, so a busy session keeps being checked every time.
+        drain_key = session_buffer_key_from_scope(scope)
+        gate = getattr(self, "_idle_drain_next_ms", None)
+        if gate is None:
+            gate = {}
+            self._idle_drain_next_ms = gate
+        if now < int(gate.get(drain_key, 0)):
+            return {"status": "idle", "due_task_count": 0, "drained_task_count": 0, "drained": [],
+                    "idle_drain_gated": True}
         records = self._idle_commit_candidate_records(scope)
         latest_status_by_task_hash: dict[int, str] = {}
         latest_order_by_task_hash: dict[int, int] = {}
@@ -728,6 +754,7 @@ class _LocalAdapterRetrievalMixin:
             latest_status_by_task_hash[task_hash] = str(record.get("status") or "")
             latest_order_by_task_hash[task_hash] = index
         due_tasks: list[Json] = []
+        scheduled_here = 0
         requested_key = session_buffer_key_from_scope(scope)
         for index, record in enumerate(records):
             if record.get("record_type") != "matrixark_async_pipeline_task":
@@ -743,10 +770,11 @@ class _LocalAdapterRetrievalMixin:
                 continue
             if latest_status_by_task_hash.get(task_hash) != "idle_commit_scheduled":
                 continue
-            if deadline_ms > now:
-                continue
             task_scope = record.get("scope", {}) if isinstance(record.get("scope"), dict) else {}
             if session_buffer_key_from_scope(task_scope) != requested_key:
+                continue
+            scheduled_here += 1
+            if deadline_ms > now:
                 continue
             due_tasks.append(record)
         due_tasks.sort(
@@ -825,6 +853,17 @@ class _LocalAdapterRetrievalMixin:
                     "batch_id_hash": result.get("batch_id_hash"),
                 }
             )
+        if scheduled_here == 0:
+            # Nothing is even SCHEDULED for this session, so nothing can come due until something
+            # schedules one -- and scheduling happens on this same path. Going quiet is free.
+            #
+            # Gating on "nothing DUE" instead was measurably worse where it counts: p50 fell but
+            # p95 went 367 -> 820 ms, because a session with a pending deadline stopped being
+            # checked, the due work piled up, and the add that finally drained paid for several
+            # session commits at once. A pending task keeps being checked every time.
+            gate[drain_key] = now + _idle_drain_min_interval_ms()
+        else:
+            gate.pop(drain_key, None)
         return {
             "status": "drained" if drained else "idle",
             "due_task_count": len(due_tasks),


### PR DESCRIPTION
`drain_due_idle_session_commits` runs on every ingest, and its only question is whether a scheduled
idle-commit deadline has elapsed. Answering it costs a typed scan.

Reading the adapter's own per-op metrics across 60 adds on a 200-memory store: an add spends
**262 ms of its 270 ms in proxy calls**, and **161 ms of that is `matrixark_scan_candidates`** --
three scans per add at 53.7 ms each. This drain is one of the three.

Re-asking a few milliseconds after the last "no" cannot change the answer, so a session with
nothing scheduled goes quiet for an interval (`MATRIXARK_IDLE_DRAIN_MIN_INTERVAL_MS`, default 1s,
0 disables).

```text
                    add p50     add p95
gate off            327.9 ms    461.3 ms
gate on             238.2 ms    409.2 ms
gate off (again)    323.1 ms    451.7 ms
```

**27% off p50 and 10% off p95.** The two off-arms sit within 5 ms of each other on p50 and 10 ms on
p95, so the effect is not the noise band.

**The gate condition is the whole design, and my first one was wrong.** Gating on "nothing DUE"
looked good on p50 and was measurably worse where it mattered: p95 went 367 -> 820 ms. A session
with a pending deadline stopped being checked, the due work piled up, and the add that finally
drained paid for several session commits at once. Gating on "nothing SCHEDULED" has no such
failure: if a task is pending, every ingest still checks it and it fires as promptly as before;
only a session where nothing could possibly come due goes quiet, and there scheduling happens on
this same path, so the gate clears itself.

Worst case for a gated session is one interval of delay on an idle commit, against an idle timeout
measured in seconds.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, 6/6 idle-commit candidate tests.
