### PR TITLE
A full drain served every command that had no key to hash

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -1511,6 +1511,11 @@ impl TemporalStoreTable {
         command_routing_key(command)
             .as_deref()
             .map(|key| self.shard_id_for_key(key))
+            // A command with no routing key pins to the handle's shard, and that is load
+            // bearing rather than a lazy default: a multi-part blob upload is Begin, then
+            // Appends, then Commit, and the staged parts live on the node that served the
+            // Begin. Hashing something per command would scatter the parts of one upload
+            // across shards and none of them would commit.
             .unwrap_or(self.shard_id)
     }
 

--- a/crates/temporalstore-rust/src/client/commands.rs
+++ b/crates/temporalstore-rust/src/client/commands.rs
@@ -18,6 +18,16 @@ pub(super) fn is_write(command: &Command) -> bool {
 }
 
 pub(super) fn command_is_dropped(command: &Command, drop_percent: u8) -> bool {
+    // A full drain has to mean every command. The hash below can only judge commands that
+    // HAVE a routing key, and the `unwrap_or(false)` on the end answers "keep sending it"
+    // for the ones that do not -- the resource-blob upload path, sequence batch queries,
+    // node-embedding reads. A table drained to 100 went on sending those.
+    //
+    // Below 100 that stands on purpose: shedding is per key by construction, so a command
+    // with nothing to hash has no share to shed.
+    if drop_percent >= 100 {
+        return true;
+    }
     command_routing_key(command)
         .as_deref()
         .map(|key| key_is_dropped_by_percent(key, drop_percent))
@@ -364,6 +374,37 @@ pub(super) fn context_compression_key(tenant_hash: u64, node_hash: u64) -> Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_full_drain_drops_commands_that_carry_no_routing_key() {
+        // The drop decision hashes a routing key and answered "not dropped" for every command
+        // that has none -- the resource-blob upload path, sequence batch queries,
+        // node-embedding reads. A table an operator had drained to 100 went on sending them.
+        let keyless = Command::ContextResourceBlobPut {
+            tenant_hash: 7,
+            payload_base64: String::new(),
+        };
+        assert_eq!(
+            command_routing_key(&keyless),
+            None,
+            "premise: this command carries no routing key to hash"
+        );
+        assert!(
+            command_is_dropped(&keyless, 100),
+            "a full drain has to drop a command with no key too, or the drain is not full"
+        );
+
+        // Below a full drain the leak stands on purpose: shedding is per key, and a command
+        // with nothing to hash has no share to shed.
+        assert!(!command_is_dropped(&keyless, 99));
+
+        // A keyed command is unaffected in both directions.
+        let keyed = Command::StringGet {
+            key: "k".to_string(),
+        };
+        assert!(command_is_dropped(&keyed, 100));
+        assert!(!command_is_dropped(&keyed, 0));
+    }
 
     #[test]
     fn is_write_agrees_with_the_engine_for_context_writes() {

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1992,6 +1992,100 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_full_drain_refuses_commands_that_carry_no_routing_key() {
+        // The drop decision hashes a routing key, and the `filter_map` that collects those
+        // keys silently discarded every command that has none -- the whole resource-blob
+        // upload path, sequence batch queries, node-embedding reads. A proxy an operator had
+        // drained to zero went on serving them in full, while the readiness probe reported it
+        // as rejecting everything.
+        //
+        // Only a FULL drain closes this. Partial shedding is per key by construction, so a
+        // command with nothing to hash stays served below 100 -- the same boundary the
+        // readiness probe draws.
+        let drained = scoped_proxy(ProxyOptions {
+            drop_percent: 100,
+            ..ProxyOptions::default()
+        });
+        let keyless = [
+            Command::ContextResourceBlobPut {
+                tenant_hash: 7,
+                payload_base64: String::new(),
+            },
+            Command::ContextResourceBlobBegin { tenant_hash: 7 },
+            Command::SequenceBatchQuery {
+                queries: Vec::new(),
+            },
+        ];
+        for command in keyless {
+            let response = drained.execute(ExecuteRequest {
+                shard_id: 1,
+                command: command.clone(),
+            });
+            assert_eq!(
+                response.status.code, "proxy_traffic_dropped",
+                "a fully drained proxy must refuse this, not serve it because the command                  carries no key to hash: {command:?}"
+            );
+        }
+
+        // The boundary stays where the readiness probe puts it: 99 is load management.
+        let shedding = scoped_proxy(ProxyOptions {
+            drop_percent: 99,
+            ..ProxyOptions::default()
+        });
+        let response = shedding.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextResourceBlobBegin { tenant_hash: 7 },
+        });
+        assert_ne!(
+            response.status.code, "proxy_traffic_dropped",
+            "below a full drain there is no key to shed on, so it is still served"
+        );
+    }
+
+    #[test]
+    fn the_same_context_node_is_shed_whatever_command_names_it() {
+        // The proxy keeps its own copy of the routing-key logic and the copies had drifted:
+        // the client keys ContextSetNodeEmbedding by (tenant, node) like every other command
+        // naming a node, the proxy keyed it not at all. A shed tenant's node was therefore
+        // refused when read and accepted when its embedding was written -- one record, two
+        // answers, from a drain that is supposed to be per key.
+        let proxy = scoped_proxy(ProxyOptions {
+            drop_percent: 50,
+            ..ProxyOptions::default()
+        });
+        let refused_node = (0..200u64)
+            .find(|node_hash| {
+                proxy
+                    .execute(ExecuteRequest {
+                        shard_id: 1,
+                        command: Command::ContextGetNode {
+                            tenant_hash: 7,
+                            node_hash: *node_hash,
+                        },
+                    })
+                    .status
+                    .code
+                    == "proxy_traffic_dropped"
+            })
+            .expect("at 50 percent some node is refused");
+
+        let response = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: 7,
+                node_hash: refused_node,
+                model_hash: 1,
+                vector: vec![0.0],
+                updated_at_ms: 1,
+            },
+        });
+        assert_eq!(
+            response.status.code, "proxy_traffic_dropped",
+            "node {refused_node} is refused when read; writing its embedding names the same              node and has to be refused too"
+        );
+    }
+
+    #[test]
     fn a_proxy_shedding_everything_fails_its_readiness_probe() {
         // Draining has two knobs. `serving_mode: NotServing` is the obvious one and the
         // probe already answered for it. `drop_percent: 100` is the other: every request

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -158,9 +158,18 @@ pub(super) fn proxy_command_routing_key(command: &Command) -> Option<String> {
             Command::ContextUpsertNode { tenant_hash, node } => {
                 Some(format!("ctx:node:{tenant_hash}:{}", node.node_hash))
             }
+            // ContextSetNodeEmbedding names a node exactly like the two above and the
+            // client keys it that way, but this copy of the logic did not key it at all --
+            // so a shed node was refused when read and accepted when its embedding was
+            // written. Same record, same drain, two answers.
             Command::ContextGetNode {
                 tenant_hash,
                 node_hash,
+            }
+            | Command::ContextSetNodeEmbedding {
+                tenant_hash,
+                node_hash,
+                ..
             } => Some(format!("ctx:node:{tenant_hash}:{node_hash}")),
             Command::ContextGetNodes {
                 tenant_hash,

--- a/crates/temporalstore-rust/src/proxy/policy.rs
+++ b/crates/temporalstore-rust/src/proxy/policy.rs
@@ -18,6 +18,18 @@ pub(super) fn proxy_policy_rejection(
         return Some(status);
     }
     let drop_percent = options.drop_percent.min(100);
+    // A full drain has to mean every request. The check below can only judge commands that
+    // HAVE a routing key and `filter_map` silently discards the ones that do not -- the
+    // resource-blob upload path, sequence batch queries, node-embedding reads. A proxy an
+    // operator had drained to zero served those in full while its readiness probe reported
+    // it as rejecting everything.
+    //
+    // Below 100 the leak stands on purpose: shedding is per key by construction, and a
+    // command with nothing to hash has no share to shed. That is the same boundary the
+    // readiness probe draws between a drain and load management.
+    if drop_percent >= 100 {
+        return Some(proxy_dropped_status());
+    }
     if drop_percent > 0
         && commands
             .iter()


### PR DESCRIPTION
drop_percent is a per-key decision: each command's routing key is hashed and the share that
falls in range is refused. Commands that carry no routing key were silently left out of that
decision -- a filter_map dropped them on the proxy, an unwrap_or(false) dropped them on the
client. The resource-blob upload path, sequence batch queries and node-embedding reads were
therefore served in full by a proxy an operator had drained to 100, while its readiness probe
reported it as rejecting everything.

A full drain now refuses every command, keyed or not. Below 100 nothing changes: shedding is
per key by construction, so a command with nothing to hash has no share to shed. That is the
same boundary the readiness probe draws between a drain and load management, and the tests pin
99 as still-serving so the two cannot drift apart.

The proxy keeps its own copy of the routing-key logic, and the copies had diverged: the client
keys ContextSetNodeEmbedding by (tenant, node) like every other command that names a node, this
one keyed it not at all. A shed node was refused when read and accepted when its embedding was
written -- one record, two answers, from a drain that is supposed to be per key.

Three tests, each watched failing before its fix rather than after:

    a_full_drain_refuses_commands_that_carry_no_routing_key    proxy   was: server_error
    a_full_drain_drops_commands_that_carry_no_routing_key      client  was: not dropped
    the_same_context_node_is_shed_whatever_command_names_it    drift   was: server_error

Worth knowing before draining a table: a full drain now also refuses the keyless maintenance
commands, the blob sweep among them, until the drain is lifted.

The keyless routing fallback in shard_id_for_command is left alone and now says why -- a
multi-part blob upload stages its parts on the node that served the Begin, so hashing something
per command would scatter one upload across shards and none of the parts would commit.


