### PR TITLE
the parser built the encoder string for chunks that throw it away

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -151,12 +151,28 @@ _SPLIT_SPAN_RE = re.compile(
 )
 
 
+def _is_cjk_codepoint(code: int) -> bool:
+    return (
+        0x3040 <= code <= 0x30FF
+        or 0x3400 <= code <= 0x4DBF
+        or 0x4E00 <= code <= 0x9FFF
+        or 0xF900 <= code <= 0xFAFF
+        or 0xFF66 <= code <= 0xFF9F
+    )
+
+
 def _span_weight(span_text: str) -> float:
-    if _CJK_CHAR_RE.match(span_text):
+    # Spans come from _SPLIT_SPAN_RE, so the first character already determines the class:
+    # a CJK span is exactly one CJK character, a latin span is all word characters, and
+    # anything else is a symbol run. A codepoint test is much cheaper than re-matching the
+    # span, and this runs once per span of every chunk. CJK is tested first because
+    # str.isalnum() is True for CJK characters.
+    code = ord(span_text[0])
+    if _is_cjk_codepoint(code):
         return 0.75
-    if _LATIN_RUN_RE.fullmatch(span_text):
+    if span_text[0].isalnum() or code == 0x5F:
         return 1.1
-    return 1.3 * max(1, len(span_text))
+    return 1.3 * len(span_text)
 
 
 def token_estimate(text: str) -> int:
@@ -458,7 +474,7 @@ def parse_resource(
                     "max_chunk_tokens": max_chunk_tokens,
                     "overlap_tokens": overlap_tokens,
                     "content_hash": piece_hash,
-                    "keywords": keywords_for_text(piece),
+                    "keywords": [] if slim_chunk_metadata_fields else keywords_for_text(piece),
                 }
             )
             if "page" in metadata and split_index:
@@ -466,7 +482,11 @@ def parse_resource(
             source_ref = _source_ref(raw_uri_text, metadata)
             metadata["citation"] = source_ref
             metadata["supersedes_chunk_hash"] = supersedes.get(source_ref) or supersedes.get(piece_hash)
-            metadata["embedding_text"] = build_embedding_text(piece, metadata, source_ref)
+            # Only build the encoder string when it will actually be kept. It is 41% of
+            # parse time and slim metadata drops it, so computing it there is pure waste;
+            # the embedding step recomputes it from the chunk when it needs it.
+            if not slim_chunk_metadata_fields:
+                metadata["embedding_text"] = build_embedding_text(piece, metadata, source_ref)
             metadata["parse_warnings"] = normalize_parse_warnings(metadata)
             metadata["raw_storage_policy"] = "raw_uri_only"
             metadata["raw_bytes_stored"] = False


### PR DESCRIPTION
Slim chunk metadata dropped `embedding_text` and `keywords` from what gets
stored, but the parser still built both for every chunk and then threw them away.
Profiling a 1.41 MB markdown skill and a 1.23 MB JSON resource with slim metadata
on, `build_embedding_text` was **41% of parse time** (1.414 s of 3.43 s) producing
strings nothing kept.

Three changes, none of which alters a single chunk:

**Build the encoder string only when it is kept.** The embedding step recomputes
it from the chunk when it needs it - that is what makes it safe to drop from
storage in the first place - so building it at parse time for a slim chunk is
pure waste.

**Skip `keywords_for_text` when slim metadata will discard it.**

**Weigh a split span by its first codepoint instead of re-matching it.**
`_span_weight` ran two regexes per span, and it runs once per span of every
chunk. Spans come from `_SPLIT_SPAN_RE`, so the first character already decides
the class: a CJK span is exactly one CJK character, a latin span is all word
characters, anything else is a symbol run. Note `str.isalnum()` is `True` for CJK
characters, so the CJK test has to come first - taking the latin branch there
would weigh a CJK span 1.1 instead of 0.75 and move every chunk boundary.

Measured on the same two documents, best of three runs on 4 pinned CPUs:

| | slim off | slim on |
|---|---|---|
| before | 2.10 s | 2.12 s |
| after | 2.11 s | **1.21 s** |

**43% faster** with slim metadata, and unchanged without it. Note that before this
change slim metadata was not faster at all (2.12 s vs 2.10 s) despite storing half
as much - the savings were purely in bytes, never in time.

## Equivalence

Chunking is unchanged. Verified against `origin/main` across markdown parsed as
both `skill` and `md`, and JSON, each with slim metadata on and off - six
configurations, all identical in chunk count, `chunk_hash`, chunk text, and
metadata keys:

    site-0.md   skill  slim=false  2126 chunks  hashes identical  text identical
    site-0.md   skill  slim=true   2126 chunks  hashes identical  text identical
    site-0.json json   slim=false  2808 chunks  hashes identical  text identical
    site-0.json json   slim=true   2808 chunks  hashes identical  text identical
    site-0.md   md     slim=false  2126 chunks  hashes identical  text identical
    site-0.md   md     slim=true   2126 chunks  hashes identical  text identical

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree - the environment has
`jsonschema` 3.2.0, which predates `Draft202012Validator`.
