### PR TITLE
a successor installs what the origin recorded, and recording stops costing the fsync queue

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1301,6 +1301,9 @@ fn publish_shard_checkpoint(
             shard_id,
             wal_index: record.sequence,
             command: record.command,
+            // What the write did travels with it. A successor installs these rather than
+            // re-running the command against its own clock and its own config.
+            outcomes: record.outcomes,
             // The local record already carries whatever pages this write produced, and a
             // page can be derived state that the command alone cannot rebuild. Mirroring
             // the command without them would publish a history a successor could not

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -735,14 +735,12 @@ impl TemporalEngine {
                 // still equals apply order (reservation + byte-append stay under this lock).
                 // The reserve-only branch appends bytes without pages, so a write carrying
                 // pages must take the staged branch or they would be dropped on the floor.
-                // The reserve-only branch appends bytes and nothing else, so anything the
-                // record has to CARRY -- pages handed in, or the outcomes this write recorded --
-                // forces the staged branch or it would be dropped on the floor. Recording
-                // outcomes therefore costs the group-commit coalescing while the gate is on,
-                // which is one more reason the flip waits until the command comes out.
+                // Staged pages still force the other branch -- their addresses are back-patched
+                // once the record's log id exists, which this path does not do. Outcomes no
+                // longer do: they are resolved before they are staged, so they ride along and a
+                // recording write keeps its place in the group-commit queue.
                 let concurrent_commit = sync
                     && carried_pages.is_empty()
-                    && !crate::wal::wal_outcome_items_enabled()
                     && (engine_concurrent_commit() || raft_apply_batch_active());
                 // Where each page this write stages ends up, so the index can carry it. Filled
                 // by the append below, which is the first moment the log id exists.
@@ -750,7 +748,15 @@ impl TemporalEngine {
                     Vec::new();
                 let append_result = if concurrent_commit {
                     self.wal_store
-                        .append_for_group_commit(request.shard_id, command)
+                        .append_for_group_commit(
+                            request.shard_id,
+                            command,
+                            if crate::wal::wal_outcome_items_enabled() {
+                                block_in_wal::take_outcomes()
+                            } else {
+                                Vec::new()
+                            },
+                        )
                         .map(|record| Some(record.sequence))
                 } else {
                     self.wal_store

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -632,6 +632,26 @@ impl TemporalEngine {
     /// a caller can fall back rather than silently skipping state. Kinds are being brought over
     /// one at a time, each gated on an equivalence test, because an apply that quietly drops a
     /// kind rebuilds a shard that is subtly wrong -- which is worse than one that refuses.
+    /// Install everything a shared-log entry recorded, or refuse the lot.
+    ///
+    /// Partial application is the failure this exists to prevent: a successor that installs four
+    /// of five items serves a shard that looks whole and is not. Refusing sends the caller back to
+    /// re-executing, which is worse but honest.
+    pub fn install_shared_outcomes(
+        &self,
+        shard_id: ShardId,
+        outcomes: &[crate::wal::WalOutcomeItem],
+    ) -> bool {
+        if outcomes.iter().any(|item| !self.apply_outcome_item(shard_id, item)) {
+            return false;
+        }
+        self.replay_installs.fetch_add(
+            outcomes.len() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        true
+    }
+
     pub(super) fn apply_outcome_item(
         &self,
         shard_id: ShardId,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5846,3 +5846,144 @@ fn binary_records_survive_a_reload_through_a_real_log_file() {
         }
     }
 }
+
+/// Recording results must not cost a write its place in the group-commit queue.
+///
+/// It used to. Anything a record had to CARRY forced the staged append branch, and outcomes were
+/// treated as one of those things -- so turning recording on turned coalescing off, and every
+/// concurrent writer paid its own fsync. That was the strongest argument for keeping the gate off,
+/// and it was a property of the plumbing rather than of durability: a staged page needs its
+/// address back-patched once the record's log id exists, and an outcome does not.
+///
+/// Asserts fewer fsyncs than writes with recording ON. Not a ratio -- the point is that coalescing
+/// ENGAGES, and on a loaded machine how much it wins varies.
+#[test]
+fn recording_results_still_coalesces_fsyncs() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    const WRITERS: usize = 8;
+    const PER_WRITER: usize = 25;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = Arc::new(TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    ));
+    engine.load_shard(1);
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
+    std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
+
+    let syncs_before = engine.write_ahead_log_store().stats(1).syncs;
+    let acked = Arc::new(AtomicUsize::new(0));
+    let gate = Arc::new(Barrier::new(WRITERS));
+    let mut handles = Vec::with_capacity(WRITERS);
+    for writer in 0..WRITERS {
+        let engine = Arc::clone(&engine);
+        let acked = Arc::clone(&acked);
+        let gate = Arc::clone(&gate);
+        handles.push(std::thread::spawn(move || {
+            gate.wait();
+            for index in 0..PER_WRITER {
+                let response = engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: format!("gc-{writer}-{index}"),
+                        value: b"v".to_vec(),
+                    },
+                });
+                if response.status.ok {
+                    acked.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let syncs = engine.write_ahead_log_store().stats(1).syncs - syncs_before;
+    let writes = acked.load(Ordering::Relaxed);
+    std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+
+    println!("[coalescing] writes={writes} fdatasyncs={syncs} while recording results");
+    assert_eq!(writes, WRITERS * PER_WRITER, "every write must ack");
+    assert!(
+        syncs < writes as u64,
+        "recording results cost the coalescing: {syncs} fsyncs for {writes} writes"
+    );
+
+    // And every acked write is still readable, which is the half a coalescing change can break.
+    for writer in 0..WRITERS {
+        for index in 0..PER_WRITER {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("gc-{writer}-{index}"),
+                },
+            });
+            assert!(
+                matches!(response.response, CommandResponse::Bytes { value: Some(ref v) } if v == b"v"),
+                "gc-{writer}-{index} did not read back"
+            );
+        }
+    }
+}
+
+/// Does a write that stages a log-resident block keep it when it takes the group-commit branch?
+///
+/// The branch predicate tests the pages the CALLER handed in, not the ones the write staged
+/// itself, and both gates default on -- so on the face of it a staged block could be dropped. This
+/// settles it by looking rather than by reading the predicate, because the answer decides whether
+/// anything needs fixing before the recording flip.
+#[test]
+fn a_group_commit_write_keeps_the_block_it_staged() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", "1");
+
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "bw-key".to_string(),
+            value: b"staged".to_vec(),
+        },
+    });
+    assert!(response.status.ok);
+    std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+
+    let carried: usize = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .iter()
+        .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+        .map(|record| record.staged_pages.len())
+        .sum();
+    println!(
+        "[block-in-wal] group-commit write: {} block(s) carried, index holds {}",
+        carried,
+        engine.wal_resident_page_count(1)
+    );
+
+    // Whatever the answer, the value must read back -- that is the property that matters.
+    let get = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "bw-key".to_string(),
+        },
+    });
+    assert!(
+        matches!(get.response, CommandResponse::Bytes { value: Some(ref v) } if v == b"staged"),
+        "a group-commit write did not read back: {:?}",
+        get.response
+    );
+}

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -104,6 +104,17 @@ pub struct SharedStoreWalEntry {
     /// before this field existed still loads.
     #[serde(default)]
     pub staged_pages: Vec<crate::wal::StagedPage>,
+    /// What this write DID, so a successor can install results instead of re-running operations.
+    ///
+    /// Carrying pages was the same idea reached halfway: a page is derived state the command
+    /// cannot rebuild, so the pages travelled beside the command. These finish the thought. A
+    /// successor that installs them needs no clock of its own, no eviction config from the
+    /// original node, and no assumption that re-executing here lands where it landed there.
+    ///
+    /// `serde(default)` and skipped when empty, so an entry written before this reads back
+    /// unchanged and replays exactly as it used to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outcomes: Vec<crate::wal::WalOutcomeItem>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -396,6 +407,17 @@ struct SharedStoreWalFrameProto {
     /// empty, so both directions stay readable across the change.
     #[prost(message, repeated, tag = "7")]
     staged_pages: Vec<SharedStoreStagedPageProto>,
+    /// What the write DID, in the SAME message the engine log uses.
+    ///
+    /// Not a shared-store item type: the shared log needs a destination, not a schema. Carrying
+    /// the engine's item means a successor installs exactly what the origin recorded, with no
+    /// conversion in between to disagree about.
+    ///
+    /// Tag 8, same compatibility shape as tag 7. Without it this path would carry the command and
+    /// silently drop the results, which is worse than not carrying them at all -- the successor
+    /// would re-execute and look correct.
+    #[prost(message, repeated, tag = "8")]
+    items: Vec<crate::sdk::v1::EngineWalItem>,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -1215,6 +1237,27 @@ where
             if wal_index <= after_wal_index {
                 continue;
             }
+            // An entry that says what its write DID is installed, not re-executed. Re-executing
+            // reproduces the write only if everything that influenced it is reproduced too, and on
+            // a SUCCESSOR that is a stronger assumption than it is on a restart: a different node,
+            // a different clock, and whatever config it happens to hold.
+            //
+            // The fallback is what makes this safe to land. An entry carrying no outcomes replays
+            // exactly as it used to, so a shared log written before this still applies.
+            if !entry.outcomes.is_empty() {
+                if !engine.install_shared_outcomes(shard_id, &entry.outcomes) {
+                    return Err(SharedStoreReplicationError::ApplyFailed {
+                        wal_index,
+                        status: Status::error(
+                            "shared_wal_outcome_refused",
+                            "a recorded outcome could not be installed; refusing to serve a shard missing it",
+                        ),
+                    });
+                }
+                report.applied += 1;
+                report.last_wal_index = wal_index;
+                continue;
+            }
             // Hand the replayed write the pages the ORIGINAL write produced. Re-executing the
             // command would otherwise substitute this node's reconstruction for the bytes that
             // were actually acked -- identical for a plain value, and not necessarily so for
@@ -1273,6 +1316,27 @@ where
                     expected,
                     actual: wal_index,
                 });
