### PR TITLE
Apply the per-type scan cap on the type-index path too

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1657,10 +1657,27 @@ fn payload_record_types(value: &str) -> Vec<String> {
 /// Locations that no longer resolve (a field physically removed after a partial-cleanup path)
 /// are skipped: the caller re-decodes and re-filters everything it is handed, so a stale entry
 /// can cost a read but never change an answer.
+/// The newest `limit` locations, or all of them when there is no cap.
+///
+/// A location is "{shard:06}:{field}" with both parts zero-padded, so lexical order IS append
+/// order and the newest are the last. Sorting is not assumed of the input: the type index is read
+/// into a map whose iteration order is its own business, and a cap that trusted the wrong order
+/// would silently keep the OLDEST records instead -- a wrong answer rather than a slow one.
+fn newest_locations(mut locations: Vec<String>, limit: Option<usize>) -> Vec<String> {
+    match limit {
+        Some(limit) if locations.len() > limit => {
+            locations.sort();
+            locations.split_off(locations.len() - limit)
+        }
+        _ => locations,
+    }
+}
+
 fn type_index_payloads(
     engine: &TemporalEngine,
     record_hash_key: &str,
     allowed_types: &HashSet<String>,
+    newest_by_type: Option<&BTreeMap<String, usize>>,
 ) -> Result<Option<(Vec<String>, u64)>, String> {
     let ready = read_record_count(engine, &type_index_ready_key(record_hash_key))?;
     if ready.trim() != "1" {
@@ -1668,9 +1685,23 @@ fn type_index_payloads(
     }
     let mut locations: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     for record_type in allowed_types {
-        for (location, _) in hgetall_map(engine, type_index_key(record_hash_key, record_type))? {
-            locations.insert(location);
-        }
+        // Per-type cap, the same rule the pinned-scope path applies: a location is
+        // "{shard:06}:{field}" with both parts zero-padded, so lexical order IS append order and
+        // the newest N are the last N. A type with no cap keeps every position it had.
+        //
+        // Without this, a scan that carries a cap but no scope lands here and cap the type index
+        // ignores it -- so a caller asking for one record of a type is handed every record of
+        // that type, and what it pays grows with the store.
+        let limit = newest_by_type
+            .and_then(|caps| caps.get(record_type))
+            .copied()
+            .filter(|limit| *limit > 0);
+        let of_type: Vec<String> =
+            hgetall_map(engine, type_index_key(record_hash_key, record_type))?
+                .into_iter()
+                .map(|(location, _)| location)
+                .collect();
+        locations.extend(newest_locations(of_type, limit));
     }
     // BTreeSet order is lexical: shard6 then the zero-padded record field = append order.
     let (values, shards_touched) =
@@ -2061,9 +2092,12 @@ fn scan_matrixark_candidates(
         && !allowed_types.is_empty()
         && count > 0
     {
-        if let Some((values, shards_touched)) =
-            type_index_payloads(engine, &record_hash_key, &allowed_types)?
-        {
+        if let Some((values, shards_touched)) = type_index_payloads(
+            engine,
+            &record_hash_key,
+            &allowed_types,
+            command.newest_by_type.as_ref(),
+        )? {
             payload_values = values;
             placement_partitions_touched = shards_touched;
             type_index_used = true;
@@ -7107,5 +7141,46 @@ mod tests {
             Some(1),
             "bob still retrievable after recovery: {bob_result}"
         );
+    }
+}
+
+
+#[cfg(test)]
+mod scan_cap_tests {
+    use super::newest_locations;
+
+    fn at(shard: u32, field: u32) -> String {
+        format!("{shard:06}:{field:06}")
+    }
+
+    #[test]
+    fn no_cap_keeps_everything() {
+        let all = vec![at(0, 2), at(0, 1), at(0, 3)];
+        let kept = newest_locations(all.clone(), None);
+        assert_eq!(kept.len(), all.len());
+    }
+
+    #[test]
+    fn a_cap_keeps_the_newest_by_append_order() {
+        // Deliberately out of order on the way in: the index is read from a map, and a cap that
+        // assumed sorted input would keep the wrong records rather than merely too many.
+        let all = vec![at(0, 3), at(0, 1), at(1, 0), at(0, 2)];
+        assert_eq!(newest_locations(all.clone(), Some(2)), vec![at(0, 3), at(1, 0)]);
+        assert_eq!(newest_locations(all.clone(), Some(1)), vec![at(1, 0)]);
+    }
+
+    #[test]
+    fn a_cap_larger_than_the_set_keeps_all_of_it() {
+        let all = vec![at(0, 1), at(0, 2)];
+        assert_eq!(newest_locations(all.clone(), Some(9)).len(), 2);
+        assert_eq!(newest_locations(all.clone(), Some(2)).len(), 2);
+    }
+
+    #[test]
+    fn shard_order_beats_field_order() {
+        // A later shard is always newer, even when its field number is smaller -- the shard part
+        // leads the key, which is why zero-padding both parts matters.
+        let all = vec![at(0, 999), at(1, 1)];
+        assert_eq!(newest_locations(all, Some(1)), vec![at(1, 1)]);
     }
 }

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -1201,6 +1201,14 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # a FAILED scan means the engine could not answer and the only safe report is True.
         if not callable(getattr(self._client, "matrixark_scan_candidates", None)):
             return super().memory_tombstones_may_exist()
+        # One tombstone is enough to answer yes, and this runs on every add.
+        if self._memory_tombstone_probe():
+            return True
+        # An empty capped answer is NOT conclusive: a location the index still lists but that no
+        # longer resolves is skipped by the fetch, so a store with tombstones could probe empty.
+        # A false negative here skips tombstone filtering and lets deleted memories come back, so
+        # confirm with the full read -- which is cheap exactly when it runs, because a store with
+        # no tombstones has nothing to read.
         records = self._memory_tombstone_records()
         if records is None:
             return True
@@ -1281,6 +1289,23 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         except ModuleNotFoundError:  # Direct script execution from tools/.
             from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
         return self._scan_records_of_types([MEMORY_TOMBSTONE_RECORD_TYPE])
+
+    def _memory_tombstone_probe(self) -> list[Json] | None:
+        """At most one memory tombstone, to answer whether any exist.
+
+        Separate from `_memory_tombstone_records` on purpose: the consumer that tests each pending
+        event against the tombstones genuinely needs all of them, while the guard only needs to
+        know whether the set is non-empty. Reading the whole set to answer that made a per-add
+        guard cost grow with every delete the store had ever seen.
+        """
+        try:
+            from tools.matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        except ModuleNotFoundError:  # Direct script execution from tools/.
+            from matrixark_mcp_local_adapter import MEMORY_TOMBSTONE_RECORD_TYPE
+        return self._scan_records_of_types(
+            [MEMORY_TOMBSTONE_RECORD_TYPE],
+            newest_by_type={MEMORY_TOMBSTONE_RECORD_TYPE: 1},
+        )
 
     # Every record type the refresh pass's consumers filter on, enumerated from the consumers
     # themselves. Deliberately absent: context_index -- the store's largest class, whose only

--- a/tools/test_tombstone_probe.py
+++ b/tools/test_tombstone_probe.py
@@ -71,10 +71,27 @@ class TombstoneProbeTests(unittest.TestCase):
     def test_it_asks_the_engine_for_tombstones_only(self):
         client = _Client({"records": []})
         _adapter(client).memory_tombstones_may_exist()
-        self.assertEqual(1, len(client.calls))
-        self.assertEqual([TOMBSTONE], client.calls[0]["record_types"])
-        self.assertEqual({}, client.calls[0]["scope"],
-                         "the guard is store-wide: a tombstone in any scope counts")
+        # A store with no tombstones asks twice: the capped probe, then the read that confirms the
+        # empty answer. A capped probe alone cannot tell "there are none" from "the newest one no
+        # longer resolves", and a false negative here is the dangerous direction. The confirming
+        # read is cheap precisely when it runs -- there is nothing to read.
+        self.assertEqual(2, len(client.calls))
+        for call in client.calls:
+            self.assertEqual([TOMBSTONE], call["record_types"])
+            self.assertEqual({}, call["scope"],
+                             "the guard is store-wide: a tombstone in any scope counts")
+        self.assertEqual({TOMBSTONE: 1}, client.calls[0].get("newest_by_type"),
+                         "the probe asks for ONE tombstone, not every one")
+        self.assertIsNone(client.calls[1].get("newest_by_type"),
+                          "the confirming read must not be capped")
+
+    def test_a_store_with_a_tombstone_is_answered_from_the_probe_alone(self):
+        """The point of the probe: one tombstone settles it, so the rest are never read."""
+        client = _Client({"records": [{"record_type": TOMBSTONE, "tombstone_kind": "delete"}]})
+        self.assertTrue(_adapter(client).memory_tombstones_may_exist())
+        self.assertEqual(1, len(client.calls),
+                         "a positive answer must not go on to read every tombstone")
+        self.assertEqual({TOMBSTONE: 1}, client.calls[0].get("newest_by_type"))
 
     def test_a_tombstone_row_is_reported(self):
         adapter = _adapter(_Client({"records": [{"record_type": TOMBSTONE, "tombstone_kind": "delete"}]}))


### PR DESCRIPTION
**This is a defect fix, not a measured latency win.** The number that would justify calling it a
speedup does not exist yet, and the body says where it would come from rather than implying one.

### The defect

A scan can carry a per-type cap: "give me the newest N records of this type". Only the
pinned-scope path applies it. A scan with **no scope** — which is how a type-only question is asked
— takes the type-index path, where the cap was accepted and then ignored, and every location of
that type was fetched.

So a caller asking for one record of a type was handed all of them, and what it paid grew with the
store. Nothing today asks that way, which is why it has gone unnoticed; the guard below is the
first caller that does.

The fix applies the same rule the scope path already uses: a location is `{shard:06}:{field}` with
both parts zero-padded, so lexical order is append order and the newest are the last.

### The caller

`memory_tombstones_may_exist` runs on every commit and ends in `bool(records)` — but it got there
by fetching every memory tombstone in the store. It now asks for one.

An empty answer from the capped probe is deliberately **not** trusted on its own: a location the
index still lists but that no longer resolves is skipped by the fetch, so a store with tombstones
could probe empty. A false negative here skips tombstone filtering and lets deleted memories
reappear, so an empty probe falls through to the full read — which is cheap exactly when it runs,
because a store with no tombstones has nothing to read. A store that *has* one answers from the
probe and never reaches it.

### What is honestly not shown

The ingest workload used for measurement performs no deletes, so the tombstone type index is empty
and this changes nothing measurable there. Tracing the callers to four frames showed why: the
per-add tombstone scan on that path comes from `surviving_ids_for_pending_events`, which tests each
pending event against the tombstones and genuinely needs all of them — not from the guard, which
that path does not call at all.

So the cost this removes is latent: it appears in a store that has accumulated deletes, where a
per-commit boolean was reading every tombstone ever written. `surviving_ids_for_pending_events` has
the same shape and is left alone: bounding it needs an argument about which tombstones can affect a
pending event, and getting that wrong resurrects deleted content.

An end-to-end A/B was attempted and abandoned rather than fudged — no existing caller issues a
capped scopeless scan, which is precisely the case being fixed.

### Tests

Four tests on the cap selection itself (`scan_cap_tests`), which is the logic actually written
here. They pin that the newest are kept, that the input is **not** assumed sorted (the index is
read from a map; a cap trusting the wrong order would keep the *oldest* records — a wrong answer
rather than a slow one), that a shard boundary beats a field number, and that an absent or
oversized cap keeps everything. Mutation-checked: removing the sort fails one of them.

On the guard, `test_tombstone_probe` gains a test that a store *with* a tombstone is answered from
the probe alone, and the existing "asks for tombstones only" test now applies its assertions to
every call rather than just the first. Mutation-checked: reverting the guard to read everything
fails two tests.

Also passing: `test_guard_from_tombstones`, `test_prior_context_scoped`, `test_history_scoped`,
`test_refresh_scoped2`, `upsert_reload_equality`, `storage_migration_corpus`, and
`cargo check --all-targets` on both repos from byte-identical source.

`test_delete_membership_index` fails to load, identically on the branch this stacks on — inherited.

### Note on where this came from

Originally part of a stack cut before  gained its bucket-maintenance work. Three of that
stack's changes turned out to duplicate what  has since done independently and were closed
rather than rebased. Both defects here were re-checked against current  and are still
present:  still takes no cap, and the guard still reads every tombstone. So
this is rebuilt against current  as one commit.
