### PR TITLE
the ingest discarded 98.7%% of its index and reported dropping nothing

### DIFF
--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -18,6 +18,7 @@ try:
         metadata_index_terms,
         ordered_unique,
         serving_resource_metadata,
+        secondary_index_budget_summary,
         source_locator_from_ref,
         take_secondary_index_terms,
     )
@@ -31,6 +32,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
         metadata_index_terms,
         ordered_unique,
         serving_resource_metadata,
+        secondary_index_budget_summary,
         source_locator_from_ref,
         take_secondary_index_terms,
     )
@@ -221,9 +223,16 @@ def append_resource_chunk_records(
         if len(pending_records) >= RESOURCE_APPEND_BATCH_RECORDS:
             pending_records = _flush_pending_records(adapter, pending_records)
     pending_records = _flush_pending_records(adapter, pending_records)
+    # index_dropped_by_cap_count only counts terms lost to the PER-CHUNK term cap, which is
+    # applied before the per-operation budget. The budget is what actually truncates a large
+    # document: at its default of 128 records per ingest call, a 2,011-chunk document offers
+    # 10,055 candidate terms and writes 128, and every count above reported that as no drop.
+    # Report the budget alongside them so the truncation is visible to the caller.
+    budget_summary = secondary_index_budget_summary(secondary_index_budget)
     return {
         "resource_chunk_hashes": resource_chunk_hashes,
         "index_candidate_count": index_candidate_count,
         "index_write_count": index_write_count,
         "index_dropped_by_cap_count": index_dropped_by_cap_count,
+        "index_budget": budget_summary,
     }


### PR DESCRIPTION
A resource or skill ingest reported that it dropped nothing while discarding 98.7%
of the index it was asked to build.

`index_dropped_by_cap_count` counts only terms lost to the **per-chunk** term cap
(`MAX_INDEX_TERMS_PER_RESOURCE_CHUNK`), and it is computed *before*
`take_secondary_index_terms` applies the **per-operation** budget. The budget is
what actually truncates a large document, and its own drop count was never
returned. Measured on a 1.5 MB markdown skill at the default
`MAX_SECONDARY_INDEX_RECORDS_PER_OPERATION=128`:

    chunks                       2,011
    index candidates            10,055
    index records written          128
    index_dropped_by_cap_count       0   <-- what the caller saw

So 9,927 index terms were discarded and the result said none were. An operator
reading those numbers would conclude the index was complete.

The budget summary is now returned alongside them:

    "index_budget": {"index_total_cap": 128,
                     "index_emitted_count": 128,
                     "index_dropped_by_total_cap_count": 9927}

and with the cap raised, the same document reports `written 10,055,
index_dropped_by_total_cap_count 0`. The message/event ingest path already
surfaced this summary (`matrixark_local_adapter_ingest.py`); the resource/skill
path did not.

## Why this matters more than 0.2% of bytes suggests

The index looks negligible — 128 records, 0.04 MB, 0.2% of what the document
writes. It is not negligible to retrieval. On a needle test over a playbook with
eight unique findable facts, real MiniLM embeddings, scored through the retrieval
`cosine`:

| method | top-1 | top-5 |
|---|---:|---:|
| vector | 0-2/8 | 3/8 |
| lexical over the same chunk text | **8/8** | **8/8** |

Repetitive playbook filler dominates a chunk's vector, so a specific fact inside
it does not surface; lexical matching finds every one. At the default cap only
**6.4%** of that document's chunks can carry any index term at all.

Indexing the whole document costs `index_share` 0.2% -> 13.5%, document total
22.33 MB -> 25.76 MB. This change does not alter the default — it makes the
tradeoff visible so the cap can be chosen deliberately rather than discovered.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery`, `test_inline_embedding_vectors`,
`test_inline_vector_dual_read` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree — `jsonschema` 3.2.0 predates
`Draft202012Validator`.
