### PR TITLE
one identifier a recorded address repeated really was redundant, and the other was not

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -694,7 +694,7 @@ impl TemporalEngine {
                 true
             }
             "string" => {
-                let Some(address) = item.address.clone() else {
+                let Some(address) = item.resolved_address() else {
                     return false;
                 };
                 super::upsert_bucket_index_page(
@@ -713,7 +713,7 @@ impl TemporalEngine {
             // encoder that produced it; a wrong decode shows up as an equivalence failure, not
             // as a silently different shard.
             "hash" => {
-                let (Some(address), Some(field)) = (item.address.clone(), item.component.clone())
+                let (Some(address), Some(field)) = (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };
@@ -736,7 +736,7 @@ impl TemporalEngine {
             // set: the component is the member, hex encoded.
             "set" => {
                 let (Some(address), Some(component)) =
-                    (item.address.clone(), item.component.clone())
+                    (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };
@@ -762,7 +762,7 @@ impl TemporalEngine {
             // list: sixteen hex digits of the sequence, biased so the text sorts in list order.
             "list" => {
                 let (Some(address), Some(component)) =
-                    (item.address.clone(), item.component.clone())
+                    (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };
@@ -789,7 +789,7 @@ impl TemporalEngine {
             // zset: sixteen hex digits of the biased score, then the member in hex.
             "zset" => {
                 let (Some(address), Some(component)) =
-                    (item.address.clone(), item.component.clone())
+                    (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };
@@ -861,7 +861,7 @@ impl TemporalEngine {
                         return false;
                     };
                     let entries = series.entry(item.object_key.clone()).or_default();
-                    match item.address.clone() {
+                    match item.resolved_address() {
                         Some(address) if !item.deleted => {
                             entries.insert(stored_key, address);
                         }
@@ -909,7 +909,7 @@ impl TemporalEngine {
                 }
                 let live_addresses = {
                     let events = shard.context_events.entry(item.object_key.clone()).or_default();
-                    match item.address.clone() {
+                    match item.resolved_address() {
                         Some(address) if !item.deleted => {
                             events.insert(event_id_hash, address);
                         }
@@ -954,7 +954,7 @@ impl TemporalEngine {
             // The whole counter series, serialized to one page. The write registers it in the
             // bucket index through the same upsert the string kind uses, so this does too.
             "control_state" => {
-                let Some(address) = item.address.clone() else {
+                let Some(address) = item.resolved_address() else {
                     return false;
                 };
                 super::upsert_bucket_index_page(
@@ -973,7 +973,7 @@ impl TemporalEngine {
             }
             "context_entity" => {
                 let (Some(address), Some(component)) =
-                    (item.address.clone(), item.component.clone())
+                    (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };
@@ -988,7 +988,7 @@ impl TemporalEngine {
                 true
             }
             "context_node" => {
-                let (Some(address), Some(field)) = (item.address.clone(), item.component.clone())
+                let (Some(address), Some(field)) = (item.resolved_address(), item.component.clone())
                 else {
                     return false;
                 };

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4125,8 +4125,11 @@ fn a_recorded_outcome_matches_the_index_entry_the_command_produced() {
     let indexed = engine
         .string_page_address(1, "outcome-key")
         .expect("the index holds an address for the key");
+    // Through the accessor, not the raw field: a recorded address omits the routing bucket the
+    // item already carries, and putting it back is what `resolved_address` is for. Comparing the
+    // raw field against an index entry compares a trimmed address with a whole one.
     assert_eq!(
-        item.address.as_ref(),
+        item.resolved_address().as_ref(),
         Some(&indexed),
         "the recorded outcome disagrees with the index entry the command built"
     );

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -179,6 +179,20 @@ fn encode_wal_payload(record: &WriteAheadLogRecord) -> Result<Vec<u8>, WriteAhea
     }
     Ok(payload)
 }
+impl WalOutcomeItem {
+    /// The address with the routing bucket the item carries put back.
+    ///
+    /// Anything installing a recorded page must go through this rather than reading `address`
+    /// directly, or the index entry it builds is missing its routing bucket -- which the
+    /// bucket-index half of the equivalence gate fails on.
+    pub fn resolved_address(&self) -> Option<crate::block_store::BlockAddress> {
+        self.address.clone().map(|mut address| {
+            address.routing_bucket = Some(self.routing_bucket);
+            address
+        })
+    }
+}
+
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WriteAheadLogRecord {
@@ -269,6 +283,44 @@ pub fn wal_outcome_items_enabled() -> bool {
 fn outcome_not_deleted(deleted: &bool) -> bool {
     !*deleted
 }
+/// The address inside a recorded outcome, without the routing bucket the item already carries.
+///
+/// The item and its address both state a routing bucket, always the same one, so every recorded
+/// outcome said it twice.
+///
+/// Their `object_id`s look equally redundant and are NOT. For a timestamped kind the item's is
+/// derived from (kind, key, COMPONENT) and the page's from (kind, key, None) -- per point against
+/// per series -- so restoring one from the other writes the wrong id into the index entry. The
+/// bucket-index half of the equivalence gate is what caught that; the field stays.
+///
+/// The page checksum stays too: the read path verifies it whenever it is present, and a rebuilt
+/// index entry without one would quietly stop being integrity-checked.
+mod outcome_address_serde {
+    use crate::block_store::BlockAddress;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<BlockAddress>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            None => serializer.serialize_none(),
+            Some(address) => {
+                let mut trimmed = address.clone();
+                trimmed.routing_bucket = None;
+                Some(trimmed).serialize(serializer)
+            }
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<BlockAddress>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<BlockAddress>::deserialize(deserializer)
+    }
+}
+
 
 /// One index mutation a write produced, stated as a result.
 ///
@@ -299,6 +351,7 @@ pub struct WalOutcomeItem {
         rename = "a",
         alias = "address",
         default,
+        with = "outcome_address_serde",
         skip_serializing_if = "Option::is_none"
     )]
     pub address: Option<crate::block_store::BlockAddress>,


### PR DESCRIPTION
one identifier a recorded address repeated really was redundant, and the other was not

An outcome's address states a routing bucket and an object id, and the item carrying it states both
as fields of its own. Dropping both on the way out and restoring them on the way back measured
311.0 -> 252.8 bytes per record, which looked like a clean sixty-byte win.

It was wrong, and the bucket-index comparison said so immediately.

The two object ids are not the same number. For a timestamped kind the ITEM's is derived from
(kind, key, component) and the PAGE's from (kind, key, none) -- per point against per series. They
coincide for a string, which is what makes the mistake easy, and diverge for every feature, context
event, index ref, audit, child, summary and compression page in the store. Restoring one from the
other writes a per-point id into a per-series index entry: a rebuild whose typed maps are perfect
and whose index names the wrong object.

So only the routing bucket is trimmed, which genuinely is the same value in both places:

    command only          186.4 B/record
    command + outcomes    471.7 B/record   (was 497.4)
    carrying both        +285.3 B/record   (was +311.0, -8.3%)

Worth recording why the bigger cut stays unavailable. The 64-character checksum in each address is
the largest single field and is load-bearing -- the page read path verifies it whenever it is
present, so a recorded address without one produces an index entry whose pages are never
integrity-checked again. The record's own framing protects the record; that checksum protects the
page bytes, and they are not substitutes.

What is left is the encoding rather than the fields. The record is JSON, and a binary codec is
worth more than every remaining field-level trim put together.

Tests: all four gates green, and the equivalence gate is what rejected the unsound half -- this is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
