### PR TITLE
the log-resident page set is bounded now, oldest written out first

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -146,6 +146,37 @@ pub struct TemporalEngine {
     maintenance_mirror: Arc<RwLock<Option<Arc<dyn crate::data_node::SharedWalSink>>>>,
 }
 
+
+/// TS_WAL_RESIDENT_PAGES: how many log-resident pages one shard may hold before the oldest are
+/// written out to the block store. Zero disables the bound entirely.
+///
+/// resident pages are bounded because an unbounded set costs twice. Each one is a registration,
+/// which is memory; each one also pins `min_registered_sequence`, and reclaim may not truncate
+/// below the lowest registration — so a set that only grows is a log that can never be reclaimed
+/// whatever the retention policy says. Measured on an ingest of distinct keys, registrations
+/// tracked writes ONE FOR ONE: 200 writes 200 held, 1200 writes 1200 held.
+///
+/// The default is deliberately generous. The recent ones are worth keeping where they are: a page
+/// written moments ago is the one a read is most likely to want, and its bytes are already in the
+/// record just written. This is a ceiling on how far behind the dump can fall, not a cache policy.
+/// How many times a sweep has moved pages out, for tests that need to know the bound fired
+/// rather than that the count merely happened to stay low.
+pub(crate) static RESIDENT_SWEEPS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+fn wal_resident_page_limit() -> usize {
+    std::env::var("TS_WAL_RESIDENT_PAGES")
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(4096)
+}
+
+/// How far below the limit a sweep goes, so a shard sitting exactly at the ceiling does not
+/// materialise on every single append.
+fn wal_resident_page_floor(limit: usize) -> usize {
+    limit.saturating_sub(limit / 4).max(1)
+}
+
 impl TemporalEngine {
     /// Mirror the deletions this engine emits on its own -- eviction drops, expiry sweeps --
     /// to the same place request-path writes go.
@@ -968,6 +999,23 @@ impl TemporalEngine {
                     ),
                     response: CommandResponse::Empty,
                 };
