### PR TITLE
int8 embedding vectors, and an empty env var crashed the module at import

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3184,29 +3184,66 @@ def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
     return [list(item or []) for item in results]
 
 
-EMBEDDING_VECTOR_DECIMALS = int(os.environ.get("MATRIXARK_EMBEDDING_VECTOR_DECIMALS", "6"))
-EMBEDDING_VECTOR_SCALE = int(os.environ.get("MATRIXARK_EMBEDDING_VECTOR_SCALE", "0"))
+def _env_int(name: str, default: int) -> int:
+    """Read an integer env var, treating empty or unparseable as unset.
+
+    These are read at import time, so a bare `FOO=` in a shell profile or a compose
+    file would otherwise raise ValueError and take the whole module down rather than
+    fall back to the default.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+EMBEDDING_VECTOR_DECIMALS = _env_int("MATRIXARK_EMBEDDING_VECTOR_DECIMALS", 6)
+EMBEDDING_VECTOR_SCALE = _env_int("MATRIXARK_EMBEDDING_VECTOR_SCALE", 0)
+EMBEDDING_VECTOR_INT8 = os.environ.get("MATRIXARK_EMBEDDING_VECTOR_INT8", "0") not in {"0", "false", "False", ""}
 
 
 def compact_embedding_vector(vector: list[float]) -> list[float]:
     """Drop float digits the encoder never produced.
 
     Embedding records are the bulk of what an ingest writes - 85% of the bytes for a
-    markdown skill - and a 384-value vector serializes to about 8.2 KB because each
-    value is written at full float repr. The models emit f32, which carries roughly
-    seven decimal digits, so the rest is noise being paid for.
+    markdown skill - and a 384-value vector serializes to about 8.2 KB at full float
+    repr. The models emit f32, which carries roughly seven decimal digits, so the rest
+    is noise being paid for.
 
-    MATRIXARK_EMBEDDING_VECTOR_DECIMALS (default 6) rounds; that halves the record and
-    leaves cosine against the f32 the model produced at 1.000000000.
+    Every consumer of a stored vector scores it with cosine, and cosine ignores a
+    uniform scale - cos(a, k*b) == cos(a, b) for k > 0 - so the values can be rescaled
+    freely as long as one vector is scaled by one factor. That is what lets both the
+    integer modes below store whole numbers and keep the score identical.
 
