### PR TITLE
a checkpoint could publish an index naming places only the primary could reach

### DIFF
--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1138,6 +1138,104 @@ impl TemporalEngine {
             .and_then(|shard| shard.strings.get(key).cloned())
     }
 
+    /// Write every in-process-only page into the block store, so the index can travel.
+    ///
+    /// A synthetic address names a page inside a WAL record or in memory. It resolves here and
+    /// nowhere else, so an index carrying one is not portable: a checkpoint uploads the slabs the
+    /// block store HAS, and a synthetic slab is not among them.
+    ///
+    /// Called before a checkpoint exports the index. Returns how many were materialised, so a
+    /// caller can tell the difference between "none needed it" and "it did not run".
+    pub fn materialize_synthetic_pages(&self, shard_id: ShardId) -> usize {
+        let addresses: Vec<(String, crate::block_store::BlockAddress)> = {
+            let shards = self.shards.read().expect("engine lock poisoned");
+            let Some(shard) = shards.get(&shard_id) else {
+                return 0;
+            };
+            shard
+                .strings
+                .iter()
+                .filter(|(_, address)| {
+                    crate::wal_record::is_wal_resident(address.page_slab_id)
+                })
+                .map(|(key, address)| (key.clone(), address.clone()))
+                .collect()
+        };
+        let mut moved = 0usize;
+        for (key, address) in addresses {
+            // Read it the way a reader here would -- through the registry that still works in
+            // this process -- and write it where anyone can find it.
+            let Some(bytes) = super::read_page_bytes(&self.cache, &self.page_store, shard_id, &address)
+            else {
+                continue;
+            };
+            let object_id = super::stable_page_object_id(shard_id, "string", &key, None);
+            let Ok(durable) = super::append_value(
+                &self.cache,
+                &self.page_store,
+                shard_id,
+                &bytes,
+                Some(object_id),
+                address.routing_bucket,
+                false,
+            ) else {
+                continue;
+            };
+            let mut shards = self.shards.write().expect("engine lock poisoned");
+            if let Some(shard) = shards.get_mut(&shard_id) {
+                shard.strings.insert(key.clone(), durable.clone());
+                super::upsert_bucket_index_page(
+                    shard,
+                    shard_id,
+                    "string",
+                    &key,
+                    None,
+                    durable,
+                    true,
+                );
+            }
+            moved += 1;
+        }
+        moved
+    }
+
+    /// How many addresses in the served index name a slab that is not a file.
+    ///
+    /// A synthetic slab id means the bytes are inside a WAL record or in memory, resolvable only
+    /// through this process's registry. A checkpoint uploads the slabs the block store HAS, so an
+    /// address like this cannot travel: it names a place that does not exist anywhere else.
+    pub(crate) fn synthetic_address_count_for_test(&self, shard_id: ShardId) -> usize {
+        let shards = self.shards.read().expect("engine lock poisoned");
+        let Some(shard) = shards.get(&shard_id) else {
+            return 0;
+        };
+        let mut count = 0usize;
+        let mut check = |address: &crate::block_store::BlockAddress| {
+            if crate::wal_record::is_wal_resident(address.page_slab_id) {
+                count += 1;
+            }
+        };
+        for address in shard.strings.values() {
+            check(address);
+        }
+        for fields in shard.hashes.values() {
+            for address in fields.values() {
+                check(address);
+            }
+        }
+        for series in shard.features.values() {
+            for address in series.values() {
+                check(address);
+            }
+        }
+        for bucket in shard.bucket_index.bucket_map.values() {
+            for page in bucket.page_index.values() {
+                check(&page.address);
+            }
+        }
+        count
+    }
+
     /// How many WAL-resident page locations this shard's index is carrying.
     ///
     /// The point of the map is that it is part of the index rather than process state, so a

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -6770,3 +6770,179 @@ fn a_read_is_answered_from_memory_before_disk_and_the_counters_say_which() {
         "promotion did not stick: {second_reads} reads on the second pass against {cold_reads} on the first"
     );
 }
