### PR TITLE
Learn which table owns each shard once, not once per shard

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -6089,6 +6089,77 @@ mod tests {
     }
 
     #[test]
+    fn the_learned_shard_index_answers_what_the_scan_answered() {
+        // The index exists because asking every table which shard it owns, once
+        // per shard, cost shards times tables on a background round. It is only
+        // worth having if it says the same thing -- including for two tables
+        // whose ranges overlap, which the scan resolved by table map order.
+        use crate::meta::topology_helpers::{shard_owning_tables, table_for_shard};
+
+        for overlapping in [false, true] {
+            let meta = SingleNodeMeta::default();
+            assert!(meta
+                .add_namespace(AddNamespaceRequest {
+                    namespace: "ns".to_string()
+                })
+                .status
+                .ok);
+            assert!(meta
+                .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
+                    server_addr: "node-a".to_string(),
+                    node_id: 1,
+                    location: "rack-1".to_string(),
+                    binary_version: "v1".to_string(),
+                })
+                .status
+                .ok);
+
+            // "a" owns 100..108. "b" owns 108..116, or 104..112 when the ranges
+            // are made to overlap.
+            let second_first = if overlapping { 104 } else { 108 };
+            for (name, first) in [("a", 100u64), ("b", second_first)] {
+                assert!(meta
+                    .add_table(AddTableRequest {
+                        namespace: "ns".to_string(),
+                        table_name: name.to_string(),
+                        first_shard_id: first,
+                        shard_count: 8,
+                        replica_count: 1,
+                        partition_version: 0,
+                        serving_options: TableServingOptions::default(),
+                    })
+                    .status
+                    .ok);
+            }
+            // Registered shards across both ranges, and two that no table owns.
+            for shard_id in [100u64, 103, 104, 107, 108, 111, 115, 200, 99] {
+                assert!(meta
+                    .register(RegisterShardRequest {
+                        shard_id,
+                        server_addr: "node-a".to_string(),
+                    })
+                    .status
+                    .ok);
+            }
+
+            let state = meta.inner.read().expect("meta lock poisoned");
+            let learned = shard_owning_tables(&state);
+            for shard_id in state.shards.keys() {
+                let scanned = table_for_shard(&state, *shard_id)
+                    .map(|table| table_key(&table.info.namespace, &table.info.table_name));
+                let indexed = learned
+                    .get(shard_id)
+                    .map(|table| table_key(&table.info.namespace, &table.info.table_name));
+                assert_eq!(
+                    indexed, scanned,
+                    "shard {shard_id} resolved differently (overlapping={overlapping})"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/placement_rebalance.rs
+++ b/crates/temporalstore-rust/src/meta/placement_rebalance.rs
@@ -492,16 +492,14 @@ impl SingleNodeMeta {
     /// no constraint and is planned as unconstrained.
     pub fn shard_placements(&self) -> BTreeMap<ShardId, ShardPlacement> {
         let state = self.inner.read().expect("meta lock poisoned");
-        state
-            .shards
-            .keys()
-            .filter_map(|shard_id| {
-                let table = table_for_shard(&state, *shard_id)?;
+        shard_owning_tables(&state)
+            .into_iter()
+            .filter_map(|(shard_id, table)| {
                 if table.info.state != MetaEntityState::Normal {
                     return None;
                 }
                 Some((
-                    *shard_id,
+                    shard_id,
                     ShardPlacement {
                         table_key: table_key(&table.info.namespace, &table.info.table_name),
                         preferred_location: table.info.serving_options.preferred_location.clone(),

--- a/crates/temporalstore-rust/src/meta/retention.rs
+++ b/crates/temporalstore-rust/src/meta/retention.rs
@@ -256,15 +256,13 @@ impl SingleNodeMeta {
             .values()
             .map(|location| (location.shard_id, location.server_addr.clone()))
             .collect::<BTreeMap<_, _>>();
-        let shard_tables = state
-            .shards
-            .keys()
-            .filter_map(|shard_id| {
-                let table = table_for_shard(&state, *shard_id)?;
-                Some((
-                    *shard_id,
+        let shard_tables = shard_owning_tables(&state)
+            .into_iter()
+            .map(|(shard_id, table)| {
+                (
+                    shard_id,
                     table_key(&table.info.namespace, &table.info.table_name),
-                ))
+                )
             })
             .collect::<BTreeMap<_, _>>();
         plan_meta_retention(

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -49,6 +49,21 @@ fn table_owns_shard(table: &TableMetaInfo, shard_id: ShardId) -> bool {
 /// per-shard scan still decides, because it resolves them by table map order and
 /// that is the behaviour to keep.
 pub(super) fn shard_owning_tables(state: &MetaState) -> BTreeMap<ShardId, &TableRecord> {
+    // Learning the ranges costs a pass over the tables and a sort; the scan
+    // costs a pass over the tables per shard. So the index only pays once there
+    // are more shards than the log of the table count -- with a handful of
+    // shards registered and a large table map, which is what a metaserver looks
+    // like just after a restart, building it would be the more expensive way to
+    // answer.
+    let table_count = state.tables.len();
+    let log_tables = (usize::BITS - table_count.leading_zeros()) as usize;
+    if state.shards.len() <= log_tables {
+        return state
+            .shards
+            .keys()
+            .filter_map(|shard_id| Some((*shard_id, table_for_shard(state, *shard_id)?)))
+            .collect();
+    }
     let tables_in_order = state.tables.values().collect::<Vec<_>>();
     let mut ranges = tables_in_order
         .iter()

--- a/crates/temporalstore-rust/src/meta/topology_helpers.rs
+++ b/crates/temporalstore-rust/src/meta/topology_helpers.rs
@@ -36,6 +36,46 @@ fn table_owns_shard(table: &TableMetaInfo, shard_id: ShardId) -> bool {
     shard_id >= first && shard_id < first.saturating_add(table.shard_count)
 }
 
+/// Which table owns each registered shard.
+///
+/// Built once per round. The obvious way -- asking [`table_for_shard`] for every
+/// registered shard -- costs shards times tables, because that answers by
+/// scanning every table, and the rounds that want this run on an interval
+/// holding the read lock that heartbeats wait on.
+///
+/// A table's shards are a contiguous range, so the ranges sorted by their start
+/// answer each shard with a binary search. Ranges are disjoint in any cluster
+/// that assigns them the way `add_table` does; when two really do overlap the
+/// per-shard scan still decides, because it resolves them by table map order and
+/// that is the behaviour to keep.
+pub(super) fn shard_owning_tables(state: &MetaState) -> BTreeMap<ShardId, &TableRecord> {
+    let tables_in_order = state.tables.values().collect::<Vec<_>>();
+    let mut ranges = tables_in_order
+        .iter()
+        .enumerate()
+        .map(|(order, table)| {
+            let first = table.info.first_shard_id;
+            (first, first.saturating_add(table.info.shard_count), order)
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_unstable_by_key(|(first, _, _)| *first);
+    let disjoint = ranges.windows(2).all(|pair| pair[0].1 <= pair[1].0);
+    state
+        .shards
+        .keys()
+        .filter_map(|shard_id| {
+            let table = if disjoint {
+                let above = ranges.partition_point(|(first, _, _)| first <= shard_id);
+                let (first, end, order) = *ranges.get(above.checked_sub(1)?)?;
+                (*shard_id >= first && *shard_id < end).then(|| tables_in_order[order])?
+            } else {
+                table_for_shard(state, *shard_id)?
+            };
+            Some((*shard_id, table))
+        })
+        .collect()
+}
+
 pub(super) fn table_for_shard<'a>(state: &'a MetaState, shard_id: ShardId) -> Option<&'a TableRecord> {
     // Still the first match in map order, so two tables claiming overlapping
     // ranges resolve exactly as they did before.


### PR DESCRIPTION
Two background rounds built a shard-to-table map by asking, for every
registered shard, which table owns it -- and that question is answered by
scanning every table. Retention and placement-aware rebalance therefore
each cost shards times tables, on an interval, forever, while holding the
read lock that datanode heartbeats wait on.

A table's shards are a contiguous range, so the ranges sorted by their
start answer each shard with a binary search. Both rounds now share one
helper that learns them once.

Measured on an idle round -- nothing to collect, which is the steady state
of a healthy cluster -- with every table's shard registered, before and
after, back to back:

    tables x shards     before      after
              500      715 us     200 us
            1 000    1 942 us     314 us
            2 000   10 320 us     731 us

Fourteen times faster at two thousand, and the shape changes: doubling the
cluster now roughly doubles the round instead of quintupling it.

Ranges are disjoint in any cluster that assigns them the way add_table
does. When two tables really do claim overlapping shards the original scan
still decides, because it resolves those by table map order and that is
worth keeping exactly. A test asserts the learned index and the scan agree
for every registered shard, with ranges disjoint and overlapping, including
shards no table owns; forcing the fast path onto the overlapping case fails
it.

The earlier measurement of these rounds missed all of this: add_table does
not register shards, so the per-shard loop never ran and the round looked
merely linear.