+            }
+            // An entry that says what its write DID is installed, not re-executed. Re-executing
+            // reproduces the write only if everything that influenced it is reproduced too, and on
+            // a SUCCESSOR that is a stronger assumption than it is on a restart: a different node,
+            // a different clock, and whatever config it happens to hold.
+            //
+            // The fallback is what makes this safe to land. An entry carrying no outcomes replays
+            // exactly as it used to, so a shared log written before this still applies.
+            if !entry.outcomes.is_empty() {
+                if !engine.install_shared_outcomes(shard_id, &entry.outcomes) {
+                    return Err(SharedStoreReplicationError::ApplyFailed {
+                        wal_index,
+                        status: Status::error(
+                            "shared_wal_outcome_refused",
+                            "a recorded outcome could not be installed; refusing to serve a shard missing it",
+                        ),
+                    });
+                }
+                report.applied += 1;
+                report.last_wal_index = wal_index;
+                continue;
             }
             // Hand the replayed write the pages the ORIGINAL write produced. Re-executing the
             // command would otherwise substitute this node's reconstruction for the bytes that
@@ -2151,7 +2215,8 @@ where
             command,
         
                         staged_pages: Vec::new(),
-                    };
+                                outcomes: Vec::new(),
+        };
         match self.mode {
             SharedStoreStorageMode::Sync if self.group_commit => {
                 self.group_commit_write(entry).await
@@ -2439,6 +2504,11 @@ fn encode_wal_proto_frame(
                 bytes: page.bytes.clone(),
             })
             .collect(),
+        items: entry
+            .outcomes
+            .iter()
+            .map(crate::wal_proto::item_to_proto)
+            .collect(),
     };
     let mut encoded = frame.encode_to_vec();
     let mut out = Vec::with_capacity(4 + encoded.len());
