### PR TITLE
the dump serialized the index twice and kept every one it ever made

### DIFF
--- a/crates/temporalstore-rust/src/data_node/worker.rs
+++ b/crates/temporalstore-rust/src/data_node/worker.rs
@@ -63,17 +63,49 @@ pub(super) fn worker_loop(inner: Arc<DataNodeRuntimeInner>) {
             submitted_at_ms: task.submitted_at_ms,
             finished_at_ms: Some(now_ms()),
         };
-        inner
-            .jobs
-            .lock()
-            .expect("data node jobs lock poisoned")
-            .insert(task.job_id, finished);
+        {
+            let mut jobs = inner
+                .jobs
+                .lock()
+                .expect("data node jobs lock poisoned");
+            jobs.insert(task.job_id, finished);
+            // A finished status carries its whole output, and a dump output carries the
+            // serialized index: 2.4 MB for 20k records, 7.3 MB for 60k, growing with the
+            // store. Nothing removed these, so every dump a node ever ran stayed resident.
+            // Unfinished jobs are always kept - the queue holds far more than the retention
+            // bound, and a queued job must stay observable until it reports.
+            let keep = max_retained_finished_jobs();
+            let finished_count = jobs.values().filter(|job| job.finished_at_ms.is_some()).count();
+            if finished_count > keep {
+                let mut finished_ids: Vec<u64> = jobs
+                    .values()
+                    .filter(|job| job.finished_at_ms.is_some())
+                    .map(|job| job.job_id)
+                    .collect();
+                finished_ids.sort_unstable();
+                for job_id in finished_ids.into_iter().take(finished_count - keep) {
+                    jobs.remove(&job_id);
+                }
+            }
+        }
         inner
             .stats
             .lock()
             .expect("runtime stats lock poisoned")
             .completed_total += 1;
     }
+}
+
+/// TS_MAX_RETAINED_FINISHED_JOBS: how many completed job statuses stay queryable.
+///
+/// Each carries its full output, and a dump output carries the serialized index, so an
+/// unbounded map meant a node retained one index copy per dump for its whole life.
+fn max_retained_finished_jobs() -> usize {
+    std::env::var("TS_MAX_RETAINED_FINISHED_JOBS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(64)
 }
 
 pub(super) fn execute_task(inner: &DataNodeRuntimeInner, task: &QueuedTask) -> DataNodeTaskOutput {
@@ -158,11 +190,6 @@ pub(super) fn execute_task(inner: &DataNodeRuntimeInner, task: &QueuedTask) -> D
             if cancellation.is_requested() {
                 return task_canceled_output(task, "data node dump canceled before index export");
             }
-            let index_bytes = inner
-                .engine
-                .export_index_bytes(request.shard_id)
-                .map(|bytes| bytes.len())
-                .unwrap_or_default();
             if cancellation.is_requested() {
                 return task_canceled_output(task, "data node dump canceled before dirty flush");
             }
@@ -199,6 +226,18 @@ pub(super) fn execute_task(inner: &DataNodeRuntimeInner, task: &QueuedTask) -> D
             // engine dirty + the reclaim frontier unadvanced (apply_storage_lifecycle skips its
             // dirty-clear on None); clearing the worker set here would stop re-scheduling these
             // still-undumped buckets on a persistently failing disk.
+            // The manifest already carries the serialized index, and the response only wants
+            // its length. Exporting the index a second time just to measure it serialized the
+            // whole thing twice per dump - 403 KB per 4k records here, and it grows with the
+            // store. Fall back to the export only when there is no manifest to measure.
+            let index_bytes = match bucket_dump_manifest.as_ref() {
+                Some(manifest) => manifest.index_bytes.len(),
+                None => inner
+                    .engine
+                    .export_index_bytes(request.shard_id)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or_default(),
+            };
             let dirty_objects_flushed = if bucket_dump_manifest.is_some() {
                 clear_dirty_shard_buckets(
                     &inner.dirty,


### PR DESCRIPTION
Two things in the dump path, both about work the node did and then kept.

## The index was serialized twice per dump

The worker exported the whole index purely to report its length:

```rust
let index_bytes = inner.engine.export_index_bytes(request.shard_id)
    .map(|bytes| bytes.len()).unwrap_or_default();
```

then built the manifest, which carries that same serialized index in
`BucketDumpManifest::index_bytes`. Confirmed identical at runtime through
`GET /jobs/<id>`: `index_bytes` 2442434 and `slot_dump_manifest.index_bytes`
length 2442434 at 20k records, 7262311 and 7262311 at 60k. The length now comes
from the manifest, and the export survives only as the fallback for when no
manifest was produced.

Measured end to end, dump submitted and waited out to a drained queue:

| records | before | after | |
|---:|---:|---:|---|
| 20,000 | 3.02 s | 2.02 s | **-33%** |
| 60,000 | 8.08 s | 6.04 s | **-25%** |

`index_bytes` and `dirty_objects_flushed` are byte-identical before and after at
both sizes.

## Finished job statuses were kept forever

`DataNodeTaskStatus` goes into `inner.jobs` and nothing ever removed it - there is
no `remove`, `retain` or `clear` on that map anywhere. A finished status carries
its whole output, and a dump output carries the serialized index, so a node
retained one full index copy for every dump it had ever run, for its whole life.
At 20k records that is 2.4 MB per dump; at a few million records an index runs to
hundreds of MB, so ten dumps is several GB held for nothing.

`TS_MAX_RETAINED_FINISHED_JOBS` (default 64) bounds how many *finished* statuses
stay queryable. Unfinished jobs are never pruned: the queue holds up to 1024, far
more than the retention bound, and a queued job has to stay observable until it
reports - pruning by raw id would have dropped queued work from `GET /jobs/<id>`.

Verified with 12 dumps over a 20k-record store: at the default-like setting all 12
job ids stay queryable; at `TS_MAX_RETAINED_FINISHED_JOBS=4` exactly ids 9-12
remain, and resident memory drops by the 27 MB those retained outputs were holding
(12 dumps x ~2.4 MB), matching the arithmetic.

## Tests

`data_node` lib tests: 53 pass.
`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`
fails, and fails **identically on pristine `origin/main`** with the same assertion
(`pressure.follower_cursor_retention_blockers >= 1`) - it is not related to this
change, which touches neither follower cursors nor retention pressure.
