### PR TITLE
a payload inside a length-framed record has nothing to escape itself from

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -172,7 +172,9 @@ pub fn decode_wal_line(line: &[u8]) -> Result<WriteAheadLogRecord, WriteAheadLog
     let payload = crate::log_framing::decode_line(line)?;
     // Which encoding a payload is in is a property of the payload, never of configuration: a log
     // written across a flag change still reads end to end.
-    if payload.first() == Some(&crate::wal_proto::BINARY_PAYLOAD_MARKER) {
+    if payload.first() == Some(&crate::wal_proto::BINARY_PAYLOAD_MARKER)
+        || payload.first() == Some(&crate::wal_proto::RAW_PAYLOAD_MARKER)
+    {
         return crate::wal_proto::decode(payload).map_err(|err| {
             WriteAheadLogError::Corruption(format!("engine wal record decode failed: {err}"))
         });
@@ -3199,6 +3201,57 @@ fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// What the two frames actually cost, measured on the file rather than argued from the
+    /// header sizes: same records, same store, one flag apart.
+    #[test]
+    fn what_each_frame_costs_on_disk() {
+        fn write_and_measure(binary: bool, dir: &std::path::Path) -> (u64, usize) {
+            let previous = std::env::var("TS_WAL_BINARY_FRAME").ok();
+            std::env::set_var("TS_WAL_BINARY_FRAME", if binary { "1" } else { "0" });
+            let store = LocalWriteAheadLogStore::new(dir);
+            let records = 200usize;
+            for index in 0..records {
+                store
+                    .append(
+                        1,
+                        Command::StringSet {
+                            // A realistic key and a value with the byte a line reader splits on,
+                            // because that byte is exactly what escaping charges for.
+                            key: format!("tenant/9/object/{index:06}/field"),
+                            value: format!("value-{index}\nsecond line\nthird").into_bytes(),
+                        },
+                    )
+                    .unwrap();
+            }
+            let path = write_ahead_log_path(dir, 1);
+            // Preallocated room is reservation, not records: measure what the records occupy.
+            let (_, record_end) = last_wal_sequence_in(&path).unwrap();
+            match previous {
+                Some(value) => std::env::set_var("TS_WAL_BINARY_FRAME", value),
+                None => std::env::remove_var("TS_WAL_BINARY_FRAME"),
+            }
+            (record_end, records)
+        }
+
+        let text_dir = tempfile::tempdir().unwrap();
+        let binary_dir = tempfile::tempdir().unwrap();
+        let (text_bytes, count) = write_and_measure(false, text_dir.path());
+        let (binary_bytes, _) = write_and_measure(true, binary_dir.path());
+
+        let text_per = text_bytes as f64 / count as f64;
+        let binary_per = binary_bytes as f64 / count as f64;
+        let saved = 100.0 * (text_per - binary_per) / text_per;
+        println!(
+            "  text   {text_bytes} bytes over {count} records = {text_per:.1} B/record\n  \
+             binary {binary_bytes} bytes over {count} records = {binary_per:.1} B/record\n  \
+             saved  {saved:.1}%"
+        );
+        assert!(
+            binary_bytes < text_bytes,
+            "the binary frame must not cost more: {binary_bytes} vs {text_bytes}"
+        );
+    }
     use crate::types::Command;
 
     #[test]

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -30,6 +30,18 @@ use crate::wal::{StagedPage, WalOutcomeItem, WriteAheadLogRecord, WriteAheadLogR
 /// this existed reads back unchanged.
 pub(crate) const BINARY_PAYLOAD_MARKER: u8 = 0xB7;
 
+/// Marker for a protobuf payload carrying NO escaping.
+///
+/// Escaping exists to keep a record free of the byte a line-oriented reader splits on. Inside a
+/// length-framed record nothing splits on anything, so the stuffing is pure cost -- and it is
+/// not small: protobuf writes field 1 as the tag byte 0x0A, so the payloads carrying the most
+/// fields are the ones paying the most for a delimiter no reader is looking for.
+///
+/// A separate marker rather than a flag read at decode time: which encoding a payload is in has
+/// to be a property of the payload, or a log written across a configuration change stops
+/// reading halfway through.
+pub(crate) const RAW_PAYLOAD_MARKER: u8 = 0xB8;
+
 /// Escapes a newline out of an encoded payload.
 ///
 /// The log is read with `reader.lines()`. A JSON payload can never contain a raw newline, so that
@@ -385,16 +397,28 @@ pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
     let mut encoded = Vec::with_capacity(message.encoded_len());
     message.encode(&mut encoded).map_err(|err| err.to_string())?;
     let mut out = Vec::with_capacity(encoded.len() + 8);
-    out.push(BINARY_PAYLOAD_MARKER);
-    out.extend_from_slice(&escape_newlines(&encoded));
+    if crate::log_framing::binary_frame_enabled() {
+        // The frame declares its own length, so the payload is written as produced.
+        out.push(RAW_PAYLOAD_MARKER);
+        out.extend_from_slice(&encoded);
+    } else {
+        out.push(BINARY_PAYLOAD_MARKER);
+        out.extend_from_slice(&escape_newlines(&encoded));
+    }
     Ok(out)
 }
 
 /// Decode a payload this module wrote. The caller has already checked the marker byte.
 pub(crate) fn decode(payload: &[u8]) -> Result<WriteAheadLogRecord, String> {
-    let unescaped = unescape_newlines(&payload[1..])?;
-    let message =
-        v1::EngineWalRecord::decode(unescaped.as_slice()).map_err(|err| err.to_string())?;
+    let body = &payload[1..];
+    let unescaped;
+    let bytes: &[u8] = if payload.first() == Some(&RAW_PAYLOAD_MARKER) {
+        body
+    } else {
+        unescaped = unescape_newlines(body)?;
+        unescaped.as_slice()
+    };
+    let message = v1::EngineWalRecord::decode(bytes).map_err(|err| err.to_string())?;
     // Absent is a legitimate record now, not a malformed one: it carries results instead.
     let command = match message.command.and_then(|command| command.kind) {
         Some(kind) => Some(


### PR DESCRIPTION
a payload inside a length-framed record has nothing to escape itself from

    text frame, escaped payload   102.3 B/record
    binary frame, raw payload      84.8 B/record      -17.1%

Measured on the file over 200 records, one flag apart, with values that contain the byte
escaping exists to hide -- because arguing this from header sizes gets it wrong. The frame
accounts for fourteen bytes of it; the rest is stuffing that stopped happening.

Escaping keeps a record free of the byte a line-oriented reader splits on. Inside a record
that declares its own length nothing splits on anything, so every escape was buying protection
from a reader that is no longer looking. It was not a rounding error either: protobuf writes
field 1 as the tag byte 0x0A, so the records carrying the most fields paid the most for a
delimiter nobody reads.

Which encoding a payload uses is now written IN the payload -- one marker for escaped, another
for raw -- and never inferred from configuration at decode time. A log written across a flag
change has both in it, and a decoder that asks the environment instead of the record stops
reading halfway through a file it wrote itself.

    engine, binary frame + raw payload   278 passed, 0 failed
    engine, text frame + escaped         278 passed, 0 failed

The measurement is a test rather than a number in this message, so the next change to the frame
has to keep it honest. It restores the flag it sets, on both paths: an earlier test in this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
