### PR TITLE
Read and write the membership index in one round trip each

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -2492,6 +2492,61 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
             return None
         return {str(v) for v in values}
 
+    def _lookup_persisted_event_members_many(self, event_ids: list[str]) -> dict[str, set[str]]:
+        """Read many membership entries in one round trip.
+
+        Every entry lives under the same hash key, so a single ``batch_hget`` replaces one read
+        per event. An id the batch response does not answer for is read singly rather than
+        treated as absent -- treating it as absent would let a partial response overwrite a
+        persisted member set with a SMALLER one, and membership is cumulative across the async
+        pipeline. Absent stays absent (omitted from the result), matching the single-key
+        contract that the caller reads with ``or set()``.
+        """
+        found: dict[str, set[str]] = {}
+        wanted = [str(event_id) for event_id in event_ids]
+        if not wanted:
+            return found
+        key = self._event_members_hash_key()
+        entries = [{"key": key, "field": event_id} for event_id in wanted]
+        try:
+            rows = self._client.batch_hget(entries)
+        except Exception:  # noqa: BLE001 - never let a backend read break the write path
+            rows = []
+        raw_by_field: dict[str, str] = {}
+        for index, row in enumerate(rows if isinstance(rows, list) else []):
+            field = ""
+            raw = ""
+            if isinstance(row, dict):
+                field = str(row.get("field") or "")
+                raw = str(row.get("value") or "")
+            elif isinstance(row, str):
+                raw = row
+            if not field and index < len(entries):
+                field = str(entries[index]["field"])
+            if field:
+                raw_by_field[field] = raw
+        for event_id in wanted:
+            if event_id in raw_by_field:
+                members = self._decode_event_members(raw_by_field[event_id])
+            else:
+                # Not answered by the batch: read it singly rather than assume absent.
+                members = self._lookup_persisted_event_members(event_id)
+            if members is not None:
+                found[event_id] = members
+        return found
+
+    @staticmethod
+    def _decode_event_members(raw: str) -> set[str] | None:
+        if not raw:
+            return None
+        try:
+            values = json.loads(raw)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(values, list):
+            return None
+        return {str(v) for v in values}
+
     def _persist_event_members(self, event_id: str, member_ids: set[str]) -> None:
         try:
             self._hset_with_backoff(
@@ -2534,10 +2589,27 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
                     continue
                 for source_id in provenance:
                     additions.setdefault(str(source_id), set()).update(identity_ids)
+        existing_by_event = self._lookup_persisted_event_members_many(list(additions))
+        pending: list[tuple[str, set[str]]] = []
         for event_id, new_members in additions.items():
-            existing = self._lookup_persisted_event_members(event_id) or set()
+            existing = existing_by_event.get(str(event_id)) or set()
             merged = existing | new_members
             if merged != existing:
+                pending.append((str(event_id), merged))
+        if not pending:
+            return
+        entries = [
+            {
+                "key": self._event_members_hash_key(),
+                "field": event_id,
+                "value": json.dumps(sorted(str(m) for m in merged), separators=(",", ":")),
+            }
+            for event_id, merged in pending
+        ]
+        try:
+            self._client.batch_hset(entries)
+        except Exception:  # noqa: BLE001 - best-effort, same as the single-key write it replaces
+            for event_id, merged in pending:
                 self._persist_event_members(event_id, merged)
 
     def __init__(

--- a/tools/test_delete_membership_index.py
+++ b/tools/test_delete_membership_index.py
@@ -310,5 +310,118 @@ class EnginePersistenceMethodsCase(unittest.TestCase):
         self.assertEqual({str(anchor), str(entity)}, members)
 
 
+class BatchedMembershipWriteThroughCase(unittest.TestCase):
+    """The batched read/write path, which the FakeClient above never reaches.
+
+    That client exposes only hget/hset, so `batch_hget`/`batch_hset` raise AttributeError,
+    the adapter falls back to per-key access, and the batched code is never executed. A
+    client that DOES batch is therefore the only way these lines are covered.
+    """
+
+    def _engine_stub(self, answer_fields=None):
+        import matrixark_mcp_temporal_adapters as eng
+
+        class BatchingFakeClient:
+            def __init__(self):
+                self.store: dict[tuple[str, str], str] = {}
+                self.batch_gets = 0
+                self.batch_sets = 0
+                self.single_gets = 0
+                self.single_sets = 0
+
+            def hset(self, key, field, value):
+                self.single_sets += 1
+                self.store[(key, field)] = value
+
+            def hget(self, key, field):
+                self.single_gets += 1
+                return self.store.get((key, field), "")
+
+            def batch_hget(self, entries):
+                self.batch_gets += 1
+                rows = []
+                for entry in entries:
+                    key, field = str(entry.get("key")), str(entry.get("field"))
+                    # answer_fields=None means answer everything (the normal case).
+                    if answer_fields is not None and field not in answer_fields:
+                        continue
+                    rows.append({"key": key, "field": field,
+                                 "value": self.store.get((key, field), "")})
+                return rows
+
+            def batch_hset(self, entries):
+                self.batch_sets += 1
+                for entry in entries:
+                    self.store[(str(entry.get("key")), str(entry.get("field")))] = str(
+                        entry.get("value"))
+
+        obj = object.__new__(eng.MatrixArkTemporalStoreDirectAdapter)
+        obj._storage_prefix = "matrixark:mcp"
+        obj._client = BatchingFakeClient()
+        obj._hset_with_backoff = lambda key, field, value: obj._client.hset(key, field, value)
+        obj._invalidate_event_member_index = lambda: None
+        return obj, eng
+
+    def _records(self, anchor, entity):
+        return [
+            {"record_type": "context_event", "event_id_hash": anchor},
+            {"record_type": "context_entity", "entity_hash": entity,
+             "source_event_ids": [anchor]},
+        ]
+
+    def test_batch_path_is_taken_and_membership_matches(self):
+        obj, _eng = self._engine_stub()
+        anchor, entity = 700, 800
+        obj._maintain_event_membership_after_append(self._records(anchor, entity))
+        self.assertEqual({str(anchor), str(entity)},
+                         obj._lookup_persisted_event_members(str(anchor)))
+        # The whole point of the change: batched, not per-key.
+        self.assertEqual(1, obj._client.batch_gets)
+        self.assertEqual(1, obj._client.batch_sets)
+        self.assertEqual(0, obj._client.single_sets)
+
+    def test_one_round_trip_each_regardless_of_event_count(self):
+        obj, _eng = self._engine_stub()
+        records = []
+        for i in range(25):
+            records.extend(self._records(1000 + i, 2000 + i))
+        obj._maintain_event_membership_after_append(records)
+        self.assertEqual(1, obj._client.batch_gets)
+        self.assertEqual(1, obj._client.batch_sets)
+        for i in range(25):
+            self.assertEqual({str(1000 + i), str(2000 + i)},
+                             obj._lookup_persisted_event_members(str(1000 + i)))
+
+    def test_membership_is_cumulative_across_appends(self):
+        obj, _eng = self._engine_stub()
+        anchor = 700
+        obj._maintain_event_membership_after_append(self._records(anchor, 800))
+        obj._maintain_event_membership_after_append([
+            {"record_type": "context_entity", "entity_hash": 900,
+             "source_event_ids": [anchor]},
+        ])
+        self.assertEqual({"700", "800", "900"},
+                         obj._lookup_persisted_event_members(str(anchor)))
+
+    def test_partial_batch_response_cannot_shrink_a_member_set(self):
+        """A field the batch does not answer for must be read singly, not assumed absent.
+
+        Assuming absent would union new members onto an EMPTY set and write back a smaller
+        set than what is stored -- silently losing membership, which a later delete needs.
+        """
+        obj, _eng = self._engine_stub(answer_fields=set())  # batch answers nothing
+        anchor = 700
+        obj._maintain_event_membership_after_append(self._records(anchor, 800))
+        before = obj._lookup_persisted_event_members(str(anchor))
+        self.assertEqual({"700", "800"}, before)
+        # Second append, with the batch still refusing to answer for this field.
+        obj._maintain_event_membership_after_append([
+            {"record_type": "context_entity", "entity_hash": 900,
+             "source_event_ids": [anchor]},
+        ])
+        self.assertEqual({"700", "800", "900"},
+                         obj._lookup_persisted_event_members(str(anchor)))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The durable event-membership write-through read the membership hash **one field at a time**, then wrote it back one field at a time. Every field lives under the same hash key, so all of it fits in one read and one write.

Counted per add, 30 adds on a warmed ~180-memory store, with the before arm run twice:

| | hget | batch_hget | hset | batch_hset | membership hget | **total round trips** |
|---|---:|---:|---:|---:|---:|---:|
| before | 19.0 | 7.0 | 4.0 | 0 | 17.0 | **42.4** |
| after | 2.0 | 9.0 | 2.0 | 2.0 | **0.0** | **27.4** |
| before (repeat) | 19.0 | 7.0 | 4.0 | 0 | 17.0 | **42.3** |

**35% fewer round trips per add.** The two before arms agree to 0.1, and the accounting reconciles exactly: −17 membership reads, +2 batched reads, −2 single writes, +2 batched writes = −15, which is the observed total.

Quoted as counts rather than milliseconds on purpose. The measured p50s were 109.7 / 113.9 / 103.2 ms, with the two *identical* before arms 6.5 ms apart — this machine's wall clock swings far more than the effect, so timing here would be noise dressed as a result. Round-trip counts are load-immune.

## Why fewer calls is the lever

Per-call cost was measured directly against record count: `ms = 3.69 fixed + 1.879 per record`. Serialization is 2.0% of an add, so the fixed part is the round trip itself — pipe write, engine work, response read. Trimming what each call carries buys almost nothing; removing calls buys the fixed cost every time.

## Safety

A field the batch does not answer for is **read singly rather than assumed absent**. That distinction is the whole risk in this change: membership is cumulative across the async pipeline, so treating an unanswered field as empty would union the new members onto an empty set and write back a *smaller* set than what is stored, silently dropping members a later delete needs.

Both new calls keep the best-effort contract of the single-key ones they replace — a backend problem falls back to the per-key path rather than failing the write.

## Tests

The existing suite passed **without ever running the new code**: its `FakeClient` exposes only `hget`/`hset`, so `batch_hget`/`batch_hset` raise `AttributeError`, the adapter takes its fallback, and the batched path is never reached. A client that batches is the only way these lines get covered, so this adds one.

Four new tests: the batch path is actually taken (asserting one batched read and one batched write, and zero single writes), one round trip each regardless of event count, membership stays cumulative across appends, and a partial batch response cannot shrink a stored member set.

The shrink guard was checked against a deliberately broken build rather than assumed meaningful — replacing the single-key fallback with "assume absent" fails `test_partial_batch_response_cannot_shrink_a_member_set` by losing exactly the two members it should have kept.

14/14 in `test_delete_membership_index.py`, 102 tests green across 8 mem0 suites, and 22/22 strict mem0 conformance against a live gateway.
