### PR TITLE
the encoder saw the heading and almost none of the chunk

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -41,6 +41,8 @@ DEFAULT_TABLE_ROWS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_TABLE_ROWS
 DEFAULT_JSON_RECORDS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_JSON_RECORDS_PER_CHUNK", "20"))
 DEFAULT_MD_PACK_SECTIONS = os.environ.get("MATRIXARK_RESOURCE_MD_PACK_SECTIONS", "1") not in {"0", "false", "False", ""}
 DEFAULT_SLIM_CHUNK_METADATA = os.environ.get("MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA", "0") not in {"0", "false", "False", ""}
+DEFAULT_EMBEDDING_TEXT_MAX_TOKENS = int(os.environ.get("MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS", "128"))
+EMBEDDING_TEXT_PREFIX_SHARE = float(os.environ.get("MATRIXARK_EMBEDDING_TEXT_PREFIX_SHARE", "0.2"))
 DEFAULT_OCR_TIMEOUT_S = float(os.environ.get("MATRIXARK_RESOURCE_OCR_TIMEOUT_S", "30"))
 
 
@@ -229,7 +231,66 @@ def keywords_for_text(text: str, limit: int = 12) -> list[str]:
     return out
 
 
-def build_embedding_text(text: str, metadata: Json, source_ref: str) -> str:
+def _truncate_to_tokens(text: str, max_tokens: int) -> str:
+    """Trim text to roughly max_tokens estimated tokens, on a span boundary."""
+    if max_tokens <= 0:
+        return ""
+    spans = [(m.start(), m.end()) for m in _SPLIT_SPAN_RE.finditer(text)]
+    if not spans:
+        return text
+    used = 0.0
+    for index, (start, end) in enumerate(spans):
+        used += _span_weight(text[start:end])
+        if used > max_tokens:
+            return text[: spans[index][0]].strip()
+    return text
+
+
+def build_embedding_text(
+    text: str,
+    metadata: Json,
+    source_ref: str,
+    max_tokens: int | None = None,
+) -> str:
+    """Build the text handed to the encoder for a chunk.
+
+    The encoder has a fixed input window (128 tokens for the multilingual MiniLM
+    used here) and silently truncates past it. Emitting every metadata field
+    first spent that whole window on the header: measured on markdown, the prefix
+    was 123 of 128 tokens and only 2.8% of the chunk's own content reached the
+    model, so chunks were matched on their heading/path/keyword header rather
+    than on what they say.
+
+    So the content leads, and a compact locating prefix is allowed only a small
+    slice of the window. ``max_tokens=0`` restores the unbounded field dump.
+    """
+    if max_tokens is None:
+        max_tokens = DEFAULT_EMBEDDING_TEXT_MAX_TOKENS
+    if max_tokens <= 0:
+        return _build_embedding_text_unbounded(text, metadata, source_ref)
+
+    prefix_budget = max(8, int(max_tokens * EMBEDDING_TEXT_PREFIX_SHARE))
+    locators: list[str] = []
+    heading_path = metadata.get("heading_path")
+    if isinstance(heading_path, list) and heading_path:
+        locators.append(" / ".join(str(item) for item in heading_path if str(item).strip()))
+    else:
+        for key in ("heading", "title", "document_title", "relative_path"):
+            value = metadata.get(key)
+            if value:
+                locators.append(str(value))
+                break
+    columns = metadata.get("columns")
+    if isinstance(columns, list) and columns:
+        locators.append(", ".join(str(item) for item in columns if str(item).strip()))
+    prefix = _truncate_to_tokens(compact_ws(" | ".join(locators)), prefix_budget)
+    body_budget = max_tokens - (token_estimate(prefix) if prefix else 0)
+    body = _truncate_to_tokens(compact_ws(text), body_budget)
+    return compact_ws(prefix + chr(10) + body) if prefix else compact_ws(body)
+
+
+def _build_embedding_text_unbounded(text: str, metadata: Json, source_ref: str) -> str:
+
     fields: list[str] = []
     for key in [
         "document_title",


### PR DESCRIPTION
The encoder has a fixed 128-token input window and silently truncates past it.
`build_embedding_text` emitted every metadata field first and the chunk's own
text last, so the window was spent on the header.

Measured against the multilingual MiniLM tokenizer over markdown and JSON chunks
parsed from 1.2-1.4 MB CN/EN documents:

| corpus | metadata prefix | share of the 128-token window | chunk content reaching the model |
|---|---|---|---|
| markdown, 240-token chunks | 123 tokens | 96% | **5 tokens (3.9%)** |
| markdown, 1000-token chunks | 121 tokens | 95% | **6.5 tokens (5.1%)** |
| JSON, 240-token chunks | 91 tokens | 71% | 37 tokens (28.9%) |

So a markdown chunk was embedded almost entirely as its `document_title`,
`heading`, `path`, `keywords` and `source` header. Neighbouring chunks under one
heading share nearly all of that header, which is the worst case for a similarity
index: the vectors that should separate them are built from the text they have in
common, and the 97% that distinguishes them never reaches the model.

The content now leads, and a compact locating prefix gets a bounded slice of the
window (`MATRIXARK_EMBEDDING_TEXT_PREFIX_SHARE`, default 0.2). The whole string is
capped at `MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS` (default 128, matching the
encoder). After:

| corpus | prefix | content reaching the model | embedding_text size |
|---|---|---|---|
| markdown, 240-token chunks | 17 tokens | **109 tokens (85.2%)** | 283 -> 126 tokens |
| markdown, 1000-token chunks | 17 tokens | **109 tokens (85.2%)** | 1046 -> 128 tokens |
| JSON, 240-token chunks | 0 tokens | **122.5 tokens (95.7%)** | 304 -> 123 tokens |

**22x more of a markdown chunk reaches the encoder.** The string also stops
carrying text the model was going to discard, so tokenization does less work per
chunk.

`MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS=0` restores the previous unbounded field
dump, which is kept as `_build_embedding_text_unbounded`.

## Why this matters more with large chunks

Chunk size is the main lever on ingest cost - for a 1.41 MB markdown document,
moving from 240 to 2000-token chunks takes it from 2126 to 204 records, 27.8 MB
to 8.9 MB resident, and 11.2 MB to 2.1 MB on disk. That is only safe if the
vector still describes the chunk. Before this change a larger chunk made the
vector *worse*, because the fixed header crowded out proportionally more content.
Now the window is spent on content at any chunk size.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree - the environment has
`jsonschema` 3.2.0, which predates `Draft202012Validator`.
