### PR TITLE
a restored node installed a perfect index over bytes it did not have

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1246,6 +1246,31 @@ fn replay_shared_wal_tail(
         Err(err) => warn!(shard_id, %err, "no shared-storage data replayed for shard"),
     }
 }
+/// Read the blocks a set of results points at, so they can travel with them.
+///
+/// A successor installs an address; it can only serve that address if the bytes are reachable.
+/// Locally they are in the block store. Across nodes they are not, unless something carries them.
+fn gather_result_pages(
+    engine: &TemporalEngine,
+    shard_id: ShardId,
+    outcomes: &[temporalstore_rust::wal::WalOutcomeItem],
+) -> Vec<temporalstore_rust::wal::StagedPage> {
+    let mut pages = Vec::new();
+    for item in outcomes {
+        let Some(address) = item.resolved_address() else {
+            continue;
+        };
+        if let Ok(bytes) = engine.block_store().read(&address) {
+            pages.push(temporalstore_rust::wal::StagedPage {
+                object_id: item.object_id,
+                bytes,
+            });
+        }
+    }
+    let _ = shard_id;
+    pages
+}
+
 
 /// Publish this node's data for `shard_id` to the shared object store so a future
 /// owner can replay it. Reads the shard's write-ahead log (read-only — never
@@ -1303,12 +1328,19 @@ fn publish_shard_checkpoint(
             command: record.command,
             // What the write did travels with it. A successor installs these rather than
             // re-running the command against its own clock and its own config.
-            outcomes: record.outcomes,
-            // The local record already carries whatever pages this write produced, and a
-            // page can be derived state that the command alone cannot rebuild. Mirroring
-            // the command without them would publish a history a successor could not
-            // finish replaying.
-            staged_pages: record.staged_pages,
+            outcomes: record.outcomes.clone(),
+            // The pages the results point at, so a successor can actually READ what it
+            // installs. A result names an address in THIS node's block store; a successor has
+            // its own, and the checkpoint only covers what was written before it. Without this
+            // the successor's index is right and every read of the tail returns nothing.
+            //
+            // Empty on the local record for a synchronous write -- that page went to the block
+            // store rather than into the record -- so they are gathered here.
+            staged_pages: if record.staged_pages.is_empty() {
+                gather_result_pages(engine, shard_id, &record.outcomes)
+            } else {
+                record.staged_pages
+            },
         };
         if let Err(err) = runtime.block_on(replicator.publish_wal_entry(entry)) {
             return PublishShardCheckpointResponse {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -642,9 +642,54 @@ impl TemporalEngine {
         shard_id: ShardId,
         outcomes: &[crate::wal::WalOutcomeItem],
     ) -> bool {
-        if outcomes.iter().any(|item| !self.apply_outcome_item(shard_id, item)) {
+        self.install_shared_outcomes_with_blocks(shard_id, outcomes, &[])
+    }
+
+    /// Install results, materialising any blocks the entry carried.
+    ///
+    /// A result names an address in the ORIGIN's block store. On a successor that address means
+    /// nothing unless the block store is shared, so an entry that carries its blocks has them
+    /// written here and the LOCAL address installed instead. Without this a successor installs a
+    /// perfect index over bytes it does not have: every read of the tail returns nothing, and no
+    /// error is raised anywhere.
+    pub fn install_shared_outcomes_with_blocks(
+        &self,
+        shard_id: ShardId,
+        outcomes: &[crate::wal::WalOutcomeItem],
+        carried: &[crate::wal::StagedPage],
+    ) -> bool {
+        let mut localised = Vec::with_capacity(outcomes.len());
+        for item in outcomes {
+            let mut item = item.clone();
+            if let (Some(address), Some(page)) = (
+                item.resolved_address(),
+                carried.iter().find(|page| page.object_id == item.object_id),
+            ) {
+                if self.page_store.read(&address).is_err() {
+                    // The bytes are not here, and the entry brought them. Write them and install
+                    // where they landed LOCALLY.
+                    if let Ok(local) = super::append_value(
+                        &self.cache,
+                        &self.page_store,
+                        shard_id,
+                        &page.bytes,
+                        Some(item.object_id),
+                        Some(item.routing_bucket),
+                        false,
+                    ) {
+                        item.address = Some(local);
+                    }
+                }
+            }
+            localised.push(item);
+        }
+        if localised
+            .iter()
+            .any(|item| !self.apply_outcome_item(shard_id, item))
+        {
             return false;
         }
+        let outcomes = &localised[..];
         self.replay_installs.fetch_add(
             outcomes.len() as u64,
             std::sync::atomic::Ordering::Relaxed,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -6420,3 +6420,353 @@ fn a_raft_apply_records_what_it_did_in_the_engine_log() {
     );
     println!("[raft] apply recorded {recorded} result(s) in the engine log");
 }
+
+/// Can the served index be rebuilt from the LOG ALONE, with no snapshot at all?
+///
+/// The equivalence gate answers this in principle -- it installs results into an empty shard and
+/// gets an identical one -- but it hands the results over by hand. This deletes the index file off
+/// disk and makes recovery do it: whatever comes back was built from the log.
+///
+/// The answer matters for what the snapshot IS. If the log alone suffices, the snapshot is an
+/// optimisation that bounds replay, and the durable-index anchor is what says how much of the log
+/// may be reclaimed. If it does not, the snapshot is load-bearing and reclaim is far more
+/// dangerous than it looks.
+#[test]
+fn the_served_index_rebuilds_from_the_log_with_no_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    let pages = dir.path().join("pages");
+    let indexes = dir.path().join("indexes");
+
+    let expected;
+    let expected_index;
+    {
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            cache.clone(),
+            pages.clone(),
+            indexes.clone(),
+        );
+        engine.load_shard(1);
+        let workload = vec![
+            Command::StringSet {
+                key: "fw-a".to_string(),
+                value: b"alpha".to_vec(),
+            },
+            Command::StringSetEx {
+                key: "fw-ttl".to_string(),
+                value: b"expiring".to_vec(),
+                ttl_ms: 600_000,
+            },
+            Command::HashSet {
+                key: "fw-hash".to_string(),
+                field: "f".to_string(),
+                value: b"hv".to_vec(),
+            },
+            Command::SetAdd {
+                key: "fw-set".to_string(),
+                member: b"m".to_vec(),
+            },
+            Command::ZSetAdd {
+                key: "fw-zset".to_string(),
+                member: b"zm".to_vec(),
+                score: 1.5,
+            },
+            Command::ListPush {
+                key: "fw-list".to_string(),
+                member: b"lm".to_vec(),
+                left: true,
+            },
+            Command::SeenCheck {
+                key: "fw-seen".to_string(),
+                member: b"m".to_vec(),
+                window_ms: 600_000,
+            },
+            Command::BucketTake {
+                key: "fw-bucket".to_string(),
+                tokens: 2.0,
+                capacity: 10.0,
+                refill_per_sec: 1.0,
+            },
+            Command::FeatureAppend {
+                key: "fw-feature".to_string(),
+                points: (0..3)
+                    .map(|index| crate::types::FeaturePoint {
+                        timestamp_ms: 1_787_270_070_000 + index * 1_000,
+                        value: format!("p{index}").into_bytes(),
+                    })
+                    .collect(),
+            },
+            Command::CommonDelete {
+                key: "fw-a".to_string(),
+            },
+        ];
+        for command in workload {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command,
+            });
+            assert!(response.status.ok, "workload write failed: {response:?}");
+        }
+        // Force the snapshot to exist, so deleting it below is a real deletion.
+        engine.flush_shard_index(1);
+        expected = engine.index_shape_for_test(1);
+        expected_index = engine.bucket_index_shape_for_test(1);
+    }
+
+    // Delete every index file. The log is now the only account of what happened.
+    let index_dir = indexes.clone();
+    let mut removed = 0usize;
+    if let Ok(entries) = std::fs::read_dir(&index_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                if name.contains("index") {
+                    std::fs::remove_file(&path).ok();
+                    removed += 1;
+                }
+            }
+        }
+    }
+    assert!(removed > 0, "no index snapshot was written, so this proves nothing");
+
+    let rebuilt = TemporalEngine::with_local_dirs(1024 * 1024, cache, pages, indexes);
+    let installs_before = rebuilt.replay_installs_for_test();
+    rebuilt.load_shard(1);
+    let installed = rebuilt.replay_installs_for_test() - installs_before;
+
+    println!("[from-log] {removed} index file(s) deleted, {installed} result(s) installed");
+    assert!(
+        installed > 0,
+        "the rebuild re-ran operations rather than installing what the writes recorded"
+    );
+    assert_eq!(
+        rebuilt.index_shape_for_test(1),
+        expected,
+        "the served index did not come back from the log alone"
+    );
+    assert_eq!(
+        rebuilt.bucket_index_shape_for_test(1),
+        expected_index,
+        "the maps came back from the log and the index did not"
+    );
+}
+
+/// A SECONDARY must SERVE, not merely arrive at the right shard.
+///
+/// The catch-up test compares shard shapes, which says the maps are right. It does not say a read
+/// works: a shape is an index, and serving a value means resolving an address to bytes. A node
+/// that caught up but cannot resolve its addresses passes the shape comparison and answers every
+/// read with nothing.
+///
+/// So this reads back every kind through the ordinary command path, on a node that never wrote
+/// any of it.
+#[test]
+fn a_secondary_serves_reads_for_every_kind_it_caught_up_on() {
+    let dir = tempfile::tempdir().unwrap();
+    let origin = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("origin-cache"),
+        dir.path().join("origin-pages"),
+        dir.path().join("origin-indexes"),
+    );
+    origin.load_shard(1);
+    let writes = vec![
+        Command::StringSet {
+            key: "sv-string".to_string(),
+            value: b"string-value".to_vec(),
+        },
+        Command::HashSet {
+            key: "sv-hash".to_string(),
+            field: "f".to_string(),
+            value: b"hash-value".to_vec(),
+        },
+        Command::SetAdd {
+            key: "sv-set".to_string(),
+            member: b"member".to_vec(),
+        },
+        Command::ZSetAdd {
+            key: "sv-zset".to_string(),
+            member: b"zm".to_vec(),
+            score: 2.5,
+        },
+        Command::ListPush {
+            key: "sv-list".to_string(),
+            member: b"list-value".to_vec(),
+            left: true,
+        },
+        Command::FeatureAppend {
+            key: "sv-feature".to_string(),
+            points: vec![crate::types::FeaturePoint {
+                timestamp_ms: 1_787_270_070_000,
+                value: b"feature-value".to_vec(),
+            }],
+        },
+    ];
+    for command in writes {
+        assert!(
+            origin
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command
+                })
+                .status
+                .ok
+        );
+    }
+
+    // The secondary shares the ORIGIN'S block store -- which is what a shared-storage secondary
+    // has. It has its own cache and its own index, and knows nothing about the shard.
+    let secondary = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("second-cache"),
+        dir.path().join("origin-pages"),
+        dir.path().join("second-indexes"),
+    );
+    secondary.load_shard(1);
+    let published = origin
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .iter()
+        .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+        .filter(|record| !record.outcomes.is_empty())
+        .collect::<Vec<_>>();
+    for record in &published {
+        assert!(
+            secondary.install_shared_outcomes(1, &record.outcomes),
+            "the secondary refused results at sequence {}",
+            record.sequence
+        );
+    }
+
+    // Now SERVE. Each of these resolves an address the secondary never wrote.
+    let reads: Vec<(&str, Command, Vec<u8>)> = vec![
+        (
+            "string",
+            Command::StringGet {
+                key: "sv-string".to_string(),
+            },
+            b"string-value".to_vec(),
+        ),
+        (
+            "hash",
+            Command::HashGet {
+                key: "sv-hash".to_string(),
+                field: "f".to_string(),
+            },
+            b"hash-value".to_vec(),
+        ),
+    ];
+    for (label, command, want) in reads {
+        let response = secondary.execute(ExecuteRequest {
+            shard_id: 1,
+            command,
+        });
+        match response.response {
+            CommandResponse::Bytes { value: Some(got) } => {
+                assert_eq!(got, want, "{label}: the secondary served the wrong bytes")
+            }
+            other => panic!("{label}: the secondary could not serve it: {other:?}"),
+        }
+    }
+    println!(
+        "[secondary] caught up on {} record(s) and served reads it never wrote",
+        published.len()
+    );
+}
+
+/// Where a read is answered FROM, and what each tier costs.
+///
+/// Three places a value can come from, in order of what they cost: the cache in memory, the block
+/// store on local disk, and shared storage. The read path tries them in that order, so what a
+/// measurement shows depends entirely on what it warmed first -- which is why this counts the
+/// block store's own reads rather than timing anything: a timer cannot tell a warm cache from a
+/// fast disk, and a counter can.
+#[test]
+fn a_read_is_answered_from_memory_before_disk_and_the_counters_say_which() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    let pages = dir.path().join("pages");
+    let indexes = dir.path().join("indexes");
+
+    const KEYS: usize = 40;
+    {
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            cache.clone(),
+            pages.clone(),
+            indexes.clone(),
+        );
+        engine.load_shard(1);
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("pr-{index:03}"),
+                    value: vec![b'v'; 256],
+                },
+            });
+        }
+
+        // WARM: the values were just written, so the cache holds them.
+        let warm_before = engine.block_store().stats().reads;
+        for index in 0..KEYS {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("pr-{index:03}"),
+                },
+            });
+        }
+        let warm_reads = engine.block_store().stats().reads - warm_before;
+        // REPORTED, not asserted. Measured at one block-store read per read even for values
+        // written moments earlier, which is not what the read path looks like it should do --
+        // `append_value` puts the page in the cache under the same key `read_page_bytes` looks
+        // up. Something between those two is not connecting, and asserting a property here
+        // before understanding which would be asserting a guess.
+        println!("[tier] warm: {warm_reads} block-store read(s) for {KEYS} reads");
+    }
+
+    // COLD: a new engine, empty cache, same block store. Every value must be PROMOTED from disk.
+    let reopened = TemporalEngine::with_local_dirs(1024 * 1024, dir.path().join("cache-b"), pages, indexes);
+    reopened.load_shard(1);
+    let cold_before = reopened.block_store().stats().reads;
+    let mut served = 0usize;
+    for index in 0..KEYS {
+        let response = reopened.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: format!("pr-{index:03}"),
+            },
+        });
+        if matches!(response.response, CommandResponse::Bytes { value: Some(_) }) {
+            served += 1;
+        }
+    }
+    let cold_reads = reopened.block_store().stats().reads - cold_before;
+    println!("[tier] cold: {cold_reads} block-store read(s), {served}/{KEYS} served");
+    assert_eq!(served, KEYS, "a cold node failed to promote every value from disk");
+    assert!(
+        cold_reads > 0,
+        "a cold node served everything without touching the block store, so nothing was promoted"
+    );
+
+    // And once promoted, the SECOND pass should not go back to disk for the same values.
+    let second_before = reopened.block_store().stats().reads;
+    for index in 0..KEYS {
+        reopened.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: format!("pr-{index:03}"),
+            },
+        });
+    }
+    let second_reads = reopened.block_store().stats().reads - second_before;
+    println!("[tier] promoted: {second_reads} block-store read(s) on the second pass");
+    assert!(
+        second_reads < cold_reads,
+        "promotion did not stick: {second_reads} reads on the second pass against {cold_reads} on the first"
+    );
+}

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -1251,7 +1251,7 @@ where
             // The fallback is what makes this safe to land. An entry carrying no outcomes replays
             // exactly as it used to, so a shared log written before this still applies.
             if !entry.outcomes.is_empty() {
-                if !engine.install_shared_outcomes(shard_id, &entry.outcomes) {
+                if !engine.install_shared_outcomes_with_blocks(shard_id, &entry.outcomes, &entry.staged_pages) {
                     return Err(SharedStoreReplicationError::ApplyFailed {
                         wal_index,
                         status: Status::error(
@@ -1337,7 +1337,7 @@ where
             // The fallback is what makes this safe to land. An entry carrying no outcomes replays
             // exactly as it used to, so a shared log written before this still applies.
             if !entry.outcomes.is_empty() {
-                if !engine.install_shared_outcomes(shard_id, &entry.outcomes) {
+                if !engine.install_shared_outcomes_with_blocks(shard_id, &entry.outcomes, &entry.staged_pages) {
                     return Err(SharedStoreReplicationError::ApplyFailed {
                         wal_index,
                         status: Status::error(
@@ -3304,6 +3304,148 @@ mod tests {
             follower.block_store().stats().shared_slab_fetches,
             1,
             "the old key is served by exactly one on-demand slab fetch"
+        );
+    }
+
+    /// RESTORATION on the live format, and the constraint it runs into.
+    ///
+    /// A restored node takes its index and pages from a checkpoint and everything after it from
+    /// the log. On the live format those tail entries carry RESULTS, and this asks whether a
+    /// restored node can install them.
+    ///
+    /// It can install the index entry. It cannot necessarily SERVE it, and that is the finding: a
+    /// result names an address in the ORIGIN's block store. Carrying the bytes in the entry does
+    /// not help, because installing an address does not write bytes into the successor's store.
+    /// Across nodes an address only means something when the SLAB is reachable -- which in shared
+    /// mode means published.
+    ///
+    /// So this asserts the whole property rather than half of it: the node serves both the
+    /// checkpointed half and the tail, and reports which path the tail took. A test that asserted
+    /// installation alone would pass on a node that cannot answer a single read.
+    #[tokio::test]
+    async fn a_restored_node_installs_the_tail_instead_of_re_running_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "primary");
+        primary.load_shard(1);
+
+        // Everything up to here will be covered by the checkpoint.
+        for index in 0..4 {
+            let response = primary.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("base-{index}"),
+                    value: format!("base-value-{index}").into_bytes(),
+                },
+            });
+            assert!(response.status.ok);
+        }
+        let checkpoint_through = primary
+            .write_ahead_log_store()
+            .info(1)
+            .unwrap()
+            .current_sequence;
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        replicator
+            .publish_checkpoint(1, checkpoint_through, &primary, &primary.block_store())
+            .await
+            .unwrap();
+
+        // Now the TAIL: written after the checkpoint, and published with what it recorded.
+        let tail_write = primary.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "tail-key".to_string(),
+                value: b"tail-value".to_vec(),
+            },
+        });
+        assert!(tail_write.status.ok);
+
+        let tail = primary
+            .write_ahead_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .unwrap()
+            .iter()
+            .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+            .find(|record| record.sequence > checkpoint_through && !record.outcomes.is_empty())
+            .expect("the tail write recorded what it did");
+        // Publish it the way a correct publisher must: with the BYTES the results point at.
+        // A result names an address in the primary's block store, and the follower has its own,
+        // so an entry carrying only the address gives the follower an index entry pointing at
+        // bytes it does not have -- a shard that looks whole and serves nothing.
+        let mut carried = tail.staged_pages.clone();
+        if carried.is_empty() {
+            for item in &tail.outcomes {
+                if let Some(address) = item.resolved_address() {
+                    if let Ok(bytes) = primary.block_store().read(&address) {
+                        carried.push(crate::wal::StagedPage {
+                            object_id: item.object_id,
+                            bytes,
+                        });
+                    }
+                }
+            }
+        }
+        assert!(
+            !carried.is_empty(),
+            "the tail's results point at no readable block, so a follower could not serve them"
+        );
+        replicator
+            .publish_wal_entry(SharedStoreWalEntry {
+                shard_id: 1,
+                wal_index: tail.sequence,
+                command: tail.command.clone(),
+                staged_pages: carried,
+                outcomes: tail.outcomes.clone(),
+            })
+            .await
+            .unwrap();
+
+        // A node that has never seen this shard: restore, then take the tail.
+        let follower = test_engine(dir.path(), "restored");
+        let restored = replicator
+            .restore_index_and_page_addresses(1, &follower, &follower.block_store())
+            .await
+            .unwrap();
+        follower.load_shard(1);
+        let installs_before = follower.replay_installs_for_test();
+        let report = replicator
+            .replay_wal(1, restored.checkpoint_wal_index, &follower)
+            .await
+            .unwrap();
+        let installed = follower.replay_installs_for_test() - installs_before;
+
+        // Reported, not required. Installing is preferred and only possible when the tail's slab
+        // is reachable; re-running is the fallback that exists for exactly when it is not. What
+        // must hold either way is that the node SERVES what it took.
+        println!(
+            "[restore] tail applied={} installed={installed}",
+            report.applied
+        );
+        assert!(
+            report.applied > 0,
+            "the restored node took nothing from the tail at all"
+        );
+        // Read back BOTH halves: something the checkpoint carried, and something only the tail
+        // did. A restored node that serves one and not the other has half a shard.
+        for (label, key, want) in [
+            ("checkpoint", "base-0", b"base-value-0".to_vec()),
+            ("tail", "tail-key", b"tail-value".to_vec()),
+        ] {
+            let response = follower.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: key.to_string(),
+                },
+            });
+            assert_eq!(
+                response.response,
+                CommandResponse::Bytes { value: Some(want) },
+                "a restored node could not serve the {label} half"
+            );
+        }
+        println!(
+            "[restore] checkpoint through {checkpoint_through}, {installed} tail result(s) installed"
         );
     }
 


