### PR TITLE
a smaller record, a round that timed itself on a clock that could move, and three nodes to prove it

### DIFF
--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -212,6 +212,41 @@ pub(super) fn min_registered_sequence(
         .min()
 }
 
+/// How many registrations this shard is holding.
+///
+/// The registry resolves a synthetic address to the record carrying its bytes, and it is process
+/// static: one entry per distinct object, held until the shard unloads. A test needs to see the
+/// count to say anything about whether it grows with the log.
+pub(super) fn registration_count(
+    block_store: &crate::block_store::LocalBlockStore,
+    shard_id: ShardId,
+) -> usize {
+    let Ok(map) = registry().lock() else {
+        return 0;
+    };
+    let owner = block_store.store_id();
+    map.keys()
+        .filter(|(store_id, shard, _)| *store_id == owner && *shard == shard_id)
+        .count()
+}
+
+/// Retire one object's registration.
+///
+/// Called when its page stops being log-resident -- materialised into the block store, so the
+/// index now names a real slab. Keeping it would pin the WAL retention floor to a record nothing
+/// needs, which is not a leak of bytes but of RECLAIM: the floor is the lowest live registration,
+/// so one stale entry holds the whole log.
+pub(super) fn deregister(
+    block_store: &crate::block_store::LocalBlockStore,
+    shard_id: ShardId,
+    object_id: u64,
+) {
+    if let Ok(mut map) = registry().lock() {
+        map.remove(&(block_store.store_id(), shard_id, object_id));
+    }
+}
+
+
 /// Forget a shard's registrations. Called when the shard unloads; a reload replays the WAL and
 /// re-derives whatever it needs.
 pub(super) fn clear_shard(block_store: &crate::block_store::LocalBlockStore, shard_id: ShardId) {

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1181,22 +1181,35 @@ impl TemporalEngine {
             ) else {
                 continue;
             };
-            let mut shards = self.shards.write().expect("engine lock poisoned");
-            if let Some(shard) = shards.get_mut(&shard_id) {
-                shard.strings.insert(key.clone(), durable.clone());
-                super::upsert_bucket_index_page(
-                    shard,
-                    shard_id,
-                    "string",
-                    &key,
-                    None,
-                    durable,
-                    true,
-                );
+            {
+                let mut shards = self.shards.write().expect("engine lock poisoned");
+                if let Some(shard) = shards.get_mut(&shard_id) {
+                    shard.strings.insert(key.clone(), durable.clone());
+                    super::upsert_bucket_index_page(
+                        shard,
+                        shard_id,
+                        "string",
+                        &key,
+                        None,
+                        durable,
+                        true,
+                    );
+                    // The index no longer names a synthetic slab for this object, so nothing can
+                    // resolve through its record any more.
+                    shard.wal_resident_pages.remove(&object_id);
+                }
             }
+            // Retire the registration too. It is what pins the WAL retention floor, and a floor
+            // held by a page that is now in the block store stops reclaim for no reason.
+            super::block_in_wal::deregister(&self.page_store, shard_id, object_id);
             moved += 1;
         }
         moved
+    }
+
+    /// How many log-resident registrations this shard holds.
+    pub(crate) fn registration_count_for_test(&self, shard_id: ShardId) -> usize {
+        super::block_in_wal::registration_count(&self.page_store, shard_id)
     }
 
     /// How many addresses in the served index name a slab that is not a file.

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -157,12 +157,24 @@ pub(super) fn annotate_storage_manager_admin_stage_fields(
 #[derive(Debug, Clone)]
 pub(super) struct StorageManagerPhaseExecutor {
     round_started_unix_ms: u64,
+    /// Monotonic start, for the DURATION.
+    ///
+    /// The unix millisecond above says WHEN the round began and is comparable across processes.
+    /// It cannot say how LONG the round took: the clock behind it is adjustable, and an
+    /// adjustment mid-round is indistinguishable from work -- which showed up as a round whose
+    /// reported duration was shorter than the stages inside it.
+    ///
+    /// Passed in rather than captured here, because this executor is constructed at the END of a
+    /// cycle. Capturing it here measures the finish and reports a round of zero, which is how the
+    /// first version of this fix was caught.
+    round_started_at: std::time::Instant,
 }
 
 impl StorageManagerPhaseExecutor {
-    pub(super) fn new(round_started_unix_ms: u64) -> Self {
+    pub(super) fn new(round_started_unix_ms: u64, round_started_at: std::time::Instant) -> Self {
         Self {
             round_started_unix_ms,
+            round_started_at,
         }
     }
 
@@ -172,7 +184,7 @@ impl StorageManagerPhaseExecutor {
         errors: &[String],
         retention_blockers: usize,
     ) -> u64 {
-        let round_duration_ms = now_ms().saturating_sub(self.round_started_unix_ms);
+        let round_duration_ms = self.round_started_at.elapsed().as_millis() as u64;
         annotate_storage_manager_admin_stage_fields(
             stages,
             self.round_started_unix_ms,

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -28,6 +28,9 @@ impl TemporalEngine {
         request: StorageManagerCycleRequest,
     ) -> StorageManagerCycleReport {
         let cycle_started_unix_ms = now_ms();
+        // The same instant, on the clock that cannot be adjusted. The pair is deliberate: one
+        // says when, the other says how long.
+        let cycle_started_at = std::time::Instant::now();
         // Each stage is timed from the end of the previous one, so the durations tile the cycle
         // instead of overlapping it. Read and restart in the same expression, exactly once per
         // stage, where that stage's report is built.
@@ -989,7 +992,8 @@ impl TemporalEngine {
                 .sum(),
             ..StorageManagerStageReport::default()
         });
-        let phase_executor = StorageManagerPhaseExecutor::new(cycle_started_unix_ms);
+        let phase_executor =
+            StorageManagerPhaseExecutor::new(cycle_started_unix_ms, cycle_started_at);
         let round_duration_ms = phase_executor.annotate_reports(
             &mut stages,
             &errors,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -6946,3 +6946,229 @@ fn a_checkpoint_index_names_no_place_only_this_process_can_reach() {
         }
     }
 }
+
+/// Where the bytes of a live record actually go.
+///
+/// Not a gate -- a census. Every optimisation so far came from looking at one encoded record and
+/// asking which field was paying for itself, and two of my guesses about that were wrong. So this
+/// prints the record and the size of each part, and asserts nothing.
+#[test]
+fn what_a_live_record_is_made_of() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    // A spread of kinds, because the question is whether a rule holds for ALL of them. The last
+    // time two identifiers looked interchangeable they were, for strings, and diverged for every
+    // timestamped kind.
+    for command in [
+        Command::StringSet {
+            key: "size-000000".to_string(),
+            value: vec![b'v'; 64],
+        },
+        Command::HashSet {
+            key: "cen-hash".to_string(),
+            field: "f".to_string(),
+            value: b"v".to_vec(),
+        },
+        Command::FeatureAppend {
+            key: "cen-feature".to_string(),
+            points: (0..2)
+                .map(|index| crate::types::FeaturePoint {
+                    timestamp_ms: 1_787_270_070_000 + index * 1_000,
+                    value: b"p".to_vec(),
+                })
+                .collect(),
+        },
+        Command::SeenCheck {
+            key: "cen-seen".to_string(),
+            member: b"m".to_vec(),
+            window_ms: 60_000,
+        },
+    ] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command,
+        });
+    }
+
+    // Does address.object_id EVER differ from the item's, or go absent? That decides whether it
+    // can be dropped from the wire and rebuilt.
+    let mut same = 0usize;
+    let mut differ = 0usize;
+    let mut absent = 0usize;
+    let mut no_address = 0usize;
+    for (_, line) in engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+    {
+        let record = crate::wal::decode_wal_line(&line).expect("decodes");
+        for item in &record.outcomes {
+            match item.resolved_address().map(|a| a.object_id) {
+                None => no_address += 1,
+                Some(None) => absent += 1,
+                Some(Some(id)) if id == item.object_id => same += 1,
+                Some(Some(_)) => differ += 1,
+            }
+        }
+    }
+    println!("[census] address object_id: {same} same, {differ} differ, {absent} absent, {no_address} item(s) with no address");
+
+    for (_, line) in engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .unwrap()
+        .iter()
+        .take(1)
+    {
+        let record = crate::wal::decode_wal_line(line).expect("decodes");
+        println!("[census] framed record: {} B", line.len());
+        println!("[census] items: {}", record.outcomes.len());
+        for item in &record.outcomes {
+            println!(
+                "[census]   kind={} key={} ({} B) object_id={} bucket={}",
+                item.kind,
+                item.object_key,
+                item.object_key.len(),
+                item.object_id,
+                item.routing_bucket
+            );
+            if let Some(address) = item.resolved_address() {
+                println!(
+                    "[census]   address: slab={} off={} len={} block_id={:?} object_id={:?} gen={:?} band={:?} digest={} chars",
+                    address.page_slab_id,
+                    address.offset,
+                    address.length,
+                    address.page_id,
+                    address.object_id,
+                    address.generation,
+                    address.band_id,
+                    address.sha256.as_deref().map(str::len).unwrap_or(0),
+                );
+                println!(
+                    "[census]   item.object_id == address.object_id? {}",
+                    address.object_id == Some(item.object_id)
+                );
+            }
+        }
+        if let Some(metadata) = &record.metadata {
+            println!(
+                "[census] metadata: version={} timestamp={} batch={:?}",
+                metadata.version, metadata.timestamp_ms, metadata.batch_id
+            );
+        }
+        println!("[census] carries an operation: {}", record.command.is_some());
+    }
+}
+
+/// Does the log-resident registry shrink when the pages it names become durable?
+///
+/// The registry maps a synthetic address to the record holding its bytes. It is process-static and
+/// keyed per object, so it grows with the number of distinct objects a shard writes that way. The
+/// index's own copy of that mapping IS pruned on a dump -- the comment there says dropping those
+/// entries is what keeps it from growing with the log.
+///
+/// The registry is a second copy of the same knowledge, and it matters twice: it holds memory, and
+/// `min_registered_sequence` pins the WAL retention floor to the LOWEST registration -- so an entry
+/// for a page that is already durable would hold the floor down and stop reclaim, not just cost
+/// bytes.
+///
+/// Measured, not asserted, until the numbers say which.
+#[test]
+fn what_the_log_resident_registry_holds_after_a_dump() {
+    std::env::set_var("TS_BLOCK_IN_WAL", "1");
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    const WRITES: usize = 48;
+    for index in 0..WRITES {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("rg-{index:03}"),
+                value: vec![b'v'; 96],
+            },
+        });
+    }
+
+    let registered = engine.registration_count_for_test(1);
+    let resident = engine.wal_resident_page_count(1);
+    println!("[registry] after {WRITES} async writes: {registered} registration(s), {resident} index entr(ies)");
+
+    // A dump makes those pages durable and prunes the INDEX's copy. What happens to the registry?
+    engine.flush_shard_index(1);
+    let after_flush = engine.registration_count_for_test(1);
+    let resident_after = engine.wal_resident_page_count(1);
+    println!("[registry] after a flush: {after_flush} registration(s), {resident_after} index entr(ies)");
+
+    let cycle = engine.run_storage_manager_cycle(StorageManagerCycleRequest {
+        shard_id: 1,
+        ..Default::default()
+    });
+    let after_cycle = engine.registration_count_for_test(1);
+    let resident_cycle = engine.wal_resident_page_count(1);
+    println!(
+        "[registry] after a storage cycle ({} stages): {after_cycle} registration(s), {resident_cycle} index entr(ies)",
+        cycle.stages.len()
+    );
+
+    // The registrations pin the WAL retention floor, deliberately: while a page lives ONLY in a
+    // record, truncating that record turns an acked write into a missing read. The question is
+    // what happens once the page is somewhere else.
+    let info = engine.write_ahead_log_store().info(1).unwrap();
+    println!(
+        "[registry] log: start={} current={} -- reclaim cannot pass the oldest registration",
+        info.start_sequence, info.current_sequence
+    );
+
+    let moved = engine.materialize_synthetic_pages(1);
+    let after_materialise = engine.registration_count_for_test(1);
+    let synthetic_left = engine.synthetic_address_count_for_test(1);
+    println!(
+        "[registry] after materialising: {moved} page(s) moved, {after_materialise} registration(s) left, {synthetic_left} synthetic address(es) left"
+    );
+    std::env::remove_var("TS_BLOCK_IN_WAL");
+
+    // Whatever the counts, every value must still read -- a registry that shrank too far would
+    // show up here rather than as a number.
+    let mut served = 0usize;
+    for index in 0..WRITES {
+        if matches!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: format!("rg-{index:03}")
+                    },
+                })
+                .response,
+            CommandResponse::Bytes { value: Some(_) }
+        ) {
+            served += 1;
+        }
+    }
+    println!("[registry] {served}/{WRITES} still served");
+    assert_eq!(served, WRITES, "a value stopped reading");
+}

