### PR TITLE
Build the live-object set in a reused buffer and replace it only when it differs

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1425,14 +1425,38 @@ pub(super) fn bucket_layout_name(layout: BucketLayoutState) -> &'static str {
 }
 
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
-    let live_object_ids: BTreeSet<u64> = bucket
-        .page_index
-        .values()
-        .filter(|page| !page.deleted)
-        .map(|page| page.object_id)
-        .collect();
-    if !live_object_ids.is_empty() {
-        bucket.object_index = live_object_ids;
+    let mut scratch = Vec::new();
+    update_bucket_layout_with(bucket, &mut scratch);
+}
+
+/// Same as `update_bucket_layout`, but reusing a caller-owned buffer for the live object ids.
+///
+/// The sweep runs this over every bucket in the shard, so building the id set used to allocate a
+/// fresh tree per bucket and then free the previous one to replace it. Sorting and deduplicating
+/// a flat buffer yields exactly the elements the tree would have held, and the buffer is reused
+/// across buckets, so the common case allocates nothing at all.
+///
+/// The stored set is replaced only when it genuinely differs. A `BTreeSet` iterates in sorted
+/// order and the buffer is sorted, so equality is a linear element-wise comparison -- not a count
+/// check, which would wrongly accept a stored set holding a stale extra id alongside a duplicated
+/// live id.
+pub(super) fn update_bucket_layout_with(bucket: &mut BucketNode, live_ids: &mut Vec<u64>) {
+    live_ids.clear();
+    live_ids.extend(
+        bucket
+            .page_index
+            .values()
+            .filter(|page| !page.deleted)
+            .map(|page| page.object_id),
+    );
+    live_ids.sort_unstable();
+    live_ids.dedup();
+    if !live_ids.is_empty() {
+        if bucket.object_index.len() != live_ids.len()
+            || !bucket.object_index.iter().eq(live_ids.iter())
+        {
+            bucket.object_index = live_ids.iter().copied().collect();
+        }
     } else if !bucket.page_index.is_empty() {
         bucket.object_index.clear();
     }
@@ -1445,6 +1469,9 @@ pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
     // than per page. When nothing in the shard has an expiry, every lookup below would miss and
     // the minimum over no values is `None` either way.
     let any_expiry = !shard.expires_at_ms.is_empty();
+    // Carried across buckets so the live-id buffer is allocated once per sweep, not once per
+    // bucket.
+    let mut live_ids: Vec<u64> = Vec::new();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
         bucket.meta_loaded = true;
         bucket.loading = false;
@@ -1465,7 +1492,7 @@ pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
         } else {
             None
         };
-        update_bucket_layout(bucket);
+        update_bucket_layout_with(bucket, &mut live_ids);
     }
 }
 

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -2175,3 +2175,154 @@ pub(super) fn validate_bucket_ownership_index(
     }
     validation
 }
