### PR TITLE
the keyword index was empty on a Chinese corpus, twice over

### DIFF
--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -38,6 +38,11 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 try:
+    from tools.matrixark_resource_parser import keywords_for_text
+except ModuleNotFoundError:  # Direct script execution from tools/.
+    from matrixark_resource_parser import keywords_for_text
+
+try:
     from tools import matrixark_mcp_ingest_resource_records as resource_record_builders
 except ModuleNotFoundError:  # Direct script execution from tools/.
     import matrixark_mcp_ingest_resource_records as resource_record_builders
@@ -191,12 +196,19 @@ def append_resource_chunk_records(
                     updated_at_ms=envelope["ingestion_time_ms"],
                 )
             )
+        # metadata_index_terms reads keywords OUT OF the stored metadata, and slim chunk
+        # metadata drops that field - which silently removed the entire content keyword index,
+        # the only part of it with any selectivity. Derive them from the chunk text instead, so
+        # what gets indexed no longer depends on what happens to be stored.
+        index_metadata = chunk.metadata
+        if not index_metadata.get("keywords"):
+            index_metadata = {**index_metadata, "keywords": keywords_for_text(chunk.text)}
         raw_chunk_index_terms = (
             [
                 context_index_name("source_type", "skill" if skill_hash is not None else "resource"),
                 context_index_name("resource_type", chunk_metadata.get("resource_type") or resource_type),
             ]
-            + metadata_index_terms(chunk.metadata)
+            + metadata_index_terms(index_metadata)
             + (
                 [context_index_name("skill_name", skill_name)]
                 + [context_index_name("skill_trigger", trigger) for trigger in skill_metadata.get("triggers", [])]

--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -244,22 +244,53 @@ def resource_content_version(raw_uri: str, units: list[Json]) -> str:
     return digest.hexdigest()[:16]
 
 
+CJK_KEYWORD_BIGRAMS = os.environ.get("MATRIXARK_RESOURCE_CJK_KEYWORDS", "1") not in {"0", "false", "False", ""}
+_CJK_RUN_RE = re.compile("[" + _CJK_CLASS + "]{2,}")
+
+
 def keywords_for_text(text: str, limit: int = 12) -> list[str]:
+    """Keywords for the secondary index.
+
+    Latin runs alone leave Chinese text with NO keywords, so on a CJK corpus the keyword
+    index — the part of the secondary index carrying any selectivity — indexes nothing.
+    Chinese has no spaces to split on, so CJK runs contribute overlapping character
+    bigrams, which a lexical index can match without a segmenter.
+
+    The two are interleaved rather than concatenated. Taking Latin first and stopping at
+    the limit lets a few English words in a mixed passage exhaust the quota, leaving the
+    Chinese half of the same chunk unindexed — which is what happened before.
+    """
     stop = {
         "the", "and", "for", "that", "with", "from", "this", "will", "are", "was", "were", "has", "have",
         "should", "into", "when", "where", "what", "which", "your", "their", "about", "after", "before",
     }
+    latin: list[str] = []
     seen: set[str] = set()
-    out: list[str] = []
     for token in re.findall(r"[A-Za-z][A-Za-z0-9_]{2,}", text.lower()):
         if token in stop or token in seen:
             continue
         seen.add(token)
-        out.append(token)
-        if len(out) >= limit:
-            break
+        latin.append(token)
+    cjk: list[str] = []
+    if CJK_KEYWORD_BIGRAMS:
+        for run in _CJK_RUN_RE.findall(text):
+            for index in range(len(run) - 1):
+                bigram = run[index : index + 2]
+                if bigram in seen:
+                    continue
+                seen.add(bigram)
+                cjk.append(bigram)
+    out: list[str] = []
+    for index in range(max(len(latin), len(cjk))):
+        if index < len(latin):
+            out.append(latin[index])
+            if len(out) >= limit:
+                return out
+        if index < len(cjk):
+            out.append(cjk[index])
+            if len(out) >= limit:
+                return out
     return out
-
 
 def _truncate_to_tokens(text: str, max_tokens: int) -> str:
     """Trim text to roughly max_tokens estimated tokens, on a span boundary."""


### PR DESCRIPTION
Two defects that between them left the secondary index unable to find anything in
a Chinese document.

## 1. Slimming chunk metadata silently deleted the keyword index

`metadata_index_terms` reads keywords **out of the stored metadata**, and
`MATRIXARK_RESOURCE_SLIM_CHUNK_METADATA=1` drops that field. Turning slim on
therefore removed every content keyword posting — the only part of the secondary
index with any selectivity — while looking like a pure storage saving:

| | index records | keyword postings | postings for terms matching EVERY chunk |
|---|---:|---:|---:|
| slim off | 21,168 | 10,538 | 8,504 (40%) |
| slim on | 10,630 | **0** | 8,504 (**80%**) |

Keywords are now derived from the chunk text at index time, so what gets indexed
no longer depends on what happens to be stored. Slim and non-slim now emit
identical index terms.

## 2. Keyword extraction was blind to Chinese

`keywords_for_text` matched `[A-Za-z][A-Za-z0-9_]{2,}` only, so Chinese text
produced **no keywords at all**:

    keywords_for_text("蓝盾数码的返利费率是百分之七点三")  ->  []

CJK runs now contribute overlapping character bigrams, which is what a lexical
index can match without a segmenter. The two sources are **interleaved**, not
concatenated: taking Latin first and stopping at the limit let a few English words
in a mixed passage exhaust the quota and leave the Chinese half of the same chunk
unindexed, which is exactly what happened before.

    "Rebate posts 45 days after delivery. 蓝盾数码的返利费率是7.3%"
    -> ['rebate', '蓝盾', 'posts', '盾数', 'days', '数码', 'delivery', '码的', ...]

`MATRIXARK_RESOURCE_CJK_KEYWORDS=0` restores Latin-only extraction.

## Chunking is unchanged

Verified against `origin/main` across markdown parsed as both `skill` and `md`,
and JSON, each with slim metadata on and off — six configurations, all identical
in chunk count, `chunk_hash`, chunk text and metadata keys.

## What this does not fix, with numbers

Retrieval still misses these facts, and the reason is a limit rather than a bug.
A needle in a 215-token chunk sat at 97% of the way through it; the query matched
zero of the chunk's keywords at the current limit of 12, and all eight of them at
a limit of 200. Complete coverage needs ~76 postings per chunk.

In the current record format that is unaffordable. Measured over a 1.5 MB
document, 2,011 chunks, 152,108 postings, and only **160 distinct terms**:

| format | size | amplification vs source |
|---|---:|---:|
| one record per (term, chunk), 428 B each | 62.1 MB | **41.3x** |
| one record per term carrying its posting list | 3.05 MB | **2.03x** |

**20.3x.** An inverted layout is what makes complete lexical coverage affordable —
160 records instead of 152,108. That is a redesign of the record shape and its
read path, not a change to make here; this PR fixes the two defects that make the
existing index unusable on a CJK corpus, and leaves the sizing evidence for it.

## Tests

`test_resource_content`, `test_skill_content_cap`, `test_placement_chunks`,
`test_ingest_one_call_file_or_text`, `test_attachment_resource_policy`,
`test_matrixark_skill_discovery`, `test_inline_embedding_vectors`,
`test_inline_vector_dual_read` pass. `test_ingest_envelope_schema` fails
identically before and after on the pristine tree — `jsonschema` 3.2.0 predates
`Draft202012Validator`.
