### PR TITLE
Send resource content as text, finalize by default, make the encoder model configurable

### DIFF
--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -213,6 +213,34 @@ holding each key and whether it currently resolves.
 
 ---
 
+## 9a. Wiring a co-resident encoder (read this before a large import)
+
+Three settings must all be right, and getting any of them wrong degrades retrieval **silently** —
+the requests still return `200` and results still look plausible, because the system falls back to
+hash vectors.
+
+```bash
+export MATRIXARK_EMBEDDING_PROVIDER=openai_compatible
+export MATRIXARK_EMBEDDING_API_BASE=http://127.0.0.1:8400/v1   # MUST end in /v1
+export MATRIXARK_EMBEDDING_API_KEY_ENV=LOCAL_ENCODER_KEY
+export LOCAL_ENCODER_KEY=any-non-empty-placeholder             # MUST be non-empty
+export MATRIXARK_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
+export MATRIXARK_REQUIRE_MODEL_EMBEDDINGS=1                    # fail loudly instead
+```
+
+- **`/v1` is required.** The endpoint is built as `<api_base>/embeddings`, so a base of
+  `http://host:8400` produces `http://host:8400/embeddings` and never reaches an OpenAI-compatible
+  encoder serving `/v1/embeddings`.
+- **The key variable must be non-empty even for a local encoder that needs no auth.** An empty value
+  makes the call be skipped before it is attempted. Any placeholder works.
+- **`MATRIXARK_REQUIRE_MODEL_EMBEDDINGS=1` turns both of the above into loud failures** instead of a
+  silent downgrade to hash vectors.
+
+Confirm it with `/v1/admin/config` — the `warnings` list names each of these mistakes explicitly — and
+verify the vectors are real by checking that the encoder receives traffic during an ingest. A correctly
+wired deployment reports `embedding.provider` as your endpoint with no embedding warnings; the vectors
+are 384-dimensional for either MiniLM model, versus 32 for the hash fallback.
+
 ## 10. What to expect
 
 Measured on 1,000 markdown/JSON documents averaging 1.3 MB, on the storage path:

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -247,6 +247,29 @@ errors and timeouts are retried three times with backoff before being reported; 
 retried, because it will not improve. Fix the cause and re-run with `--resume` to retry only what
 failed.
 
+**`http 500` with `resource produced more than max_total_chunks`** — a large document produced more
+chunks than the cap allows. The parser defaults to ~240-token chunks, so a 1 MB document makes
+roughly 2,500 chunks against a default cap of 2,048 and every such document fails. Raise the cap, or
+use larger chunks (which also cuts memory substantially):
+
+```bash
+export MATRIXARK_RESOURCE_MAX_TOTAL_CHUNKS=20000     # headroom for ~1 MB documents
+export MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS=240       # chunk size; larger = fewer chunks
+```
+
+Chunk size is a real trade-off, not just a limit. Larger chunks mean far fewer records and much less
+memory, but the encoder only embeds the first `MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS` tokens of each
+chunk (128 by default, 256 for the MiniLM models). A chunk much longer than that window has its tail
+left out of the semantic index. Keeping the chunk size at or below the embedding window is the
+configuration that indexes everything you store.
+
+**`http 500` with `wal_commit_failed: json error: expected value at line 1 column 1`** — a durable
+commit hit WAL frames it could not parse, which happens when binary framing is enabled without its
+block-footer prerequisite. Set `TS_WAL_BLOCK_FOOTER=1`. If a store has already been written in the
+mixed state, recovery will refuse to load it (`wal_scan_failed: ... refusing load rather than serving
+a truncated prefix`) — that refusal is correct, and the store needs to be recreated rather than
+forced open.
+
 **`http 401`** — the key variable is unset or empty. Confirm with `echo ${MATRIXARK_API_KEY:+set}`.
 
 **Ingest is much slower than expected** — check `/v1/admin/config` for warnings, confirm the server

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -115,6 +115,59 @@ want under a scheduler or in a log-sensitive environment.
 
 ---
 
+## 4a. The ingestion portal (no terminal required)
+
+For customers who would rather not run a CLI, the gateway serves a page at
+**`/v1/admin/ingestion`**. Point a browser at it, paste an admin key, name a directory or a list of
+paths, and start the import; the page shows each job's progress, rate and ETA, and lists failures as
+they happen. It also renders the deployment's model configuration and any warnings, so a
+misconfigured encoder is visible before a large import rather than after.
+
+Fetching the page needs no credentials; every action on it calls an admin-gated endpoint, so the page
+is inert without a key.
+
+**Configure the boundary first.** Jobs may only read documents beneath a configured root:
+
+```bash
+export MATRIXARK_INGESTION_ROOT=/srv/playbooks
+```
+
+Anything resolving outside it — an absolute path elsewhere, a `..` traversal, or a symlink pointing
+out — is refused. With the variable unset, submitting paths is refused outright rather than
+defaulting to the filesystem root.
+
+The same operations are available as JSON if you would rather script them:
+
+```bash
+curl -X POST http://your-host:8080/v1/admin/ingestion/jobs      -H "Authorization: Bearer $MATRIXARK_API_KEY"      -H 'Content-Type: application/json'      -d '{"directory":"/srv/playbooks","user_id":"acme_team"}'
+
+curl http://your-host:8080/v1/admin/ingestion/jobs -H "Authorization: Bearer $MATRIXARK_API_KEY"
+```
+
+## 4b. Metrics and Grafana
+
+The gateway exposes Prometheus counters at **`/v1/metrics`** — aggregate only, with no keys and no
+tenant identifiers, so it is safe to scrape without credentials the way an exporter normally is:
+
+```
+matrixark_ingestion_jobs_total        matrixark_ingestion_documents_done
+matrixark_ingestion_jobs_running      matrixark_ingestion_documents_failed
+matrixark_ingestion_documents_total   matrixark_ingestion_bytes_total
+```
+
+Add a scrape job and import `docs/ops/matrixark-ingestion-dashboard.json` into Grafana for the
+matching panels: imports running, documents ingested, failures, ingest rate, source throughput and
+import backlog. The backlog panel is the one to watch on a long import — a backlog that stops falling
+while no job is running means the import died partway.
+
+```yaml
+scrape_configs:
+  - job_name: matrixark_gateway
+    metrics_path: /v1/metrics
+    static_configs:
+      - targets: ["your-host:8080"]
+```
+
 ## 5. Interrupting and resuming
 
 Ingest is a **keyed upsert**: each document carries a stable `identity_key` derived from its path, so

