### PR TITLE
prior context fetched 256 events so a consumer could stop at eight

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -389,6 +389,57 @@ _SUBJECT_RESCOPE_DROP = frozenset({
 
 
 
+def _prior_context_probe_window() -> int:
+    """How many newest events the cheap first pass fetches. 0 disables the probe entirely."""
+    import os as _os
+
+    raw = _os.environ.get("MATRIXARK_PRIOR_CONTEXT_PROBE_WINDOW", "").strip()
+    if not raw:
+        return 32
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 32
+
+
+def _prior_context_probe_is_enough(records: list, scope: object) -> bool:
+    """Does this small subset already hold every event the consumer would select?
+
+    The consumer stops at `MAX_PRIOR_MESSAGES` matches walking newest-first, so a subset holding
+    that many matches yields exactly the same selection. Counts scope matches only -- the consumer
+    also accepts a session-key match, so this undercounts, which escalates rather than truncates.
+    """
+    if not isinstance(scope, dict) or not scope:
+        return False
+    try:
+        from tools.matrixark_mcp_core import (
+            MAX_PRIOR_MESSAGES,
+            scope_from_serving_record,
+            scope_matches,
+        )
+    except (ModuleNotFoundError, ImportError):
+        try:
+            from matrixark_mcp_core import (
+                MAX_PRIOR_MESSAGES,
+                scope_from_serving_record,
+                scope_matches,
+            )
+        except (ModuleNotFoundError, ImportError):
+            return False
+    matched = 0
+    for record in records:
+        if not isinstance(record, dict) or record.get("record_type") != "context_event":
+            continue
+        try:
+            if scope_matches(scope_from_serving_record(record), scope):
+                matched += 1
+                if matched >= MAX_PRIOR_MESSAGES:
+                    return True
+        except Exception:  # noqa: BLE001 - an unanswerable match escalates.
+            return False
+    return False
+
+
 def _prior_context_event_window() -> int:
     """How many of a subject's newest events prior context fetches. 0 disables the cap.
 
@@ -1919,17 +1970,44 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # fetch, and it counts only matches; the margin is what keeps a busy multi-session subject
         # seeing the same eight it saw before.
         newest_events = _prior_context_event_window()
-        subset = self._scan_records_of_types(
-            [
-                "context_event",
-                "context_summary",
-                "context_pack_audit",
-                MEMORY_TOMBSTONE_RECORD_TYPE,
-                MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
-            ],
-            scope=engine_scope if pinned_hashes else None,
-            newest_by_type=({"context_event": newest_events} if newest_events else None),
-        )
+        wanted_types = [
+            "context_event",
+            "context_summary",
+            "context_pack_audit",
+            MEMORY_TOMBSTONE_RECORD_TYPE,
+            MEMORY_RETENTION_CUTOFF_RECORD_TYPE,
+        ]
+        engine_scope_arg = engine_scope if pinned_hashes else None
+
+        # `collect_prior_context` walks these newest-first and STOPS at the eighth event that
+        # matches the request's session or scope. The window exists for the subject that
+        # interleaves sessions, where the eight matches are scattered among many events -- but on
+        # the common subject the eight newest events ARE the eight matches, and fetching 256 to
+        # hand over a list the consumer abandons after eight is the waste. Measured at steady
+        # state on a 300-memory subject: 384 records and 1.32 MB fetched per add, 89 ms, of which
+        # 256 events were 901 KB.
+        #
+        # So probe with a small window first and escalate only when it cannot satisfy the
+        # consumer. The test is deliberately STRICTER than the consumer's: it counts only events
+        # matching by scope, while the consumer also accepts a session-key match. Undercounting
+        # escalates and costs a second fetch; it can never serve fewer matches than the consumer
+        # would have found.
+        probe_events = _prior_context_probe_window()
+        subset = None
+        if probe_events and newest_events and probe_events < newest_events:
+            probe = self._scan_records_of_types(
+                wanted_types,
+                scope=engine_scope_arg,
+                newest_by_type={"context_event": probe_events},
+            )
+            if probe is not None and _prior_context_probe_is_enough(probe, scope):
+                subset = probe
+        if subset is None:
+            subset = self._scan_records_of_types(
+                wanted_types,
+                scope=engine_scope_arg,
+                newest_by_type=({"context_event": newest_events} if newest_events else None),
+            )
         if subset is None:
             return self.read_all()
         # Summaries and other compact records can live in the latest-state HASH rather than the


### PR DESCRIPTION
`collect_prior_context` walks the records newest-first and stops at the eighth event matching the
request's session or scope. `prior_context_records` hands it a window of 256 events.

Measured at steady state on a 300-memory subject, with the adapter's own per-call timing: one add
spent **89.4 ms in a single `matrixark_scan_candidates`** -- 42% of a 212 ms add -- fetching **384
records and 1.32 MB**, of which 256 events were 901 KB, to select eight.

The window is not wrong: it is there for the subject that interleaves sessions, where the eight
matches are scattered among many events. But on the common subject the eight newest events ARE the
eight matches. So this probes with a small window first (32, `MATRIXARK_PRIOR_CONTEXT_PROBE_WINDOW`)
and escalates to the full window only when the probe cannot satisfy the consumer.

```text
                       add p50     add p95
probe off (256 only)   207.0 ms    461.4 ms
probe 32               125.3 ms    375.0 ms
probe off again        204.0 ms    479.1 ms
```

**39% off add latency**, with the two off-arms 1.5% apart.

**The selection is provably unchanged, which is the part that matters.** The escalation test counts
only events matching by SCOPE, while the consumer accepts a session-key match *or* a scope match --
so the consumer's match set is a superset of the test's. If the probe subset holds eight scope
matches, the consumer walking the same newest-first order reaches its eighth match no later, and
every record it selects is inside the probe subset. Undercounting can only cause an escalation --
a second fetch -- never a short answer.

Summaries, tombstones and retention cutoffs are fetched exactly as before: the probe changes the
event window only, and those are what make the subset reproduce live-view semantics.

Verified: 22/22 strict mem0 conformance, 7/7 mem0 unit suites, retrieval returning the same items
on every arm.
