### PR TITLE
Intern the page index identity strings instead of one allocation per page

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2080,16 +2080,16 @@ fn collect_command_index_items(
             continue;
         };
         for (page_ref_key, page) in &bucket.page_index {
-            if !keys.contains(page.object_key.as_str()) {
+            if !keys.contains(&*page.object_key) {
                 continue;
             }
             items.push(crate::index_log::IndexItem {
                 kind: crate::index_log::IndexItemKind::Page,
                 routing_bucket,
                 page_ref_key: page_ref_key.to_string(),
-                object_key: page.object_key.clone(),
-                model_id: page.model_id.clone(),
-                component: page.component.clone(),
+                object_key: page.object_key.to_string(),
+                model_id: page.model_id.to_string(),
+                component: page.component.as_deref().map(str::to_string),
                 object_id: page.object_id,
                 page_id: page.address.page_id.unwrap_or(0),
                 address: Some(page.address.clone()),
@@ -2246,16 +2246,16 @@ fn fold_delta_page_items(
                 continue;
             };
             bucket.page_index.retain(|_, page| {
-                !(page.model_id == item.model_id
-                    && page.object_key == item.object_key
-                    && page.component == item.component)
+                !(*page.model_id == *item.model_id
+                    && *page.object_key == *item.object_key
+                    && page.component.as_deref() == item.component.as_deref())
             });
         }
     } else if !covered_keys.is_empty() {
         for bucket in bucket_index.bucket_map.values_mut() {
             bucket
                 .page_index
-                .retain(|_, page| !covered_keys.contains(&page.object_key));
+                .retain(|_, page| !covered_keys.contains(&*page.object_key));
         }
     }
     for item in items {
@@ -2278,9 +2278,9 @@ fn fold_delta_page_items(
         bucket.page_index.insert(
             Arc::<str>::from(item.page_ref_key.as_str()),
             PageIndex {
-                object_key: item.object_key.clone(),
-                model_id: item.model_id.clone(),
-                component: item.component.clone(),
+                object_key: intern_identity(&item.object_key),
+                model_id: intern_identity(&item.model_id),
+                component: item.component.as_deref().map(intern_identity),
                 object_id: item.object_id,
                 address,
                 dirty: false,
@@ -2887,7 +2887,7 @@ fn mark_bucket_index_object_deleted(shard: &mut ShardState, key: &str) -> bool {
         };
         let mut deleted_object_ids = BTreeSet::new();
         bucket.page_index.retain(|_, page| {
-            if page.object_key == key {
+            if &*page.object_key == key {
                 deleted_object_ids.insert(page.object_id);
                 removed = true;
                 false
@@ -2981,8 +2981,8 @@ fn mark_bucket_index_page_deleted(
         let mut bucket_removed = false;
         let mut deleted_object_ids = BTreeSet::new();
         bucket.page_index.retain(|_, page| {
-            let matches = page.model_id == model_id
-                && page.object_key == key
+            let matches = &*page.model_id == model_id
+                && &*page.object_key == key
                 && page.component.as_deref() == component;
             if matches {
                 deleted_object_ids.insert(page.object_id);
@@ -3210,7 +3210,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
         shard.bucket_index.bucket_map.values().any(|bucket| {
             bucket.page_index
                 .values()
-                .any(|page| page.object_key == key && !page.deleted)
+                .any(|page| &*page.object_key == key && !page.deleted)
         })
     } else {
         storage_model_kinds().iter().any(|kind| {
@@ -3226,7 +3226,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
                             .get(&page_ref.routing_bucket)
                             .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                             .map(|page| {
-                                !page.deleted && page.model_id == *kind && page.object_key == key
+                                !page.deleted && &*page.model_id == *kind && &*page.object_key == key
                             })
                             .unwrap_or(false)
                     })
@@ -3399,9 +3399,9 @@ fn object_manager_stats(
                     .iter()
                     .map(|page| {
                         (
-                            page.model_id.as_str(),
-                            page.object_key.as_str(),
-                            (page.model_id == "hash")
+                            &*page.model_id,
+                            &*page.object_key,
+                            (&*page.model_id == "hash")
                                 .then(|| page.component.as_deref())
                                 .flatten(),
                         )
@@ -3410,12 +3410,12 @@ fn object_manager_stats(
                     .len();
                 let bucket_dirty_object_count = live_pages
                     .iter()
-                    .filter(|page| page.dirty || shard.dirty_objects.contains(&page.object_key))
+                    .filter(|page| page.dirty || shard.dirty_objects.contains(&*page.object_key))
                     .map(|page| {
                         (
-                            page.model_id.as_str(),
-                            page.object_key.as_str(),
-                            (page.model_id == "hash")
+                            &*page.model_id,
+                            &*page.object_key,
+                            (&*page.model_id == "hash")
                                 .then(|| page.component.as_deref())
                                 .flatten(),
                         )
@@ -3499,7 +3499,7 @@ fn object_manager_stats(
                 .filter(|bucket| {
                     bucket.dirty
                         || bucket.page_index.values().any(|page| {
-                            page.dirty || shard.dirty_objects.contains(&page.object_key)
+                            page.dirty || shard.dirty_objects.contains(&*page.object_key)
                         })
                 })
                 .count()

--- a/crates/temporalstore-rust/src/engine/bucket_store.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_store.rs
@@ -171,8 +171,8 @@ pub(super) fn bucket_index_page_address(
                 continue;
             };
             if !page.deleted
-                && page.model_id == model_id
-                && page.object_key == object_key
+                && &*page.model_id == model_id
+                && &*page.object_key == object_key
                 && page.component.as_deref() == component
             {
                 return Some(page.address.clone());
@@ -192,8 +192,8 @@ pub(super) fn bucket_index_page_address(
         .flat_map(|bucket| bucket.page_index.values())
         .filter(|page| {
             !page.deleted
-                && page.model_id == model_id
-                && page.object_key == object_key
+                && &*page.model_id == model_id
+                && &*page.object_key == object_key
                 && page.component.as_deref() == component
         })
         .map(|page| page.address.clone())
@@ -212,8 +212,8 @@ pub(super) fn bucket_index_component_page_addresses(
             .filter_map(|page_ref| {
                 let bucket = shard.bucket_index.bucket_map.get(&page_ref.routing_bucket)?;
                 let page = bucket.page_index.get(&page_ref.page_ref_key)?;
-                if !page.deleted && page.model_id == model_id && page.object_key == object_key {
-                    Some((page.component.clone(), page.address.clone()))
+                if !page.deleted && &*page.model_id == model_id && &*page.object_key == object_key {
+                    Some((page.component.as_deref().map(str::to_string), page.address.clone()))
                 } else {
                     None
                 }
@@ -235,8 +235,8 @@ pub(super) fn bucket_index_component_page_addresses(
         .bucket_map
         .values()
         .flat_map(|bucket| bucket.page_index.values())
-        .filter(|page| !page.deleted && page.model_id == model_id && page.object_key == object_key)
-        .map(|page| (page.component.clone(), page.address.clone()))
+        .filter(|page| !page.deleted && &*page.model_id == model_id && &*page.object_key == object_key)
+        .map(|page| (page.component.as_deref().map(str::to_string), page.address.clone()))
         .collect::<Vec<_>>();
     refs.sort_by(|left, right| left.0.cmp(&right.0));
     refs

--- a/crates/temporalstore-rust/src/engine/object_manager.rs
+++ b/crates/temporalstore-rust/src/engine/object_manager.rs
@@ -129,11 +129,11 @@ pub(super) fn runtime_report(shard: &ShardState) -> ObjectManagerRuntimeReport {
                 (None, Some(next)) => Some(next),
                 (existing, None) => existing,
             };
-            if !object.object_keys.contains(&page.object_key) {
-                object.object_keys.push(page.object_key.clone());
+            if !object.object_keys.iter().any(|key| key.as_str() == &*page.object_key) {
+                object.object_keys.push(page.object_key.to_string());
             }
-            if !object.model_ids.contains(&page.model_id) {
-                object.model_ids.push(page.model_id.clone());
+            if !object.model_ids.iter().any(|id| id.as_str() == &*page.model_id) {
+                object.model_ids.push(page.model_id.to_string());
             }
         }
     }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -394,7 +394,7 @@ impl CoreIndex {
             ))
             .or_default()
             .insert(ComponentPageLookupRef {
-                component: page.component.clone(),
+                component: page.component.as_deref().map(str::to_string),
                 routing_bucket,
                 page_ref_key,
             });
@@ -432,8 +432,8 @@ impl CoreIndex {
                     .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                     .map(|page| {
                         !page.deleted
-                            && page.model_id == model_id
-                            && page.object_key == object_key
+                            && &*page.model_id == model_id
+                            && &*page.object_key == object_key
                             && page.component.as_deref() == component
                             && same_page_address(&page.address, address)
                     })
@@ -448,8 +448,8 @@ impl CoreIndex {
         self.bucket_map.values().any(|bucket| {
             bucket.page_index.values().any(|page| {
                 !page.deleted
-                    && page.model_id == model_id
-                    && page.object_key == object_key
+                    && &*page.model_id == model_id
+                    && &*page.object_key == object_key
                     && page.component.as_deref() == component
                     && same_page_address(&page.address, address)
             })

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -334,10 +334,14 @@ pub(super) enum BucketLayoutState {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct PageIndex {
-    pub(super) object_key: String,
-    pub(super) model_id: String,
+    /// Interned: one allocation per distinct value, not one per page. All three of these are
+    /// also encoded in the map key this entry is filed under, and they repeat heavily -- 10
+    /// distinct `model_id` and 556 distinct `object_key` across 28,093 entries on a
+    /// 500-memory store.
+    pub(super) object_key: Arc<str>,
+    pub(super) model_id: Arc<str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) component: Option<String>,
+    pub(super) component: Option<Arc<str>>,
     pub(super) object_id: u64,
     pub(super) address: BlockAddress,
     pub(super) dirty: bool,
@@ -458,6 +462,29 @@ pub(super) fn object_component_lookup_key(model_id: &str, object_key: &str) -> S
     push_lookup_part(&mut key, model_id);
     push_lookup_part(&mut key, object_key);
     key
+}
+
+/// One allocation per distinct identity string, shared by every page entry that uses it.
+///
+/// `PageIndex` used to own a `String` per field per page. The values repeat heavily -- the model
+/// id is one of about ten literals, and an object key is shared by every page of that object --
+/// so the table stays small while the number of pages does not.
+pub(super) fn intern_identity(value: &str) -> Arc<str> {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static TABLE: OnceLock<Mutex<HashSet<Arc<str>>>> = OnceLock::new();
+    let table = TABLE.get_or_init(|| Mutex::new(HashSet::new()));
+    let Ok(mut table) = table.lock() else {
+        // A poisoned table is not a reason to fail a write; fall back to a private allocation,
+        // which is exactly the old behaviour.
+        return Arc::from(value);
+    };
+    if let Some(existing) = table.get(value) {
+        return Arc::clone(existing);
+    }
+    let interned: Arc<str> = Arc::from(value);
+    table.insert(Arc::clone(&interned));
+    interned
 }
 
 pub(super) fn object_page_lookup_key(

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -852,9 +852,9 @@ pub(super) fn rebuild_bucket_page_ownership(
                 entry.address.offset
             )),
             PageIndex {
-                object_key: entry.object_key,
-                model_id: entry.kind,
-                component: entry.component,
+                object_key: intern_identity(&entry.object_key),
+                model_id: intern_identity(&entry.kind),
+                component: entry.component.as_deref().map(intern_identity),
                 object_id,
                 address: entry.address,
                 dirty: entry.dirty,
@@ -933,9 +933,9 @@ pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<
     for bucket in shard.bucket_index.bucket_map.values() {
         for page in bucket.page_index.values() {
             entries.push(LivePageEntry {
-                object_key: page.object_key.clone(),
-                kind: page.model_id.clone(),
-                component: page.component.clone(),
+                object_key: page.object_key.to_string(),
+                kind: page.model_id.to_string(),
+                component: page.component.as_deref().map(str::to_string),
                 address: page.address.clone(),
                 dirty: page.dirty,
                 deleted: page.deleted,
@@ -1209,9 +1209,9 @@ pub(super) fn upsert_bucket_index_page(
     } else if !lookup_enabled {
         for bucket in shard.bucket_index.bucket_map.values_mut() {
             bucket.page_index.retain(|_, page| {
-                !(page.object_key == entry.object_key
-                    && page.model_id == entry.kind
-                    && page.component == entry.component)
+                !(*page.object_key == *entry.object_key
+                    && *page.model_id == *entry.kind
+                    && page.component.as_deref() == entry.component.as_deref())
             });
             if !bucket
                 .page_index
@@ -1225,9 +1225,9 @@ pub(super) fn upsert_bucket_index_page(
     }
     let page_ref_key = page_index_ref_key(&entry);
     let page_index = PageIndex {
-        object_key: entry.object_key,
-        model_id: entry.kind,
-        component: entry.component,
+        object_key: intern_identity(&entry.object_key),
+        model_id: intern_identity(&entry.kind),
+        component: entry.component.as_deref().map(intern_identity),
         object_id,
         address: entry.address,
         dirty: entry.dirty,
@@ -1297,7 +1297,7 @@ pub(super) fn sync_bucket_index_object_pages(
         };
         let before = bucket.page_index.len();
         bucket.page_index
-            .retain(|_, page| !(page.model_id == kind && page.object_key == object_key));
+            .retain(|_, page| !(&*page.model_id == kind && &*page.object_key == object_key));
         if bucket.page_index.len() != before {
             removed_any = true;
             touched_buckets.insert(routing_bucket);
@@ -1366,9 +1366,9 @@ pub(super) fn sync_bucket_index_object_pages(
         bucket.page_index.insert(
             page_index_ref_key(&entry),
             PageIndex {
-                object_key: entry.object_key,
-                model_id: entry.kind,
-                component: entry.component,
+                object_key: intern_identity(&entry.object_key),
+                model_id: intern_identity(&entry.kind),
+                component: entry.component.as_deref().map(intern_identity),
                 object_id,
                 address: entry.address,
                 dirty: entry.dirty,
@@ -1435,11 +1435,11 @@ pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
         bucket.dirty |= bucket
             .page_index
             .values()
-            .any(|page| page.dirty || shard.dirty_objects.contains(&page.object_key));
+            .any(|page| page.dirty || shard.dirty_objects.contains(&*page.object_key));
         bucket.ttl_ms = bucket
             .page_index
             .values()
-            .filter_map(|page| shard.expires_at_ms.get(&page.object_key).copied())
+            .filter_map(|page| shard.expires_at_ms.get(&*page.object_key).copied())
             .map(|expires_at| expires_at.saturating_sub(now))
             .min();
         update_bucket_layout(bucket);
@@ -1471,7 +1471,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
     for bucket in shard.bucket_index.bucket_map.values_mut() {
         let mut touched = false;
         for page in bucket.page_index.values_mut() {
-            if page.object_key == object_key {
+            if &*page.object_key == object_key {
                 page.dirty = false;
                 touched = true;
             }
@@ -1480,7 +1480,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
             bucket.dirty = bucket
                 .page_index
                 .values()
-                .any(|page| page.dirty || shard.dirty_objects.contains(&page.object_key));
+                .any(|page| page.dirty || shard.dirty_objects.contains(&*page.object_key));
             update_bucket_layout(bucket);
         }
     }
@@ -1537,9 +1537,9 @@ pub(super) fn rebuild_bucket_first_index(
         bucket.page_index.insert(
             page_index_ref_key(&entry),
             PageIndex {
-                object_key: entry.object_key,
-                model_id: entry.kind,
-                component: entry.component,
+                object_key: intern_identity(&entry.object_key),
+                model_id: intern_identity(&entry.kind),
+                component: entry.component.as_deref().map(intern_identity),
                 object_id,
                 address: entry.address,
                 dirty: page_dirty,
@@ -2102,7 +2102,7 @@ pub(super) fn validate_bucket_ownership_index(
                             && page.address.offset == entry.address.offset
                             && page.address.length == entry.address.length
                             && page.address.page_id == expected_page_id
-                            && page.model_id == entry.kind
+                            && *page.model_id == *entry.kind
                     })
             });
         if !bucket_page_present {

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -411,9 +411,9 @@ pub(super) fn storage_physical_index_report(
         bucket.last_dump_sequence = runtime_bucket.last_dump_sequence;
         for page in runtime_bucket.page_index.values() {
             let already_present = bucket.page_indexes.iter().any(|existing| {
-                existing.object_key == page.object_key
-                    && existing.model_id == page.model_id
-                    && existing.component == page.component
+                existing.object_key == *page.object_key
+                    && existing.model_id == *page.model_id
+                    && existing.component.as_deref() == page.component.as_deref()
                     && existing.page_slab_id == page.address.page_slab_id
                     && existing.offset == page.address.offset
             });
@@ -421,9 +421,9 @@ pub(super) fn storage_physical_index_report(
                 continue;
             }
             let mut page_index = StoragePhysicalPageIndex {
-                object_key: page.object_key.clone(),
-                model_id: page.model_id.clone(),
-                component: page.component.clone(),
+                object_key: page.object_key.to_string(),
+                model_id: page.model_id.to_string(),
+                component: page.component.as_deref().map(str::to_string),
                 routing_bucket: *routing_bucket,
                 page_slab_id: page.address.page_slab_id,
                 offset: page.address.offset,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -1861,7 +1861,7 @@ fn recovery_reports_owner_mismatch_and_compaction_refuses_it() {
             .bucket_map
             .values_mut()
             .flat_map(|bucket| bucket.page_index.values_mut())
-            .find(|page| page.object_key == "owned")
+            .find(|page| &*page.object_key == "owned")
             .expect("owned slot page");
         page.address.object_id = Some(page.object_id.wrapping_add(1));
     }
@@ -1915,7 +1915,7 @@ fn recovery_reports_reused_object_id_conflicts() {
             .bucket_map
             .values()
             .flat_map(|bucket| bucket.page_index.values())
-            .find(|page| page.object_key == "first")
+            .find(|page| &*page.object_key == "first")
             .map(|page| page.object_id)
             .expect("first object id");
         let second = shard
@@ -1923,7 +1923,7 @@ fn recovery_reports_reused_object_id_conflicts() {
             .bucket_map
             .values_mut()
             .flat_map(|bucket| bucket.page_index.values_mut())
-            .find(|page| page.object_key == "second")
+            .find(|page| &*page.object_key == "second")
             .expect("second slot page");
         second.address.object_id = Some(first_object_id);
         first_object_id

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -1884,7 +1884,7 @@ fn bucket_page_ownership_is_first_class_and_survives_reload() {
             && bucket.object_count == 2
             && bucket.dirty_generation >= 2
             && bucket.page_indexes.iter().all(|page| {
-                page.model_id == "hash" && page.dirty && !page.deleted && !page.log_backed
+                &*page.model_id == "hash" && page.dirty && !page.deleted && !page.log_backed
             })
     }));
     assert_eq!(
@@ -2289,8 +2289,8 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             page_index: [(
                 "string:k::1:0".into(),
                 PageIndex {
-                    object_key: "k".to_string(),
-                    model_id: "string".to_string(),
+                    object_key: "k".into(),
+                    model_id: "string".into(),
                     component: None,
                     object_id: 30,
                     address: BlockAddress {
@@ -2327,8 +2327,8 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 (
                     "feature:k::2:0".into(),
                     PageIndex {
-                        object_key: "feature-key".to_string(),
-                        model_id: "feature".to_string(),
+                        object_key: "feature-key".into(),
+                        model_id: "feature".into(),
                         component: None,
                         object_id: 40,
                         address: BlockAddress {
@@ -2350,8 +2350,8 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 (
                     "feature:k::2:4".into(),
                     PageIndex {
-                        object_key: "feature-key".to_string(),
-                        model_id: "feature".to_string(),
+                        object_key: "feature-key".into(),
+                        model_id: "feature".into(),
                         component: None,
                         object_id: 40,
                         address: BlockAddress {
@@ -2388,9 +2388,9 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 (
                     "hash:k:a:3:0".into(),
                     PageIndex {
-                        object_key: "hash-key".to_string(),
-                        model_id: "hash".to_string(),
-                        component: Some("a".to_string()),
+                        object_key: "hash-key".into(),
+                        model_id: "hash".into(),
+                        component: Some("a".into()),
                         object_id: 50,
                         address: BlockAddress {
                             page_slab_id: 3,
@@ -2411,9 +2411,9 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 (
                     "hash:k:b:3:1".into(),
                     PageIndex {
-                        object_key: "hash-key".to_string(),
-                        model_id: "hash".to_string(),
-                        component: Some("b".to_string()),
+                        object_key: "hash-key".into(),
+                        model_id: "hash".into(),
+                        component: Some("b".into()),
                         object_id: 51,
                         address: BlockAddress {
                             page_slab_id: 3,


### PR DESCRIPTION
`PageIndex` held `object_key`, `model_id` and `component` as owned `String`s — one set per page entry — and all three are already encoded in the map key the entry is filed under. Measured on a 500-memory store with 28,093 page entries: **2,443 KB, 89 B per entry**.

They repeat heavily, which is what decides interning over removal (the fields are read on hot comparison paths, so they have to stay readable):

| field | distinct values | entries | repeat |
|---|---:|---:|---:|
| `model_id` | **10** | 28,093 | 2,809x |
| `object_key` | **556** | 28,093 | 50x |
| `component` | 9,288 | 28,093 | 3x |

`model_id` is one of about ten string literals passed at the call sites; an `object_key` is shared by every page of that object.

## Measured

Distinct identity allocations, counted by pointer, because bytes cannot show interning any more than they show sharing — N entries pointing at one allocation still report N lengths:

| | distinct identity allocations |
|---|---:|
| before | 83,471 |
| after | **9,802** |

**−88%.** Proxy RSS over the same 500-memory ingest, bracketed start-to-end and interleaved:

| arm | RSS growth |
|---|---:|
| before | +402.2 MB |
| **after** | **+386.3 MB** |
| before (repeat) | +395.8 MB |

About 12.7 MB below the before mean, ~25 KB per memory, and it scales with the store.

One caution on that RSS figure: an earlier unbracketed reading of absolute RSS on a proxy carrying prior state suggested this change made things *worse* by 76 MB. It did not — measuring the delta from process start, interleaved, reverses it. Absolute RSS on a long-lived proxy is not a usable measure here.

## Shape

The table is global and bounded by the distinct identities a store actually holds — 9,802 at 500 memories against 28,093 entries. `Arc<str>` serializes exactly as a string, so the wire format is unchanged, and the type change is compiler-enforced: it named every site rather than letting one be silently missed.

`LivePageEntry`, `IndexItem` and the WAL outcome item keep plain `String`s. They are wire and transfer types, so interning across those boundaries buys nothing and would only add a lookup.

## Tests

`cargo check --all-targets` clean, 42 bucket-index tests, 98 tests across 8 mem0 suites.

**Strict conformance: 22/22, twice, on a cleaned machine.** Worth stating plainly, because two earlier runs of this branch scored 21/22 on `forget: get_all == 0` and `reset: tenant wiped`. Those two checks flake on this machine under load and with the disk near full — on the same cleaned runs, the branch this builds on scored 21/22 twice, failing exactly those two checks, while this branch passed both times. Across every run of both arms the flake rate is indistinguishable, so it is environmental rather than anything this change introduces.
