### PR TITLE
Table lookups take a read lock, because they are reads

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -636,7 +636,14 @@ struct ClientInner {
     options: ClientOptions,
     routes: Mutex<HashMap<ShardId, CachedRoute>>,
     backend_failures: Mutex<HashMap<String, BackendFailureState>>,
-    tables: Mutex<HashMap<String, TableOptions>>,
+    /// Table options by "namespace/table".
+    ///
+    /// A reader-writer lock, not a mutex: every table-scoped request reads this at least
+    /// twice -- once to resolve the table and once for its options -- and writes happen
+    /// only when a table is opened, refreshed by the metaserver sync, or dropped. Under a
+    /// mutex those reads serialized against each other for no reason, which made resolving
+    /// a cached table the most expensive thing the proxy did per request.
+    tables: RwLock<HashMap<String, TableOptions>>,
     meta_sync_tables: Mutex<HashMap<String, ClientMetaSyncTableState>>,
     stats: Mutex<ClientStats>,
     /// Topology version this client last heard from the metaserver.
@@ -752,7 +759,7 @@ impl TemporalStoreClient {
                 options,
                 routes: Mutex::default(),
                 backend_failures: Mutex::default(),
-                tables: Mutex::default(),
+                tables: RwLock::default(),
                 meta_sync_tables: Mutex::default(),
                 stats: Mutex::default(),
                 known_topology_version: AtomicU64::new(0),
@@ -771,7 +778,7 @@ impl TemporalStoreClient {
         let combine_name = table_combine_name(&namespace, &table_name);
         self.inner
             .tables
-            .lock()
+            .write()
             .expect("client table cache lock poisoned")
             .insert(combine_name, options.clone());
         self.ensure_meta_sync_table_state(&namespace, &table_name);
@@ -810,7 +817,7 @@ impl TemporalStoreClient {
         let options = self
             .inner
             .tables
-            .lock()
+            .read()
             .expect("client table cache lock poisoned")
             .get(&table_combine_name(&namespace, &table_name))
             .cloned()?;
@@ -1001,7 +1008,7 @@ impl TemporalStoreTable {
         self.client
             .inner
             .tables
-            .lock()
+            .read()
             .expect("client table cache lock poisoned")
             .get(&table_combine_name(&self.namespace, &self.table_name))
             .cloned()

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -186,7 +186,7 @@ impl TemporalStoreClient {
             .collect::<Vec<_>>();
         self.inner
             .tables
-            .lock()
+            .write()
             .expect("client table cache lock poisoned")
             .insert(table_key.clone(), options.clone());
 
@@ -441,7 +441,7 @@ impl TemporalStoreClient {
         let mut tables = self
             .inner
             .tables
-            .lock()
+            .read()
             .expect("client table cache lock poisoned")
             .keys()
             .cloned()
@@ -540,7 +540,7 @@ impl TemporalStoreClient {
         let removed = self
             .inner
             .tables
-            .lock()
+            .write()
             .expect("client table cache lock poisoned")
             .remove(&table_combine_name(table.namespace(), table.table_name()))
             .is_some();
@@ -579,7 +579,7 @@ impl TemporalStoreClient {
         let table_cache_size = self
             .inner
             .tables
-            .lock()
+            .read()
             .expect("client table cache lock poisoned")
             .len();
         let backend_failure_count = self
@@ -627,7 +627,7 @@ impl TemporalStoreClient {
         let tables = self
             .inner
             .tables
-            .lock()
+            .read()
             .expect("client table cache lock poisoned")
             .clone();
         let routes = self

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1980,6 +1980,67 @@ fn proxy_addr_port(addr: &str) -> u16 {
 mod tests {
     use super::*;
 
+    /// What looking up an already-cached table costs, per request, under contention.
+    ///
+    /// The proxy resolves a table on every table-scoped request. On the cache-HIT path --
+    /// which is the normal one -- it clones the namespace and table name so the miss path
+    /// can still own them, `cached_table` builds a third string for the map key, and
+    /// cloning the stored options allocates a fourth for the preferred location. Four
+    /// allocations, a mutex, and an Arc clone, to answer a question the cache already knows.
+    ///
+    /// Measured under threads because the mutex is shared; run with `--ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn bench_proxy_cached_table_lookup() {
+        let threads: usize = std::env::var("BENCH_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8);
+        let per_thread: usize = std::env::var("BENCH_ITERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50_000);
+
+        let proxy = std::sync::Arc::new(scoped_proxy(ProxyOptions::default()));
+        // Seed the cache directly; open_table inserts the options without needing a
+        // metaserver, which is what the hit path reads.
+        let _seeded = proxy
+            .client()
+            .open_table("ns", "tbl", crate::client::TableOptions::default());
+        assert!(
+            proxy.client().cached_table("ns", "tbl").is_some(),
+            "the cache must be warm or this measures the miss path"
+        );
+
+        let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let proxy = std::sync::Arc::clone(&proxy);
+            let gate = std::sync::Arc::clone(&gate);
+            handles.push(std::thread::spawn(move || {
+                gate.wait();
+                for _ in 0..per_thread {
+                    let table = proxy
+                        .table_for_request("ns".to_string(), "tbl".to_string())
+                        .expect("cached table");
+                    std::hint::black_box(&table);
+                }
+            }));
+        }
+        gate.wait();
+        let start = std::time::Instant::now();
+        for handle in handles {
+            handle.join().expect("bench thread panicked");
+        }
+        let elapsed = start.elapsed();
+        let ops = (threads * per_thread) as u128;
+        println!(
+            "BENCH cached_table_lookup threads={threads} ops={ops} ns_per_op={} ops_per_sec={}",
+            elapsed.as_nanos() / ops,
+            ops * 1_000_000_000 / elapsed.as_nanos().max(1)
+        );
+    }
+
     #[test]
     fn a_pushed_topology_check_interval_reaches_the_request_path() {
         // The interval is mirrored outside the options lock so the request path can read


### PR DESCRIPTION
Every table-scoped request resolves its table at least twice: once to find it, and once
more for its options on the way to the wire. Both went through a mutex over the table
cache, so eight threads reading a map that none of them modified queued behind each other.

It is a reader-writer lock now. Only three of the eight places that touch this cache
write: opening a table, the metaserver sync refreshing one, and forgetting one. The rest
are lookups, counts and a snapshot for a report.

Measured with eight threads contending, resolving a table that is already cached:

  before   499 ns/op   2.0M ops/sec
  after    112 ns/op   8.9M ops/sec

For scale against the earlier work on this path: the proxy's own per-request bookkeeping
was 433 ns/op and is now 24, but resolving the table was 499 of the same nanoseconds all
along. Per-request overhead in total goes from about 932 ns/op to about 136.

What is left in the lookup is allocation, not contention: the caller clones the namespace
and table name so the cache-miss path can still own them, the key is built by formatting
a third string, and cloning the stored options allocates a fourth. That is the next thing
worth measuring, and it is a smaller number than this one.