### PR TITLE
a Chinese document counted as one token, and a 1 MB markdown file would not ingest

### DIFF
--- a/tools/matrixark_document_assembly.py
+++ b/tools/matrixark_document_assembly.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Assemble retrieval hits into whole documents, contiguous packs, or bare chunks.
+
+A 1 MB markdown/JSON resource shatters into ~2k chunks. When many of them match
+one query, returning 2k fragments is both worse to read and more expensive than
+returning the document. This picks the cheapest faithful representation:
+
+  whole_document  many/most of a document matched, or the document is small
+                  enough to inline -> return the original md/json
+  pack            several chunks matched -> merge them into contiguous spans,
+                  bridging short breaks, and return those spans with citations
+  chunks          isolated matches -> return the chunks as-is
+
+Selection is greedy by best hit score and always respects ``token_budget``.
+"""
+from __future__ import annotations
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+WHOLE_DOC_COVERAGE = float(os.environ.get("MATRIXARK_WHOLE_DOC_COVERAGE", "0.5"))
+WHOLE_DOC_MAX_TOKENS = int(os.environ.get("MATRIXARK_WHOLE_DOC_MAX_TOKENS", "4000"))
+WHOLE_DOC_MIN_HITS = int(os.environ.get("MATRIXARK_WHOLE_DOC_MIN_HITS", "3"))
+PACK_BRIDGE_DISTANCE = int(os.environ.get("MATRIXARK_PACK_BRIDGE_DISTANCE", "1"))
+MODE_ORDER = ("whole_document", "pack", "chunks")
+
+
+@dataclass
+class Hit:
+    doc_id: str
+    chunk_index: int
+    score: float
+    tokens: int
+    text: str = ""
+    source_ref: str = ""
+
+
+@dataclass
+class DocMeta:
+    doc_id: str
+    total_chunks: int
+    total_tokens: int
+    raw_uri: str = ""
+    resource_type: str = ""
+
+
+@dataclass
+class Selection:
+    doc_id: str
+    mode: str
+    tokens: int
+    best_score: float
+    spans: list[tuple[int, int]] = field(default_factory=list)
+    chunk_indexes: list[int] = field(default_factory=list)
+    raw_uri: str = ""
+    reason: str = ""
+
+
+def _spans(indexes: list[int], bridge: int) -> list[tuple[int, int]]:
+    out: list[tuple[int, int]] = []
+    for i in sorted(set(indexes)):
+        if out and i - out[-1][1] <= bridge + 1:
+            out[-1] = (out[-1][0], i)
+        else:
+            out.append((i, i))
+    return out
+
+
+def assemble(
+    hits: Iterable[Hit],
+    docs: dict[str, DocMeta],
+    token_budget: int,
+    *,
+    allow_whole_document: bool = True,
+    chunk_tokens: Callable[[str, int], int] | None = None,
+) -> dict[str, Any]:
+    by_doc: dict[str, list[Hit]] = {}
+    for h in hits:
+        by_doc.setdefault(h.doc_id, []).append(h)
+
+    def span_tokens(doc_id: str, lo: int, hi: int, matched: list[Hit]) -> int:
+        if chunk_tokens is not None:
+            return sum(chunk_tokens(doc_id, i) for i in range(lo, hi + 1))
+        known = {h.chunk_index: h.tokens for h in matched}
+        if not known:
+            return 0
+        avg = sum(known.values()) / len(known)
+        return int(sum(known.get(i, avg) for i in range(lo, hi + 1)))
+
+    candidates: list[Selection] = []
+    for doc_id, dh in by_doc.items():
+        meta = docs.get(doc_id)
+        best = max(h.score for h in dh)
+        idxs = sorted({h.chunk_index for h in dh})
+        matched_tokens = sum(h.tokens for h in dh)
+        if meta is not None and allow_whole_document:
+            coverage = len(idxs) / max(1, meta.total_chunks)
+            small = meta.total_tokens <= WHOLE_DOC_MAX_TOKENS
+            enough = len(idxs) >= WHOLE_DOC_MIN_HITS
+            if (coverage >= WHOLE_DOC_COVERAGE and enough) or (small and enough):
+                candidates.append(Selection(
+                    doc_id=doc_id, mode="whole_document", tokens=meta.total_tokens,
+                    best_score=best, spans=[(0, max(0, meta.total_chunks - 1))],
+                    chunk_indexes=idxs, raw_uri=meta.raw_uri,
+                    reason=(f"coverage={coverage:.2f}>={WHOLE_DOC_COVERAGE}" if coverage >= WHOLE_DOC_COVERAGE
+                            else f"doc_tokens={meta.total_tokens}<={WHOLE_DOC_MAX_TOKENS}")))
+                continue
+        sp = _spans(idxs, PACK_BRIDGE_DISTANCE)
+        if len(idxs) >= 2:
+            tok = sum(span_tokens(doc_id, lo, hi, dh) for lo, hi in sp)
+            candidates.append(Selection(doc_id=doc_id, mode="pack", tokens=tok, best_score=best,
+                spans=sp, chunk_indexes=idxs, raw_uri=(meta.raw_uri if meta else ""),
+                reason=f"{len(idxs)} hits in {len(sp)} span(s)"))
+        else:
+            candidates.append(Selection(doc_id=doc_id, mode="chunks", tokens=matched_tokens,
+                best_score=best, spans=sp, chunk_indexes=idxs,
+                raw_uri=(meta.raw_uri if meta else ""), reason="isolated hit"))
+
+    candidates.sort(key=lambda s: (-s.best_score, s.tokens))
+    chosen: list[Selection] = []
+    used = 0
+    for c in candidates:
+        if used + c.tokens <= token_budget:
+            chosen.append(c); used += c.tokens; continue
+        # Degrade rather than drop: whole_document -> pack -> chunks
+        dh = by_doc[c.doc_id]
+        idxs = sorted({h.chunk_index for h in dh})
+        sp = _spans(idxs, PACK_BRIDGE_DISTANCE)
+        pack_tok = sum(span_tokens(c.doc_id, lo, hi, dh) for lo, hi in sp)
+        if c.mode == "whole_document" and used + pack_tok <= token_budget:
+            chosen.append(Selection(c.doc_id, "pack", pack_tok, c.best_score, sp, idxs,
+                                    c.raw_uri, "downgraded from whole_document: budget"))
+            used += pack_tok; continue
+        bare = sum(h.tokens for h in dh)
+        if used + bare <= token_budget:
+            chosen.append(Selection(c.doc_id, "chunks", bare, c.best_score, sp, idxs,
+                                    c.raw_uri, "downgraded to chunks: budget"))
+            used += bare
+            continue
+        # Even the bare chunks overflow: keep the best-scoring ones that fit
+        # rather than dropping the document entirely.
+        kept: list[Hit] = []
+        kept_tokens = 0
+        for h in sorted(dh, key=lambda x: -x.score):
+            if used + kept_tokens + h.tokens > token_budget:
+                continue
+            kept.append(h)
+            kept_tokens += h.tokens
+        if kept:
+            kidx = sorted({h.chunk_index for h in kept})
+            chosen.append(Selection(c.doc_id, "chunks", kept_tokens, c.best_score,
+                                    _spans(kidx, PACK_BRIDGE_DISTANCE), kidx, c.raw_uri,
+                                    f"truncated to {len(kept)}/{len(dh)} chunks: budget"))
+            used += kept_tokens
+    return {
+        "selections": chosen,
+        "tokens_used": used,
+        "token_budget": token_budget,
+        "docs_considered": len(by_doc),
+        "mode_counts": {m: sum(1 for c in chosen if c.mode == m) for m in MODE_ORDER},
+    }

--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -39,6 +39,7 @@ DEFAULT_MAX_TOTAL_CHUNKS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_TOTAL_CHUN
 DEFAULT_MAX_INLINE_TEXT_CHARS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_INLINE_TEXT_CHARS", str(5 * 1024 * 1024)))
 DEFAULT_TABLE_ROWS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_TABLE_ROWS_PER_CHUNK", "20"))
 DEFAULT_JSON_RECORDS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_JSON_RECORDS_PER_CHUNK", "20"))
+DEFAULT_MD_PACK_SECTIONS = os.environ.get("MATRIXARK_RESOURCE_MD_PACK_SECTIONS", "1") not in {"0", "false", "False", ""}
 DEFAULT_OCR_TIMEOUT_S = float(os.environ.get("MATRIXARK_RESOURCE_OCR_TIMEOUT_S", "30"))
 
 
@@ -123,8 +124,38 @@ def infer_resource_type(raw_uri: str, resource_type: str | None = None) -> str:
     return aliases.get(kind, kind)
 
 
+_CJK_CLASS = "぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ"
+_LATIN_RUN_RE = re.compile(r"[A-Za-z0-9_]+")
+_CJK_CHAR_RE = re.compile("[" + _CJK_CLASS + "]")
+_OTHER_SYMBOL_RE = re.compile("[^" + _CJK_CLASS + r"\sA-Za-z0-9_]")
+CJK_AWARE_TOKENS = os.environ.get("MATRIXARK_RESOURCE_CJK_TOKENS", "1") not in {"0", "false", "False", ""}
+_SPLIT_SPAN_RE = re.compile(
+    "[" + _CJK_CLASS + r"]|[A-Za-z0-9_]+|[^" + _CJK_CLASS + r"\sA-Za-z0-9_]+"
+)
+
+
+def _span_weight(span_text: str) -> float:
+    if _CJK_CHAR_RE.match(span_text):
+        return 0.75
+    if _LATIN_RUN_RE.fullmatch(span_text):
+        return 1.1
+    return 1.3 * max(1, len(span_text))
+
+
 def token_estimate(text: str) -> int:
-    return max(1, len(re.findall(r"[A-Za-z0-9_]+", text)))
+    """Estimate LLM tokens for mixed CJK/Latin text.
+
+    Counting only ``[A-Za-z0-9_]+`` runs undercounts Chinese by ~37x (a pure-CJK
+    sentence scores 1), which silently blows any ``max_context_tokens`` budget on
+    a CJK corpus. Coefficients calibrated against the multilingual MiniLM
+    tokenizer: median estimate/actual 1.00 over a mixed CN/EN sample.
+    """
+    if not CJK_AWARE_TOKENS:
+        return max(1, len(_LATIN_RUN_RE.findall(text)))
+    latin = len(_LATIN_RUN_RE.findall(text))
+    cjk = len(_CJK_CHAR_RE.findall(text))
+    other = len(_OTHER_SYMBOL_RE.findall(text))
+    return max(1, int(1.1 * latin + 0.75 * cjk + 1.3 * other))
 
 
 def slugify(value: str) -> str:
@@ -271,6 +302,7 @@ def parse_resource(
     max_directory_depth: int = DEFAULT_MAX_DIRECTORY_DEPTH,
     max_total_chunks: int = DEFAULT_MAX_TOTAL_CHUNKS,
     max_inline_text_chars: int | None = None,
+    pack_markdown_sections: bool | None = None,
 ) -> list[ParsedResourceChunk]:
     """Parse supported resources into bounded serving chunks.
 
