### PR TITLE
Stop rebuilding a bucket index once per superseded page ref

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1186,6 +1186,12 @@ pub(super) fn upsert_bucket_index_page(
     );
     if let Some(page_refs) = direct_page_refs {
         for page_ref in page_refs {
+            // A ref in the bucket we are about to write needs no maintenance here: the end of
+            // this function rebuilds it, and that rebuild REPLACES object_index wholesale from
+            // page_index. Doing it per ref costs two walks of the bucket -- the `any` scan and
+            // the layout rebuild -- and both are thrown away. A ref in a DIFFERENT bucket is not
+            // covered by that rebuild, so it keeps the full treatment.
+            let superseded_in_target_bucket = page_ref.routing_bucket == routing_bucket;
             let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&page_ref.routing_bucket) else {
                 continue;
             };
@@ -1193,6 +1199,9 @@ pub(super) fn upsert_bucket_index_page(
                 .page_index
                 .remove(&page_ref.page_ref_key)
                 .map(|page| page.object_id);
+            if superseded_in_target_bucket {
+                continue;
+            }
             if let Some(removed_object_id) = removed_object_id {
                 if !bucket
                     .page_index


### PR DESCRIPTION
`upsert_bucket_index_page` removes an object's superseded page refs, and for each one it walks the whole bucket **twice**:

```rust
let removed_object_id = bucket.page_index.remove(&page_ref.page_ref_key).map(|p| p.object_id);
if let Some(removed_object_id) = removed_object_id {
    if !bucket.page_index.values().any(|page| page.object_id == removed_object_id) {  // O(pages)
        bucket.object_index.remove(&removed_object_id);
    }
    update_bucket_layout(bucket);                                                      // O(pages)
}
```

`update_bucket_layout` rebuilds a fresh `BTreeSet` of every live object id in the bucket. Then, unconditionally, the end of the same function inserts the new page and calls it again — and that call does `bucket.object_index = live_object_ids`, a **wholesale replace**. So for a ref in the bucket being written, everything the loop computed is overwritten moments later.

This skips that work when the superseded ref is in the bucket the function is about to rebuild. A ref in a *different* routing bucket is not covered by that rebuild and keeps the full treatment.

## Why it matters: basic ingestion is quadratic in store size

Per-entry cost of the bucket upsert, measured against corpus size with entries-per-add held flat:

| memories | add p50 | entries/add | upsert µs/entry |
|---:|---:|---:|---:|
| 170 | 165 ms | 137.8 | 94.6 |
| 420 | 356 ms | 138.0 | 352.4 |
| 720 | 939 ms | 137.6 | **1070.6** |

Entries per add barely moves; the *per-entry* cost grows with the store, so an add gets quadratically slower as the corpus fills. This upsert is 73% of the apply phase, the apply phase is 46% of `batch_execute`, and `batch_execute` is 99% of an append.

## Measured effect

Counted, not timed — page-index entries visited per add, with each arm run twice:

| | @220 memories | @520 memories |
|---|---:|---:|
| before | 261,249 / 260,008 | 621,687 / 620,465 |
| after | **179,033 / 180,033** | **426,289 / 427,304** |

**−31% pages walked**, and the repeats agree to within 0.6%.

I am claiming the work removed, not a latency number: p50 went 166/166 → 149/163 ms at 520 memories, which is suggestive but inside this machine's spread. The point is that the removed work is part of the term that grows with the corpus — 81k fewer page visits per add at 220 memories, 195k fewer at 520.

This does not make the path linear. At ~12.7 layout rebuilds per written entry, most come from the other twelve call sites, and `update_bucket_layout` is still O(pages in bucket) at every one of them. The principled fix is a per-bucket `object_id → live page count` so the "does this object still have a live page?" test is O(1) and the layout needs only the two counts `classify_bucket_layout` actually takes. That touches twelve `page_index` mutation sites across three files and deserves its own change; this one is the provably-redundant subset.

## Tests

22/22 strict mem0 conformance, 0 failures. 98 tests across 8 mem0 suites. 42 bucket-index tests.

The full `--lib` run shows 8 failures, and none are from this change: run individually with `--test-threads=1`, seven pass on both this branch and pristine main, and the eighth (`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`) fails on pristine main too. The rest are parallel-run flakes — one of them, `appending_does_not_get_slower_as_the_log_grows`, is a timing assertion, and the machine was at load 30 with another build running.
