### PR TITLE
recovery installed pages it never registered, and answered None for writes it had acked

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -700,6 +700,19 @@ impl TemporalEngine {
             // async_storage only changes whether the commit BLOCKS: sync -> fsync,
             // async (or bulk backfill) -> buffered, no fsync (a fire-and-forget
             // commit). Page/index materialization stays deferred to dump.
+            // Drain what this execution recorded, on EVERY path -- not only the ones that go
+            // on to append. Staging happens during execution, but the append below is guarded,
+            // so any write that does not reach it left its items sitting in the thread's
+            // buffer for whatever wrote next on that thread to adopt as its own. Replay is the
+            // loud case: it re-executes commands with `replaying_wal()` true, stages an item
+            // for everything it re-applies, and appends none of it -- so the first write after
+            // a recovery inherited the recovery's items and recorded them as changes it had
+            // made itself. A later replay then installs them, and if one cannot be applied it
+            // aborts the whole shard load, taking unrelated keys down with it.
+            let mut staged_outcomes = block_in_wal::take_outcomes();
+            if !crate::wal::wal_outcome_items_enabled() {
+                staged_outcomes.clear();
+            }
             if write_command && !replaying_wal() {
                 // A write that changed the shard and recorded nothing cannot be replaced by its
                 // record. Off unless a sweep asks for it; when it is on, every existing test that
@@ -707,7 +720,7 @@ impl TemporalEngine {
                 // the mutating surface than a hand-listed fixture per command ever would.
                 if crate::wal::wal_outcome_items_enabled()
                     && crate::wal::wal_outcome_strict()
-                    && block_in_wal::staged_outcome_count() == 0
+                    && staged_outcomes.is_empty()
                 {
                     let rendered = format!("{command:?}");
                     let label = rendered
@@ -751,11 +764,7 @@ impl TemporalEngine {
                         .append_for_group_commit(
                             request.shard_id,
                             command,
-                            if crate::wal::wal_outcome_items_enabled() {
-                                block_in_wal::take_outcomes()
-                            } else {
-                                Vec::new()
-                            },
+                            std::mem::take(&mut staged_outcomes),
                         )
                         .map(|record| Some(record.sequence))
                 } else {
@@ -779,11 +788,7 @@ impl TemporalEngine {
                                 }
                                 std::mem::take(&mut carried_pages)
                             },
-                            if crate::wal::wal_outcome_items_enabled() {
-                                block_in_wal::take_outcomes()
-                            } else {
-                                Vec::new()
-                            },
+                            std::mem::take(&mut staged_outcomes),
                         )
                         .map(|(record, log_id)| {
                             // Point every page this record carries at the record, keyed on the

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -453,11 +453,17 @@ pub(super) fn validate_command_preconditions(
     command: &Command,
 ) -> Result<(), Status> {
     match command {
+        // Expiry checks here use the SAME replay-aware clock as the executor's
+        // `remove_if_expired`. Validation runs only on the leader today, where the two
+        // clocks coincide, so this changes no production behaviour. It removes a split
+        // that would matter the moment anything validates during replay: deciding
+        // "is this key expired" against the restart clock is what makes a replayed
+        // command fail its precondition and abort a shard load.
         Command::CommonExpire { key, .. } => {
             if shard
                 .expires_at_ms
                 .get(key)
-                .map(|expires_at| *expires_at <= now_ms())
+                .map(|expires_at| *expires_at <= resolve_now_ms())
                 .unwrap_or(false)
                 || !record_exists(shard, key)
             {
@@ -870,7 +876,7 @@ pub(super) fn validate_command_preconditions(
         if shard
             .expires_at_ms
             .get(key)
-            .map(|expires_at| *expires_at <= now_ms())
+            .map(|expires_at| *expires_at <= resolve_now_ms())
             .unwrap_or(false)
         {
             return Ok(());

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -29,6 +29,10 @@ fn timestamped_series_mut<'a>(
     })
 }
 
+#[cfg(test)]
+pub(crate) static LAST_REPLAY_WATERMARK: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 impl TemporalEngine {
     pub fn new(cache: MultiLayerCache) -> Self {
         Self::with_cache_and_block_store(cache, LocalBlockStore::default())
@@ -254,6 +258,12 @@ impl TemporalEngine {
             };
             (loaded, replay_watermark)
         };
+        // What this load decided to SKIP. A recovery that loses a write loses it by choosing a
+        // watermark, and that choice is invisible from outside: the shard loads clean, no error
+        // is returned, and the value is simply absent afterwards. Recorded so a failing test can
+        // say which watermark it was rather than leaving it to be guessed at.
+        #[cfg(test)]
+        LAST_REPLAY_WATERMARK.store(replay_watermark, std::sync::atomic::Ordering::SeqCst);
         // MANIFEST-CONFORMANCE FOLD recovery (gate on only): seed the band catalog from the folded
         // band-catalog anchor recovered from the index-log. This is applied AFTER the block
         // store already reconciled its catalog from the durable pages on open, so it only
@@ -1292,6 +1302,25 @@ impl TemporalEngine {
         shard_id: ShardId,
         watermark: u64,
     ) -> Result<(), Status> {
+        // Replay both re-executes commands and installs recorded outcomes, and BOTH stage
+        // outcome items -- while replay itself never appends, so nothing ever takes them.
+        // What it leaves behind is picked up by the next write on this thread and written
+        // into that write's record as changes it made itself; a later replay then installs
+        // them, and a single one that cannot be applied aborts the whole shard load, taking
+        // unrelated keys down with it. Threads are reused across requests in a server and
+        // across tests here, so "the next write" is routinely someone else entirely.
+        //
+        // A guard rather than a drain at the end: every early return below leaks otherwise,
+        // and the interesting exits -- an unreadable scan, a refused outcome -- are early
+        // returns by construction.
+        struct DrainStagedOnExit;
+        impl Drop for DrainStagedOnExit {
+            fn drop(&mut self) {
+                let _ = super::block_in_wal::take_outcomes();
+            }
+        }
+        let _drain_staged = DrainStagedOnExit;
+
         // A corrupt / unreadable WAL scan is DATA LOSS, not "nothing to replay": swallowing it
         // to Ok(()) would load the shard from the stale base index only, silently discarding
         // the committed WAL tail and defeating the caller's refuse-load-on-DataLoss guard. An
@@ -1321,7 +1350,11 @@ impl TemporalEngine {
         // failure (a value-preserving bit-flip surfaces as `Corruption`) instead of dropping
         // the record via `.ok()`, which would silently truncate the replayed tail.
         let mut pending: Vec<WriteAheadLogRecord> = Vec::new();
-        for (_, line) in records {
+        // Where each record physically lives. The scan hands this back and replay used to drop
+        // it (`for (_, line)`), which is why the registration below could not be done at all.
+        let mut log_id_by_sequence: std::collections::HashMap<u64, u64> =
+            std::collections::HashMap::new();
+        for (log_id, line) in records {
             let record = crate::wal::decode_wal_line(&line).map_err(|err| {
                 Status::error(
                     "wal_record_corruption",
@@ -1331,6 +1364,7 @@ impl TemporalEngine {
                 )
             })?;
             if record.sequence > watermark {
+                log_id_by_sequence.insert(record.sequence, log_id);
                 pending.push(record);
             }
         }
@@ -1364,6 +1398,8 @@ impl TemporalEngine {
         let _guard = WalReplayGuard::enter();
         let mut expected = watermark.saturating_add(1);
         let mut replayed_through = watermark;
+        let mut wal_resident_updates: Vec<(u64, crate::engine::state::WalResidentPage)> =
+            Vec::new();
         for record in pending {
             // Strict sequence continuity, matching the WAL replay, which
             // returns DataLoss and aborts Load on a hole in the retained WAL. A gap means
@@ -1386,6 +1422,36 @@ impl TemporalEngine {
                     .expect("config lock poisoned")
                     .insert(shard_id, config_log[config_cursor].config.clone());
                 config_cursor += 1;
+            }
+            // A page whose only durable copy is INSIDE this record is addressable only if
+            // something says where it lives. The write path registered exactly that when it
+            // appended; replay registered nothing, so recovery installed outcomes naming pages
+            // the successor could not resolve -- and a read for one of them answered None. Not
+            // an error, not an empty shard: a durably acknowledged write reported as absent,
+            // which is the quietest way a store can lose data. Registering here, where the log
+            // id is still in hand, makes a replayed record as addressable as a written one.
+            if super::block_in_wal::enabled() && !record.staged_pages.is_empty() {
+                if let Some(&log_id) = log_id_by_sequence.get(&record.sequence) {
+                    super::block_in_wal::register_record(
+                        &self.page_store,
+                        shard_id,
+                        &record.staged_pages,
+                        log_id,
+                        record.sequence,
+                        &self.wal_store,
+                    );
+                    // The same fact written where it survives this process, so a later reload
+                    // rehydrates it instead of rediscovering that it cannot.
+                    wal_resident_updates.extend(record.staged_pages.iter().map(|page| {
+                        (
+                            page.object_id,
+                            crate::engine::state::WalResidentPage {
+                                log_id,
+                                sequence: record.sequence,
+                            },
+                        )
+                    }));
+                }
             }
             // A record that says what its write DID is installed, not re-executed. Re-executing
             // reproduces state only if everything that influenced the original execution is
@@ -1440,6 +1506,14 @@ impl TemporalEngine {
             }
             replayed_through = record.sequence;
             expected = expected.saturating_add(1);
+        }
+        if !wal_resident_updates.is_empty() {
+            let mut shards = self.shards.write().expect("engine lock poisoned");
+            if let Some(shard) = shards.get_mut(&shard_id) {
+                for (object_id, placement) in wal_resident_updates {
+                    shard.wal_resident_pages.insert(object_id, placement);
+                }
+            }
         }
         // Restore the latest config for post-recovery client writes: any config entries stamped
         // at/after the last replayed sequence (future-effective changes) were intentionally not

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1588,6 +1588,42 @@ fn expiry_sweep_emits_wal_tombstone_like_native() {
     );
 }
 
+
+/// Pins the two clocks these recovery tests depend on: the timestamp stamped onto each WAL
+/// record (which replay reads back as the leader clock) and the clock the engine computes
+/// deadlines with. Both are restored on drop, including on panic, so a pinned clock can
+/// never leak into another test on this thread.
+static PINNED_LEADER_CLOCK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct PinnedLeaderClock(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+impl PinnedLeaderClock {
+    fn at(leader_now_ms: u64) -> Self {
+        // The record clock is process-wide, so two tests pinning it at once would stamp each
+        // other's records. Held for the few writes that need it, released on drop.
+        let guard = PINNED_LEADER_CLOCK_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::wal::set_test_record_clock_ms(Some(leader_now_ms));
+        crate::engine::set_replay_clock_ms(Some(leader_now_ms));
+        PinnedLeaderClock(guard)
+    }
+
+    fn real_now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock before epoch")
+            .as_millis() as u64
+    }
+}
+
+impl Drop for PinnedLeaderClock {
+    fn drop(&mut self) {
+        crate::wal::set_test_record_clock_ms(None);
+        crate::engine::set_replay_clock_ms(None);
+    }
+}
+
 #[test]
 fn wal_replay_uses_leader_timestamp_for_ttl_deadline_like_native() {
     // resolves a TTL to an ABSOLUTE deadline on the leader before logging it
@@ -1652,14 +1688,6 @@ fn wal_replay_uses_leader_timestamp_for_ttl_deadline_like_native() {
 
 #[test]
 fn wal_replay_conditional_write_uses_leader_clock_for_lazy_expiry_like_native() {
-    // A logged conditional write (SET XX) that fired on the leader because the key was
-    // live must fire identically on replay. The implicit lazy-expiry gate
-    // (remove_if_expired) runs first inside the handler; if it consults the real restart
-    // clock instead of the per-record leader timestamp, a key that was live at leader time
-    // (but whose ORIGINAL deadline has since passed) is dropped during replay, the SET XX
-    // takes the "not exists" branch, and a durably-committed write is silently lost --
-    // diverging the recovered node from the leader. Regression for that hole: replay must
-    // reproduce the leader's branch.
     let dir = tempfile::tempdir().unwrap();
     let page_dir = dir.path().join("pages");
     let index_dir = dir.path().join("indexes");
@@ -1683,45 +1711,91 @@ fn wal_replay_conditional_write_uses_leader_clock_for_lazy_expiry_like_native() 
             })
             .ok
     );
-    // Record 1: create k with a SHORT deadline (~120ms from now).
-    engine.execute(ExecuteRequest {
-        shard_id: 1,
-        command: Command::StringSetEx {
-            key: "k".to_string(),
-            value: b"v1".to_vec(),
-            ttl_ms: 120,
-        },
-    });
-    // Record 2: immediately (k still live on the leader) a SET XX that refreshes k=v2 with
-    // a FAR-future deadline. On the leader this fires because k exists.
-    let cond = engine.execute(ExecuteRequest {
-        shard_id: 1,
-        command: Command::StringSetConditional {
-            key: "k".to_string(),
-            value: b"v2".to_vec(),
-            ttl_ms: Some(10 * 60 * 1000),
-            condition: StringSetCondition::IfExists,
-            return_old: false,
-        },
-    });
-    assert_eq!(
-        cond.response,
-        CommandResponse::Integer { value: 1 },
-        "SET XX must fire on the leader while k is live"
-    );
 
-    // Downtime longer than record 1's original 120ms deadline (but far under the refreshed
-    // 10-minute deadline the SET XX installed).
-    std::thread::sleep(std::time::Duration::from_millis(300));
+    // An hour of downtime, STATED rather than slept for. Sleeping for it was the defect in
+    // this test: the two writes below have to land while k is still live, so a real deadline
+    // made that a race against whatever else the machine was doing, and any stall longer than
+    // the TTL failed the test on a property it is not about.
+    let leader_now_ms = PinnedLeaderClock::real_now_ms() - 60 * 60 * 1000;
+    {
+        let _clock = PinnedLeaderClock::at(leader_now_ms);
+        // Record 1: create k with a one-minute deadline, an hour before restart.
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetEx {
+                key: "k".to_string(),
+                value: b"v1".to_vec(),
+                ttl_ms: 60 * 1000,
+            },
+        });
+        // Record 2: a SET XX refreshing k=v2 with a deadline that OUTLASTS the downtime. On
+        // the leader this fires because k is live at leader time, and it now fires
+        // unconditionally, because the deadline and the check read the same pinned clock.
+        let cond = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetConditional {
+                key: "k".to_string(),
+                value: b"v2".to_vec(),
+                ttl_ms: Some(2 * 60 * 60 * 1000),
+                condition: StringSetCondition::IfExists,
+                return_old: false,
+            },
+        });
+        assert_eq!(
+            cond.response,
+            CommandResponse::Integer { value: 1 },
+            "SET XX must fire on the leader while k is live"
+        );
+    }
+    // These writes are asynchronous: the commit does not block, so a returned write does not
+    // mean the record has reached the file. The engine has no Drop that flushes, so dropping
+    // it is not a barrier either -- the successor below can open the log before the last
+    // record lands in it, and a replay test whose log is missing its last record fails
+    // looking exactly like a recovery defect. Flush, then check there is something to replay.
+    let flushed = engine
+        .write_ahead_log_store()
+        .flush(1)
+        .expect("flush the log before the engine goes away");
+    let _ = flushed;
+    assert!(
+        engine.write_ahead_log_store().stats(1).writes >= 2,
+        "premise: the log must hold the writes this test is about to replay, got {}",
+        engine.write_ahead_log_store().stats(1).writes
+    );
     drop(engine);
 
+    // Restart on the REAL clock. Record 1's deadline lapsed 59 minutes ago; the deadline the
+    // SET XX installed is still an hour out. Replay installs record 1's outcome (an absolute
+    // leader-time deadline) and re-executes record 2, whose lazy-expiry check picks the
+    // branch: against the leader clock k is live and the write survives; against the restart
+    // clock k reads expired and a durably-committed write is silently lost.
     let restarted = TemporalEngine::with_local_dirs(
         1024 * 1024,
         dir.path().join("cache-b"),
         &page_dir,
         &index_dir,
     );
-    restarted.load_shard(1);
+    // Assert the LOAD, not just what is readable after it. `load_shard` throws its response
+    // away, so a shard that refused to recover looks identical to one that recovered empty --
+    // every assertion below then reports a missing value and blames replay for dropping it,
+    // which is the wrong end of the failure and is exactly how this was read for several
+    // rounds.
+    let loaded = restarted.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(
+        loaded.status.ok,
+        "the shard refused the load: {:?}",
+        loaded.status
+    );
+
     let get = restarted.execute(ExecuteRequest {
         shard_id: 1,
         command: Command::StringGet {
@@ -1769,34 +1843,61 @@ fn wal_replay_rearmed_expire_does_not_abort_recovery_like_native() {
             })
             .ok
     );
-    // Durable canary that survives iff replay runs to completion (not aborted mid-way).
-    engine.execute(ExecuteRequest {
-        shard_id: 1,
-        command: Command::StringSet {
-            key: "canary".to_string(),
-            value: b"present".to_vec(),
-        },
-    });
-    // Create k with a short deadline, then re-arm it via EXPIRE (also short). Both logged.
-    engine.execute(ExecuteRequest {
-        shard_id: 1,
-        command: Command::StringSetEx {
-            key: "k".to_string(),
-            value: b"v".to_vec(),
-            ttl_ms: 100,
-        },
-    });
-    let rearmed = engine.execute(ExecuteRequest {
-        shard_id: 1,
-        command: Command::CommonExpire {
-            key: "k".to_string(),
-            ttl_ms: 100,
-        },
-    });
-    assert!(rearmed.status.ok, "EXPIRE on a live key should succeed on the leader");
 
-    // Downtime longer than k's deadline: at replay time k's original deadline has lapsed.
-    std::thread::sleep(std::time::Duration::from_millis(250));
+    // An hour of downtime, stated rather than slept for, as in the sibling test. What this
+    // test needs is that k's deadline has LAPSED by restart -- a premise that now holds by
+    // construction. It previously held only if the sleep outlasted the TTL, and widening the
+    // TTL to steady the race quietly inverted it: 250ms of downtime against a 1500ms
+    // deadline left the key live at restart, so the test passed without ever building the
+    // situation it exists to check.
+    let leader_now_ms = PinnedLeaderClock::real_now_ms() - 60 * 60 * 1000;
+    {
+        let _clock = PinnedLeaderClock::at(leader_now_ms);
+        // Durable canary that survives iff replay runs to completion (not aborted mid-way).
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "canary".to_string(),
+                value: b"present".to_vec(),
+            },
+        });
+        // Create k with a one-minute deadline, then re-arm it via EXPIRE. Both logged, both
+        // an hour before restart, so both deadlines are in the past by the time replay runs.
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSetEx {
+                key: "k".to_string(),
+                value: b"v".to_vec(),
+                ttl_ms: 60 * 1000,
+            },
+        });
+        let rearmed = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonExpire {
+                key: "k".to_string(),
+                ttl_ms: 60 * 1000,
+            },
+        });
+        assert!(
+            rearmed.status.ok,
+            "EXPIRE on a live key should succeed on the leader"
+        );
+    }
+    // These writes are asynchronous: the commit does not block, so a returned write does not
+    // mean the record has reached the file. The engine has no Drop that flushes, so dropping
+    // it is not a barrier either -- the successor below can open the log before the last
+    // record lands in it, and a replay test whose log is missing its last record fails
+    // looking exactly like a recovery defect. Flush, then check there is something to replay.
+    let flushed = engine
+        .write_ahead_log_store()
+        .flush(1)
+        .expect("flush the log before the engine goes away");
+    let _ = flushed;
+    assert!(
+        engine.write_ahead_log_store().stats(1).writes >= 3,
+        "premise: the log must hold the writes this test is about to replay, got {}",
+        engine.write_ahead_log_store().stats(1).writes
+    );
     drop(engine);
 
     let restarted = TemporalEngine::with_local_dirs(
@@ -1805,7 +1906,44 @@ fn wal_replay_rearmed_expire_does_not_abort_recovery_like_native() {
         &page_dir,
         &index_dir,
     );
-    restarted.load_shard(1);
+    // Assert the LOAD, not just what is readable after it. `load_shard` throws its response
+    // away, so a shard that refused to recover looks identical to one that recovered empty --
+    // every assertion below then reports a missing value and blames replay for dropping it,
+    // which is the wrong end of the failure and is exactly how this was read for several
+    // rounds.
+    let loaded = restarted.load_shard_with(LoadShardRequest {
+        shard_id: 1,
+        load_version: 0,
+        local_node_id: None,
+        shard_uri: String::new(),
+        start_routing_bucket: 0,
+        end_routing_bucket: u32::MAX,
+        readonly: false,
+        table_name: String::new(),
+    });
+    assert!(
+        loaded.status.ok,
+        "the shard refused the load: {:?}",
+        loaded.status
+    );
+
+    // THE PREMISE, ASSERTED. This test is only meaningful if k's deadline actually lapsed
+    // while the engine was down; if it did not, the situation it exists to check was never
+    // built and the canary below passes for free. That is not hypothetical -- widening this
+    // test's TTL to steady a race once left 250ms of downtime against a 1500ms deadline, and
+    // it kept passing while checking nothing. So: k must be GONE at restart.
+    let lapsed = restarted.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringGet {
+            key: "k".to_string(),
+        },
+    });
+    assert_eq!(
+        lapsed.response,
+        CommandResponse::Bytes { value: None },
+        "premise: k's re-armed deadline must have lapsed during the downtime, or this test \
+         is not exercising a replayed EXPIRE whose deadline is in the past"
+    );
     let canary = restarted.execute(ExecuteRequest {
         shard_id: 1,
         command: Command::StringGet {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -7172,3 +7172,158 @@ fn what_the_log_resident_registry_holds_after_a_dump() {
     println!("[registry] {served}/{WRITES} still served");
     assert_eq!(served, WRITES, "a value stopped reading");
 }
+
+#[test]
+fn a_replay_leaves_nothing_staged_for_the_next_write_to_adopt() {
+    // Outcomes are staged during execution and taken at the append. Replay executes and does
+    // not append, so whatever it staged stayed on the thread -- and the next write on that
+    // thread appended a record carrying it, claiming changes it never made. Threads are
+    // reused, in a server across requests and here across tests, so "the next write" is
+    // routinely someone else entirely.
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    for i in 0..4 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("key-{i}"),
+                value: b"value".to_vec(),
+            },
+        });
+    }
+    drop(engine);
+
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+
+    assert_eq!(
+        crate::engine::block_in_wal::staged_outcome_count(),
+        0,
+        "a replay must leave nothing staged: whatever it leaves behind is adopted by the next \
+         write on this thread and recorded as that write's own doing"
+    );
+}
+
+#[test]
+fn an_async_write_is_never_lost_across_a_restart() {
+    // The symptom three separate tests kept showing: an async write is acknowledged, the log
+    // holds it, the shard loads with no error -- and the value is gone. Losing a write that way
+    // is a decision, not a crash: recovery picks a watermark and replays only past it, so a
+    // watermark chosen above a record skips it silently. This runs the whole cycle enough times
+    // to catch an intermittent one and reports the watermark it chose when it does.
+    for attempt in 0..120 {
+        let dir = tempfile::tempdir().unwrap();
+        let page_dir = dir.path().join("pages");
+        let index_dir = dir.path().join("indexes");
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache-a"),
+            &page_dir,
+            &index_dir,
+        );
+        engine.load_shard(1);
+        assert!(
+            engine
+                .set_config(SetConfigRequest {
+                    shard_id: 1,
+                    config: Config {
+                        version: 2,
+                        async_storage: true,
+                        ..Config::default()
+                    },
+                })
+                .ok
+        );
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: "k".to_string(),
+                value: b"async-durable".to_vec(),
+            },
+        });
+        let before = engine.write_ahead_log_store().stats(1);
+        engine
+            .write_ahead_log_store()
+            .flush(1)
+            .expect("flush before the engine goes away");
+        drop(engine);
+
+        let restarted = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache-b"),
+            &page_dir,
+            &index_dir,
+        );
+        // Ask the successor what it can SEE before asking what it recovered. A load that
+        // refused, a log the successor cannot read, and a replay that read the record and
+        // applied nothing are three different defects that all look like one missing value.
+        let loaded = restarted.load_shard_with(LoadShardRequest {
+            shard_id: 1,
+            load_version: 0,
+            local_node_id: None,
+            shard_uri: String::new(),
+            start_routing_bucket: 0,
+            end_routing_bucket: u32::MAX,
+            readonly: false,
+            table_name: String::new(),
+        });
+        let seen = restarted.write_ahead_log_store().stats(1);
+        let installs = restarted.replay_installs_for_test();
+        let registrations = restarted.registration_count_for_test(1);
+        let synthetic = restarted.synthetic_address_count_for_test(1);
+        let got = restarted.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: "k".to_string(),
+            },
+        });
+        let watermark =
+            crate::engine::lifecycle::LAST_REPLAY_WATERMARK.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            loaded.status.ok,
+            "attempt {attempt}: the successor refused the load: {:?}",
+            loaded.status
+        );
+        assert_eq!(
+            got.response,
+            CommandResponse::Bytes {
+                value: Some(b"async-durable".to_vec())
+            },
+            "attempt {attempt}: an acknowledged async write was lost across a restart. \
+             the writer left {} records up to sequence {}; the successor saw {} records up to \
+             sequence {}, replayed from watermark {watermark}, installed {} outcomes, holds              {} page registrations and {} unresolvable addresses",
+            before.writes,
+            before.last_sequence,
+            seen.writes,
+            seen.last_sequence,
+            installs,
+            registrations,
+            synthetic
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2935,7 +2935,36 @@ fn last_wal_sequence_in(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
     Ok((decode_wal_line(&line)?.sequence, good_offset))
 }
 
+/// Test-only override for the wall clock stamped onto a record. Recovery tests need records
+/// whose leader timestamps are OLD relative to restart, and the only honest way to get that
+/// is to state the timestamp: the alternative is sleeping for the difference and racing every
+/// other thread on the machine for it.
+///
+/// Process-wide rather than per-thread, and that is the whole point. A write does not promise
+/// to append on the thread that executed it -- group commit exists precisely so it does not --
+/// so a per-thread pin was applied or skipped depending on where the append happened to land,
+/// which made the record's timestamp real often enough to fail one run in twenty-five. Zero
+/// means unset; callers pin it only inside a guard that restores it.
+#[cfg(test)]
+static TEST_RECORD_CLOCK_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn set_test_record_clock_ms(clock_ms: Option<u64>) {
+    TEST_RECORD_CLOCK_MS.store(
+        clock_ms.unwrap_or(0),
+        std::sync::atomic::Ordering::SeqCst,
+    );
+}
+
 fn current_time_ms() -> u64 {
+    #[cfg(test)]
+    {
+        let pinned = TEST_RECORD_CLOCK_MS.load(std::sync::atomic::Ordering::SeqCst);
+        if pinned != 0 {
+            return pinned;
+        }
+    }
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)


### PR DESCRIPTION
recovery installed pages it never registered, and answered None for writes it had acked

    an async write, acknowledged, one record in the log, load clean, replay from sequence 0
    -> the value reads back absent, about once in twenty-five restarts

Replay scans the log as (log id, bytes) and threw the log id away on the first line:
`for (_, line) in records`. That id is the one thing a page registration needs. So a record
carrying a page whose ONLY durable copy is inside that record replayed like this: the outcome
installed, putting an address into the served index, and nothing registered where the page
actually lives. The address resolved to nothing and the read answered None.

Measured at the moment of loss, identically across runs:

    installed 1 outcome, holds 0 page registrations, 2 unresolvable addresses

No error. No refused load. No aborted replay. Every layer reported success and the write was
gone -- the quietest way a store can lose data, and it needs only asynchronous storage plus a
page still living in the log at shutdown, which is why it surfaced as a flaky test instead of
an outage. Replay now registers each record's pages where the log id is still in hand, and
writes the placement down so a later reload rehydrates it rather than rediscovering that it
cannot.

    960 restart cycles after:  0 lost
    the same probe before:     ~1 in 25

This is the third instance of one shape today. Installed but not served: a node whose maps
compare equal and whose addresses resolve to nothing passes every comparison and answers
nothing. That is why recovery is checked here by SERVING READS and never by comparing state.

AND REPLAY LEFT ITS STAGED ITEMS ON THE THREAD FOR THE NEXT WRITE TO ADOPT.

Outcome items are staged during execution and taken at the append. Replay executes, installs,
and never appends -- so everything it staged stayed in the thread's buffer, and the next write
on that thread appended a record claiming changes it had never made. A later replay installs
those, and a single one that cannot be applied aborts the whole shard load, taking unrelated
keys with it. Threads are reused across requests in a server and across tests here, so "the
next write" is routinely someone else entirely. A probe measures it directly: four items left
staged after a four-write replay, zero after. It is a guard rather than a drain at the end,
because replay's interesting exits -- an unreadable scan, a refused outcome -- are early
returns, and those leaked too. The same drain now runs on every path out of a write, not only
the two that append.

Expiry is also decided by one clock now. The executor asked the replay-aware clock and command
validation asked the real one; on a leader they are the same number, so the split was
invisible until a test pinned one of them. Replay does not validate and outside replay they
are identical, so nothing in production behaves differently -- verified, not assumed. What it
removes is a split that would matter the moment anything validated during replay, which is
exactly how a replayed command fails a precondition and aborts a load.

THE TESTS THAT FOUND THIS WERE FIRST MADE WORSE.

Two recovery tests were racing the machine: they needed a deadline that lapsed during
downtime, and got it by sleeping past a short TTL, so any stall longer than the TTL failed an
assertion neither test is about. Widening the windows was the wrong fix twice over. It
enlarges a race instead of removing it, and the two numbers are coupled -- the downtime has to
outlast the deadline. In the re-arming test the TTL grew and the sleep did not, which INVERTED
the premise: 250ms of downtime against a 1500ms deadline left the key live at restart, so the
test stopped building the situation it exists to check and passed anyway. It was caught before
it merged and that ship was stopped.

Both tests now STATE their downtime instead of sleeping through it: a cfg(test) seam on the
one function that stamps a record's leader timestamp, pinned with the deadline clock to an
hour ago and restored on drop. Process-wide, deliberately -- a write does not promise to
append on the thread that executed it, so a per-thread pin was applied or skipped depending on
where the append landed. Downtime went from 120ms-that-had-to-be-won to an hour that holds by
construction, and 2.75s of sleeping went to none.

Three assertions were added because their absence is what hid the defect for so long. The
re-arming test asserts its own premise, so it can never again pass while checking nothing.
Both assert the LOAD, not just what is readable after it: `load_shard` throws its response
away, so a shard that refused to recover looked exactly like one that recovered empty, and
every failure read as "replay dropped my write" -- the wrong end of the failure, and where
several rounds of this were spent. And both check the log holds what they are about to replay,

🤖 Generated with [Claude Code](https://claude.com/claude-code)
