### PR TITLE
A write-disabled proxy forwarded every write its own list had missed

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1992,6 +1992,62 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_write_disabled_proxy_refuses_everything_the_engine_calls_a_write() {
+        // The proxy kept its own hand-maintained list of what counts as a write and it had
+        // fallen fourteen commands behind the engine's -- every list and sorted-set mutation
+        // among them. So a proxy an operator had put in WriteDisabled took a ZSetAdd and a
+        // ListPush and forwarded them, and the write inflight quota never counted them either.
+        //
+        // The client and the data node both delegate to the engine's classifier, each after
+        // this same drift did damage. This was the third copy.
+        let proxy = scoped_proxy(ProxyOptions {
+            serving_mode: ProxyServingMode::WriteDisabled,
+            ..ProxyOptions::default()
+        });
+        let writes = [
+            Command::ZSetAdd {
+                key: "k".to_string(),
+                member: b"m".to_vec(),
+                score: 1.0,
+            },
+            Command::ListPush {
+                key: "k".to_string(),
+                member: b"m".to_vec(),
+                left: true,
+            },
+            Command::CommonPersist {
+                key: "k".to_string(),
+            },
+        ];
+        for command in writes {
+            assert!(
+                crate::engine::is_write_command(&command),
+                "premise: the engine calls this a write: {command:?}"
+            );
+            let response = proxy.execute(ExecuteRequest {
+                shard_id: 1,
+                command: command.clone(),
+            });
+            assert_eq!(
+                response.status.code, "proxy_write_disabled",
+                "a write-disabled proxy must refuse what the engine calls a write, not                  forward it because its own list is short: {command:?}"
+            );
+        }
+
+        // A read is still served -- the fix must not turn the whole proxy off.
+        let read = proxy.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringGet {
+                key: "k".to_string(),
+            },
+        });
+        assert_ne!(
+            read.status.code, "proxy_write_disabled",
+            "reads are still served while writes are disabled"
+        );
+    }
+
+    #[test]
     fn a_full_drain_refuses_commands_that_carry_no_routing_key() {
         // The drop decision hashes a routing key, and the `filter_map` that collects those
         // keys silently discarded every command that has none -- the whole resource-blob

--- a/crates/temporalstore-rust/src/proxy/commands.rs
+++ b/crates/temporalstore-rust/src/proxy/commands.rs
@@ -4,46 +4,16 @@
 use crate::types::Command;
 
 pub(super) fn proxy_command_is_write(command: &Command) -> bool {
-    matches!(
-        command,
-        Command::CommonDelete { .. }
-            | Command::CommonExpire { .. }
-            | Command::StringSet { .. }
-            | Command::StringSetEx { .. }
-            | Command::StringSetConditional { .. }
-            | Command::StringDelete { .. }
-            | Command::HashSet { .. }
-            | Command::HashMultiSet { .. }
-            | Command::HashIncrBy { .. }
-            | Command::HashDelete { .. }
-            | Command::SetAdd { .. }
-            | Command::SetRemove { .. }
-            | Command::FeatureAppend { .. }
-            | Command::FeatureAppendWithPolicy { .. }
-            | Command::FeatureReplace { .. }
-            | Command::FeatureDelete { .. }
-            | Command::SequenceAdd { .. }
-            | Command::ControlStateIncrement { .. }
-            | Command::ControlStateIncrementWithOptions { .. }
-            | Command::ControlStateChangeAdd { .. }
-            | Command::ControlStateSet { .. }
-            | Command::ControlStateSetAndGet { .. }
-            | Command::ControlStateSetAndGetWithOptions { .. }
-            | Command::ControlStateSelectionSet { .. }
-            | Command::ContextUpsertNode { .. }
-            | Command::ContextWriteEvent { .. }
-            | Command::ContextWriteExtractedEvent { .. }
-            | Command::ContextWriteIndexRef { .. }
-            | Command::ContextWritePackAudit { .. }
-            | Command::ContextMarkSummaryDirty { .. }
-            | Command::ContextMarkEmbeddingDirty { .. }
-            | Command::ContextUpsertEntity { .. }
-            | Command::ContextUpsertChildRef { .. }
-            | Command::ContextSetNodeEmbedding { .. }
-            | Command::ContextUpsertSummary { .. }
-            | Command::ContextWriteCompressionEvent { .. }
-            | Command::ContextCompressEvents { .. }
-    )
+    // Delegate to the engine's write-command classifier -- the same one that gates WAL
+    // persistence, and the one the client and the data node already delegate to after a
+    // hand-maintained subset drifted in each of them.
+    //
+    // This copy had drifted too, by fourteen commands: every list and sorted-set mutation
+    // (ListPush/ListPop, ZSetAdd/ZSetRemove/ZSetIncrBy/ZSetPop), BucketTake, SeenCheck,
+    // CommonPersist and the whole resource-blob upload path. Both things this answers for
+    // were wrong as a result -- a proxy in Readonly or WriteDisabled forwarded those writes
+    // instead of refusing them, and the write inflight quota never counted them.
+    crate::engine::is_write_command(command)
 }
 
 fn proxy_command_key(command: &Command) -> Option<&str> {


### PR DESCRIPTION
What counts as a write is answered in four places. The engine owns the classifier that gates WAL
persistence; the client and the data node each delegate to it, and each does so because a
hand-maintained subset there had already drifted and done damage. The proxy was the fourth, and
the only one still keeping its own list.

That list had fallen fourteen commands behind:

    ListPush ListPop                              every list mutation
    ZSetAdd ZSetRemove ZSetIncrBy ZSetPop         every sorted-set mutation
    BucketTake SeenCheck CommonPersist
    ContextResourceBlobBegin/Append/Commit/Put/Fetch/Sweep

Nothing went the other way -- the list was short, never wrong. Both things it answers for were
wrong as a result. A proxy an operator had put in Readonly or WriteDisabled took those commands
and forwarded them, so the switch that exists to stop writes did not stop them; and the write
inflight quota never counted them, so max_inflight_write_requests bounded a subset of the writes.

The new test asserts the engine calls each command a write before sending it, so it states its
own premise rather than trusting the list it is checking. Watched failing first: a ZSetAdd came
back server_error -- forwarded, not refused.

Delegating rather than extending the list. A longer copy is the same defect with a later date on
it, and this is the third time this drift has been found in a different copy of it.

    proxy 66, client 33 -- 0 failed


