### PR TITLE
a batch staged six items and drained none of them

### DIFF
--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -120,6 +120,23 @@ impl TemporalEngine {
     }
 
     pub fn batch_execute(&self, request: BatchExecuteRequest) -> BatchExecuteResponse {
+        // Every command here executes through `execute_on_shard`, which STAGES an outcome item,
+        // and the records this path appends are built from the commands -- so nothing ever took
+        // what was staged. Those items stayed in the thread's buffer, and the next write on that
+        // thread appended them as its own doing. Threads are reused across requests, so "the next
+        // write" is routinely a different request entirely.
+        //
+        // A guard rather than a drain at the end, because this function returns early on a
+        // missing shard and on a failed durable commit, and those exits leaked too. Discarding is
+        // correct while batch records carry their commands: replay re-executes them, so the items
+        // describe work that is already accounted for.
+        struct DrainStagedOnExit;
+        impl Drop for DrainStagedOnExit {
+            fn drop(&mut self) {
+                let _ = super::block_in_wal::take_outcomes();
+            }
+        }
+        let _drain_staged = DrainStagedOnExit;
         let command_count = request.commands.len();
         let mut responses = Vec::with_capacity(command_count);
         if command_count == 0 {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -8894,3 +8894,45 @@ fn registrations_plateau_instead_of_tracking_writes() {
         );
     }
 }
+
+/// a batch leaves nothing staged for the next write to adopt.
+///
+/// Outcomes are staged during execution and taken at the append. The batch path executes every
+/// command in the batch — staging an item for each — and then appends records built from the
+/// COMMANDS, never touching what was staged. So the items sit in the thread's buffer, and the
+/// next write on that thread appends them as its own doing.
+///
+/// This is the same defect already fixed for replay and for the single-write path, in the one
+/// place left. Threads are reused across requests in a server and across tests here, so "the next
+/// write" is routinely someone else entirely.
+#[test]
+fn a_batch_leaves_nothing_staged_for_the_next_write_to_adopt() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+
+    let batch = engine.batch_execute(BatchExecuteRequest {
+        shard_id: 1,
+        commands: (0..6)
+            .map(|index| Command::StringSet {
+                key: format!("batched-{index}"),
+                value: b"v".to_vec(),
+            })
+            .collect(),
+    });
+    assert!(batch.status.ok, "the batch itself must succeed");
+
+    assert_eq!(
+        crate::engine::block_in_wal::staged_outcome_count(),
+        0,
+        "a batch must leave nothing staged: whatever it leaves is picked up by the next write on \
+         this thread and written into that write's record as changes it made itself"
+    );
+}


### PR DESCRIPTION
a batch staged six items and drained none of them

    six commands in, six items left behind, right: 0

Outcomes are staged during execution and taken at the append. Every command in a batch executes
through the same path as any other write, so each stages an item -- and then the records this
path appends are built from the COMMANDS, and nothing ever takes what was staged. The items sit
in the thread's buffer until the next write on that thread appends them as its own doing.
Threads are reused across requests, so that next write is routinely a different request.

This is the same defect already fixed twice: once in replay, which executes and never appends,
and once on the single-write path, where the append is guarded and the exits that skip it leaked.
This was the third and last place, and the reason it survived two fixes is worth writing down:
staging and taking are separated by a conditional, so every path that executes commands without
appending inherits the leak in silence. Nothing about a new path announces that it has one.

A guard rather than a drain at the end. This function returns early on a missing shard and on a
failed durable commit, and both of those exits leaked too.

Discarding is right while these records carry their commands: replay re-executes them, so the
staged items describe work already accounted for. That stops being true the moment batch records
carry results instead, which is the change these items are wanted for -- and which is worth
having for three reasons at once, now measured:

    batch records carry commands   exempt from data-only entirely, which is why batching
                                   measures +32% bytes against separate writes
    one ingest writes 8 records    plus 8 barriers; batching fixes the barriers (-87%) and
                                   makes the bytes worse
    one record, eight items        17.1% smaller than eight, and atomic by construction, so the
                                   commit marker stops being needed at all


🤖 Generated with [Claude Code](https://claude.com/claude-code)
