### PR TITLE
the log carries what a write DID, by default, and a record got smaller doing it

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1264,10 +1264,18 @@ impl TemporalEngine {
             // recovery reconstructs the identical absolute deadlines the leader logged
             // (resolve-then-log) instead of extending every recently-SETEX'd key.
             set_replay_clock_ms(record.metadata.as_ref().map(|meta| meta.timestamp_ms));
-            let response = self.execute(ExecuteRequest {
-                shard_id,
-                command: record.command,
-            });
+            // Neither results nor an operation. Refusing is the only honest answer: replaying it
+            // as nothing would serve a shard missing a durable write and report success.
+            let Some(command) = record.command else {
+                return Err(Status::error(
+                    "wal_replay_record_empty",
+                    format!(
+                        "WAL record at sequence {} carries neither results nor an operation; refusing load rather than skipping a durable write",
+                        record.sequence
+                    ),
+                ));
+            };
+            let response = self.execute(ExecuteRequest { shard_id, command });
             if !response.status.ok {
                 return Err(Status::error(
                     "wal_replay_failed",
@@ -1583,7 +1591,7 @@ mod batch_truncation_tests {
         WriteAheadLogRecord {
             shard_id: 1,
             sequence: seq,
-            command,
+            command: Some(command),
             metadata: Some(metadata),
             staged_pages: Vec::new(),
             outcomes: Vec::new(),

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1511,10 +1511,10 @@ fn wal_replay_gap_refuses_load_like_dataloss() {
         wal.append_replayed_record(WriteAheadLogRecord {
             shard_id: 1,
             sequence: seq,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: format!("k{seq}"),
                 value: b"v".to_vec(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5514,19 +5514,23 @@ fn what_each_command_recorded_describes_everything_it_changed() {
     );
 }
 
-/// What a record COSTS, measured through the engine rather than the log.
+/// What a record COSTS, before and after -- measured through the engine, not the log.
 ///
-/// The reclaim harness appends straight to the WAL store, so it never stages an outcome and its
-/// record bytes are identical with the gate on and off -- byte-for-byte identical base offsets are
-/// how that was caught. Anything measuring the cost of recording outcomes has to go through
+/// The reclaim harness appends straight to the log and never stages a result, so its records are
+/// byte-identical either way; its base offsets matched to the byte across both runs, which is how
+/// that was caught rather than reported as a saving. Anything measuring this has to go through
 /// execute().
 ///
-/// This reports bytes per record both ways and asserts only the direction: carrying a command AND
-/// its outcomes must be bigger than carrying the command alone. The absolute numbers are printed
-/// for the record, not asserted, because they move with the workload.
+/// BEFORE is what shipped: the operation, in text. AFTER is what ships now: results, in protobuf,
+/// with no operation. Both arms set every flag explicitly, because the defaults are the thing
+/// under test and inheriting them would compare a configuration against itself -- which this test
+/// did, silently, the moment the defaults flipped.
 #[test]
-fn what_recording_outcomes_costs_per_record() {
-    fn wal_bytes_for(outcomes: bool, writes: usize) -> (u64, u64) {
+fn a_record_carrying_results_is_smaller_than_one_carrying_the_operation() {
+    fn wal_bytes(binary: &str, record_results: &str, data_only: &str, writes: usize) -> (u64, u64) {
+        std::env::set_var("TS_WAL_BINARY_RECORDS", binary);
+        std::env::set_var("TS_WAL_OUTCOME_ITEMS", record_results);
+        std::env::set_var("TS_WAL_DATA_ONLY", data_only);
         let dir = tempfile::tempdir().unwrap();
         let engine = TemporalEngine::with_local_dirs(
             1024 * 1024,
@@ -5535,9 +5539,6 @@ fn what_recording_outcomes_costs_per_record() {
             dir.path().join("indexes"),
         );
         engine.load_shard(1);
-        if outcomes {
-            std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
-        }
         for index in 0..writes {
             let response = engine.execute(ExecuteRequest {
                 shard_id: 1,
@@ -5548,64 +5549,40 @@ fn what_recording_outcomes_costs_per_record() {
             });
             assert!(response.status.ok);
         }
-        std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
         let records = engine
             .write_ahead_log_store()
             .scan(1, 0, u64::MAX, u64::MAX)
             .unwrap();
         let total: u64 = records.iter().map(|(_, line)| line.len() as u64).sum();
-        (total, records.len() as u64)
+        let count = records.len() as u64;
+        std::env::remove_var("TS_WAL_BINARY_RECORDS");
+        std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+        std::env::remove_var("TS_WAL_DATA_ONLY");
+        (total, count)
     }
 
     const WRITES: usize = 2_000;
-    let (without, count_without) = wal_bytes_for(false, WRITES);
-    let (with, count_with) = wal_bytes_for(true, WRITES);
-    let per_without = without as f64 / count_without as f64;
-    let per_with = with as f64 / count_with as f64;
+    let (before, before_n) = wal_bytes("0", "0", "0", WRITES);
+    let (after, after_n) = wal_bytes("1", "1", "1", WRITES);
+    let per_before = before as f64 / before_n as f64;
+    let per_after = after as f64 / after_n as f64;
 
-    println!("[record cost] command only      : {without} B over {count_without} records = {per_without:.1} B/record");
-    println!("[record cost] command + outcomes: {with} B over {count_with} records = {per_with:.1} B/record");
+    println!("[record cost] BEFORE  operation, text     : {per_before:.1} B/record");
+    println!("[record cost] AFTER   results, protobuf   : {per_after:.1} B/record");
     println!(
-        "[record cost] carrying both costs {:.1} B/record ({:+.1}%)",
-        per_with - per_without,
-        (per_with - per_without) / per_without * 100.0
+        "[record cost] {:+.1} B/record ({:+.1}%)",
+        per_after - per_before,
+        (per_after - per_before) / per_before * 100.0
     );
 
-    // Print one record each way. A ratio says something is expensive; the bytes say WHAT.
-    {
-        let dir = tempfile::tempdir().unwrap();
-        let engine = TemporalEngine::with_local_dirs(
-            1024 * 1024,
-            dir.path().join("c"),
-            dir.path().join("p"),
-            dir.path().join("i"),
-        );
-        engine.load_shard(1);
-        std::env::set_var("TS_WAL_OUTCOME_ITEMS", "1");
-        engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::StringSet {
-                key: "size-000000".to_string(),
-                value: vec![b'v'; 64],
-            },
-        });
-        std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
-        for (_, line) in engine
-            .write_ahead_log_store()
-            .scan(1, 0, u64::MAX, u64::MAX)
-            .unwrap()
-            .iter()
-            .take(1)
-        {
-            println!("[record cost] one record with outcomes ({} B):", line.len());
-            println!("{}", String::from_utf8_lossy(line));
-        }
-    }
-
-    assert!(count_with >= count_without, "the workload changed shape between runs");
+    assert_eq!(before_n, after_n, "the two arms wrote different record counts");
+    // The whole argument for making this the default. A record that states results carries MORE
+    // information than one that states an operation, and if it also costs more bytes then going
+    // live is a regression dressed as progress.
     assert!(
-        per_with > per_without,
-        "recording outcomes alongside the command should cost bytes; if it does not, the gate is          not reaching the append path and this measurement is meaningless"
+        per_after < per_before,
+        "a record carrying results ({per_after:.1} B) must not cost more than one carrying the \
+         operation ({per_before:.1} B)"
     );
 }
 
@@ -5724,7 +5701,7 @@ fn a_record_encoded_as_protobuf_reads_back_identical() {
         // Both branches set the flag explicitly. Leaving the text branch to inherit the ambient
         // environment meant that under a suite run with the binary flag on, the "text" encoding
         // was binary and the comparison silently tested one encoding against itself.
-        std::env::remove_var("TS_WAL_BINARY_RECORDS");
+        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
         let framed = crate::wal::encode_wal_line_for_test(record).expect("text encodes");
         text_bytes += framed.len();
 

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -90,7 +90,13 @@ pub struct SharedStoreWalEntry {
     pub shard_id: ShardId,
     #[serde(rename = "wal_index")]
     pub wal_index: u64,
-    pub command: Command,
+    /// The operation, for an entry that cannot say what it DID.
+    ///
+    /// Absent once the entry carries results, exactly as in the engine record it comes from. An
+    /// entry published before results existed still carries one, and a successor still replays it
+    /// by re-running it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<Command>,
     /// The pages this write produced, carried beside the command that produced them.
     ///
     /// A command is not always enough to rebuild what it wrote. A page can be DERIVED state --
@@ -696,7 +702,7 @@ where
         entry: SharedStoreWalEntry,
     ) -> Result<Option<AppendBlobReceipt>, SharedStoreReplicationError> {
         let key = self.wal_blob_key(entry.shard_id);
-        let command_metadata = wal_command_metadata(&entry.command)?;
+        let command_metadata = wal_command_metadata(entry.command.as_ref())?;
         let frame = encode_wal_proto_frame(&entry)?;
         let receipt = self
             .append_blob_with_retry(&key, Bytes::from(frame))
@@ -792,7 +798,7 @@ where
         for entry in entries {
             let frame = encode_wal_proto_frame(entry)?;
             frame_lengths.push(frame.len() as u64);
-            command_metadata.push(wal_command_metadata(&entry.command)?);
+            command_metadata.push(wal_command_metadata(entry.command.as_ref())?);
             wal_payload.extend_from_slice(&frame);
         }
         let receipt = self
@@ -1262,11 +1268,17 @@ where
             // command would otherwise substitute this node's reconstruction for the bytes that
             // were actually acked -- identical for a plain value, and not necessarily so for
             // derived state.
+            let Some(command) = entry.command else {
+                return Err(SharedStoreReplicationError::ApplyFailed {
+                    wal_index,
+                    status: Status::error(
+                        "shared_wal_entry_empty",
+                        "entry carries neither results nor an operation; refusing rather than skipping a durable write",
+                    ),
+                });
+            };
             let response = engine.execute_with_carried_pages(
-                ExecuteRequest {
-                    shard_id,
-                    command: entry.command,
-                },
+                ExecuteRequest { shard_id, command },
                 entry.staged_pages,
             );
             if !response.status.ok {
@@ -1342,11 +1354,17 @@ where
             // command would otherwise substitute this node's reconstruction for the bytes that
             // were actually acked -- identical for a plain value, and not necessarily so for
             // derived state.
+            let Some(command) = entry.command else {
+                return Err(SharedStoreReplicationError::ApplyFailed {
+                    wal_index,
+                    status: Status::error(
+                        "shared_wal_entry_empty",
+                        "entry carries neither results nor an operation; refusing rather than skipping a durable write",
+                    ),
+                });
+            };
             let response = engine.execute_with_carried_pages(
-                ExecuteRequest {
-                    shard_id,
-                    command: entry.command,
-                },
+                ExecuteRequest { shard_id, command },
                 entry.staged_pages,
             );
             if !response.status.ok {
@@ -1399,9 +1417,19 @@ where
                         ),
                     ))
                 })?;
+            // Neither results nor an operation: refusing beats skipping a durable write.
+            let Some(command) = read.entry.command else {
+                return Err(SharedStoreReplicationError::ApplyFailed {
+                    wal_index: *wal_index,
+                    status: Status::error(
+                        "shared_wal_entry_empty",
+                        "entry carries neither results nor an operation",
+                    ),
+                });
+            };
             let response = engine.execute(ExecuteRequest {
                 shard_id,
-                command: read.entry.command,
+                command,
             });
             if !response.status.ok {
                 return Err(SharedStoreReplicationError::ApplyFailed {
@@ -2212,7 +2240,7 @@ where
         let entry = SharedStoreWalEntry {
             shard_id,
             wal_index,
-            command,
+            command: Some(command),
         
                         staged_pages: Vec::new(),
                                 outcomes: Vec::new(),
@@ -2462,9 +2490,20 @@ struct WalCommandMetadata {
     encoding: u32,
 }
 
+/// Describe the operation an entry carries, for the offset sidecar.
+///
+/// An entry carrying results has no operation to describe, and this sidecar exists to say how the
+/// operation was encoded. Empty is the honest answer rather than a fabricated one.
 fn wal_command_metadata(
-    command: &Command,
+    command: Option<&Command>,
 ) -> Result<WalCommandMetadata, SharedStoreReplicationError> {
+    let Some(command) = command else {
+        return Ok(WalCommandMetadata {
+            byte_size: 0,
+            sha256: sha256_hex(&[]),
+            encoding: WAL_COMMAND_ENCODING_JSON_SERDE,
+        });
+    };
     let (command_payload, command_encoding) = match command_to_sdk_proto(command) {
         Some(command) => (command.encode_to_vec(), WAL_COMMAND_ENCODING_SDK_PROTO),
         None => (
@@ -2482,12 +2521,13 @@ fn wal_command_metadata(
 fn encode_wal_proto_frame(
     entry: &SharedStoreWalEntry,
 ) -> Result<Vec<u8>, SharedStoreReplicationError> {
-    let (command_payload, command_encoding) = match command_to_sdk_proto(&entry.command) {
-        Some(command) => (command.encode_to_vec(), WAL_COMMAND_ENCODING_SDK_PROTO),
-        None => (
-            serde_json::to_vec(&entry.command)?,
-            WAL_COMMAND_ENCODING_JSON_SERDE,
-        ),
+    let (command_payload, command_encoding) = match entry.command.as_ref() {
+        // No operation to carry: the entry states results instead.
+        None => (Vec::new(), WAL_COMMAND_ENCODING_JSON_SERDE),
+        Some(command) => match command_to_sdk_proto(command) {
+            Some(encoded) => (encoded.encode_to_vec(), WAL_COMMAND_ENCODING_SDK_PROTO),
+            None => (serde_json::to_vec(command)?, WAL_COMMAND_ENCODING_JSON_SERDE),
+        },
     };
     let frame = SharedStoreWalFrameProto {
         shard_id: entry.shard_id,
@@ -2588,7 +2628,7 @@ fn decode_wal_proto_frame_exact(
     Ok(SharedStoreWalEntry {
         shard_id: frame.shard_id,
         wal_index: frame.wal_index,
-        command,
+        command: Some(command),
         outcomes: frame
             .items
             .into_iter()
@@ -2895,10 +2935,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -3119,9 +3159,9 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::CommonDelete {
+                command: Some(Command::CommonDelete {
                     key: "gone".to_string(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -3210,10 +3250,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -3297,10 +3337,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -3567,10 +3607,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -3673,10 +3713,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: key.to_string(),
                         value: key.as_bytes().to_vec(),
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),
@@ -3731,10 +3771,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: key.to_string(),
                         value,
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),
@@ -3982,10 +4022,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "after".to_string(),
                     value: b"wal-value".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -4101,10 +4141,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: key.to_string(),
                         value: key.as_bytes().to_vec(),
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),
@@ -4159,10 +4199,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: key.to_string(),
                         value,
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),
@@ -4209,10 +4249,10 @@ mod tests {
         let entry = SharedStoreWalEntry {
             shard_id: 1,
             wal_index: 1,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: b"v".to_vec(),
-            },
+            }),
             staged_pages: vec![crate::wal::StagedPage {
                 object_id: 77,
                 bytes: b"derived-page-bytes".to_vec(),
@@ -4241,10 +4281,10 @@ mod tests {
         let entry = SharedStoreWalEntry {
             shard_id: 1,
             wal_index: 1,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: b"v".to_vec(),
-            },
+            }),
             staged_pages: Vec::new(),
                     outcomes: Vec::new(),
         };
@@ -4464,10 +4504,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 2,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "gap".to_string(),
                     value: b"v".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -4854,10 +4894,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 1,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "k".to_string(),
                     value: b"v".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -4907,10 +4947,10 @@ mod tests {
             .publish_wal_entry(SharedStoreWalEntry {
                 shard_id: 1,
                 wal_index: 1,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "retry".to_string(),
                     value: b"ok".to_vec(),
-                },
+                }),
             
                                    staged_pages: Vec::new(),
                                                outcomes: Vec::new(),
@@ -4966,10 +5006,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: format!("k{wal_index}"),
                         value: vec![wal_index as u8],
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),
@@ -5036,10 +5076,10 @@ mod tests {
                 .publish_wal_entry(SharedStoreWalEntry {
                     shard_id: 1,
                     wal_index,
-                    command: Command::StringSet {
+                    command: Some(Command::StringSet {
                         key: key.to_string(),
                         value,
-                    },
+                    }),
                 
                                        staged_pages: Vec::new(),
                                                        outcomes: Vec::new(),

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -225,8 +225,19 @@ pub struct WriteAheadLogRecord {
     pub shard_id: ShardId,
     #[serde(rename = "q", alias = "sequence")]
     pub sequence: u64,
-    #[serde(rename = "c", alias = "command")]
-    pub command: Command,
+    /// The operation this write performed, for a record that cannot say what it DID.
+    ///
+    /// Absent once a record carries its results, which is the point: replaying an operation
+    /// reproduces state only if everything that influenced it is reproduced too, and a record that
+    /// states results needs none of that. Present on every record written before results existed,
+    /// and on any write that still records nothing, so both replay exactly as they always did.
+    #[serde(
+        rename = "c",
+        alias = "command",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub command: Option<Command>,
     #[serde(
         rename = "m",
         alias = "metadata",
@@ -276,6 +287,49 @@ pub fn wal_outcome_strict() -> bool {
         .unwrap_or(false)
 }
 
+/// TS_WAL_DATA_ONLY: stop writing the operation into a record that already states its results.
+///
+/// Default ON. Carrying both is strictly bigger for no benefit -- the results are what replay
+/// installs, and the operation is consulted only when there are none. Set to a falsey value to
+/// keep writing both, which is what a consumer reading records directly would want.
+pub fn wal_data_only_enabled() -> bool {
+    std::env::var("TS_WAL_DATA_ONLY")
+        .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
+}
+
+/// What a record should carry as its operation, given what it recorded and what is behind it.
+///
+/// A result names where a block LANDED. Installing it reproduces the write only if a reader can
+/// then FIND that block, and there are two ways it cannot.
+///
+/// An asynchronous write leaves its block buffered, so a crash can leave a record whose result
+/// points at bytes that were never written. And a write whose block travels INSIDE the record --
+/// the log-resident path -- needs that block registered against the record's log id before any
+/// read can resolve it, which the write path does and installing an address does not.
+///
+/// So results replace the operation only for a synchronous write whose block went to the block
+/// store: durable, and findable without anything else having to happen. Everything else keeps its
+/// operation and recovers by re-running it, exactly as before.
+///
+/// Both halves were found the same way: a recovery test failing 8 runs in 12 against 0 in 12 on
+/// the code before this, measured interleaved on one machine because an uncontrolled comparison
+/// had already told me the opposite once.
+///
+/// Extending data-only to carried blocks means registering them during replay, which is a change
+/// to the install path rather than to this rule.
+pub(crate) fn record_command(
+    command: Command,
+    outcomes: &[WalOutcomeItem],
+    blocks_are_recoverable: bool,
+) -> Option<Command> {
+    if outcomes.is_empty() || !wal_data_only_enabled() || !blocks_are_recoverable {
+        Some(command)
+    } else {
+        None
+    }
+}
+
 
 /// TS_WAL_OUTCOME_ITEMS: also record what a write DID, beside the command that did it.
 ///
@@ -292,13 +346,16 @@ pub fn wal_outcome_strict() -> bool {
 /// payoff only arrives when replay switches to the outcomes and the command comes out. The flip
 /// belongs with that change, not before it.
 pub fn wal_outcome_items_enabled() -> bool {
-    matches!(
+    // Default ON. Recording stopped costing the group-commit coalescing once results travelled
+    // through the reserve-only append, and recovery prefers installing them over re-running an
+    // operation wherever it has them. The variable now opts OUT.
+    !matches!(
         std::env::var("TS_WAL_OUTCOME_ITEMS")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -964,7 +1021,9 @@ impl LocalWriteAheadLogStore {
                 shard_id,
                 sequence: seq,
                 metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
-                command,
+                // Durable AND in the block store: the two conditions under which installing an
+                // address is enough on its own.
+                command: record_command(command, &outcomes, sync && staged_pages.is_empty()),
                 staged_pages,
                 outcomes,
             };
@@ -1040,7 +1099,9 @@ impl LocalWriteAheadLogStore {
             shard_id,
             sequence: seq,
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
-            command,
+            // This path exists to coalesce the fsync of a SYNCHRONOUS write, so the blocks behind
+            // these results are durable by the time the barrier this record waits on returns.
+            command: record_command(command, &outcomes, true),
             staged_pages: Vec::new(),
             outcomes,
         };
@@ -1137,7 +1198,8 @@ impl LocalWriteAheadLogStore {
                     shard_id,
                     sequence: seq,
                     metadata: Some(metadata),
-                    command,
+                    // No results on this path, so the operation is what replay has.
+                    command: Some(command),
                     staged_pages: Vec::new(),
                     outcomes: Vec::new(),
                 };
@@ -1862,21 +1924,36 @@ impl LocalWriteAheadLogStore {
         let (_, header_len) = read_wal_base(&path)?;
         let mut file = File::open(&path)?;
         file.seek(SeekFrom::Start(header_len))?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
         let mut start_sequence = 0_u64;
         let mut current_sequence = 0_u64;
         let mut records = 0_usize;
-        for line in reader.lines() {
-            let line = line?;
-            if line.trim().is_empty() {
+        // Read BYTE lines, not String lines.
+        //
+        // `lines()` yields a String and therefore demands valid UTF-8 of every record. That held
+        // for as long as every payload was text, and it fails on the first binary record with
+        // "stream did not contain valid UTF-8" -- before the decoder, which handles both
+        // encodings, ever gets to look at it. Escaping the newline out of a binary payload keeps
+        // records SPLITTABLE; it cannot make arbitrary bytes valid UTF-8, and nothing should
+        // require them to be.
+        let mut line = Vec::new();
+        loop {
+            line.clear();
+            if reader.read_until(b'\n', &mut line)? == 0 {
+                break;
+            }
+            while line.last() == Some(&b'\n') || line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            if line.is_empty() {
                 continue;
             }
             // The records may end before the file does: a trailing zeros run is preallocated
             // room, not a record, and it always comes last.
-            if line.bytes().all(|byte| byte == 0) {
+            if line.iter().all(|byte| *byte == 0) {
                 break;
             }
-            let record = decode_wal_line(line.as_bytes())?;
+            let record = decode_wal_line(&line)?;
             if start_sequence == 0 {
                 start_sequence = record.sequence;
             }
@@ -3071,6 +3148,9 @@ mod tests {
 
     #[test]
     fn wal_interior_corruption_is_fatal_not_silent_truncation() {
+        // Pins the TEXT encoding: the corruption this injects is a line that fails to parse
+        // as a document, which is a text-shaped fault by construction.
+        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for i in 0..4 {
@@ -3109,6 +3189,10 @@ mod tests {
             restarted.scan(1, 0, u64::MAX, u64::MAX).is_err(),
             "interior WAL corruption must be fatal, not silently truncated to the last good record"
         );
+    
+        // Unpin it: this variable is process-global, and leaving it set makes every
+        // test that runs after this one inherit an encoding it never asked for.
+        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     #[test]
@@ -3161,10 +3245,10 @@ mod tests {
         let make = |sequence: u64, key: &str| WriteAheadLogRecord {
             shard_id: 3,
             sequence,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: key.to_string(),
                 value: b"v".to_vec(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -3355,7 +3439,7 @@ mod tests {
             shard_id: 3,
             sequence: 8,
             metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
-            command,
+            command: Some(command),
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
         };
@@ -4035,10 +4119,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 1,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: Vec::new(),
-            },
+            }),
             metadata: None,
             staged_pages: vec![StagedPage {
                 object_id: 7,
@@ -4076,10 +4160,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 3,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: b"v".to_vec(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4147,6 +4231,9 @@ mod tests {
     /// between two shapes measured together rather than as absolute figures.
     #[test]
     fn payload_shape_footprint_and_latency() {
+        // Pins the TEXT encoding: this test is about the shape of a text payload, which the
+        // binary one does not have. It asserts a property of that encoding, not of the log.
+        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
         fn run(array_shape: bool, value_len: usize, records: u64) -> (u64, f64) {
             crate::bytes_serde::set_array_shape_for_measurement(array_shape);
             let dir = tempfile::tempdir().unwrap();
@@ -4205,6 +4292,10 @@ mod tests {
         }
         // Leave the process on the default for whatever test runs next.
         crate::bytes_serde::set_array_shape_for_measurement(false);
+    
+        // Unpin it: this variable is process-global, and leaving it set makes every
+        // test that runs after this one inherit an encoding it never asked for.
+        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     /// What is left in a small record once the payload stops being the problem.
@@ -4278,10 +4369,10 @@ mod tests {
         assert_eq!(record.sequence, 7);
         assert_eq!(
             record.command,
-            Command::StringSet {
+            Some(Command::StringSet {
                 key: "k".to_string(),
                 value: b"hi".to_vec(),
-            }
+            })
         );
         let metadata = record.metadata.expect("the metadata block should load");
         assert_eq!(metadata.version, WRITE_AHEAD_LOG_FORMAT_VERSION);
@@ -4311,10 +4402,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 3,
             sequence: 11,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "round-trip".to_string(),
                 value: vec![0u8, 127, 255],
-            },
+            }),
             metadata: Some(WriteAheadLogRecordMetadata {
                 version: WRITE_AHEAD_LOG_FORMAT_VERSION,
                 timestamp_ms: 42,
@@ -4649,10 +4740,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 9,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: all_bytes.clone(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4672,14 +4763,14 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 3,
-            command: Command::HashMultiSet {
+            command: Some(Command::HashMultiSet {
                 key: "k".to_string(),
                 entries: vec![
                     ("first".to_string(), vec![1u8; 600]),
                     ("second".to_string(), vec![2u8; 600]),
                     ("third".to_string(), vec![3u8; 600]),
                 ],
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4695,10 +4786,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 4,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: newlines.clone(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4715,12 +4806,15 @@ mod tests {
     /// A record with nothing worth carrying is written exactly as it was before.
     #[test]
     fn a_record_with_no_payload_is_unchanged_on_disk() {
+        // Pins the TEXT encoding: this test is about the shape of a text payload, which the
+        // binary one does not have. It asserts a property of that encoding, not of the log.
+        std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 5,
-            command: Command::StringGet {
+            command: Some(Command::StringGet {
                 key: "k".to_string(),
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4731,6 +4825,10 @@ mod tests {
             serde_json::to_vec(&record).unwrap(),
             "a record that carries nothing must be byte-identical to the document"
         );
+    
+        // Unpin it: this variable is process-global, and leaving it set makes every
+        // test that runs after this one inherit an encoding it never asked for.
+        std::env::remove_var("TS_WAL_BINARY_RECORDS");
     }
 
     /// Records written before payloads were carried still load.
@@ -4744,10 +4842,10 @@ mod tests {
         let decoded = decode_wal_line(&framed).unwrap();
         assert_eq!(
             decoded.command,
-            Command::StringSet {
+            Some(Command::StringSet {
                 key: "k".to_string(),
                 value: b"hi".to_vec(),
-            }
+            })
         );
     }
 
@@ -4757,10 +4855,10 @@ mod tests {
         let record = WriteAheadLogRecord {
             shard_id: 1,
             sequence: 8,
-            command: Command::StringSet {
+            command: Some(Command::StringSet {
                 key: "k".to_string(),
                 value: vec![7u8; 900],
-            },
+            }),
             metadata: None,
             staged_pages: Vec::new(),
             outcomes: Vec::new(),
@@ -4801,7 +4899,7 @@ mod tests {
         assert_eq!(scanned.len(), payloads.len(), "every record should be there");
         for (index, (_, line)) in scanned.iter().enumerate() {
             let record = decode_wal_line(line).unwrap();
-            match record.command {
+            match record.command.expect("a record built with an operation still carries one") {
                 Command::StringSet { value, .. } => {
                     assert_eq!(value, payloads[index], "record {index} came back changed")
                 }
@@ -4884,7 +4982,7 @@ mod tests {
                 .position(|byte| *byte == b'\n')
                 .map_or(bytes.len(), |at| at + 1);
             let record = decode_wal_line(&bytes[..end]).unwrap();
-            match record.command {
+            match record.command.expect("a record built with an operation still carries one") {
                 Command::StringSet { value: found, .. } => {
                     assert_eq!(&found, value, "log id {log_id} resolved to the wrong record")
                 }

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -81,9 +81,12 @@ fn unescape_newlines(bytes: &[u8]) -> Result<Vec<u8>, String> {
 /// its first byte says it is -- so turning it on and off again leaves a log that still reads end
 /// to end.
 pub(crate) fn binary_records_enabled() -> bool {
+    // Default ON. Reading never consults this -- a payload is decoded by what its first byte says
+    // it is -- so a log written across the flip reads end to end in either direction, and turning
+    // it off again is not a one-way door.
     std::env::var("TS_WAL_BINARY_RECORDS")
-        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+        .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
+        .unwrap_or(true)
 }
 
 fn address_to_proto(address: &BlockAddress) -> v1::WalBlockAddress {
@@ -215,12 +218,15 @@ pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
     let message = v1::EngineWalRecord {
         shard_id: record.shard_id,
         sequence: record.sequence,
-        command: Some(v1::WalCommand {
-            kind: Some(
-                crate::raft::wal_proto::command_to_proto(&record.command)
-                    .map_err(|err| err.to_string())?,
-            ),
-        }),
+        command: match record.command.as_ref() {
+            Some(command) => Some(v1::WalCommand {
+                kind: Some(
+                    crate::raft::wal_proto::command_to_proto(command)
+                        .map_err(|err| err.to_string())?,
+                ),
+            }),
+            None => None,
+        },
         metadata: record
             .metadata
             .as_ref()
@@ -250,13 +256,13 @@ pub(crate) fn decode(payload: &[u8]) -> Result<WriteAheadLogRecord, String> {
     let unescaped = unescape_newlines(&payload[1..])?;
     let message =
         v1::EngineWalRecord::decode(unescaped.as_slice()).map_err(|err| err.to_string())?;
-    let command = message
-        .command
-        .and_then(|command| command.kind)
-        .ok_or_else(|| String::from("engine wal record carried no command"))
-        .and_then(|kind| {
-            crate::raft::wal_proto::command_from_proto(kind).map_err(|err| err.to_string())
-        })?;
+    // Absent is a legitimate record now, not a malformed one: it carries results instead.
+    let command = match message.command.and_then(|command| command.kind) {
+        Some(kind) => Some(
+            crate::raft::wal_proto::command_from_proto(kind).map_err(|err| err.to_string())?,
+        ),
+        None => None,
+    };
     Ok(WriteAheadLogRecord {
         shard_id: message.shard_id,
         sequence: message.sequence,

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -312,10 +312,10 @@ mod tests {
             let record = WriteAheadLogRecord {
                 shard_id: 1,
                 sequence: 1,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: key.to_string(),
                     value: value.clone(),
-                },
+                }),
                 metadata: Some(WriteAheadLogRecordMetadata {
                     version: crate::wal::WRITE_AHEAD_LOG_FORMAT_VERSION,
                     timestamp_ms: 1_787_270_070_192,
@@ -428,10 +428,10 @@ mod tests {
             let record = WriteAheadLogRecord {
                 shard_id: 1,
                 sequence: 1,
-                command: Command::StringSet {
+                command: Some(Command::StringSet {
                     key: "scale-key-000000000".to_string(),
                     value: vec![118u8; value_len],
-                },
+                }),
                 metadata: Some(WriteAheadLogRecordMetadata {
                     version: crate::wal::WRITE_AHEAD_LOG_FORMAT_VERSION,
                     timestamp_ms: 1_787_270_070_192,

--- a/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
+++ b/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
@@ -29,6 +29,10 @@ fn cold_event(event_id_hash: u64, event_time_ms: u64, text: &str) -> ContextEven
 
 #[test]
 fn cold_raw_ingestion_writes_wal_and_avoids_cache_promotion() {
+    // Keep the OPERATION in each record: the assertions below read it, and a record carrying
+    // results does not carry one. It has to be set before the writes, not before the reads --
+    // the records are already on disk by then.
+    std::env::set_var("TS_WAL_DATA_ONLY", "0");
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
         16 * 1024,
@@ -104,19 +108,23 @@ fn cold_raw_ingestion_writes_wal_and_avoids_cache_promotion() {
         .map(|record| serde_json::from_slice::<WriteAheadLogRecord>(&record.data).unwrap())
         .collect::<Vec<_>>();
     assert_eq!(wal_records.len(), 4);
+    // This asserts on the OPERATION, which a record carries only when it is not carrying results
+    // instead. `cold_storage` decides whether a write populates the cache -- it is a property of
+    // how the write was made, not of what it did, so no recorded result mentions it. The test opts
+    // out of the data-only default at the top of the file for exactly that reason.
     assert!(wal_records.iter().take(3).all(|record| matches!(
         record.command,
-        Command::ContextWriteEvent {
+        Some(Command::ContextWriteEvent {
             cold_storage: true,
             ..
-        }
+        })
     )));
     assert!(matches!(
         wal_records.last().unwrap().command,
-        Command::ContextWriteExtractedEvent {
+        Some(Command::ContextWriteExtractedEvent {
             cold_storage: true,
             ..
-        }
+        })
     ));
     assert_eq!(engine.cache().stats().puts, cache_puts_before);
 


### PR DESCRIPTION
the log carries what a write DID, by default, and a record got smaller doing it

    BEFORE  operation, text      186.4 B/record
    AFTER   results, protobuf    171.2 B/record   -15.3 B (-8.2%)

Three defaults flip together because each alone is a regression. Results alone doubles a record.
Dropping the operation alone lands it near 350-400 against today's 186, since one result costs more
than an entire operation-carrying record. Only the encoding turns the removal into a saving.

The record's operation is optional now, and absent is a legitimate record rather than a malformed
one. Replaying an operation reproduces state only if everything that influenced it is reproduced
too; a record that states results needs none of that.

WHEN results may replace the operation is narrower than it first looks, and getting it wrong was a
recovery defect rather than a missed optimisation. A result names where a block LANDED, so
installing it reproduces the write only if a reader can then FIND that block. Two ways it cannot: an
asynchronous write leaves its block buffered, and a log-resident write puts the block INSIDE the
record, where it needs registering against the record's log id before any read resolves it. So
results replace the operation only for a synchronous write whose block went to the block store.
Everything else records what it did AND keeps its operation, and recovers by re-running it.

That rule cost three attempts. The first guess -- async durability -- was implemented and did not
help. The measurements that led there were uncontrolled: 0/10 against 3/10, then 0/15, then 0/12.
Building both binaries and interleaving their runs on one machine gave 0/12 against 8/12, which is
the only reading that meant anything. Running with output uncaptured hid it completely.

A second defect, same shape as the first, one layer down: `info()` read the log with `lines()`,
which yields a String and therefore demands valid UTF-8 of every record. Escaping the newline out
of a binary payload keeps records splittable; it cannot make arbitrary bytes valid UTF-8, and
nothing should require them to be. It reads byte lines now. That was six of the nine failures the
gate caught; the other three are tests asserting properties of the text payload, and they pin that
encoding explicitly -- and unpin it, because leaving a process-global variable set made every later
test inherit an encoding it never asked for, and turned an unrelated recovery test red.

Nothing written before this stops working. A record carrying an operation still replays by running
it. Reading never consults a flag, so a log written across the flip reads end to end in either
direction. A record carrying NEITHER refuses the load in all three replay paths rather than being
skipped, because skipping it serves a shard missing a durable write and reports success.

Gates: engine 257/0 on the new defaults and 257/0 with all three off, wal 165/0, shared_store 35/0,
raft 249/0, part4 75/0, zero silent writes. The one red left is a data_node test that fails 8/8 on

🤖 Generated with [Claude Code](https://claude.com/claude-code)
