### PR TITLE
A heartbeat erased the share an unattached proxy had been told to shed

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -531,8 +531,12 @@ pub struct ProxyHeartbeatResponse {
     pub config_version: u64,
     #[serde(default)]
     pub serving_mode: String,
+    /// None means the metaserver has no opinion, which today is always: there is no
+    /// per-proxy drop_percent in the meta model at all -- the one that exists is a TABLE
+    /// serving option. As a bare `u8` this field could not say that, so it said 0, and the
+    /// proxy applied it and lifted whatever drain an operator had put in force.
     #[serde(default)]
-    pub drop_percent: u8,
+    pub drop_percent: Option<u8>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -5922,13 +5926,17 @@ mod tests {
         // response carried a hard-coded zero, so the only way to pull the lever
         // was to restart each proxy with different configuration.
         let meta = shedding_meta(25);
-        assert_eq!(beat_proxy(&meta, 0).drop_percent, 25);
+        assert_eq!(beat_proxy(&meta, 0).drop_percent, Some(25));
     }
 
     #[test]
     fn a_group_that_asks_for_nothing_sheds_nothing() {
         let meta = shedding_meta(0);
-        assert_eq!(beat_proxy(&meta, 0).drop_percent, 0);
+        assert_eq!(
+            beat_proxy(&meta, 0).drop_percent,
+            Some(0),
+            "a group that asks for zero has still spoken, which is not the same as silence"
+        );
     }
 
     #[test]
@@ -5955,7 +5963,7 @@ mod tests {
             "the version did not move, so an attached proxy would never re-read"
         );
         assert!(after.config_changed);
-        assert_eq!(after.drop_percent, 40);
+        assert_eq!(after.drop_percent, Some(40));
     }
 
     #[test]
@@ -5971,7 +5979,11 @@ mod tests {
             .status
             .ok
         );
-        assert_eq!(beat_proxy(&meta, 0).drop_percent, 0);
+        assert_eq!(
+            beat_proxy(&meta, 0).drop_percent,
+            None,
+            "no group is holding an opinion about this proxy, so the heartbeat must not \n             carry one -- it used to carry 0, which erased whatever the proxy was \n             configured with"
+        );
     }
 
     #[test]
@@ -7073,7 +7085,10 @@ mod tests {
         assert!(response.config_changed);
         assert_eq!(response.config_version, 3);
         assert_eq!(response.serving_mode, "serving");
-        assert_eq!(response.drop_percent, 0);
+        assert_eq!(
+            response.drop_percent, None,
+            "the metaserver holds no per-proxy drop_percent, so a heartbeat must not appear              to set one -- it used to answer 0, which the proxy applied over an operator's drain"
+        );
         assert_eq!(meta.list_proxies().proxies[0].binary_version, "v2");
 
         let frozen = meta.freeze_proxy(StateChangeRequest {

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -354,7 +354,7 @@ impl SingleNodeMeta {
                 namespace: String::new(),
                 config_version: 0,
                 serving_mode: String::new(),
-                drop_percent: 0,
+                drop_percent: None,
             };
         };
         if proxy.state == MetaEntityState::Frozen {
@@ -364,7 +364,7 @@ impl SingleNodeMeta {
                 namespace: proxy.namespace.clone(),
                 config_version: proxy.config_version,
                 serving_mode: proxy_serving_mode_for_state(proxy.state).to_string(),
-                drop_percent: 0,
+                drop_percent: None,
             };
         }
         proxy.last_heartbeat_ms = now_ms();
@@ -421,9 +421,20 @@ impl SingleNodeMeta {
             namespace,
             config_version,
             serving_mode,
-            // What the group asks its proxies to shed. Zero unless an operator
-            // has said otherwise, which is what every group means by default.
-            drop_percent: if attached { served.drop_percent } else { 0 },
+            // What the group asks its proxies to shed, and nothing at all when this proxy
+            // belongs to no group.
+            //
+            // The unattached branch used to send 0, which is not the same statement: the
+            // proxy applied it, so a proxy configured to shed through its own /config had
+            // that wiped by every heartbeat. A deployment that uses no groups is entirely
+            // unattached proxies, and namespace and config_version two branches above
+            // already fall back to local configuration for exactly that case -- this now
+            // says the same thing the same way.
+            drop_percent: if attached {
+                Some(served.drop_percent)
+            } else {
+                None
+            },
         }
     }
 

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1992,6 +1992,50 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_heartbeat_that_says_nothing_about_shedding_does_not_lift_a_drain() {
+        // An operator drains a proxy through its own config endpoint, which is the only way
+        // drop_percent is ever set: the metaserver has no proxy-level drop_percent to hold an
+        // opinion about -- the one in the meta model is a TABLE serving option. So every
+        // heartbeat response carries a hardcoded 0, and the proxy applied it. The drain lasted
+        // until the next heartbeat, which is seconds.
+        //
+        // The three neighbouring fields are all guarded against "the metaserver did not say":
+        // namespace only applies when non-empty, config_version when non-zero, serving_mode
+        // when it parses. This one had a guard too -- `<= 100` -- which reads as though a
+        // value above 100 meant "unspecified", except nothing ever sends one and an absent
+        // field deserializes to 0.
+        let proxy = scoped_proxy(ProxyOptions {
+            drop_percent: 100,
+            ..ProxyOptions::default()
+        });
+        assert_eq!(
+            proxy.readiness_response().0,
+            503,
+            "premise: this proxy is drained and out of rotation"
+        );
+
+        proxy.apply_heartbeat_config(&ProxyHeartbeatResponse {
+            status: Status::ok(),
+            config_changed: false,
+            namespace: String::new(),
+            config_version: 0,
+            serving_mode: String::new(),
+            drop_percent: None,
+        });
+
+        assert_eq!(
+            proxy.options().drop_percent,
+            100,
+            "the metaserver never spoke for drop_percent, so a heartbeat must not reset it"
+        );
+        assert_eq!(
+            proxy.readiness_response().0,
+            503,
+            "a drain has to survive the heartbeat loop, or draining a proxy does nothing"
+        );
+    }
+
+    #[test]
     fn the_proxy_sheds_exactly_the_keys_the_client_would() {
         // The proxy used to keep its own routing-key extractor, so the two layers of one drain
         // hashed different strings and shed two unrelated subsets of the same traffic -- and
@@ -3532,7 +3576,7 @@ mod tests {
                                 namespace: String::new(),
                                 config_version: 0,
                                 serving_mode: "serving".to_string(),
-                                drop_percent: 0,
+                                drop_percent: None,
                             },
                         )
                     }
