### PR TITLE
Update a bucket's layout incrementally on the upsert path

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1258,10 +1258,18 @@ pub(super) fn upsert_bucket_index_page(
             bucket.dirty_generation = bucket.dirty_generation.saturating_add(1);
         }
         bucket.in_memory = true;
-        bucket.object_index.insert(object_id);
+        if !page_index.deleted {
+            bucket.object_index.insert(object_id);
+        }
         bucket.page_index
             .insert(page_ref_key.clone(), page_index.clone());
-        update_bucket_layout(bucket);
+        // Not a full `update_bucket_layout` here on purpose. That walks every page in the bucket
+        // and allocates a fresh BTreeSet of live object ids, and on this path the set is already
+        // right: a superseded ref belongs to the SAME object as the page being written (the
+        // lookup that produced it is keyed by the same identity), and the id being written was
+        // just inserted. Only the two counts change, and those are all the classifier takes.
+        bucket.layout =
+            classify_bucket_layout(bucket.object_index.len(), bucket.page_index.len());
     }
     shard
         .bucket_index


### PR DESCRIPTION
Basic ingestion got slower as the store grew, and this is one of the terms responsible.

`update_bucket_layout` walks every page in a bucket and allocates a fresh `BTreeSet` of live
object ids, then classifies the layout from two numbers: how many live objects, how many pages.
The upsert path called it after every page write, so writing one page cost a walk of every page
already in the bucket — the cost of an add grew with the store.

On that path the walk cannot change the answer:

* a superseded page ref comes from the object lookup keyed by `(kind, object_key, component)`,
  so it belongs to the **same** object as the page being written — removing it and inserting the
  new page leaves the set of live objects exactly as it was;
* the id being written is inserted explicitly on the line above;
* `classify_bucket_layout` only ever reads `object_index.len()` and `page_index.len()`.

So the set is already correct and only the two counts move. This updates them directly. A
superseded ref living in a **different** routing bucket is not covered by that reasoning, and
that branch still does the full maintenance.

### Measured

Pages walked per add is the growth term itself, and unlike wall-clock it does not move with
machine load. Two corpus sizes, so a change in *scaling* shows up as a widening difference rather
than a constant one. Each arm run twice:

| corpus | before | after | |
|---|---:|---:|---|
| 220 memories | 178,173 / 178,454 | 68,826 / 68,880 | **−61%** |
| 520 memories | 589,499 / 589,713 | 163,630 / 163,684 | **−72%** |

The saving widens with corpus size, which is what removing a growth term looks like — a constant
saving would show the same percentage in both rows. The two runs of each arm agree to within
0.3%, so the counts are the claim here.

Wall-clock moved the same way (p50 298 → 172 ms at 520 memories, and the before-arm curve
148 → 298 ms flattens to 140 → 172 ms), but this box swings far more than that between runs — one
repeat of the before arm recorded 9,265 ms under load. Treat the latency figures as consistent
with the counts, not as the measurement.

### Tests

* strict mem0 conformance 22/22, twice
* `upsert_reload_equality` passes — this is the load-bearing one: reload rebuilds the layout from
  scratch, so it fails if the incremental update ever disagrees with a full rebuild
* `storage_migration_corpus`, `bulk_install_index_durability`, `storage_crash_harness` pass
* `cargo check --all-targets` clean on both repos

`delta_served_index` and `cold_raw_ingestion` fail here, but they fail identically on pristine
`main` and on the branch this stacks on — inherited, not introduced. Both die in 0.05s parsing
empty output, which looks environmental rather than a code fault.
