### PR TITLE
Remove one component's page refs by range instead of walking them all

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -443,9 +443,25 @@ impl CoreIndex {
             .remove(&object_page_lookup_key(model_id, object_key, component));
         let component_lookup_key = object_component_lookup_key(model_id, object_key);
         if let Some(component_refs) = self.object_component_lookup.get_mut(&component_lookup_key) {
-            let before = component_refs.len();
-            component_refs.retain(|page_ref| page_ref.component.as_deref() != component);
-            let removed = before - component_refs.len();
+            // `ComponentPageLookupRef` orders on `component` first, so every ref for one component
+            // is a contiguous range and can be found by seeking to it. Walking the whole set
+            // instead cost time proportional to how many components the object has -- and for a
+            // shard hash the components ARE its fields, so writing one field walked every field
+            // already in that hash, once per field written.
+            let first = ComponentPageLookupRef {
+                component: component.map(str::to_string),
+                routing_bucket: 0,
+                page_ref_key: String::new(),
+            };
+            let doomed: Vec<ComponentPageLookupRef> = component_refs
+                .range(first..)
+                .take_while(|page_ref| page_ref.component.as_deref() == component)
+                .cloned()
+                .collect();
+            let removed = doomed.len();
+            for page_ref in doomed {
+                component_refs.remove(&page_ref);
+            }
             if removed > 0 {
                 if let Some(total) = self.object_component_page_refs.as_mut() {
                     *total = total.saturating_sub(removed);
@@ -590,4 +606,121 @@ pub(super) enum PackedFeaturePageDecode {
 pub(super) struct SeenSet {
     pub(super) by_member: BTreeMap<Vec<u8>, u64>,
     pub(super) by_time: BTreeMap<(u64, Vec<u8>), ()>,
+}
+
+
+#[cfg(test)]
+mod component_lookup_tests {
+    use super::*;
+
+    fn core_with(object: &str, components: &[Option<&str>]) -> CoreIndex {
+        let mut index = CoreIndex::default();
+        let set = index
+            .object_component_lookup
+            .entry(object_component_lookup_key("hash", object))
+            .or_default();
+        for (i, component) in components.iter().enumerate() {
+            set.insert(ComponentPageLookupRef {
+                component: component.map(str::to_string),
+                routing_bucket: i as u32,
+                page_ref_key: format!("p{i}"),
+            });
+        }
+        index
+    }
+
+    fn components_left(index: &CoreIndex, object: &str) -> Vec<Option<String>> {
+        index
+            .object_component_lookup
+            .get(&object_component_lookup_key("hash", object))
+            .map(|refs| refs.iter().map(|r| r.component.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn removing_one_component_leaves_the_others() {
+        let mut index = core_with("k", &[Some("a"), Some("b"), Some("c")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("b"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("c".to_string())]
+        );
+    }
+
+    #[test]
+    fn removing_the_first_and_last_components_works() {
+        let mut index = core_with("k", &[Some("a"), Some("b"), Some("c")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("a"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("b".to_string()), Some("c".to_string())]
+        );
+        index.remove_object_page_lookup_entry("hash", "k", Some("c"));
+        assert_eq!(components_left(&index, "k"), vec![Some("b".to_string())]);
+    }
+
+    #[test]
+    fn a_none_component_is_removable_and_does_not_take_the_others() {
+        // `None` sorts before every `Some`, so it is the range's first element -- the case most
+        // likely to run off the front of the set.
+        let mut index = core_with("k", &[None, Some("a"), Some("b")]);
+        index.remove_object_page_lookup_entry("hash", "k", None);
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("b".to_string())]
+        );
+    }
+
+    #[test]
+    fn every_ref_sharing_a_component_goes() {
+        let mut index = CoreIndex::default();
+        let set = index
+            .object_component_lookup
+            .entry(object_component_lookup_key("hash", "k"))
+            .or_default();
+        for i in 0..3u32 {
+            set.insert(ComponentPageLookupRef {
+                component: Some("dup".to_string()),
+                routing_bucket: i,
+                page_ref_key: format!("p{i}"),
+            });
+        }
+        set.insert(ComponentPageLookupRef {
+            component: Some("keep".to_string()),
+            routing_bucket: 9,
+            page_ref_key: "p9".to_string(),
+        });
+        index.remove_object_page_lookup_entry("hash", "k", Some("dup"));
+        assert_eq!(components_left(&index, "k"), vec![Some("keep".to_string())]);
+    }
+
+    #[test]
+    fn removing_an_absent_component_changes_nothing() {
+        let mut index = core_with("k", &[Some("a"), Some("b")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("zzz"));
+        assert_eq!(
+            components_left(&index, "k"),
+            vec![Some("a".to_string()), Some("b".to_string())]
+        );
+    }
+
+    #[test]
+    fn emptying_the_set_drops_the_key_entirely() {
+        let mut index = core_with("k", &[Some("only")]);
+        index.remove_object_page_lookup_entry("hash", "k", Some("only"));
+        assert!(index
+            .object_component_lookup
+            .get(&object_component_lookup_key("hash", "k"))
+            .is_none());
+    }
+
+    #[test]
+    fn the_running_ref_total_is_decremented_by_what_was_removed() {
+        // main keeps a running total beside the map; `retain` derived the decrement by
+        // differencing the length, and this form knows it directly. Same number either way.
+        let mut index = core_with("k", &[Some("a"), Some("b"), Some("c")]);
+        index.object_component_page_refs = Some(3);
+        index.remove_object_page_lookup_entry("hash", "k", Some("b"));
+        assert_eq!(index.object_component_page_refs, Some(2));
+    }
 }


### PR DESCRIPTION
Writing one field of a hash walks every field already in that hash. This stops it.

`remove_object_page_lookup_entry` drops the page refs for one component with `retain`, which visits
every ref the object has. For an ordinary object that is nothing. **For a shard hash the
"components" are its fields** — so writing one field walks every field already in that hash, once
per field written, and what a write costs grows with how much has already been written to it.

`ComponentPageLookupRef` derives `Ord` with `component` first, so the set is ordered by component
and every ref for one component sits in a contiguous run. Seeking to that run and removing only its
members drops exactly the same refs — `retain` kept the complement — in O(log n + k) instead of
O(n).

### Measured, on this branch against `main`

Component refs **visited** per add is the mechanism and, unlike wall clock, does not move with
machine load. 300 memories, arms alternating, two rounds:

| arm | refs visited per add | removals per add | set size |
|---|---:|---:|---:|
| `main` | 161 227 · 161 834 | 146.5 | 1 101 |
| **this branch** | **93 · 93** | 146.5 | 1 100 |

Same removals, same set, **1 700× fewer refs visited**. Add p50 moved 201/183 → 185/121 ms, but
this machine swings more than that between runs, so the counts carry the claim and the clock is
reported only as consistent with them.

`TS_WAL_BLOCK_FOOTER=1` was set in **both** arms. Without it `main` runs about 6.4 s per add and a
fill never finishes — that is a separate defect with its own change, and holding it constant is
what makes this comparison about this change.

### Tests

Seven tests beside the code (`component_lookup_tests`): removing a middle, first and last
component; a `None` component, which sorts before every `Some` and is the case most likely to run
off the front of the range; several refs sharing one component, all of which must go; an absent
component changing nothing; an emptied set dropping its key; and the running ref total being
decremented by exactly what was removed — `retain` derived that count by differencing the length,
and the range form knows it directly, so it is worth pinning that they agree.

Mutation-checked on an earlier revision of this change: seeking from the start of the set instead
of from the component fails two of them.

`cargo check --all-targets` clean on both repos, from a byte-identical file.

### Note on where this came from

This was originally part of a stack cut before `main` gained its bucket-maintenance work. Three of
that stack's changes turned out to duplicate what `main` has since done independently and are being
closed rather than rebased. This one is not duplicated — the walk is still there on `main` — so it
is rebuilt here against current `main` as a single commit touching a single file.