+
+
+#[cfg(test)]
+mod bucket_layout_tests {
+    use super::*;
+    use crate::block_store::BlockAddress;
+
+    fn address() -> BlockAddress {
+        BlockAddress {
+            page_slab_id: 0,
+            offset: 0,
+            length: 0,
+            page_id: None,
+            object_id: None,
+            routing_bucket: None,
+            generation: None,
+            band_id: None,
+            sha256: None,
+        }
+    }
+
+    fn page(object_id: u64, deleted: bool) -> PageIndex {
+        PageIndex {
+            object_key: format!("k{object_id}"),
+            model_id: "m".to_string(),
+            component: None,
+            object_id,
+            address: address(),
+            dirty: false,
+            deleted,
+            log_backed: false,
+        }
+    }
+
+    /// A bucket whose pages carry the given (object id, deleted) pairs, with `stored` already
+    /// recorded as the live-object index.
+    fn bucket(pages: &[(u64, bool)], stored: &[u64]) -> BucketNode {
+        let mut node = BucketNode::default();
+        for (i, (object_id, deleted)) in pages.iter().enumerate() {
+            node.page_index
+                .insert(format!("p{i}"), page(*object_id, *deleted));
+        }
+        node.object_index = stored.iter().copied().collect();
+        node
+    }
+
+    /// The set a from-scratch rebuild produces, and what it does with it. This is the behaviour
+    /// the buffered path has to match exactly.
+    fn expected(node: &BucketNode) -> (ObjectIndex, BucketLayoutState) {
+        let live: BTreeSet<u64> = node
+            .page_index
+            .values()
+            .filter(|page| !page.deleted)
+            .map(|page| page.object_id)
+            .collect();
+        let mut index = node.object_index.clone();
+        if !live.is_empty() {
+            index = live;
+        } else if !node.page_index.is_empty() {
+            index.clear();
+        }
+        let layout = classify_bucket_layout(index.len(), node.page_index.len());
+        (index, layout)
+    }
+
+    fn check(pages: &[(u64, bool)], stored: &[u64]) {
+        let mut node = bucket(pages, stored);
+        let (want_index, want_layout) = expected(&node);
+        let mut scratch = Vec::new();
+        update_bucket_layout_with(&mut node, &mut scratch);
+        assert_eq!(
+            node.object_index, want_index,
+            "object index differs for pages={pages:?} stored={stored:?}"
+        );
+        assert_eq!(
+            node.layout, want_layout,
+            "layout differs for pages={pages:?} stored={stored:?}"
+        );
+    }
+
+    #[test]
+    fn buffered_update_matches_a_full_rebuild() {
+        // No pages at all: the index is left alone, which is not the same as clearing it.
+        check(&[], &[]);
+        check(&[], &[7, 8]);
+        // The ordinary case, and the case the write path now keeps correct in advance.
+        check(&[(1, false), (2, false), (3, false)], &[]);
+        check(&[(1, false), (2, false), (3, false)], &[1, 2, 3]);
+        // Pages arriving out of order still produce a sorted set.
+        check(&[(9, false), (2, false), (5, false)], &[2, 5, 9]);
+        // Duplicate live ids collapse to one element.
+        check(&[(4, false), (4, false), (4, false)], &[4]);
+        // Some deleted, some live.
+        check(&[(1, true), (2, false), (3, true)], &[1, 2, 3]);
+        // Every page deleted, but pages exist: the index is cleared.
+        check(&[(1, true), (2, true)], &[1, 2]);
+        // Stored index is stale in both directions.
+        check(&[(1, false), (2, false)], &[5, 6, 7]);
+        check(&[(1, false)], &[]);
+        // Stale, and the SAME SIZE as the correct set -- a length check alone would keep it.
+        check(&[(1, false), (2, false)], &[1, 99]);
+        check(&[(1, false), (2, false)], &[98, 99]);
+        check(&[(5, false)], &[6]);
+    }
+
+    #[test]
+    fn same_length_different_contents_is_not_mistaken_for_unchanged() {
+        // The stored index has exactly as many ids as the live pages produce, and shares one of
+        // them, so any shortcut that compares only sizes concludes "unchanged" and leaves 99 in
+        // place. The correct set is {1, 2}.
+        let mut node = bucket(&[(1, false), (2, false)], &[1, 99]);
+        let mut scratch = Vec::new();
+        update_bucket_layout_with(&mut node, &mut scratch);
+        assert_eq!(
+            node.object_index,
+            [1, 2].into_iter().collect::<ObjectIndex>(),
+            "a stored index of the same size but different contents must be replaced"
+        );
+    }
+
+    #[test]
+    fn a_stale_extra_id_beside_a_duplicate_is_not_mistaken_for_unchanged() {
+        // Two live pages sharing an id, and a stored index holding that id plus a stale one. Every
+        // live id IS present in the stored index and the counts DO match (2 pages, 2 stored), so a
+        // shortcut built on those two facts would leave the stale id in place. The correct set is
+        // {1}, and this must produce it.
+        let mut node = bucket(&[(1, false), (1, false)], &[1, 99]);
+        let mut scratch = Vec::new();
+        update_bucket_layout_with(&mut node, &mut scratch);
+        assert_eq!(node.object_index, [1].into_iter().collect::<ObjectIndex>());
+        assert_eq!(node.layout, classify_bucket_layout(1, 2));
+    }
+
+    #[test]
+    fn the_buffer_is_reusable_across_buckets() {
+        // The sweep carries one buffer over every bucket, so a leftover from the previous bucket
+        // must not leak into the next one.
+        let mut scratch = Vec::new();
+        let mut first = bucket(&[(1, false), (2, false)], &[]);
+        update_bucket_layout_with(&mut first, &mut scratch);
+        assert_eq!(first.object_index, [1, 2].into_iter().collect::<ObjectIndex>());
+
+        let mut second = bucket(&[(7, false)], &[]);
+        update_bucket_layout_with(&mut second, &mut scratch);
+        assert_eq!(second.object_index, [7].into_iter().collect::<ObjectIndex>());
+
+        let mut third = bucket(&[(3, true)], &[3]);
+        update_bucket_layout_with(&mut third, &mut scratch);
+        assert!(third.object_index.is_empty());
+    }
+}


