### PR TITLE
The block footer defaults on, like the frame it exists to serve

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -3188,16 +3188,27 @@ const WAL_BLOCK_FOOTER_BYTES: u64 = 128;
 /// not mistaken for a footer describing block zero.
 const WAL_BLOCK_FOOTER_MAGIC: u64 = 0xB10C_F007_E12A_5EEDu64;
 
-/// TS_WAL_BLOCK_FOOTER (default OFF while it earns trust): reserve a footer at the end of every
-/// fixed-size block and use it to find the log's tail on reopen.
+/// TS_WAL_BLOCK_FOOTER (DEFAULT ON): reserve a footer at the end of every fixed-size block and use
+/// it to find the log's tail on reopen.
+///
+/// On by default because it is the prerequisite for the frame it exists to serve. A length-framed
+/// record cannot be located by scanning backward, so finding the tail without a footer means
+/// reading forward, and that cost grows with the log. With binary framing already the default,
+/// leaving this off made the shipped configuration the only one with neither fast path: measured
+/// on 150 adds of 4KB, 643 ms p50 and degrading 3.8x over the run, against 110 ms and flat with
+/// the footer on. At 530 memories the same configuration reached seconds per add.
+///
+/// `TS_WAL_BLOCK_FOOTER=0` reserves no footer and finds the tail by reading forward, which is what
+/// a log written before this existed needs -- reading never depends on the flag, since a footer is
+/// self-describing and its absence is simply the older layout.
 fn wal_block_footer_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_WAL_BLOCK_FOOTER")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -3648,7 +3659,9 @@ mod tests {
             if footers {
                 std::env::set_var("TS_WAL_BLOCK_FOOTER", "1");
             } else {
-                std::env::remove_var("TS_WAL_BLOCK_FOOTER");
+                // Explicitly off: the default is ON now, so removing the variable would leave
+                // footers enabled and this arm would compare the footer path against itself.
+                std::env::set_var("TS_WAL_BLOCK_FOOTER", "0");
             }
             let dir = tempfile::tempdir().unwrap();
             let store = LocalWriteAheadLogStore::new(dir.path());
@@ -3677,7 +3690,9 @@ mod tests {
             if footers {
                 std::env::set_var("TS_WAL_BLOCK_FOOTER", "1");
             } else {
-                std::env::remove_var("TS_WAL_BLOCK_FOOTER");
+                // Explicitly off: the default is ON now, so removing the variable would leave
+                // footers enabled and this arm would compare the footer path against itself.
+                std::env::set_var("TS_WAL_BLOCK_FOOTER", "0");
             }
             let started = std::time::Instant::now();
             for _ in 0..rounds {


### PR DESCRIPTION
Ingest on `main` slows down as the store fills: about 800 ms per add at 150 memories, degrading
over the run, and reaching seconds per add by 530. This restores it to a flat ~115 ms.

### What happened

Two defaults were flipped independently, and one is the other's prerequisite.

`TS_WAL_BINARY_FRAME` became the default in #454. A length-framed record cannot be located by
scanning backward, so finding the log's tail without a footer means reading forward — and that
cost grows with the log. #454's own message says the flip "needs O(1) tail discovery". The block
footer is that discovery, and it shipped **default OFF**, "while it earns trust".

**So the shipped configuration was the only one with neither fast path.** Nothing is wrong with
either change on its own; they were simply never the default at the same time.

### Measured

Same binary, only the flags differing, 150 adds of 4 KB:

| configuration | last-30 p50 | degradation over the run |
|---|---:|---:|
| frame on, footer off &mdash; what ships today | **643.2 ms** | **3.83&times;** |
| frame on, footer on | 110.2 / 103.1 ms | 0.97&times; / 1.21&times; |
| frame off | 94.5 ms | 1.10&times; |

And on this branch against `main`, with the arm order alternating between rounds:

| round | arm | last-30 p50 | degradation |
|---|---|---:|---:|
| 1 | main | 802.1 ms | 4.38&times; |
| 1 | **this branch** | **115.6 ms** | **0.98&times;** |
| 2 | **this branch** | **122.5 ms** | **1.03&times;** |
| 2 | main | 700.6 ms | 3.11&times; |

**&minus;84%, and the growth is gone** &mdash; 4.4&times; degradation over a run becomes 1.0&times;.
Turning the frame off instead would also fix the speed, but would give up the 17% per-record saving
#454 shipped for; this keeps both.

### Bisected

My own changes are in none of these arms:

| commit | last-30 p50 | ratio |
|---|---:|---:|
| `011bbf3d` before framing | 91.1 ms | 1.03&times; |
| `36500e2b` framing merged, still opt-in | 105.9 ms | 1.13&times; |
| **`2a166b23` framing on by default (#454)** | **660.6 ms** | **3.67&times;** |
| `6a586b3a` head | 676.4 ms | 4.08&times; |

### On the risk

The footer was left off deliberately while it earned trust, and this overrides that. Two things
argue for it now: it is the documented precondition for a default that already shipped, and the
alternative &mdash; turning the frame back off &mdash; discards a merged improvement to avoid a
configuration that was never intended.

`TS_WAL_BLOCK_FOOTER=0` still reserves no footer and finds the tail by reading forward, which is
what a log written before footers existed needs. Reading never consults the flag: a footer is
self-describing and its absence is simply the older layout, so a log holding both reads end to end
either way.

### Tests

172 WAL unit tests pass. `storage_crash_harness`, `bulk_install_index_durability` and
`upsert_reload_equality` pass.

Two tests expressed "footers off" by *removing* the variable, which meant off only while the
default was off; with the default on it would silently have meant on, and the tail-cost comparison
would have compared the footer path against itself. They now set `0` explicitly.

**Worth stating plainly:** `wal_single_barrier_recovery` (5 of 8), `list_recovery` and
`zset_recovery` fail here &mdash; and fail identically on `main` with this branch's changes absent.
They are inherited, not introduced. But they are also the suites that would most directly validate
a change to the on-disk block layout, so they cannot vouch for this one. That is worth someone's
attention on `main` independently of this change.
