### PR TITLE
Make the durability barrier counters readable from outside the process

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3239,6 +3239,21 @@ fn execute_record_log_request(
             empty_output(root)
         }
         "hgetall" | "scan_hash" => hash_entries_output(&engine, request.key, root)?,
+        // Read the durability barrier counters. They are collected by every site that takes a
+        // barrier and were, until now, unreachable from outside the process -- so the one number
+        // that says how much of a write is barrier-bound could not be measured, only argued.
+        // `field == "reset"` clears them first, so a harness can bracket a span.
+        "durability_barriers" => {
+            if request.field == "reset" {
+                temporalstore_rust::durability_metrics::reset();
+            }
+            let counts = temporalstore_rust::durability_metrics::snapshot();
+            let mut map = serde_json::Map::new();
+            for (site, count) in counts {
+                map.insert(site.to_string(), serde_json::json!(count));
+            }
+            json_output(serde_json::Value::Object(map), root)?
+        }
         "matrixark_scan_candidates" => {
             json_output(scan_matrixark_candidates(&engine, &request)?, root)?
         }
@@ -3380,6 +3395,8 @@ fn validate_request(request: &RecordLogRequest) -> Result<(), String> {
                 Err("forget requires a scope object".to_string())
             }
         }
+        // Read-only counter dump: no key, no field, nothing to validate.
+        "durability_barriers" => Ok(()),
         "hset" | "hget" | "hdel" => {
             require_non_empty("key", &request.key)?;
             require_non_empty("field", &request.field)
@@ -4857,6 +4874,66 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// The barrier counters are only useful if something outside the process can read them.
+    ///
+    /// They are recorded at every barrier site and were exposed nowhere, so the one number that
+    /// says how much of a write is barrier-bound could not be measured, only argued. This asserts
+    /// both halves a harness needs: a durable write moves the counters, and `reset` clears them
+    /// so a span can be bracketed instead of diffing lifetime totals by hand.
+    #[test]
+    fn durability_barriers_op_reports_and_resets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let engine = TemporalEngine::with_local_dirs(
+            1 << 20,
+            root.join("bar-cache"),
+            root.join("bar-pages"),
+            root.join("bar-index"),
+        );
+        engine.load_shard(DEFAULT_SHARD_ID);
+
+        let mut clear = request("durability_barriers");
+        clear.field = "reset".to_string();
+        execute_record_log_request(&engine, clear, root.clone()).expect("reset");
+
+        let prefix = "matrixark:barriertest";
+        let mut append = request("matrixark_batch_append_records");
+        append.key = format!("{prefix}:record_count");
+        append.value = "1".to_string();
+        append.entries_compact = vec![CompactHashEntry(
+            format!("{prefix}:records:000000"),
+            format!("{:020}", 0),
+            "{\"record_type\":\"context_event\"}".to_string(),
+        )];
+        execute_record_log_request(&engine, append, root.clone()).expect("append");
+
+        let output = execute_record_log_request(
+            &engine,
+            request("durability_barriers"),
+            root.clone(),
+        )
+        .expect("read");
+        let after_write: u64 = output.extra.values().filter_map(Value::as_u64).sum();
+        assert!(
+            after_write > 0,
+            "a durable write recorded no barriers: {:?}",
+            output.extra
+        );
+
+        let mut clear = request("durability_barriers");
+        clear.field = "reset".to_string();
+        execute_record_log_request(&engine, clear, root.clone()).expect("reset again");
+
+        let output =
+            execute_record_log_request(&engine, request("durability_barriers"), root)
+                .expect("read back");
+        let after_reset: u64 = output.extra.values().filter_map(Value::as_u64).sum();
+        assert!(
+            after_reset < after_write,
+            "reset did not clear the counters: {after_write} then {after_reset}"
+        );
     }
 
     fn request(op: &str) -> RecordLogRequest {


### PR DESCRIPTION
`durability_metrics` counts every durability barrier by the site that takes it, and its own doc comment explains why: *"A write's latency is roughly `barriers x fsync` ... Attributing them by reasoning about the code has produced confident wrong answers here more than once."* It ends by saying the split exists "so a harness reads one place."

There is no such place. The counters are recorded at 14 sites and exposed nowhere — no op, and `snapshot()` has no caller outside the module. The one number that says how much of a write is barrier-bound was collected and then unreachable.

This adds a read-only op that returns the snapshot, plus `field: "reset"` so a harness can bracket a measured span instead of diffing lifetime totals by hand.

## What it immediately showed

Barriers per `add` on the real gateway path, 40 adds on a warmed 200-memory store:

| counter | per add |
|---|---:|
| `engine_wal_group_commit` | 10.00 |
| `engine_index_log_append` | 6.08 |
| `engine_wal_dir` | 0.15 |
| others | 0.22 |
| **total** | **16.45** |

**16.45 barriers per add — about 18 ms of a 119 ms add, or 15%.** The batch append takes exactly one barrier per call, as its comment claims; the rest is the index log and four single-op writes.

That number is the point of the change. Before it, the honest answer to "how much of a write is fsync?" was a guess, and my own guess was wrong by 4x: measuring through a different adapter showed one barrier *per record* and implied appends were ~60% fsync. A backtrace showed those barriers came from the single-command op path, not the batch — an artifact of the benchmark, not the system. With the op, that took one measurement to settle instead of an afternoon of inference.

## Shape

Read-only and side-effect free apart from the explicit reset. The counter map is already maintained unconditionally — the module keeps it on rather than behind a build flag, on the grounds that a flag would be off exactly when someone needs the numbers — so this adds no write-path cost, only a way to read what is already there.

## Tests

One test asserting both halves a harness depends on: a durable write moves the counters, and `reset` clears them. Checked against a deliberately broken build — disabling the reset branch fails it.

`cargo check --all-targets` clean.
