### PR TITLE
The keyword index caps, not the routing range, are the largest memory lever

### DIFF
--- a/docs/runtime_tuning.md
+++ b/docs/runtime_tuning.md
@@ -70,7 +70,7 @@ TEMPORALSTORE_BLOCKCACHE_SSD_PATH=/mnt/ssd-cache/temporalstore \
 bash tools/run_ssd_blockcache_smoke_ubuntu22.sh
 ```
 
-## Routing Slot Range (the largest lever on resident memory)
+## Routing Slot Range (a large lever on resident memory)
 
 | Environment variable | Default | Meaning |
 | --- | ---: | --- |
@@ -111,6 +111,71 @@ after a restart that recovered from the on-disk artifacts.
 The range also bounds how finely slots can be divided between shards, so keep it
 comfortably above the shard count you expect to grow into.
 
+## Keyword Index Coverage (the largest lever on resident memory)
+
+Resident memory tracks the **number of records**, and for resource/skill ingest
+most records are index postings, not content. Counted over four ~1.3 MB CN/EN
+md+json documents at 1000-token chunks with posting lists on:
+
+| record type | per document | per chunk | share of records |
+| --- | ---: | ---: | ---: |
+| `context_index` | 3571 | 7.66 | **75.8%** |
+| `resource_chunk` | 466 | 1.00 | 9.9% |
+| `context_embedding` | 466 | 1.00 | 9.9% |
+| `skill_section` | 206 | 0.44 | 4.4% |
+
+So how many keywords each chunk indexes decides the memory bill — more than the
+chunk size, and more than whether per-chunk vectors are stored. Four caps apply
+together and the smallest wins, so raise or lower them as a set:
+
+| Environment variable | Default |
+| --- | ---: |
+| `MATRIXARK_INDEX_KEYWORD_LIMIT` | `12` |
+| `MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK` | `6` |
+| `MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK` | `10` |
+| `MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD` | `10` |
+
+Measured over 200 sampled chunks, with resident memory projected at the measured
+~2.7 KB per record for a 10,000-document corpus:
+
+| cap | records / doc | terms indexed | tail term reachable | 10k-doc records | projected resident |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| `12` | 1555 | 9.4% | 59% | 15.6M | 39 GB |
+| `25` | 1768 | 19.4% | 76% | 17.7M | 44 GB |
+| `50` | 2412 | 38.1% | 91% | 24.1M | 61 GB |
+| `100` | 4640 | 75.4% | 98% | 46.4M | 117 GB |
+| `200` | 4708 | 100.0% | 98% | 47.1M | 118 GB |
+| `400` | 4708 | 100.0% | 98% | 47.1M | 118 GB |
+
+Two columns because they answer different questions. *Terms indexed* is the share
+of a chunk's distinct terms that are searchable at all. *Tail term reachable* is
+whether a phrase in the last tenth of a chunk can be found — the case that makes
+large chunks worth using, since the encoder's 128-token window embeds only the
+first fraction of a 1000-token chunk.
+
+**Do not set these above 100.** Coverage of the tail saturates there: `200` and
+`400` cost the same memory as `100` and find nothing more. Going from `100` to
+`50` halves resident memory for seven points of tail recall, which is usually the
+right trade for a large corpus. The `12` default is cheap but reaches only 59% of
+tails, which is why specific-phrase lookups miss on long chunks.
+
+```bash
+MATRIXARK_INDEX_KEYWORD_LIMIT=50 MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK=50 MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK=50 MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD=50 MATRIXARK_INDEX_POSTING_LISTS=1 matrixark_rust_datanode
+```
+
+Keep `MATRIXARK_INDEX_POSTING_LISTS=1` whenever coverage is raised: it stores one
+record per term carrying its posting list instead of one per (term, chunk), which
+is what makes any coverage above the default affordable.
+
+### Sizing a corpus
+
+A ~1.3 MB document at 1000-token chunks is about **4,700 records**, not a few
+hundred — roughly 466 chunks, each becoming ~10 records. A 10,000-document corpus
+is therefore ~47M records at full coverage, and resident memory, not ingest time,
+is what limits it to a single node. Measured with four parallel client processes,
+that corpus ingests in about 3.6 hours; it does not fit in one node's memory at
+cap 100 or above.
+
 ## Why This Matters
 
 The earlier 10 MB/256 MB constants changed performance behavior:
@@ -120,6 +185,9 @@ The earlier 10 MB/256 MB constants changed performance behavior:
 - Replicator loop and batch sizes trade CPU for secondary freshness.
 - Blockcache capacity should match the actual memory and SSD budget of the node.
 - The routing slot range decides how many records share a slot, and the per-slot
-  structures are what resident memory is mostly made of.
+  structures are much of what resident memory is made of.
+- The keyword index caps decide how many records exist at all: for resource and
+  skill ingest, index postings are ~76% of them, which makes coverage the largest
+  single lever on resident memory.
 
 Use environment variables per run, then record the exact values with the benchmark result folder.

--- a/docs/runtime_tuning.md
+++ b/docs/runtime_tuning.md
@@ -138,30 +138,46 @@ together and the smallest wins, so raise or lower them as a set:
 Measured over 200 sampled chunks, with resident memory projected at the measured
 ~2.7 KB per record for a 10,000-document corpus:
 
-| cap | records / doc | terms indexed | tail term reachable | 10k-doc records | projected resident |
-| ---: | ---: | ---: | ---: | ---: | ---: |
-| `12` | 1555 | 9.4% | 59% | 15.6M | 39 GB |
-| `25` | 1768 | 19.4% | 76% | 17.7M | 44 GB |
-| `50` | 2412 | 38.1% | 91% | 24.1M | 61 GB |
-| `100` | 4640 | 75.4% | 98% | 46.4M | 117 GB |
-| `200` | 4708 | 100.0% | 98% | 47.1M | 118 GB |
-| `400` | 4708 | 100.0% | 98% | 47.1M | 118 GB |
+| cap | records / doc | terms indexed | 10k-doc records | projected resident |
+| ---: | ---: | ---: | ---: | ---: |
+| `12` | 1555 | 9.4% | 15.6M | 39 GB |
+| `25` | 1768 | 19.4% | 17.7M | 44 GB |
+| `50` | 2412 | 38.1% | 24.1M | 61 GB |
+| `100` | 4640 | 75.4% | 46.4M | 117 GB |
+| `200` | 4708 | 100.0% | 47.1M | 118 GB |
+| `400` | 4708 | 100.0% | 47.1M | 118 GB |
 
-Two columns because they answer different questions. *Terms indexed* is the share
-of a chunk's distinct terms that are searchable at all. *Tail term reachable* is
-whether a phrase in the last tenth of a chunk can be found — the case that makes
-large chunks worth using, since the encoder's 128-token window embeds only the
-first fraction of a 1000-token chunk.
+Coverage is **position-dependent**, and that decides the choice. Keywords are taken
+in document order, so a lower cap keeps the start of a chunk and drops the end.
+Planting a distinctive phrase at four depths in each of 121 chunks and asking
+whether it appears in an emitted index record:
 
-**Do not set these above 100.** Coverage of the tail saturates there: `200` and
-`400` cost the same memory as `100` and find nothing more. Going from `100` to
-`50` halves resident memory for seven points of tail recall, which is usually the
-right trade for a large corpus. The `12` default is cheap but reaches only 59% of
-tails, which is why specific-phrase lookups miss on long chunks.
+| cap | 10% in | 50% in | 90% in | 97% in |
+| ---: | ---: | ---: | ---: | ---: |
+| `12` | 17% | 6% | 0% | 0% |
+| `25` | 30% | 12% | 9% | 3% |
+| `50` | 98% | 12% | 12% | 12% |
+| `100` | 100% | 99% | 64% | 36% |
+| `200` | 100% | 100% | 100% | 100% |
+
+**`100` is the worst choice on this curve.** It costs 117 GB against 118 GB for
+`200` — within a percent — and finds only 36% of phrases near the end of a chunk
+where `200` finds all of them. Either pay for `200` and index everything, or drop
+to `50` or the `12` default and accept that only the opening of each chunk is
+searchable. There is no useful middle.
+
+That matters most exactly where large chunks are used: the encoder's 128-token
+window embeds only the first fraction of a 1000-token chunk, so the keyword index
+is the *only* way to reach the rest of it.
 
 ```bash