+
+/// Does the served index ever hold an address only THIS process can resolve?
+///
+/// Two slab ids are synthetic: one means "the page is inside a WAL record", the other means "the
+/// page is in memory". Neither is a file in the block store. Both are resolved through a registry
+/// that is process-local -- a static map in this process, keyed by a pointer to this process's
+/// block store.
+///
+/// That is fine for a restart, which rebuilds the registry from the index. It is not obviously
+/// fine for a NEW NODE: a checkpoint uploads the slabs the block store actually has, and a
+/// synthetic slab is not one of them. An index entry naming one would arrive somewhere it can
+/// never be resolved -- and would read as nothing, with no error.
+///
+/// This measures whether the served index contains such addresses at all, and under what settings.
+/// It asserts nothing about the answer: the point is to establish the fact before deciding what to
+/// do about it.
+#[test]
+fn how_many_served_addresses_only_this_process_can_resolve() {
+    // Every combination that could put a page somewhere other than the block store: the log-in-
+    // record path, the reserve-only append that skips staging, and asynchronous writes whose
+    // pages are buffered rather than written.
+    let cases: Vec<(&str, &str, &str, bool)> = vec![
+        ("default", "1", "1", false),
+        ("log-in-record OFF", "0", "1", false),
+        ("group-commit OFF", "1", "0", false),
+        ("async writes", "1", "1", true),
+        ("async + group-commit OFF", "1", "0", true),
+    ];
+    for (label, block_in_wal, concurrent, async_storage) in cases {
+        std::env::set_var("TS_BLOCK_IN_WAL", block_in_wal);
+        std::env::set_var("TS_ENGINE_CONCURRENT_COMMIT", concurrent);
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        if async_storage {
+            assert!(
+                engine
+                    .set_config(SetConfigRequest {
+                        shard_id: 1,
+                        config: Config {
+                            version: 2,
+                            async_storage: true,
+                            ..Config::default()
+                        },
+                    })
+                    .ok
+            );
+        }
+        for index in 0..24 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("syn-{index:03}"),
+                    value: vec![b'v'; 128],
+                },
+            });
+        }
+
+        let synthetic = engine.synthetic_address_count_for_test(1);
+        let resident = engine.wal_resident_page_count(1);
+        println!(
+            "[synthetic] {label}: {synthetic} served address(es) resolvable only in-process, {resident} log-resident page(s) tracked"
+        );
+
+        // And after a flush, which is what a checkpoint exports.
+        engine.flush_shard_index(1);
+        let after_flush = engine.synthetic_address_count_for_test(1);
+        println!("[synthetic] {label}: {after_flush} after the index is flushed");
+
+        // If any exist, say whether a value behind one still READS -- in this process it should,
+        // because the registry is right here. The question a checkpoint raises is whether it
+        // would read anywhere else, and that is what the count above is for.
+        if after_flush > 0 {
+            let probe = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: "syn-000".to_string(),
+                },
+            });
+            println!(
+                "[synthetic] {label}: in-process read {}",
+                if matches!(probe.response, CommandResponse::Bytes { value: Some(_) }) {
+                    "served"
+                } else {
+                    "EMPTY"
+                }
+            );
+        }
+        std::env::remove_var("TS_BLOCK_IN_WAL");
+        std::env::remove_var("TS_ENGINE_CONCURRENT_COMMIT");
+    }
+}
+
+/// A checkpoint's index must name only places the checkpoint can carry.
+///
+/// An asynchronous write leaves its page in a WAL record or in memory, named by a synthetic slab
+/// id that is not a file. It serves here, through a registry local to this process. A checkpoint
+/// uploads the slabs the block store HAS, so a synthetic one is never uploaded, and a node
+/// restoring that index holds addresses it can never resolve -- reads that return nothing, with no
+/// error anywhere.
+///
+/// So the pages are materialised before the index is exported. This asserts the property that
+/// makes a checkpoint portable: after materialising, ZERO addresses in the served index name a
+/// slab that is not a file -- and every value still reads.
+#[test]
+fn a_checkpoint_index_names_no_place_only_this_process_can_reach() {
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    for index in 0..24 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("pt-{index:03}"),
+                value: format!("portable-{index}").into_bytes(),
+            },
+        });
+        assert!(response.status.ok);
+    }
+
+    let before = engine.synthetic_address_count_for_test(1);
+    assert!(
+        before > 0,
+        "this test needs async writes to produce in-process-only addresses, and got none"
+    );
+
+    let moved = engine.materialize_synthetic_pages(1);
+    let after = engine.synthetic_address_count_for_test(1);
+    println!("[portable] {before} in-process-only address(es), {moved} materialised, {after} left");
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+
+    assert_eq!(
+        after, 0,
+        "the index still names {after} place(s) a restoring node could not reach"
+    );
+
+    // And every value still reads, which is the half a page move can break.
+    for index in 0..24 {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: format!("pt-{index:03}"),
+            },
+        });
+        let want = format!("portable-{index}").into_bytes();
+        match response.response {
+            CommandResponse::Bytes { value: Some(got) } => {
+                assert_eq!(got, want, "pt-{index:03} came back changed after materialising")
+            }
+            other => panic!("pt-{index:03} stopped reading after materialising: {other:?}"),
+        }
+    }
+}

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -980,6 +980,19 @@ where
         // (bucket_dump_manifest_methods) which fsyncs pages+WAL before recording slab ids. Without
         // this a relaxed (bulk) writer could enumerate a slab whose tail bytes are not yet on disk,
         // uploading a torn page or racing a not-yet-durable slab into the checkpoint.