--- a/docs/ops/matrixark-ingestion-dashboard.json
+++ b/docs/ops/matrixark-ingestion-dashboard.json
@@ -1,0 +1,182 @@
+{
+  "title": "MatrixArk Ingestion",
+  "uid": "matrixark-ingestion",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "10s",
+  "time": { "from": "now-6h", "to": "now" },
+  "tags": ["matrixark", "ingestion"],
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Gateway",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(matrixark_ingestion_documents_total, instance)",
+        "refresh": 1,
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Imports running",
+      "description": "Ingestion jobs currently walking a document list. Zero with documents still remaining means an import stopped early.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text", "value": null },
+              { "color": "blue", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_ingestion_jobs_running{instance=~\"$instance\"})",
+          "legendFormat": "running"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Documents ingested",
+      "description": "Cumulative successful documents across every job this worker has run.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_ingestion_documents_done{instance=~\"$instance\"})",
+          "legendFormat": "done"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Failures",
+      "description": "Documents that exhausted their retries. Any sustained non-zero value means part of the import is not in the store.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_ingestion_documents_failed{instance=~\"$instance\"})",
+          "legendFormat": "failed"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Remaining",
+      "description": "Documents submitted but not yet processed.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_ingestion_documents_total{instance=~\"$instance\"}) - sum(matrixark_ingestion_documents_done{instance=~\"$instance\"}) - sum(matrixark_ingestion_documents_failed{instance=~\"$instance\"})",
+          "legendFormat": "remaining"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Ingest rate",
+      "description": "Documents per second, successes and failures separately. A failure line that tracks the success line means the import is systematically broken rather than hitting occasional bad documents.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 8, "lineWidth": 2 } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(matrixark_ingestion_documents_done{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "ingested"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(matrixark_ingestion_documents_failed{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "failed"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Source throughput",
+      "description": "Bytes of source documents accepted per second.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": {
+        "defaults": { "unit": "Bps", "custom": { "fillOpacity": 8, "lineWidth": 2 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(matrixark_ingestion_bytes_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Import backlog",
+      "description": "Submitted minus processed. A backlog that stops falling while no job is running is the signature of an import that died partway.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 12 },
+      "fieldConfig": {
+        "defaults": { "custom": { "fillOpacity": 12, "lineWidth": 2 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(matrixark_ingestion_documents_total{instance=~\"$instance\"}) - sum(matrixark_ingestion_documents_done{instance=~\"$instance\"}) - sum(matrixark_ingestion_documents_failed{instance=~\"$instance\"})",
+          "legendFormat": "backlog"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(matrixark_ingestion_jobs_running{instance=~\"$instance\"})",
+          "legendFormat": "jobs running"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/context_minilm_embed_server.py
+++ b/tools/context_minilm_embed_server.py
@@ -10,13 +10,22 @@ POST /v1/embeddings  {"model": "...", "input": "text" | ["t1","t2",...]}
 Run detached; prints the bound port to stdout as: LISTENING <port>
 """
 import json
+import os
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 from sentence_transformers import SentenceTransformer
 
-MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+# The model is configurable so a deployment can run the encoder its retrieval was tuned for --
+# e.g. a multilingual model for mixed CN/EN corpora. MATRIXARK_EMBEDDING_MODEL_PATH takes a
+# local directory; MATRIXARK_EMBEDDING_MODEL takes a hub id. Both MiniLM variants emit 384
+# dimensions, so switching between them does not change the stored vector width.
+MODEL_NAME = (
+    os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH", "").strip()
+    or os.environ.get("MATRIXARK_EMBEDDING_MODEL", "").strip()
+    or "sentence-transformers/all-MiniLM-L6-v2"
+)
 print("loading model...", file=sys.stderr, flush=True)
 _MODEL = SentenceTransformer(MODEL_NAME)
 _LOCK = threading.Lock()

--- a/tools/matrixark_batch_ingest.py
+++ b/tools/matrixark_batch_ingest.py
@@ -142,7 +142,13 @@ def resource_type_for(path: str) -> str:
 # ingest
 # ---------------------------------------------------------------------------------------------
 def post_document(
-    base_url: str, path: str, *, user_id: str, api_key: str, timeout_s: float
+    base_url: str,
+    path: str,
+    *,
+    user_id: str,
+    api_key: str,
+    timeout_s: float,
+    finalize: bool = True,
 ) -> Tuple[bool, str]:
     """Ingest one document. Returns (ok, detail). Retries transient failures with backoff."""
     try:
@@ -156,10 +162,19 @@ def post_document(
         "resource_type": resource_type_for(path),
         "raw_uri": os.path.abspath(path),
         "identity_key": identity_key_for(path),
-        "content": content,
-        "messages": [{"role": "user", "content": content}],
+        # The ingest envelope takes resource content as `text`/`resource_text` -- NOT `content`,
+        # which is silently ignored. See docs/INGEST_SCHEMA.md ("Content requirement by kind").
+        "text": content,
         "user_id": user_id,
         "scope": {"user_id": user_id},
+        # Block until the document is durable rather than accepting it as a deferred event, so a
+        # reported success means the document is actually retrievable.
+        "wait": True,
+        # A document is a COMPLETE unit, unlike a streaming chat message. Without this the gateway
+        # accepts the ingest as a lightweight event and defers materialisation to a background
+        # drain, so the document is not retrievable when the call returns -- a batch import would
+        # report 1000 successes and read back nothing.
+        "finalize": finalize,
     }
     payload = json.dumps(body).encode("utf-8")
     url = base_url.rstrip("/") + "/v1/ingest"
@@ -314,7 +329,12 @@ def run(args: argparse.Namespace) -> int:
             except OSError:
                 size = 0
             ok, detail = post_document(
-                args.base_url, path, user_id=args.user_id, api_key=api_key, timeout_s=args.timeout
+                args.base_url,
+                path,
+                user_id=args.user_id,
+                api_key=api_key,
+                timeout_s=args.timeout,
+                finalize=not args.no_finalize,
             )
             if ok:
                 with state_lock:
@@ -374,6 +394,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--resume", action="store_true", help="skip documents recorded in --state")
     parser.add_argument("--status-file", help="write JSON progress here on every update")
     parser.add_argument("--dry-run", action="store_true", help="list what would be sent, send nothing")
+    parser.add_argument(
+        "--no-finalize",
+        action="store_true",
+        help="accept documents without materialising them now (they stay unretrievable "
+             "until a background drain runs); only for streaming callers",
+    )
     parser.add_argument("--quiet", action="store_true", help="suppress the per-document progress line")
     return parser
 

--- a/tools/matrixark_ingestion_jobs.py
+++ b/tools/matrixark_ingestion_jobs.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-process ingestion jobs: start a batch import over HTTP and watch it while it runs.
+
+The CLI (``matrixark_batch_ingest``) covers an operator with shell access. This covers the customer
+who wants to hand over a list of skills and watch the import from a page, without a terminal — and it
+gives Prometheus something to scrape, so an import shows up on a dashboard next to everything else.
+
+A job runs in a background thread inside the gateway worker, walking the same
+``post_document`` path the CLI uses, so both routes behave identically and there is one
+implementation of the wire shape to keep correct.
+
+**Path safety.** An HTTP endpoint that ingests server-side paths is a file-disclosure risk: without a
+boundary, "ingest /etc" is a valid request. Every resolved path must therefore sit inside
+``MATRIXARK_INGESTION_ROOT``. When that variable is unset, submitting paths is refused outright
+rather than defaulting to the filesystem root — the safe default for a feature whose whole job is
+reading files the caller names.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+from typing import Dict, List, Optional
+
+import matrixark_batch_ingest as batch
+
+MAX_RETAINED_JOBS = 50
+MAX_PATHS_PER_JOB = 100_000
+
+
+class IngestionRootNotConfigured(Exception):
+    """Raised when a job is submitted but no ingestion root bounds it."""
+
+
+class PathOutsideRoot(Exception):
+    """Raised when a submitted path resolves outside the configured ingestion root."""
+
+
+def ingestion_root() -> Optional[str]:
+    root = os.environ.get("MATRIXARK_INGESTION_ROOT", "").strip()
+    return os.path.abspath(root) if root else None
+
+
+def _resolve_within_root(path: str, root: str) -> str:
+    """Absolute path, proven to sit inside `root`. Resolves symlinks so a link cannot escape."""
+    resolved = os.path.realpath(os.path.abspath(path))
+    root_real = os.path.realpath(root)
+    if resolved != root_real and not resolved.startswith(root_real + os.sep):
+        raise PathOutsideRoot(path)
+    return resolved
+
+
+def resolve_request_paths(
+    *, paths: Optional[List[str]] = None, directory: Optional[str] = None,
+    globs: Optional[List[str]] = None,
+) -> List[str]:
+    """Every document a job should ingest, each one proven to be inside the ingestion root."""
+    root = ingestion_root()
+    if root is None:
+        raise IngestionRootNotConfigured(
+            "MATRIXARK_INGESTION_ROOT is not set: submitting server-side paths is refused so the "
+            "endpoint cannot be used to read arbitrary files. Set it to the directory holding the "
+            "documents to import."
+        )
+
+    collected: List[str] = []
+    if directory:
+        safe_dir = _resolve_within_root(directory, root)
+        collected.extend(batch.discover_from_dir(safe_dir, globs or list(batch.DEFAULT_GLOBS)))
+    for path in paths or []:
+        collected.append(_resolve_within_root(path, root))
+
+    seen = set()
+    unique: List[str] = []
+    for path in collected:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique[:MAX_PATHS_PER_JOB]
+
+
+class Job:
+    """One import: its counters, and the thread walking the document list."""
+
+    def __init__(self, job_id: str, paths: List[str], options: Dict[str, object]) -> None:
+        self.id = job_id
+        self.paths = paths
+        self.options = options
+        self.state = "queued"
+        self.total = len(paths)
+        self.done = 0
+        self.failed = 0
+        self.bytes = 0
+        self.started_at = time.time()
+        self.finished_at: Optional[float] = None
+        self.failures: List[Dict[str, str]] = []
+        self.current: Optional[str] = None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+
+    def snapshot(self) -> Dict[str, object]:
+        with self._lock:
+            elapsed = (self.finished_at or time.time()) - self.started_at
+            processed = self.done + self.failed
+            rate = processed / elapsed if elapsed > 0 else 0.0
+            remaining = max(0, self.total - processed)
+            return {
+                "job_id": self.id,
+                "state": self.state,
+                "total": self.total,
+                "done": self.done,
+                "failed": self.failed,
+                "remaining": remaining,
+                "bytes": self.bytes,
+                "elapsed_s": round(elapsed, 1),
+                "docs_per_s": round(rate, 3),
+                "eta_s": round(remaining / rate, 1) if rate > 0 and remaining else 0,
+                "current": self.current,
+                "failures": list(self.failures[:20]),
+                "user_id": self.options.get("user_id"),
+            }
+
+    def cancel(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        base_url = str(self.options.get("base_url") or "http://127.0.0.1:8080")
+        user_id = str(self.options.get("user_id") or "default")
+        api_key = os.environ.get(str(self.options.get("api_key_env") or "MATRIXARK_API_KEY"), "")
+        timeout_s = float(self.options.get("timeout_s") or 1800.0)
+
+        with self._lock:
+            self.state = "running"
+        for path in self.paths:
+            if self._stop.is_set():
+                with self._lock:
+                    self.state = "cancelled"
+                    self.finished_at = time.time()
+                    self.current = None
+                return
+            with self._lock:
+                self.current = path
+            try:
+                size = os.path.getsize(path)
+            except OSError:
+                size = 0
+            ok, detail = batch.post_document(
+                base_url, path, user_id=user_id, api_key=api_key, timeout_s=timeout_s
+            )
+            with self._lock:
+                if ok:
+                    self.done += 1
+                    self.bytes += size
+                else:
+                    self.failed += 1
+                    if len(self.failures) < 100:
+                        self.failures.append({"path": path, "detail": detail})
+        with self._lock:
+            self.state = "failed" if self.failed and not self.done else "completed"
+            self.finished_at = time.time()
+            self.current = None
+
+
+class JobRegistry:
+    """Every job this worker has run, newest first, bounded so a long-lived worker cannot grow."""
+
+    def __init__(self) -> None:
+        self._jobs: Dict[str, Job] = {}
+        self._order: List[str] = []
+        self._lock = threading.Lock()
+
+    def submit(self, paths: List[str], options: Dict[str, object]) -> Job:
+        job = Job(uuid.uuid4().hex[:12], paths, options)
+        with self._lock:
+            self._jobs[job.id] = job
+            self._order.insert(0, job.id)
+            while len(self._order) > MAX_RETAINED_JOBS:
+                dropped = self._order.pop()
+                self._jobs.pop(dropped, None)
+        threading.Thread(target=job.run, name="ingest-job-%s" % job.id, daemon=True).start()
+        return job
+
+    def get(self, job_id: str) -> Optional[Job]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def list(self) -> List[Dict[str, object]]:
+        with self._lock:
+            jobs = [self._jobs[jid] for jid in self._order if jid in self._jobs]
+        return [job.snapshot() for job in jobs]
+
+    def totals(self) -> Dict[str, float]:
+        """Aggregate counters, shaped for a Prometheus scrape."""
+        with self._lock:
+            jobs = list(self._jobs.values())
+        totals = {
+            "jobs_total": float(len(jobs)),
+            "jobs_running": 0.0,
+            "documents_total": 0.0,
+            "documents_done": 0.0,
+            "documents_failed": 0.0,
+            "bytes_total": 0.0,
+        }
+        for job in jobs:
+            snap = job.snapshot()
+            if snap["state"] == "running":
+                totals["jobs_running"] += 1
+            totals["documents_total"] += float(snap["total"])
+            totals["documents_done"] += float(snap["done"])
+            totals["documents_failed"] += float(snap["failed"])
+            totals["bytes_total"] += float(snap["bytes"])
+        return totals
+
+
+REGISTRY = JobRegistry()
+
+
+def prometheus_text(extra: Optional[Dict[str, float]] = None) -> str:
+    """Ingestion counters in Prometheus text exposition format."""
+    totals = REGISTRY.totals()
+    lines = [
+        "# HELP matrixark_ingestion_jobs_total Ingestion jobs submitted to this worker.",
+        "# TYPE matrixark_ingestion_jobs_total counter",
+        "matrixark_ingestion_jobs_total %g" % totals["jobs_total"],
+        "# HELP matrixark_ingestion_jobs_running Ingestion jobs currently running.",
+        "# TYPE matrixark_ingestion_jobs_running gauge",
+        "matrixark_ingestion_jobs_running %g" % totals["jobs_running"],
+        "# HELP matrixark_ingestion_documents_total Documents across all jobs.",
+        "# TYPE matrixark_ingestion_documents_total counter",
+        "matrixark_ingestion_documents_total %g" % totals["documents_total"],
+        "# HELP matrixark_ingestion_documents_done Documents ingested successfully.",
+        "# TYPE matrixark_ingestion_documents_done counter",
+        "matrixark_ingestion_documents_done %g" % totals["documents_done"],
+        "# HELP matrixark_ingestion_documents_failed Documents that failed to ingest.",
+        "# TYPE matrixark_ingestion_documents_failed counter",
+        "matrixark_ingestion_documents_failed %g" % totals["documents_failed"],
+        "# HELP matrixark_ingestion_bytes_total Source bytes ingested.",
+        "# TYPE matrixark_ingestion_bytes_total counter",
+        "matrixark_ingestion_bytes_total %g" % totals["bytes_total"],
+    ]
+    for name, value in sorted((extra or {}).items()):
+        lines.append("# TYPE %s gauge" % name)
+        lines.append("%s %g" % (name, value))
+    return "\n".join(lines) + "\n"

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -188,13 +188,35 @@ def _api_embedding_config(provider: str) -> tuple[str, str, str, str]:
     return endpoint, os.environ.get(key_env, "").strip(), model, key_env
 
 
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def require_model_embeddings(path: str) -> bool:
+    """True when a failed real-encoder call must raise instead of falling back to hash vectors.
+
+    Three knobs name this idea and they are easy to confuse:
+    ``MATRIXARK_REQUIRE_API_EMBEDDINGS`` (hosted/OpenAI-compatible endpoints) and
+    ``MATRIXARK_REQUIRE_OSS_EMBEDDINGS`` (a locally loaded sentence-transformers model) each guard one
+    path, while ``MATRIXARK_REQUIRE_MODEL_EMBEDDINGS`` reads like the provider-agnostic form of both --
+    it is what an operator naturally reaches for, and it appears in the deployment config map. It
+    previously enforced NOTHING, so a deployment that set it still degraded silently to 32-dimension
+    hash vectors while reporting success. It is now honoured on both paths.
+
+    Silent degradation is the failure worth preventing here: hash vectors answer 200, retrieve
+    plausibly, and poison the store with mismatched-dimension data that only shows up as bad recall
+    much later.
+    """
+    return _truthy_env("MATRIXARK_REQUIRE_MODEL_EMBEDDINGS") or _truthy_env(path)
+
+
 def api_embedding_for_texts(texts: list[str], provider: str) -> list[list[float]]:
     """Embed via an OpenAI-compatible or Voyage embeddings API. Falls back to the deterministic
     encoder on missing key / network error unless MATRIXARK_REQUIRE_API_EMBEDDINGS is set (then it
     raises, so production fails fast instead of silently poisoning the store with mismatched-dim vectors)."""
     global _EMBEDDING_FALLBACK_USED
     endpoint, api_key, model, key_env = _api_embedding_config(provider)
-    require = os.environ.get("MATRIXARK_REQUIRE_API_EMBEDDINGS", "").strip().lower() in {"1", "true", "yes"}
+    require = require_model_embeddings("MATRIXARK_REQUIRE_API_EMBEDDINGS")
     if not api_key:
         if require:
             raise MatrixArkError(f"API embeddings require {key_env} for provider '{provider}'")
@@ -247,7 +269,7 @@ def oss_embedding_for_text(text: str) -> list[float]:
         vector = encoder.encode([text], normalize_embeddings=True, show_progress_bar=False)[0]
         return [round(float(value), 6) for value in vector]
     except Exception as exc:  # pragma: no cover - depends on optional local model packages.
-        if os.environ.get("MATRIXARK_REQUIRE_OSS_EMBEDDINGS", "").strip().lower() in {"1", "true", "yes"}:
+        if require_model_embeddings("MATRIXARK_REQUIRE_OSS_EMBEDDINGS"):
             raise MatrixArkError(f"OSS embedding model is required but unavailable: {model_ref}: {exc}") from exc
         _EMBEDDING_FALLBACK_USED = True
         previous = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER")

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1099,11 +1099,28 @@ def _model_config_snapshot() -> Json:
             "embedding_provider is deterministic: retrieval uses hash vectors, not semantic "
             "embeddings. Set MATRIXARK_EMBEDDING_PROVIDER and MATRIXARK_REQUIRE_MODEL_EMBEDDINGS=1."
         )
-    elif not require_model_embeddings:
-        warnings.append(
-            "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS is not set: if the encoder becomes unreachable the "
-            "gateway silently falls back to hash vectors instead of failing the request."
-        )
+    else:
+        if not require_model_embeddings:
+            warnings.append(
+                "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS is not set: if the encoder becomes unreachable "
+                "the gateway falls back to hash vectors instead of failing the request."
+            )
+        # Two configuration mistakes silently degrade an OpenAI-compatible encoder to hash vectors,
+        # and neither is visible from the outside: the request 200s and retrieval still returns
+        # plausible results. Both are cheap to check here.
+        api_base = embedding["api_base"]
+        if api_base and not api_base.rstrip("/").endswith("/v1"):
+            warnings.append(
+                "MATRIXARK_EMBEDDING_API_BASE (" + api_base + ") does not end in /v1: the endpoint "
+                "is built as <base>/embeddings, so an OpenAI-compatible encoder serving "
+                "/v1/embeddings is never reached and every vector is a hash fallback."
+            )
+        if not embedding["api_key_configured"]:
+            warnings.append(
+                "embedding key env " + embedding_key_env + " is empty: the embedding call is skipped "
+                "before it is attempted, even for a local encoder that needs no auth. Set it to any "
+                "non-empty placeholder for a local endpoint."
+            )
 
     return {
         "status": "ok",

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -978,6 +978,20 @@ async def _json(send: Callable, status: int, payload: Json,
     await send({"type": "http.response.body", "body": data})
 
 
+async def _text(send: Callable, status: int, body: str,
+                content_type: str = "text/plain; charset=utf-8",
+                extra_headers: Optional[list[Tuple[bytes, bytes]]] = None) -> None:
+    """A plain-text response. Used for the Prometheus exposition format, which needs its own
+    content type rather than JSON or HTML."""
+    data = body.encode("utf-8")
+    headers = [(b"content-type", content_type.encode()),
+               (b"content-length", str(len(data)).encode())]
+    if extra_headers:
+        headers.extend(extra_headers)
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": data})
+
+
 async def _html(send: Callable, status: int, body: bytes,
                 extra_headers: Optional[list[Tuple[bytes, bytes]]] = None) -> None:
     headers = [(b"content-type", b"text/html; charset=utf-8"),
@@ -1004,6 +1018,30 @@ _PORTAL_FALLBACK_HTML = (
     "<code>GET /v1/admin/api_key_usage</code> — each with an admin-scoped "
     "<code>Authorization: Bearer &lt;key&gt;</code>.</p>"
 )
+
+
+_INGESTION_PORTAL_CACHE: dict[str, Optional[bytes]] = {"bytes": None}
+
+
+def _ingestion_portal_html_bytes() -> bytes:
+    """The ingestion portal page (cached), read from the committed file next to this module."""
+    cached = _INGESTION_PORTAL_CACHE.get("bytes")
+    if cached is not None:
+        return cached
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal", "ingestion_portal.html")
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except Exception:  # pragma: no cover - deployments without the file bundled
+        data = (
+            "<!doctype html><meta charset='utf-8'><title>MatrixArk Ingestion</title>"
+            "<h1>MatrixArk Ingestion</h1><p>The bundled page "
+            "(<code>tools/portal/ingestion_portal.html</code>) was not found. The JSON endpoints "
+            "still work: <code>POST /v1/admin/ingestion/jobs</code>, "
+            "<code>GET /v1/admin/ingestion/jobs</code>, and <code>GET /v1/metrics</code>.</p>"
+        ).encode("utf-8")
+    _INGESTION_PORTAL_CACHE["bytes"] = data
+    return data
 
 
 def _portal_html_bytes() -> bytes:
@@ -1868,6 +1906,83 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             if denied is not None:
                 return await _json(send, 403, denied)
             return await _json(send, 200, _model_config_snapshot())
+
+        # ---- Prometheus scrape (no auth: counters only, no tenant data) ----------------------
+        # The gateway had no /metrics, so the customer-facing API surface was invisible to the
+        # dashboards while the engine below it was fully instrumented. These are aggregate
+        # ingestion counters -- no keys, no tenant identifiers, nothing per-user -- so the endpoint
+        # is safe to scrape without credentials, the way an exporter normally is.
+        if method == "GET" and path == "/v1/metrics":
+            try:
+                import matrixark_ingestion_jobs as _jobs
+                body = _jobs.prometheus_text()
+            except Exception:
+                body = "# ingestion job registry unavailable" + chr(10)
+            return await _text(send, 200, body, content_type="text/plain; version=0.0.4")
+
+        # ---- ingestion portal page (static HTML, no auth to FETCH) ---------------------------
+        # Same posture as the key portal: fetching the page needs nothing, every action on it calls
+        # an admin-gated endpoint, so the page is inert without a valid admin key.
+        if method == "GET" and path == "/v1/admin/ingestion":
+            return await _html(send, 200, _ingestion_portal_html_bytes())
+
+        # ---- ingestion jobs: list (auth + admin scope) ---------------------------------------
+        if method == "GET" and path == "/v1/admin/ingestion/jobs":
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _usage_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            import matrixark_ingestion_jobs as _jobs
+            return await _json(send, 200, {
+                "status": "ok",
+                "jobs": _jobs.REGISTRY.list(),
+                "ingestion_root": _jobs.ingestion_root(),
+            })
+
+        # ---- ingestion jobs: submit (auth + admin scope) -------------------------------------
+        # Starts a background import over documents the caller names. Every path is resolved inside
+        # MATRIXARK_INGESTION_ROOT (see matrixark_ingestion_jobs) so this cannot be turned into a
+        # file-disclosure endpoint; with no root configured, submission is refused rather than
+        # defaulting to the whole filesystem.
+        if method == "POST" and path == "/v1/admin/ingestion/jobs":
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _usage_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            raw, too_big = await _read_body_capped(receive, 1 << 20)
+            if too_big or raw is None:
+                return await _json(send, 413, {"error": "body_too_large"})
+            try:
+                payload = json.loads(raw.decode("utf-8") or "{}")
+            except Exception:
+                return await _json(send, 400, {"error": "invalid_json"})
+            import matrixark_ingestion_jobs as _jobs
+            try:
+                documents = _jobs.resolve_request_paths(
+                    paths=payload.get("paths"),
+                    directory=payload.get("directory"),
+                    globs=payload.get("globs"),
+                )
+            except _jobs.IngestionRootNotConfigured as exc:
+                return await _json(send, 400, {"error": "ingestion_root_not_configured",
+                                               "detail": str(exc)})
+            except _jobs.PathOutsideRoot as exc:
+                return await _json(send, 403, {"error": "path_outside_ingestion_root",
+                                               "detail": str(exc)})
+            if not documents:
+                return await _json(send, 400, {"error": "no_documents_matched"})
+            job = _jobs.REGISTRY.submit(documents, {
+                "base_url": payload.get("base_url") or ("http://127.0.0.1:%d" % cfg.port
+                                                        if getattr(cfg, "port", None) else None),
+                "user_id": payload.get("user_id") or "default",
+                "api_key_env": payload.get("api_key_env") or "MATRIXARK_API_KEY",
+                "timeout_s": payload.get("timeout_s") or 1800.0,
+            })
+            return await _json(send, 202, job.snapshot())
 
         # ---- get_all via GET /v1/memories (auth + context:retrieve) -------------------------
         # Convenience read: list a scope's active memories. Scope identity comes from the query

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1975,6 +1975,17 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                                "detail": str(exc)})
             if not documents:
                 return await _json(send, 400, {"error": "no_documents_matched"})
+            # A preview resolves and counts the documents without importing them, so a customer can
+            # confirm the selection is what they meant before committing to a long run.
+            if payload.get("preview"):
+                return await _json(send, 200, {
+                    "status": "preview",
+                    "total": len(documents),
+                    "bytes": sum((os.path.getsize(p) if os.path.exists(p) else 0)
+                                 for p in documents[:5000]),
+                    "sample": documents[:25],
+                    "truncated": len(documents) > 25,
+                })
             job = _jobs.REGISTRY.submit(documents, {
                 "base_url": payload.get("base_url") or ("http://127.0.0.1:%d" % cfg.port
                                                         if getattr(cfg, "port", None) else None),
@@ -1982,6 +1993,24 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "api_key_env": payload.get("api_key_env") or "MATRIXARK_API_KEY",
                 "timeout_s": payload.get("timeout_s") or 1800.0,
             })
+            return await _json(send, 202, job.snapshot())
+
+        # ---- cancel a running ingestion job (auth + admin scope) -----------------------------
+        # Stops the job before its next document; documents already imported stay imported, which
+        # is safe because ingest is a keyed upsert and a later re-run replaces rather than duplicates.
+        if method == "POST" and path.startswith("/v1/admin/ingestion/jobs/") and path.endswith("/cancel"):
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _usage_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            import matrixark_ingestion_jobs as _jobs
+            job_id = path[len("/v1/admin/ingestion/jobs/"):-len("/cancel")]
+            job = _jobs.REGISTRY.get(job_id)
+            if job is None:
+                return await _json(send, 404, {"error": "unknown_job", "job_id": job_id})
+            job.cancel()
             return await _json(send, 202, job.snapshot())
 
         # ---- get_all via GET /v1/memories (auth + context:retrieve) -------------------------

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -6,112 +6,195 @@
 <title>MatrixArk Ingestion</title>
 <style>
   :root{
-    --bg:#f4f6f8; --panel:#fff; --ink:#151a20; --muted:#5b6672; --line:#dde3ea;
-    --accent:#0e6e6b; --ok:#1e7a5a; --warn:#9a6510; --crit:#a8443a;
-    --ok-bg:#dceee6; --warn-bg:#f7ead3; --crit-bg:#f7e0dd;
+    --bg:#f2f5f7; --panel:#fff; --panel-2:#f7f9fb;
+    --ink:#141a20; --muted:#5c6773; --faint:#8b95a1; --line:#dce3ea;
+    --accent:#0d6b68; --accent-ink:#fff; --accent-soft:#d9ecea;
+    --ok:#1c7a58; --ok-soft:#dbeee5;
+    --warn:#93610f; --warn-soft:#f7ead2;
+    --crit:#a6423a; --crit-soft:#f7dfdc;
+    --shadow:0 1px 2px rgba(20,26,32,.05), 0 4px 14px rgba(20,26,32,.05);
+    --radius:10px;
   }
   @media (prefers-color-scheme:dark){
     :root{
-      --bg:#0e1216; --panel:#161c22; --ink:#e3e9ef; --muted:#8d99a7; --line:#28313b;
-      --accent:#3fb3a8; --ok:#4cb68b; --warn:#d9a441; --crit:#d7756a;
-      --ok-bg:#123227; --warn-bg:#33280f; --crit-bg:#351e1b;
+      --bg:#0d1115; --panel:#151b21; --panel-2:#1a212a;
+      --ink:#e4e9ef; --muted:#8d99a7; --faint:#6c7885; --line:#27303a;
+      --accent:#3fb3a8; --accent-ink:#06231f; --accent-soft:#11302e;
+      --ok:#4cb68b; --ok-soft:#113126;
+      --warn:#d9a441; --warn-soft:#31270f;
+      --crit:#d7756a; --crit-soft:#341e1b;
+      --shadow:0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.28);
     }
   }
   *{box-sizing:border-box}
+  html{-webkit-text-size-adjust:100%}
   body{margin:0;background:var(--bg);color:var(--ink);
-       font:15px/1.55 "IBM Plex Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
-  .wrap{max-width:940px;margin:0 auto;padding:32px 20px 64px}
-  h1{font-size:26px;margin:0 0 4px;letter-spacing:-.01em}
-  .sub{color:var(--muted);margin:0 0 24px}
-  h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);
-     margin:0 0 12px;padding-bottom:8px;border-bottom:1px solid var(--line)}
-  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;
-        padding:18px 20px;margin-bottom:18px}
-  label{display:block;font-size:13px;color:var(--muted);margin:10px 0 4px}
-  input,select{width:100%;padding:8px 10px;border:1px solid var(--line);border-radius:6px;
-               background:var(--bg);color:var(--ink);font:inherit;font-size:14px}
-  .row{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-  button{background:var(--accent);color:#fff;border:0;border-radius:6px;padding:9px 16px;
-         font:inherit;font-weight:600;cursor:pointer;margin-top:14px}
-  button.secondary{background:transparent;color:var(--accent);border:1px solid var(--accent)}
-  button:disabled{opacity:.5;cursor:not-allowed}
+       font:15px/1.55 "IBM Plex Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+       -webkit-font-smoothing:antialiased}
+  .wrap{max-width:1000px;margin:0 auto;padding:28px 20px 72px}
+  .mono{font-family:"IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,monospace}
+
+  /* header */
+  header{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:6px}
+  h1{font-size:24px;margin:0;letter-spacing:-.015em;font-weight:650}
+  .dot{width:8px;height:8px;border-radius:50%;background:var(--faint);display:inline-block;
+       margin-right:6px;vertical-align:middle}
+  .dot.live{background:var(--ok)} .dot.down{background:var(--crit)}
+  .conn{font-size:13px;color:var(--muted)}
+  .lede{color:var(--muted);margin:2px 0 22px;max-width:64ch}
+
+  /* summary */
+  .summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:22px}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
+        padding:14px 16px;box-shadow:var(--shadow)}
+  .stat b{display:block;font-size:26px;line-height:1.1;font-weight:650;
+          font-variant-numeric:tabular-nums;font-family:"IBM Plex Mono",monospace}
+  .stat span{display:block;font-size:12.5px;color:var(--muted);margin-top:5px}
+  .stat.ok b{color:var(--ok)} .stat.warn b{color:var(--warn)} .stat.crit b{color:var(--crit)}
+
+  section{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
+          padding:18px 20px;margin-bottom:16px;box-shadow:var(--shadow)}
+  h2{font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);
+     margin:0 0 14px;font-weight:600;display:flex;align-items:center;gap:10px}
+  h2 .aux{margin-left:auto;text-transform:none;letter-spacing:0;font-size:12px;font-weight:400}
+
+  label{display:block;font-size:13px;color:var(--muted);margin:12px 0 5px;font-weight:500}
+  input[type=text],input[type=password],textarea{
+    width:100%;padding:9px 11px;border:1px solid var(--line);border-radius:7px;
+    background:var(--panel-2);color:var(--ink);font:inherit;font-size:14px}
+  textarea{min-height:74px;resize:vertical;font-family:"IBM Plex Mono",monospace;font-size:13px}
+  input:focus,textarea:focus,button:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media (max-width:620px){.grid2{grid-template-columns:1fr}}
+
+  .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:16px;align-items:center}
+  button{background:var(--accent);color:var(--accent-ink);border:0;border-radius:7px;
+         padding:9px 16px;font:inherit;font-weight:600;cursor:pointer}
+  button.ghost{background:transparent;color:var(--accent);border:1px solid var(--accent)}
+  button.link{background:none;border:0;color:var(--accent);padding:4px 2px;font-weight:500;
+              text-decoration:underline;text-underline-offset:2px}
+  button.danger{background:transparent;color:var(--crit);border:1px solid var(--crit);
+                padding:5px 11px;font-size:13px}
+  button:disabled{opacity:.45;cursor:not-allowed}
+  .check{display:flex;align-items:center;gap:7px;font-size:13px;color:var(--muted);cursor:pointer}
+
+  .msg{padding:10px 13px;border-radius:7px;font-size:14px;margin-top:14px;line-height:1.5}
+  .msg.err{background:var(--crit-soft);color:var(--crit)}
+  .msg.ok{background:var(--ok-soft);color:var(--ok)}
+  .msg.info{background:var(--accent-soft);color:var(--accent)}
+  .note{background:var(--warn-soft);color:var(--warn);padding:10px 13px;border-radius:7px;
+        font-size:13.5px;margin-bottom:9px;line-height:1.5}
+  /* Config warnings and errors quote long unbreakable tokens (env var names, endpoints, paths).
+     Without this they force the whole page to scroll sideways on a narrow viewport. */
+  .note,.msg,.hint,td,.job-stats,.lede{overflow-wrap:anywhere}
+  .hint{font-size:13px;color:var(--faint);margin-top:9px;line-height:1.5}
+
   table{width:100%;border-collapse:collapse;font-size:14px}
-  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line)}
-  th{font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--muted)}
-  td.num{text-align:right;font-family:"IBM Plex Mono",ui-monospace,monospace;
-         font-variant-numeric:tabular-nums}
-  .pill{display:inline-block;font-size:11px;font-weight:600;text-transform:uppercase;
-        letter-spacing:.05em;padding:2px 8px;border-radius:20px}
-  .pill.running{background:var(--warn-bg);color:var(--warn)}
-  .pill.completed{background:var(--ok-bg);color:var(--ok)}
-  .pill.failed,.pill.cancelled{background:var(--crit-bg);color:var(--crit)}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  tr:last-child td{border-bottom:0}
+  th{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);
+     font-weight:600;white-space:nowrap}
+  td.num{text-align:right;font-family:"IBM Plex Mono",monospace;font-variant-numeric:tabular-nums}
+
+  .job{border:1px solid var(--line);border-radius:8px;padding:13px 15px;margin-bottom:10px;
+       background:var(--panel-2)}
+  .job-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  .job-id{font-family:"IBM Plex Mono",monospace;font-size:13px;color:var(--muted)}
+  .pill{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;
+        padding:3px 9px;border-radius:20px;white-space:nowrap}
+  .pill.running{background:var(--accent-soft);color:var(--accent)}
+  .pill.completed{background:var(--ok-soft);color:var(--ok)}
   .pill.queued{background:var(--line);color:var(--muted)}
-  .bar{height:6px;background:var(--line);border-radius:4px;overflow:hidden;margin-top:6px}
-  .bar>i{display:block;height:100%;background:var(--accent);transition:width .4s}
-  .msg{padding:10px 12px;border-radius:6px;font-size:14px;margin-top:12px}
-  .msg.err{background:var(--crit-bg);color:var(--crit)}
-  .msg.ok{background:var(--ok-bg);color:var(--ok)}
-  .warn-item{background:var(--warn-bg);color:var(--warn);padding:9px 12px;border-radius:6px;
-             font-size:13.5px;margin-bottom:8px}
-  .hint{font-size:13px;color:var(--muted);margin-top:8px}
-  code{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:13px}
+  .pill.failed,.pill.cancelled{background:var(--crit-soft);color:var(--crit)}
+  .job-meta{margin-left:auto;font-size:13px;color:var(--muted);
+            font-variant-numeric:tabular-nums}
+  .bar{height:7px;background:var(--line);border-radius:5px;overflow:hidden;margin:11px 0 8px}
+  .bar>i{display:block;height:100%;background:var(--accent);transition:width .45s ease}
+  .bar>i.done{background:var(--ok)} .bar>i.bad{background:var(--crit)}
+  .job-stats{display:flex;gap:18px;flex-wrap:wrap;font-size:13px;color:var(--muted);
+             font-variant-numeric:tabular-nums}
+  .job-stats b{color:var(--ink);font-weight:600}
+  .current{font-family:"IBM Plex Mono",monospace;font-size:12px;color:var(--faint);
+           margin-top:7px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  details{margin-top:9px}
+  summary{cursor:pointer;font-size:13px;color:var(--crit)}
+  details ul{margin:7px 0 0;padding-left:18px;font-size:12.5px;color:var(--muted)}
+  details li{margin-bottom:3px;font-family:"IBM Plex Mono",monospace;word-break:break-all}
+
+  pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
+      overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
+  .empty{color:var(--faint);font-size:14px;padding:6px 0}
   a{color:var(--accent)}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
 </style>
 </head>
 <body>
 <div class="wrap">
 
-  <h1>Ingestion</h1>
-  <p class="sub">Hand over a list of skill documents, start the import, and watch it run.</p>
+  <header>
+    <h1>Ingestion</h1>
+    <span class="conn"><span id="dot" class="dot"></span><span id="conn">connecting…</span></span>
+  </header>
+  <p class="lede">Point MatrixArk at a set of skill documents, watch the import run, and confirm the
+    deployment is configured the way you expect before you commit to a long one.</p>
 
-  <div class="card">
-    <h2>Access</h2>
-    <label for="key">Admin API key — held in this page only, never stored</label>
-    <input id="key" type="password" placeholder="Bearer key with admin scope" autocomplete="off">
-    <div class="hint">Every action below calls an admin-gated endpoint. The page is inert without a key.</div>
-  </div>
+  <div class="summary" id="summary"></div>
 
-  <div class="card">
-    <h2>Deployment</h2>
-    <div id="config">Loading configuration…</div>
-  </div>
+  <section>
+    <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
+    <label for="key">Admin API key</label>
+    <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <div class="hint">Reading this page needs nothing; every action calls an admin-gated endpoint, so the
+      page is inert without a key. “Remember” keeps it in this tab only and forgets it when the tab
+      closes — it is never written to disk or sent anywhere but this gateway.</div>
+  </section>
 
-  <div class="card">
-    <h2>Start an import</h2>
-    <label for="dir">Directory — every matching document beneath it</label>
-    <input id="dir" placeholder="/srv/playbooks">
-    <label for="paths">Or an explicit list, one path per line</label>
-    <input id="paths" placeholder="/srv/playbooks/acme/checkout.md">
-    <div class="row">
+  <section>
+    <h2>Deployment <span class="aux" id="cfgTime"></span></h2>
+    <div id="config"><div class="empty">Loading configuration…</div></div>
+  </section>
+
+  <section>
+    <h2>Import documents</h2>
+    <div class="grid2">
+      <div>
+        <label for="dir">Directory</label>
+        <input id="dir" type="text" placeholder="/srv/playbooks" spellcheck="false">
+        <div class="hint">Searched recursively. Must sit inside the deployment’s ingestion root.</div>
+      </div>
       <div>
         <label for="globs">File patterns</label>
-        <input id="globs" value="*.md, *.markdown, *.json">
-      </div>
-      <div>
+        <input id="globs" type="text" value="*.md, *.markdown, *.json" spellcheck="false">
         <label for="user">Ingest as user</label>
-        <input id="user" value="default">
+        <input id="user" type="text" value="default" spellcheck="false">
       </div>
     </div>
-    <button id="start">Start import</button>
-    <button id="refresh" class="secondary">Refresh</button>
+    <label for="paths">Or list documents explicitly — one path per line</label>
+    <textarea id="paths" placeholder="/srv/playbooks/acme/checkout.md&#10;/srv/playbooks/globex/pricing.json" spellcheck="false"></textarea>
+
+    <div class="actions">
+      <button id="preview" class="ghost">Preview selection</button>
+      <button id="start" disabled>Start import</button>
+      <span class="hint" style="margin:0">Preview first — it shows exactly what would be sent.</span>
+    </div>
     <div id="startMsg"></div>
-    <div class="hint">Paths must sit inside the deployment's configured ingestion root. Re-importing a
-      document replaces it rather than duplicating it, so restarting an interrupted import is safe.</div>
-  </div>
+    <div class="hint">Re-importing a document replaces it rather than duplicating it, so a stopped
+      import can simply be run again.</div>
+  </section>
 
-  <div class="card">
-    <h2>Jobs</h2>
-    <div id="jobs">No jobs yet.</div>
-  </div>
+  <section>
+    <h2>Jobs <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
+    <div id="jobs"><div class="empty">Loading…</div></div>
+  </section>
 
-  <div class="card">
-    <h2>Metrics</h2>
-    <p class="hint" style="margin-top:0">Ingestion counters are exported for Prometheus at
-      <code>/v1/metrics</code> — no credentials, no tenant data. Point a scrape job at it and import
-      <code>docs/ops/matrixark-ingestion-dashboard.json</code> into Grafana for the matching panels.</p>
-    <pre id="metrics" style="background:var(--bg);border:1px solid var(--line);border-radius:6px;
-      padding:12px;overflow-x:auto;font-size:12.5px;margin:0">Loading…</pre>
-  </div>
+  <section>
+    <h2>Metrics <span class="aux"><button class="link" id="copyScrape">copy Prometheus scrape config</button></span></h2>
+    <p class="hint" style="margin-top:0">Aggregate counters are exported at <span class="mono">/v1/metrics</span>
+      — no keys, no tenant identifiers — so it is safe to scrape without credentials. Import
+      <span class="mono">docs/ops/matrixark-ingestion-dashboard.json</span> into Grafana for the
+      matching panels; the <em>import backlog</em> panel is the one to watch on a long run.</p>
+    <pre id="metrics">Loading…</pre>
+  </section>
 
 </div>
 
@@ -119,146 +202,291 @@
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
-  var timer = null;
+  var lastPreview = null, timer = null;
 
+  /* ---------- helpers ---------- */
   function auth() {
     var k = $("key").value.trim();
-    return k ? { "Authorization": "Bearer " + k } : {};
+    return k ? { Authorization: "Bearer " + k } : {};
+  }
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  function say(el, text, cls) {
+    el.innerHTML = text ? '<div class="msg ' + (cls || "info") + '">' + esc(text) + "</div>" : "";
+  }
+  function bytes(n) {
+    if (!n) { return "0 B"; }
+    var u = ["B", "KB", "MB", "GB", "TB"], i = Math.floor(Math.log(n) / Math.log(1024));
+    return (n / Math.pow(1024, i)).toFixed(i ? 1 : 0) + " " + u[i];
+  }
+  function secs(s) {
+    if (!s) { return "—"; }
+    if (s < 60) { return Math.round(s) + "s"; }
+    if (s < 3600) { return Math.floor(s / 60) + "m " + Math.round(s % 60) + "s"; }
+    return Math.floor(s / 3600) + "h " + Math.round((s % 3600) / 60) + "m";
+  }
+  function conn(state, text) {
+    $("dot").className = "dot " + state;
+    $("conn").textContent = text;
   }
 
-  function say(el, text, cls) {
-    el.innerHTML = "";
-    if (!text) { return; }
-    var d = document.createElement("div");
-    d.className = "msg " + (cls || "");
-    d.textContent = text;
-    el.appendChild(d);
+  /* ---------- summary ---------- */
+  function renderSummary(jobs) {
+    var running = 0, done = 0, failed = 0, remaining = 0, rate = 0, b = 0;
+    jobs.forEach(function (j) {
+      if (j.state === "running") { running++; rate += j.docs_per_s || 0; }
+      done += j.done; failed += j.failed; remaining += j.remaining; b += j.bytes || 0;
+    });
+    var cards = [
+      { n: running, l: running === 1 ? "import running" : "imports running", c: running ? "ok" : "" },
+      { n: done, l: "documents ingested", c: "" },
+      { n: failed, l: failed === 1 ? "failure" : "failures", c: failed ? "crit" : "" },
+      { n: remaining ? remaining : bytes(b), l: remaining ? "remaining" : "source ingested", c: remaining ? "warn" : "" }
+    ];
+    $("summary").innerHTML = cards.map(function (c) {
+      return '<div class="stat ' + c.c + '"><b>' + esc(c.n) + "</b><span>" + esc(c.l) + "</span></div>";
+    }).join("");
+  }
+
+  /* ---------- deployment config ---------- */
+  function renderConfig(d) {
+    var rows = [
+      ["Embedding", d.embedding.provider + (d.embedding.model ? " · " + d.embedding.model : "")],
+      ["Encoder endpoint", d.embedding.api_base || "not set"],
+      ["Fail closed", d.embedding.require_model_embeddings ? "yes — a failed encoder call errors"
+                                                           : "no — falls back to hash vectors"],
+      ["Extraction", d.extraction.provider + (d.extraction.model ? " · " + d.extraction.model : "")],
+      ["Extraction key", d.extraction.api_key_configured
+        ? d.extraction.api_key_env + " is set" : d.extraction.api_key_env + " is empty"],
+      ["Skill budget", d.skills.shared_skill_budget_ratio + " of " + d.skills.max_budget_tokens +
+                       " tokens · " + d.skills.skill_chunks_per_skill + " sections per skill"]
+    ];
+    var html = (d.warnings || []).map(function (w) {
+      return '<div class="note">' + esc(w) + "</div>";
+    }).join("");
+    html += "<table>" + rows.map(function (r) {
+      return "<tr><th>" + esc(r[0]) + "</th><td>" + esc(r[1]) + "</td></tr>";
+    }).join("") + "</table>";
+    $("config").innerHTML = html;
+    $("cfgTime").textContent = "checked " + new Date().toLocaleTimeString();
   }
 
   function loadConfig() {
     fetch("/v1/admin/config", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (d) {
-        var host = $("config");
-        host.innerHTML = "";
-        var t = document.createElement("table");
-        var rows = [
-          ["Embedding", d.embedding.provider + (d.embedding.model ? " — " + d.embedding.model : "")],
-          ["Encoder endpoint", d.embedding.api_base || "(not set)"],
-          ["Extraction", d.extraction.provider + (d.extraction.model ? " — " + d.extraction.model : "")],
-          ["Skill budget", d.skills.shared_skill_budget_ratio + " of " +
-                           d.skills.max_budget_tokens + " tokens"]
-        ];
-        rows.forEach(function (r) {
-          var tr = document.createElement("tr");
-          var th = document.createElement("th"); th.textContent = r[0];
-          var td = document.createElement("td"); td.textContent = r[1];
-          tr.appendChild(th); tr.appendChild(td); t.appendChild(tr);
-        });
-        host.appendChild(t);
-        (d.warnings || []).forEach(function (w) {
-          var el = document.createElement("div");
-          el.className = "warn-item";
-          el.textContent = w;
-          host.appendChild(el);
-        });
-      })
+      .then(function (d) { conn("live", "connected"); renderConfig(d); })
       .catch(function (e) {
-        $("config").textContent = e === 401
-          ? "Enter an admin key to read the deployment configuration."
-          : "Could not read configuration (" + e + ").";
+        if (e === 401 || e === 403) {
+          conn("live", "connected");
+          $("config").innerHTML = '<div class="empty">Enter an admin key above to see how this ' +
+            "deployment is configured.</div>";
+        } else {
+          conn("down", "gateway unreachable");
+          $("config").innerHTML = '<div class="msg err">Could not reach the gateway.</div>';
+        }
       });
   }
 
+  /* ---------- jobs ---------- */
+  function jobHtml(j) {
+    var processed = j.done + j.failed;
+    var pct = j.total ? Math.round((processed / j.total) * 100) : 0;
+    var barCls = j.failed && !j.done ? "bad" : (j.state === "completed" ? "done" : "");
+    var h = '<div class="job"><div class="job-head">' +
+      '<span class="pill ' + esc(j.state) + '">' + esc(j.state) + "</span>" +
+      '<span class="job-id">' + esc(j.job_id) + "</span>" +
+      (j.user_id ? '<span class="job-id">· ' + esc(j.user_id) + "</span>" : "") +
+      '<span class="job-meta">' + pct + "% of " + j.total + "</span>";
+    if (j.state === "running" || j.state === "queued") {
+      h += '<button class="danger" data-cancel="' + esc(j.job_id) + '">Stop</button>';
+    }
+    h += '</div><div class="bar"><i class="' + barCls + '" style="width:' + pct + '%"></i></div>' +
+      '<div class="job-stats">' +
+      "<span><b>" + j.done + "</b> ingested</span>" +
+      "<span><b>" + j.failed + "</b> failed</span>" +
+      "<span><b>" + bytes(j.bytes) + "</b> source</span>" +
+      "<span><b>" + (j.docs_per_s || 0) + "</b> docs/s</span>" +
+      "<span>elapsed <b>" + secs(j.elapsed_s) + "</b></span>" +
+      (j.remaining ? "<span>eta <b>" + secs(j.eta_s) + "</b></span>" : "") +
+      "</div>";
+    if (j.current) { h += '<div class="current">' + esc(j.current) + "</div>"; }
+    if (j.failures && j.failures.length) {
+      h += "<details><summary>" + j.failures.length + " failure" +
+        (j.failures.length === 1 ? "" : "s") + "</summary><ul>" +
+        j.failures.map(function (f) {
+          return "<li>" + esc(f.detail) + " — " + esc(f.path) + "</li>";
+        }).join("") + "</ul></details>";
+    }
+    return h + "</div>";
+  }
+
   function renderJobs(jobs) {
-    var host = $("jobs");
-    host.innerHTML = "";
-    if (!jobs.length) { host.textContent = "No jobs yet."; return; }
-    var t = document.createElement("table");
-    t.innerHTML = "<tr><th>Job</th><th>State</th><th>Progress</th>" +
-                  "<th>Done</th><th>Failed</th><th>Rate</th><th>ETA</th></tr>";
-    jobs.forEach(function (j) {
-      var pct = j.total ? Math.round(((j.done + j.failed) / j.total) * 100) : 0;
-      var tr = document.createElement("tr");
-      tr.innerHTML =
-        "<td><code>" + j.job_id + "</code></td>" +
-        "<td><span class='pill " + j.state + "'>" + j.state + "</span></td>" +
-        "<td>" + pct + "% of " + j.total +
-          "<div class='bar'><i style='width:" + pct + "%'></i></div></td>" +
-        "<td class='num'>" + j.done + "</td>" +
-        "<td class='num'>" + j.failed + "</td>" +
-        "<td class='num'>" + j.docs_per_s + "/s</td>" +
-        "<td class='num'>" + (j.eta_s ? j.eta_s + "s" : "—") + "</td>";
-      t.appendChild(tr);
-    });
-    host.appendChild(t);
-    var failing = jobs.filter(function (j) { return j.failures && j.failures.length; });
-    failing.forEach(function (j) {
-      var d = document.createElement("div");
-      d.className = "warn-item";
-      d.textContent = j.job_id + ": " + j.failures.length + " failure(s), first — " +
-                      j.failures[0].detail + " (" + j.failures[0].path + ")";
-      host.appendChild(d);
+    renderSummary(jobs);
+    if (!jobs.length) {
+      $("jobs").innerHTML = '<div class="empty">No imports yet. Preview a selection above, then ' +
+        "start one — progress appears here.</div>";
+      return;
+    }
+    $("jobs").innerHTML = jobs.map(jobHtml).join("");
+    Array.prototype.forEach.call($("jobs").querySelectorAll("[data-cancel]"), function (b) {
+      b.addEventListener("click", function () { cancelJob(b.getAttribute("data-cancel")); });
     });
   }
 
   function loadJobs() {
     fetch("/v1/admin/ingestion/jobs", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (d) { renderJobs(d.jobs || []); })
+      .then(function (d) { conn("live", "connected"); renderJobs(d.jobs || []); })
       .catch(function (e) {
-        $("jobs").textContent = e === 401 ? "Enter an admin key to list jobs." : "Could not list jobs.";
+        if (e === 401 || e === 403) {
+          $("jobs").innerHTML = '<div class="empty">Enter an admin key to list imports.</div>';
+          renderSummary([]);
+        } else { conn("down", "gateway unreachable"); }
       });
   }
 
+  function cancelJob(id) {
+    fetch("/v1/admin/ingestion/jobs/" + encodeURIComponent(id) + "/cancel",
+          { method: "POST", headers: auth() })
+      .then(loadJobs)
+      .catch(function () { say($("startMsg"), "Could not stop " + id + ".", "err"); });
+  }
+
+  /* ---------- metrics ---------- */
   function loadMetrics() {
     fetch("/v1/metrics")
       .then(function (r) { return r.text(); })
       .then(function (t) {
-        $("metrics").textContent = t.split("\n").filter(function (l) {
-          return l && l.charAt(0) !== "#";
-        }).join("\n") || "(no samples yet)";
+        var lines = t.split("\n").filter(function (l) { return l && l.charAt(0) !== "#"; });
+        $("metrics").textContent = lines.length ? lines.join("\n") : "(no samples yet)";
       })
       .catch(function () { $("metrics").textContent = "Metrics endpoint unavailable."; });
   }
 
-  $("start").addEventListener("click", function () {
+  /* ---------- request body ---------- */
+  function requestBody() {
     var body = { user_id: $("user").value.trim() || "default" };
     var dir = $("dir").value.trim();
     var paths = $("paths").value.trim();
     if (dir) { body.directory = dir; }
-    if (paths) { body.paths = paths.split(/[\n,]/).map(function (s) { return s.trim(); })
-                                   .filter(Boolean); }
-    var globs = $("globs").value.trim();
-    if (globs) { body.globs = globs.split(",").map(function (s) { return s.trim(); }).filter(Boolean); }
-    if (!body.directory && !body.paths) {
-      say($("startMsg"), "Give a directory or at least one path.", "err");
-      return;
+    if (paths) {
+      body.paths = paths.split("\n").map(function (s) { return s.trim(); }).filter(Boolean);
     }
-    $("start").disabled = true;
-    fetch("/v1/admin/ingestion/jobs", {
+    var globs = $("globs").value.trim();
+    if (globs) {
+      body.globs = globs.split(",").map(function (s) { return s.trim(); }).filter(Boolean);
+    }
+    return (body.directory || body.paths) ? body : null;
+  }
+
+  function post(body) {
+    return fetch("/v1/admin/ingestion/jobs", {
       method: "POST",
       headers: Object.assign({ "Content-Type": "application/json" }, auth()),
       body: JSON.stringify(body)
-    })
-      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
-      .then(function (res) {
-        if (res.ok) {
-          say($("startMsg"), "Started " + res.d.job_id + " over " + res.d.total + " document(s).", "ok");
-          loadJobs();
-        } else {
-          say($("startMsg"), res.d.detail || res.d.error || "Could not start the import.", "err");
-        }
-      })
-      .catch(function () { say($("startMsg"), "Could not reach the gateway.", "err"); })
-      .then(function () { $("start").disabled = false; });
+    }).then(function (r) {
+      return r.json().then(function (d) { return { ok: r.ok, status: r.status, d: d }; });
+    });
+  }
+
+  function explain(res) {
+    var d = res.d || {};
+    if (res.status === 401) { return "That key was not accepted. Check it carries an admin scope."; }
+    if (d.error === "ingestion_root_not_configured") {
+      return "This deployment has no ingestion root, so server-side paths are refused. Set " +
+             "MATRIXARK_INGESTION_ROOT to the directory holding your documents and restart.";
+    }
+    if (d.error === "path_outside_ingestion_root") {
+      return "That path sits outside the deployment's ingestion root: " + (d.detail || "");
+    }
+    if (d.error === "no_documents_matched") {
+      return "Nothing matched. Check the directory, and that your patterns cover the file types.";
+    }
+    return d.detail || d.error || "The gateway rejected the request.";
+  }
+
+  /* ---------- actions ---------- */
+  $("preview").addEventListener("click", function () {
+    var body = requestBody();
+    if (!body) { say($("startMsg"), "Give a directory or at least one path.", "err"); return; }
+    body.preview = true;
+    $("preview").disabled = true;
+    post(body).then(function (res) {
+      if (!res.ok) { lastPreview = null; $("start").disabled = true; say($("startMsg"), explain(res), "err"); return; }
+      lastPreview = res.d;
+      $("start").disabled = false;
+      var sample = res.d.sample.slice(0, 6).join("\n");
+      $("startMsg").innerHTML =
+        '<div class="msg ok">' + res.d.total + " document" + (res.d.total === 1 ? "" : "s") +
+        " match, " + bytes(res.d.bytes) + " of source. Ready to import.</div>" +
+        "<pre style='margin-top:10px'>" + esc(sample) +
+        (res.d.truncated ? "\n… and " + (res.d.total - res.d.sample.length) + " more" : "") + "</pre>";
+    }).catch(function () {
+      say($("startMsg"), "Could not reach the gateway.", "err");
+    }).then(function () { $("preview").disabled = false; });
   });
 
-  $("refresh").addEventListener("click", function () { loadConfig(); loadJobs(); loadMetrics(); });
-  $("key").addEventListener("change", function () { loadConfig(); loadJobs(); });
+  $("start").addEventListener("click", function () {
+    var body = requestBody();
+    if (!body) { return; }
+    $("start").disabled = true;
+    post(body).then(function (res) {
+      if (res.ok) {
+        say($("startMsg"), "Started " + res.d.job_id + " over " + res.d.total +
+            " document" + (res.d.total === 1 ? "" : "s") + ".", "ok");
+        lastPreview = null;
+        loadJobs();
+      } else {
+        say($("startMsg"), explain(res), "err");
+        $("start").disabled = false;
+      }
+    }).catch(function () {
+      say($("startMsg"), "Could not reach the gateway.", "err");
+      $("start").disabled = false;
+    });
+  });
 
-  loadConfig(); loadJobs(); loadMetrics();
-  timer = setInterval(function () { loadJobs(); loadMetrics(); }, 4000);
+  $("copyScrape").addEventListener("click", function () {
+    var cfg = "scrape_configs:\n  - job_name: matrixark_gateway\n    metrics_path: /v1/metrics\n" +
+              "    static_configs:\n      - targets: [\"" + location.host + "\"]\n";
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(cfg).then(function () {
+        $("copyScrape").textContent = "copied";
+        setTimeout(function () { $("copyScrape").textContent = "copy Prometheus scrape config"; }, 1800);
+      });
+    }
+  });
+
+  /* invalidate a stale preview when the selection changes */
+  ["dir", "paths", "globs", "user"].forEach(function (id) {
+    $(id).addEventListener("input", function () { lastPreview = null; $("start").disabled = true; });
+  });
+
+  /* key handling */
+  try {
+    var saved = sessionStorage.getItem("matrixark_admin_key");
+    if (saved) { $("key").value = saved; $("remember").checked = true; }
+  } catch (e) { /* storage unavailable */ }
+  function persistKey() {
+    try {
+      if ($("remember").checked) { sessionStorage.setItem("matrixark_admin_key", $("key").value); }
+      else { sessionStorage.removeItem("matrixark_admin_key"); }
+    } catch (e) { /* storage unavailable */ }
+  }
+  $("key").addEventListener("change", function () { persistKey(); loadConfig(); loadJobs(); });
+  $("remember").addEventListener("change", persistKey);
+
+  function tick() { loadJobs(); loadMetrics(); }
+  function schedule() {
+    if (timer) { clearInterval(timer); timer = null; }
+    if ($("auto").checked) { timer = setInterval(tick, 4000); }
+  }
+  $("auto").addEventListener("change", schedule);
+
+  loadConfig(); tick(); schedule();
 })();
 </script>
 </body>

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MatrixArk Ingestion</title>
+<style>
+  :root{
+    --bg:#f4f6f8; --panel:#fff; --ink:#151a20; --muted:#5b6672; --line:#dde3ea;
+    --accent:#0e6e6b; --ok:#1e7a5a; --warn:#9a6510; --crit:#a8443a;
+    --ok-bg:#dceee6; --warn-bg:#f7ead3; --crit-bg:#f7e0dd;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{
+      --bg:#0e1216; --panel:#161c22; --ink:#e3e9ef; --muted:#8d99a7; --line:#28313b;
+      --accent:#3fb3a8; --ok:#4cb68b; --warn:#d9a441; --crit:#d7756a;
+      --ok-bg:#123227; --warn-bg:#33280f; --crit-bg:#351e1b;
+    }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:15px/1.55 "IBM Plex Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+  .wrap{max-width:940px;margin:0 auto;padding:32px 20px 64px}
+  h1{font-size:26px;margin:0 0 4px;letter-spacing:-.01em}
+  .sub{color:var(--muted);margin:0 0 24px}
+  h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);
+     margin:0 0 12px;padding-bottom:8px;border-bottom:1px solid var(--line)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;
+        padding:18px 20px;margin-bottom:18px}
+  label{display:block;font-size:13px;color:var(--muted);margin:10px 0 4px}
+  input,select{width:100%;padding:8px 10px;border:1px solid var(--line);border-radius:6px;
+               background:var(--bg);color:var(--ink);font:inherit;font-size:14px}
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  button{background:var(--accent);color:#fff;border:0;border-radius:6px;padding:9px 16px;
+         font:inherit;font-weight:600;cursor:pointer;margin-top:14px}
+  button.secondary{background:transparent;color:var(--accent);border:1px solid var(--accent)}
+  button:disabled{opacity:.5;cursor:not-allowed}
+  table{width:100%;border-collapse:collapse;font-size:14px}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line)}
+  th{font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--muted)}
+  td.num{text-align:right;font-family:"IBM Plex Mono",ui-monospace,monospace;
+         font-variant-numeric:tabular-nums}
+  .pill{display:inline-block;font-size:11px;font-weight:600;text-transform:uppercase;
+        letter-spacing:.05em;padding:2px 8px;border-radius:20px}
+  .pill.running{background:var(--warn-bg);color:var(--warn)}
+  .pill.completed{background:var(--ok-bg);color:var(--ok)}
+  .pill.failed,.pill.cancelled{background:var(--crit-bg);color:var(--crit)}
+  .pill.queued{background:var(--line);color:var(--muted)}
+  .bar{height:6px;background:var(--line);border-radius:4px;overflow:hidden;margin-top:6px}
+  .bar>i{display:block;height:100%;background:var(--accent);transition:width .4s}
+  .msg{padding:10px 12px;border-radius:6px;font-size:14px;margin-top:12px}
+  .msg.err{background:var(--crit-bg);color:var(--crit)}
+  .msg.ok{background:var(--ok-bg);color:var(--ok)}
+  .warn-item{background:var(--warn-bg);color:var(--warn);padding:9px 12px;border-radius:6px;
+             font-size:13.5px;margin-bottom:8px}
+  .hint{font-size:13px;color:var(--muted);margin-top:8px}
+  code{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:13px}
+  a{color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Ingestion</h1>
+  <p class="sub">Hand over a list of skill documents, start the import, and watch it run.</p>
+
+  <div class="card">
+    <h2>Access</h2>
+    <label for="key">Admin API key — held in this page only, never stored</label>
+    <input id="key" type="password" placeholder="Bearer key with admin scope" autocomplete="off">
+    <div class="hint">Every action below calls an admin-gated endpoint. The page is inert without a key.</div>
+  </div>
+
+  <div class="card">
+    <h2>Deployment</h2>
+    <div id="config">Loading configuration…</div>
+  </div>
+
+  <div class="card">
+    <h2>Start an import</h2>
+    <label for="dir">Directory — every matching document beneath it</label>
+    <input id="dir" placeholder="/srv/playbooks">
+    <label for="paths">Or an explicit list, one path per line</label>
+    <input id="paths" placeholder="/srv/playbooks/acme/checkout.md">
+    <div class="row">
+      <div>
+        <label for="globs">File patterns</label>
+        <input id="globs" value="*.md, *.markdown, *.json">
+      </div>
+      <div>
+        <label for="user">Ingest as user</label>
+        <input id="user" value="default">
+      </div>
+    </div>
+    <button id="start">Start import</button>
+    <button id="refresh" class="secondary">Refresh</button>
+    <div id="startMsg"></div>
+    <div class="hint">Paths must sit inside the deployment's configured ingestion root. Re-importing a
+      document replaces it rather than duplicating it, so restarting an interrupted import is safe.</div>
+  </div>
+
+  <div class="card">
+    <h2>Jobs</h2>
+    <div id="jobs">No jobs yet.</div>
+  </div>
+
+  <div class="card">
+    <h2>Metrics</h2>
+    <p class="hint" style="margin-top:0">Ingestion counters are exported for Prometheus at
+      <code>/v1/metrics</code> — no credentials, no tenant data. Point a scrape job at it and import
+      <code>docs/ops/matrixark-ingestion-dashboard.json</code> into Grafana for the matching panels.</p>
+    <pre id="metrics" style="background:var(--bg);border:1px solid var(--line);border-radius:6px;
+      padding:12px;overflow-x:auto;font-size:12.5px;margin:0">Loading…</pre>
+  </div>
+
+</div>
+
+<script>
+(function () {
+  "use strict";
+  var $ = function (id) { return document.getElementById(id); };
+  var timer = null;
+
+  function auth() {
+    var k = $("key").value.trim();
+    return k ? { "Authorization": "Bearer " + k } : {};
+  }
+
+  function say(el, text, cls) {
+    el.innerHTML = "";
+    if (!text) { return; }
+    var d = document.createElement("div");
+    d.className = "msg " + (cls || "");
+    d.textContent = text;
+    el.appendChild(d);
+  }
+
+  function loadConfig() {
+    fetch("/v1/admin/config", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) {
+        var host = $("config");
+        host.innerHTML = "";
+        var t = document.createElement("table");
+        var rows = [
+          ["Embedding", d.embedding.provider + (d.embedding.model ? " — " + d.embedding.model : "")],
+          ["Encoder endpoint", d.embedding.api_base || "(not set)"],
+          ["Extraction", d.extraction.provider + (d.extraction.model ? " — " + d.extraction.model : "")],
+          ["Skill budget", d.skills.shared_skill_budget_ratio + " of " +
+                           d.skills.max_budget_tokens + " tokens"]
+        ];
+        rows.forEach(function (r) {
+          var tr = document.createElement("tr");
+          var th = document.createElement("th"); th.textContent = r[0];
+          var td = document.createElement("td"); td.textContent = r[1];
+          tr.appendChild(th); tr.appendChild(td); t.appendChild(tr);
+        });
+        host.appendChild(t);
+        (d.warnings || []).forEach(function (w) {
+          var el = document.createElement("div");
+          el.className = "warn-item";
+          el.textContent = w;
+          host.appendChild(el);
+        });
+      })
+      .catch(function (e) {
+        $("config").textContent = e === 401
+          ? "Enter an admin key to read the deployment configuration."
+          : "Could not read configuration (" + e + ").";
+      });
+  }
+
+  function renderJobs(jobs) {
+    var host = $("jobs");
+    host.innerHTML = "";
+    if (!jobs.length) { host.textContent = "No jobs yet."; return; }
+    var t = document.createElement("table");
+    t.innerHTML = "<tr><th>Job</th><th>State</th><th>Progress</th>" +
+                  "<th>Done</th><th>Failed</th><th>Rate</th><th>ETA</th></tr>";
+    jobs.forEach(function (j) {
+      var pct = j.total ? Math.round(((j.done + j.failed) / j.total) * 100) : 0;
+      var tr = document.createElement("tr");
+      tr.innerHTML =
+        "<td><code>" + j.job_id + "</code></td>" +
+        "<td><span class='pill " + j.state + "'>" + j.state + "</span></td>" +
+        "<td>" + pct + "% of " + j.total +
+          "<div class='bar'><i style='width:" + pct + "%'></i></div></td>" +
+        "<td class='num'>" + j.done + "</td>" +
+        "<td class='num'>" + j.failed + "</td>" +
+        "<td class='num'>" + j.docs_per_s + "/s</td>" +
+        "<td class='num'>" + (j.eta_s ? j.eta_s + "s" : "—") + "</td>";
+      t.appendChild(tr);
+    });
+    host.appendChild(t);
+    var failing = jobs.filter(function (j) { return j.failures && j.failures.length; });
+    failing.forEach(function (j) {
+      var d = document.createElement("div");
+      d.className = "warn-item";
+      d.textContent = j.job_id + ": " + j.failures.length + " failure(s), first — " +
+                      j.failures[0].detail + " (" + j.failures[0].path + ")";
+      host.appendChild(d);
+    });
+  }
+
+  function loadJobs() {
+    fetch("/v1/admin/ingestion/jobs", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) { renderJobs(d.jobs || []); })
+      .catch(function (e) {
+        $("jobs").textContent = e === 401 ? "Enter an admin key to list jobs." : "Could not list jobs.";
+      });
+  }
+
+  function loadMetrics() {
+    fetch("/v1/metrics")
+      .then(function (r) { return r.text(); })
+      .then(function (t) {
+        $("metrics").textContent = t.split("\n").filter(function (l) {
+          return l && l.charAt(0) !== "#";
+        }).join("\n") || "(no samples yet)";
+      })
+      .catch(function () { $("metrics").textContent = "Metrics endpoint unavailable."; });
+  }
+
+  $("start").addEventListener("click", function () {
+    var body = { user_id: $("user").value.trim() || "default" };
+    var dir = $("dir").value.trim();
+    var paths = $("paths").value.trim();
+    if (dir) { body.directory = dir; }
+    if (paths) { body.paths = paths.split(/[\n,]/).map(function (s) { return s.trim(); })
+                                   .filter(Boolean); }
+    var globs = $("globs").value.trim();
+    if (globs) { body.globs = globs.split(",").map(function (s) { return s.trim(); }).filter(Boolean); }
+    if (!body.directory && !body.paths) {
+      say($("startMsg"), "Give a directory or at least one path.", "err");
+      return;
+    }
+    $("start").disabled = true;
+    fetch("/v1/admin/ingestion/jobs", {
+      method: "POST",
+      headers: Object.assign({ "Content-Type": "application/json" }, auth()),
+      body: JSON.stringify(body)
+    })
+      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
+      .then(function (res) {
+        if (res.ok) {
+          say($("startMsg"), "Started " + res.d.job_id + " over " + res.d.total + " document(s).", "ok");
+          loadJobs();
+        } else {
+          say($("startMsg"), res.d.detail || res.d.error || "Could not start the import.", "err");
+        }
+      })
+      .catch(function () { say($("startMsg"), "Could not reach the gateway.", "err"); })
+      .then(function () { $("start").disabled = false; });
+  });
+
+  $("refresh").addEventListener("click", function () { loadConfig(); loadJobs(); loadMetrics(); });
+  $("key").addEventListener("change", function () { loadConfig(); loadJobs(); });
+
+  loadConfig(); loadJobs(); loadMetrics();
+  timer = setInterval(function () { loadJobs(); loadMetrics(); }, 4000);
+})();
+</script>
+</body>
+</html>

--- a/tools/test_matrixark_batch_ingest.py
+++ b/tools/test_matrixark_batch_ingest.py
@@ -105,6 +105,77 @@ class ResourceTypeTest(unittest.TestCase):
         self.assertEqual(batch.resource_type_for("a/notes.markdown"), "markdown")
 
 
+class EnvelopeShapeTest(unittest.TestCase):
+    """The wire shape a document is sent in.
+
+    Two mistakes here are silent rather than loud, which is why they are pinned: the ingest envelope
+    reads resource content from ``text``/``resource_text`` and IGNORES an unknown ``content`` field,
+    and an ingest that is neither finalized nor waited on is accepted as a deferred event and is not
+    retrievable when the call returns. Either one makes a batch import report success while storing
+    nothing useful.
+    """
+
+    def setUp(self) -> None:
+        self.captured = {}
+        self.doc = os.path.join(tempfile.mkdtemp(), "playbook.md")
+        with open(self.doc, "w", encoding="utf-8") as handle:
+            handle.write("# Playbook" + chr(10) + chr(10) +
+                         "## Step 1" + chr(10) + "Apply the coupon." + chr(10))
+
+        class FakeResponse:
+            status = 202
+
+            def read(self):
+                return b"{}"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def fake_urlopen(request, timeout=None):
+            self.captured["url"] = request.full_url
+            self.captured["body"] = json.loads(request.data.decode("utf-8"))
+            return FakeResponse()
+
+        self._real = batch.urllib.request.urlopen
+        batch.urllib.request.urlopen = fake_urlopen
+
+    def tearDown(self) -> None:
+        batch.urllib.request.urlopen = self._real
+
+    def test_resource_content_is_sent_as_text_not_content(self) -> None:
+        ok, _ = batch.post_document(
+            "http://h:8080", self.doc, user_id="u", api_key="", timeout_s=5
+        )
+        self.assertTrue(ok)
+        body = self.captured["body"]
+        self.assertIn("text", body)
+        self.assertIn("Apply the coupon", body["text"])
+        # `content` is not part of the envelope; sending it would be silently dropped.
+        self.assertNotIn("content", body)
+
+    def test_documents_are_finalized_and_waited_on_by_default(self) -> None:
+        batch.post_document("http://h:8080", self.doc, user_id="u", api_key="", timeout_s=5)
+        body = self.captured["body"]
+        self.assertTrue(body["finalize"])
+        self.assertTrue(body["wait"])
+
+    def test_finalize_can_be_turned_off_for_streaming_callers(self) -> None:
+        batch.post_document(
+            "http://h:8080", self.doc, user_id="u", api_key="", timeout_s=5, finalize=False
+        )
+        self.assertFalse(self.captured["body"]["finalize"])
+
+    def test_identity_and_scope_travel_with_the_document(self) -> None:
+        batch.post_document("http://h:8080", self.doc, user_id="acme", api_key="", timeout_s=5)
+        body = self.captured["body"]
+        self.assertEqual(body["identity_key"], batch.identity_key_for(self.doc))
+        self.assertEqual(body["scope"], {"user_id": "acme"})
+        self.assertTrue(self.captured["url"].endswith("/v1/ingest"))
+
+
 class ArgumentTest(unittest.TestCase):
     def test_resume_without_a_state_file_is_rejected(self) -> None:
         self.assertEqual(batch.main(["--dir", ".", "--resume"]), 2)

--- a/tools/test_matrixark_gateway_admin_config.py
+++ b/tools/test_matrixark_gateway_admin_config.py
@@ -60,10 +60,40 @@ class ModelConfigSnapshotTest(unittest.TestCase):
                 "MATRIXARK_EXTRACTION_API_KEY_ENV": "DEEPSEEK_API_KEY",
                 "DEEPSEEK_API_KEY": "present",
                 "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+                "MATRIXARK_EMBEDDING_API_BASE": "http://127.0.0.1:8400/v1",
+                "MATRIXARK_EMBEDDING_API_KEY_ENV": "LOCAL_ENCODER_KEY",
+                "LOCAL_ENCODER_KEY": "placeholder",
                 "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS": "1",
             }
         )
         self.assertEqual(gateway._model_config_snapshot()["warnings"], [])
+
+    def test_an_embedding_base_url_without_v1_is_called_out(self) -> None:
+        # <base>/embeddings never reaches an encoder serving /v1/embeddings, and the request still
+        # succeeds with hash vectors -- invisible without this warning.
+        os.environ.update(
+            {
+                "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+                "MATRIXARK_EMBEDDING_API_BASE": "http://127.0.0.1:8400",
+                "MATRIXARK_EMBEDDING_API_KEY_ENV": "LOCAL_ENCODER_KEY",
+                "LOCAL_ENCODER_KEY": "placeholder",
+                "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS": "1",
+            }
+        )
+        joined = " ".join(gateway._model_config_snapshot()["warnings"])
+        self.assertIn("does not end in /v1", joined)
+
+    def test_an_empty_embedding_key_is_called_out_even_for_a_local_encoder(self) -> None:
+        os.environ.update(
+            {
+                "MATRIXARK_EMBEDDING_PROVIDER": "openai_compatible",
+                "MATRIXARK_EMBEDDING_API_BASE": "http://127.0.0.1:8400/v1",
+                "MATRIXARK_EMBEDDING_API_KEY_ENV": "LOCAL_ENCODER_KEY",
+                "MATRIXARK_REQUIRE_MODEL_EMBEDDINGS": "1",
+            }
+        )
+        joined = " ".join(gateway._model_config_snapshot()["warnings"])
+        self.assertIn("is empty", joined)
 
     def test_a_named_provider_with_an_empty_key_is_called_out(self) -> None:
         os.environ["MATRIXARK_EXTRACTION_PROVIDER"] = "openai_compatible"

--- a/tools/test_matrixark_ingestion_jobs.py
+++ b/tools/test_matrixark_ingestion_jobs.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ingestion job path safety and progress accounting.
+
+The path tests carry the weight here. This endpoint ingests server-side files the caller names, so
+without a boundary it is a file-disclosure endpoint: "ingest /etc" would be a valid request. Every
+resolved path must sit inside ``MATRIXARK_INGESTION_ROOT``, traversal and symlinks included, and an
+unset root must refuse rather than default to the filesystem root.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_ingestion_jobs as jobs  # noqa: E402
+
+
+class PathSafetyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = os.environ.get("MATRIXARK_INGESTION_ROOT")
+        self.root = tempfile.mkdtemp(prefix="ingest-root-")
+        self.outside = tempfile.mkdtemp(prefix="ingest-outside-")
+        for name in ("a.md", "b.json"):
+            with open(os.path.join(self.root, name), "w", encoding="utf-8") as handle:
+                handle.write("# doc")
+        with open(os.path.join(self.outside, "secret.md"), "w", encoding="utf-8") as handle:
+            handle.write("# secret")
+        os.environ["MATRIXARK_INGESTION_ROOT"] = self.root
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop("MATRIXARK_INGESTION_ROOT", None)
+        else:
+            os.environ["MATRIXARK_INGESTION_ROOT"] = self._saved
+
+    def test_documents_inside_the_root_resolve(self) -> None:
+        found = jobs.resolve_request_paths(directory=self.root)
+        self.assertEqual(sorted(os.path.basename(p) for p in found), ["a.md", "b.json"])
+
+    def test_a_path_outside_the_root_is_refused(self) -> None:
+        with self.assertRaises(jobs.PathOutsideRoot):
+            jobs.resolve_request_paths(paths=[os.path.join(self.outside, "secret.md")])
+
+    def test_traversal_out_of_the_root_is_refused(self) -> None:
+        with self.assertRaises(jobs.PathOutsideRoot):
+            jobs.resolve_request_paths(directory=os.path.join(self.root, "..", "..", "etc"))
+
+    def test_a_symlink_pointing_outside_the_root_is_refused(self) -> None:
+        link = os.path.join(self.root, "escape.md")
+        try:
+            os.symlink(os.path.join(self.outside, "secret.md"), link)
+        except (OSError, NotImplementedError):  # pragma: no cover - platforms without symlinks
+            self.skipTest("symlinks unavailable")
+        with self.assertRaises(jobs.PathOutsideRoot):
+            jobs.resolve_request_paths(paths=[link])
+
+    def test_an_unset_root_refuses_rather_than_defaulting_to_the_filesystem(self) -> None:
+        os.environ.pop("MATRIXARK_INGESTION_ROOT", None)
+        with self.assertRaises(jobs.IngestionRootNotConfigured):
+            jobs.resolve_request_paths(paths=["/etc/passwd"])
+
+    def test_duplicates_are_removed_and_order_preserved(self) -> None:
+        a = os.path.join(self.root, "a.md")
+        found = jobs.resolve_request_paths(paths=[a, a, os.path.join(self.root, "b.json")])
+        self.assertEqual([os.path.basename(p) for p in found], ["a.md", "b.json"])
+
+
+class ProgressTest(unittest.TestCase):
+    def test_a_fresh_job_reports_everything_remaining(self) -> None:
+        job = jobs.Job("j1", ["/x/a.md", "/x/b.md"], {"user_id": "u"})
+        snap = job.snapshot()
+        self.assertEqual((snap["total"], snap["done"], snap["remaining"]), (2, 0, 2))
+        self.assertEqual(snap["state"], "queued")
+
+    def test_counters_and_eta_move_with_progress(self) -> None:
+        job = jobs.Job("j2", ["/x/a.md", "/x/b.md", "/x/c.md", "/x/d.md"], {})
+        job.done, job.failed, job.bytes = 2, 1, 4096
+        snap = job.snapshot()
+        self.assertEqual((snap["done"], snap["failed"], snap["remaining"]), (2, 1, 1))
+        self.assertEqual(snap["bytes"], 4096)
+
+    def test_prometheus_text_is_valid_exposition_format(self) -> None:
+        text = jobs.prometheus_text()
+        lines = [l for l in text.split("\n") if l and not l.startswith("#")]
+        self.assertTrue(lines, "expected at least one sample line")
+        for line in lines:
+            name, _, value = line.partition(" ")
+            self.assertTrue(name.startswith("matrixark_ingestion_"), name)
+            float(value)  # every sample must parse as a number
+        # HELP/TYPE must accompany each metric family.
+        self.assertIn("# HELP matrixark_ingestion_documents_done", text)
+        self.assertIn("# TYPE matrixark_ingestion_documents_done counter", text)
+
+    def test_the_registry_is_bounded(self) -> None:
+        registry = jobs.JobRegistry()
+        for index in range(jobs.MAX_RETAINED_JOBS + 10):
+            job = jobs.Job("job%d" % index, [], {})
+            with registry._lock:  # submit() would start threads; exercise retention directly
+                registry._jobs[job.id] = job
+                registry._order.insert(0, job.id)
+                while len(registry._order) > jobs.MAX_RETAINED_JOBS:
+                    registry._jobs.pop(registry._order.pop(), None)
+        self.assertEqual(len(registry.list()), jobs.MAX_RETAINED_JOBS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #464, from running the batch ingester end to end against a live gateway.

## Two silent failures in the ingester

**Resource content was sent as `content`.** The ingest envelope reads it from
`text`/`resource_text` (docs/INGEST_SCHEMA.md, "Content requirement by kind"); `content` is not a
field it knows, so it was dropped and the request fell back to the `messages` copy.

**Documents were neither finalized nor waited on.** Such an ingest is accepted as a deferred
lightweight event — the call returns `202` and the document is *not* retrievable when it returns.

Together these meant a batch import could report a thousand successes and read back nothing. A
document is a complete unit, unlike a streaming chat message, so `finalize` and `wait` now default
on; `--no-finalize` keeps the old behaviour for streaming callers.

Four new tests pin the wire shape, since both mistakes are silent: the payload must carry `text`,
must not carry `content`, and must default to finalize + wait.

## Encoder model is configurable

`MATRIXARK_EMBEDDING_MODEL_PATH` (local directory) or `MATRIXARK_EMBEDDING_MODEL` (hub id), so a
deployment can run the encoder its retrieval was tuned for. Both MiniLM variants emit 384
dimensions, so switching does not change the stored vector width. Verified live: the multilingual
model scores 0.738 cosine between an English query and its Chinese equivalent, and encodes 198
texts/s on two cores.

## Guide

Documents the two failures a large-document import actually hits: the chunk cap (~240-token chunks
make a 1 MB document produce ~2510 chunks against a default cap of 2048, and chunk size trades
memory against how much of each chunk the embedding window covers) and the `TS_WAL_BLOCK_FOOTER`
prerequisite for durable commits.

27 tests pass.