-MATRIXARK_INDEX_KEYWORD_LIMIT=50 MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK=50 MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK=50 MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD=50 MATRIXARK_INDEX_POSTING_LISTS=1 matrixark_rust_datanode
+# Index everything: every phrase reachable, ~118 GB resident for 10k documents.
+MATRIXARK_INDEX_KEYWORD_LIMIT=200 MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK=200 MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK=200 MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD=200 MATRIXARK_INDEX_POSTING_LISTS=1 matrixark_rust_datanode
 ```
+
+To halve the memory instead, use `50` across all four — accepting that only the
+opening of each chunk is searchable. Do not stop at `100`: it pays `200`'s memory
+for a third of its reach.
 
 Keep `MATRIXARK_INDEX_POSTING_LISTS=1` whenever coverage is raised: it stores one
 record per term carrying its posting list instead of one per (term, chunk), which

--- a/docs/runtime_tuning.md
+++ b/docs/runtime_tuning.md
@@ -170,6 +170,30 @@ That matters most exactly where large chunks are used: the encoder's 128-token
 window embeds only the first fraction of a 1000-token chunk, so the keyword index
 is the *only* way to reach the rest of it.
 
+### Pair the cap with the chunk size
+
+The cap has to exceed the number of distinct terms in a chunk, and that number
+grows with the chunk. The same measurement across chunk sizes:
+
+| chunk tokens | cap | 10% in | 50% in | 90% in | 97% in | index terms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 240 | `50` | 100% | 91% | 45% | 33% | 2738 |
+| 240 | `100` | 100% | 100% | 100% | 100% | 3761 |
+| 240 | `200` | 100% | 100% | 100% | 100% | 3761 |
+| 500 | `100` | 100% | 100% | 98% | 82% | 1784 |
+| 500 | `200` | 100% | 100% | 100% | 100% | 1855 |
+| 1000 | `100` | 100% | 99% | 64% | 36% | 972 |
+| 1000 | `200` | 100% | 100% | 100% | 100% | 1193 |
+
+A 240-token chunk is fully covered by `100` — raising it to `200` changes nothing
+because the chunk has no more terms to index. A 1000-token chunk needs `200`.
+
+**Larger chunks are the cheaper way to buy full reach.** Over the same source
+text, 1000-token chunks at `200` index 1193 terms where 240-token chunks at `100`
+index 3761 — about a third of the records for identical reach at every depth.
+With posting lists on, index records track distinct terms, so that ratio is the
+memory ratio. Prefer big chunks with a high cap over small chunks with a low one.
+
 ```bash
 # Index everything: every phrase reachable, ~118 GB resident for 10k documents.
 MATRIXARK_INDEX_KEYWORD_LIMIT=200 MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK=200 MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK=200 MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD=200 MATRIXARK_INDEX_POSTING_LISTS=1 matrixark_rust_datanode