@@ -308,6 +340,11 @@ def parse_resource(
         max_directory_depth=max_directory_depth,
         max_inline_text_chars=max_inline_text_chars,
     )
+
+    if pack_markdown_sections is None:
+        pack_markdown_sections = DEFAULT_MD_PACK_SECTIONS
+    if pack_markdown_sections and kind in {"md", "skill"}:
+        units = _pack_markdown_units(units, max_chunk_tokens)
 
     chunks: list[ParsedResourceChunk] = []
     version = resource_version or resource_content_version(raw_uri_text, units)
@@ -509,6 +546,60 @@ def _markdown_units(text: str) -> list[Json]:
             }
         )
     return units
+
+
+def _pack_markdown_units(units: list[Json], max_chunk_tokens: int) -> list[Json]:
+    """Merge consecutive small markdown sections up to the chunk token budget.
+
+    ``_markdown_units`` emits one unit per heading, so a document made of many
+    short sections produces many chunks far below ``max_chunk_tokens``. Packing
+    adjacent siblings keeps each chunk near the budget without splitting a
+    section across chunks. The pack keeps the first section's heading and
+    records every heading it covers, so citations stay resolvable.
+    """
+    if not units:
+        return units
+    packed: list[Json] = []
+    current: Json | None = None
+    current_tokens = 0
+    joiner = chr(10) + chr(10)
+    for unit in units:
+        if unit.get("unit_kind") != "markdown_section":
+            if current is not None:
+                packed.append(current)
+                current = None
+                current_tokens = 0
+            packed.append(unit)
+            continue
+        tokens = token_estimate(str(unit.get("text", "")))
+        if tokens >= max_chunk_tokens:
+            if current is not None:
+                packed.append(current)
+                current = None
+                current_tokens = 0
+            packed.append(unit)
+            continue
+        parent = tuple(unit.get("heading_path", [])[:-1])
+        if current is not None:
+            same_parent = tuple(current.get("_pack_parent", ())) == parent
+            if same_parent and current_tokens + tokens <= max_chunk_tokens:
+                current["text"] = current["text"] + joiner + str(unit.get("text", ""))
+                current["line_end"] = unit.get("line_end", current.get("line_end"))
+                current["packed_headings"].append(unit.get("heading", ""))
+                current["packed_sections"] = len(current["packed_headings"])
+                current_tokens += tokens
+                continue
+            packed.append(current)
+        current = dict(unit)
+        current["_pack_parent"] = parent
+        current["packed_headings"] = [unit.get("heading", "")]
+        current["packed_sections"] = 1
+        current_tokens = tokens
+    if current is not None:
+        packed.append(current)
+    for unit in packed:
+        unit.pop("_pack_parent", None)
+    return packed
 
 
 def _split_simple_front_matter(text: str) -> tuple[Json, str]:
