### PR TITLE
an append that never reached its delimiter is not a record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -126,6 +126,13 @@ fn read_raw_record<R: std::io::BufRead>(reader: &mut R) -> std::io::Result<Optio
         if read == 0 {
             return Ok(None);
         }
+        // A delimited record that never reached its delimiter was an interrupted append.
+        // Returning it as a record hands the caller a fragment, which fails to decode and gets
+        // reported as corruption -- refusing a load that should simply cut the fragment away.
+        // `next_frame` applies exactly this rule to exactly these bytes; this agrees with it.
+        if !line.ends_with(b"\n") {
+            return Ok(None);
+        }
         return Ok(Some(line));
     }
     // Binary: marker, varint length, four checksum bytes, then exactly that many payload bytes.
@@ -5245,10 +5252,13 @@ mod tests {
                 .read_at_log_id(1, *log_id, 4096)
                 .unwrap()
                 .unwrap_or_else(|| panic!("log id {log_id} should still resolve"));
-            let end = bytes
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map_or(bytes.len(), |at| at + 1);
+            // Where this record ends is the frame's answer, not the first newline's: a
+            // length-framed payload carries 0x0A itself, so the first one is usually inside the
+            // record and slicing there hands a decoder half a record.
+            let end = match crate::log_framing::next_frame(&bytes) {
+                Ok(Some((consumed, _))) if consumed > 0 => consumed,
+                _ => bytes.len(),
+            };
             let record = decode_wal_line(&bytes[..end]).unwrap();
             match record.command.expect("a record built with an operation still carries one") {
                 Command::StringSet { value: found, .. } => {
@@ -5438,10 +5448,13 @@ mod tests {
                 .read_at_log_id(1, *log_id, 4096)
                 .unwrap()
                 .unwrap_or_else(|| panic!("sequence {sequence} should have been kept"));
-            let end = bytes
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map_or(bytes.len(), |at| at + 1);
+            // Where this record ends is the frame's answer, not the first newline's: a
+            // length-framed payload carries 0x0A itself, so the first one is usually inside the
+            // record and slicing there hands a decoder half a record.
+            let end = match crate::log_framing::next_frame(&bytes) {
+                Ok(Some((consumed, _))) if consumed > 0 => consumed,
+                _ => bytes.len(),
+            };
             assert_eq!(decode_wal_line(&bytes[..end]).unwrap().sequence, *sequence);
         }
 
@@ -5630,10 +5643,13 @@ mod tests {
                 .unwrap_or_else(|| {
                     panic!("sequence {sequence} is at or above the block-retention floor and was removed")
                 });
-            let end = bytes
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map_or(bytes.len(), |at| at + 1);
+            // Where this record ends is the frame's answer, not the first newline's: a
+            // length-framed payload carries 0x0A itself, so the first one is usually inside the
+            // record and slicing there hands a decoder half a record.
+            let end = match crate::log_framing::next_frame(&bytes) {
+                Ok(Some((consumed, _))) if consumed > 0 => consumed,
+                _ => bytes.len(),
+            };
             assert_eq!(decode_wal_line(&bytes[..end]).unwrap().sequence, *sequence);
         }
         set_wal_segment_bytes_for_test(None);
@@ -5833,9 +5849,24 @@ mod tests {
             }
             assert_eq!(5, sequence_end);
             let path = dir.path().join("shard-1.wal.jsonl");
-            // Find where the records stop (the last newline) and plant garbage after it.
+            // Find where the records stop and plant garbage after it. The last newline answers
+            // that only for records delimited by one -- a length-framed payload carries 0x0A of
+            // its own, so the search lands inside a record and the garbage would overwrite half
+            // of it, testing something else entirely. Walk the frames to their end instead.
             let bytes = fs::read(&path).unwrap();
-            let record_end = bytes.iter().rposition(|byte| *byte == b'\n').unwrap() + 1;
+            let record_end = {
+                let mut at = data_start(&bytes);
+                while at < bytes.len() {
+                    if bytes[at] == 0 {
+                        break;
+                    }
+                    match crate::log_framing::next_frame(&bytes[at..]) {
+                        Ok(Some((consumed, _))) if consumed > 0 => at += consumed,
+                        _ => break,
+                    }
+                }
+                at
+            };
             {
                 use std::io::{Seek, Write};
                 let mut file = OpenOptions::new().write(true).open(&path).unwrap();
@@ -5873,8 +5904,21 @@ mod tests {
                 if name.starts_with("shard-1.wal.") && name.ends_with(".jsonl") && name != "shard-1.wal.jsonl" {
                     sealed += 1;
                     let bytes = fs::read(&path).unwrap();
-                    assert!(
-                        !bytes.is_empty() && *bytes.last().unwrap() == b'\n',
+                    assert!(!bytes.is_empty(), "a sealed piece must hold its records");
+                    // The property is that the piece ends AT its last record, with no
+                    // reservation left behind it. A trailing newline tested that only while a
+                    // record ended with one; walking the frames tests it for either format, and
+                    // tests it harder: the records must tile the file exactly.
+                    let mut at = data_start(&bytes);
+                    while at < bytes.len() {
+                        match crate::log_framing::next_frame(&bytes[at..]) {
+                            Ok(Some((consumed, _))) if consumed > 0 => at += consumed,
+                            _ => break,
+                        }
+                    }
+                    assert_eq!(
+                        at,
+                        bytes.len(),
                         "a sealed piece must end exactly at its last record, not in zeros"
                     );
                 }


### PR DESCRIPTION
an append that never reached its delimiter is not a record

`read_raw_record` returned a trailing unterminated line as though it were a record. The caller
then failed to decode the fragment and reported corruption -- refusing a load that should have
cut the fragment away and opened. An interrupted append is the ordinary outcome of a crash;
treating it as damage turns every one of them into an outage.

`next_frame` already applied the right rule to exactly these bytes, and had for as long as it
existed. The two readers disagreed about the same file. They agree now.

That is the same distinction as the one this frame got wrong once already, showing up a layer
down: a fragment with nothing after it is a torn tail, a complete record gone bad with healthy
records after it is corruption, and the two need opposite handling. Length framing forces the
question to be answered deliberately -- the delimited reader got it for free by looking for the
delimiter, which is exactly why it never had to think about it.

AND SIX MORE PLACES COMPUTED A RECORD'S END FROM THE FIRST NEWLINE.

Three read a chunk at a log id and sliced at the first 0x0A -- the same shape as the bug fixed
in `read_page`, which was halving records rather than misreading them. One found "where the
records stop" by the LAST newline, then planted its torn-write garbage there; under a length
frame that offset is inside a record, so the test was overwriting half a good record and
asserting on the result. One asserted a sealed piece ends with a newline; the property is that
it ends AT its last record, which is now checked by walking the frames and requiring them to
tile the file exactly -- a stricter test than the one it replaces. One rebuilt a log from lines
to inject interior corruption, and now injects a complete, correctly framed record whose
contents are not a record, which is what committed corruption actually is.

    with the length frame   17 tests failing -> 2
    with the text frame     167 passed, 0 failed, at every step

Twelve places in this codebase decided where a record ends by looking for a newline: four in
the readers and eight in the tests. Twelve is the honest reason the payloads were byte-stuffed
instead: escaping keeps all twelve correct at once. It was never the design, it was the price
of not having fixed them.

The two that remain simulate a crash midway through a segment roll and read the partial frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
