### PR TITLE
records are framed by their length now, by default

### DIFF
--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -63,25 +63,33 @@ pub(crate) const FRAME_MAGIC: &[u8] = FRAME_MAGIC_V2;
 /// legacy unframed record is a JSON document starting with `{`.
 pub(crate) const FRAME_MAGIC_V3: u8 = 0xB3;
 
-/// Whether new records are written with the binary frame.
+/// Whether new records are written with the binary frame. DEFAULT ON.
 ///
-/// OPT-IN, and the reason is worth stating: a length-framed record cannot be found by scanning
-/// BACKWARD. The tail scan that locates a log's last record looks for the final newline, which
-/// works only while every record ends with one -- a binary payload has no trailing delimiter and
-/// contains 0x0A bytes of its own, so a reverse search lands inside a payload. Walking forward
-/// finds the tail correctly but reads the whole file, and with TS_PHASE1_FLAT off that scan runs
-/// on EVERY append, which would turn ingest quadratic.
+/// The cost this removes is not the newline byte, it is what a delimiter forces on everything
+/// that reads: a reader scanning for `\n` cannot be handed a payload containing one, so every
+/// binary record had to be stuffed on the way in and unstuffed on the way out -- two full copies
+/// of each record, plus a byte for every 0x0A and 0x1B inside it. Measured over 200 records:
+/// 102.3 -> 84.8 bytes each, and `what_each_frame_costs_on_disk` keeps that honest.
 ///
-/// Making this the default therefore needs O(1) tail discovery -- last record offset and
-/// sequence recorded as the log is written, rather than searched for afterwards.
+/// The one thing length framing takes away is the ability to find a log's tail by scanning
+/// BACKWARD: a length prefix is only readable from in front of the record it describes, so the
+/// tail has to be walked to. That walk reads the file, which would be ruinous if it ran per
+/// append -- and it does not: TS_PHASE1_FLAT resolves the sequence from the warm cache plus a
+/// length stat, leaving the walk for a cold open. (A log format that frames by length usually
+/// records where its last record is as it writes, which bounds even that; the descriptors for
+/// it exist in `storage_descriptor` and are not yet wired.)
+///
+/// Off (`TS_WAL_BINARY_FRAME=0`) writes the delimited frame again. Reading never depends on this
+/// flag: which frame a record uses is a property of the record, so a log holding both -- which
+/// is what an upgrade leaves -- reads end to end either way.
 pub(crate) fn binary_frame_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_WAL_BINARY_FRAME")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2501,8 +2501,10 @@ fn wal_bulk_relaxed_durability() -> bool {
 /// on-disk length is still exactly what we last left it (`verified_len_by_shard`) -- an O(1)
 /// `metadata()` stat instead of the O(n) scan. Safe because (a) the append lock is cross-process, so
 /// any external appender changes the length and forces the full scan, and (b) we only ever append
-/// complete framed lines, so a length match rules out a torn tail. Default OFF, byte-identical to
-/// the unconditional-scan path when off. Mirrors the warm-cache fast path already used by
+/// complete framed records, so a length match rules out a torn tail. DEFAULT ON (the comment here
+/// said OFF long after the code said otherwise, and a stale default in a comment is worse than no
+/// comment: it was read as fact while deciding whether another gate could be turned on).
+/// Byte-identical to the unconditional-scan path when off. Mirrors the warm-cache fast path already used by
 /// `index_log::append_delta` and `append_replayed_record`.
 fn wal_fast_append_seq() -> bool {
     wal_env_flag_default_on("TS_PHASE1_FLAT")
@@ -6040,10 +6042,13 @@ mod tests {
         // And every earlier address still resolves to the record it was handed out for.
         for (sequence, earlier) in &written {
             if let Some(bytes) = reopened.read_at_log_id(1, *earlier, 4096).unwrap() {
-                let end = bytes
-                    .iter()
-                    .position(|byte| *byte == b'\n')
-                    .map_or(bytes.len(), |at| at + 1);
+                // The frame says where this record ends. The first newline does not: a
+                // length-framed payload carries 0x0A itself, so slicing there hands the
+                // decoder half a record.
+                let end = match crate::log_framing::next_frame(&bytes) {
+                    Ok(Some((consumed, _))) if consumed > 0 => consumed,
+                    _ => bytes.len(),
+                };
                 assert_eq!(
                     decode_wal_line(&bytes[..end]).unwrap().sequence,
                     *sequence,
@@ -6183,10 +6188,13 @@ mod tests {
         // And every address handed out before the crash still resolves to its own record.
         for (sequence, earlier) in &written {
             if let Some(bytes) = reopened.read_at_log_id(1, *earlier, 4096).unwrap() {
-                let end = bytes
-                    .iter()
-                    .position(|byte| *byte == b'\n')
-                    .map_or(bytes.len(), |at| at + 1);
+                // The frame says where this record ends. The first newline does not: a
+                // length-framed payload carries 0x0A itself, so slicing there hands the
+                // decoder half a record.
+                let end = match crate::log_framing::next_frame(&bytes) {
+                    Ok(Some((consumed, _))) if consumed > 0 => consumed,
+                    _ => bytes.len(),
+                };
                 assert_eq!(
                     decode_wal_line(&bytes[..end]).unwrap().sequence,
                     *sequence,


### PR DESCRIPTION
records are framed by their length now, by default

    was   102.3 B/record
    now    84.8 B/record      -17.1%, measured on the file over 200 records

Six bytes of frame where the delimited one spent twenty, and payloads written exactly as
produced. The saving is real but it is the smaller half: a reader that finds records by
scanning for a delimiter cannot be handed a payload containing one, so every binary record was
stuffed on the way in and unstuffed on the way out -- two full copies of each record, plus a
byte for every 0x0A and 0x1B inside it. None of that happens now.

Reading never consults the flag. Which frame a record uses is a property of the record, so a
log holding both -- which is what an upgrade leaves, and what a reclaim rewrite spanning one
produces -- reads end to end in either direction. TS_WAL_BINARY_FRAME=0 writes the delimited
frame again for anything that needs it.

Verified as a matrix, because a default that only works on fresh data is the worst kind of
pass:

    default (length frame)     engine 281, wal 167, shared_store 37, raft 252 -- all 0 failed
    TS_WAL_BINARY_FRAME=0      the same, all 0 failed
    TS_PHASE1_FLAT=0           the same, all 0 failed

AND A COMMENT SAID THE OPPOSITE OF ITS CODE, WHICH IS WHY THIS TOOK LONGER.

Length framing removes one thing: a log's tail can no longer be found by scanning BACKWARD,
because a length prefix is only readable from in front of the record it describes. The tail has
to be walked to, and walking reads the file. Whether that is affordable depends entirely on
whether the walk happens per append or per open -- and TS_PHASE1_FLAT decides it, by resolving
the sequence from a warm cache plus a length stat.

Its doc comment says "Default OFF". Its code says `wal_env_flag_default_on`. It has been ON.
That comment was read as fact while deciding whether this frame could be defaulted, and the
answer came out wrong for a week's worth of reasoning. The comment is corrected, and says why a
stale default in a comment is worse than none.

What the walk costs when it does run is now measured rather than asserted: with the cache off,
the engine suite takes 8041s against 497s. Sixteen times, which is the argument for the tail
metadata a length-framed log usually keeps -- and those descriptors already exist in
`storage_descriptor`, unwired.

The last of the tests that read a log as text are converted: 17 failing under this frame when

🤖 Generated with [Claude Code](https://claude.com/claude-code)