### PR DESCRIPTION
Documents the knob that decides resident memory for resource/skill ingest, and corrects the section that claimed to be the largest lever.

## Where the records are

Resident memory tracks the **number of records**, and most records from an ingest are index postings, not content. Counted over four ~1.3 MB CN/EN md+json documents at 1000-token chunks with posting lists on:

| record type | per document | per chunk | share |
| --- | ---: | ---: | ---: |
| `context_index` | 3571 | 7.66 | **75.8%** |
| `resource_chunk` | 466 | 1.00 | 9.9% |
| `context_embedding` | 466 | 1.00 | 9.9% |
| `skill_section` | 206 | 0.44 | 4.4% |

So keyword coverage sets the bill — more than chunk size, more than whether per-chunk vectors are stored. The routing-slot range is worth ~45%; the caps are worth 3x, so the "largest lever" title moves.

## Cost

| cap | records/doc | terms indexed | 10k records | resident |
| ---: | ---: | ---: | ---: | ---: |
| `12` | 1555 | 9.4% | 15.6M | 39 GB |
| `25` | 1768 | 19.4% | 17.7M | 44 GB |
| `50` | 2412 | 38.1% | 24.1M | 61 GB |
| `100` | 4640 | 75.4% | 46.4M | 117 GB |
| `200` | 4708 | 100.0% | 47.1M | 118 GB |

## Reach, which is position-dependent

Keywords are taken in document order, so a lower cap keeps the start of a chunk and drops the end. Planting a distinctive phrase at four depths in each of 121 chunks and asking whether it appears in an **emitted index record**:

| cap | 10% in | 50% in | 90% in | 97% in |
| ---: | ---: | ---: | ---: | ---: |
| `12` | 17% | 6% | 0% | 0% |
| `25` | 30% | 12% | 9% | 3% |
| `50` | 98% | 12% | 12% | 12% |
| `100` | 100% | 99% | 64% | 36% |
| `200` | 100% | 100% | 100% | 100% |

**`100` is the worst point on the curve.** It costs 117 GB against 118 GB for `200` — within a percent — and reaches 36% of phrases near the end of a chunk where `200` reaches all of them. Either index everything at `200`, or drop to `50` or the `12` default and accept that only the opening of each chunk is searchable. There is no useful middle.

This matters most exactly where large chunks are used: the encoder's 128-token window embeds only the first fraction of a 1000-token chunk, so the keyword index is the only way to reach the rest.

### A correction, kept visible

The first version of this page measured reach with a proxy — whether *any* term from a chunk's last tenth appeared in its keywords. That saturates at 98% by cap 100 and led to the opposite advice: "never set these above 100". The real question is whether *that* phrase is indexed, and the two diverge sharply. The `terms indexed` column was right all along; the missing quarter at cap 100 is precisely the tail.

## Sizing

A ~1.3 MB document at 1000-token chunks is **~4,700 records**, not a few hundred (~466 chunks x ~10 records each), so a 10,000-document corpus is ~47M records. With four parallel client processes it ingests in ~3.6 h — **time is not the constraint; resident memory is**, and it does not fit one node at full coverage.

Documentation only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
