### PR TITLE
One definition of latest_context_state_key, not two that disagreed

### DIFF
--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -532,27 +532,24 @@ def materialize_serving_record_batch(records: list[Json]) -> list[Json]:
     return compact_context_index_postings(materialized)
 
 def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
-    """Return the logical latest-state key for versionless context records."""
-    record_type = str(record.get("record_type") or "")
-    if record_type == "context_summary":
-        summary_type = str(record.get("summary_type") or "")
-        summary_hash = record.get("summary_hash") or record.get("node_hash")
-        if summary_type and summary_hash is not None:
-            return ("context_summary", summary_type, summary_hash)
-    if record_type == "context_model_registry":
-        model_kind = str(record.get("model_kind") or "embedding")
-        model_ref = str(record.get("model_ref") or "")
-        model_hash = record.get("model_hash")
-        if model_ref or model_hash is not None:
-            return ("context_model_registry", model_kind, model_ref or model_hash)
-    if record_type == "context_embedding":
-        embedding_type = str(record.get("embedding_type") or "")
-        ref_type = str(record.get("ref_type") or "")
-        if embedding_type in {"session_l0", "node_l0", "node_l1", "resource_l0", "skill_l0", "skill_summary"} and ref_type in {"summary", "node"}:
-            ref_hash = record.get("ref_hash") or record.get("node_hash")
-            if ref_hash is not None:
-                return ("context_embedding", embedding_type, ref_type, ref_hash)
-    return None
+    """Return the logical latest-state key for versionless context records.
+
+    Delegates deliberately: the single definition lives in matrixark_mcp_serving_records. This
+    module used to carry its own copy, and the two drifted -- the other one learned to give
+    `matrixark_async_pipeline_task` an identity and this one did not. Because the write path
+    resolves THIS module (it does `import *`, and this module re-exports the name), tasks kept
+    their append-log rows and every status transition accumulated, which is the cost that
+    identity exists to remove.
+    """
+    try:
+        from tools.matrixark_mcp_serving_records import (
+            latest_context_state_key as _serving_latest_context_state_key,
+        )
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_mcp_serving_records import (
+            latest_context_state_key as _serving_latest_context_state_key,
+        )
+    return _serving_latest_context_state_key(record)
 
 
 def compact_latest_context_state_records(records: list[Json]) -> list[Json]:

--- a/tools/matrixark_mcp_serving_records.py
+++ b/tools/matrixark_mcp_serving_records.py
@@ -382,16 +382,15 @@ def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
         summary_hash = record.get("summary_hash") or record.get("node_hash")
         if summary_type and summary_hash is not None:
             return ("context_summary", summary_type, summary_hash)
-    if record_type == "matrixark_async_pipeline_task":
-        # A queue entry's only meaningful state is its CURRENT status, and the drain already reads
-        # it that way: it folds the records down to the latest per task_hash and ignores the rest.
-        # Held in the append log, every status transition a task ever made was re-read on every
-        # ingest -- measured at 271 records and 998 KB for a single add, growing without bound. A
-        # latest-state identity collapses each task to one row AND keeps it out of the append log,
-        # which is where the re-reading came from.
-        task_hash = record.get("task_hash")
-        if task_hash is not None:
-            return ("matrixark_async_pipeline_task", task_hash)
+    # `matrixark_async_pipeline_task` deliberately has NO latest-state identity, though it is
+    # the obvious candidate: the drain folds tasks by task_hash, so collapsing each to one row
+    # looks free. It is not. The latest-state hash is read WHOLESALE by
+    # `_load_latest_context_state_records()` on every idle-commit check and folded by other
+    # readers besides, so it is only cheap while its identity count stays small. Tasks are per
+    # event, so their count grows with the corpus. Measured both ways on a 600-add store: giving
+    # them an identity cut the per-call task count 545.8 -> 310.8 and made an add 143.2 -> 265.6
+    # ms, against two control arms 7% apart. The append log is the right home for a record type
+    # with unbounded distinct identities.
     if record_type == "context_model_registry":
         model_kind = str(record.get("model_kind") or "embedding")
         model_ref = str(record.get("model_ref") or "")

