### PR TITLE
Calibration derives what it needs from a proxy once

### DIFF
--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -212,18 +212,41 @@ pub fn plan_proxy_calibration(
         }
     }
 
+    // Everything below is asked once per group, and none of it changes with
+    // the group being asked.
+    //
+    // Each proxy's location was parsed, and allocated, again for every group in
+    // the tier. Its group membership was found by walking every proxy again for
+    // every group. Both are properties of the proxy.
+    let proxy_locations = sorted_proxies
+        .iter()
+        .map(|proxy| Location::parse(&proxy.location))
+        .collect::<Vec<_>>();
+    let mut attached_by_group: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+    for proxy in &sorted_proxies {
+        // A frozen proxy is attached but not serving, so it does not count
+        // toward the target -- otherwise a group silently runs short every time
+        // the failure detector freezes one of its members.
+        if proxy.group.is_empty() || proxy.state != MetaEntityState::Normal {
+            continue;
+        }
+        attached_by_group
+            .entry(proxy.group.as_str())
+            .or_default()
+            .push(proxy.proxy_addr.clone());
+    }
+
     // 2. Per group, compare the target against what is actually serving.
     let mut wanted_attach = Vec::new();
+    // Which proxies this round has already promised to a group. Asked once per
+    // eligible proxy per group, which is why it is a set and not a scan of the
+    // attachments planned so far.
+    let mut claimed: BTreeSet<String> = BTreeSet::new();
     for (name, group) in &live_groups {
-        let mut attached = sorted_proxies
-            .iter()
-            .filter(|proxy| proxy.group == **name)
-            // A frozen proxy is attached but not serving, so it does not count
-            // toward the target -- otherwise a group silently runs short every
-            // time the failure detector freezes one of its members.
-            .filter(|proxy| proxy.state == MetaEntityState::Normal)
-            .map(|proxy| proxy.proxy_addr.clone())
-            .collect::<Vec<_>>();
+        let mut attached = attached_by_group
+            .get(*name)
+            .cloned()
+            .unwrap_or_default();
         attached.sort();
 
         let target = group.instance_num as usize;
@@ -246,17 +269,15 @@ pub fn plan_proxy_calibration(
         let pattern = Location::parse(&group.location);
         let eligible = sorted_proxies
             .iter()
-            .filter(|proxy| is_idle_candidate(proxy))
-            .filter(|proxy| Location::parse(&proxy.location).belongs_to(&pattern))
-            .filter(|proxy| {
-                !wanted_attach
-                    .iter()
-                    .any(|a: &ProxyAttachment| a.proxy_addr == proxy.proxy_addr)
-            })
-            .map(|proxy| proxy.proxy_addr.clone())
+            .enumerate()
+            .filter(|(_, proxy)| is_idle_candidate(proxy))
+            .filter(|(index, _)| proxy_locations[*index].belongs_to(&pattern))
+            .filter(|(_, proxy)| !claimed.contains(proxy.proxy_addr.as_str()))
+            .map(|(_, proxy)| proxy.proxy_addr.clone())
             .collect::<Vec<_>>();
 
         for addr in eligible.iter().take(short) {
+            claimed.insert(addr.clone());
             wanted_attach.push(ProxyAttachment {
                 proxy_addr: addr.clone(),
                 group: (*name).to_string(),


### PR DESCRIPTION
A calibration round walks the proxy groups, and for each one it walked every
proxy three times over: once to collect what is attached to that group, once
to parse every proxy's location and test it against the group's, and once
more -- inside a filter -- to scan the attachments already planned this
round.

None of that varies with the group asking. A proxy's location is the same
string whichever group considers it, and parsing allocated a fresh one every
time. Which group a proxy is attached to is a property of the proxy, known
before the walk begins. And "has this round already promised this proxy" is
a membership question that was being answered by scanning the plan so far,
so the cost grew with each attachment made.

    groups x proxies      before      after
        25 x    250     2 324 us     701 us
        50 x    500    10 479 us   3 238 us
       100 x  1 000    58 020 us  11 772 us

Five times faster at the largest, measured before and after back to back,
and what is left grows with groups times proxies rather than faster than it.

The rule that two groups never claim the same proxy is what the scan was
buying. It has a test, and removing the set that replaced the scan fails it.
