### PR TITLE
a record can say how long it is instead of being hunted for a newline

### DIFF
--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -288,18 +288,26 @@ pub(super) fn read_page(
         }
     }
     // Adaptive pread: most records terminate well inside 128KB, so try that first and escalate
-    // only when the line does not end in the chunk -- a fixed 1MB upper bound makes every
+    // only when the record does not end in the chunk -- a fixed 1MB upper bound makes every
     // point read cost a megabyte of I/O.
+    //
+    // Where the record ends is asked of the FRAME, not guessed from a newline. Looking for one
+    // is right only while a record cannot contain the byte it ends with: a length-framed record
+    // carries 0x0A freely, so `contains` answers yes on the first payload that holds one and the
+    // split then cuts the record in half. The frame reader says "not all here yet" for exactly
+    // the case the newline probe was approximating, so escalation reads better than it did.
     let mut record = None;
     for size in [128u64 << 10, 1 << 20, u64::MAX] {
         let bytes = store.read_at_log_id(shard_id, log_id, size).ok()??;
-        let complete = bytes.contains(&10u8) || (bytes.len() as u64) < size;
-        if !complete {
-            continue;
+        match crate::log_framing::next_frame(&bytes) {
+            Ok(Some((consumed, _))) => {
+                record = decode_wal_line(&bytes[..consumed]).ok();
+                break;
+            }
+            // The record declares more bytes than this window holds: read a bigger one.
+            Ok(None) => continue,
+            Err(_) => return None,
         }
-        let line = bytes.split(|byte| *byte == 10u8).next()?;
-        record = decode_wal_line(line).ok();
-        break;
     }
     let record = record?;
     let pages = record.staged_pages;

--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -1042,23 +1042,36 @@ fn atomic_batch_is_all_or_nothing_when_commit_marker_lost() {
 
     // Simulate the lost commit marker: drop the last WAL line (batch_index == batch_size).
     let wal_path = index_dir.join("wals").join("shard-1.wal.jsonl");
-    // Read as BYTES. A record is newline-delimited but not necessarily text -- the binary
-    // encoding is valid UTF-8 only by accident -- and a test that edits the log has no business
-    // assuming which encoding wrote it.
+    // Read as BYTES and walk the records by their FRAMES, not by newlines. A record is only a
+    // "line" while the frame ends with one; once it declares its own length the payload carries
+    // 0x0A freely, and splitting on that byte cuts records in half -- which makes this test
+    // build a log no writer would ever produce and then assert on how recovery handles it.
+    // Asking the frame where each record ends works whichever frame wrote it.
     let contents = std::fs::read(&wal_path).expect("wal file should exist");
-    // Under preallocation the file ends in a zeros reservation; the records are the non-zero
-    // lines, and the commit marker is the last of THOSE -- popping blindly would drop the
-    // reservation and leave the marker standing.
-    let mut lines: Vec<&[u8]> = contents
-        .split(|byte| *byte == b'\n')
-        .filter(|line| !line.is_empty() && !line.iter().all(|byte| *byte == 0))
-        .collect();
-    assert!(lines.len() >= 4, "expected keep + 3 batch records, got {}", lines.len());
-    lines.pop(); // drop the batch commit-marker record
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut at = 0usize;
+    while at < contents.len() {
+        // The preallocated zeros reservation trails the records and is not one of them.
+        if contents[at] == 0 {
+            break;
+        }
+        match crate::log_framing::next_frame(&contents[at..]) {
+            Ok(Some((consumed, _))) if consumed > 0 => {
+                spans.push((at, at + consumed));
+                at += consumed;
+            }
+            _ => break,
+        }
+    }
+    assert!(
+        spans.len() >= 4,
+        "expected keep + 3 batch records, got {}",
+        spans.len()
+    );
+    spans.pop(); // drop the batch commit-marker record
     let mut truncated = Vec::new();
-    for line in lines {
-        truncated.extend_from_slice(line);
-        truncated.push(b'\n');
+    for (start, end) in spans {
+        truncated.extend_from_slice(&contents[start..end]);
     }
     std::fs::write(&wal_path, truncated).expect("rewrite wal");
 

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -100,16 +100,26 @@ fn control_api_reads_and_scans_wal_stream() {
     assert!(stream.status.ok);
     // Decode the records rather than matching on how a field is spelled: the endpoint returns
     // the log's records, and that is what should be asserted.
-    let sequences: Vec<u64> = stream
-        .data
-        .split(|byte| *byte == b'\n')
-        .filter(|line| !line.is_empty())
-        .map(|line| {
-            crate::wal::decode_wal_line(line)
-                .expect("the stream should carry decodable records")
-                .sequence
-        })
-        .collect();
+    // Walk the frames the stream carries rather than splitting it on newlines: a record ends
+    // where its frame says it does, and a length-framed payload contains 0x0A of its own.
+    let mut sequences: Vec<u64> = Vec::new();
+    let mut at = 0usize;
+    while at < stream.data.len() {
+        if stream.data[at] == 0 {
+            break;
+        }
+        match crate::log_framing::next_frame(&stream.data[at..]) {
+            Ok(Some((consumed, _))) if consumed > 0 => {
+                sequences.push(
+                    crate::wal::decode_wal_line(&stream.data[at..at + consumed])
+                        .expect("the stream should carry decodable records")
+                        .sequence,
+                );
+                at += consumed;
+            }
+            _ => break,
+        }
+    }
     assert_eq!(
         sequences,
         vec![1, 2],

--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -48,6 +48,96 @@ pub(crate) const FRAME_MAGIC_V1: &[u8] = b"#tsf1 ";
 /// The prefix new writes use.
 pub(crate) const FRAME_MAGIC: &[u8] = FRAME_MAGIC_V2;
 
+/// Marker for the binary frame: one byte, then a varint length, then the CRC32C as four raw
+/// bytes, then the payload. No delimiter and no trailing newline.
+///
+/// The text frames spend about twenty bytes to say what this says in seven: a six-byte magic
+/// repeated on every record, a decimal length, a checksum written as sixteen hex characters
+/// where four bytes carry the same number, and a newline. The newline is the expensive one.
+/// It is not the byte -- it is that a reader scanning for `\n` cannot be handed a payload
+/// containing one, so binary records have to be byte-stuffed on the way in and unstuffed on
+/// the way out: two full copies of every record, plus a byte for every 0x0A and 0x1B in it.
+/// A length-framed reader needs none of that, because the record already says how long it is.
+///
+/// 0xB3 is not a byte any earlier frame can start with: the text frames start with `#` and a
+/// legacy unframed record is a JSON document starting with `{`.
+pub(crate) const FRAME_MAGIC_V3: u8 = 0xB3;
+
+/// Whether new records are written with the binary frame.
+///
+/// OPT-IN, and the reason is worth stating: a length-framed record cannot be found by scanning
+/// BACKWARD. The tail scan that locates a log's last record looks for the final newline, which
+/// works only while every record ends with one -- a binary payload has no trailing delimiter and
+/// contains 0x0A bytes of its own, so a reverse search lands inside a payload. Walking forward
+/// finds the tail correctly but reads the whole file, and with TS_PHASE1_FLAT off that scan runs
+/// on EVERY append, which would turn ingest quadratic.
+///
+/// Making this the default therefore needs O(1) tail discovery -- last record offset and
+/// sequence recorded as the log is written, rather than searched for afterwards.
+pub(crate) fn binary_frame_enabled() -> bool {
+    matches!(
+        std::env::var("TS_WAL_BINARY_FRAME")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn write_varint(value: u64, out: &mut Vec<u8>) {
+    let mut value = value;
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            return;
+        }
+    }
+}
+
+/// Read a varint, returning the value and how many bytes it used. `None` when the bytes run out
+/// mid-varint, which is a torn tail rather than damage.
+fn read_varint(bytes: &[u8]) -> Option<(u64, usize)> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    for (index, byte) in bytes.iter().enumerate() {
+        if shift > 63 {
+            return None;
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, index + 1));
+        }
+        shift += 7;
+    }
+    None
+}
+
+/// Encode `payload` as a binary frame. The payload travels exactly as given -- no escaping,
+/// because nothing downstream scans it for a delimiter.
+pub(crate) fn encode_frame(payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(payload.len() + 10);
+    out.push(FRAME_MAGIC_V3);
+    write_varint(payload.len() as u64, &mut out);
+    out.extend_from_slice(&crate::checksum::crc32c(payload).to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Encode with whichever frame new writes are configured to use.
+pub(crate) fn encode_record(payload: &[u8]) -> Vec<u8> {
+    if binary_frame_enabled() {
+        encode_frame(payload)
+    } else {
+        encode_line(payload)
+    }
+}
+
 /// Prefix of the reclaim-base header, the optional first line of a log file.
 ///
 /// A reclaim drops a prefix of the file, shifting every surviving record down by the number of
@@ -149,6 +239,15 @@ pub(crate) fn encode_line(payload: &[u8]) -> Vec<u8> {
 /// record whose declared length or digest does not match its payload is COMMITTED corruption
 /// and returns `Err`.
 pub(crate) fn decode_line(line: &[u8]) -> Result<&[u8], FramingError> {
+    // decode_line binary: a binary frame declares its own length, so nothing may be stripped
+    // from the end of it. The newline strip below is right for a text record and would silently
+    // eat a byte from any binary payload that happens to end in 0x0A.
+    if line.first() == Some(&FRAME_MAGIC_V3) {
+        return match next_frame(line)? {
+            Some((_, payload)) => Ok(payload),
+            None => Err(FramingError("binary record is incomplete".to_string())),
+        };
+    }
     let line = strip_trailing_newline(line);
     // Pick the checksum by prefix so both framed formats round-trip out of one file: an
     // upgrade, or a GC rewrite spanning one, leaves v1 and v2 records interleaved.
@@ -201,6 +300,29 @@ pub(crate) fn next_frame(bytes: &[u8]) -> Result<Option<(usize, &[u8])>, Framing
     if bytes.is_empty() {
         return Ok(None);
     }
+    if bytes[0] == FRAME_MAGIC_V3 {
+        let Some((declared_len, varint_len)) = read_varint(&bytes[1..]) else {
+            return Ok(None); // torn mid-varint
+        };
+        let header_len = 1 + varint_len + 4;
+        if bytes.len() < header_len {
+            return Ok(None); // torn before the checksum is complete
+        }
+        let declared_len = declared_len as usize;
+        let mut digest = [0u8; 4];
+        digest.copy_from_slice(&bytes[1 + varint_len..header_len]);
+        let expected = u32::from_le_bytes(digest);
+        if bytes.len() < header_len + declared_len {
+            return Ok(None); // fewer bytes than declared: a torn tail
+        }
+        let payload = &bytes[header_len..header_len + declared_len];
+        if crate::checksum::crc32c(payload) != expected {
+            return Err(FramingError(
+                "framed record digest does not match its payload".to_string(),
+            ));
+        }
+        return Ok(Some((header_len + declared_len, payload)));
+    }
     let (checksum_of, header_prefix_len): (fn(&[u8]) -> String, usize) =
         if bytes.starts_with(FRAME_MAGIC_V2) {
             (crc_digest_hex, FRAME_MAGIC_V2.len())
@@ -251,6 +373,52 @@ pub(crate) fn next_frame(bytes: &[u8]) -> Result<Option<(usize, &[u8])>, Framing
 pub(crate) fn read_frame<R: std::io::BufRead>(
     reader: &mut R,
 ) -> Result<Option<(usize, Vec<u8>)>, FramingError> {
+    // A binary frame is decided by its first byte, before the text-magic scan below.
+    {
+        let first = {
+            let buffered = reader.fill_buf().map_err(|err| FramingError(err.to_string()))?;
+            buffered.first().copied()
+        };
+        match first {
+            None => return Ok(None),
+            Some(byte) if byte == FRAME_MAGIC_V3 => {
+                let mut marker = [0u8; 1];
+                if reader.read_exact(&mut marker).is_err() {
+                    return Ok(None);
+                }
+                let mut length_bytes = Vec::with_capacity(5);
+                let declared_len = loop {
+                    let mut byte = [0u8; 1];
+                    if reader.read_exact(&mut byte).is_err() {
+                        return Ok(None); // torn mid-varint
+                    }
+                    length_bytes.push(byte[0]);
+                    if let Some((value, _)) = read_varint(&length_bytes) {
+                        break value as usize;
+                    }
+                    if length_bytes.len() > 10 {
+                        return Err(FramingError("record length is not a varint".to_string()));
+                    }
+                };
+                let mut digest = [0u8; 4];
+                if reader.read_exact(&mut digest).is_err() {
+                    return Ok(None);
+                }
+                let mut payload = vec![0u8; declared_len];
+                if reader.read_exact(&mut payload).is_err() {
+                    return Ok(None); // fewer bytes than declared: a torn tail
+                }
+                if crate::checksum::crc32c(&payload) != u32::from_le_bytes(digest) {
+                    return Err(FramingError(
+                        "framed record digest does not match its payload".to_string(),
+                    ));
+                }
+                let consumed = 1 + length_bytes.len() + 4 + declared_len;
+                return Ok(Some((consumed, payload)));
+            }
+            Some(_) => {}
+        }
+    }
     let longest_magic = FRAME_MAGIC_V1.len().max(FRAME_MAGIC_V2.len());
     let mut header = Vec::with_capacity(longest_magic + 32);
     let mut spaces = 0usize;
@@ -318,9 +486,19 @@ pub(crate) fn read_frame<R: std::io::BufRead>(
             "framed record digest does not match its payload".to_string(),
         ));
     }
-    let mut trailing = [0u8; 1];
-    let consumed_newline =
-        matches!(reader.read_exact(&mut trailing), Ok(())) && trailing[0] == b'\n';
+    // PEEK, do not read: this byte belongs to the next record whenever it is not the newline
+    // the encoder appends, and read_exact would swallow it. Nothing exercised this before --
+    // both readers here had no callers at all -- so the stream corruption it causes had never
+    // had the chance to happen.
+    let consumed_newline = {
+        let buffered = reader.fill_buf().map_err(|err| FramingError(err.to_string()))?;
+        if buffered.first() == Some(&b'\n') {
+            reader.consume(1);
+            true
+        } else {
+            false
+        }
+    };
     let consumed = header.len() + declared_len + usize::from(consumed_newline);
     Ok(Some((consumed, payload)))
 }
@@ -367,6 +545,153 @@ fn split_once_space(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_binary_frame_round_trips_bytes_no_text_frame_could_carry() {
+        // The point of the frame: a payload containing newlines, escape bytes and invalid
+        // UTF-8 travels EXACTLY as given. The text frames cannot do this without stuffing the
+        // payload first, which is two extra copies of every record.
+        let payload: Vec<u8> = vec![0x00, b'\n', 0x1B, 0xff, 0xfe, b'\n', b'{', 0x80];
+        let framed = encode_frame(&payload);
+        let (consumed, decoded) = next_frame(&framed).unwrap().unwrap();
+        assert_eq!(decoded, payload.as_slice());
+        assert_eq!(consumed, framed.len(), "consumed must be the whole frame");
+        // and the payload is embedded verbatim, not escaped
+        assert!(framed.windows(payload.len()).any(|window| window == payload.as_slice()));
+    }
+
+    #[test]
+    fn a_binary_frame_is_smaller_than_the_text_frame_it_replaces() {
+        let payload = vec![b'x'; 100];
+        let binary = encode_frame(&payload).len();
+        let text = encode_line(&payload).len();
+        assert!(
+            binary < text,
+            "binary {binary} should be smaller than text {text}"
+        );
+        // 1 marker + 1 varint + 4 crc = 6 over the payload.
+        assert_eq!(binary - payload.len(), 6);
+        assert_eq!(text - payload.len(), 20);
+    }
+
+    #[test]
+    fn a_torn_binary_frame_reads_as_nothing_rather_than_as_damage() {
+        // Every truncation of a frame is an interrupted append, not corruption: it must read as
+        // "no record here" so the caller truncates, never as an error that refuses the load.
+        let framed = encode_frame(b"a durable write");
+        for cut in 1..framed.len() {
+            let torn = &framed[..cut];
+            assert!(
+                matches!(next_frame(torn), Ok(None)),
+                "a frame cut at {cut} must read as a torn tail"
+            );
+        }
+    }
+
+    #[test]
+    fn a_flipped_bit_in_a_complete_binary_frame_is_committed_corruption() {
+        let mut framed = encode_frame(b"a durable write");
+        let last = framed.len() - 1;
+        framed[last] ^= 0x01;
+        assert!(next_frame(&framed).is_err());
+    }
+
+    #[test]
+    fn binary_and_text_frames_read_out_of_one_file_in_either_order() {
+        // An upgrade leaves both in one file, and a reclaim rewrite can interleave them. Every
+        // reader has to walk the mixture without knowing which is coming.
+        let mut file = Vec::new();
+        file.extend_from_slice(&encode_line(b"{\"written\":\"before\"}"));
+        file.extend_from_slice(&encode_frame(b"binary\n\x1bpayload"));
+        file.extend_from_slice(&encode_line(b"{\"written\":\"between\"}"));
+        file.extend_from_slice(&encode_frame(b"another\nbinary"));
+
+        let mut cursor = &file[..];
+        let mut payloads = Vec::new();
+        while let Some((consumed, payload)) = next_frame(cursor).unwrap() {
+            payloads.push(payload.to_vec());
+            cursor = &cursor[consumed..];
+        }
+        assert_eq!(
+            payloads,
+            vec![
+                b"{\"written\":\"before\"}".to_vec(),
+                b"binary\n\x1bpayload".to_vec(),
+                b"{\"written\":\"between\"}".to_vec(),
+                b"another\nbinary".to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_streaming_reader_agrees_with_the_slice_reader_byte_for_byte() {
+        // `scan` derives a record's log id from how many bytes the reader consumed, so the two
+        // readers disagreeing by one byte would silently mis-address every record after it.
+        let mut file = Vec::new();
+        file.extend_from_slice(&encode_line(b"{\"a\":1}"));
+        file.extend_from_slice(&encode_frame(b"binary\none"));
+        file.extend_from_slice(&encode_line(b"{\"b\":2}"));
+        file.extend_from_slice(&encode_frame(b"binary\ntwo"));
+
+        let mut slice_offsets = Vec::new();
+        let mut cursor = &file[..];
+        let mut at = 0usize;
+        while let Some((consumed, _)) = next_frame(cursor).unwrap() {
+            at += consumed;
+            slice_offsets.push(at);
+            cursor = &cursor[consumed..];
+        }
+
+        let mut stream_offsets = Vec::new();
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(file.clone()));
+        let mut at = 0usize;
+        while let Some((consumed, _)) = read_frame(&mut reader).unwrap() {
+            at += consumed;
+            stream_offsets.push(at);
+        }
+
+        assert_eq!(slice_offsets, stream_offsets);
+        assert_eq!(slice_offsets.last().copied(), Some(file.len()));
+    }
+
+    #[test]
+    fn the_streaming_reader_does_not_eat_the_byte_after_a_text_record() {
+        // A text record is followed by its newline, but a binary record is not followed by
+        // anything -- the probe for that newline must not consume the next record's marker.
+        let mut file = Vec::new();
+        file.extend_from_slice(&encode_line(b"{\"first\":true}"));
+        file.extend_from_slice(&encode_frame(b"second"));
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(file));
+        let (_, first) = read_frame(&mut reader).unwrap().unwrap();
+        assert_eq!(first, b"{\"first\":true}".to_vec());
+        let (_, second) = read_frame(&mut reader).unwrap().unwrap();
+        assert_eq!(second, b"second".to_vec());
+    }
+
+    #[test]
+    fn an_empty_payload_frames_and_unframes() {
+        let framed = encode_frame(b"");
+        let (consumed, payload) = next_frame(&framed).unwrap().unwrap();
+        assert!(payload.is_empty());
+        assert_eq!(consumed, framed.len());
+    }
+
+    #[test]
+    fn a_payload_longer_than_one_varint_byte_round_trips() {
+        // 300 bytes needs a two-byte varint; 20_000 needs three. Off-by-one in the length
+        // encoding would only show up past 127 bytes.
+        for size in [128usize, 300, 20_000] {
+            let payload = vec![b'z'; size];
+            let framed = encode_frame(&payload);
+            let (consumed, decoded) = next_frame(&framed).unwrap().unwrap();
+            assert_eq!(decoded.len(), size);
+            assert_eq!(consumed, framed.len());
+            let mut reader = std::io::BufReader::new(std::io::Cursor::new(framed.clone()));
+            let (stream_consumed, stream_payload) = read_frame(&mut reader).unwrap().unwrap();
+            assert_eq!(stream_consumed, framed.len());
+            assert_eq!(stream_payload.len(), size);
+        }
+    }
 
     #[test]
     fn framed_round_trip_recovers_exact_payload() {

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -96,6 +96,78 @@ pub fn encode_wal_line_for_test(
     Ok(crate::log_framing::encode_line(&encode_wal_payload(record)?))
 }
 
+
+/// Read one record's bytes AS FRAMED, or `None` at the end of the records.
+///
+/// The readers below all used `read_until(b'\n')`, which is only correct while every record is
+/// newline-terminated -- and that requirement is the reason binary payloads have to be
+/// byte-stuffed before they are written. This reads a binary frame by the length it declares
+/// and a text record up to its newline, so one loop walks a file holding both.
+///
+/// Returns the bytes exactly as they sit on disk, because callers hand them to
+/// `decode_wal_line`, and the byte count is what `scan` turns into a record's log id.
+fn read_raw_record<R: std::io::BufRead>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let first = {
+        let buffered = reader.fill_buf()?;
+        buffered.first().copied()
+    };
+    let Some(first) = first else {
+        return Ok(None);
+    };
+    // A zero where a record should start is preallocated room, never a record: reservations are
+    // written as zeros and always trail the records. No frame can begin with one -- the text
+    // frames begin with `#`, a legacy record with `{`, a binary frame with its marker.
+    if first == 0 {
+        return Ok(None);
+    }
+    if first != crate::log_framing::FRAME_MAGIC_V3 {
+        let mut line = Vec::new();
+        let read = reader.read_until(b'\n', &mut line)?;
+        if read == 0 {
+            return Ok(None);
+        }
+        return Ok(Some(line));
+    }
+    // Binary: marker, varint length, four checksum bytes, then exactly that many payload bytes.
+    let mut raw = Vec::with_capacity(64);
+    let mut marker = [0u8; 1];
+    if reader.read_exact(&mut marker).is_err() {
+        return Ok(None);
+    }
+    raw.push(marker[0]);
+    let mut declared: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let mut byte = [0u8; 1];
+        if reader.read_exact(&mut byte).is_err() {
+            return Ok(None); // torn mid-varint
+        }
+        raw.push(byte[0]);
+        declared |= u64::from(byte[0] & 0x7f) << shift;
+        if byte[0] & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift > 63 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "record length is not a varint",
+            ));
+        }
+    }
+    let mut digest = [0u8; 4];
+    if reader.read_exact(&mut digest).is_err() {
+        return Ok(None);
+    }
+    raw.extend_from_slice(&digest);
+    let mut payload = vec![0u8; declared as usize];
+    if reader.read_exact(&mut payload).is_err() {
+        return Ok(None); // fewer bytes than declared: a torn tail
+    }
+    raw.extend_from_slice(&payload);
+    Ok(Some(raw))
+}
+
 pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLogError> {
     let payload = crate::log_framing::decode_line(line)?;
     // Which encoding a payload is in is a property of the payload, never of configuration: a log
@@ -1419,15 +1491,15 @@ impl LocalWriteAheadLogStore {
             let mut reader = BufReader::new(file);
             let mut log_id = base;
             loop {
-                let mut line = Vec::new();
-                let read = reader.read_until(b'\n', &mut line)?;
-                if read == 0 {
+                // Reads a record by the length it declares when it is framed that way, and to
+                // the newline when it is not, so one loop walks a log holding both. The
+                // preallocated zero run that trails the records ends the loop from inside the
+                // reader: no frame can start with a zero byte.
+                let Some(line) = read_raw_record(&mut reader)? else {
                     break;
-                }
-                // A trailing run of zeros with no newline is a preallocated reservation, not a
-                // record: records stop here. A torn NON-zero tail cannot reach this loop -- the
-                // repair scan above already truncated it.
-                if !line.ends_with(b"\n") && line.iter().all(|byte| *byte == 0) {
+                };
+                let read = line.len();
+                if read == 0 {
                     break;
                 }
                 let next_log_id = log_id.saturating_add(read as u64);
@@ -1728,10 +1800,11 @@ impl LocalWriteAheadLogStore {
         let mut records_after = 0usize;
         let mut split = None;
         let mut cursor = header_len;
-        let mut line = Vec::new();
         loop {
-            line.clear();
-            let read = reader.read_until(b'\n', &mut line)?;
+            let Some(line) = read_raw_record(&mut reader)? else {
+                break;
+            };
+            let read = line.len();
             if read == 0 {
                 break;
             }
@@ -1936,22 +2009,19 @@ impl LocalWriteAheadLogStore {
         // encodings, ever gets to look at it. Escaping the newline out of a binary payload keeps
         // records SPLITTABLE; it cannot make arbitrary bytes valid UTF-8, and nothing should
         // require them to be.
-        let mut line = Vec::new();
         loop {
-            line.clear();
-            if reader.read_until(b'\n', &mut line)? == 0 {
+            let Some(mut line) = read_raw_record(&mut reader)? else {
                 break;
-            }
-            while line.last() == Some(&b'\n') || line.last() == Some(&b'\r') {
-                line.pop();
+            };
+            // Only a text record carries a trailing newline; a binary frame ends where its
+            // declared length ends, and trimming it would take a byte of the payload.
+            if line.first() != Some(&crate::log_framing::FRAME_MAGIC_V3) {
+                while line.last() == Some(&b'\n') || line.last() == Some(&b'\r') {
+                    line.pop();
+                }
             }
             if line.is_empty() {
                 continue;
-            }
-            // The records may end before the file does: a trailing zeros run is preallocated
-            // room, not a record, and it always comes last.
-            if line.iter().all(|byte| *byte == 0) {
-                break;
             }
             let record = decode_wal_line(&line)?;
             if start_sequence == 0 {
@@ -2637,7 +2707,7 @@ fn append_record_locked(
     // Frame the record with a length + SHA-256 digest so a later value-preserving bit-flip in
     // this committed line is detected on read (see `crate::log_framing`). Offsets/stats below
     // use the real byte length, so framing is transparent to the append report and replication.
-    let bytes = crate::log_framing::encode_line(&encode_wal_payload(record)?);
+    let bytes = crate::log_framing::encode_record(&encode_wal_payload(record)?);
     let prealloc = wal_preallocate_enabled();
     let mut file = if prealloc {
         // Positioned write, not O_APPEND: with a reservation, the physical end of the file is
@@ -2841,9 +2911,55 @@ fn last_wal_sequence_at(root: &Path, shard_id: ShardId) -> Result<(u64, u64), Wr
 /// `(last sequence, record end)` for one piece. The record end is the byte offset just past the
 /// last complete record -- the file's length, unless a torn tail was repaired or a preallocated
 /// zeros reservation follows the records (kept, not truncated: it is not damage, it is room).
+/// `(last sequence, record end)` found by walking the records FORWARD from the start.
+///
+/// The windowed scan below finds a log's last record by searching backward for the final
+/// newline. That is exact for records that end in one and wrong for records that do not: a
+/// length-framed payload carries 0x0A bytes of its own, so the search lands in the middle of a
+/// payload and reports a boundary that was never a boundary. There is no backward equivalent --
+/// a length prefix can only be read from in front of the record it describes -- so the frames
+/// have to be walked in order.
+///
+/// The cost is the file rather than its last window, which is why the binary frame is opt-in.
+fn last_wal_sequence_forward(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
+    let (_, header_len) = read_wal_base(path)?;
+    let file = File::open(path)?;
+    let len = file.metadata()?.len();
+    if len <= header_len {
+        return Ok((0, len.min(header_len)));
+    }
+    let mut reader = BufReader::new(file);
+    reader.seek(SeekFrom::Start(header_len))?;
+    let mut last_sequence = 0u64;
+    let mut record_end = header_len;
+    while let Some(raw) = read_raw_record(&mut reader)? {
+        if raw.is_empty() {
+            break;
+        }
+        // A blank line carries nothing and is skipped, exactly as the windowed scan skips it.
+        if raw.iter().all(|byte| byte.is_ascii_whitespace()) {
+            record_end = record_end.saturating_add(raw.len() as u64);
+            continue;
+        }
+        // A record that will not decode here is a torn tail: everything before it stands, and
+        // the end of the good prefix is where it starts.
+        match decode_wal_line(&raw) {
+            Ok(record) => {
+                last_sequence = last_sequence.max(record.sequence);
+                record_end = record_end.saturating_add(raw.len() as u64);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Ok((last_sequence, record_end))
+}
+
 fn last_wal_sequence_in(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
     if !path.exists() {
         return Ok((0, 0));
+    }
+    if crate::log_framing::binary_frame_enabled() {
+        return last_wal_sequence_forward(path);
     }
     let (_, header_len) = read_wal_base(path)?;
     let file = OpenOptions::new().read(true).write(true).open(path)?;


### PR DESCRIPTION
a record can say how long it is instead of being hunted for a newline

    text frame    #tsf2 <decimal len> <crc32c as hex> <payload>\n     20 bytes
    binary frame  <marker><varint len><crc32c, four bytes><payload>    6 bytes

The newline is the expensive part, and not because of the byte. A reader that finds records by
scanning for `\n` cannot be handed a payload containing one, so every binary record was
byte-stuffed on the way in and unstuffed on the way out: two full copies of each record, plus a
byte for every 0x0A and 0x1B inside it. A reader that is told the length needs none of that.
The payload now travels exactly as produced.

THE LENGTH-AWARE READERS ALREADY EXISTED AND NOTHING CALLED THEM.

`next_frame` and `read_frame` were written, documented as what readers use -- "Readers use
next_frame or read_frame instead, which take the length the record declares" -- and had zero
callers, no tests, and one bug apiece. The real readers went on scanning for newlines, and the
byte-stuffing was added afterwards to keep them working. The escaping existed to prop up a
reader that had already been replaced, on paper.

`read_frame` probed for the trailing newline with `read_exact`, which CONSUMES the byte it
looks at. Any record not followed by a newline lost its successor's first byte. It never fired
because nothing called it; it would have fired on every record the moment it was wired up.

Six places assumed a record is a line: the backward tail scan, `info()`'s trim, `decode_line`'s
strip, `read_page`'s split, and tests that build or parse logs as text. That spread is the
honest reason stuffing was chosen over fixing the readers -- escaping makes all six true at
once. `read_page` was the one that lost data rather than merely misparsing: it found a record's
end with `bytes.contains(&10)` and `split(b'\n').next()`, which answers on the first payload
holding that byte and cuts the record in half. It asks the frame now, and the frame's "not all
here yet" is exactly the signal its window-escalation was approximating.

    engine        275 passed, 0 failed   -- both frames
    raft          265 passed, 0 failed
    shared_store   37 passed, 0 failed
    log_framing    20 passed, 0 failed

BINARY FRAMING IS OPT-IN, AND THE REASON IS STRUCTURAL.

A length-framed record cannot be found by scanning BACKWARD. The tail scan that locates a log's
last record searches for the final newline; a length-framed payload carries 0x0A of its own, so
the search lands inside a payload and reports a boundary that never was one. There is no
backward equivalent -- a length prefix is only readable from in front of the record it
describes -- so the frames have to be walked in order. That is correct and it reads the file
rather than its last window, and with TS_PHASE1_FLAT off the append path resolves the tail per
write, so defaulting it would make ingest quadratic.

Which is why a log format that frames by length keeps the position and sequence of its last
record as it writes them, rather than searching afterwards. That is the next piece, and until
it exists this stays behind TS_WAL_BINARY_FRAME.

Tests that read a log as lines still assume the text frame -- sixteen of them, all in the WAL
unit tests, all about reclaim, rolling, torn tails and base headers. They pass on the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