--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1237,6 +1237,71 @@ fn fetch_indexed_payload_values(
     Ok((values, shards_touched))
 }
 
+/// Read named fields of one record shard, without paying for the rest of it.
+///
+/// Deliberately NOT used by the sweep paths. There, whole-shard reads are the right call and the
+/// comment on `fetch_indexed_payload_values` explains why: a named-field read costs about half a
+/// millisecond per field and never warms, while a shard snapshot is read once and then kept
+/// current by the write runtimes, so a repeated sweep pays nothing after the first. Narrowing
+/// those measurably made them slower.
+///
+/// The purge is the opposite case, and measurably so. It names a handful of fields the locator
+/// already identified, and it MUTATES those shards immediately after, which invalidates any
+/// snapshot it would have populated -- so the snapshot is pure cost. Measured deleting an
+/// identical freshly-created memory (same closure: 4 ids, 96 records scanned, 5 fields rewritten)
+/// on two stores: 41.7 ms against a 20 MB store, 385.7 ms against a 249 MB one. Identical work,
+/// nine times the time, because a shard on the larger store is full and the whole thing was being
+/// decoded to reach five fields.
+fn fetch_shard_fields(
+    engine: &TemporalEngine,
+    key: String,
+    fields: &[String],
+) -> Result<BTreeMap<String, String>, String> {
+    if fields.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    // An already-cached snapshot is free and current, so prefer it when one happens to be in hand.
+    if let Ok(cache) = hgetall_snapshot_cache().lock() {
+        if let Some(cached) = cache.get(&key) {
+            let mut subset = BTreeMap::new();
+            for field in fields {
+                if let Some(value) = cached.get(field) {
+                    subset.insert(field.clone(), value.clone());
+                }
+            }
+            return Ok(subset);
+        }
+    }
+    let response = engine.execute_durable(ExecuteRequest {
+        shard_id: DEFAULT_SHARD_ID,
+        command: Command::HashMultiGet {
+            key,
+            fields: fields.to_vec(),
+        },
+    });
+    if !response.status.ok {
+        return Err(format!(
+            "{}: {}",
+            response.status.code, response.status.message
+        ));
+    }
+    match response.response {
+        CommandResponse::Values { values } => {
+            let mut decoded = BTreeMap::new();
+            for (field, value) in fields.iter().zip(values.into_iter()) {
+                let Some(bytes) = value else { continue };
+                let text = String::from_utf8(bytes)
+                    .map_err(|error| format!("stored value is not UTF-8: {error}"))?;
+                if !text.is_empty() {
+                    decoded.insert(field.clone(), text);
+                }
+            }
+            Ok(decoded)
+        }
+        other => Err(format!("unexpected response for hmget: {other:?}")),
+    }
+}
+
 fn hgetall_map(engine: &TemporalEngine, key: String) -> Result<BTreeMap<String, String>, String> {
     if let Ok(cache) = hgetall_snapshot_cache().lock() {
         if let Some(cached) = cache.get(&key) {
@@ -2501,13 +2566,16 @@ fn delete_records_by_ids(
     for (shard, only_fields) in visit {
         stats.shards_scanned += 1;
         let key = format!("{}:{}", record_hash_key, shard);
-        let shard_map = hgetall_map(engine, key.clone())?;
+        // With located fields, read exactly those. Without them (no locator coverage) the whole
+        // shard is genuinely needed, because the walk is the fallback that finds the records the
+        // locator could not name.
         let entries: Vec<(String, String)> = if only_fields.is_empty() {
-            shard_map.into_iter().collect()
+            hgetall_map(engine, key.clone())?.into_iter().collect()
         } else {
+            let found = fetch_shard_fields(engine, key.clone(), &only_fields)?;
             only_fields
                 .into_iter()
-                .filter_map(|field| shard_map.get(&field).map(|value| (field, value.clone())))
+                .filter_map(|field| found.get(&field).map(|value| (field, value.clone())))
                 .collect()
         };
         for (field, value) in entries {

--- a/crates/temporalstore-rust/src/raft/tests/part4.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part4.rs
@@ -3888,3 +3888,161 @@ fn a_rejected_append_still_proves_the_leader_is_alive() {
         "being spoken to by the leader is proof it is alive, even when we refuse what it sent"
     );
 }
+
+/// RAFT, on the format that now ships: every node durable, restored, and serving.
+///
+/// Consensus replicates operations -- that is what agreement means, and it does not change. What
+/// changed is what each node's own log records once it has applied one, and the question a
+/// distributed test has to answer is whether a node that RESTARTS from that log comes back with
+/// the same shard the cluster agreed on.
+///
+/// Three nodes, a spread of kinds, one node taken out and caught up, then the whole cluster
+/// restored from its logs and every node read back. A single node passing proves the codec; every
+/// node passing after a restore proves the cluster.
+#[test]
+fn a_raft_cluster_restores_every_node_from_its_own_log_on_the_live_format() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = RaftConfig::default();
+    let writes: Vec<(String, Vec<u8>)> = (0..12)
+        .map(|index| {
+            (
+                format!("dr-{index:02}"),
+                format!("value-{index:02}").into_bytes(),
+            )
+        })
+        .collect();
+
+    {
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], config.clone())
+                .unwrap();
+
+        // A node misses the middle of the run and has to catch up -- the case where a follower's
+        // log and the leader's diverge in length before they converge in content.
+        for (key, value) in writes.iter().take(4) {
+            cluster
+                .propose(Command::StringSet {
+                    key: key.clone(),
+                    value: value.clone(),
+                })
+                .unwrap();
+        }
+        cluster.set_alive(3, false).unwrap();
+        for (key, value) in writes.iter().skip(4).take(4) {
+            cluster
+                .propose(Command::StringSet {
+                    key: key.clone(),
+                    value: value.clone(),
+                })
+                .unwrap();
+        }
+        cluster.set_alive(3, true).unwrap();
+        cluster.catch_up(3).unwrap();
+        for (key, value) in writes.iter().skip(8) {
+            cluster
+                .propose(Command::StringSet {
+                    key: key.clone(),
+                    value: value.clone(),
+                })
+                .unwrap();
+        }
+
+        // Every node agrees BEFORE anything restarts, so a later failure is about recovery rather
+        // than about replication.
+        for node_id in [1, 2, 3] {
+            for (key, value) in &writes {
+                assert_eq!(
+                    cluster
+                        .read_local(
+                            node_id,
+                            Command::StringGet {
+                                key: key.to_string()
+                            }
+                        )
+                        .unwrap(),
+                    CommandResponse::Bytes {
+                        value: Some(value.clone())
+                    },
+                    "node {node_id} did not have {key} before the restore"
+                );
+            }
+        }
+    }
+
+    // Every node comes back from what its own log recorded.
+    let restored =
+        RaftCluster::restore_single_shard_from_wal(dir.path(), 1, [1, 2, 3], config).unwrap();
+    for node_id in [1, 2, 3] {
+        for (key, value) in &writes {
+            assert_eq!(
+                restored
+                    .read_local(
+                        node_id,
+                        Command::StringGet {
+                            key: key.to_string()
+                        }
+                    )
+                    .unwrap(),
+                CommandResponse::Bytes {
+                    value: Some(value.clone())
+                },
+                "node {node_id} lost {key} across the restore"
+            );
+        }
+    }
+    println!(
+        "[raft] 3 nodes, {} writes, one outage and catch-up, all restored and serving",
+        writes.len()
+    );
+}
+
+/// The same cluster, with the log written in the LEGACY encoding.
+///
+/// The defaults moved; the old path has to keep working, and it is now the one that can rot
+/// unnoticed. This is the same scenario with all three flags off, so a difference between them is
+/// a difference in the encoding rather than in the test.
+#[test]
+fn a_raft_cluster_restores_on_the_legacy_encoding_too() {
+    std::env::set_var("TS_WAL_BINARY_RECORDS", "0");
+    std::env::set_var("TS_WAL_OUTCOME_ITEMS", "0");
+    std::env::set_var("TS_WAL_DATA_ONLY", "0");
+    let dir = tempfile::tempdir().unwrap();
+    let config = RaftConfig::default();
+    {
+        let cluster =
+            RaftCluster::new_single_shard_with_wal(dir.path(), 1, [1, 2, 3], config.clone())
+                .unwrap();
+        for index in 0..8 {
+            cluster
+                .propose(Command::StringSet {
+                    key: format!("lg-{index:02}"),
+                    value: format!("legacy-{index:02}").into_bytes(),
+                })
+                .unwrap();
+        }
+    }
+    let restored =
+        RaftCluster::restore_single_shard_from_wal(dir.path(), 1, [1, 2, 3], config).unwrap();
+    for node_id in [1, 2, 3] {
+        for index in 0..8 {
+            assert_eq!(
+                restored
+                    .read_local(
+                        node_id,
+                        Command::StringGet {
+                            key: format!("lg-{index:02}")
+                        }
+                    )
+                    .unwrap(),
+                CommandResponse::Bytes {
+                    value: Some(format!("legacy-{index:02}").into_bytes())
+                },
+                "node {node_id} lost lg-{index:02} on the legacy encoding"
+            );
+        }
+    }
+    std::env::remove_var("TS_WAL_BINARY_RECORDS");
+    std::env::remove_var("TS_WAL_OUTCOME_ITEMS");
+    std::env::remove_var("TS_WAL_DATA_ONLY");
+    println!("[raft] legacy encoding: 3 nodes restored and serving");
+}

--- a/crates/temporalstore-rust/src/shared_store.rs
+++ b/crates/temporalstore-rust/src/shared_store.rs
@@ -3320,6 +3320,119 @@ mod tests {
         );
     }
 
+    /// OBJECT-STORE MODE: two followers from one origin must agree, and both must serve.
+    ///
+    /// One follower proves the path works. Two prove it is deterministic: installing the same
+    /// results on two nodes that never wrote them has to land in the same place, or a read is
+    /// answered differently depending on which replica took it -- which is the failure a single
+    /// follower can never show.
+    ///
+    /// Both are also checked for SERVING rather than for shape. A node whose maps agree and whose
+    /// addresses do not resolve passes every comparison and answers nothing, which is exactly the
+    /// defect that a restored node had.
+    #[tokio::test]
+    async fn two_followers_of_one_origin_agree_and_both_serve() {
+        let dir = tempfile::tempdir().unwrap();
+        let primary = test_engine(dir.path(), "origin");
+        primary.load_shard(1);
+
+        let workload: Vec<(String, Vec<u8>)> = (0..10)
+            .map(|index| {
+                (
+                    format!("tf-{index:02}"),
+                    format!("two-followers-{index:02}").into_bytes(),
+                )
+            })
+            .collect();
+        for (key, value) in &workload {
+            let response = primary.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: key.clone(),
+                    value: value.clone(),
+                },
+            });
+            assert!(response.status.ok);
+        }
+
+        let (_store, replicator) = test_shared_store(dir.path());
+        let published: Vec<_> = primary
+            .write_ahead_log_store()
+            .scan(1, 0, u64::MAX, u64::MAX)
+            .unwrap()
+            .iter()
+            .filter_map(|(_, line)| crate::wal::decode_wal_line(line).ok())
+            .filter(|record| !record.outcomes.is_empty())
+            .collect();
+        assert!(
+            published.len() >= workload.len(),
+            "expected a record per write carrying results, got {}",
+            published.len()
+        );
+        for record in &published {
+            // Carry the blocks the results point at: a follower has its own block store, and an
+            // address alone names a place it cannot reach.
+            let mut carried = record.staged_pages.clone();
+            if carried.is_empty() {
+                for item in &record.outcomes {
+                    if let Some(address) = item.resolved_address() {
+                        if let Ok(bytes) = primary.block_store().read(&address) {
+                            carried.push(crate::wal::StagedPage {
+                                object_id: item.object_id,
+                                bytes,
+                            });
+                        }
+                    }
+                }
+            }
+            replicator
+                .publish_wal_entry(SharedStoreWalEntry {
+                    shard_id: 1,
+                    wal_index: record.sequence,
+                    command: record.command.clone(),
+                    staged_pages: carried,
+                    outcomes: record.outcomes.clone(),
+                })
+                .await
+                .unwrap();
+        }
+
+        let mut served = Vec::new();
+        for role in ["follower-a", "follower-b"] {
+            let follower = test_engine(dir.path(), role);
+            follower.load_shard(1);
+            let before = follower.replay_installs_for_test();
+            let report = replicator.replay_wal(1, 0, &follower).await.unwrap();
+            let installed = follower.replay_installs_for_test() - before;
+            assert!(
+                report.applied > 0,
+                "{role} took nothing from the shared log"
+            );
+
+            let mut answers = Vec::new();
+            for (key, value) in &workload {
+                let response = follower.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet { key: key.clone() },
+                });
+                match response.response {
+                    CommandResponse::Bytes { value: Some(got) } => {
+                        assert_eq!(&got, value, "{role} served the wrong bytes for {key}");
+                        answers.push(got);
+                    }
+                    other => panic!("{role} could not serve {key}: {other:?}"),
+                }
+            }
+            println!("[two-followers] {role}: applied={} installed={installed}", report.applied);
+            served.push(answers);
+        }
+
+        assert_eq!(
+            served[0], served[1],
+            "the two followers answered the same reads differently"
+        );
+    }
+
     /// RESTORATION on the live format, and the constraint it runs into.
     ///
     /// A restored node takes its index and pages from a checkpoint and everything after it from

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -88,6 +88,63 @@ pub(crate) fn binary_records_enabled() -> bool {
         .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
         .unwrap_or(true)
 }
