### PR TITLE
Skip the per-page expiry lookup when nothing has an expiry

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1441,6 +1441,10 @@ pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
 
 pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
     let now = now_ms();
+    // Emptiness is a property of the shard, not of a bucket, so it is checked once here rather
+    // than per page. When nothing in the shard has an expiry, every lookup below would miss and
+    // the minimum over no values is `None` either way.
+    let any_expiry = !shard.expires_at_ms.is_empty();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
         bucket.meta_loaded = true;
         bucket.loading = false;
@@ -1451,12 +1455,16 @@ pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
             .page_index
             .values()
             .any(|page| page.dirty || shard.dirty_objects.contains(&page.object_key));
-        bucket.ttl_ms = bucket
-            .page_index
-            .values()
-            .filter_map(|page| shard.expires_at_ms.get(&page.object_key).copied())
-            .map(|expires_at| expires_at.saturating_sub(now))
-            .min();
+        bucket.ttl_ms = if any_expiry {
+            bucket
+                .page_index
+                .values()
+                .filter_map(|page| shard.expires_at_ms.get(&page.object_key).copied())
+                .map(|expires_at| expires_at.saturating_sub(now))
+                .min()
+        } else {
+            None
+        };
         update_bucket_layout(bucket);
     }
 }


### PR DESCRIPTION
`refresh_bucket_runtime_flags` walks every bucket in the shard, and for each bucket looked up
every page's object key in `shard.expires_at_ms` to find the soonest expiry. That hashes a string
per page, and it ran whether or not anything in the shard had an expiry at all.

On basic ingestion nothing does. Measured directly: `expires_at_ms` holds **zero** entries
throughout, while the sweep performs that lookup on 163,864 pages per add at 520 memories, ten
times over. Every one of those lookups misses.

The guard cannot change the result. With an empty map `get` returns `None` for every page, so the
`filter_map` yields nothing and `min()` is `None` — which is exactly what the guard substitutes.
It is hoisted out of the bucket loop because emptiness is a property of the shard, not of a
bucket. When anything *does* have an expiry, the original path runs unchanged.

### Measured

Time spent inside the sweep, per add, at 520 memories. Three samples of 30 adds per run, two runs
per arm:

| arm | samples (ms/add) | median |
|---|---|---:|
| before | 20.13 · 20.45 · 20.97 · 22.02 · 23.31 · 24.28 | 21.5 |
| **after** | 18.02 · 18.16 · 18.27 · 16.03 · 16.08 · 18.37 | **18.1** |

−16% on the median, and every guarded sample falls below every unguarded one. An earlier run at
lower sample size agrees (16.36 · 16.69 against 19.01 · 27.05), so all eight guarded points across
two independent runs sit below all eight unguarded points.

**At 220 memories the two arms are indistinguishable** (7.9 vs 8.2 ms/add, overlapping spreads).
The saving only separates from this machine's noise once the store is large enough, which fits
the mechanism: the cost is per page walked, so it grows with the corpus while the noise does not.

Where the rest of the sweep goes, for anyone picking this up: rebuilding each bucket's live-object
set is 57.7%, this expiry walk was 35.8%, the all-deleted check 6.0%, and the dirty check 0.5%.

### Not done, and why

Folding the sweep's four per-bucket walks into a single pass was tried and **measured 34% slower**
(28.0 vs 20.9 ms/add at 520), so it is not included here. The two cheap checks short-circuit after
about one page, so the original was effectively two walks rather than four, and a fused loop pays
full deleted/dirty work on every page instead. Walk count was not the cost; per-page work is.

### Tests

* `upsert_reload_equality` passes — reload rebuilds this state from scratch, so it fails if the
  computed values ever disagree with a full rebuild
* `storage_migration_corpus`, `bulk_install_index_durability`, `storage_crash_harness` pass
* `cargo check --all-targets` clean, both repos, byte-identical source

Strict mem0 conformance was run interleaved against the branch this stacks on, five rounds each on
the same machine state: **base 22·21·22·21·21**, **this branch 22·22·21·22·22**. Both arms flake,
on the two checks (`reset: tenant wiped`, `forget: get_all == 0`) that flake on this box
regardless of branch, and the guarded arm flaked less than the base. An earlier pair of runs that
failed two `delete:` checks was taken with the disk at 99% full, which reproduces that failure
shape on either arm; those runs are not evidence about this change.

`delta_served_index` and `cold_raw_ingestion` fail, identically on pristine `main` — inherited,
not introduced.
