### PR TITLE
A storage-manager test that has never run

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2043,6 +2043,7 @@ fn a_metrics_reap_collects_the_counters_it_says_it_did() {
     );
 }
 
+#[test]
 fn storage_manager_cycle_runs_as_bounded_background_data_node_task() {
     let dir = tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(


### PR DESCRIPTION
storage_manager_cycle_runs_as_bounded_background_data_node_task carries no #[test], so
the harness has never executed it. It is the only function in that file without one --
every neighbour has it -- which makes it a test that was written and then silently left
out rather than a helper.

It passes. So this restores coverage rather than fixing behaviour, and the coverage is
worth having: it asserts the storage manager cycle runs as a BOUNDED background task,
which is the one thing that keeps a cycle from occupying the runtime it shares with
request work.

The compiler had been reporting it for as long as it has been there -- "function ... is
never used" -- in a build that emits enough warnings for one more to go unread.