@@ -2519,6 +2589,11 @@ fn decode_wal_proto_frame_exact(
         shard_id: frame.shard_id,
         wal_index: frame.wal_index,
         command,
+        outcomes: frame
+            .items
+            .into_iter()
+            .map(crate::wal_proto::item_from_proto)
+            .collect(),
         staged_pages: frame
             .staged_pages
             .into_iter()
@@ -2826,7 +2901,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -3048,7 +3124,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -3139,7 +3216,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -3225,7 +3303,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -3494,7 +3573,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -3599,7 +3679,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
         }
@@ -3656,7 +3737,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
         }
@@ -3906,7 +3988,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -4024,7 +4107,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
         }
@@ -4081,7 +4165,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
         }
@@ -4132,6 +4217,7 @@ mod tests {
                 object_id: 77,
                 bytes: b"derived-page-bytes".to_vec(),
             }],
+                    outcomes: Vec::new(),
         };
         replicator.publish_wal_entry(entry.clone()).await.unwrap();
 
@@ -4160,6 +4246,7 @@ mod tests {
                 value: b"v".to_vec(),
             },
             staged_pages: Vec::new(),
+                    outcomes: Vec::new(),
         };
         let mut legacy = serde_json::to_value(&entry).unwrap();
         legacy
@@ -4383,7 +4470,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -4772,7 +4860,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
 
@@ -4824,7 +4913,8 @@ mod tests {
                 },
             
                                    staged_pages: Vec::new(),
-                               })
+                                               outcomes: Vec::new(),
+            })
             .await
             .unwrap();
     }
@@ -4882,7 +4972,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
         }