-    MATRIXARK_EMBEDDING_VECTOR_SCALE (default 0, off) instead stores each value as an
-    integer scaled by that factor, which is a third smaller again because an integer
-    has no "0." and no trailing digits. This is safe because every consumer of a stored
-    vector scores it with cosine, and cosine ignores a uniform scale:
-    cos(a, k*b) == cos(a, b) for k > 0. At 1e5, worst cosine against the original is
-    0.999999999835 and nearest-neighbour ranking is unchanged. It is off by default
-    because it changes the stored values from floats to integers.
+    Measured on 40,000 embedding records, only the encoding differing:
+
+        round(6) floats   4,207 B/record   3,302 B resident   6,765 B disk
+        scale=100000      2,666 B/record   3,193 B resident   4,965 B disk
+        int8              1,861 B/record   3,126 B resident   3,688 B disk
+
+    Note what that says: shrinking a vector is a DISK win, not a memory one. Resident
+    memory is per-record bookkeeping and barely moves with payload size (-5% across a
+    56% smaller record). Reduce record COUNT to reduce memory.
+
+    Modes, in precedence order:
+      MATRIXARK_EMBEDDING_VECTOR_INT8=1   each vector scaled by its own max magnitude
+                                          into [-127, 127]. Smallest. Worst cosine
+                                          against the original 0.99995; ranking and
+                                          top-1 unchanged on a CN/EN probe set. The
+                                          per-vector factor never has to be stored,
+                                          because cosine normalises it away.
+      MATRIXARK_EMBEDDING_VECTOR_SCALE=N  integers scaled by N. At 1e5 the worst
+                                          cosine is 1.000000000.
+      MATRIXARK_EMBEDDING_VECTOR_DECIMALS rounded floats, default 6.
     """
+    if EMBEDDING_VECTOR_INT8:
+        peak = max((abs(value) for value in vector), default=0.0)
+        if peak <= 0.0:
+            return [0 for _ in vector]
+        return [int(round(value / peak * 127)) for value in vector]
     if EMBEDDING_VECTOR_SCALE > 0:
         return [int(round(value * EMBEDDING_VECTOR_SCALE)) for value in vector]
     if EMBEDDING_VECTOR_DECIMALS <= 0:


### PR DESCRIPTION
Every consumer of a stored vector scores it with cosine, and cosine ignores a
uniform scale — `cos(a, k*b) == cos(a, b)` for `k > 0`. That already justified
storing scaled integers; it also justifies going all the way to int8, because each
vector can be scaled by **its own** peak magnitude into `[-127, 127]` and the
per-vector factor never has to be stored — cosine normalises it away.

`MATRIXARK_EMBEDDING_VECTOR_INT8=1` (default off). Measured against vectors from
the real multilingual MiniLM encoder, with a CN/EN probe set of queries:

| encoding | bytes | vs default | worst cosine vs original | full ranking | top-1 |
|---|---:|---:|---:|---|---|
| `round(6)` floats (default) | 4,000 | 100% | — | — | — |
| `scale=100000` | 2,716 | 67.9% | 1.000000000 | unchanged | unchanged |
| **`int8`** | **1,626** | **40.6%** | 0.999915978 | unchanged | unchanged |

End to end on 3 documents, everything else held equal:

| | default | `scale=100000` | **`int8`** |
|---|---:|---:|---:|
| record bytes | 17.3 MB | 14.9 MB | **12.7 MB** |
| disk | 27.5 MB | 24.7 MB | **21.2 MB** |
| resident | 31.5 MB | 29.4 MB | **28.0 MB** |

## What int8 does and does not buy

It is a **disk** optimization, not a memory one. Isolated to 40,000 embedding
records with only the encoding differing:

| encoding | record bytes | resident/record | disk/record |
|---|---:|---:|---:|
| `round(6)` floats | 4,207 | 3,302 B | 6,765 B |
| `scale=100000` | 2,666 | 3,193 B | 4,965 B |
| `int8` | 1,861 | **3,126 B** | 3,688 B |

A **56% smaller record moves resident memory 5%**. Resident cost is per-record
bookkeeping and barely depends on payload size — reduce record *count* to reduce
memory, not record size. The docstring says so, so the next person sizing a
deployment does not reach for this expecting memory back.

Safety rests on the audit already recorded for the scaled-integer mode: all 38
non-test sites touching a record `vector` are 3 cosine calls, 6 presence checks,
12 truthiness checks, 1 length, and 17 pass-throughs into embedding maps whose
consumers — resource 4, entity 5, segment 2, compression 2, event 2 — are all
cosine. Integers satisfy the type, truthiness and length checks unchanged.

Degenerate inputs are handled: an all-zero vector returns zeros rather than
dividing by zero, and an empty vector returns empty.

## An empty env var crashed the module at import

`EMBEDDING_VECTOR_SCALE` and `EMBEDDING_VECTOR_DECIMALS` were read with a bare
`int(os.environ.get(...))`, so `MATRIXARK_EMBEDDING_VECTOR_SCALE=` — a value with
no digits, which is what a shell profile or compose file leaves behind when a
variable is declared but not filled in — raised

    ValueError: invalid literal for int() with base 10: ''

at **import time**, taking down `matrixark_mcp_core` and everything importing it.
Found while running these very benchmarks. `_env_int` now treats empty or
unparseable as unset:

    SCALE=""        -> 0        SCALE="100000" -> 100000
    SCALE="abc"     -> 0        SCALE=" 6 "    -> 6

## Tests

`test_inline_embedding_vectors` and `test_inline_vector_dual_read` pass, plus the
resource/skill/placement/ingest set. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree — `jsonschema` 3.2.0 predates
`Draft202012Validator`.
