### PR TITLE
The append handler decoded every record twice, once per side index

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1565,9 +1565,14 @@ fn record_shard_key_parts(key: &str) -> Option<(&str, &str)> {
 }
 
 /// The record types stored in one shard-field payload, bundle-expanded.
-fn payload_record_types(value: &str) -> Vec<String> {
+/// Distinct `record_type`s across already-decoded records.
+///
+/// Split out of `payload_record_types` so a caller that has already decoded the payload -- the
+/// batch-append handler, which also needs the records for the scope index -- does not decode it
+/// a second time just to read one field.
+fn records_record_types(records: &[Value]) -> Vec<String> {
     let mut types: Vec<String> = Vec::new();
-    for record in decode_matrixark_payload(value) {
+    for record in records {
         if let Some(record_type) = record.get("record_type").and_then(Value::as_str) {
             if !record_type.is_empty() && !types.iter().any(|t| t == record_type) {
                 types.push(record_type.to_string());
@@ -1575,6 +1580,10 @@ fn payload_record_types(value: &str) -> Vec<String> {
         }
     }
     types
+}
+
+fn payload_record_types(value: &str) -> Vec<String> {
+    records_record_types(&decode_matrixark_payload(value))
 }
 
 /// Payload values for the requested types via the type index, in append order.
@@ -2974,14 +2983,19 @@ fn execute_record_log_request(
                         let Ok(value_text) = std::str::from_utf8(value) else {
                             continue;
                         };
-                        for record_type in payload_record_types(value_text) {
+                        // Both side indexes come from the same records, so decode once. This
+                        // used to call `payload_record_types` (itself a wrapper over
+                        // `decode_matrixark_payload`) and then decode the same string again,
+                        // deserializing every appended record into a Value tree twice.
+                        let decoded = decode_matrixark_payload(value_text);
+                        for record_type in records_record_types(&decoded) {
                             index_entries
                                 .entry(type_index_key(base, &record_type))
                                 .or_default()
                                 .push((format!("{shard6}:{field}"), b"1".to_vec()));
                         }
-                        for record in decode_matrixark_payload(value_text) {
-                            for bucket in record_scope_buckets(&record) {
+                        for record in &decoded {
+                            for bucket in record_scope_buckets(record) {
                                 index_entries
                                     .entry(scope_index_key(base, &bucket))
                                     .or_default()


### PR DESCRIPTION
The batch-append handler derives two side indexes from every entry it writes: the type index needs each record's `record_type`, and the scope index needs its scope buckets. It got them like this:

```rust
for record_type in payload_record_types(value_text) { ... }   // parses value_text
for record in decode_matrixark_payload(value_text) { ... }    // parses it AGAIN
```

`payload_record_types` is a thin wrapper over `decode_matrixark_payload`, so **every record on the append path was deserialized into a `serde_json::Value` tree twice** — once per index, from the same string, producing the same records.

This decodes once and derives both indexes from the result. The two loops read disjoint fields of the same records in the same order, so the entries produced are unchanged.

## Measured

Parses per `add`, counted in the proxy rather than timed:

| | `decode_matrixark_payload` calls / add |
|---|---:|
| before | 386.00 |
| after | **318.75** |

**−67 parses per add, −17%.**

**On the latency effect, and a correction.** An earlier revision of this description claimed the append's engine time fell 95.28/98.30 → 86.34 ms/add. That was measured while this machine sat at load 22–30 with another build running, and it does not survive scrutiny: timing the handler's phases directly shows the whole side-index phase — everything this change touches — costs **1.21 ms/add**, so halving its parses is worth a fraction of a millisecond, not ~10 ms. The 86.34 arm was noise. I have left the claim out rather than restate it more carefully, because the honest number is "too small to measure end to end on this machine".

What the phase timing does establish is where the append's cost actually sits:

| phase | ms/add | share |
|---|---:|---:|
| group entries | 0.02 | 0.0% |
| build side indexes | 1.21 | 0.9% |
| engine batch | 133.12 | **99.1%** |

So this change is worth taking on its own terms — strictly less work, no behaviour change — and not as a latency fix. The latency is in `batch_execute`.

## Tests

36/36 proxy tests pass, including the three covering exactly what this touches — `type_index_sees_records_appended_after_the_backfill`, `type_index_serves_the_second_scan_with_the_walks_answer`, and `scope_index_skips_scopeless_records_of_other_types`.

22/22 strict mem0 conformance against a live gateway, 0 failures.

`payload_record_types` keeps its signature for its other callers; the parse is simply split out so a caller holding decoded records can skip it.
