### PR TITLE
chunk size decided the memory bill and had no knob

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -42,6 +42,20 @@ DEFAULT_JSON_RECORDS_PER_CHUNK = int(os.environ.get("MATRIXARK_RESOURCE_JSON_REC
 DEFAULT_MD_PACK_SECTIONS = os.environ.get("MATRIXARK_RESOURCE_MD_PACK_SECTIONS", "1") not in {"0", "false", "False", ""}
 DEFAULT_SLIM_CHUNK_METADATA = os.environ.get("MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA", "0") not in {"0", "false", "False", ""}
 DEFAULT_EMBEDDING_TEXT_MAX_TOKENS = int(os.environ.get("MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS", "128"))
+# Chunk size is the dominant lever on ingest cost: for a 1.41 MB markdown file,
+# 240-token chunks are 2126 records and 27.8 MB resident, 2000-token chunks are
+# 204 records and 8.9 MB. It had no knob, so no deployment could reach it.
+DEFAULT_MAX_CHUNK_TOKENS = int(os.environ.get("MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS", "240"))
+DEFAULT_OVERLAP_TOKENS = int(os.environ.get("MATRIXARK_RESOURCE_OVERLAP_TOKENS", "24"))
+# Both caps bind, whichever is hit first. Deriving the character cap from the
+# token cap keeps raising one from being silently cancelled by the other.
+DEFAULT_MAX_CHUNK_CHARS = int(
+    os.environ.get(
+        "MATRIXARK_RESOURCE_MAX_CHUNK_CHARS",
+        str(1400 if DEFAULT_MAX_CHUNK_TOKENS <= 240 else DEFAULT_MAX_CHUNK_TOKENS * 8),
+    )
+)
+DEFAULT_OVERLAP_CHARS = int(os.environ.get("MATRIXARK_RESOURCE_OVERLAP_CHARS", "120"))
 EMBEDDING_TEXT_PREFIX_SHARE = float(os.environ.get("MATRIXARK_EMBEDDING_TEXT_PREFIX_SHARE", "0.2"))
 DEFAULT_OCR_TIMEOUT_S = float(os.environ.get("MATRIXARK_RESOURCE_OCR_TIMEOUT_S", "30"))
 
@@ -352,10 +366,10 @@ def parse_resource(
     *,
     resource_type: str | None = None,
     text: str | None = None,
-    max_chunk_chars: int = 1400,
-    overlap_chars: int = 120,
-    max_chunk_tokens: int = 240,
-    overlap_tokens: int = 24,
+    max_chunk_chars: int = DEFAULT_MAX_CHUNK_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+    max_chunk_tokens: int = DEFAULT_MAX_CHUNK_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
     chunk_hash_base: int | None = None,
     resource_version: str | None = None,
     supersedes_chunk_hashes: dict[str, int] | None = None,


### PR DESCRIPTION
Chunk size is the dominant lever on what a document costs to ingest, and no
deployment could reach it. `max_chunk_chars`, `overlap_chars`, `max_chunk_tokens`
and `overlap_tokens` were literal defaults in `parse_resource`'s signature, and no
caller in the tree passes any of them - including the skill path, which reaches
`parse_resource` through `matrixark_skill_parser.parse_skill`. Every other limit
in this module is already env-driven (`MATRIXARK_RESOURCE_MAX_TOTAL_CHUNKS`,
`MATRIXARK_RESOURCE_MAX_INLINE_TEXT_CHARS`, `MATRIXARK_RESOURCE_MAX_FILE_BYTES`);
these four were not.

What it costs, measured on a 1.41 MB CN/EN markdown skill ingested into a
4-CPU-pinned node (chunk records written through `/batch_execute`):

| max_chunk_tokens | chunks | record bytes | resident | disk | write |
|---:|---:|---:|---:|---:|---:|
| 240 (today) | 2126 | 6.51 MB | 27.8 MB | 11.24 MB | 1.65 s |
| 1000 | 411 | 1.70 MB | 11.7 MB | 2.60 MB | 0.59 s |
| 2000 | 204 | 1.57 MB | 8.9 MB | 2.06 MB | 0.35 s |

Resident memory in the storage engine is ~5.2 KB per record and does not depend
on payload size - a 64x payload range moves it 6% - so record count, not bytes,
is what sets the memory bill. Cutting 2126 records to 204 is the difference
between 27.8 MB and 8.9 MB resident for one document, and between roughly 120 GB
and 12 GB projected across 10k such documents.

It also sets the embedding bill, which is per chunk: at the 18.4 chunks/s this
encoder sustains on 4 CPUs, 10k documents is 321 hours of encoding at 240-token
chunks and 31 hours at 2000.

New knobs, all defaulting to exactly today's values:

| env | default |
|---|---|
| `MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS` | `240` |
| `MATRIXARK_RESOURCE_OVERLAP_TOKENS` | `24` |
| `MATRIXARK_RESOURCE_MAX_CHUNK_CHARS` | `1400`, or `tokens * 8` once tokens is raised above 240 |
| `MATRIXARK_RESOURCE_OVERLAP_CHARS` | `120` |

The character cap derives from the token cap once the token cap is raised,
because both bind and whichever is hit first wins: raising only
`MAX_CHUNK_TOKENS` to 2000 while the character cap stayed at 1400 would have left
chunk count unchanged, which is a trap worth not shipping. At the default token
setting the character cap stays literally 1400, so nothing changes for anyone who
does not set these.

Verified: at the defaults this produces 2126 markdown chunks and 2808 JSON chunks
for the sample documents, identical to before the change.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree - the environment has
`jsonschema` 3.2.0, which predates `Draft202012Validator`.
