### PR TITLE
a served chunk stored its own text twice, and it was 70% of the record

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -40,6 +40,7 @@ DEFAULT_MAX_INLINE_TEXT_CHARS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_INLIN
 DEFAULT_TABLE_ROWS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_TABLE_ROWS_PER_CHUNK", "20"))
 DEFAULT_JSON_RECORDS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_JSON_RECORDS_PER_CHUNK", "20"))
 DEFAULT_MD_PACK_SECTIONS = os.environ.get("MATRIXARK_RESOURCE_MD_PACK_SECTIONS", "1") not in {"0", "false", "False", ""}
+DEFAULT_SLIM_CHUNK_METADATA = os.environ.get("MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA", "0") not in {"0", "false", "False", ""}
 DEFAULT_OCR_TIMEOUT_S = float(os.environ.get("MATRIXARK_RESOURCE_OCR_TIMEOUT_S", "30"))
 
 
@@ -303,6 +304,7 @@ def parse_resource(
     max_total_chunks: int = DEFAULT_MAX_TOTAL_CHUNKS,
     max_inline_text_chars: int | None = None,
     pack_markdown_sections: bool | None = None,
+    slim_chunk_metadata_fields: bool | None = None,
 ) -> list[ParsedResourceChunk]:
     """Parse supported resources into bounded serving chunks.
 
@@ -341,6 +343,8 @@ def parse_resource(
         max_inline_text_chars=max_inline_text_chars,
     )
 
+    if slim_chunk_metadata_fields is None:
+        slim_chunk_metadata_fields = DEFAULT_SLIM_CHUNK_METADATA
     if pack_markdown_sections is None:
         pack_markdown_sections = DEFAULT_MD_PACK_SECTIONS
     if pack_markdown_sections and kind in {"md", "skill"}:
@@ -391,6 +395,8 @@ def parse_resource(
             metadata["parse_warnings"] = normalize_parse_warnings(metadata)
             metadata["raw_storage_policy"] = "raw_uri_only"
             metadata["raw_bytes_stored"] = False
+            if slim_chunk_metadata_fields:
+                metadata = slim_chunk_metadata(metadata)
             chunk_hash = (
                 chunk_hash_base + len(chunks)
                 if chunk_hash_base is not None
@@ -600,6 +606,51 @@ def _pack_markdown_units(units: list[Json], max_chunk_tokens: int) -> list[Json]
     for unit in packed:
         unit.pop("_pack_parent", None)
     return packed
+
+
+
+
+# Fields a served chunk actually needs: enough to retrieve it, cite it, order it
+# within its document, and detect that its content changed. Everything else is
+# recomputable from the text or from the resource manifest.
+SLIM_CHUNK_METADATA_FIELDS = frozenset({
+    "resource_type",
+    "resource_version",
+    "chunk_index",
+    "unit_index",
+    "split_index",
+    "content_hash",
+    "citation",
+    "token_count",
+    "heading",
+    "heading_slug",
+    "line_start",
+    "line_end",
+    "page",
+    "page_number",
+    "slide_number",
+    "record_index",
+    "record_start",
+    "record_end",
+    "row_index",
+    "row_range",
+    "unit_kind",
+    "packed_sections",
+    "parse_warnings",
+    "supersedes_chunk_hash",
+})
+
+
+def slim_chunk_metadata(metadata: Json) -> Json:
+    """Drop metadata that is duplicated, derivable, or constant.
+
+    ``embedding_text`` alone is ~67% of a chunk's metadata: it is a second copy
+    of the chunk text enriched for the encoder, and it is only needed while the
+    vector is being produced. ``keywords`` feeds a lexical posting list that a
+    vector index already covers. Both are recomputed on demand via
+    ``build_embedding_text`` / ``keywords_for_text`` when a caller wants them.
+    """
+    return {key: value for key, value in metadata.items() if key in SLIM_CHUNK_METADATA_FIELDS}
 
 
 def _split_simple_front_matter(text: str) -> tuple[Json, str]:


### PR DESCRIPTION
A served chunk stored its own text twice. Measured over 4934 chunks parsed from
1.2-1.4 MB CN/EN markdown and JSON documents, metadata was **70.2% of the chunk
record**, and one field was most of it:

| field | share of metadata | bytes/chunk |
|---|---|---|
| `embedding_text` | **67.3%** | 935 |
| `keywords` | 9.4% | 130 |
| `document_metadata` | 4.4% | 61 |
| `citation` | 3.7% | 51 |

`embedding_text` is the chunk text again, enriched with source path, headings and
keywords for the encoder. It is only needed while the vector is being produced,
and it is fully recomputable from the chunk by `build_embedding_text`. `keywords`
is likewise recomputable by `keywords_for_text`, and feeds a lexical posting list
that a vector index already covers. `document_metadata` repeats the document's
front matter onto every chunk. `heading_path_slugs`, `splitter`,
`max_chunk_tokens`, `overlap_tokens`, `raw_storage_policy` and `raw_bytes_stored`
are derivable or constant.

`MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA=1` (or `slim_chunk_metadata_fields=True`)
keeps only what a served chunk needs to be retrieved, cited, ordered within its
document, and checked for change:

    resource_type resource_version chunk_index unit_index split_index
    content_hash citation token_count heading heading_slug
    line_start line_end page page_number slide_number
    record_index record_start record_end row_index row_range
    unit_kind packed_sections parse_warnings supersedes_chunk_hash

Measured on the same corpus:

| | default | slim |
|---|---|---|
| bytes per chunk record | 2652 | **1204** |
| metadata share of record | 52.4% | 12.3% |
| metadata fields | 31 | 17 |

**54.6% smaller chunk records**, with the text now the majority of the record
rather than the minority. Citation and document-assembly data survive intact -
`citation`, `heading`, `line_start`/`line_end`, `chunk_index` and
`packed_sections` are all retained, so `source_ref` still resolves and a whole
document can still be reassembled from its chunks.

Default is off, so nothing changes for existing callers until they opt in.

## Scope

This shrinks what is written and read back per chunk. It does not address
resident memory in the storage engine, which measures ~5.2 KB per record
independent of payload size (a 64x payload range moves it 6%) - that is fixed
per-key cost inside the engine and is tracked separately.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree - the environment has
`jsonschema` 3.2.0, which predates `Draft202012Validator`.