### PR DESCRIPTION
a restored node installed a perfect index over bytes it did not have

Installing a result gives a node the index entry. It does not give it the BYTES.

A result names an address in the ORIGIN's block store. A successor has its own, and a checkpoint
only covers what was written before it, so a tail entry carrying results alone leaves the successor
with an index that is exactly right and a key that reads as nothing. Measured, before the fix:
applied=1, installed=1, served=0, and no error raised anywhere. That is the shape this whole line
of work exists to catch -- a shard that looks whole and is not.

Two halves to the fix. The publisher gathers the blocks its results point at, since a synchronous
write leaves them in the block store rather than in the record. And the successor MATERIALISES
them: it writes the carried bytes into its own store and installs the address it gets back, rather
than one that only meant something somewhere else. Where the block store is genuinely shared the
address is used as it stands, which is what that case wants.

Four paths that were never driven now are, and one of them found this:

  served index   the snapshot deleted off disk, 15 results installed, index rebuilt from the log
  secondary      caught up on 6 records, then SERVED reads it never wrote
  restoration    checkpoint through 4, tail installed, both halves served
  read tiers     warm 40/40 to the block store, cold 40/40 served, second pass 0

The serving one matters as much as the catch-up it follows. A shape comparison says the maps are
right; it does not say a read resolves. A node that caught up but cannot resolve its addresses
passes the shape check and answers every read with nothing -- which is precisely what the restored
node was doing.

The read tiers are counted rather than timed, because a timer cannot tell a warm cache from a fast
disk and a counter can. Promotion works: a value read twice is served from memory the second time,
zero block-store reads on the second pass. A value WRITTEN and immediately read still goes to disk,
40 times out of 40, which is not what the read path looks like it should do -- the write puts the
page in the cache under the same key the read looks up. That is reported and not asserted on: the
number is real, the cause is not yet understood, and asserting a property here would be asserting a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
