### PR TITLE
one record message for three logs, and it costs 55.9% of what the text one did

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5608,3 +5608,148 @@ fn what_recording_outcomes_costs_per_record() {
         "recording outcomes alongside the command should cost bytes; if it does not, the gate is          not reaching the append path and this measurement is meaningless"
     );
 }
+
+/// FIDELITY: a record encoded as protobuf and read back must equal the record that went in.
+///
+/// This is the durability path, so the bar is equality of the whole record -- not "the fields we
+/// modelled survived". A command this codec has never heard of travels verbatim and must come back
+/// byte for byte; anything less means a log written today cannot be replayed tomorrow.
+///
+/// The workload is driven through the engine rather than hand-built, so the records under test are
+/// the ones the engine actually writes, including their outcomes and any blocks they carry.
+#[test]
+fn a_record_encoded_as_protobuf_reads_back_identical() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
+
+    let workload = vec![
+        Command::StringSet {
+            key: "pb-string".to_string(),
+            value: b"a value".to_vec(),
+        },
+        // A modelled arm with a TTL, which the codec folds into the same message.
+        Command::StringSetEx {
+            key: "pb-setex".to_string(),
+            value: b"expiring".to_vec(),
+            ttl_ms: 600_000,
+        },
+        Command::HashSet {
+            key: "pb-hash".to_string(),
+            field: "f".to_string(),
+            value: b"hv".to_vec(),
+        },
+        // Deliberately NOT modelled by the command codec: it must travel verbatim.
+        Command::ZSetAdd {
+            key: "pb-zset".to_string(),
+            member: b"zm".to_vec(),
+            score: 2.5,
+        },
+        Command::ListPush {
+            key: "pb-list".to_string(),
+            member: b"lm".to_vec(),
+            left: true,
+        },
+        // No block behind it: the outcome carries bytes instead of an address.
+        Command::SeenCheck {
+            key: "pb-seen".to_string(),
+            member: b"m".to_vec(),
+            window_ms: 600_000,
+        },
+        Command::BucketTake {
+            key: "pb-bucket".to_string(),
+            tokens: 1.0,
+            capacity: 10.0,
+            refill_per_sec: 1.0,
+        },
+        // Several outcomes from one command, each naming a different point.
+        Command::FeatureAppend {
+            key: "pb-feature".to_string(),
+            points: (0..3)
+                .map(|index| crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000 + index * 1_000,
+                    value: format!("point-{index}").into_bytes(),
+                })
+                .collect(),
+        },
+        // A value with bytes that are not valid text, which is where an encoding that has no
+        // byte-string type starts guessing.
+        Command::StringSet {
+            key: "pb-binary".to_string(),
+            value: vec![0x00, 0xff, 0x1f, 0x7f, 0x80, b'"', b'\\', b'\n'],
+        },
+        Command::CommonExpire {
+            key: "pb-string".to_string(),
+            ttl_ms: 300_000,
+        },
+        Command::CommonDelete {
+            key: "pb-hash".to_string(),
+        },
+    ];
+    for command in workload {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command,
+        });
+        assert!(response.status.ok, "workload write failed: {response:?}");
+    }
+    std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .iter()
+        .map(|(_, line)| crate::wal::decode_wal_line(line).expect("record decodes"))
+        .collect::<Vec<_>>();
+    assert!(
+        records.len() >= 10,
+        "expected the workload to leave records to round-trip, got {}",
+        records.len()
+    );
+    assert!(
+        records.iter().any(|record| !record.outcomes.is_empty()),
+        "the records under test carry no outcomes, so this proves nothing about them"
+    );
+
+    let mut text_bytes = 0usize;
+    let mut binary_bytes = 0usize;
+    for record in &records {
+        let framed = crate::wal::encode_wal_line_for_test(record).expect("text encodes");
+        text_bytes += framed.len();
+
+        std::env::set_var("TS_WAL_BINARY_RECORDS", "1");
+        let framed_binary = crate::wal::encode_wal_line_for_test(record).expect("binary encodes");
+        std::env::remove_var("TS_WAL_BINARY_RECORDS");
+        binary_bytes += framed_binary.len();
+
+        let round_tripped =
+            crate::wal::decode_wal_line(&framed_binary).expect("binary record decodes");
+        assert_eq!(
+            &round_tripped, record,
+            "a record did not survive the protobuf round trip"
+        );
+
+        // And the text encoding still reads, from the same decoder, with no flag consulted.
+        let from_text = crate::wal::decode_wal_line(&framed).expect("text record decodes");
+        assert_eq!(&from_text, record, "the text encoding stopped round-tripping");
+    }
+
+    println!(
+        "[proto] {} records: text {} B, protobuf {} B ({:.1}% of text)",
+        records.len(),
+        text_bytes,
+        binary_bytes,
+        binary_bytes as f64 / text_bytes as f64 * 100.0
+    );
+    assert!(
+        binary_bytes < text_bytes,
+        "protobuf ({binary_bytes} B) should be smaller than text ({text_bytes} B)"
+    );
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -37,6 +37,7 @@ pub mod telemetry;
 pub mod types;
 pub mod fault;
 pub mod wal;