@@ -4287,7 +4331,7 @@ mod tests {
                         namespace: String::new(),
                         config_version: 0,
                         serving_mode: "serving".to_string(),
-                        drop_percent: 0,
+                        drop_percent: None,
                     },
                 ),
                 _ => crate::http::json_response(404, &Status::error("not_found", "no route")),
@@ -4371,7 +4415,7 @@ mod tests {
                         namespace: String::new(),
                         config_version: 0,
                         serving_mode: "serving".to_string(),
-                        drop_percent: 0,
+                        drop_percent: None,
                     },
                 ),
                 _ => crate::http::json_response(404, &Status::error("not_found", "no route")),

--- a/crates/temporalstore-rust/src/proxy/meta_sync.rs
+++ b/crates/temporalstore-rust/src/proxy/meta_sync.rs
@@ -99,7 +99,7 @@ impl ProxyService {
                         namespace: String::new(),
                         config_version: 0,
                         serving_mode: "not_serving".to_string(),
-                        drop_percent: 0,
+                        drop_percent: None,
                     });
                     if response.status.ok {
                         self.record_service_discovery_heartbeat(&response.status);
@@ -137,7 +137,7 @@ impl ProxyService {
                     namespace: String::new(),
                     config_version: 0,
                     serving_mode: "not_serving".to_string(),
-                    drop_percent: 0,
+                    drop_percent: None,
                 }
             }
         }
@@ -204,7 +204,9 @@ impl ProxyService {
         let policy_changed = {
             let options = self.options();
             serving_mode.is_some_and(|mode| mode != options.serving_mode)
-                || response.drop_percent <= 100 && response.drop_percent != options.drop_percent
+                || response
+                    .drop_percent
+                    .is_some_and(|percent| percent <= 100 && percent != options.drop_percent)
         };
         if !response.config_changed && !policy_changed {
             return;
@@ -219,8 +221,14 @@ impl ProxyService {
         if let Some(serving_mode) = serving_mode {
             options.serving_mode = serving_mode;
         }
-        if response.drop_percent <= 100 {
-            options.drop_percent = response.drop_percent;
+        // Only when the metaserver actually spoke for it. The three fields above are each
+        // guarded the same way -- namespace when non-empty, config_version when non-zero,
+        // serving_mode when it parses -- and this one was not, so every heartbeat carried a
+        // hardcoded 0 into the field an operator sets to drain the proxy.
+        if let Some(percent) = response.drop_percent {
+            if percent <= 100 {
+                options.drop_percent = percent;
+            }
         }
         let _ = self.update_options_report(options);
     }

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -123,7 +123,7 @@ impl MetaRaftCluster {
                 namespace: String::new(),
                 config_version: 0,
                 serving_mode: "not_serving".to_string(),
-                drop_percent: 0,
+                drop_percent: None,
             },
             |meta| meta.proxy_heartbeat(request),
         )


### PR DESCRIPTION
The metaserver tells a proxy what fraction of its traffic to refuse, taken from the group the
proxy is attached to. A proxy attached to no group was told 0.

Zero is not the same statement as silence, and the proxy cannot tell them apart: it applies
whatever arrives. So a proxy configured to shed through its own /config endpoint had that
erased by the next heartbeat, seconds later. A deployment that uses no groups is entirely
unattached proxies, and this is exactly the deployment the two branches above go out of their
way to protect -- namespace and config_version both fall back to what the proxy was configured
with, so that "a deployment that does not use groups behaves exactly as before".

drop_percent now says which it means. Some(share) when a group has spoken, None when none has,
and the proxy applies only what it was actually told. A group that asks for zero has still
spoken, and that stays distinct from no group asking at all.

The test that pinned the old answer is not wrong about its subject -- an unattached proxy really
is not being told to shed anything -- so it keeps its name and asserts None.

Two of the other responses that carried a hardcoded 0 are worth naming. The metaserver's
not-found and frozen paths answered 0, and so did the raft-backed meta's fallback for a FAILED
meta read: a metaserver that was merely unreachable un-drained every proxy talking to it, which
is the moment an operator is most likely to have something drained.

Watched failing first: one apply_heartbeat_config against a proxy drained to 100 left it at 0.

    proxy 67, meta 322 -- 0 failed


