### PR TITLE
a skill chunk stored the same vector twice, and nothing could tell

### DIFF
--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -47,6 +47,10 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
 # 8504 of them, four per chunk. append() is defined as append_many([record]), so the
 # records can be gathered and handed over in batches without changing what is written
 # or the order it is written in.
+DEDUPE_SKILL_CHUNK_EMBEDDING = os.environ.get(
+    "MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING", "1"
+) not in {"0", "false", "False", ""}
+
 RESOURCE_APPEND_BATCH_RECORDS = int(
     os.environ.get("MATRIXARK_RESOURCE_APPEND_BATCH_RECORDS", "512")
 )
@@ -156,18 +160,24 @@ def append_resource_chunk_records(
                     updated_at_ms=envelope["ingestion_time_ms"],
                 )
             )
-        pending_records.append(
-            resource_record_builders.context_embedding_record(
-                embedding_type="resource_chunk",
-                ref_type="resource_chunk",
-                ref_hash=chunk.chunk_hash,
-                node_hash=node_hash,
-                node_path=node_path,
-                vector=vector,
-                scope=resource_record_scope,
-                updated_at_ms=envelope["ingestion_time_ms"],
+        # A skill chunk used to store the SAME vector twice, once as embedding_type
+        # resource_chunk and once as skill_section, with the same ref_hash. Retrieval keys
+        # its vector map on ref_hash ALONE and both land in it, so the second copy only ever
+        # overwrote the first with an identical value - about 37% of what a skill ingest
+        # writes, for nothing. Skills now store the skill_section copy only.
+        if skill_hash is None or not DEDUPE_SKILL_CHUNK_EMBEDDING:
+            pending_records.append(
+                resource_record_builders.context_embedding_record(
+                    embedding_type="resource_chunk",
+                    ref_type="resource_chunk",
+                    ref_hash=chunk.chunk_hash,
+                    node_hash=node_hash,
+                    node_path=node_path,
+                    vector=vector,
+                    scope=resource_record_scope,
+                    updated_at_ms=envelope["ingestion_time_ms"],
+                )
             )
-        )
         if skill_hash is not None:
             pending_records.append(
                 resource_record_builders.context_embedding_record(


### PR DESCRIPTION
A skill chunk stored the **same vector twice**. The ingest emitted
`context_embedding` once with `embedding_type: "resource_chunk"` and once with
`"skill_section"` — same `ref_hash`, same vector, same node, same scope.

Retrieval keys its vector map on `ref_hash` **alone**
(`matrixark_local_adapter_retrieve.py:1343-1346` and `:1499-1502`, where both
`embedding_type` branches write into `resource_embedding_vectors[ref_hash]`), so
the second record only ever overwrote the first with an identical value.

Measured on a 2,126-chunk markdown skill:

| | before | after |
|---|---:|---:|
| embedding records | 4,252 | **2,126** |
| records total | 8,632 | **6,506** |
| bytes written | 23.23 MB | **14.57 MB** |

**-37.3% of what a skill ingest writes**, for a record nothing could observe.

`MATRIXARK_DEDUPE_SKILL_CHUNK_EMBEDDING=0` restores the second copy.

## Why this is retrieval-neutral, checked three ways

I rejected this change earlier on the belief that the embedding refresher would
regenerate the dropped record. That was wrong, and the check is specific:
`_embedding_target_for_context_record` in
`matrixark_local_adapter_context_node.py` branches on `context_event`,
`context_segment`, `context_entity`, `context_node`, `context_summary` and
`context_compression_event`, and returns `None` for anything else — it never
covers `resource_chunk` or `skill_section`, so it cannot regenerate them.

Second, the Rust retrieval path does not read these vectors:
`retrieve_pack.rs` contains no mention of `context_embedding` and no vector
field read; `native_serving.rs:163` only names the type when classifying records.

Third, emitted records were compared directly, with and without the change, over
the same parsed chunks and the same vectors, rebuilding the map exactly as
retrieval does:

    map entries                       2126  ->  2126
    every chunk resolves a vector             true
    vector identical for every chunk          true
    non-embedding records identical           true

Same map, same vectors, half the embedding records.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery`, `test_inline_embedding_vectors`,
`test_inline_vector_dual_read` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree — `jsonschema` 3.2.0 predates
`Draft202012Validator`.