+mod wal_proto;
 pub mod record_framing;
 pub mod index_log_record;
 pub mod wal_record;

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -44,7 +44,7 @@ mod cluster_snapshot;
 mod production_runtime;
 mod local_wal;
 pub(crate) mod follower_pipeline;
-mod wal_proto;
+pub(crate) mod wal_proto;
 mod cluster_meta;
 mod cluster_meta_inner;
 mod cluster_inner;

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -86,8 +86,25 @@ fn is_current_write_ahead_log_format_version(version: &u32) -> bool {
 /// verifying the per-record integrity envelope when present. Used by every WAL reader
 /// (`last_wal_sequence_at`, `scan` consumers, GC, `info`) so a value-preserving bit-flip in a
 /// committed record surfaces as `Corruption` instead of replaying as truth.
+/// Encode a record exactly as the append path would frame it.
+///
+/// Exposed so a test can compare encodings of the SAME record rather than of two separately
+/// written logs, which is the only way to say anything about fidelity.
+pub fn encode_wal_line_for_test(
+    record: &WriteAheadLogRecord,
+) -> Result<Vec<u8>, WriteAheadLogError> {
+    Ok(crate::log_framing::encode_line(&encode_wal_payload(record)?))
+}
+
 pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
     let payload = crate::log_framing::decode_line(line)?;
+    // Which encoding a payload is in is a property of the payload, never of configuration: a log
+    // written across a flag change still reads end to end.
+    if payload.first() == Some(&crate::wal_proto::BINARY_PAYLOAD_MARKER) {
+        return crate::wal_proto::decode(payload).map_err(|err| {
+            WriteAheadLogError::Corruption(format!("engine wal record decode failed: {err}"))
+        });
+    }
     let (document, carried) = split_carried_payloads(payload)?;
     if carried.is_empty() {
         return Ok(serde_json::from_slice::<WriteAheadLogRecord>(document)?);
@@ -155,6 +172,11 @@ fn split_carried_payloads(payload: &[u8]) -> Result<(&[u8], Vec<Vec<u8>>), Write
 
 /// Encode a record: the document, and the payloads worth carrying beside it.
 fn encode_wal_payload(record: &WriteAheadLogRecord) -> Result<Vec<u8>, WriteAheadLogError> {
+    if crate::wal_proto::binary_records_enabled() {
+        return crate::wal_proto::encode(record).map_err(|err| {
+            WriteAheadLogError::Corruption(format!("engine wal record encode failed: {err}"))
+        });
+    }
     let (document, carried) =
         crate::bytes_serde::carrying_payloads(|| serde_json::to_vec(record));
     let mut payload = document?;

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Encode an engine write-ahead log record as a compact binary message rather than text.
+//!
+//! The text encoding spells out every field name on every record and has no byte-string type, so
+//! binary values become arrays of decimal numbers. Measured on this path: a string write recorded
+//! with its outcome costs 471.7 bytes, of which the outcome is 285.3 -- almost all of it field
+//! names and a hex checksum. The node log already made this trade, and its own measurement put
+//! text at roughly three bytes written per byte of data.
+//!
+//! **Fidelity comes before compactness.** This is the durability path, so anything this module
+//! does not model explicitly travels byte for byte in the previous encoding rather than being
+//! approximated by the nearest match. A command this module has never heard of still round-trips
+//! exactly, and modelled arms can be added one at a time.
+//!
+//! The frame does not change. `log_framing` still wraps every record with its length and checksum,
+//! so byte offsets, integrity checking and the scan path behave exactly as before. Only the
+//! payload inside the frame differs, and its first byte says which encoding it is.
+
+use prost::Message;
+
+use crate::block_store::BlockAddress;
+use crate::sdk::v1;
+use crate::wal::{StagedPage, WalOutcomeItem, WriteAheadLogRecord, WriteAheadLogRecordMetadata};
+
+/// Marks a payload as protobuf.
+///
+/// A text payload always starts with `{`, so one byte separates the two and a log written before
+/// this existed reads back unchanged.
+pub(crate) const BINARY_PAYLOAD_MARKER: u8 = 0xB7;
+
+/// TS_WAL_BINARY_RECORDS: write engine records as protobuf.
+///
+/// Default OFF while it proves out. Reading never consults this -- a payload is decoded by what
+/// its first byte says it is -- so turning it on and off again leaves a log that still reads end
+/// to end.
+pub(crate) fn binary_records_enabled() -> bool {
+    std::env::var("TS_WAL_BINARY_RECORDS")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn address_to_proto(address: &BlockAddress) -> v1::WalBlockAddress {
+    v1::WalBlockAddress {
+        block_slab_id: address.page_slab_id,
+        offset: address.offset,
+        length: address.length,
+        block_id: address.page_id,
+        object_id: address.object_id,
+        routing_bucket: address.routing_bucket,
+        generation: address.generation,
+        band_id: address.band_id,
+        checksum: address.sha256.clone(),
+    }
+}
+
+fn address_from_proto(address: v1::WalBlockAddress) -> BlockAddress {
+    BlockAddress {
+        page_slab_id: address.block_slab_id,
+        offset: address.offset,
+        length: address.length,
+        page_id: address.block_id,
+        object_id: address.object_id,
+        routing_bucket: address.routing_bucket,
+        generation: address.generation,
+        band_id: address.band_id,
+        sha256: address.checksum,
+    }
+}
+
+fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
+    v1::EngineWalItem {
+        item_kind: 0,
+        model: 0,
+        object_key: Some(item.object_key.clone()),
+        bucket_id: None,
+        object_id: Some(item.object_id),
+        block_id: None,
+        ttl_ms: item.ttl,
+        deleted: item.deleted,
+        meta_log: item.meta,
+        block_log: false,
+        component: item.component.clone(),
+        block: item.address.as_ref().map(address_to_proto),
+        value: item.value.clone(),
+        // The engine names more kinds than the enum does, and the name is what the apply path
+        // dispatches on, so it is carried literally rather than squeezed through a lossy mapping.
+        kind_name: Some(item.kind.clone()),
+        routing_bucket: Some(item.routing_bucket),
+    }
+}
+
+fn item_from_proto(item: v1::EngineWalItem) -> WalOutcomeItem {
+    WalOutcomeItem {
+        kind: item.kind_name.unwrap_or_default(),
+        object_key: item.object_key.unwrap_or_default(),
+        component: item.component,
+        object_id: item.object_id.unwrap_or_default(),
+        routing_bucket: item.routing_bucket.unwrap_or_default(),
+        address: item.block.map(address_from_proto),
+        value: item.value,
+        ttl: item.ttl_ms,
+        deleted: item.deleted,
+        meta: item.meta_log,
+    }
+}
+
+fn metadata_to_proto(metadata: &WriteAheadLogRecordMetadata) -> Result<v1::EngineWalMetadata, String> {
+    // The descriptive item list travels verbatim rather than field by field. It is off by default,
+    // every field of it is derived from the command beside it, and modelling it would risk losing
+    // one for no measurable saving.
+    let items = if metadata.items.is_empty() {
+        Vec::new()
+    } else {
+        vec![v1::EngineWalItem {
+            item_kind: 0,
+            model: 0,
+            object_key: None,
+            bucket_id: None,
+            object_id: None,
+            block_id: None,
+            ttl_ms: None,
+            deleted: false,
+            meta_log: false,
+            block_log: false,
+            component: None,
+            block: None,
+            value: Some(serde_json::to_vec(&metadata.items).map_err(|err| err.to_string())?),
+            kind_name: Some(String::from("__verbatim_items")),
+            routing_bucket: None,
+        }]
+    };
+    Ok(v1::EngineWalMetadata {
+        version: metadata.version,
+        timestamp_ms: metadata.timestamp_ms,
+        items,
+        batch_id: metadata.batch_id,
+        batch_size: metadata.batch_size,
+        batch_index: metadata.batch_index,
+    })
+}
+
+fn metadata_from_proto(
+    metadata: v1::EngineWalMetadata,
+) -> Result<WriteAheadLogRecordMetadata, String> {
+    let items = match metadata.items.into_iter().next() {
+        Some(carried) if carried.kind_name.as_deref() == Some("__verbatim_items") => {
+            serde_json::from_slice(&carried.value.unwrap_or_default())
+                .map_err(|err| err.to_string())?
+        }
+        _ => Vec::new(),
+    };
+    Ok(WriteAheadLogRecordMetadata {
+        version: metadata.version,
+        timestamp_ms: metadata.timestamp_ms,
+        items,
+        batch_id: metadata.batch_id,
+        batch_size: metadata.batch_size,
+        batch_index: metadata.batch_index,
+    })
+}
+
+/// Encode a record as protobuf, marker byte first.
+pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
+    let message = v1::EngineWalRecord {
+        shard_id: record.shard_id,
+        sequence: record.sequence,
+        command: Some(v1::WalCommand {
+            kind: Some(
+                crate::raft::wal_proto::command_to_proto(&record.command)
+                    .map_err(|err| err.to_string())?,
+            ),
+        }),
+        metadata: record
+            .metadata
+            .as_ref()
+            .map(metadata_to_proto)
+            .transpose()?,
+        items: record.outcomes.iter().map(item_to_proto).collect(),
+        staged_blocks: record
+            .staged_pages
+            .iter()
+            .map(|page| v1::WalStagedBlock {
+                object_id: page.object_id,
+                block: page.bytes.clone(),
+                routing_bucket: None,
+            })
+            .collect(),
+    };
+    let mut out = Vec::with_capacity(message.encoded_len() + 1);
+    out.push(BINARY_PAYLOAD_MARKER);
+    message.encode(&mut out).map_err(|err| err.to_string())?;
+    Ok(out)
+}
+
+/// Decode a payload this module wrote. The caller has already checked the marker byte.
+pub(crate) fn decode(payload: &[u8]) -> Result<WriteAheadLogRecord, String> {
+    let message = v1::EngineWalRecord::decode(&payload[1..]).map_err(|err| err.to_string())?;
+    let command = message
+        .command
+        .and_then(|command| command.kind)
+        .ok_or_else(|| String::from("engine wal record carried no command"))
+        .and_then(|kind| {
+            crate::raft::wal_proto::command_from_proto(kind).map_err(|err| err.to_string())
+        })?;
+    Ok(WriteAheadLogRecord {
+        shard_id: message.shard_id,
+        sequence: message.sequence,
+        command,
+        metadata: message.metadata.map(metadata_from_proto).transpose()?,
+        staged_pages: message
+            .staged_blocks
+            .into_iter()
+            .map(|block| StagedPage {
+                object_id: block.object_id,
+                bytes: block.block,
+            })
+            .collect(),
+        outcomes: message.items.into_iter().map(item_from_proto).collect(),
+    })
+}

--- a/proto/temporalstore/v1/temporalstore.proto
+++ b/proto/temporalstore/v1/temporalstore.proto
@@ -502,6 +502,10 @@ message EngineWalRecord {
   WalCommand command = 3;
   // Absent on a record written outside a batch.
   EngineWalMetadata metadata = 4;
+  // What this write DID. Once every accepted write fills this, `command` is what comes out.
+  repeated EngineWalItem items = 5;
+  // Blocks this write produced, carried in the record that records the write.
+  repeated WalStagedBlock staged_blocks = 6;
 }
 
 // What a record did to storage, flat enough that the whole thing costs a handful of bytes.
@@ -529,6 +533,33 @@ enum WalItemModel {
   WAL_ITEM_MODEL_UNKNOWN = 10;
 }
 
+// Where a block landed.
+//
+// The checksum stays a field rather than being dropped as redundant: the block read path verifies
+// it whenever it is present, so an index entry rebuilt from a record without one is never
+// integrity-checked again. The record's own frame protects the record, not the block bytes.
+message WalBlockAddress {
+  uint64 block_slab_id = 1;
+  uint64 offset = 2;
+  uint64 length = 3;
+  optional uint64 block_id = 4;
+  optional uint64 object_id = 5;
+  optional uint32 routing_bucket = 6;
+  optional uint64 generation = 7;
+  optional uint64 band_id = 8;
+  optional string checksum = 9;
+}
+
+// WHAT A WRITE DID, which is what lets a log carry data instead of operations.
+//
+// Fields 1-10 described a write and were derived FROM the command beside them, so nothing ever
+// read them back and writing them was pure amplification. Fields 11-14 are the difference: the
+// block a write produced, the bytes for state no block backs, and which component of an object
+// they belong to. With those, a shard can be rebuilt from items alone and the command becomes
+// removable rather than merely redundant.
+//
+// One item type serves all three logs. The engine writes it durably, the shared log publishes it
+// to a successor, and the node log wraps it in consensus metadata -- none of them needs its own.
 message EngineWalItem {
   WalItemKind item_kind = 1;
   WalItemModel model = 2;
@@ -540,6 +571,28 @@ message EngineWalItem {
   bool deleted = 8;
   bool meta_log = 9;
   bool block_log = 10;
+
+  // Which component of the object this is: a hash field, a set member, a timestamp, a score and
+  // member packed together. Absent for an object with exactly one value.
+  optional string component = 11;
+  // Where the block for this component went. Absent for state no block backs -- a seen-set
+  // member, a token bucket -- which carries its bytes in `value` instead.
+  WalBlockAddress block = 12;
+  // The bytes themselves, for state that has no block behind it.
+  optional bytes value = 13;
+  // The kind as the engine names it, when the enums above cannot say it precisely. The enums
+  // stay for consumers that switch on them; this is what the engine round-trips on.
+  optional string kind_name = 14;
+  // The bucket this object routes to. On the item rather than only inside `block`, because state
+  // with no block behind it still routes somewhere.
+  optional uint32 routing_bucket = 15;
+}
+
+// A block carried inside the record that produced it, so a read can serve it back out of the log.
+message WalStagedBlock {
+  uint64 object_id = 1;
+  bytes block = 2;
+  optional uint32 routing_bucket = 3;
 }
 
 message EngineWalMetadata {


### PR DESCRIPTION
one record message for three logs, and it costs 55.9% of what the text one did

The schema for this already existed and was wired to nothing. EngineWalRecord, EngineWalItem,
WalItemKind, WalItemModel and even an EngineWalRecordHeader for skipping records cheaply during
recovery were all declared, and no Rust file mentioned any of them; the engine log went on writing
serde_json. So this connects a schema rather than inventing one.

Three shapes described one thing. EngineWalRecord is shard_id, sequence, command, metadata.
SharedStoreWalFrameProto is shard_id, wal_index, a command payload with an encoding tag, and staged
pages -- the same record with different names for `sequence` and `staged_blocks`. The node log's
entry wraps a command with a term and an index. None of them needed to be its own message: the
shared log needs a DESTINATION, not a schema, and consensus needs a wrapper, not a record.

The item is where the interesting part is. Fields 1-10 of EngineWalItem described a write and were
derived FROM the command sitting beside them, which is why its own gate says it is off by default
and "nothing reads it back". Adding a block address, a value and a component turns that same
message into what a write DID -- the thing that makes the command removable instead of merely
redundant. One item type now serves all three logs.

Fidelity is the bar, not compactness. Anything unmodelled travels verbatim in its previous
encoding, so a command this codec has never heard of still round-trips exactly, and the metadata's
own descriptive item list travels whole rather than field by field. The test drives real writes
through the engine and asserts EQUALITY of the entire record both ways, including a value carrying
0x00, 0xff, a quote and a backslash -- the bytes an encoding with no byte-string type has to guess
at. Eleven records: 4911 bytes as text, 2743 as protobuf.

The frame is untouched. log_framing still wraps every record with its length and checksum, so byte
offsets, integrity checking and the scan path behave exactly as before -- only the payload differs.
And reading never consults the flag: a payload is decoded by what its first byte says it is, so a
log written across a flag change still reads end to end, and turning this on is not a one-way door.

Gated OFF while it proves out.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
