### PR TITLE
Ingest was slow because a metrics timer counted the shard, not because writes were

### DIFF
--- a/crates/temporalstore-rust/src/data_node/runtime_storage.rs
+++ b/crates/temporalstore-rust/src/data_node/runtime_storage.rs
@@ -781,9 +781,22 @@ impl DataNodeRuntime {
         let handle = thread::spawn(move || {
             let mut round = 0u64;
             let mut current_backoff_ms = options.initial_backoff_ms;
-            // A cycle whose completion outlived the short wait below. Its report is collected
+            // Cycles whose completion outlived the short wait below. Their reports are collected
             // on a later tick instead of being thrown away -- see the comment at the wait.
-            let mut uncollected_cycle_job: Option<u64> = None;
+            //
+            // A LIST, not a single slot. With one slot the report was lost every time: the
+            // top-of-tick poll saw the cycle still running, the cycle finished later in that same
+            // tick, `has_pending` then went false so a new cycle was submitted, and submitting
+            // overwrote the slot before anything polled the finished job again. Every cycle was
+            // abandoned exactly one tick before it completed, so `last_completed_cycle` stayed
+            // None forever and every derived figure -- bytes reclaimed, pressure after, WAL and
+            // index-log floors -- stayed at zero while the manager was doing real work.
+            //
+            // Bounded by `has_pending_storage_manager`, which allows only one cycle in flight per
+            // shard, so this holds a couple of entries at most; the cap is a backstop, not a
+            // budget.
+            let mut uncollected_cycle_jobs: Vec<u64> = Vec::new();
+            const MAX_UNCOLLECTED_CYCLE_JOBS: usize = 64;
             loop {
                 let delay_ms =
                     storage_manager_runtime_delay_ms(&options, round, current_backoff_ms);
@@ -822,16 +835,32 @@ impl DataNodeRuntime {
                 // do. Any cycle that actually dumped buckets or reclaimed WAL outlived the
                 // budget and had its report dropped, so the reported dirty-bucket count,
                 // selected buckets and reclaim floors sat at zero while the manager was busy.
-                if let Some(job_id) = uncollected_cycle_job {
-                    if let Some(cycle) =
-                        wait_for_storage_manager_cycle_completion(&runtime, job_id, 0)
-                    {
-                        let mut report = thread_report
-                            .lock()
-                            .expect("storage manager runtime report lock poisoned");
-                        apply_storage_manager_cycle_to_runtime_report(&mut report, cycle);
-                        uncollected_cycle_job = None;
+                if !uncollected_cycle_jobs.is_empty() {
+                    let mut still_running = Vec::with_capacity(uncollected_cycle_jobs.len());
+                    for job_id in std::mem::take(&mut uncollected_cycle_jobs) {
+                        match runtime.job_status(job_id) {
+                            Some(status) if status.finished_at_ms.is_some() => {
+                                // Finished: collect the report if it carried one, and stop
+                                // tracking either way so a job that finished without a usable
+                                // output cannot pin a slot forever.
+                                if let Some(DataNodeTaskOutput::StorageManager(response)) =
+                                    status.output
+                                {
+                                    let mut report = thread_report
+                                        .lock()
+                                        .expect("storage manager runtime report lock poisoned");
+                                    apply_storage_manager_cycle_to_runtime_report(
+                                        &mut report,
+                                        response.report,
+                                    );
+                                }
+                            }
+                            Some(_) => still_running.push(job_id),
+                            // Gone from the jobs map (pruned): nothing left to collect.
+                            None => {}
+                        }
                     }
+                    uncollected_cycle_jobs = still_running;
                 }
                 let should_submit = !runtime
                     .inner
@@ -885,7 +914,10 @@ impl DataNodeRuntime {
                             .expect("storage manager runtime report lock poisoned");
                         apply_storage_manager_cycle_to_runtime_report(&mut report, cycle);
                     } else {
-                        uncollected_cycle_job = Some(submitted.job_id);
+                        if uncollected_cycle_jobs.len() >= MAX_UNCOLLECTED_CYCLE_JOBS {
+                            uncollected_cycle_jobs.remove(0);
+                        }
+                        uncollected_cycle_jobs.push(submitted.job_id);
                     }
                 }
             }

--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2194,6 +2194,103 @@ fn storage_manager_scheduler_submits_deduplicated_background_cycles() {
 
 // shared-corpus: storage_manager_continuous_background_runtime
 #[test]
+fn storage_manager_runtime_collects_the_report_of_a_cycle_that_outlived_its_wait() {
+    // A completed cycle's report must reach the runtime report even when the cycle takes longer
+    // than the short in-loop wait.
+    //
+    // It did not. The loop tracked the outstanding cycle in a single slot: the top-of-tick poll
+    // saw the cycle still running, the cycle finished later in that same tick, `has_pending` then
+    // went false so a new cycle was submitted, and submitting OVERWROTE the slot before anything
+    // polled the finished job again. Every cycle was abandoned exactly one tick before it
+    // completed. Measured on the unfixed code: 432 collection attempts across 45 cycles, 47 of
+    // which finished with a valid report, and not one was ever collected.
+    //
+    // The visible cost is that `last_completed_cycle` stays None forever, and with it every
+    // derived figure -- bytes reclaimed, pressure after, the WAL and index-log floors -- reads
+    // zero while the storage manager is doing real work. That is the operator's evidence that
+    // reclaim ran, and reclaim is the only thing that recovers the disk growth from repeated
+    // dumps.
+    let dir = tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        256,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    let runtime = DataNodeRuntime::new(
+        engine,
+        DataNodeRuntimeOptions {
+            worker_threads: 1,
+            max_queue_depth: 8,
+            max_background_queue_depth: 2,
+        },
+    );
+    assert!(
+        runtime
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 9,
+                table_name: "storage-manager-collect".to_string(),
+                shard_uri: "local://storage-manager-collect/9".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 16_383,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+    for index in 0..32 {
+        runtime.execute(ExecuteRequest {
+            shard_id: 9,
+            command: Command::StringSet {
+                key: format!("collect-{index}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+
+    let manager = runtime.start_storage_manager_runtime(StorageManagerRuntimeOptions {
+        // A 5ms interval against cycles that take far longer is the case that broke: the wait
+        // budget is tied to the interval, so essentially every cycle outlives it.
+        interval_ms: 5,
+        jitter_percent: 50,
+        initial_backoff_ms: 3,
+        max_backoff_ms: 40,
+        request: StorageManagerCycleRequest {
+            shard_id: 9,
+            max_dump_buckets_per_round: 3,
+            enable_prepare: true,
+            enable_wal_reclaim: true,
+            enable_evict: true,
+            enable_page_reclaim: true,
+            enable_index_gc: true,
+            ..StorageManagerCycleRequest::default()
+        },
+        controller: RequestController { timeout_ms: 30_000 },
+    });
+
+    wait_until(Duration::from_secs(15), || {
+        manager.report().last_completed_cycle.is_some()
+    });
+    let report = manager.report();
+    manager.stop();
+
+    assert!(
+        report.rounds_submitted >= 1,
+        "expected at least one submitted cycle, got {report:?}"
+    );
+    assert!(
+        report.last_completed_cycle.is_some(),
+        "a finished cycle's report was never collected: {report:?}"
+    );
+    assert_eq!(
+        report.submit_failures, 0,
+        "cycles should submit cleanly: {report:?}"
+    );
+}
+
+#[test]
 fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags() {
     let dir = tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -44,7 +44,10 @@ pub(crate) mod eviction_sampler;
 pub(crate) use command_validation::{command_object_keys, is_write_command};
 pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 mod storage_bucket_internals;
-pub use storage_bucket_internals::{live_page_scan_entries, reset_live_page_scan_entries};
+pub use storage_bucket_internals::{
+    bucket_page_index_visits, live_page_scan_entries, reset_bucket_page_index_visits,
+    reset_live_page_scan_entries,
+};
 mod compaction;
 mod storage_reporting;
 mod hashing;

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -684,10 +684,10 @@ impl TemporalEngine {
             // O(store) rebuild on EVERY record -> O(n^2). The single reconstruct
             // rebuilds the first-index once at the end, so deferring here is
             // correctness-preserving.
-            if !defer_bucket_index_reconstruct()
+            let rebuilt_bucket_index = !defer_bucket_index_reconstruct()
                 && (!command_updates_bucket_index_directly(&command)
-                    || shard.bucket_index.bucket_map.is_empty())
-            {
+                    || shard.bucket_index.bucket_map.is_empty());
+            if rebuilt_bucket_index {
                 rebuild_bucket_first_index(
                     request.shard_id,
                     shard,
@@ -696,7 +696,15 @@ impl TemporalEngine {
                 );
             }
             if !defer_bucket_index_reconstruct() {
-                refresh_bucket_runtime_flags(shard);
+                if rebuilt_bucket_index {
+                    // The rebuild replaced bucket_map wholesale, so the record of which buckets
+                    // changed no longer describes it; recompute everything.
+                    refresh_bucket_runtime_flags(shard);
+                } else {
+                    // Refresh only what this write touched. Sweeping the shard here cost
+                    // O(total pages) on EVERY write, which made ingestion quadratic in the corpus.
+                    refresh_pending_bucket_runtime_flags(shard);
+                }
             }
             // Every
             // write records a WAL entry before any page is written.

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3503,8 +3503,27 @@ fn object_manager_stats(
                 .iter()
                 .filter_map(|(bucket_id, bucket)| bucket.dirty.then_some(*bucket_id))
                 .collect::<BTreeSet<_>>();
-            for object_key in &shard.dirty_objects {
-                dirty_buckets.extend(bucket_index_target_buckets_for_object_key(shard, object_key));
+            // The loop below asks, per dirty object, which buckets hold its pages -- building a
+            // composite lookup key each time. `dirty_objects` grows with the ingest, and this
+            // runs on the heartbeat timer under the shard read lock, so it was the shard-sized
+            // work that made writes cost more as the store grew: profiling a running ingest
+            // showed `bucket_index_target_buckets_for_object_key` and `push_lookup_part` rising
+            // together with `RwLock::write_contended`.
+            //
+            // The answer is a set of bucket ids, so it cannot exceed the number of buckets. Once
+            // every bucket is already in it the loop cannot change the result, and during ingest
+            // that is the normal case -- `mark_async_dirty_object` marks an object's routing
+            // bucket dirty as it records the object, so the collect above already has them.
+            // Stopping there is exact, not an approximation.
+            let bucket_total = shard.bucket_index.bucket_map.len();
+            if dirty_buckets.len() < bucket_total {
+                for object_key in &shard.dirty_objects {
+                    dirty_buckets
+                        .extend(bucket_index_target_buckets_for_object_key(shard, object_key));
+                    if dirty_buckets.len() >= bucket_total {
+                        break;
+                    }
+                }
             }
             dirty_buckets.len()
         } else {

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -45,8 +45,8 @@ pub(crate) use command_validation::{command_object_keys, is_write_command};
 pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 mod storage_bucket_internals;
 pub use storage_bucket_internals::{
-    bucket_page_index_visits, live_page_scan_entries, reset_bucket_page_index_visits,
-    reset_live_page_scan_entries,
+    bucket_page_index_visits, bucket_visit_sites, live_page_scan_entries,
+    reset_bucket_page_index_visits, reset_live_page_scan_entries,
 };
 mod compaction;
 mod storage_reporting;

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3390,12 +3390,17 @@ fn object_manager_stats(
             if !shard.bucket_index.object_component_lookup.is_empty() {
                 (
                     shard.bucket_index.object_component_lookup.len(),
-                    shard
-                        .bucket_index
-                        .object_component_lookup
-                        .values()
-                        .map(BTreeSet::len)
-                        .sum::<usize>(),
+                    // Maintained incrementally; the walk is the fallback for an index that has
+                    // been deserialized but not yet rebuilt. This runs on the heartbeat timer
+                    // under the shard read lock, so walking here shows up as write contention.
+                    shard.bucket_index.object_component_page_refs.unwrap_or_else(|| {
+                        shard
+                            .bucket_index
+                            .object_component_lookup
+                            .values()
+                            .map(BTreeSet::len)
+                            .sum::<usize>()
+                    }),
                     shard.dirty_objects.len(),
                 )
             } else {

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -69,6 +69,23 @@ pub(super) struct ShardState {
     /// is not found, and the read falls through exactly as it did before this existed.
     #[serde(default)]
     pub(super) wal_resident_pages: BTreeMap<u64, WalResidentPage>,
+    /// Routing buckets whose derived runtime flags may be stale, so a write can refresh the
+    /// buckets it touched instead of sweeping the shard.
+    ///
+    /// `refresh_bucket_runtime_flags` recomputes `in_memory` / `deleted` / `dirty` / `ttl_ms` /
+    /// `layout` for EVERY bucket, and the single-write path called it on every write. Each bucket
+    /// costs `O(its pages)`, so the sweep is `O(total pages)` per write and ingestion is quadratic
+    /// in the corpus. Note that the routing-slot range does not soften this: fewer slots means
+    /// fewer, larger buckets and the same total page count.
+    ///
+    /// Recorded where the routing bucket is already known -- the bucket-index upsert, the removal
+    /// paths, and the async dirty mark -- rather than inferred from the key, because a stored
+    /// address may carry an explicit routing bucket that disagrees with `page_routing_bucket`.
+    ///
+    /// Not persisted: on load this is empty, and every load and recovery path already runs the
+    /// full sweep, so a fresh process starts from fully recomputed flags.
+    #[serde(skip)]
+    pub(super) buckets_pending_flag_refresh: BTreeSet<u32>,
     /// Deadlines, kept in key order so a sweep can resume from its cursor and look at the
     /// window rather than at everything.
     pub(super) expires_at_ms: BTreeMap<String, u64>,

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -285,6 +285,22 @@ pub(super) struct CoreIndex {
     pub(super) object_page_lookup: ObjectPageLookup,
     #[serde(default)]
     pub(super) object_component_lookup: ObjectComponentLookup,
+    /// Running total of page refs across `object_component_lookup`, or `None` when not known.
+    ///
+    /// The stats path reports this number, and computing it as
+    /// `object_component_lookup.values().map(BTreeSet::len).sum()` walks every object in the
+    /// shard. That runs on a TIMER -- the server heartbeat, every 3s by default -- while holding
+    /// the shard read lock that writers need, so its cost grows with the store and lands on the
+    /// write path as lock contention. Measured on a 200k-record ingest in five equal phases: with
+    /// the heartbeat at 1s the last phase cost 3.0x the first and the datanode's own CPU grew
+    /// 3.3-3.7x; with the heartbeat off, 0.84-0.94x -- flat.
+    ///
+    /// Maintained by the two methods below, which are the only places the lookup is mutated, and
+    /// recomputed by `rebuild_object_page_lookup`. `None` means "not established yet" (a
+    /// freshly deserialized index, before any rebuild) and the reader falls back to the walk,
+    /// so a missing value costs time rather than correctness.
+    #[serde(skip)]
+    pub(super) object_component_page_refs: Option<usize>,
 }
 
 pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
@@ -359,6 +375,9 @@ pub(super) struct PageIndex {
 
 impl CoreIndex {
     pub(super) fn rebuild_object_page_lookup(&mut self) {
+        // The rebuild is already O(pages); establishing the total here costs nothing extra and
+        // is what lets the stats path stop walking the shard.
+        self.object_component_page_refs = Some(0);
         self.object_page_lookup.clear();
         self.object_component_lookup.clear();
         let refs = self
@@ -395,7 +414,8 @@ impl CoreIndex {
                 routing_bucket,
                 page_ref_key: page_ref_key.clone(),
             });
-        self.object_component_lookup
+        let added = self
+            .object_component_lookup
             .entry(object_component_lookup_key(
                 &page.model_id,
                 &page.object_key,
@@ -406,6 +426,11 @@ impl CoreIndex {
                 routing_bucket,
                 page_ref_key,
             });
+        if added {
+            if let Some(total) = self.object_component_page_refs.as_mut() {
+                *total = total.saturating_add(1);
+            }
+        }
     }
 
     pub(super) fn remove_object_page_lookup_entry(
@@ -418,7 +443,14 @@ impl CoreIndex {
             .remove(&object_page_lookup_key(model_id, object_key, component));
         let component_lookup_key = object_component_lookup_key(model_id, object_key);
         if let Some(component_refs) = self.object_component_lookup.get_mut(&component_lookup_key) {
+            let before = component_refs.len();
             component_refs.retain(|page_ref| page_ref.component.as_deref() != component);
+            let removed = before - component_refs.len();
+            if removed > 0 {
+                if let Some(total) = self.object_component_page_refs.as_mut() {
+                    *total = total.saturating_sub(removed);
+                }
+            }
             if component_refs.is_empty() {
                 self.object_component_lookup.remove(&component_lookup_key);
             }

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1261,7 +1261,7 @@ pub(super) fn upsert_bucket_index_page(
                 {
                     bucket.object_index.remove(&removed_object_id);
                 }
-                update_bucket_layout(bucket);
+                classify_bucket_layout_in_place(bucket);
             }
         }
     } else if !lookup_enabled {
@@ -1280,7 +1280,7 @@ pub(super) fn upsert_bucket_index_page(
             {
                 bucket.object_index.remove(&object_id);
             }
-            update_bucket_layout(bucket);
+            classify_bucket_layout_in_place(bucket);
         }
     }
     let page_ref_key = page_index_ref_key(&entry);
@@ -1314,7 +1314,7 @@ pub(super) fn upsert_bucket_index_page(
         bucket.object_index.insert(object_id);
         bucket.page_index
             .insert(page_ref_key.clone(), page_index.clone());
-        update_bucket_layout(bucket);
+        classify_bucket_layout_in_place(bucket);
         touched_buckets.push(routing_bucket);
     }
     shard
@@ -1471,6 +1471,20 @@ pub(super) fn bucket_layout_name(layout: BucketLayoutState) -> &'static str {
     }
 }
 
+/// Re-derive only the layout label, taking `object_index` as already correct.
+///
+/// `update_bucket_layout` rebuilds that set by scanning every page in the bucket. On the write
+/// path the scan is redundant: an insert has just added its object id and a removal has just
+/// dropped one, so the scan re-derives what is already stored -- and being the last pass without
+/// a short-circuit, it is the whole of what makes a write cost more as the store grows.
+///
+/// `bucket_object_index_already_matches_a_from_scratch_recompute` holds that invariant across
+/// inserts, superseding overwrites, expiries and deletes. Reconstruct paths, which build
+/// `bucket_map` from page entries where nothing maintained the set, keep the full rebuild.
+fn classify_bucket_layout_in_place(bucket: &mut BucketNode) {
+    bucket.layout = classify_bucket_layout(bucket.object_index.len(), bucket.page_index.len());
+}
+
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
     note_site(&bucket_visit_sites::LAYOUT, bucket.page_index.len());
     let live_object_ids: BTreeSet<u64> = bucket
@@ -1497,29 +1511,60 @@ pub(super) fn note_bucket_flags_stale(shard: &mut ShardState, routing_bucket: u3
 }
 
 /// Recompute one bucket's derived flags. The whole body of the sweep, for a single bucket.
+///
+/// `rebuild_object_index` decides whether the live-object set is recomputed by scanning every
+/// page, or taken as already correct and only re-classified.
+///
+/// The mutation sites maintain that set themselves -- a page insert adds its object id, a removal
+/// drops the id once no live page carries it -- so on the write path the scan finds exactly what
+/// is already stored and is pure overhead. It is also the LAST guaranteed full pass in bucket
+/// maintenance (`deleted` and `dirty` both short-circuit; the TTL pass is skipped when nothing
+/// expires), so it is the whole of what still scales with the corpus.
+///
+/// The load, recovery and reconstruct paths are a different matter: they rebuild `bucket_map`
+/// from page entries, where the set has NOT been maintained and must be derived. Those keep the
+/// scan. `bucket_object_index_already_matches_a_from_scratch_recompute` is the evidence for
+/// dropping it everywhere else.
 fn refresh_one_bucket_runtime_flags(
     bucket: &mut BucketNode,
     now: u64,
     dirty_objects: &BTreeSet<String>,
     expires_at_ms: &BTreeMap<String, u64>,
+    rebuild_object_index: bool,
 ) {
-    note_site(&bucket_visit_sites::REFRESH_FLAGS, bucket.page_index.len());
     bucket.meta_loaded = true;
     bucket.loading = false;
     bucket.in_memory = !bucket.page_index.is_empty();
+    // `all` and `any` stop at the first page that decides the answer, so neither is a reliable
+    // full pass; during ingest the dirty check in particular answers on page one.
     bucket.deleted =
         !bucket.page_index.is_empty() && bucket.page_index.values().all(|page| page.deleted);
     bucket.dirty |= bucket
         .page_index
         .values()
         .any(|page| page.dirty || dirty_objects.contains(&page.object_key));
-    bucket.ttl_ms = bucket
-        .page_index
-        .values()
-        .filter_map(|page| expires_at_ms.get(&page.object_key).copied())
-        .map(|expires_at| expires_at.saturating_sub(now))
-        .min();
-    update_bucket_layout(bucket);
+    // The TTL is the one guaranteed full pass: a minimum has to look at every page, and each
+    // look is a map lookup keyed by the page's object key. When nothing in the shard has an
+    // expiry that whole pass is dead work -- the minimum over an empty selection is None, which
+    // is exactly what the field already holds. A store that never sets a TTL is the common case
+    // for bulk ingest, and this is where its per-bucket cost was going.
+    if expires_at_ms.is_empty() {
+        bucket.ttl_ms = None;
+    } else {
+        note_site(&bucket_visit_sites::REFRESH_FLAGS, bucket.page_index.len());
+        bucket.ttl_ms = bucket
+            .page_index
+            .values()
+            .filter_map(|page| expires_at_ms.get(&page.object_key).copied())
+            .map(|expires_at| expires_at.saturating_sub(now))
+            .min();
+    }
+    if rebuild_object_index {
+        update_bucket_layout(bucket);
+    } else {
+        bucket.layout =
+            classify_bucket_layout(bucket.object_index.len(), bucket.page_index.len());
+    }
 }
 
 /// Refresh EVERY bucket in the shard. `O(total pages)`.
@@ -1529,9 +1574,21 @@ fn refresh_one_bucket_runtime_flags(
 /// [`refresh_pending_bucket_runtime_flags`] instead -- this sweep on every write is what made
 /// ingestion quadratic in the corpus.
 pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
+    refresh_all_bucket_runtime_flags(shard, true);
+}
+
+/// The sweep, with the object-index rebuild made optional. See
+/// [`refresh_one_bucket_runtime_flags`] for when it can be skipped.
+fn refresh_all_bucket_runtime_flags(shard: &mut ShardState, rebuild_object_index: bool) {
     let now = now_ms();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
-        refresh_one_bucket_runtime_flags(bucket, now, &shard.dirty_objects, &shard.expires_at_ms);
+        refresh_one_bucket_runtime_flags(
+            bucket,
+            now,
+            &shard.dirty_objects,
+            &shard.expires_at_ms,
+            rebuild_object_index,
+        );
     }
     // The sweep covered everything, so nothing is left outstanding.
     shard.buckets_pending_flag_refresh.clear();
@@ -1562,7 +1619,8 @@ pub(super) fn refresh_pending_bucket_runtime_flags(shard: &mut ShardState) {
     // this guard hands the work back to the sweep, which is where it belongs.
     let bucket_count = shard.bucket_index.bucket_map.len();
     if shard.buckets_pending_flag_refresh.len().saturating_mul(2) >= bucket_count {
-        refresh_bucket_runtime_flags(shard);
+        // Still the write path, so the object-index scan stays off; only the traversal changes.
+        refresh_all_bucket_runtime_flags(shard, false);
         return;
     }
     let now = now_ms();
@@ -1571,7 +1629,13 @@ pub(super) fn refresh_pending_bucket_runtime_flags(shard: &mut ShardState) {
         let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&routing_bucket) else {
             continue;
         };
-        refresh_one_bucket_runtime_flags(bucket, now, &shard.dirty_objects, &shard.expires_at_ms);
+        refresh_one_bucket_runtime_flags(
+            bucket,
+            now,
+            &shard.dirty_objects,
+            &shard.expires_at_ms,
+            false,
+        );
     }
 }
 

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1547,6 +1547,24 @@ pub(super) fn refresh_pending_bucket_runtime_flags(shard: &mut ShardState) {
     if shard.buckets_pending_flag_refresh.is_empty() {
         return;
     }
+    // Refreshing bucket-by-bucket costs a map lookup each, where the full sweep is one ordered
+    // pass. That only pays while the touched set is a small share of the shard's buckets.
+    //
+    // It is not always small. With a wide routing range every key lands in its own bucket, so a
+    // batch touches a few hundred of millions and the targeted path wins outright. With a narrow
+    // range -- `TS_SHARD_END_ROUTING_SLOT=1023`, the setting that cuts resident memory 45% and is
+    // the one to run in production -- there are only 1024 buckets and a 500-command batch hashes
+    // across essentially all of them. The targeted path then visits exactly the same pages as the
+    // sweep and adds a lookup per bucket on top: measured 1.6-2.2x SLOWER over 200k and 400k
+    // records, in four runs out of four.
+    //
+    // So choose. Measured at default slots the targeted path is 1.3-2.7x faster; at 1023 slots
+    // this guard hands the work back to the sweep, which is where it belongs.
+    let bucket_count = shard.bucket_index.bucket_map.len();
+    if shard.buckets_pending_flag_refresh.len().saturating_mul(2) >= bucket_count {
+        refresh_bucket_runtime_flags(shard);
+        return;
+    }
     let now = now_ms();
     let pending = std::mem::take(&mut shard.buckets_pending_flag_refresh);
     for routing_bucket in pending {

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -838,6 +838,7 @@ pub(super) fn mark_async_dirty_object(
         });
     bucket.dirty = true;
     bucket.dirty_generation = bucket.dirty_generation.saturating_add(1).max(1);
+    note_bucket_flags_stale(shard, routing_bucket);
 }
 
 pub(super) fn rebuild_bucket_page_ownership(
@@ -1220,6 +1221,9 @@ pub(super) fn upsert_bucket_index_page(
         dirty,
         deleted: false,
     };
+    // Buckets whose pages this upsert disturbs. Collected while the bucket borrows are live and
+    // recorded once they end, so the per-write refresh can skip the rest of the shard.
+    let mut touched_buckets: Vec<u32> = Vec::new();
     let lookup_enabled = !shard.bucket_index.object_page_lookup.is_empty();
     let direct_page_refs = if lookup_enabled {
         shard
@@ -1244,6 +1248,7 @@ pub(super) fn upsert_bucket_index_page(
             let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&page_ref.routing_bucket) else {
                 continue;
             };
+            touched_buckets.push(page_ref.routing_bucket);
             let removed_object_id = bucket
                 .page_index
                 .remove(&page_ref.page_ref_key)
@@ -1260,8 +1265,9 @@ pub(super) fn upsert_bucket_index_page(
             }
         }
     } else if !lookup_enabled {
-        for bucket in shard.bucket_index.bucket_map.values_mut() {
+        for (routing_bucket, bucket) in shard.bucket_index.bucket_map.iter_mut() {
             note_site(&bucket_visit_sites::REMOVE_ALL_BUCKETS, bucket.page_index.len());
+            touched_buckets.push(*routing_bucket);
             bucket.page_index.retain(|_, page| {
                 !(page.object_key == entry.object_key
                     && page.model_id == entry.kind
@@ -1309,10 +1315,12 @@ pub(super) fn upsert_bucket_index_page(
         bucket.page_index
             .insert(page_ref_key.clone(), page_index.clone());
         update_bucket_layout(bucket);
+        touched_buckets.push(routing_bucket);
     }
     shard
         .bucket_index
         .insert_object_page_lookup(routing_bucket, page_ref_key, &page_index);
+    shard.buckets_pending_flag_refresh.extend(touched_buckets);
 }
 
 pub(super) fn sync_bucket_index_object_pages(
@@ -1479,26 +1487,73 @@ pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
     bucket.layout = classify_bucket_layout(bucket.object_index.len(), bucket.page_index.len());
 }
 
+/// Note that a bucket's derived runtime flags may be stale.
+///
+/// Called where the routing bucket is already in hand. Recording it is cheap; the alternative --
+/// deriving it from the object key later -- is not sound, because a stored address may carry an
+/// explicit routing bucket that disagrees with `page_routing_bucket`.
+pub(super) fn note_bucket_flags_stale(shard: &mut ShardState, routing_bucket: u32) {
+    shard.buckets_pending_flag_refresh.insert(routing_bucket);
+}
+
+/// Recompute one bucket's derived flags. The whole body of the sweep, for a single bucket.
+fn refresh_one_bucket_runtime_flags(
+    bucket: &mut BucketNode,
+    now: u64,
+    dirty_objects: &BTreeSet<String>,
+    expires_at_ms: &BTreeMap<String, u64>,
+) {
+    note_site(&bucket_visit_sites::REFRESH_FLAGS, bucket.page_index.len());
+    bucket.meta_loaded = true;
+    bucket.loading = false;
+    bucket.in_memory = !bucket.page_index.is_empty();
+    bucket.deleted =
+        !bucket.page_index.is_empty() && bucket.page_index.values().all(|page| page.deleted);
+    bucket.dirty |= bucket
+        .page_index
+        .values()
+        .any(|page| page.dirty || dirty_objects.contains(&page.object_key));
+    bucket.ttl_ms = bucket
+        .page_index
+        .values()
+        .filter_map(|page| expires_at_ms.get(&page.object_key).copied())
+        .map(|expires_at| expires_at.saturating_sub(now))
+        .min();
+    update_bucket_layout(bucket);
+}
+
+/// Refresh EVERY bucket in the shard. `O(total pages)`.
+///
+/// Correct everywhere and the right thing after a load, a recovery or a reconstruct, where the
+/// set of changed buckets is not known. On the per-write path use
+/// [`refresh_pending_bucket_runtime_flags`] instead -- this sweep on every write is what made
+/// ingestion quadratic in the corpus.
 pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
     let now = now_ms();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
-        note_site(&bucket_visit_sites::REFRESH_FLAGS, bucket.page_index.len());
-        bucket.meta_loaded = true;
-        bucket.loading = false;
-        bucket.in_memory = !bucket.page_index.is_empty();
-        bucket.deleted =
-            !bucket.page_index.is_empty() && bucket.page_index.values().all(|page| page.deleted);
-        bucket.dirty |= bucket
-            .page_index
-            .values()
-            .any(|page| page.dirty || shard.dirty_objects.contains(&page.object_key));
-        bucket.ttl_ms = bucket
-            .page_index
-            .values()
-            .filter_map(|page| shard.expires_at_ms.get(&page.object_key).copied())
-            .map(|expires_at| expires_at.saturating_sub(now))
-            .min();
-        update_bucket_layout(bucket);
+        refresh_one_bucket_runtime_flags(bucket, now, &shard.dirty_objects, &shard.expires_at_ms);
+    }
+    // The sweep covered everything, so nothing is left outstanding.
+    shard.buckets_pending_flag_refresh.clear();
+}
+
+/// Refresh only the buckets recorded as touched, and clear the record.
+///
+/// Equivalent to the full sweep for the buckets that changed; an untouched bucket's flags are a
+/// function of its own pages plus the two shard-wide maps, and both of those are noted against the
+/// buckets they affect. `bucket_runtime_flags_match_full_sweep` in the engine tests checks that
+/// equivalence against a real workload rather than leaving it as an argument.
+pub(super) fn refresh_pending_bucket_runtime_flags(shard: &mut ShardState) {
+    if shard.buckets_pending_flag_refresh.is_empty() {
+        return;
+    }
+    let now = now_ms();
+    let pending = std::mem::take(&mut shard.buckets_pending_flag_refresh);
+    for routing_bucket in pending {
+        let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&routing_bucket) else {
+            continue;
+        };
+        refresh_one_bucket_runtime_flags(bucket, now, &shard.dirty_objects, &shard.expires_at_ms);
     }
 }
 

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -777,6 +777,38 @@ fn note_bucket_page_visits(count: usize) {
     BUCKET_PAGE_INDEX_VISITS.fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Per-site attribution for [`BUCKET_PAGE_INDEX_VISITS`], so a scaling result names the walk that
+/// caused it rather than leaving it to be inferred from arithmetic.
+pub mod bucket_visit_sites {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub(super) static LAYOUT: AtomicU64 = AtomicU64::new(0);
+    pub(super) static CLEAR_DIRTY: AtomicU64 = AtomicU64::new(0);
+    pub(super) static REFRESH_FLAGS: AtomicU64 = AtomicU64::new(0);
+    pub(super) static REMOVE_ALL_BUCKETS: AtomicU64 = AtomicU64::new(0);
+
+    /// `(layout, clear_dirty, refresh_flags, remove_all_buckets)` visits since the last reset.
+    pub fn snapshot() -> (u64, u64, u64, u64) {
+        (
+            LAYOUT.load(Ordering::Relaxed),
+            CLEAR_DIRTY.load(Ordering::Relaxed),
+            REFRESH_FLAGS.load(Ordering::Relaxed),
+            REMOVE_ALL_BUCKETS.load(Ordering::Relaxed),
+        )
+    }
+
+    pub fn reset() {
+        for counter in [&LAYOUT, &CLEAR_DIRTY, &REFRESH_FLAGS, &REMOVE_ALL_BUCKETS] {
+            counter.store(0, Ordering::Relaxed);
+        }
+    }
+}
+
+fn note_site(site: &std::sync::atomic::AtomicU64, count: usize) {
+    site.fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
+    note_bucket_page_visits(count);
+}
+
 pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
     let entries = if !shard.bucket_index.bucket_map.is_empty() {
         collect_bucket_index_live_page_entries(shard)
@@ -1229,6 +1261,7 @@ pub(super) fn upsert_bucket_index_page(
         }
     } else if !lookup_enabled {
         for bucket in shard.bucket_index.bucket_map.values_mut() {
+            note_site(&bucket_visit_sites::REMOVE_ALL_BUCKETS, bucket.page_index.len());
             bucket.page_index.retain(|_, page| {
                 !(page.object_key == entry.object_key
                     && page.model_id == entry.kind
@@ -1431,7 +1464,7 @@ pub(super) fn bucket_layout_name(layout: BucketLayoutState) -> &'static str {
 }
 
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
-    note_bucket_page_visits(bucket.page_index.len());
+    note_site(&bucket_visit_sites::LAYOUT, bucket.page_index.len());
     let live_object_ids: BTreeSet<u64> = bucket
         .page_index
         .values()
@@ -1449,6 +1482,7 @@ pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
 pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
     let now = now_ms();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
+        note_site(&bucket_visit_sites::REFRESH_FLAGS, bucket.page_index.len());
         bucket.meta_loaded = true;
         bucket.loading = false;
         bucket.in_memory = !bucket.page_index.is_empty();
@@ -1491,7 +1525,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
     }
     shard.dirty_objects.remove(object_key);
     for bucket in shard.bucket_index.bucket_map.values_mut() {
-        note_bucket_page_visits(bucket.page_index.len());
+        note_site(&bucket_visit_sites::CLEAR_DIRTY, bucket.page_index.len());
         let mut touched = false;
         for page in bucket.page_index.values_mut() {
             if page.object_key == object_key {
@@ -1500,7 +1534,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
             }
         }
         if touched {
-            note_bucket_page_visits(bucket.page_index.len());
+            note_site(&bucket_visit_sites::CLEAR_DIRTY, bucket.page_index.len());
             bucket.dirty = bucket
                 .page_index
                 .values()

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -754,6 +754,29 @@ pub fn reset_live_page_scan_entries() {
     LIVE_PAGE_SCAN_ENTRIES.store(0, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Running total of bucket `page_index` entries visited by the bucket-maintenance walks.
+///
+/// Distinct from [`LIVE_PAGE_SCAN_ENTRIES`], which counts materialized live-page entries. This
+/// one counts the cheaper-looking `bucket.page_index.values()` passes -- `update_bucket_layout`
+/// and the per-object dirty-state clear. Each is `O(pages in the bucket)` and they run inside
+/// loops over buckets, so their cost is a product, not a sum, and does not show up in any single
+/// obvious place.
+static BUCKET_PAGE_INDEX_VISITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Bucket `page_index` entries visited since the last reset.
+pub fn bucket_page_index_visits() -> u64 {
+    BUCKET_PAGE_INDEX_VISITS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Reset the bucket-visit counter. For tests measuring one operation's maintenance volume.
+pub fn reset_bucket_page_index_visits() {
+    BUCKET_PAGE_INDEX_VISITS.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn note_bucket_page_visits(count: usize) {
+    BUCKET_PAGE_INDEX_VISITS.fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
+}
+
 pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
     let entries = if !shard.bucket_index.bucket_map.is_empty() {
         collect_bucket_index_live_page_entries(shard)
@@ -1408,6 +1431,7 @@ pub(super) fn bucket_layout_name(layout: BucketLayoutState) -> &'static str {
 }
 
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
+    note_bucket_page_visits(bucket.page_index.len());
     let live_object_ids: BTreeSet<u64> = bucket
         .page_index
         .values()
@@ -1467,6 +1491,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
     }
     shard.dirty_objects.remove(object_key);
     for bucket in shard.bucket_index.bucket_map.values_mut() {
+        note_bucket_page_visits(bucket.page_index.len());
         let mut touched = false;
         for page in bucket.page_index.values_mut() {
             if page.object_key == object_key {
@@ -1475,6 +1500,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
             }
         }
         if touched {
+            note_bucket_page_visits(bucket.page_index.len());
             bucket.dirty = bucket
                 .page_index
                 .values()

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -226,6 +226,9 @@ impl TemporalEngine {
             }
         }
         let mut mutated_any = false;
+        // Set if any command in this batch rebuilt the bucket index, which invalidates the
+        // per-batch record of touched buckets and forces the full sweep below.
+        let mut rebuilt_bucket_index = false;
         let mut wal_commands = Vec::new();
         // Accumulate the object keys every mutating command in the batch touched, for the
         // single O(delta) index-log append below (delta path). Empty when the flag is off.
@@ -346,6 +349,9 @@ impl TemporalEngine {
                         start_routing_bucket,
                         end_routing_bucket,
                     );
+                    // The rebuild replaced bucket_map wholesale, so the record of which buckets
+                    // this batch touched no longer describes it.
+                    rebuilt_bucket_index = true;
                 }
                 if write_command {
                     wal_commands.push(command_for_post_write);
@@ -357,7 +363,14 @@ impl TemporalEngine {
             });
         }
         if mutated_any {
-            refresh_bucket_runtime_flags(shard);
+            if rebuilt_bucket_index {
+                refresh_bucket_runtime_flags(shard);
+            } else {
+                // Refresh only the buckets this batch disturbed. The full sweep is
+                // O(total pages), so running it per batch left bulk ingest quadratic in the
+                // corpus -- with a smaller constant than the per-write sweep, but the same shape.
+                refresh_pending_bucket_runtime_flags(shard);
+            }
             // Every write records a WAL entry before any page is written. async_storage only
             // changes whether the commit BLOCKS: sync -> fsync, async (or bulk backfill) ->
             // buffered, no fsync (a fire-and-forget commit).

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3499,6 +3499,106 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
     }
 }
 
+/// The same, for the batch path -- which is the one bulk ingest actually runs.
+///
+/// `batch_execute` swept every bucket once per batch rather than once per write. That is a much
+/// smaller constant than the per-write sweep, but the same `O(total pages)` shape, so a bulk
+/// import still paid for the whole corpus on every batch. Measured per BATCH, and the flags are
+/// compared against a full sweep for the same reason as the single-write case: a bucket left
+/// stale-false in `dirty` never gets flushed.
+#[test]
+fn batch_bucket_maintenance_does_not_grow_with_the_store() {
+    const BATCH: usize = 32;
+    const MEASURED_BATCHES: usize = 5;
+
+    fn visits_per_batch(object_count: usize) -> (f64, usize) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..object_count {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("batch-fill-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        crate::engine::reset_bucket_page_index_visits();
+        for batch in 0..MEASURED_BATCHES {
+            let commands = (0..BATCH)
+                .map(|item| Command::StringSet {
+                    key: format!("batch-measured-{batch}-{item}"),
+                    value: vec![b'v'; 64],
+                })
+                .collect();
+            engine.batch_execute(BatchExecuteRequest {
+                shard_id: 1,
+                commands,
+            });
+        }
+        let visited = crate::engine::bucket_page_index_visits();
+
+        // Same equivalence requirement as the single-write path: sweeping afterwards must not
+        // move anything the targeted refresh already settled.
+        let snapshot = |engine: &TemporalEngine| {
+            let shards = engine.shards.read().expect("shards lock poisoned");
+            let shard = shards.get(&1).expect("shard 1 loaded");
+            shard
+                .bucket_index
+                .bucket_map
+                .iter()
+                .map(|(id, bucket)| {
+                    (
+                        *id,
+                        (
+                            bucket.in_memory,
+                            bucket.deleted,
+                            bucket.dirty,
+                            format!("{:?}", bucket.layout),
+                            bucket.object_index.iter().copied().collect::<Vec<_>>(),
+                        ),
+                    )
+                })
+                .collect::<std::collections::BTreeMap<_, _>>()
+        };
+        let before_sweep = snapshot(&engine);
+        {
+            let mut shards = engine.shards.write().expect("shards lock poisoned");
+            let shard = shards.get_mut(&1).expect("shard 1 loaded");
+            crate::engine::storage_bucket_internals::refresh_bucket_runtime_flags(shard);
+        }
+        let after_sweep = snapshot(&engine);
+        assert_eq!(
+            before_sweep, after_sweep,
+            "batch targeted refresh disagreed with a full sweep at {object_count} objects"
+        );
+
+        (visited as f64 / MEASURED_BATCHES as f64, before_sweep.len())
+    }
+
+    let (small, small_buckets) = visits_per_batch(200);
+    let (large, large_buckets) = visits_per_batch(800);
+    println!(
+        "
+  200 objects -> {small:>9.1} page-index visits per {BATCH}-command batch ({small_buckets} buckets)
+           800 objects -> {large:>9.1} page-index visits per {BATCH}-command batch ({large_buckets} buckets)
+           growth: {:.2}x cost for 4x the corpus
+",
+        if small > 0.0 { large / small } else { 0.0 }
+    );
+
+    assert!(
+        large <= small * 1.5 + 1.0,
+        "per-batch bucket maintenance grew with the store: {small:.1} -> {large:.1}          visits/batch for 200 -> 800 objects"
+    );
+}
+
 /// The per-write targeted refresh must leave the same flags as sweeping the whole shard.
 ///
 /// The write path refreshes only the buckets it recorded as touched. That is only correct if a

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3741,6 +3741,100 @@ fn bucket_runtime_flags_match_full_sweep() {
     );
 }
 
+/// The flat per-write cost holds only while a batch touches a SMALL SHARE of the buckets.
+///
+/// This is the limitation the sibling tests cannot see, because they run at the default routing
+/// range where every key lands in its own bucket: a write touches one bucket of many, the
+/// targeted refresh skips the rest, and cost is flat.
+///
+/// Narrow the range -- `TS_SHARD_END_ROUTING_SLOT=1023`, the setting that cuts resident memory
+/// 45% and the one to run in production -- and there are only 1024 buckets. A batch of any size
+/// hashes across essentially all of them, so there is nothing to skip: the targeted path visits
+/// the same pages as the sweep and the guard correctly hands the work back to the sweep, which is
+/// `O(total pages)` per batch. Bucket maintenance is therefore STILL linear per write there.
+///
+/// Measured end to end at 1023 slots, five equal 40k-record phases: 6.3s -> 14.9s while every
+/// byte written stayed flat (index log 1.02x, WAL 1.01x). At the default range the same run grows
+/// 1.64x. The remedy is not to choose a path but to stop rescanning: keep each bucket's live-page
+/// count, dirty-page count and minimum TTL incrementally, so refreshing a bucket is O(1) and the
+/// range stops mattering.
+///
+/// This test PINS the current behaviour so the limitation is visible and a future fix has
+/// something to flip, rather than living only in a commit message.
+#[test]
+fn bucket_maintenance_is_still_linear_at_a_narrow_routing_range() {
+    fn visits_per_write(object_count: usize) -> f64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        // The range travels on the load request, NOT the environment: the datanode binary reads
+        // TS_SHARD_*_ROUTING_SLOT and puts it here. Setting those vars around a bare
+        // `load_shard` leaves the shard on the u32::MAX default, and this test then silently
+        // measures the wide range and agrees with its sibling -- which is exactly what the first
+        // version of it did.
+        assert!(
+            engine
+                .load_shard_with(crate::control::LoadShardRequest {
+                    shard_id: 1,
+                    table_name: "narrow-routing".to_string(),
+                    shard_uri: "local://narrow-routing/1".to_string(),
+                    start_routing_bucket: 0,
+                    end_routing_bucket: 63,
+                    readonly: false,
+                    load_version: 1,
+                    local_node_id: Some(1),
+                })
+                .status
+                .ok
+        );
+        for index in 0..object_count {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("narrow-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        const MEASURED_WRITES: usize = 20;
+        crate::engine::reset_bucket_page_index_visits();
+        for index in 0..MEASURED_WRITES {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("narrow-measured-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let visited = crate::engine::bucket_page_index_visits();
+        visited as f64 / MEASURED_WRITES as f64
+    }
+
+    let small = visits_per_write(200);
+    let large = visits_per_write(800);
+    println!(
+        "
+  64 routing slots:
+    200 objects -> {small:>8.1} page-index visits per write
+             800 objects -> {large:>8.1} page-index visits per write
+             growth: {:.2}x for 4x the corpus (flat would be 1.00)
+",
+        if small > 0.0 { large / small } else { 0.0 }
+    );
+
+    // Documents the gap rather than asserting it away: at a narrow range the cost still tracks
+    // the corpus. When per-bucket aggregates land this fails, and that is the point.
+    assert!(
+        large > small * 2.0,
+        "expected per-write cost to still grow with the corpus at 64 routing slots          ({small:.1} -> {large:.1}); if this now holds flat, the aggregate work landed and this          test should become an equality check"
+    );
+}
+
 /// Bucket maintenance must not make a write cost more as the store grows.
 ///
 /// `update_bucket_layout` rebuilds a bucket's whole object set from `page_index`, and the

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3741,7 +3741,135 @@ fn bucket_runtime_flags_match_full_sweep() {
     );
 }
 
-/// The flat per-write cost holds only while a batch touches a SMALL SHARE of the buckets.
+/// Every bucket's `object_index` must already equal a from-scratch recompute.
+///
+/// `update_bucket_layout` rebuilds that set by scanning all of a bucket's pages, with no
+/// short-circuit -- it is the remaining guaranteed full pass in bucket maintenance, and the whole
+/// of what still scales with the corpus once the TTL pass is skipped.
+///
+/// The rebuild looks redundant: the mutation sites already maintain the set, inserting an
+/// object id when a page is added and removing it when the last live page for it goes. If that
+/// invariant genuinely holds, refreshing a bucket never needs the scan and can classify from the
+/// two lengths it already has.
+///
+/// This is the evidence for that "if". It runs a workload that exercises inserts, overwrites that
+/// supersede a page, hash fields, expiries and deletes, then recomputes the live-object set from
+/// each bucket's pages and requires it to match what is stored. A mutation site that fails to
+/// maintain the set shows up here as a named mismatch -- which is what makes dropping the scan
+/// safe rather than hopeful.
+#[test]
+fn bucket_object_index_already_matches_a_from_scratch_recompute() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    assert!(
+        engine
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 1,
+                table_name: "object-index-invariant".to_string(),
+                shard_uri: "local://object-index-invariant/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 63,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+    for index in 0..150 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("inv-str-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("inv-hash-{}", index % 11),
+                field: format!("f-{index}"),
+                value: vec![b'h'; 32],
+            },
+        });
+        if index % 3 == 0 {
+            // Supersede an existing page: this is the path that removes page refs.
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("inv-str-{}", index / 2),
+                    value: vec![b'w'; 96],
+                },
+            });
+        }
+        if index % 7 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonExpire {
+                    key: format!("inv-str-{index}"),
+                    ttl_ms: 60_000,
+                },
+            });
+        }
+        if index % 9 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("inv-str-{}", index / 4),
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let mut checked = 0usize;
+    let mut mismatches = Vec::new();
+    for (routing_bucket, bucket) in shard.bucket_index.bucket_map.iter() {
+        let recomputed: std::collections::BTreeSet<u64> = bucket
+            .page_index
+            .values()
+            .filter(|page| !page.deleted)
+            .map(|page| page.object_id)
+            .collect();
+        // Mirrors update_bucket_layout: an empty live set over an empty page index leaves the
+        // stored set untouched, so only compare where the rebuild would actually assign.
+        if recomputed.is_empty() && bucket.page_index.is_empty() {
+            continue;
+        }
+        checked += 1;
+        let expected = if recomputed.is_empty() {
+            std::collections::BTreeSet::new()
+        } else {
+            recomputed
+        };
+        if bucket.object_index != expected {
+            mismatches.push(format!(
+                "  bucket {routing_bucket}: stored {:?} != recomputed {:?}",
+                bucket.object_index, expected
+            ));
+        }
+    }
+    assert!(checked > 0, "workload produced no buckets to check");
+    assert!(
+        mismatches.is_empty(),
+        "object_index is NOT maintained incrementally by {} of {checked} bucket(s), so the          layout rebuild is load-bearing and cannot be dropped:
+{}",
+        mismatches.len(),
+        mismatches.join("
+")
+    );
+    println!("
+  {checked} buckets: stored object_index matches a from-scratch recompute
+");
+}
+
+/// Per-write cost must be flat at a NARROW routing range too, not only a wide one.
 ///
 /// This is the limitation the sibling tests cannot see, because they run at the default routing
 /// range where every key lands in its own bucket: a write touches one bucket of many, the
@@ -3759,10 +3887,14 @@ fn bucket_runtime_flags_match_full_sweep() {
 /// count, dirty-page count and minimum TTL incrementally, so refreshing a bucket is O(1) and the
 /// range stops mattering.
 ///
-/// This test PINS the current behaviour so the limitation is visible and a future fix has
-/// something to flip, rather than living only in a commit message.
+/// Counted at 64 slots as each pass came off: 12.6 -> 39.0 (3.10x), then 8.4 -> 26.0 after
+/// skipping the TTL pass when nothing expires, then 4.2 -> 13.0 once the refresh classifies
+/// instead of rescanning, then flat once the upsert does too. Only the last changed the SHAPE,
+/// because rebuilding the live-object set is the one pass with no short-circuit: `deleted`
+/// stops at the first live page and `dirty` at the first dirty one, but that rebuild reads
+/// every page every time.
 #[test]
-fn bucket_maintenance_is_still_linear_at_a_narrow_routing_range() {
+fn bucket_maintenance_is_flat_at_a_narrow_routing_range() {
     fn visits_per_write(object_count: usize) -> f64 {
         let dir = tempfile::tempdir().unwrap();
         let engine = TemporalEngine::with_local_dirs(
@@ -3821,17 +3953,19 @@ fn bucket_maintenance_is_still_linear_at_a_narrow_routing_range() {
         "
   64 routing slots:
     200 objects -> {small:>8.1} page-index visits per write
-             800 objects -> {large:>8.1} page-index visits per write
-             growth: {:.2}x for 4x the corpus (flat would be 1.00)
-",
-        if small > 0.0 { large / small } else { 0.0 }
+    800 objects -> {large:>8.1} page-index visits per write
+"
     );
 
-    // Documents the gap rather than asserting it away: at a narrow range the cost still tracks
-    // the corpus. When per-bucket aggregates land this fails, and that is the point.
+    // An absolute bound, not a ratio: the work is meant to be independent of the corpus, and a
+    // ratio is undefined once it reaches zero. 4x the objects must not buy more than a constant.
     assert!(
-        large > small * 2.0,
-        "expected per-write cost to still grow with the corpus at 64 routing slots          ({small:.1} -> {large:.1}); if this now holds flat, the aggregate work landed and this          test should become an equality check"
+        large <= 2.0,
+        "per-write bucket maintenance should not scan pages at a narrow routing range, got {large:.1} visits/write at 800 objects (200 objects: {small:.1})"
+    );
+    assert!(
+        large <= small + 2.0,
+        "per-write bucket maintenance grew with the corpus at 64 routing slots: {small:.1} -> {large:.1} visits/write for 200 -> 800 objects"
     );
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3741,6 +3741,108 @@ fn bucket_runtime_flags_match_full_sweep() {
     );
 }
 
+/// The maintained page-ref total must equal the walk it replaced.
+///
+/// The stats path reports that number and used to derive it by summing every set in
+/// `object_component_lookup` -- a walk over every object in the shard, run on the heartbeat timer
+/// while holding the shard read lock writers need. Measured on a 200k-record ingest in five equal
+/// phases: heartbeat at 1s, the last phase cost 3.0x the first and the datanode's own CPU grew
+/// 3.3-3.7x; heartbeat off, 0.84-0.94x. Turning the timer off removed the growth entirely, which
+/// is what identified the walk rather than the write path.
+///
+/// It is now kept as a running total, so it can drift instead of merely being slow. This drives
+/// inserts, superseding overwrites that remove page refs, hash fields with components, expiries
+/// and deletes, then compares the maintained value against the sum it is meant to equal.
+#[test]
+fn maintained_component_page_ref_total_matches_the_walk() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    assert!(
+        engine
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 1,
+                table_name: "page-ref-total".to_string(),
+                shard_uri: "local://page-ref-total/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 63,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+    for index in 0..140 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("tot-str-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("tot-hash-{}", index % 9),
+                field: format!("f-{index}"),
+                value: vec![b'h'; 32],
+            },
+        });
+        if index % 3 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("tot-str-{}", index / 2),
+                    value: vec![b'w'; 96],
+                },
+            });
+        }
+        if index % 6 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonExpire {
+                    key: format!("tot-str-{index}"),
+                    ttl_ms: 60_000,
+                },
+            });
+        }
+        if index % 8 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("tot-str-{}", index / 4),
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let walked: usize = shard
+        .bucket_index
+        .object_component_lookup
+        .values()
+        .map(std::collections::BTreeSet::len)
+        .sum();
+    let maintained = shard
+        .bucket_index
+        .object_component_page_refs
+        .expect("the total should be established once the lookup has been built");
+    assert!(walked > 0, "workload produced no component page refs to compare");
+    assert_eq!(
+        maintained, walked,
+        "maintained component page-ref total drifted from the walk it replaces:          {maintained} vs {walked}"
+    );
+    println!("
+  component page refs: maintained {maintained} == walked {walked}
+");
+}
+
 /// Every bucket's `object_index` must already equal a from-scratch recompute.
 ///
 /// `update_bucket_layout` rebuilds that set by scanning all of a bucket's pages, with no

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3510,7 +3510,7 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
 /// machine, and it reports per-write cost so growth is visible rather than implied.
 #[test]
 fn bucket_maintenance_per_write_does_not_grow_with_the_store() {
-    fn visits_per_write(object_count: usize) -> (u64, f64) {
+    fn visits_per_write(object_count: usize) -> (u64, f64, (u64, u64, u64, u64)) {
         let dir = tempfile::tempdir().unwrap();
         let engine = TemporalEngine::with_local_dirs(
             1024 * 1024,
@@ -3531,6 +3531,7 @@ fn bucket_maintenance_per_write_does_not_grow_with_the_store() {
         }
         const MEASURED_WRITES: usize = 20;
         crate::engine::reset_bucket_page_index_visits();
+        crate::engine::bucket_visit_sites::reset();
         for index in 0..MEASURED_WRITES {
             engine.execute(ExecuteRequest {
                 shard_id: 1,
@@ -3541,19 +3542,31 @@ fn bucket_maintenance_per_write_does_not_grow_with_the_store() {
             });
         }
         let visited = crate::engine::bucket_page_index_visits();
-        (visited, visited as f64 / MEASURED_WRITES as f64)
+        let sites = crate::engine::bucket_visit_sites::snapshot();
+        (visited, visited as f64 / MEASURED_WRITES as f64, sites)
     }
 
-    let (small_total, small_each) = visits_per_write(200);
-    let (large_total, large_each) = visits_per_write(800);
+    let (small_total, small_each, small_sites) = visits_per_write(200);
+    let (large_total, large_each, large_sites) = visits_per_write(800);
 
+    let per = |value: u64| value as f64 / 20.0;
     println!(
         "
-  200 objects -> {small_total:>9} page-index visits for 20 writes ({small_each:>9.1} per write)
-           800 objects -> {large_total:>9} page-index visits for 20 writes ({large_each:>9.1} per write)
+  200 objects -> {small_total:>9} visits for 20 writes ({small_each:>9.1} per write)
+           800 objects -> {large_total:>9} visits for 20 writes ({large_each:>9.1} per write)
            growth: {:.2}x cost for 4x the corpus
+
+           per-write attribution      200 objects    800 objects
+             update_bucket_layout     {:>9.1}      {:>9.1}
+             clear_dirty (all bkts)   {:>9.1}      {:>9.1}
+             refresh_runtime_flags    {:>9.1}      {:>9.1}
+             remove (all bkts)        {:>9.1}      {:>9.1}
 ",
-        if small_each > 0.0 { large_each / small_each } else { 0.0 }
+        if small_each > 0.0 { large_each / small_each } else { 0.0 },
+        per(small_sites.0), per(large_sites.0),
+        per(small_sites.1), per(large_sites.1),
+        per(small_sites.2), per(large_sites.2),
+        per(small_sites.3), per(large_sites.3),
     );
 
     // 4x the corpus must not cost materially more PER WRITE. Allowed a little slack for

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3741,6 +3741,100 @@ fn bucket_runtime_flags_match_full_sweep() {
     );
 }
 
+/// The dirty-bucket count must equal the answer the unshortened scan would give.
+///
+/// The stats path counts dirty buckets by collecting the buckets already marked dirty and then
+/// asking, per dirty object, which buckets hold its pages. `dirty_objects` grows by one per
+/// record ingested and each pass builds a composite lookup key, so that loop was shard-sized work
+/// on the heartbeat timer, under the read lock writers need.
+///
+/// It now stops once every bucket is in the set, because the answer is a set of bucket ids and
+/// cannot grow past the bucket count. That is exact rather than approximate -- but "exact by
+/// argument" is what this test exists to check, by recomputing the count the long way and
+/// requiring equality.
+///
+/// Measured, 200k records in five equal phases at 1023 slots, growth of the last phase over the
+/// first with the heartbeat at 1s: 3.42/2.17 before, 1.14/0.93 after, against 0.84-0.94 with the
+/// heartbeat switched off entirely.
+#[test]
+fn dirty_bucket_count_matches_the_unshortened_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    assert!(
+        engine
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 1,
+                table_name: "dirty-bucket-count".to_string(),
+                shard_uri: "local://dirty-bucket-count/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 63,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+    // Mixed enough that not every bucket ends up dirty: the short-circuit must not fire in the
+    // case where the loop still has something to contribute.
+    for index in 0..90 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("dbc-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        if index % 4 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("dbc-{}", index / 3),
+                },
+            });
+        }
+    }
+
+    let reported = engine
+        .shard_stats(1)
+        .expect("shard 1 loaded")
+        .object_manager
+        .dirty_bucket_count;
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    // The same computation with no early exit.
+    let mut expected: std::collections::BTreeSet<u32> = shard
+        .bucket_index
+        .bucket_map
+        .iter()
+        .filter_map(|(bucket_id, bucket)| bucket.dirty.then_some(*bucket_id))
+        .collect();
+    for object_key in &shard.dirty_objects {
+        expected.extend(crate::engine::bucket_index_target_buckets_for_object_key(
+            shard, object_key,
+        ));
+    }
+    assert!(
+        !shard.bucket_index.bucket_map.is_empty(),
+        "workload produced no buckets"
+    );
+    assert_eq!(
+        reported,
+        expected.len(),
+        "dirty bucket count diverged from the unshortened scan: {reported} vs {}",
+        expected.len()
+    );
+    println!("
+  dirty buckets: reported {reported} == unshortened {}
+", expected.len());
+}
+
 /// The maintained page-ref total must equal the walk it replaced.
 ///
 /// The stats path reports that number and used to derive it by summing every set in

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3499,6 +3499,148 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
     }
 }
 
+/// The per-write targeted refresh must leave the same flags as sweeping the whole shard.
+///
+/// The write path refreshes only the buckets it recorded as touched. That is only correct if a
+/// bucket nobody recorded genuinely cannot have changed, which is an argument about every site
+/// that mutates a bucket, `dirty_objects` or `expires_at_ms`. Rather than rest on the argument,
+/// this runs a mixed workload and then sweeps every bucket: if the targeted path ever misses one,
+/// the sweep moves it and the comparison fails, naming the bucket and the field.
+///
+/// `ttl_ms` is a countdown recomputed from the clock, so it is compared as present/absent rather
+/// than by value; every other flag is exact.
+#[test]
+fn bucket_runtime_flags_match_full_sweep() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // A mix, so the comparison covers inserts, overwrites, hash fields, expiries and deletes
+    // rather than one shape of write.
+    for index in 0..120 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("flags-str-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("flags-hash-{}", index % 17),
+                field: format!("field-{index}"),
+                value: vec![b'h'; 32],
+            },
+        });
+        if index % 5 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("flags-str-{}", index / 2),
+                    value: vec![b'w'; 64],
+                },
+            });
+        }
+        if index % 7 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonExpire {
+                    key: format!("flags-str-{index}"),
+                    ttl_ms: 60_000,
+                },
+            });
+        }
+        if index % 11 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("flags-str-{}", index / 3),
+                },
+            });
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct BucketFlags {
+        in_memory: bool,
+        deleted: bool,
+        dirty: bool,
+        has_ttl: bool,
+        layout: String,
+        object_index: Vec<u64>,
+        page_count: usize,
+    }
+
+    let capture = |engine: &TemporalEngine| -> std::collections::BTreeMap<u32, BucketFlags> {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        shard
+            .bucket_index
+            .bucket_map
+            .iter()
+            .map(|(routing_bucket, bucket)| {
+                (
+                    *routing_bucket,
+                    BucketFlags {
+                        in_memory: bucket.in_memory,
+                        deleted: bucket.deleted,
+                        dirty: bucket.dirty,
+                        has_ttl: bucket.ttl_ms.is_some(),
+                        layout: format!("{:?}", bucket.layout),
+                        object_index: bucket.object_index.iter().copied().collect(),
+                        page_count: bucket.page_index.len(),
+                    },
+                )
+            })
+            .collect()
+    };
+
+    let after_targeted = capture(&engine);
+    {
+        let mut shards = engine.shards.write().expect("shards lock poisoned");
+        let shard = shards.get_mut(&1).expect("shard 1 loaded");
+        crate::engine::storage_bucket_internals::refresh_bucket_runtime_flags(shard);
+    }
+    let after_full_sweep = capture(&engine);
+
+    assert!(
+        !after_targeted.is_empty(),
+        "workload produced no buckets, so the comparison would be vacuous"
+    );
+
+    let mut differences = Vec::new();
+    for (routing_bucket, targeted) in &after_targeted {
+        let swept = after_full_sweep
+            .get(routing_bucket)
+            .expect("the sweep cannot add or drop buckets");
+        if targeted != swept {
+            differences.push(format!(
+                "  bucket {routing_bucket}: targeted {targeted:?} != swept {swept:?}"
+            ));
+        }
+    }
+    assert!(
+        differences.is_empty(),
+        "the per-write targeted refresh left {} bucket(s) in a different state than a full sweep,          so a mutation site is not recording the bucket it touched:
+{}",
+        differences.len(),
+        differences.join("
+")
+    );
+    println!(
+        "
+  {} buckets compared; targeted refresh matches a full sweep on every flag
+",
+        after_targeted.len()
+    );
+}
+
 /// Bucket maintenance must not make a write cost more as the store grows.
 ///
 /// `update_bucket_layout` rebuilds a bucket's whole object set from `page_index`, and the

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3499,6 +3499,71 @@ fn corrupt_index_log_delta_refuses_load_rather_than_silently_skipping() {
     }
 }
 
+/// Bucket maintenance must not make a write cost more as the store grows.
+///
+/// `update_bucket_layout` rebuilds a bucket's whole object set from `page_index`, and the
+/// per-object dirty-state clear walks every bucket in the shard. Both are `O(pages)` and both sit
+/// inside loops, so the write path can be quadratic in the corpus while every individual function
+/// still looks cheap.
+///
+/// Counted, not timed: the number is work done, so the test cannot pass by running on a fast
+/// machine, and it reports per-write cost so growth is visible rather than implied.
+#[test]
+fn bucket_maintenance_per_write_does_not_grow_with_the_store() {
+    fn visits_per_write(object_count: usize) -> (u64, f64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Fill to the target corpus size first; only the writes AFTER the reset are measured.
+        for index in 0..object_count {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("bucket-maint-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        const MEASURED_WRITES: usize = 20;
+        crate::engine::reset_bucket_page_index_visits();
+        for index in 0..MEASURED_WRITES {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("bucket-maint-measured-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let visited = crate::engine::bucket_page_index_visits();
+        (visited, visited as f64 / MEASURED_WRITES as f64)
+    }
+
+    let (small_total, small_each) = visits_per_write(200);
+    let (large_total, large_each) = visits_per_write(800);
+
+    println!(
+        "
+  200 objects -> {small_total:>9} page-index visits for 20 writes ({small_each:>9.1} per write)
+           800 objects -> {large_total:>9} page-index visits for 20 writes ({large_each:>9.1} per write)
+           growth: {:.2}x cost for 4x the corpus
+",
+        if small_each > 0.0 { large_each / small_each } else { 0.0 }
+    );
+
+    // 4x the corpus must not cost materially more PER WRITE. Allowed a little slack for
+    // bucket-fill effects; a linear-in-corpus path shows up here as ~4x and fails loudly.
+    assert!(
+        large_each <= small_each * 1.5 + 1.0,
+        "per-write bucket maintenance grew with the store: {small_each:.1} -> {large_each:.1}          visits/write for 200 -> 800 objects"
+    );
+}
+
 /// Eviction cost must track how many victims are wanted, not how much the shard holds.
 ///
 /// Measured with the live-page scan counter rather than a clock, so the number is the work done


### PR DESCRIPTION
Bulk ingest got slower as the store grew. Most of that turned out to be a **metrics timer**, not the write path.

## The result

200k records in five equal phases at `TS_SHARD_END_ROUTING_SLOT=1023`, growth of the last phase over the first, heartbeat at 1s:

| | wall | datanode CPU |
|---|---|---|
| before | 3.42 / 2.17 | 3.65 / 2.52 |
| **after** | **1.14 / 0.93** | **1.46 / 1.14** |
| heartbeat off (reference) | 0.94 / 0.84 | 1.10 / 0.86 |

Ingest is linear with the timer running: the fixed build matches the curve that previously required switching the heartbeat off entirely. Client CPU is flat in every arm (0.77-1.01), so this is the server. Bytes written were flat throughout (index log 1.02x, WAL 1.01x) and every engine counter was flat — the extra CPU was spent counting the store, not writing to it.

## What it was

`send_heartbeat` -> `loaded_shard_stats` -> `object_manager_stats` computes a dirty-bucket count by asking, per dirty object, which buckets hold its pages — building a composite lookup key each time. `dirty_objects` gains an entry per record ingested, and this runs on a timer (3s by default) **while holding the shard read lock writers need**, so its cost grew with the store and landed on the write path as lock contention.

The loop now stops once every bucket is in the set. That is exact, not approximate: the answer is a set of bucket ids and cannot exceed the bucket count, and during ingest they are all present already because `mark_async_dirty_object` marks an object's routing bucket as it records the object.

## How it was found

Sampling the datanode's stacks early and late in one ingest and diffing them. The first attempt showed *nothing* growing — a frame count over all threads is dominated by parked ones. Discarding parked stacks surfaced `bucket_index_target_buckets_for_object_key`, `push_lookup_part`, `send_heartbeat` and `RwLock::write_contended` rising together.

Before that, a CPU split settled where the cost lived at all: per phase, the datanode's own `utime+stime` grew 2.45x while the client's stayed at 1.03x.

## What each commit earned

Being explicit, because they do not contribute equally:

- **The dirty-bucket short-circuit is the fix.** It removed the dominant cost (3.42/2.17 -> 1.14/0.93).
- **The component-sum counter** removed a second O(store) walk from the same timer and, measured on its own, did **not** move the curve (2.34/2.72). Kept because it removes real work, not because it fixed this.
- **The write-path flattening** is real and counted flat at every routing range, but was never dominant — which is why every end-to-end A/B against it came back null.

## Write path: flat, and how that was established

Bucket maintenance did `O(total pages)` work per write. Counted at 64 routing slots, page-index visits per write, as each pass came off:

```
                                             200 obj   800 obj   growth
original                                        12.6      39.0     3.10x
+ skip the TTL pass when nothing expires         8.4      26.0     3.10x
+ refresh classifies instead of rescanning       4.2      13.0     3.10x
+ upsert classifies instead of rescanning         0.0       0.0     flat
```

Only the last changed the SHAPE, which identifies the pass that mattered: `deleted` (`.all()`) and `dirty` (`.any()`) short-circuit, and the TTL minimum over nothing is `None` — but rebuilding the live-object set reads every page every time. It is also redundant on the write path, because the mutation sites already maintain that set.

An earlier attribution rejected exactly this change as the largest risk for the smallest term. It counted which FUNCTION was called, never the scan inside it, and named the wrong remedy.

## Correctness

Three guards, each written so a mistake fails by name rather than silently:

- `bucket_object_index_already_matches_a_from_scratch_recompute` — recomputes every bucket's live-object set from its pages after inserts, superseding overwrites, hash fields, expiries and deletes, and requires equality with what is stored. This is what makes dropping the rebuild safe rather than hopeful.
- `dirty_bucket_count_matches_the_unshortened_scan` — recomputes the count with no early exit: 63 == 63, on a workload with deletes so buckets remain that the loop must still contribute.
- `maintained_component_page_ref_total_matches_the_walk` — 262 == 262. A maintained counter can drift where a walk could only be slow.

Plus `bucket_runtime_flags_match_full_sweep`, unchanged: 137 buckets, targeted refresh identical to a full sweep. A stale-false `bucket.dirty` is a bucket that never gets flushed, so this matters more than any timing.

Reconstruct paths keep the full rebuild — `rebuild_bucket_page_ownership`, `rebuild_bucket_first_index`, `sync_bucket_index_object_pages`, `reconcile_secondary_views_from_bucket_index` — since they build `bucket_map` from page entries where nothing maintained the set.

## Also here: the storage manager never recorded a completed cycle

The runtime tracked its outstanding cycle in ONE slot. The top-of-tick poll saw it still running; it finished later in that same tick; `has_pending` went false so a new cycle was submitted; and submitting overwrote the slot before anything polled the finished job again. Every cycle was abandoned exactly one tick before completing.

Measured on the unfixed code: 45 cycles submitted, 47 jobs finished carrying a valid report, 432 collection attempts across 3060 polls, **zero reports collected**. `last_completed_cycle` stayed `None` forever, and with it every derived figure — bytes reclaimed, pressure after, WAL and index-log floors — read zero while the manager did real work. That report is how an operator confirms a reclaim cycle ran, and reclaim is the only thing that recovers the disk repeated dumps grow.

Verified by mutation: the new test times out at 15s against the unfixed loop, passes in 0.91s with it.

## What is NOT claimed

**No end-to-end md/json ingest speedup is claimed from the write-path commits.** They showed no separation at 28k-226k records in either direction; at the largest size the unchanged build was faster. On this machine within-arm variance reached 3-5x on identical work, so those totals cannot resolve differences of that size. The heartbeat result is quoted because its effect (3x vs 0.9x) is far outside that noise and reproduces in both reps.

Memory is unaffected: RSS within 0.4% across every build and both routing configurations (525-528 MB at default slots, 550-551 MB at 1023).

## Verification

- 41 bucket tests pass.
- Full engine lib suite: **1317 passed, 1 failed**. That failure (`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`) is pre-existing — it reproduces 2/2 on pristine `origin/main`. It now fails at a later assertion because the storage-manager fix lets it get further; its remaining assertions want one snapshot holding live dirty work AND retention blockers AND advanced WAL floors, which do not co-occur under a workload that writes once at the start. Left alone rather than weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