+            }
+        }
+        // Locks are released and the barrier is done: a safe point to bound the resident set.
+        // Not inside the write lock -- moving a page takes the same lock -- and not before the
+        // barrier, because the write this call is acking must reach disk first.
+        if write_command && !replaying_wal() {
+            let limit = wal_resident_page_limit();
+            if limit > 0
+                && block_in_wal::registration_count(&self.page_store, request.shard_id) > limit
+            {
+                let moved = self.materialize_oldest_resident_pages(
+                    request.shard_id,
+                    wal_resident_page_floor(limit),
+                );
+                if moved > 0 {
+                    RESIDENT_SWEEPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
             }
         }
         ExecuteResponse {

--- a/crates/temporalstore-rust/src/engine/block_in_wal.rs
+++ b/crates/temporalstore-rust/src/engine/block_in_wal.rs
@@ -217,6 +217,29 @@ pub(super) fn min_registered_sequence(
 /// The registry resolves a synthetic address to the record carrying its bytes, and it is process
 /// static: one entry per distinct object, held until the shard unloads. A test needs to see the
 /// count to say anything about whether it grows with the log.
+/// The objects this shard has registered, oldest WAL sequence first.
+///
+/// Oldest first because that is the order in which they stop being worth holding: the lowest
+/// registered sequence is the one pinning the log's retention floor, so retiring it is what lets
+/// reclaim move at all. Newest are kept because a page written a moment ago is the one a read is
+/// most likely to want, and it is already in the record the writer just wrote.
+pub(super) fn oldest_registered_objects(
+    block_store: &crate::block_store::LocalBlockStore,
+    shard_id: ShardId,
+) -> Vec<(u64, u64)> {
+    let Ok(map) = registry().lock() else {
+        return Vec::new();
+    };
+    let owner = block_store.store_id();
+    let mut entries: Vec<(u64, u64)> = map
+        .iter()
+        .filter(|((store_id, shard, _), _)| *store_id == owner && *shard == shard_id)
+        .map(|((_, _, object_id), (_, _, sequence))| (*sequence, *object_id))
+        .collect();
+    entries.sort_unstable();
+    entries
+}
+
 pub(super) fn registration_count(
     block_store: &crate::block_store::LocalBlockStore,
     shard_id: ShardId,

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -1156,7 +1156,40 @@ impl TemporalEngine {
     ///
     /// Called before a checkpoint exports the index. Returns how many were materialised, so a
     /// caller can tell the difference between "none needed it" and "it did not run".
+    /// Move the OLDEST log-resident pages into the block store, keeping the most recent
+    /// `keep` where they are. Returns how many moved.
+    ///
+    /// A page whose only durable copy is inside a WAL record costs twice. It holds a registration,
+    /// which is memory, and that registration pins `min_registered_sequence` -- reclaim may not
+    /// truncate below the lowest one, so a registry that only grows is a log that can never be
+    /// reclaimed no matter what the retention policy says. Measured on an ingest of distinct keys,
+    /// registrations track writes ONE FOR ONE: 200 writes, 200 held; 1200 writes, 1200 held.
+    ///
+    /// So the recent stay resident -- they are the ones a read is most likely to want, and their
+    /// bytes are in the record just written -- and everything older is written where anyone can
+    /// find it. Oldest first, because the oldest is the one holding the floor down.
+    pub fn materialize_oldest_resident_pages(&self, shard_id: ShardId, keep: usize) -> usize {
+        let ordered = super::block_in_wal::oldest_registered_objects(&self.page_store, shard_id);
+        if ordered.len() <= keep {
+            return 0;
+        }
+        let retiring: std::collections::HashSet<u64> = ordered[..ordered.len() - keep]
+            .iter()
+            .map(|(_, object_id)| *object_id)
+            .collect();
+        self.materialize_resident_pages_where(shard_id, |object_id| retiring.contains(&object_id))
+    }
+
     pub fn materialize_synthetic_pages(&self, shard_id: ShardId) -> usize {
+        self.materialize_resident_pages_where(shard_id, |_| true)
+    }
+
+    /// The one implementation both callers use: everything, or only what `wanted` selects.
+    fn materialize_resident_pages_where(
+        &self,
+        shard_id: ShardId,
+        wanted: impl Fn(u64) -> bool,
+    ) -> usize {
         let addresses: Vec<(String, crate::block_store::BlockAddress)> = {
             let shards = self.shards.read().expect("engine lock poisoned");
             let Some(shard) = shards.get(&shard_id) else {
@@ -1173,13 +1206,16 @@ impl TemporalEngine {
         };
         let mut moved = 0usize;
         for (key, address) in addresses {
+            let object_id = super::stable_page_object_id(shard_id, "string", &key, None);
+            if !wanted(object_id) {
+                continue;
+            }
             // Read it the way a reader here would -- through the registry that still works in
             // this process -- and write it where anyone can find it.
             let Some(bytes) = super::read_page_bytes(&self.cache, &self.page_store, shard_id, &address)
             else {
                 continue;
             };
-            let object_id = super::stable_page_object_id(shard_id, "string", &key, None);
             let Ok(durable) = super::append_value(
                 &self.cache,
                 &self.page_store,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -8642,3 +8642,255 @@ fn a_record_carrying_its_blocks_states_results_instead_of_the_operation() {
         );
     }
 }
+
+/// what the log-resident registry does under sustained writes.
+///
+/// Every asynchronous write whose page has nowhere durable to go yet leaves a registration: one
+/// entry naming the record that holds the only copy. Two things ride on that entry. It costs
+/// memory, which is the smaller half. It also pins `min_registered_sequence`, and reclaim may not
+/// truncate below the lowest registration -- so a registry that only grows is a log that can
+/// never be reclaimed, whatever the retention policy says.
+///
+/// Nothing on the local write path retires them: the drain is a dump, and shared-store
+/// checkpointing. This measures what happens in between.
+#[test]
+fn what_the_log_resident_registry_does_under_sustained_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+
+    let mut seen = Vec::new();
+    for batch in 1..=6 {
+        for index in 0..200 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    // Distinct keys: a rewrite of the same key REPLACES its registration, so
+                    // reusing keys would measure replacement rather than growth.
+                    key: format!("object-{:06}", batch * 1000 + index),
+                    value: vec![b'v'; 256],
+                },
+            });
+        }
+        seen.push((batch * 200, engine.registration_count_for_test(1)));
+    }
+
+    let floor_pinned = seen.last().map(|(_, count)| *count).unwrap_or(0);
+    println!("  writes -> registrations held");
+    for (writes, held) in &seen {
+        println!("  {writes:>6} -> {held:>6}");
+    }
+    println!(
+        "  a dump moves them out; between dumps the floor is pinned by {floor_pinned} entries"
+    );
+
+    // The shape is the finding: if this tracks writes one-for-one it is unbounded between dumps.
+    let (first_writes, first_held) = seen[0];
+    let (last_writes, last_held) = *seen.last().unwrap();
+    let grew = last_held as f64 / (first_held.max(1)) as f64;
+    let wrote = last_writes as f64 / first_writes as f64;
+    println!("  writes x{wrote:.1}, registrations x{grew:.1}");
+}
+
+/// what eight records per ingest cost, and what a batch already saves.
+///
+/// An ingest here is not one write. Measured elsewhere on the real path: a single ingest writes
+/// EIGHT records -- node, event, index ref, dirty marker, two summary refs, retrieval node,
+/// uniqueness -- and eight barriers, perfectly linear as ingests multiply. So the per-record
+/// constant this work has been shrinking gets multiplied by eight before it reaches a user, and
+/// the interesting question is not how big a record is but how many of them one operation makes.
+///
+/// This measures the two shapes that exist today: eight separate writes against one atomic batch
+/// of eight. The record format already carries `repeated items`, so a third shape is possible --
+/// one record holding eight outcomes -- and what it would save is the difference between the
+/// per-record overhead paid once and paid eight times.
+#[test]
+fn what_eight_records_per_ingest_cost() {
+    fn write_and_measure(batched: bool, ingests: usize) -> (u64, u64, u64) {
+        let dir = tempfile::tempdir().unwrap();
+        let page_dir = dir.path().join("pages");
+        let index_dir = dir.path().join("indexes");
+        let engine = TemporalEngine::with_local_dirs(
+            8 * 1024 * 1024,
+            dir.path().join("cache"),
+            &page_dir,
+            &index_dir,
+        );
+        engine.load_shard(1);
+        let before = engine.write_ahead_log_store().stats(1);
+        for ingest in 0..ingests {
+            // The eight writes one ingest makes, as distinct keys.
+            let parts = [
+                "node", "event", "index_ref", "dirty", "summary_a", "summary_b", "retrieval",
+                "unique",
+            ];
+            if batched {
+                let commands: Vec<Command> = parts
+                    .iter()
+                    .map(|part| Command::StringSet {
+                        key: format!("ingest-{ingest:05}/{part}"),
+                        value: vec![b'v'; 96],
+                    })
+                    .collect();
+                assert!(
+                    engine
+                        .batch_execute(BatchExecuteRequest {
+                            shard_id: 1,
+                            commands,
+                        })
+                        .status
+                        .ok
+                );
+            } else {
+                for part in parts {
+                    engine.execute(ExecuteRequest {
+                        shard_id: 1,
+                        command: Command::StringSet {
+                            key: format!("ingest-{ingest:05}/{part}"),
+                            value: vec![b'v'; 96],
+                        },
+                    });
+                }
+            }
+        }
+        engine.write_ahead_log_store().flush(1).ok();
+        let after = engine.write_ahead_log_store().stats(1);
+        let path = index_dir.join("wals").join("shard-1.wal.jsonl");
+        let (_, record_end) = crate::wal::last_wal_sequence_in_for_test(&path).unwrap_or((0, 0));
+        (
+            record_end,
+            after.writes.saturating_sub(before.writes),
+            after.syncs.saturating_sub(before.syncs),
+        )
+    }
+
+    let ingests = 200usize;
+    let (loose_bytes, loose_writes, loose_syncs) = write_and_measure(false, ingests);
+    let (batch_bytes, batch_writes, batch_syncs) = write_and_measure(true, ingests);
+    let payload = (ingests * 8 * 96) as u64;
+
+    println!(
+        "  {ingests} ingests, 8 writes each, 96 B values ({payload} B of value)\n  \
+         separate   {loose_bytes:>9} B log   {loose_writes:>6} appends   {loose_syncs:>6} syncs   \
+         {:>6.0} B/ingest\n  \
+         batched    {batch_bytes:>9} B log   {batch_writes:>6} appends   {batch_syncs:>6} syncs   \
+         {:>6.0} B/ingest\n  \
+         batching saves {:.1}% of the log and {:.1}% of the barriers",
+        loose_bytes as f64 / ingests as f64,
+        batch_bytes as f64 / ingests as f64,
+        100.0 * (loose_bytes as f64 - batch_bytes as f64) / loose_bytes.max(1) as f64,
+        100.0 * (loose_syncs as f64 - batch_syncs as f64) / loose_syncs.max(1) as f64,
+    );
+}
+
+/// registrations plateau instead of tracking writes, and every value still reads.
+///
+/// Without a bound this set grows one entry per distinct object written — measured at 200 writes
+/// 200 held, 1200 writes 1200 held — which is memory that never comes back and a reclaim floor
+/// that never moves. With one, the recent stay resident and the rest are written where anyone can
+/// find them.
+///
+/// The second half is the half worth having: a bound that loses data is not a bound, it is a
+/// deletion policy. Every value written is read back after the sweeps have run.
+#[test]
+fn registrations_plateau_instead_of_tracking_writes() {
+    let previous = std::env::var("TS_WAL_RESIDENT_PAGES").ok();
+    std::env::set_var("TS_WAL_RESIDENT_PAGES", "64");
+    let before_sweeps = crate::engine::RESIDENT_SWEEPS.load(std::sync::atomic::Ordering::Relaxed);
+
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024,
+        dir.path().join("cache"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+    assert!(
+        engine
+            .set_config(SetConfigRequest {
+                shard_id: 1,
+                config: Config {
+                    version: 2,
+                    async_storage: true,
+                    ..Config::default()
+                },
+            })
+            .ok
+    );
+
+    let total = 600usize;
+    let mut held = Vec::new();
+    for index in 0..total {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("object-{index:05}"),
+                value: vec![b'v'; 128],
+            },
+        });
+        if index % 100 == 99 {
+            held.push((index + 1, engine.registration_count_for_test(1)));
+        }
+    }
+    let after_sweeps = crate::engine::RESIDENT_SWEEPS.load(std::sync::atomic::Ordering::Relaxed);
+    match previous {
+        Some(value) => std::env::set_var("TS_WAL_RESIDENT_PAGES", value),
+        None => std::env::remove_var("TS_WAL_RESIDENT_PAGES"),
+    }
+
+    println!("  writes -> registrations held (limit 64)");
+    for (writes, count) in &held {
+        println!("  {writes:>6} -> {count:>6}");
+    }
+    println!("  sweeps: {}", after_sweeps - before_sweeps);
+
+    assert!(
+        after_sweeps > before_sweeps,
+        "the bound never fired, so this proves nothing about it"
+    );
+    let peak = held.iter().map(|(_, count)| *count).max().unwrap_or(0);
+    assert!(
+        peak <= 128,
+        "registrations should stay near the limit, peaked at {peak} over {total} writes"
+    );
+
+    // A bound that loses data is a deletion policy. Everything written must still read.
+    for index in 0..total {
+        assert_eq!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringGet {
+                        key: format!("object-{index:05}"),
+                    },
+                })
+                .response,
+            CommandResponse::Bytes {
+                value: Some(vec![b'v'; 128])
+            },
+            "object-{index:05} was lost when its page was moved out"
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -3453,6 +3453,11 @@ fn last_wal_sequence_forward_from(
     Ok((last_sequence, record_end))
 }
 
+/// Where the records of one log end, for measurements that need bytes rather than counts.
+pub fn last_wal_sequence_in_for_test(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
+    last_wal_sequence_in(path)
+}
+
 fn last_wal_sequence_in(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
     if !path.exists() {
         return Ok((0, 0));
@@ -3703,6 +3708,253 @@ fn sync_parent_dir(path: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// eight records against one record holding eight items, on identical outcomes.
+    ///
+    /// An ingest writes eight things. Today that is eight records, each paying a frame, a shard
+    /// id, a sequence, a timestamp and — in a batch — three more fields of batch bookkeeping so
+    /// the group can be recovered as a unit. The record format already carries `repeated items`,
+    /// so the same eight outcomes fit in one record that is atomic by construction and needs no
+    /// commit marker at all.
+    ///
+    /// This encodes both shapes from the same items and compares them, which says what the change
+    /// is worth before anything is rebuilt to get it.
+    #[test]
+    fn eight_records_against_one_record_holding_eight() {
+        fn item(index: usize) -> WalOutcomeItem {
+            WalOutcomeItem {
+                kind: "string".to_string(),
+                object_key: format!("ingest-00042/{index}"),
+                component: None,
+                object_id: 1000 + index as u64,
+                routing_bucket: 7,
+                address: None,
+                value: Some(vec![b'v'; 96]),
+                ttl: None,
+                deleted: false,
+                meta: false,
+            }
+        }
+
+        // Shape one: eight records, one item each, as a batch (so batch metadata is counted).
+        let mut separate = 0usize;
+        for index in 0..8 {
+            let record = WriteAheadLogRecord {
+                shard_id: 1,
+                sequence: 100 + index as u64,
+                command: None,
+                metadata: Some(WriteAheadLogRecordMetadata {
+                    version: WRITE_AHEAD_LOG_FORMAT_VERSION,
+                    timestamp_ms: 1_787_270_070_192,
+                    items: Vec::new(),
+                    batch_id: Some(9),
+                    batch_size: Some(8),
+                    batch_index: Some(index as u32 + 1),
+                }),
+                staged_pages: Vec::new(),
+                outcomes: vec![item(index)],
+            };
+            separate += crate::log_framing::encode_record(&encode_wal_payload(&record).unwrap()).len();
+        }
+
+        // Shape two: one record carrying all eight. Atomic because it is one record.
+        let record = WriteAheadLogRecord {
+            shard_id: 1,
+            sequence: 100,
+            command: None,
+            metadata: Some(WriteAheadLogRecordMetadata {
+                version: WRITE_AHEAD_LOG_FORMAT_VERSION,
+                timestamp_ms: 1_787_270_070_192,
+                items: Vec::new(),
+                batch_id: None,
+                batch_size: None,
+                batch_index: None,
+            }),
+            staged_pages: Vec::new(),
+            outcomes: (0..8).map(item).collect(),
+        };
+        let together = crate::log_framing::encode_record(&encode_wal_payload(&record).unwrap()).len();
+
+        println!(
+            "  eight records   {separate:>6} B\n  \
+             one record      {together:>6} B\n  \
+             saving          {:>6} B   {:.1}%",
+            separate.saturating_sub(together),
+            100.0 * (separate as f64 - together as f64) / separate as f64,
+        );
+        // And it must still decode to the same eight outcomes.
+        let framed = crate::log_framing::encode_record(&encode_wal_payload(&record).unwrap());
+        let back = decode_wal_line(&framed).unwrap();
+        assert_eq!(back.outcomes.len(), 8, "one record must carry all eight");
+        assert!(
+            together < separate,
+            "one record should not cost more than eight: {together} against {separate}"
+        );
+    }
+
+    /// Resident bytes this process holds, from the kernel rather than from a guess.
+    fn resident_bytes() -> u64 {
+        let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let kb: u64 = rest
+                    .trim()
+                    .trim_end_matches(" kB")
+                    .trim()
+                    .parse()
+                    .unwrap_or(0);
+                return kb * 1024;
+            }
+        }
+        0
+    }
+
+    /// what the log holds in memory, and whether it grows with the LOG or with the SHARDS.
+    ///
+    /// The claim this exists to check is one I had been repeating from reading the struct: every
+    /// map the log retains is keyed by shard, so memory is bounded by shard count and not by how
+    /// much has been written. That is an argument. This is the measurement.
+    ///
+    /// Ignored: it allocates thousands of shards and reads RSS, which is a process-wide number
+    /// and useless beside other tests.
+    ///
+    ///   cargo test -p temporalstore-rust --lib what_the_log_holds_in_memory -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn what_the_log_holds_in_memory() {
+        set_wal_segment_bytes_for_test(None);
+        const SHARDS: u64 = 1_000;
+
+        // A: one record per shard. Whatever the log keeps per shard is now resident.
+        let dir_a = tempfile::tempdir().unwrap();
+        let before_a = resident_bytes();
+        let store_a = LocalWriteAheadLogStore::new(dir_a.path());
+        for shard in 1..=SHARDS {
+            store_a
+                .append_with_sync(
+                    shard,
+                    Command::StringSet {
+                        key: format!("k{shard}"),
+                        value: vec![b'v'; 128],
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+        let after_a = resident_bytes();
+        let per_shard = (after_a.saturating_sub(before_a)) as f64 / SHARDS as f64;
+
+        // B: the same shards, a hundred times the records. If memory tracks the LOG this grows a
+        // hundredfold; if it tracks the SHARDS it does not move.
+        let dir_b = tempfile::tempdir().unwrap();
+        let before_b = resident_bytes();
+        let store_b = LocalWriteAheadLogStore::new(dir_b.path());
+        for shard in 1..=SHARDS {
+            for index in 0..100 {
+                store_b
+                    .append_with_sync(
+                        shard,
+                        Command::StringSet {
+                            key: format!("k{shard}-{index}"),
+                            value: vec![b'v'; 128],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+        }
+        let after_b = resident_bytes();
+        let per_shard_deep = (after_b.saturating_sub(before_b)) as f64 / SHARDS as f64;
+
+        println!(
+            "  {SHARDS} shards, 1 record each     resident +{:>9} B   {:>8.0} B/shard\n  \
+             {SHARDS} shards, 100 records each   resident +{:>9} B   {:>8.0} B/shard\n  \
+             records written: {} against {}   ratio of per-shard cost: {:.2}x",
+            after_a.saturating_sub(before_a),
+            per_shard,
+            after_b.saturating_sub(before_b),
+            per_shard_deep,
+            SHARDS,
+            SHARDS * 100,
+            per_shard_deep / per_shard.max(1.0),
+        );
+        // A hundredfold more log for the same shards must not cost a hundredfold more memory.
+        // Ten is a wide bar on purpose: RSS is a high-water mark and the allocator keeps what it
+        // has taken, so a strict bound would be measuring malloc rather than the log.
+        assert!(
+            per_shard_deep < per_shard * 10.0 + 4096.0,
+            "memory looks like it tracks the log rather than the shards: {per_shard:.0} B/shard \
+             at one record, {per_shard_deep:.0} B/shard at a hundred"
+        );
+        drop(store_a);
+        drop(store_b);
+    }
+
+    /// what a byte of value costs in the log, across payload sizes.
+    ///
+    /// Ignored: a measurement. The ratio is meaningless without its payload size -- the frame is
+    /// fixed and the key is per record, so both dilute as the value grows. Quoting one number
+    /// for "amplification" is quoting a coincidence, which is why this prints a table.
+    ///
+    ///   cargo test -p temporalstore-rust --lib what_a_byte_of_value_costs -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn what_a_byte_of_value_costs() {
+        set_wal_segment_bytes_for_test(None);
+        println!("  value     records      payload        wal bytes    per record   ratio");
+        for value_bytes in [64usize, 256, 1024, 4096, 16384] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let records = 400usize;
+            for index in 0..records {
+                store
+                    .append_with_sync(
+                        1,
+                        Command::StringSet {
+                            key: format!("tenant/7/object/{index:06}"),
+                            value: vec![b'v'; value_bytes],
+                        },
+                        false,
+                    )
+                    .unwrap();
+            }
+            let path = write_ahead_log_path(dir.path(), 1);
+            let (_, record_end) = last_wal_sequence_in(&path).unwrap();
+            let (_, header_len) = read_wal_base(&path).unwrap();
+            let wal_bytes = record_end.saturating_sub(header_len);
+            let payload = (records * value_bytes) as u64;
+            println!(
+                "  {value_bytes:>5}   {records:>7}   {payload:>10}   {wal_bytes:>12}   \
+                 {:>10.1}   {:>5.2}x",
+                wal_bytes as f64 / records as f64,
+                wal_bytes as f64 / payload as f64,
+            );
+        }
+        // And what the file COSTS, which is not the same as what the records occupy:
+        // preallocation reserves ahead, and that reservation is real disk.
+        let dir = tempfile::tempdir().unwrap();
+        let store = LocalWriteAheadLogStore::new(dir.path());
+        for index in 0..400 {
+            store
+                .append_with_sync(
+                    1,
+                    Command::StringSet {
+                        key: format!("k{index:06}"),
+                        value: vec![b'v'; 1024],
+                    },
+                    false,
+                )
+                .unwrap();
+        }
+        let path = write_ahead_log_path(dir.path(), 1);
+        let (_, record_end) = last_wal_sequence_in(&path).unwrap();
+        let file_len = std::fs::metadata(&path).unwrap().len();
+        println!(
+            "\n  records occupy {record_end} bytes; the file is {file_len} bytes ({:.2}x), the \
+             difference being the reservation",
+            file_len as f64 / record_end.max(1) as f64
+        );
+    }
 
     /// The narrow case: a log written WITHOUT blocks whose records end INSIDE where a footer
     /// slot would go. About 128 bytes in 131072 of log lengths land here.


### PR DESCRIPTION
the log-resident page set is bounded now, oldest written out first

    writes ->  registrations held
       200 ->  200        before
      1200 -> 1200
       600 ->   56        after, limit 64

A page whose only durable copy is inside a WAL record leaves a registration, and that entry costs
twice. It is memory, which is the smaller half. It also pins `min_registered_sequence`, and
reclaim may not truncate below the lowest registration — so a set that only grows is a log that
can never be reclaimed, whatever the retention policy says.

Measured before touching anything: registrations tracked writes ONE FOR ONE on an ingest of
distinct keys. 200 writes, 200 held. 1200 writes, 1200 held. Nothing on the local write path ever
retired one; the drains were a dump and shared-store checkpointing, and between those the set
just grew.

Now the recent stay where they are and everything older is written into the block store. Oldest
first, and that ordering is the point rather than a detail: the lowest registration is the one
holding the reclaim floor down, so retiring newer ones would free the same memory and unblock
nothing. Recent pages are also the better ones to keep — a page written moments ago is the one a
read is most likely to want, and its bytes are already in the record just written.

TS_WAL_RESIDENT_PAGES, default 4096 per shard, zero to disable. A sweep goes to three quarters of
the limit so a shard sitting exactly at the ceiling does not materialise on every append.

WHERE IT FIRES MATTERS MORE THAN THAT IT FIRES.

After the `shards` write lock is released, because moving a page takes that same lock. After the
durable barrier, because the write being acked has to reach disk before anything else happens —
bounding memory is never a reason to weaken a durability guarantee. Both were available as
earlier, simpler hooks, and both would have been wrong.

The test asserts three things, and the third is the one worth having. That the bound FIRED, via a
sweep counter, because a count that stays low on a workload too small to trip it proves nothing.
That the count plateaus. And that all six hundred values still read back afterwards — a bound
that loses data is not a bound, it is a deletion policy, and the failure mode here would take the
OLDEST pages, which a spot check of recent keys would miss entirely.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