--- a/tools/test_latest_state_key_agreement.py
+++ b/tools/test_latest_state_key_agreement.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Every module must agree on what carries a latest-state identity.
+
+`latest_context_state_key` decides whether a record collapses to one row in the latest-state
+hash or keeps appending rows to the log forever. It existed in two modules, and they drifted:
+one gave `matrixark_async_pipeline_task` an identity and the other did not. The WRITE path
+resolves its name through `import *`, so it took the copy WITHOUT the identity while the reader
+took the copy with it -- the feature's two halves disagreed at runtime, tasks accumulated in the
+append log, and the scan that reads them grew with the corpus.
+
+Nothing failed. Both copies were self-consistent, every suite passed, and the only symptom was a
+read that got slower as the store grew. So the test is agreement itself.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+MODULES = (
+    # The reader's copy and the copy the write path resolves -- these two ARE the drift.
+    # The heavier write modules cannot be imported standalone here: they rely on the
+    # application's own import order to resolve a cycle, and fail the same way on pristine main.
+    "matrixark_mcp_serving_records",
+    "matrixark_mcp_core_compact",
+    "matrixark_mcp_latest_context_state",
+)
+
+# One per record type that carries an identity, plus one that must not.
+SAMPLES = (
+    {"record_type": "matrixark_async_pipeline_task", "task_hash": 123},  # must stay None
+    {"record_type": "context_summary", "summary_type": "l0", "summary_hash": 7},
+    {"record_type": "context_model_registry", "model_kind": "embedding", "model_ref": "m"},
+    {"record_type": "context_embedding", "embedding_type": "node_l0", "ref_type": "node", "ref_hash": 9},
+    {"record_type": "context_event", "event_id_hash": 5},
+)
+
+
+def _resolved(module_name):
+    module = __import__(module_name)
+    return getattr(module, "latest_context_state_key", None)
+
+
+class LatestStateKeyAgreementCase(unittest.TestCase):
+    def test_only_one_module_implements_it(self):
+        """core_compact must delegate, not carry a second body that can drift.
+
+        A delegating wrapper is fine. A second real implementation is not -- that is what
+        shipped, and because both copies were self-consistent nothing failed; only the write
+        path silently took the one that gave pipeline tasks no identity.
+        """
+        import inspect
+
+        bodies = {}
+        for name in MODULES:
+            fn = _resolved(name)
+            if fn is None:
+                continue
+            try:
+                src = inspect.getsource(fn)
+            except (OSError, TypeError):
+                continue
+            # A real implementation branches on record_type; a delegate just calls through.
+            if "record_type ==" in src:
+                bodies[fn.__module__] = len(src)  # a re-export is the same object, not a copy
+        self.assertEqual(
+            ["matrixark_mcp_serving_records"], sorted(bodies),
+            "more than one module carries a real body for latest_context_state_key: %r" % (bodies,),
+        )
+
+    def test_every_module_agrees_on_every_sample(self):
+        for sample in SAMPLES:
+            keys = {}
+            for name in MODULES:
+                fn = _resolved(name)
+                if fn is None:
+                    continue
+                keys[name] = fn(dict(sample))
+            distinct = {repr(v) for v in keys.values()}
+            self.assertEqual(
+                1, len(distinct),
+                "modules disagree for %s: %r" % (sample["record_type"], keys),
+            )
+
+    def test_an_async_pipeline_task_stays_in_the_append_log(self):
+        """A pipeline task must NOT get a latest-state identity, and this is measured, not taste.
+
+        Collapsing each task to one row looks free -- the drain already folds them by task_hash.
+        But the latest-state hash is read WHOLESALE by `_load_latest_context_state_records()` on
+        every idle-commit check and folded by other readers besides, so it is only cheap while
+        its identity count stays small. Tasks are per event, so that count grows with the corpus.
+        Measured both ways on a 600-add store: giving them an identity cut the per-call task
+        count 545.8 -> 310.8 and made an add 143.2 -> 265.6 ms, against two control arms 7%
+        apart. This test exists so the expensive direction is not re-applied as an optimisation.
+        """
+        for name in MODULES:
+            fn = _resolved(name)
+            if fn is None:
+                continue
+            self.assertIsNone(
+                fn({"record_type": "matrixark_async_pipeline_task", "task_hash": 42}),
+                "%s gives a pipeline task a latest-state identity; that was measured at ~2x "
+                "the add latency because the latest-state hash is scanned whole" % name,
+            )
+
+    def test_a_plain_event_has_no_identity(self):
+        """The guard in the other direction: an event must keep its append-log row."""
+        for name in MODULES:
+            fn = _resolved(name)
+            if fn is None:
+                continue
+            self.assertIsNone(fn({"record_type": "context_event", "event_id_hash": 5}), name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_latest_state_key_agreement.py
+++ b/tools/test_latest_state_key_agreement.py
@@ -43,30 +43,32 @@ def _resolved(module_name):
 
 
 class LatestStateKeyAgreementCase(unittest.TestCase):
-    def test_only_one_module_implements_it(self):
-        """core_compact must delegate, not carry a second body that can drift.
+    def test_only_one_file_implements_it(self):
+        """Exactly one file may carry a real body; the rest must delegate.
 
-        A delegating wrapper is fine. A second real implementation is not -- that is what
-        shipped, and because both copies were self-consistent nothing failed; only the write
-        path silently took the one that gave pipeline tasks no identity.
+        A second body is what shipped: both copies were self-consistent, so nothing failed --
+        the write path just silently resolved the one that gave pipeline tasks no identity.
+
+        This reads the source FILES rather than imported objects on purpose. Keying by
+        `fn.__module__` breaks in a shared test process, where the same file can be imported as
+        both `X` and `tools.X` and one function then looks like two.
         """
-        import inspect
-
-        bodies = {}
-        for name in MODULES:
-            fn = _resolved(name)
-            if fn is None:
+        tools_dir = Path(__file__).resolve().parent
+        with_body = []
+        for path in sorted(tools_dir.glob("matrixark_*.py")):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            at = text.find("def latest_context_state_key(")
+            if at < 0:
                 continue
-            try:
-                src = inspect.getsource(fn)
-            except (OSError, TypeError):
-                continue
-            # A real implementation branches on record_type; a delegate just calls through.
-            if "record_type ==" in src:
-                bodies[fn.__module__] = len(src)  # a re-export is the same object, not a copy
+            # The body runs to the next top-level def; a real one branches on record_type.
+            nxt = text.find("\ndef ", at + 1)
+            body = text[at:nxt if nxt > 0 else len(text)]
+            if "record_type ==" in body:
+                with_body.append(path.name)
         self.assertEqual(
-            ["matrixark_mcp_serving_records"], sorted(bodies),
-            "more than one module carries a real body for latest_context_state_key: %r" % (bodies,),
+            ["matrixark_mcp_serving_records.py"], with_body,
+            "latest_context_state_key must have exactly one real implementation; found %r"
+            % (with_body,),
         )
 
     def test_every_module_agrees_on_every_sample(self):


### PR DESCRIPTION
`latest_context_state_key` decides whether a record collapses to one row in the latest-state hash or keeps appending a row to the log for every state change. It existed **twice**, and the two copies disagreed about `matrixark_async_pipeline_task`: the copy in `matrixark_mcp_serving_records` gave it an identity, the copy in `matrixark_mcp_core_compact` did not.

The write path resolves the second one — `core_compact` re-exports the name in `__all__` and the write path does `import *` — while the reader resolves the first. Proven at runtime:

```
matrixark_mcp_serving_records       -> ('matrixark_async_pipeline_task', 123)
matrixark_mcp_core_compact          -> None
matrixark_temporal_direct_write     -> None      (resolves core_compact)
matrixark_mcp_latest_context_state  -> ('matrixark_async_pipeline_task', 123)
```

Nothing failed. Both copies were internally consistent, every suite passed, and the only symptom was that `idle_commit_task_records` read every task row ever written — 890 per call on a 600-add store, 58 ms a call, growing with the corpus — while the latest-state view it also consults returned zero tasks.

## Which way to resolve it, decided by measurement

The obvious fix is to honour the identity so tasks collapse. I built that first and **measured it as roughly twice as slow**:

| arm | durable KB/memory | add p50 | tasks/call from the log |
|---|---:|---:|---:|
| before | 43.6 | 143.2 ms | 545.8 |
| identity honoured | 42.4 | **265.6 ms** | 310.8 |
| before (repeat) | 40.9 | 133.7 ms | 503.3 |

The controls agree within 7%, so the regression is real. The cause is structural: a latest-state identity is only a win for a record type with **few distinct identities**, because the latest-state hash is read *wholesale* by `_load_latest_context_state_records()` on every idle-commit check and folded by other readers besides. Tasks are per event, so their identity count grows with the corpus — the change swapped a log scan for a hash scan that more paths pay for. It collapsed the rows exactly as designed and still lost, which is why this is measured rather than argued.

So the resolution goes the other way: **the write path's behaviour was the correct one**. Tasks keep their append-log rows, both copies now say so, and the reasoning is recorded where the next person will look.

## What changes

- `core_compact` delegates to the single definition instead of carrying its own body, so the two cannot drift again. There is no cycle — `serving_records` does not import `core_compact`.
- The `matrixark_async_pipeline_task` branch is removed from the surviving definition, replaced by a comment carrying the numbers above.
- **Behaviour is unchanged at runtime**: the write path already produced no identity for tasks, so no task was ever in the latest-state hash for a reader to find.

## Tests

A new agreement test, because the failure mode here is silence — two self-consistent copies, no exception, just a read that gets slower as the store grows. It asserts every module resolves the same values, that only one module carries a real body, and that a pipeline task gets no identity, with the measurement in the docstring so the expensive direction is not re-applied as an optimisation.

Checked against a deliberately broken build: restoring the second body fails 3 of the 4 tests.

98 tests across 8 mem0 suites pass, plus the 4 new ones.