+        // Make the index PORTABLE before exporting it. A page that lives in a WAL record or in
+        // memory is named by a slab that is not a file, resolvable only through this process's
+        // registry -- so an index carrying one names a place the restoring node cannot reach, and
+        // that read returns nothing with no error. Materialising them first means the index names
+        // only slabs this checkpoint actually uploads.
+        let materialised = engine.materialize_synthetic_pages(shard_id);
+        if materialised > 0 {
+            tracing::info!(
+                shard_id,
+                pages = materialised,
+                "materialised in-process-only pages so the checkpoint index can travel"
+            );
+        }
         block_store.sync_durable()?;
         let checkpoint_id = uuid::Uuid::new_v4().to_string();
         let prefix = self.checkpoint_prefix(shard_id, &checkpoint_id);


### PR DESCRIPTION
a checkpoint could publish an index naming places only the primary could reach

An address in the served index is usually a slab, an offset and a length -- a file the block store
has, which a checkpoint uploads and a restoring node can read. Two slab ids are not files. One
means the page is inside a log record, the other means it is in memory, and both resolve through a
registry that is local to the process holding them.

Counted across five write paths, because which paths produce them was the question:

    default                    0
    log-in-record OFF          0
    group-commit OFF           0
    async writes              48   (24 pages, each named twice)
    async + group-commit OFF  48

A synchronous write leaves the index fully portable, which is why restore has always worked. An
asynchronous one does not. Those 48 addresses serve perfectly in the process that wrote them, and
still serve after a RESTART -- the index persists the log-id mapping and the log is the same file.

A new node is where it breaks. A checkpoint uploads the slabs the block store HAS, and a slab that
is not a file is never among them; the persisted log ids name the origin's log, not the
newcomer's. So the newcomer restores an index whose entries are exactly right, pointing at places
it cannot reach, and answers those reads with nothing. No error is raised, because nothing is
wrong except where the bytes are.

So a checkpoint now materialises them before exporting: each in-process-only page is read through
the registry that still works here, written into the block store, and the index updated to where
it landed. After that the index names only slabs the checkpoint itself carries. The test asserts
the property rather than the mechanism -- zero unreachable addresses afterwards -- and re-reads
every value, because moving a page is exactly the operation that can lose one.

This is the same finding as the restored tail, one layer up: installing an address only works if
whoever installs it can reach what it names. That was true for a record's results and it is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
