### PR TITLE
Recompute a bucket's layout only when its pages changed

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2245,7 +2245,7 @@ fn fold_delta_page_items(
             let Some(bucket) = bucket_index.bucket_map.get_mut(&item.routing_bucket) else {
                 continue;
             };
-            bucket.page_index.retain(|_, page| {
+            bucket.page_index.mutate().retain(|_, page| {
                 !(page.model_id == item.model_id
                     && page.object_key == item.object_key
                     && page.component == item.component)
@@ -2254,7 +2254,7 @@ fn fold_delta_page_items(
     } else if !covered_keys.is_empty() {
         for bucket in bucket_index.bucket_map.values_mut() {
             bucket
-                .page_index
+                .page_index.mutate()
                 .retain(|_, page| !covered_keys.contains(&page.object_key));
         }
     }
@@ -2275,7 +2275,7 @@ fn fold_delta_page_items(
                 ..BucketNode::default()
             });
         bucket.object_index.insert(item.object_id);
-        bucket.page_index.insert(
+        bucket.page_index.mutate().insert(
             item.page_ref_key.clone(),
             PageIndex {
                 object_key: item.object_key.clone(),
@@ -2886,7 +2886,7 @@ fn mark_bucket_index_object_deleted(shard: &mut ShardState, key: &str) -> bool {
             continue;
         };
         let mut deleted_object_ids = BTreeSet::new();
-        bucket.page_index.retain(|_, page| {
+        bucket.page_index.mutate().retain(|_, page| {
             if page.object_key == key {
                 deleted_object_ids.insert(page.object_id);
                 removed = true;
@@ -2980,7 +2980,7 @@ fn mark_bucket_index_page_deleted(
         };
         let mut bucket_removed = false;
         let mut deleted_object_ids = BTreeSet::new();
-        bucket.page_index.retain(|_, page| {
+        bucket.page_index.mutate().retain(|_, page| {
             let matches = page.model_id == model_id
                 && page.object_key == key
                 && page.component.as_deref() == component;

--- a/crates/temporalstore-rust/src/engine/persistence.rs
+++ b/crates/temporalstore-rust/src/engine/persistence.rs
@@ -247,7 +247,7 @@ impl TemporalEngine {
         // resurrecting a stale persisted dirty flag.
         for bucket in shard.bucket_index.bucket_map.values_mut() {
             bucket.dirty = false;
-            for page in bucket.page_index.values_mut() {
+            for page in bucket.page_index.mutate().values_mut() {
                 page.dirty = false;
             }
         }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -273,6 +273,67 @@ pub(super) struct CoreIndex {
 pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
 pub(super) type ObjectIndex = BTreeSet<u64>;
 pub(super) type PageIndexMap = BTreeMap<String, PageIndex>;
+
+/// A bucket's pages, carrying a version that changes whenever they do.
+///
+/// There is deliberately no `DerefMut`. Reads go through `Deref` and look exactly like reads of
+/// the map; anything that CHANGES the pages has to call `mutate()`, which bumps the version. That
+/// makes "I changed the pages but forgot to invalidate what was derived from them" a compile
+/// error rather than stale state discovered somewhere else entirely.
+///
+/// `serde(transparent)` keeps the on-disk shape identical to the bare map -- the version is
+/// derived state, not part of the record. A bucket read back from disk therefore starts at
+/// version 0 with nothing yet derived, so the first sweep after a load recomputes.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(super) struct VersionedPageIndex {
+    map: PageIndexMap,
+    #[serde(skip)]
+    version: u64,
+}
+
+impl std::ops::Deref for VersionedPageIndex {
+    type Target = PageIndexMap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl VersionedPageIndex {
+    /// Changes whenever the pages change. Compare against a stored copy to tell whether anything
+    /// derived from the pages needs recomputing.
+    pub(super) fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Read-write access to the pages, bumping the version. Call it to change the pages, not to
+    /// read them -- a bump only costs a needless recompute, but it is still worth not doing.
+    pub(super) fn mutate(&mut self) -> &mut PageIndexMap {
+        self.version = self.version.wrapping_add(1);
+        &mut self.map
+    }
+}
+
+impl<'a> IntoIterator for &'a VersionedPageIndex {
+    type Item = (&'a String, &'a PageIndex);
+    type IntoIter = std::collections::btree_map::Iter<'a, String, PageIndex>;
+
+    /// Iterating by reference is a read, so it goes straight to the map. The only way to get at
+    /// it mutably remains `mutate()`.
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
+}
+
+impl FromIterator<(String, PageIndex)> for VersionedPageIndex {
+    fn from_iter<I: IntoIterator<Item = (String, PageIndex)>>(iter: I) -> Self {
+        Self {
+            map: iter.into_iter().collect(),
+            version: 0,
+        }
+    }
+}
 pub(super) type ObjectPageLookup = BTreeMap<String, BTreeSet<PageLookupRef>>;
 pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageLookupRef>>;
 
@@ -314,7 +375,14 @@ pub(super) struct BucketNode {
     #[serde(default, alias = "deleted_object_ids")]
     pub(super) deleted_object_index: ObjectIndex,
     #[serde(default, alias = "page_refs")]
-    pub(super) page_index: PageIndexMap,
+    pub(super) page_index: VersionedPageIndex,
+    /// The `page_index` version that `object_index` and `layout` were last computed from.
+    ///
+    /// Not serialized: a bucket that has just been loaded has derived nothing yet, and `None`
+    /// makes the first sweep after a load recompute rather than trusting a version number that
+    /// means nothing across a restart.
+    #[serde(skip)]
+    pub(super) layout_from_pages_version: Option<u64>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -2364,6 +2364,41 @@ mod bucket_layout_tests {
     }
 
     #[test]
+    fn the_page_index_serializes_exactly_as_the_bare_map() {
+        let node = bucket(&[(1, false), (2, true), (3, false)], &[1, 3]);
+        let bare: PageIndexMap = node
+            .page_index
+            .iter()
+            .map(|(key, page)| (key.clone(), page.clone()))
+            .collect();
+        assert_eq!(
+            serde_json::to_string(&node.page_index).expect("wrapper encodes"),
+            serde_json::to_string(&bare).expect("map encodes"),
+            "the version must not reach the wire -- the record shape is a durable contract"
+        );
+    }
+
+    #[test]
+    fn a_page_index_read_back_has_derived_nothing_yet() {
+        let node = bucket(&[(1, false), (2, false)], &[1, 2]);
+        let encoded = serde_json::to_string(&node).expect("bucket encodes");
+        assert!(
+            !encoded.contains("layout_from_pages_version"),
+            "the derived-from version must not reach the wire"
+        );
+
+        let round: BucketNode = serde_json::from_str(&encoded).expect("bucket decodes");
+        assert_eq!(round.page_index.len(), 2, "pages survive the round trip");
+        assert_eq!(
+            round.layout_from_pages_version, None,
+            "a freshly loaded bucket has derived nothing, so the next sweep must recompute"
+        );
+        // And that is exactly what happens: the recorded version does not match the pages, so the
+        // check the sweep makes asks for a recompute.
+        assert_ne!(round.layout_from_pages_version, Some(round.page_index.version()));
+    }
+
+    #[test]
     fn the_buffer_is_reusable_across_buckets() {
         // The sweep carries one buffer over every bucket, so a leftover from the previous bucket
         // must not leak into the next one.

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1492,7 +1492,15 @@ pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
         } else {
             None
         };
-        update_bucket_layout_with(bucket, &mut live_ids);
+        // `object_index` and `layout` depend on the pages and nothing else, and nothing outside
+        // `update_bucket_layout` writes either of them -- so when the pages have not changed, the
+        // stored values are already what a recompute would produce. The version cannot be missed:
+        // the pages cannot be mutated except through `mutate()`, which bumps it.
+        let pages_version = bucket.page_index.version();
+        if bucket.layout_from_pages_version != Some(pages_version) {
+            update_bucket_layout_with(bucket, &mut live_ids);
+            bucket.layout_from_pages_version = Some(pages_version);
+        }
     }
 }
 
@@ -2306,6 +2314,53 @@ mod bucket_layout_tests {
         update_bucket_layout_with(&mut node, &mut scratch);
         assert_eq!(node.object_index, [1].into_iter().collect::<ObjectIndex>());
         assert_eq!(node.layout, classify_bucket_layout(1, 2));
+    }
+
+    #[test]
+    fn reading_the_pages_does_not_change_the_version_but_mutating_does() {
+        let mut node = bucket(&[(1, false)], &[1]);
+        let start = node.page_index.version();
+        // Reads, through Deref and by reference.
+        assert_eq!(node.page_index.len(), 1);
+        assert!(!node.page_index.is_empty());
+        let _ = node.page_index.values().count();
+        for (_key, _page) in &node.page_index {}
+        assert_eq!(
+            node.page_index.version(),
+            start,
+            "reading the pages must not look like a change"
+        );
+
+        node.page_index.mutate().insert("p9".to_string(), page(9, false));
+        assert_ne!(
+            node.page_index.version(),
+            start,
+            "changing the pages must change the version"
+        );
+    }
+
+    #[test]
+    fn a_changed_page_set_is_not_treated_as_up_to_date() {
+        // Stand in for what the sweep does: derive, record the version, then change the pages and
+        // confirm the recorded version no longer matches, so the next sweep recomputes.
+        let mut node = bucket(&[(1, false)], &[]);
+        let mut scratch = Vec::new();
+        update_bucket_layout_with(&mut node, &mut scratch);
+        node.layout_from_pages_version = Some(node.page_index.version());
+
+        // A page removed through `mutate()` -- the only way to remove one.
+        node.page_index.mutate().clear();
+        assert_ne!(
+            node.layout_from_pages_version,
+            Some(node.page_index.version()),
+            "a bucket whose pages changed must not look up to date"
+        );
+
+        // And recomputing from the emptied pages leaves the index alone, as a from-scratch
+        // rebuild would for a bucket with no pages at all.
+        let before = node.object_index.clone();
+        update_bucket_layout_with(&mut node, &mut scratch);
+        assert_eq!(node.object_index, before);
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -842,7 +842,7 @@ pub(super) fn rebuild_bucket_page_ownership(
                 }
             });
         bucket.object_index.insert(object_id);
-        bucket.page_index.insert(
+        bucket.page_index.mutate().insert(
             format!(
                 "{}:{}:{}:{}:{}",
                 entry.kind,
@@ -1196,7 +1196,7 @@ pub(super) fn upsert_bucket_index_page(
                 continue;
             };
             let removed_object_id = bucket
-                .page_index
+                .page_index.mutate()
                 .remove(&page_ref.page_ref_key)
                 .map(|page| page.object_id);
             if superseded_in_target_bucket {
@@ -1215,7 +1215,7 @@ pub(super) fn upsert_bucket_index_page(
         }
     } else if !lookup_enabled {
         for bucket in shard.bucket_index.bucket_map.values_mut() {
-            bucket.page_index.retain(|_, page| {
+            bucket.page_index.mutate().retain(|_, page| {
                 !(page.object_key == entry.object_key
                     && page.model_id == entry.kind
                     && page.component == entry.component)
@@ -1261,7 +1261,7 @@ pub(super) fn upsert_bucket_index_page(
         if !page_index.deleted {
             bucket.object_index.insert(object_id);
         }
-        bucket.page_index
+        bucket.page_index.mutate()
             .insert(page_ref_key.clone(), page_index.clone());
         // Not a full `update_bucket_layout` here on purpose. That walks every page in the bucket
         // and allocates a fresh BTreeSet of live object ids, and on this path the set is already
@@ -1311,7 +1311,7 @@ pub(super) fn sync_bucket_index_object_pages(
             continue;
         };
         let before = bucket.page_index.len();
-        bucket.page_index
+        bucket.page_index.mutate()
             .retain(|_, page| !(page.model_id == kind && page.object_key == object_key));
         if bucket.page_index.len() != before {
             removed_any = true;
@@ -1378,7 +1378,7 @@ pub(super) fn sync_bucket_index_object_pages(
         bucket.in_memory = true;
         bucket.object_index.insert(object_id);
         bucket.deleted_object_index.remove(&object_id);
-        bucket.page_index.insert(
+        bucket.page_index.mutate().insert(
             page_index_ref_key(&entry),
             PageIndex {
                 object_key: entry.object_key,
@@ -1520,7 +1520,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
     shard.dirty_objects.remove(object_key);
     for bucket in shard.bucket_index.bucket_map.values_mut() {
         let mut touched = false;
-        for page in bucket.page_index.values_mut() {
+        for page in bucket.page_index.mutate().values_mut() {
             if page.object_key == object_key {
                 page.dirty = false;
                 touched = true;
@@ -1584,7 +1584,7 @@ pub(super) fn rebuild_bucket_first_index(
         }
         bucket.in_memory |= true;
         bucket.object_index.insert(object_id);
-        bucket.page_index.insert(
+        bucket.page_index.mutate().insert(
             page_index_ref_key(&entry),
             PageIndex {
                 object_key: entry.object_key,
@@ -2214,7 +2214,7 @@ mod bucket_layout_tests {
     fn bucket(pages: &[(u64, bool)], stored: &[u64]) -> BucketNode {
         let mut node = BucketNode::default();
         for (i, (object_id, deleted)) in pages.iter().enumerate() {
-            node.page_index
+            node.page_index.mutate()
                 .insert(format!("p{i}"), page(*object_id, *deleted));
         }
         node.object_index = stored.iter().copied().collect();

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -441,7 +441,7 @@ impl TemporalEngine {
                 // Record the dumped-log sequence (informational; not part of the fingerprint).
                 bucket.last_dump_sequence = bucket.last_dump_sequence.max(manifest.wal_sequence);
                 bucket.dirty = false;
-                for page in bucket.page_index.values_mut() {
+                for page in bucket.page_index.mutate().values_mut() {
                     page.dirty = false;
                 }
             }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -1860,7 +1860,7 @@ fn recovery_reports_owner_mismatch_and_compaction_refuses_it() {
             .bucket_index
             .bucket_map
             .values_mut()
-            .flat_map(|bucket| bucket.page_index.values_mut())
+            .flat_map(|bucket| bucket.page_index.mutate().values_mut())
             .find(|page| page.object_key == "owned")
             .expect("owned slot page");
         page.address.object_id = Some(page.object_id.wrapping_add(1));
@@ -1922,7 +1922,7 @@ fn recovery_reports_reused_object_id_conflicts() {
             .bucket_index
             .bucket_map
             .values_mut()
-            .flat_map(|bucket| bucket.page_index.values_mut())
+            .flat_map(|bucket| bucket.page_index.mutate().values_mut())
             .find(|page| page.object_key == "second")
             .expect("second slot page");
         second.address.object_id = Some(first_object_id);


### PR DESCRIPTION
A sweep refreshes every bucket in the shard after each write, and a write touches one or two of
them. Everything it recomputes for the other few hundred is discarded unchanged — measured, **100%
of the layout rebuilds produced the set already stored**.

The usual way to fix that is to track which buckets changed, and the usual problem with it is that
a call site which changes the pages and forgets to record the change leaves stale state, with
nothing failing anywhere near the mistake. So this makes forgetting impossible rather than
unlikely.

`page_index` becomes a wrapper that `Deref`s for reads and has **no `DerefMut`**. Around 190 read
sites compile exactly as before. Every site that *mutates* the pages stops compiling until it goes
through `mutate()`, which bumps a version — 18 of them, found by the compiler rather than by
grepping. A new call site that changes the pages cannot skip the version: it will not build.

The sweep then recomputes a bucket's layout only when its page version differs from the one that
layout was computed from.

### Measured

At 520 memories, three samples of 30 adds per run, two runs per arm:

| arm | layouts recomputed per add | sweep ms/add |
|---|---|---|
| before | 3 383 · 3 569 · 3 753 | 13.90 · 14.71 · 16.17 · 15.04 · 15.86 · 16.78 |
| **after** | **60 · 60 · 60** | **5.99 · 6.30 · 6.29 · 6.20 · 6.47 · 6.45** |

The recompute count is the mechanism and it is load-immune: **3 383 → 60**, identical in every
sample, which is ten sweeps times the handful of buckets a write actually touches. Sweep time
follows at −59% on the median, with the two arms' ranges not overlapping.

### Scope, and what is deliberately left unconditional

Only the layout recompute is skipped.

* `deleted` and `in_memory` have writers elsewhere that set them independently of the pages
  (`= false` / `= true` on the load paths), and this sweep currently overwrites those. Skipping
  them would preserve a value the sweep used to clobber — a behaviour change, so they stay.
* `dirty` and `ttl_ms` read shard-level state that a per-bucket page version does not cover.

All four remain cheap: the dirty and deleted tests short-circuit after about a page, and the expiry
walk is already skipped when nothing has an expiry. `object_index` and `layout` are written by
nothing but the layout update itself, so preserving them across a skip preserves exactly what a
recompute would produce.

The version cannot go stale in the dangerous direction: the other callers of the layout update do
not touch the recorded version, so they leave it *behind* the page version — which costs a
redundant recompute, never a skipped one.

### Tests

Eight tests next to the code (`bucket_layout_tests`), all mutation-checked:

* the buffered update matches a from-scratch rebuild across empty buckets, all-deleted buckets,
  duplicate ids, out-of-order pages, and stored sets stale in either direction — including sets
  **the same size as the correct one but holding different ids**
* reading the pages does not change the version; mutating them does
* a bucket whose pages changed is not treated as up to date
* the encoded page index is **byte-identical to the bare map**, and a bucket read back has derived
  nothing yet, so the first sweep after a load recomputes

That last one matters because this changes the type of a serialized field. Removing the attribute
that keeps the encoding transparent makes it fail, so it is testing something.

Also passing: `upsert_reload_equality`, `storage_migration_corpus`, `bulk_install_index_durability`,
`storage_crash_harness`, `inmemory_dirty_summary`, `delta_index_log_gc`, `resource_blob_store`, and
`cargo check --all-targets` on both repos from byte-identical source.

`list_recovery`, `zset_recovery`, `wal_single_barrier_recovery` (5 of 8), `delta_served_index` and
`cold_raw_ingestion` fail — all of them identically on pristine `main` and on the branch this
stacks on. Inherited, not introduced. Worth someone's attention on `main` separately: several are
recovery suites and they die in under a tenth of a second, which looks environmental rather than
logical.

Strict mem0 conformance was run interleaved with the arm order alternating between rounds. It is a
smoke test here and not the basis for the correctness claim: the same binary has scored one failure
in five rounds and then five in six, and every failing check appears on both arms in both
positions.
