### PR TITLE
Remove one component's page refs by range instead of walking them all

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -469,7 +469,24 @@ impl CoreIndex {
             .remove(&object_page_lookup_key(model_id, object_key, component));
         let component_lookup_key = object_component_lookup_key(model_id, object_key);
         if let Some(component_refs) = self.object_component_lookup.get_mut(&component_lookup_key) {
-            component_refs.retain(|page_ref| page_ref.component.as_deref() != component);
+            // `ComponentPageLookupRef` orders on `component` first, so every ref for one component
+            // is a contiguous range and can be found by seeking to it. Walking the whole set
+            // instead cost time proportional to how many components the object has -- and for a
+            // shard hash the components ARE its fields, so writing one field walked every field
+            // already in that hash.
+            let first = ComponentPageLookupRef {
+                component: component.map(str::to_string),
+                routing_bucket: 0,
+                page_ref_key: String::new(),
+            };
+            let doomed: Vec<ComponentPageLookupRef> = component_refs
+                .range(first..)
+                .take_while(|page_ref| page_ref.component.as_deref() == component)
+                .cloned()
+                .collect();
+            for page_ref in doomed {
+                component_refs.remove(&page_ref);
+            }
             if component_refs.is_empty() {
                 self.object_component_lookup.remove(&component_lookup_key);
             }
@@ -609,4 +626,113 @@ pub(super) enum PackedFeaturePageDecode {
 pub(super) struct SeenSet {
     pub(super) by_member: BTreeMap<Vec<u8>, u64>,
     pub(super) by_time: BTreeMap<(u64, Vec<u8>), ()>,
+}
+
+
+#[cfg(test)]
+mod component_lookup_tests {
+    use super::*;
+
+    fn core_with(object: &str, components: &[Option<&str>]) -> CoreIndex {
+        let mut index = CoreIndex::default();
+        let set = index
+            .object_component_lookup
+            .entry(object_component_lookup_key("hash", object))
+            .or_default();
+        for (i, component) in components.iter().enumerate() {
+            set.insert(ComponentPageLookupRef {
+                component: component.map(str::to_string),
+                routing_bucket: i as u32,
+                page_ref_key: format!("p{i}"),
+            });
+        }
+        index
+    }
+
+    fn components_left(index: &CoreIndex, object: &str) -> Vec<Option<String>> {
+        index
+            .object_component_lookup
+            .get(&object_component_lookup_key("hash", object))
+            .map(|refs| refs.iter().map(|r| r.component.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn removing_one_component_leaves_the_others() {
+        let mut index = core_with("k", &[Some("a"), Some("b"), Some("c")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("b"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("c".to_string())]
+        );
+    }
+
+    #[test]
+    fn removing_the_first_and_last_components_works() {
+        let mut index = core_with("k", &[Some("a"), Some("b"), Some("c")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("a"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("b".to_string()), Some("c".to_string())]
+        );
+        index.remove_object_page_lookup_entry("hash", "k", Some("c"));
+        assert_eq!(components_left(&index, "k"), vec![Some("b".to_string())]);
+    }
+
+    #[test]
+    fn a_none_component_is_removable_and_does_not_take_the_others() {
+        // `None` sorts before every `Some`, so it is the range's first element -- the case most
+        // likely to run off the front of the set.
+        let mut index = core_with("k", &[None, Some("a"), Some("b")]);
+        index.remove_object_page_lookup_entry("hash", "k", None);
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("b".to_string())]
+        );
+    }
+
+    #[test]
+    fn every_ref_sharing_a_component_goes() {
+        // One component can hold several refs (different buckets/pages); all of them must go, the
+        // way the walk that this replaces would have dropped them.
+        let mut index = CoreIndex::default();
+        let set = index
+            .object_component_lookup
+            .entry(object_component_lookup_key("hash", "k"))
+            .or_default();
+        for i in 0..3u32 {
+            set.insert(ComponentPageLookupRef {
+                component: Some("dup".to_string()),
+                routing_bucket: i,
+                page_ref_key: format!("p{i}"),
+            });
+        }
+        set.insert(ComponentPageLookupRef {
+            component: Some("keep".to_string()),
+            routing_bucket: 9,
+            page_ref_key: "p9".to_string(),
+        });
+        index.remove_object_page_lookup_entry("hash", "k", Some("dup"));
+        assert_eq!(components_left(&index, "k"), vec![Some("keep".to_string())]);
+    }
+
+    #[test]
+    fn removing_an_absent_component_changes_nothing() {
+        let mut index = core_with("k", &[Some("a"), Some("b")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("zzz"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("b".to_string())]
+        );
+    }
+
+    #[test]
+    fn emptying_the_set_drops_the_key_entirely() {
+        let mut index = core_with("k", &[Some("only")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("only"));
+        assert!(index
+            .object_component_lookup
+            .get(&object_component_lookup_key("hash", "k"))
+            .is_none());
+    }
 }


### PR DESCRIPTION
Writing one field of a hash cost time proportional to how many fields that hash already held. This
removes that.

`remove_object_page_lookup_entry` dropped the page refs for one component using `retain`, which
visits every ref the object has. For an ordinary object that is nothing. **For a shard hash the
"components" are its fields** — so writing a single field walked every field already in that hash,
and this runs once per field written.

`ComponentPageLookupRef` derives `Ord` with `component` as its first field, so the set is ordered
by component and every ref for one component sits in a contiguous range. Seeking to that range and
removing only its members is O(log n + k) instead of O(n), and removes exactly the same refs —
`retain` kept everything whose component differs, which is the complement of what this drops.

### Measured

Per-field cost inside `upsert_bucket_index_page`, and the enclosing apply phase. Two corpus sizes,
two runs per arm, same probes on both arms:

| | 230 memories | 530 memories |
|---|---|---|
| before, µs/field | 42 · 38 | **83 · 76** |
| **after, µs/field** | 11 · 12 | **13 · 12** |
| before, ms/add | 5.75 · 5.23 | 11.49 · 10.44 |
| **after, ms/add** | 1.47 · 1.61 | **1.73 · 1.71** |

**The growth is gone, not just reduced.** Before, per-field cost doubled as the corpus did — 42 to
83 µs while fields-per-hash went 511 to 1184. After, it is flat: 12 µs at 230 memories and 12 µs
at 530. That flatness is the result; the −85% at this particular size is a consequence of it, and
it gets larger as a store grows.

The apply phase falls from 23.5 to 15.0 ms per add at 530 memories (−36%). End-to-end add p50 moved
125 → 112 ms, but this box swings more than that between runs, so the per-field counters carry the
claim and the wall clock is reported only as consistent with them.

### How it was found

Working down from the top rather than guessing: an add spends its time in `batch_execute`; that
splits into apply / WAL append / post-batch, and only apply grew with the corpus; apply is
essentially `execute_on_shard`; that is 88 hash commands per add, of which `HashMultiSet` at 50
calls is 68–77%; inside those, `upsert_bucket_index_page` was 69% and doubling while the
block-store append beside it stayed flat; inside that, 92.9% was this one call.

Two hypotheses were measured and refuted on the way. Full index rebuilds on the write path: zero
per add, the guards hold. Merging multi-set commands that share a hash key: 3.85 commands per batch
target 3.85 distinct keys, so there is nothing to merge.

### Tests

Six tests on the removal itself (`component_lookup_tests`): removing a middle, first and last
component; a `None` component, which sorts before every `Some` and is the case most likely to run
off the front of the range; several refs sharing one component, all of which must go; an absent
component changing nothing; and an emptied set dropping its key.

Mutation-checked: seeking from the start of the set instead of from the component fails two of
them.

Also passing: `upsert_reload_equality`, `storage_migration_corpus`, `bulk_install_index_durability`,
`storage_crash_harness`, `inmemory_dirty_summary`, `delta_index_log_gc`, `delta_index_cost`,
`resource_blob_store`, the `engine::state` and `storage_bucket_internals` unit tests, and
`cargo check --all-targets` on both repos from byte-identical source.

Strict mem0 conformance was run interleaved with the arm order alternating: **base 19·22·20·22**,
**this branch 19·22·22·21** — the same failure rate on both arms, in both positions, entirely on
the checks that flake on this machine regardless of branch. It is a smoke test here, not the basis
for the correctness claim.
