### PR TITLE
a record carrying its own blocks no longer carries the operation too

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -8530,3 +8530,115 @@ fn an_async_write_is_never_lost_across_a_restart() {
         );
     }
 }
+
+#[test]
+fn a_record_carrying_its_blocks_states_results_instead_of_the_operation() {
+    // The log records what a write DID, not what it was asked to do -- and that now includes a
+    // write whose blocks travel inside its own record. It could not before: an installed result
+    // names an address, and a block living in the record was unreachable by address until replay
+    // began registering the blocks of every record it replays. With that in place the operation
+    // is redundant for these too, and redundant bytes in a log are paid for on every write.
+    //
+    // What legitimately keeps its operation: an ASYNCHRONOUS write carrying nothing. Its result
+    // names a block-store address a crash may leave unwritten, and no registration recovers a
+    // block that was never stored.
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+    for index in 0..8 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{index}"),
+                value: vec![b'v'; 256],
+            },
+        });
+    }
+    engine
+        .write_ahead_log_store()
+        .flush(1)
+        .expect("flush before reading the log back");
+
+    let records = engine
+        .write_ahead_log_store()
+        .scan(1, 0, u64::MAX, u64::MAX)
+        .expect("the log should read back");
+    let mut carrying_blocks = 0usize;
+    let mut carrying_blocks_with_command = 0usize;
+    for (_, line) in &records {
+        let record = crate::wal::decode_wal_line(line).expect("a record should decode");
+        if record.staged_pages.is_empty() {
+            continue;
+        }
+        carrying_blocks += 1;
+        if record.command.is_some() {
+            carrying_blocks_with_command += 1;
+        }
+    }
+    assert!(
+        carrying_blocks > 0,
+        "this workload must produce records carrying their blocks, or it proves nothing"
+    );
+    // Assert both directions of the flag, because the property belongs to the flag rather than
+    // to the log. With data-only off, every record is SUPPOSED to carry its operation -- that is
+    // what the switch means -- and a test asserting otherwise unconditionally says the legacy
+    // configuration is broken when it is behaving exactly as asked.
+    if crate::wal::wal_data_only_enabled() {
+        assert_eq!(
+            carrying_blocks_with_command, 0,
+            "{carrying_blocks_with_command} of {carrying_blocks} records carrying their own \
+             blocks still carry the operation as well"
+        );
+    } else {
+        assert_eq!(
+            carrying_blocks_with_command, carrying_blocks,
+            "with data-only off every record keeps its operation: {carrying_blocks_with_command} \
+             of {carrying_blocks} did"
+        );
+    }
+
+    // And the point of all of it: the shard still comes back.
+    drop(engine);
+    let restarted = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+    for index in 0..8 {
+        assert_eq!(
+            restarted
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: format!("k{index}"),
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(vec![b'v'; 256])
+            },
+            "k{index} must survive a restart on results alone"
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -389,16 +389,20 @@ pub fn wal_data_only_enabled() -> bool {
 /// the log-resident path -- needs that block registered against the record's log id before any
 /// read can resolve it, which the write path does and installing an address does not.
 ///
-/// So results replace the operation only for a synchronous write whose block went to the block
-/// store: durable, and findable without anything else having to happen. Everything else keeps its
-/// operation and recovers by re-running it, exactly as before.
+/// So results replace the operation when the block behind them can be found afterwards: a
+/// synchronous write whose block is already in the block store, or ANY write carrying its block
+/// inside the record, because replay now registers what it replays. What is left is the
+/// asynchronous write with nothing carried -- its result names a block-store address a crash may
+/// leave unwritten, and registering cannot conjure a block that was never stored. That one keeps
+/// its operation and recovers by re-running it.
 ///
 /// Both halves were found the same way: a recovery test failing 8 runs in 12 against 0 in 12 on
 /// the code before this, measured interleaved on one machine because an uncontrolled comparison
 /// had already told me the opposite once.
 ///
-/// Extending data-only to carried blocks means registering them during replay, which is a change
-/// to the install path rather than to this rule.
+/// The carried-block half of that measurement predates replay registering blocks. The rule tried
+/// then -- accepting carried blocks -- failed 5 runs in 12 precisely because nothing registered
+/// them on the way back in. That is now done, which is what makes the same rule correct.
 pub(crate) fn record_command(
     command: Command,
     outcomes: &[WalOutcomeItem],
@@ -1109,7 +1113,15 @@ impl LocalWriteAheadLogStore {
                 metadata: Some(WriteAheadLogRecordMetadata::single_command(&command)),
                 // Durable AND in the block store: the two conditions under which installing an
                 // address is enough on its own.
-                command: record_command(command, &outcomes, sync && staged_pages.is_empty()),
+                // A carried block is findable after recovery now: replay registers the blocks
+                // of every record it replays, which is the one thing the rule below was waiting
+                // for. So a record carrying its own blocks can state results and drop the
+                // operation, the same as a synchronous write whose blocks are already durable.
+                //
+                // What still cannot: an ASYNCHRONOUS write with nothing carried. Its result names
+                // an address in the block store that a crash may leave unwritten, and no amount
+                // of registering helps a block that was never stored.
+                command: record_command(command, &outcomes, sync || !staged_pages.is_empty()),
                 staged_pages,
                 outcomes,
             };
@@ -1825,14 +1837,27 @@ impl LocalWriteAheadLogStore {
         // the size of the whole file.
         let mut source = File::open(&path)?;
         source.seek(SeekFrom::Start(header_len))?;
-        let mut reader = BufReader::new(source.take(record_end.saturating_sub(header_len)));
+        // Bounded by the cursor below rather than by `take`, because a Take is not seekable and
+        // stepping over a block's footer is a seek. the reclaim walk crosses blocks now.
+        let mut reader = BufReader::new(source);
+        let walk_until = record_end;
         let mut records_before = 0usize;
         let mut records_after = 0usize;
         let mut split = None;
         let mut cursor = header_len;
         loop {
-            let Some(line) = read_raw_record(&mut reader)? else {
+            if cursor >= walk_until {
                 break;
+            }
+            let Some(line) = read_raw_record(&mut reader)? else {
+                // Padding before a closed block's footer, or the end. The footer decides.
+                match block_is_closed(&mut reader, cursor, header_len, walk_until)? {
+                    Some(next) => {
+                        cursor = next;
+                        continue;
+                    }
+                    None => break,
+                }
             };
             let read = line.len();
             if read == 0 {
@@ -2039,10 +2064,20 @@ impl LocalWriteAheadLogStore {
         // encodings, ever gets to look at it. Escaping the newline out of a binary payload keeps
         // records SPLITTABLE; it cannot make arbitrary bytes valid UTF-8, and nothing should
         // require them to be.
+        let (_, info_header_len) = read_wal_base(&path)?;
+        let info_len = path.metadata().map(|meta| meta.len()).unwrap_or(0);
+        let mut info_at = info_header_len;
         loop {
             let Some(mut line) = read_raw_record(&mut reader)? else {
-                break;
+                match block_is_closed(&mut reader, info_at, info_header_len, info_len)? {
+                    Some(next) => {
+                        info_at = next;
+                        continue;
+                    }
+                    None => break,
+                }
             };
+            info_at = info_at.saturating_add(line.len() as u64);
             // Only a text record carries a trailing newline; a binary frame ends where its
             // declared length ends, and trimming it would take a byte of the payload.
             if line.first() != Some(&crate::log_framing::FRAME_MAGIC_V3) {


### PR DESCRIPTION
a record carrying its own blocks no longer carries the operation too

A result names where a block landed, and installing it reproduces the write only if a reader can
then find that block. Two cases could not. One was a write whose block travels INSIDE its record:
unreachable by address, because nothing registered it on the way back in. Those records kept
their operation and recovered by re-running it, carrying both descriptions of the same write.

Replay registers the blocks of every record it replays now. That was the missing half, and the
rule here said so in as many words -- "extending data-only to carried blocks means registering
them during replay, which is a change to the install path rather than to this rule." The install
path changed. This is the rule catching up.

    the same rule, before replay registered blocks   5 failures in 12
    the same rule, after                             0 in 8, recovery family

Worth stating plainly: this exact condition was tried earlier and measured as wrong. It was not
wrong, it was early. Nothing in the failure separated the two -- a record installing an address
that resolves to nothing looks identical to a rule that should not exist -- and what stood
between them was a precondition written down here and then satisfied somewhere else entirely.

What still carries its operation is not a leftover: an ASYNCHRONOUS write carrying nothing. Its
result names a block-store address a crash may leave unwritten, and registering cannot recover a
block that was never stored. That record re-runs on replay because re-running is the only thing
that rebuilds it.

AND THE LAST TWO WALKS LEARNED ABOUT BLOCKS.

The reclaim split walk and `info()` still read records as one contiguous run, which is what
every reader here assumed before a footer began interrupting them. Reclaim is the one that
mattered: it rewrites the log, so a walk that stopped at the first footer would decide to drop
records it simply could not see.

Reclaim needed more than a check inserted. It read through a `take()`, which is not seekable,
and stepping over a footer is a seek -- so it is bounded by an explicit cursor now. That is the
fourth distinct way blocks reach into code with no reason to know about them, after records not
straddling boundaries, the stream being discontinuous, and zeros meaning two different things.

    footer off   wal 172, engine 282, shared_store 37, raft 252 -- all 0 failed
    footer on    wal 172 -- 0 failed

The property test asserts the flag in BOTH directions, which it did not at first: with data-only
off every record is SUPPOSED to keep its operation, and asserting the absence unconditionally
called the legacy configuration broken for behaving exactly as asked. The gate caught that and
refused, which is the second time today a red gate was the thing telling the truth.

Two changes in one commit because a ship of the first was still running its gates when the
second was written, which makes both results meaningless and is exactly what the tree-hash guard
refuses. Ships do not overlap edits; that rule has now failed three times as something to

🤖 Generated with [Claude Code](https://claude.com/claude-code)
