### PR TITLE
int8 vectors lose half the top-10, and the docstring said otherwise

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3228,13 +3228,24 @@ def compact_embedding_vector(vector: list[float]) -> list[float]:
     memory is per-record bookkeeping and barely moves with payload size (-5% across a
     56% smaller record). Reduce record COUNT to reduce memory.
 
+    A cosine number close to 1 is NOT sufficient evidence here. int8 scores 0.99992
+    against the original vector, which looks harmless, but the margins between competing
+    near-neighbours in a real corpus are smaller than that error. Measured over 500
+    candidate chunks from one document with six CN/EN queries, against the float
+    ranking:
+
+        scale=100000   top-1 correct 6/6   exact top-10 order 6/6   overlap 10.0/10
+        int8           top-1 correct 1/6   exact top-10 order 0/6   overlap  4.8/10
+
+    int8 loses half the top-10. An earlier six-vector probe showed ranking preserved
+    and was simply too small to reorder anything. Prefer scale=100000, which is
+    exact on this test and still 67.9% of the float size.
+
     Modes, in precedence order:
       MATRIXARK_EMBEDDING_VECTOR_INT8=1   each vector scaled by its own max magnitude
-                                          into [-127, 127]. Smallest. Worst cosine
-                                          against the original 0.99995; ranking and
-                                          top-1 unchanged on a CN/EN probe set. The
-                                          per-vector factor never has to be stored,
-                                          because cosine normalises it away.
+                                          into [-127, 127]. Smallest, but it CHANGES
+                                          RANKING on a realistic candidate set and is
+                                          not recommended for retrieval - see below.
       MATRIXARK_EMBEDDING_VECTOR_SCALE=N  integers scaled by N. At 1e5 the worst
                                           cosine is 1.000000000.
       MATRIXARK_EMBEDDING_VECTOR_DECIMALS rounded floats, default 6.


### PR DESCRIPTION
The int8 mode merged in #233 documents "ranking and top-1 unchanged". That claim
came from a six-vector probe, and it does not survive a realistic candidate set.

Measured over **500 candidate chunks** from one document, with six CN/EN queries,
scoring through the same `cosine` retrieval uses and comparing against the float
ranking:

| encoding | top-1 correct | exact top-10 order | mean top-10 overlap |
|---|---:|---:|---:|
| `scale=100000` | **6/6** | **6/6** | **10.0/10** |
| `int8` | **1/6** | **0/6** | **4.8/10** |

**int8 loses half the top-10.** The cosine number was the misleading part: 0.99992
against the original vector looks harmless, but the margins between competing
near-neighbours in a real corpus are smaller than that error — which is exactly
the regime retrieval operates in. Six vectors were too far apart to reorder;
500 similar chunks are not.

Nothing about the default changes — int8 was already off. What changes is that
the docstring no longer invites someone to turn it on for retrieval, and it now
carries the measurement that shows why not:

    scale=100000   top-1 correct 6/6   exact top-10 order 6/6   overlap 10.0/10
    int8           top-1 correct 1/6   exact top-10 order 0/6   overlap  4.8/10

`scale=100000` remains the recommendation: exact on this test and still 67.9% of
the float size.

int8 is left in place rather than removed — it is legitimate where ranking does
not matter (bulk archival, a coarse prefilter re-scored at full precision), and
it is 40.6% of float size. It just must not be the retrieval path.

## Why this was caught

The ingestion benchmarks only measured bytes, memory and time. A vector encoding
can win all three and still be wrong, and nothing in the ingest path would say so.
The check that found it scores real model embeddings of real parsed chunks through
the retrieval `cosine` and compares the resulting order — the thing a user
actually experiences.