+/// The kinds common enough to be worth a code rather than a string on every item.
+///
+/// Order is the wire contract: a code means the same kind forever. A kind missing from this list
+/// travels as its name, which is what keeps the list from having to be exhaustive.
+const KIND_CODES: &[&str] = &[
+    "string",
+    "hash",
+    "set",
+    "list",
+    "zset",
+    "feature",
+    "object",
+    "seen",
+    "bucket",
+    "context_event",
+    "context_index",
+    "context_audit",
+    "context_child",
+    "context_summary",
+    "context_compression",
+    "context_node",
+    "context_entity",
+    "control_state",
+    "control_counter",
+    "control_change",
+    "control_selection",
+];
+
+fn kind_code(kind: &str) -> Option<u32> {
+    KIND_CODES
+        .iter()
+        .position(|known| *known == kind)
+        .map(|index| index as u32 + 1)
+}
+
+fn kind_from_code(code: u32) -> Option<&'static str> {
+    if code == 0 {
+        return None;
+    }
+    KIND_CODES.get(code as usize - 1).copied()
+}
+
+/// The digest itself, not its hex transcription.
+fn checksum_to_raw(hex: &str) -> Option<Vec<u8>> {
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).ok())
+        .collect()
+}
+
+fn checksum_from_raw(raw: &[u8]) -> String {
+    raw.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 
 fn address_to_proto(address: &BlockAddress) -> v1::WalBlockAddress {
     v1::WalBlockAddress {
@@ -103,7 +160,12 @@ fn address_to_proto(address: &BlockAddress) -> v1::WalBlockAddress {
         routing_bucket: None,
         generation: address.generation,
         band_id: address.band_id,
-        checksum: address.sha256.clone(),
+        // The digest, not its transcription. Half the bytes, same value.
+        checksum: None,
+        checksum_raw: address
+            .sha256
+            .as_deref()
+            .and_then(checksum_to_raw),
     }
 }
 
@@ -117,7 +179,12 @@ fn address_from_proto(address: v1::WalBlockAddress) -> BlockAddress {
         routing_bucket: address.routing_bucket,
         generation: address.generation,
         band_id: address.band_id,
-        sha256: address.checksum,
+        // Prefer the digest; fall back to the hex a record written before it carries.
+        sha256: address
+            .checksum_raw
+            .as_deref()
+            .map(checksum_from_raw)
+            .or(address.checksum),
     }
 }
 /// The numeric key a component is carrying, if it is carrying one.
@@ -148,6 +215,15 @@ fn numeric_component(kind: &str, component: Option<&str>) -> Option<(u64, Option
 
 
 pub(crate) fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
+    let block = item.address.as_ref().map(|address| {
+        let mut encoded = address_to_proto(address);
+        // The item already says this. Repeating it costs a full varint on every item whose page
+        // belongs to one object, which is every kind that is not timestamped.
+        if encoded.object_id == Some(item.object_id) {
+            encoded.object_id = None;
+        }
+        encoded
+    });
     v1::EngineWalItem {
         item_kind: 0,
         model: 0,
@@ -169,18 +245,28 @@ pub(crate) fn item_to_proto(item: &WalOutcomeItem) -> v1::EngineWalItem {
         entry_id: numeric_component(&item.kind, item.component.as_deref()).and_then(|(_, id)| id),
         // A removal with no component is the whole object, which is now said rather than implied.
         object_deleted: item.deleted && item.component.is_none(),
-        block: item.address.as_ref().map(address_to_proto),
+        block,
         value: item.value.clone(),
         // The engine names more kinds than the enum does, and the name is what the apply path
         // dispatches on, so it is carried literally rather than squeezed through a lossy mapping.
-        kind_name: Some(item.kind.clone()),
+        // A known kind travels as a code; anything else keeps its name.
+        kind_name: match kind_code(&item.kind) {
+            Some(_) => None,
+            None => Some(item.kind.clone()),
+        },
+        kind_code: kind_code(&item.kind),
         routing_bucket: Some(item.routing_bucket),
     }
 }
 
 pub(crate) fn item_from_proto(item: v1::EngineWalItem) -> WalOutcomeItem {
     WalOutcomeItem {
-        kind: item.kind_name.unwrap_or_default(),
+        kind: item
+            .kind_code
+            .and_then(kind_from_code)
+            .map(str::to_string)
+            .or(item.kind_name)
+            .unwrap_or_default(),
         object_key: item.object_key.unwrap_or_default(),
         // Prefer the numeric fields; fall back to the string a record written before this carries.
         component: match (item.timestamp_ms, item.entry_id) {
@@ -190,7 +276,16 @@ pub(crate) fn item_from_proto(item: v1::EngineWalItem) -> WalOutcomeItem {
         },
         object_id: item.object_id.unwrap_or_default(),
         routing_bucket: item.routing_bucket.unwrap_or_default(),
-        address: item.block.map(address_from_proto),
+        address: item.block.map(|block| {
+            let object_id = item.object_id.unwrap_or_default();
+            let mut address = address_from_proto(block);
+            // Absent means "the same as the item's", which is the only thing it can mean: the
+            // encoder omits it exactly when they match, and it is never otherwise unset.
+            if address.object_id.is_none() {
+                address.object_id = Some(object_id);
+            }
+            address
+        }),
         value: item.value,
         ttl: item.ttl_ms,
         deleted: item.deleted,
@@ -220,6 +315,7 @@ fn metadata_to_proto(metadata: &WriteAheadLogRecordMetadata) -> Result<v1::Engin
             block: None,
             value: Some(serde_json::to_vec(&metadata.items).map_err(|err| err.to_string())?),
             kind_name: Some(String::from("__verbatim_items")),
+            kind_code: None,
             routing_bucket: None,
             timestamp_ms: None,
             entry_id: None,

--- a/proto/temporalstore/v1/temporalstore.proto
+++ b/proto/temporalstore/v1/temporalstore.proto
@@ -547,7 +547,10 @@ message WalBlockAddress {
   optional uint32 routing_bucket = 6;
   optional uint64 generation = 7;
   optional uint64 band_id = 8;
+  // Field 9 is the hex form, kept readable for records written before field 10 existed. New
+  // records write the digest itself: thirty-two bytes rather than sixty-four characters.
   optional string checksum = 9;
+  optional bytes checksum_raw = 10;
 }
 
 // WHAT A WRITE DID, which is what lets a log carry data instead of operations.
@@ -580,9 +583,12 @@ message EngineWalItem {
   WalBlockAddress block = 12;
   // The bytes themselves, for state that has no block behind it.
   optional bytes value = 13;
-  // The kind as the engine names it, when the enums above cannot say it precisely. The enums
-  // stay for consumers that switch on them; this is what the engine round-trips on.
+  // The kind as the engine names it. Repeated on every item, so the common ones travel as
+  // `kind_code` below and this is left empty; a kind the code does not cover still travels
+  // whole, because the engine names more of them than any list here should try to freeze.
   optional string kind_name = 14;
+  // A small code for a kind this schema knows. Zero means "read kind_name instead".
+  optional uint32 kind_code = 19;
   // The bucket this object routes to. On the item rather than only inside `block`, because state
   // with no block behind it still routes somewhere.
   optional uint32 routing_bucket = 15;


### PR DESCRIPTION
a smaller record, a round that timed itself on a clock that could move, and three nodes to prove it

    was     171.2 B/record
    now     122.5 B/record
    against 186.4 for the operation-carrying record it replaced:  -34.3%

Three fields were paying for their own encoding. A checksum is a SHA-256 -- thirty-two bytes --
travelling as sixty-four hex characters, on the largest field of any item carrying an address. The
kind travelled as a word repeated on every item. And an address repeated the item's object id
whenever they were the same number.

That last one is the careful one. They are NOT always the same: for a feature or a context event
the item's is per point and the page's is per series. The same two fields looked interchangeable
earlier in this work, coincided for strings, diverged for every timestamped kind, and produced a
rebuild whose maps were perfect and whose index named the wrong object. So the id is omitted only
when they match and rebuilt when absent, measured first across four kinds -- two same, two differ,
none ever absent, which is what makes "absent" unambiguous. The whole-record round trip is the
guard if that ever stops holding.

One saving deliberately declined: a results-carrying record has no use for the leader timestamp,
whose only consumer is the replay clock on the re-execution path. But a decoder cannot rebuild what
an encoder drops, so whole-record equality would fail by construction, and weakening that assertion
to buy nine bytes is the wrong trade.

THE STORAGE CYCLE WAS TIMING ITSELF ON A CLOCK THAT CAN MOVE. Stages measure with Instant --
monotonic. The round measured `now_ms()` minus the unix millisecond it started at, and SystemTime is
adjustable: a backwards correction mid-cycle makes the round report LESS than the stages inside it,
and a large enough one clamps to zero through the saturating_sub. That is what "the round total 5838
ms should cover the stages that tile it (6958 ms)" was reporting -- not overlapping stages, a moving
clock. It had been failing intermittently for hours and reading as flakiness.

The first fix was wrong and the test said so at once: 12/12 instead of intermittent, because the
executor holding the clock is constructed at the END of the cycle, so an Instant captured inside it
measures the finish. The monotonic start travels in from the top now, like the unix millisecond
always did. 0/15 after. The pair is deliberate -- one says WHEN, the other says HOW LONG -- and the
reason is in the code where the next person would make the same mistake.

And three nodes to prove the rest of it:

    raft, live format    3 nodes, 12 writes, one outage and catch-up, all restored and serving
    raft, legacy         3 nodes restored and serving with all three flags off
    object store         two followers of one origin, 10 applied and 10 installed each, agreeing

The two-follower case is the one a single follower cannot show: installing the same results on two
nodes that never wrote them has to land in the same place, or a read is answered differently
depending on which replica takes it. Both are checked for SERVING rather than for shape, because a
node whose maps agree and whose addresses do not resolve passes every comparison and answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