@@ -4951,7 +5042,8 @@ mod tests {
                     },
                 
                                        staged_pages: Vec::new(),
-                                   })
+                                                       outcomes: Vec::new(),
+                })
                 .await
                 .unwrap();
             append_receipts.push(receipt.expect("protobuf append blob should return offsets"));

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1013,10 +1013,18 @@ impl LocalWriteAheadLogStore {
     /// writers (see `group_commit_sync`). Mirrors the byte-append half of
     /// `append_with_sync`'s group branch, minus the in-line barrier call. The caller MUST
     /// await `commit_barrier(shard_id, record.sequence)` before acking a synchronous write.
+    /// Append without the durable barrier, carrying what the write recorded.
+    ///
+    /// Outcomes were kept off this path on the assumption that anything a record must CARRY forces
+    /// the staged branch. That is true of staged pages, whose addresses are back-patched once the
+    /// log id exists. It is not true of outcomes: their addresses are already resolved by the time
+    /// they are staged, so they travel in the record like any other field -- and keeping them out
+    /// cost every write its place in the group-commit queue for no durability reason.
     pub fn append_for_group_commit(
         &self,
         shard_id: ShardId,
         command: Command,
+        outcomes: Vec<WalOutcomeItem>,
     ) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         fs::create_dir_all(&inner.root)?;
@@ -1034,7 +1042,7 @@ impl LocalWriteAheadLogStore {
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
             command,
             staged_pages: Vec::new(),
-            outcomes: Vec::new(),
+            outcomes,
         };
         // sync=false: write the bytes, defer the fdatasync to `commit_barrier`. Same as the
         // group branch of append_with_sync. `last_flushed_sequence` is NOT advanced here (the
@@ -6051,6 +6059,7 @@ mod tests {
                         key: format!("k{index:06}"),
                         value: vec![118u8; 64],
                     },
+                    Vec::new(),
                 )
                 .unwrap()
                 .sequence;

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -118,7 +118,7 @@ fn address_from_proto(address: v1::WalBlockAddress) -> BlockAddress {
     }
 }
 
-fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
+pub(crate) fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
     v1::EngineWalItem {
         item_kind: 0,
         model: 0,
@@ -140,7 +140,7 @@ fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
     }
 }
 
-fn item_from_proto(item: v1::EngineWalItem) -> WalOutcomeItem {
+pub(crate) fn item_from_proto(item: v1::EngineWalItem) -> WalOutcomeItem {
     WalOutcomeItem {
         kind: item.kind_name.unwrap_or_default(),
         object_key: item.object_key.unwrap_or_default(),


### PR DESCRIPTION
a successor installs what the origin recorded, and recording stops costing the fsync queue

Two things kept results from being the normal payload rather than an opt-in, and neither was about
durability.

Recording cost the group-commit coalescing. Anything a record had to CARRY forced the staged append
branch, and outcomes were treated as one of those things -- so turning recording on gave every
concurrent writer its own fsync. That is true of a staged block, whose address is back-patched once
the record's log id exists; `register_record` does that, and it takes staged blocks and nothing
else. An outcome's address is resolved before it is ever staged. So the exclusion was caution, and
removing it costs nothing: 200 concurrent writes now take 135 barriers with recording ON, where
they took 200.

And a successor still re-executed. When a shard moves, the log is scanned and each record's
operation is copied into the shared log for the new owner to run again. That is a stronger
assumption on a successor than on a restart: a different node, a different clock, and whatever
config it happens to hold. The code already half-knew -- it carries the origin's blocks beside the
operation, with a comment saying re-execution would otherwise substitute this node's
reconstruction for the bytes that were acked. Carrying results finishes that thought.

The shared frame carries the ENGINE's item message, not one of its own. The shared log needs a
destination, not a schema; a successor installs exactly what the origin recorded, with no
conversion in between to disagree about. Without that field the protobuf path would have carried
the operation and silently dropped the results -- worse than carrying neither, because the
successor would re-execute and look correct.

Both paths fall back. An entry carrying no results replays exactly as it used to, so a shared log
written before this still applies, and a partial install is refused rather than half-applied: a
successor that installs four items of five serves a shard that looks whole and is not.

Noted while measuring, not fixed here: a write that takes the group-commit branch carries ZERO
staged blocks, because the branch tests the blocks the CALLER handed in and not the ones the write
staged itself. Both gates default on, so the block-in-log path is inert for an ordinary
synchronous write. No data is lost -- the block goes to the block store as it always did -- and it
predates this change: pristine main fails the same way. It is a feature that is on by default and
doing nothing by default, which is worth someone's attention.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