### PR DESCRIPTION
Refreshing a shard's bucket flags rebuilt each bucket's live-object set from scratch: collect a
fresh `BTreeSet` of the ids on its live pages, then assign it over the old one. That runs for every
bucket in the shard, on every sweep, ten sweeps per add — allocating tree nodes to build each set
and freeing the previous tree to replace it.

Almost none of it changes anything. Measured on this path, **100% of those rebuilds produce a set
identical to the one already stored**, because the write path now maintains that set as pages are
written rather than leaving it to be recomputed afterwards.

This computes the same set in a buffer the sweep reuses across buckets — sorted and deduplicated,
so it holds exactly the elements the `BTreeSet` held — and replaces the stored set only when it
genuinely differs. A `BTreeSet` iterates in sorted order, so the comparison is linear. In the
common case nothing is allocated and nothing is assigned.

### Measured

Time inside the sweep, per add, at 520 memories. Three samples of 30 adds per run, two runs per
arm:

| arm | samples (ms/add) | median |
|---|---|---:|
| before | 14.35 · 15.56 · 15.96 · 15.03 · 16.09 · 15.98 | 15.6 |
| **after** | 14.16 · 13.70 · 14.77 · 12.56 · 13.55 · 14.68 | **13.9** |

−11% on the median, with five of the six samples below every sample of the other arm. Taken
together with the expiry guard this stacks on, the sweep has gone from about 21.5 to 13.9 ms per
add at this corpus size.

### What was deliberately not done

The cheap version of this check — "every live id is already present, and the counts match" — is
**not sound**. A stored set holding a stale extra id alongside a duplicated live id satisfies both
clauses while the correct set differs. Comparing the actual elements has no such hole, and the
tests below pin exactly that case.

### Tests

Three tests are added next to the code, comparing the new path against a from-scratch rebuild over
constructed buckets: empty buckets, all-deleted buckets, duplicate ids, out-of-order pages, stored
sets that are stale in either direction, and stored sets that are **the same size as the correct
one but hold different ids**.

They were mutation-checked rather than assumed to work. Breaking the comparison so it never
replaces the stored set is caught (3 of 3 fail); weakening it to a bare length check is caught by
the same-size cases. Removing the deduplication is *not* caught, and that is correct — collecting
into a `BTreeSet` deduplicates regardless, so dropping it costs a missed fast path but cannot
change the stored set.

Also passing: `upsert_reload_equality` (reload rebuilds this state from scratch, so it fails if the
computed values ever disagree), `storage_migration_corpus`, `bulk_install_index_durability`,
`storage_crash_harness`, and `cargo check --all-targets` on both repos from byte-identical source.

Strict mem0 conformance was run interleaved against the branch this stacks on, with the arm order
alternating between rounds. It does not discriminate here and is reported as such: the *same
binary* scored one failure in five rounds and then five in six, and every failing check
(`reset: tenant wiped`, `forget: get_all == 0`, and a `delete:` pair) appears on both arms in both
positions — the base arm produced the `delete:` pair while running first. The run-to-run variance
on this machine is larger than any difference between the arms, which is why the equivalence tests
above carry the correctness claim instead.

`delta_served_index` and `cold_raw_ingestion` fail, identically on pristine `main` — inherited,
not introduced.
