### PR TITLE
a committed event kept its body in memory for the life of the process

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4456,6 +4456,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         if pending:
                             source_set = set(source_ids)
                             self._session_pending_event_ids_by_key[key] = [event_id for event_id in pending if event_id not in source_set]
+                        # A committed event's body is dead weight here. `_context_event_by_hash`
+                        # exists so the session buffer can hand back the events it is still
+                        # holding; every consumer of it looks up PENDING ids. Nothing was ever
+                        # removed, so the map kept one parsed record per event for the life of the
+                        # process: gateway RSS grew 31 -> 59 MB over 800 ingests, about 35 KB a
+                        # memory, and it did not stop.
+                        #
+                        # Dropping a committed body is safe because it is a cache, not a store:
+                        # the read path that populates it re-reads and re-populates on a miss.
+                        # The committed ID set stays -- it is what marks an event done, and it is
+                        # eight bytes rather than a record.
+                        for event_id in source_ids:
+                            self._context_event_by_hash.pop(event_id, None)
                 continue
             if record_type == "context_node":
                 try:


### PR DESCRIPTION
`_context_event_by_hash` holds one parsed `context_event` per event so the session buffer can hand
back the events it is still carrying. Every consumer of it looks up **pending** ids -- and nothing
ever removed an entry.

So the map grew with the corpus and never shrank. Measured on the gateway process, 800 ingests of a
62-byte message:

```text
                gateway RSS        growth
before        31.1 -> 60.9 MB   38.1 KB per memory
after         31.1 -> 53.1 MB   28.1 KB per memory
```

**26% off the per-memory growth rate.** The Rust proxy is flat at 9.3 MB across both arms, so this
is Python-side retention, not the store.

A `context_batch_commit` already moves ids from pending to committed; the bodies become dead weight
at exactly that moment, so that is where they are now dropped. It is safe because this is a cache,
not a store: the read path that fills it re-reads and re-fills on a miss. The committed ID set
stays -- it is what marks an event done, and an id is eight bytes rather than a record.

This does not stop the growth, it slows it: 28.1 KB per memory remains and the next retainer has
not been identified yet. Reporting the number rather than implying the problem is solved.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites including read-your-writes, which is
the one that would break if a body were dropped while still pending.