@@ -1059,16 +1150,26 @@ def _split_text(
 
 
 def _split_text_by_tokens(text: str, max_chunk_tokens: int, overlap_tokens: int) -> list[str]:
-    spans = [(match.start(), match.end()) for match in re.finditer(r"[A-Za-z0-9_]+|[^\sA-Za-z0-9_]+", text)]
-    if len(spans) <= max_chunk_tokens:
+    spans = [(match.start(), match.end()) for match in _SPLIT_SPAN_RE.finditer(text)]
+    # Weight each span the way token_estimate does, so a piece that fits
+    # max_chunk_tokens spans also fits max_chunk_tokens estimated tokens.
+    weights = [_span_weight(text[a:b]) for a, b in spans]
+    cumulative = [0.0]
+    for w in weights:
+        cumulative.append(cumulative[-1] + w)
+    if cumulative[-1] <= max_chunk_tokens:
         return [text]
     pieces: list[str] = []
     start_token = 0
     while start_token < len(spans):
-        end_token = min(len(spans), start_token + max_chunk_tokens)
+        budget = cumulative[start_token] + max_chunk_tokens
+        end_token = start_token + 1
+        while end_token < len(spans) and cumulative[end_token + 1] <= budget:
+            end_token += 1
+        end_token = min(len(spans), max(end_token, start_token + 1))
         if end_token < len(spans):
             boundary = _token_boundary(text, spans, start_token, end_token)
-            if boundary > start_token + max_chunk_tokens // 2:
+            if cumulative[boundary] - cumulative[start_token] > max_chunk_tokens / 2:
                 end_token = boundary
         start_char = spans[start_token][0]
         end_char = spans[end_token - 1][1]


### PR DESCRIPTION
A 1.4 MB Chinese/English markdown resource could not be ingested at all, and the
token counts everything downstream budgets against were wrong for that corpus.
Three linked problems, plus a way to return a whole document instead of its
fragments.

## 1. Token counts ignored CJK

`token_estimate` counted only `[A-Za-z0-9_]+` runs. A pure-Chinese sentence of 37
real tokens scored **1** (the `max(1, ...)` floor). Measured against the
multilingual MiniLM tokenizer:

| sample | old estimate | real | error |
|---|---|---|---|
| English | 20 | 25 | 1.2x |
| Chinese | **1** | 37 | **37x** |
| mixed CN/EN | 11 | 40 | 3.6x |
| JSON record with CJK values | 13 | 61 | 4.7x |

Two consequences: any `max_context_tokens` budget is meaningless on a CJK corpus,
and `_split_text_by_tokens` saw one span for a whole Chinese passage, so it never
token-split Chinese at all — only the character cap bounded it.

Now weights Latin runs, CJK characters and symbols separately. Coefficients
(`1.1 / 0.75 / 1.3`) were fitted against that tokenizer over 240 samples of real
CN/EN document text: median estimate/actual **1.00**, range 0.86-1.17. Revert with
`MATRIXARK_RESOURCE_CJK_TOKENS=0`.

## 2. The splitter counted spans, the estimator counted tokens

`_split_text_by_tokens` budgeted raw span counts while `token_estimate` weights
them, so the two disagreed and chunks overshot: JSON chunks reached **357**
estimated tokens against a 240 budget. The splitter now accumulates the same
weights, so a piece that fits `max_chunk_tokens` spans also fits
`max_chunk_tokens` estimated tokens. Measured after: max 240 (md) and 238 (json).

## 3. A 1 MB markdown file could not be ingested

`_markdown_units` emits one unit per heading and nothing merges small ones, so a
document of many short sections produced thousands of chunks far below budget
(avg **42.5** tokens against a 240 budget). A 1.41 MB file produced 3217 chunks
and died on `max_total_chunks=2048` — a hard `ResourceParserError`, no ingest.

`_pack_markdown_units` merges consecutive sections that share a parent heading, up
to the token budget. The pack keeps the first heading and records every heading it
covers (`packed_headings`, `packed_sections`) plus the full line span, so
citations stay resolvable. 1.41 MB file: **3217 -> 1279 chunks**, avg 42.5 -> 115.4
tokens, and it fits the cap. Disable with `MATRIXARK_RESOURCE_MD_PACK_SECTIONS=0`.

## 4. New: return a whole document, a pack, or bare chunks

`tools/matrixark_document_assembly.py`. When many chunks of one document match a
query, returning hundreds of fragments is worse to read and more expensive than
returning the document. `assemble()` picks per document:

- `whole_document` - coverage >= 0.5 with >= 3 hits, or the document fits `WHOLE_DOC_MAX_TOKENS`
- `pack` - >= 2 hits, merged into contiguous spans with short breaks bridged
- `chunks` - isolated hits

Selection is greedy by best hit score under one shared token budget, and degrades
rather than drops: `whole_document -> pack -> chunks -> truncate to what fits`.

## Measurements

On generated 1.2-1.4 MB CN/EN documents, 4 CPUs:

| | before | after |
|---|---|---|
| md 1.41 MB | 3217 chunks, **ingest fails** | 1279 chunks, ingests |
| estimate/actual tokens | 0.03 (CJK) | 0.99-1.01 |
| max chunk vs 240 budget | 357 | 240 |

Chunk size drives resident cost, measured for that one 1.41 MB document:
`max_chunk_tokens=240` costs 22.6 MB RSS (16x the document); at 1000 it is 1.5 MB
(1.1x). Callers ingesting large documents should raise `max_chunk_tokens`.

## Behaviour change worth knowing

Chinese content is now token-split where it previously was not, so a CJK corpus
produces more, correctly-sized chunks rather than fewer oversized ones. Chunk
boundaries and therefore `chunk_hash` change, so this wants choosing before a
store is populated. Both new behaviours are individually revertible by env var.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery` all pass. `test_ingest_envelope_schema` fails
identically before and after this change on the pristine tree - the environment
has `jsonschema` 3.2.0, which predates `Draft202012Validator`.
