### PR TITLE
The page-ref key was stored three times per page; share one allocation

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 rmp-serde = "1.3"
 hex = "0.4"
 prost = "0.13"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2086,7 +2086,7 @@ fn collect_command_index_items(
             items.push(crate::index_log::IndexItem {
                 kind: crate::index_log::IndexItemKind::Page,
                 routing_bucket,
-                page_ref_key: page_ref_key.clone(),
+                page_ref_key: page_ref_key.to_string(),
                 object_key: page.object_key.clone(),
                 model_id: page.model_id.clone(),
                 component: page.component.clone(),
@@ -2276,7 +2276,7 @@ fn fold_delta_page_items(
             });
         bucket.object_index.insert(item.object_id);
         bucket.page_index.insert(
-            item.page_ref_key.clone(),
+            Arc::<str>::from(item.page_ref_key.as_str()),
             PageIndex {
                 object_key: item.object_key.clone(),
                 model_id: item.model_id.clone(),

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -366,7 +366,7 @@ impl CoreIndex {
     pub(super) fn insert_object_page_lookup(
         &mut self,
         routing_bucket: u32,
-        page_ref_key: String,
+        page_ref_key: Arc<str>,
         page: &PageIndex,
     ) {
         if page.deleted {

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
+use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
@@ -272,7 +273,9 @@ pub(super) struct CoreIndex {
 
 pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
 pub(super) type ObjectIndex = BTreeSet<u64>;
-pub(super) type PageIndexMap = BTreeMap<String, PageIndex>;
+/// Keyed by the page-ref string. `Arc<str>` so the object lookups below can hold the same
+/// allocation instead of each storing its own copy of the same key.
+pub(super) type PageIndexMap = BTreeMap<Arc<str>, PageIndex>;
 pub(super) type ObjectPageLookup = BTreeMap<String, BTreeSet<PageLookupRef>>;
 pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageLookupRef>>;
 
@@ -280,7 +283,8 @@ pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageL
 pub(super) struct PageLookupRef {
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
-    pub(super) page_ref_key: String,
+    /// Shares the `page_index` map key's allocation rather than copying it.
+    pub(super) page_ref_key: Arc<str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -289,7 +293,8 @@ pub(super) struct ComponentPageLookupRef {
     pub(super) component: Option<String>,
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
-    pub(super) page_ref_key: String,
+    /// Shares the `page_index` map key's allocation rather than copying it.
+    pub(super) page_ref_key: Arc<str>,
 }
 
 /// Rust-native core index mirroring the shape:

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -843,14 +843,14 @@ pub(super) fn rebuild_bucket_page_ownership(
             });
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            format!(
+            Arc::<str>::from(format!(
                 "{}:{}:{}:{}:{}",
                 entry.kind,
                 entry.object_key,
                 entry.component.clone().unwrap_or_default(),
                 entry.address.page_slab_id,
                 entry.address.offset
-            ),
+            )),
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
@@ -1088,7 +1088,8 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
     entries
 }
 
-pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> String {
+/// The page-index key, as the shared allocation the object lookups also hold.
+pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> Arc<str> {
     format!(
         "{}:{}:{}:{}:{}:{}:{}:{}",
         entry.kind,
@@ -1100,6 +1101,7 @@ pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> String {
         entry.address.page_id.unwrap_or_default(),
         entry.address.generation.unwrap_or_default()
     )
+    .into()
 }
 
 pub(super) fn page_physical_identity_key(
@@ -1251,7 +1253,7 @@ pub(super) fn upsert_bucket_index_page(
         bucket.in_memory = true;
         bucket.object_index.insert(object_id);
         bucket.page_index
-            .insert(page_ref_key.clone(), page_index.clone());
+            .insert(Arc::clone(&page_ref_key), page_index.clone());
         update_bucket_layout(bucket);
     }
     shard

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2287,7 +2287,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             in_memory: true,
             object_index: [30].into_iter().collect(),
             page_index: [(
-                "string:k::1:0".to_string(),
+                "string:k::1:0".into(),
                 PageIndex {
                     object_key: "k".to_string(),
                     model_id: "string".to_string(),
@@ -2325,7 +2325,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             object_index: [40].into_iter().collect(),
             page_index: [
                 (
-                    "feature:k::2:0".to_string(),
+                    "feature:k::2:0".into(),
                     PageIndex {
                         object_key: "feature-key".to_string(),
                         model_id: "feature".to_string(),
@@ -2348,7 +2348,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     },
                 ),
                 (
-                    "feature:k::2:4".to_string(),
+                    "feature:k::2:4".into(),
                     PageIndex {
                         object_key: "feature-key".to_string(),
                         model_id: "feature".to_string(),
@@ -2386,7 +2386,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             object_index: [50, 51].into_iter().collect(),
             page_index: [
                 (
-                    "hash:k:a:3:0".to_string(),
+                    "hash:k:a:3:0".into(),
                     PageIndex {
                         object_key: "hash-key".to_string(),
                         model_id: "hash".to_string(),
@@ -2409,7 +2409,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     },
                 ),
                 (
-                    "hash:k:b:3:1".to_string(),
+                    "hash:k:b:3:1".into(),
                     PageIndex {
                         object_key: "hash-key".to_string(),
                         model_id: "hash".to_string(),


### PR DESCRIPTION
The page-ref key — `kind:object_key:component:slab:offset:length:page_id:generation` — is stored **three times per page**: as the `page_index` map key, again in `PageLookupRef.page_ref_key`, and again in `ComponentPageLookupRef.page_ref_key`. Three separate allocations of byte-identical strings.

Measured on a 500-memory store with 28,093 page entries, the in-memory index holds **15.9 MB of identity strings**, and the three copies of this one key are **3,208 KB each — 9.6 MB of that total**.

Making all three `Arc<str>` lets the lookups hold the map key's allocation instead of copying it.

## Measured

Counting distinct allocations by pointer identity, because byte counts cannot show sharing — three `Arc`s pointing at one allocation still report three lengths:

| | page-ref key holders | distinct allocations |
|---|---:|---:|
| after | 83,466 | **27,822** |

Exactly 3.000 holders per allocation, collapsed to one each. Proxy RSS over the same 500-memory ingest went **425.9 → 412.5 MB**, about 27 KB per memory, and it scales with the store.

## Why this shape

The wire format does not change: serde serializes `Arc<str>` exactly as a string (it needs the `rc` feature, enabled here). And a type change is compiler-enforced — every holder of the key had to be updated or the build fails, which is the opposite of the usual risk with a shared-state optimization where a missed site goes silently wrong. The compiler named nine sites; all nine are in this diff.

`WalOutcomeItem.page_ref_key` deliberately stays a plain `String`. It is a wire type that gets serialized and shipped, so sharing an allocation across that boundary buys nothing.

On reload, serde's `rc` support does not restore sharing — each key deserializes into its own allocation. That is fine here: `rebuild_object_page_lookup` clones the map key's `Arc` into both lookups, and `Arc::clone` shares, so the sharing comes back on the standard post-load path.

## What this does not address

The same measurement shows two further duplications, left for separate changes:

- `PageIndex` stores `object_key`, `model_id` and `component` — all three already encoded in the map key it is filed under (89 B per entry, 2,442 KB).
- `model_id` has **10 distinct values across 28,093 entries** and `object_key` has **556**, so both are candidates for interning rather than a `String` per page.

## Tests

`cargo check --all-targets` clean. 42 bucket-index tests, 22/22 strict mem0 conformance with 0 failures, 98 tests across 8 mem0 suites.

The full `--lib` run shows 7 failures. None are from this change: run individually with `--test-threads=1`, six pass on both this branch and pristine main, and the seventh (`storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_flags`) fails on pristine main too. That set includes `a_numeric_component_travels_as_a_number_and_returns_intact`, which exercises the component path this change touches — it passes on both.
