### PR TITLE
Say that a metaserver raft group is one process

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2303,6 +2303,29 @@ fn parse_meta_raft_nodes() -> Vec<ProductionRaftNode> {
         })
 }
 
+/// What to say about a metaserver raft group's node list, if anything.
+///
+/// A metaserver raft group is built entirely inside the process that starts it,
+/// and no meta raft entry is ever sent between processes. With one node that is
+/// simply the truth: the group is this process. With more, the list describes
+/// peers that will never be dialled -- and if a second metaserver is started
+/// from the same list it keeps its own metadata, makes the same node leader,
+/// and answers ok to writes the first never sees.
+///
+/// Returned rather than logged so it can be tested; the caller logs it.
+fn unreplicated_meta_raft_warning(nodes: &[ProductionRaftNode]) -> Option<String> {
+    if nodes.len() <= 1 {
+        return None;
+    }
+    Some(format!(
+        "metaserver raft is configured with {} nodes, but meta raft entries are never sent \
+         between processes: this group is built inside this process alone. One metaserver \
+         started from this list is consistent; a second one started from it keeps its own \
+         metadata and the two diverge silently.",
+        nodes.len()
+    ))
+}
+
 fn parse_meta_raft_node(index: usize, value: &str) -> Option<ProductionRaftNode> {
     if let Some((id, addr)) = value.split_once('=') {
         return Some(ProductionRaftNode {
@@ -2486,6 +2509,29 @@ mod tests {
             std::env::remove_var(key);
         }
         out
+    }
+
+    #[test]
+    fn a_meta_raft_group_says_it_does_not_span_processes() {
+        // The group is built inside the process that starts it and no meta raft
+        // entry is ever sent between processes, so a list of peers describes
+        // addresses that will never be dialled. One node is that truth stated
+        // plainly and needs nothing said; more than one is worth saying, because
+        // a second metaserver started from the same list diverges in silence.
+        let node = |node_id| ProductionRaftNode {
+            node_id,
+            addr: format!("10.0.0.{node_id}:17001"),
+        };
+        assert_eq!(unreplicated_meta_raft_warning(&[]), None);
+        assert_eq!(unreplicated_meta_raft_warning(&[node(1)]), None);
+
+        let warning = unreplicated_meta_raft_warning(&[node(1), node(2), node(3)])
+            .expect("three nodes is worth saying something about");
+        assert!(warning.contains("3"), "it should say how many: {warning}");
+        assert!(
+            warning.contains("diverge"),
+            "it should say what goes wrong: {warning}"
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -6,8 +6,15 @@
 impl MetaBackend {
     fn from_env() -> std::io::Result<Self> {
         if env_bool("TS_META_RAFT", false) || std::env::var("TS_META_RAFT_NODES").is_ok() {
+            let options = runtime_options_from_env();
+            if let Some(warning) = unreplicated_meta_raft_warning(&options.nodes) {
+                tracing::warn!(
+                    nodes = options.nodes.len(),
+                    "{warning}"
+                );
+            }
             return Ok(Self::Raft(
-                ProductionMetaRaftRuntime::start(runtime_options_from_env())
+                ProductionMetaRaftRuntime::start(options)
                     .expect("failed to initialize metaserver raft runtime"),
             ));
         }


### PR DESCRIPTION
MetaRaftCluster builds every node of the group -- leader and followers --
inside the process that starts it. Its own documentation says that is a
fixture: "Local metaserver Raft fixture for unit tests and validation
harnesses. Production metaserver Raft must use the networked production
runtime." There is no networked meta runtime. Every raft transport in the
tree belongs to the data raft, and the addresses configured for the meta
group are checked for being present and distinct and then never dialled.

One metaserver running that group is coherent, and that is what has always
been happening. A second metaserver started from the same node list is not:
it builds its own copy of the group, makes the same node leader, and accepts
metadata the first will never see. Measured with two runtimes started from
one three-node list:

    both started: a.leader=1 b.leader=1
    add_namespace on node 1 -> ok
    namespaces visible: node1=1 node2=0
    add_namespace on node 2 -> ok
    after both writes: node1=1 node2=1

Two stores, two different namespaces, every write answered ok.

A process cannot see its siblings, so this cannot tell one metaserver from
three and does not refuse to start -- refusing would break the single
process that is running the group correctly today, which is also what
TS_META_RAFT with no node list configures. It says so instead, once, at
startup, where somebody setting the list up will read it.

The message is a function rather than an inline log line so a test can hold
it to saying how many nodes and what goes wrong.
