### PR TITLE
a record stored a route it already had the parts to rebuild

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+
 import json
 import time
 from typing import Any
@@ -29,6 +31,39 @@ _ROUTE_KEYS_WORTH_STORING = (
 # to `routing_key` / `partition_key` only when it is absent, which it is not.
 
 
+def _drop_derivable_route_enabled() -> bool:
+    """ON by default; MATRIXARK_DROP_DERIVABLE_ROUTE=0 keeps the old persisted route."""
+    return os.environ.get("MATRIXARK_DROP_DERIVABLE_ROUTE", "1").strip().lower() not in {
+        "0", "false", "no", "off",
+    }
+
+
+def _placement_is_derivable(record: Json) -> bool:
+    """Can this record's placement be rebuilt from what it already carries?
+
+    Two ways, and an index posting only has the second:
+
+    * the record states `placement_key` and `placement_hash` at its top level, which
+      `attach_context_placement` writes beside the very route being dropped; or
+    * it states `scope_key` and `node_hash`, from which the pair is a pure function --
+      `placement_key = f"context:{scope_key}:node={node_hash}"` and `placement_hash =
+      stable_hash(placement_key)`.
+
+    Index postings take the second path and are where this matters most: measured over 300
+    ingests, an add writes ~10 postings and each carried 159 bytes of route and 58 of
+    `posting_policy` -- a constant with ONE distinct value in the whole store, and no reader.
+    """
+    if record.get("placement_key") and record.get("placement_hash"):
+        return True
+    if not record.get("scope_key"):
+        return False
+    node_hash = record.get("node_hash")
+    try:
+        return int(node_hash or 0) != 0
+    except (TypeError, ValueError):
+        return False
+
+
 def slim_persisted_storage_route(record: Json) -> Json:
     """Persist the placement half of `storage_route`, not the derived half.
 
@@ -47,6 +82,24 @@ def slim_persisted_storage_route(record: Json) -> Json:
     route = record.get("storage_route")
     if not isinstance(route, dict) or not route:
         return record
+    # The two keys this used to keep -- placement_key and placement_hash -- are written onto the
+    # record's TOP LEVEL by the same function that builds this route
+    # (`attach_context_placement`), so the nested pair was a second copy of fields sitting beside
+    # it. Nothing reads the nested ones: a search for a read of `storage_route["placement_key"]`
+    # or `.get("placement_key")` on a route finds none, while the top-level `placement_key` is what
+    # consumers actually use.
+    #
+    # And the pair is not information either. `placement_key` is
+    # `f"context:{scope_key}:node={node_hash}"` and `placement_hash` is `stable_hash` of it, both
+    # from fields already on the record -- so a reader that wanted them could rebuild them exactly.
+    #
+    # Measured over 300 ingests by walking the page segments, `storage_route` cost 1.76 KB per add
+    # across records, and 161 bytes on every one of the ~10 index postings an add writes.
+    if _drop_derivable_route_enabled() and _placement_is_derivable(record):
+        slim = dict(record)
+        slim.pop("storage_route", None)
+        slim.pop("posting_policy", None)
+        return slim
     kept = {key: route[key] for key in _ROUTE_KEYS_WORTH_STORING if key in route}
     if len(kept) == len(route):
         return record


### PR DESCRIPTION
`attach_context_placement` writes `placement_key` and `placement_hash` onto a record's top level
AND nests a second copy of the same two inside `storage_route`. Nothing reads the nested pair --
searching for a read of `storage_route["placement_key"]` finds none, while the top-level field is
what consumers use.

They are not information either:

```python
placement_key  = f"context:{scope_key}:node={node_hash}"
placement_hash = stable_hash(placement_key)
```

Both from fields the record already carries, so a reader that wanted them could rebuild them
exactly. This drops the persisted route whenever that is true -- either the record states the pair
at its top level, or it states `scope_key` and `node_hash`. An **index posting** only satisfies the
second, and postings are where this weighs most: an add writes ~10 of them and each carried 159
bytes of route plus 58 of `posting_policy`, a constant with ONE distinct value across the whole
store and no reader at all.

```text
                  posting size   add p50
before                 776 B     236.0 / 240.8 ms
after                  565 B     221.3 ms
```

**27% off every index posting and 7% off add latency**, with the two before-arms 5 ms apart.

What it does NOT do, stated plainly because the measurement says so: page bytes do not move
(34.97 / 34.83 / 34.97 KB per add across the three arms). Postings are about 15% of what a page
holds, so trimming a quarter of them is a few percent -- under this box's run-to-run spread. The
win here is less data written and less work per add, not smaller pages.

`MATRIXARK_DROP_DERIVABLE_ROUTE=0` restores the old persisted route.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, retrieval returning the same items
on every arm.
