### PR TITLE
a stored embedding is only ever scored with cosine, which ignores scale

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3185,6 +3185,7 @@ def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
 
 
 EMBEDDING_VECTOR_DECIMALS = int(os.environ.get("MATRIXARK_EMBEDDING_VECTOR_DECIMALS", "6"))
+EMBEDDING_VECTOR_SCALE = int(os.environ.get("MATRIXARK_EMBEDDING_VECTOR_SCALE", "0"))
 
 
 def compact_embedding_vector(vector: list[float]) -> list[float]:
@@ -3193,12 +3194,21 @@ def compact_embedding_vector(vector: list[float]) -> list[float]:
     Embedding records are the bulk of what an ingest writes - 85% of the bytes for a
     markdown skill - and a 384-value vector serializes to about 8.2 KB because each
     value is written at full float repr. The models emit f32, which carries roughly
-    seven decimal digits, so the rest is noise being paid for. Rounding to six
-    decimals halves the record and leaves cosine similarity against the f32 value the
-    model produced at 1.000000000.
+    seven decimal digits, so the rest is noise being paid for.
 
-    Set MATRIXARK_EMBEDDING_VECTOR_DECIMALS=0 to store full precision.
+    MATRIXARK_EMBEDDING_VECTOR_DECIMALS (default 6) rounds; that halves the record and
+    leaves cosine against the f32 the model produced at 1.000000000.
+
+    MATRIXARK_EMBEDDING_VECTOR_SCALE (default 0, off) instead stores each value as an
+    integer scaled by that factor, which is a third smaller again because an integer
+    has no "0." and no trailing digits. This is safe because every consumer of a stored
+    vector scores it with cosine, and cosine ignores a uniform scale:
+    cos(a, k*b) == cos(a, b) for k > 0. At 1e5, worst cosine against the original is
+    0.999999999835 and nearest-neighbour ranking is unchanged. It is off by default
+    because it changes the stored values from floats to integers.
     """
+    if EMBEDDING_VECTOR_SCALE > 0:
+        return [int(round(value * EMBEDDING_VECTOR_SCALE)) for value in vector]
     if EMBEDDING_VECTOR_DECIMALS <= 0:
         return vector
     return [round(value, EMBEDDING_VECTOR_DECIMALS) for value in vector]


### PR DESCRIPTION
A stored embedding is only ever scored with cosine, and cosine ignores a uniform
scale — `cos(a, k*b) == cos(a, b)` for `k > 0`. So the values can be stored as
scaled integers, which are a third smaller than the rounded floats because an
integer carries no `0.` and no trailing digits.

`MATRIXARK_EMBEDDING_VECTOR_SCALE` (default `0`, off) stores each value as
`int(round(value * scale))`. Against vectors from the real multilingual MiniLM
encoder:

| encoding | bytes | vs current | worst cosine vs the original | ranking |
|---|---:|---:|---:|---|
| current, `round(6)` | 4,001 | 100% | — | — |
| **`scale=100000`** | **2,716** | **67.9%** | **0.999999999835** | unchanged |
| `scale=10000` | 2,332 | 58.3% | 0.999999984899 | unchanged |

End to end on 3 documents, everything else held equal:

| | default (6 dp) | `scale=100000` |
|---|---:|---:|
| record bytes | 17.3 MB | **14.9 MB** |
| disk | 27.4 MB | **24.7 MB** |
| resident | 32.0 MB | **28.7 MB** |
| ingest time | 4.8 s | **4.3 s** |

Off by default because it changes the stored values from floats to integers.

## Why this is safe — the audit

Every non-test site that touches a record `vector` was enumerated and classified.
38 sites:

| what the site does | count |
|---|---:|
| `cosine(...)` | 3 |
| presence / `isinstance` check | 6 |
| truthiness (`and record.get("vector"):`) | 12 |
| `len()` / dim | 1 |
| pass-through into an embedding map | 17 |

**Nothing performs arithmetic on a stored vector except cosine.** Every
pass-through map was then followed to its consumers:

    resource_embedding_vectors      4 consumers, 4 via cosine
    entity_embedding_vectors        5 consumers, 5 via cosine
    segment_embedding_vectors       2 consumers, 2 via cosine
    compression_embedding_vectors   2 consumers, 2 via cosine
    event_embedding_vectors         2 consumers, 2 via cosine

15 of 15, all cosine. Integers satisfy the type, truthiness and length checks
unchanged. No Rust source reads the `vector` field of these records.

This also rules the alternative out: **base64 would not be safe.** It fails
`isinstance(record.get("vector"), list)` at six sites and changes `len()`
semantics at another, and `cosine()` returns `0.0` on a length mismatch with no
warning — so a missed site degrades retrieval silently rather than erroring.

Mixed stores are fine: cosine is normalized, so a float vector and an integer
vector in the same store both score correctly and comparably against a query.

## Noted while auditing

`skill_embedding_vectors` is populated at two sites and passed through
`matrixark_mcp_retrieve_scan_state.py:150`, but nothing ever reads it back — it is
write-only state. Left alone here; flagging it rather than changing it.

## Tests

`test_inline_embedding_vectors` and `test_inline_vector_dual_read` pass, plus the
resource/skill/placement/ingest set. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree — `jsonschema` 3.2.0 predates
`Draft202012Validator`.
