### PR TITLE
The gauge that says a metric family is covered could not say otherwise

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1908,6 +1908,26 @@ pub(super) fn proxy_metric_families_from(rendered: &str) -> Vec<String> {
     families
 }
 
+/// The mapping table, answered against the metrics a render actually produced.
+///
+/// `covered` is set where each mapping is built, and it was set to `true` there, so it said
+/// the same thing whether or not the proxy still published the family the mapping names. Both
+/// things that read it -- the JSON report and the `metric_family_parity` gauge -- therefore
+/// could not fall to 0 whatever happened to the metrics they claim to track. The sibling list
+/// on this report was already fixed the same way, for the same reason.
+pub(super) fn proxy_metric_mappings_against(rendered: &str) -> Vec<ProxyMetricFamilyMapping> {
+    let families = proxy_metric_families_from(rendered);
+    proxy_metrics_parity_mappings()
+        .into_iter()
+        .map(|mut mapping| {
+            mapping.covered = families
+                .iter()
+                .any(|family| *family == mapping.rust_prometheus_family);
+            mapping
+        })
+        .collect()
+}
+
 fn proxy_metrics_parity_mappings() -> Vec<ProxyMetricFamilyMapping> {
     vec![
         proxy_metric_mapping(
@@ -1972,7 +1992,9 @@ fn proxy_metric_mapping(
         rust_prometheus_family: rust_prometheus_family.to_string(),
         rust_labels: rust_labels.into_iter().map(str::to_string).collect(),
         grafana_panel: grafana_panel.to_string(),
-        covered: true,
+        // Unproven here on purpose; `proxy_metric_mappings_against` answers it from the
+        // metrics that were actually rendered.
+        covered: false,
     }
 }
 
@@ -1990,6 +2012,50 @@ fn proxy_addr_port(addr: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_mapping_claims_coverage_only_while_the_family_is_published() {
+        // `covered` is set where each mapping is built, and it was built as true, so the
+        // JSON report and the metric_family_parity gauge said "covered" whether or not the
+        // proxy still published the family named. A check that cannot fail is not a check:
+        // if a family were renamed or dropped, the gauge would have gone on reading 1 and
+        // the dashboard built on it would have gone quiet with nothing to say so.
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let rendered = proxy.prometheus_metrics();
+
+        let live = proxy_metric_mappings_against(&rendered);
+        assert!(!live.is_empty(), "premise: there are mappings to check");
+        assert!(
+            live.iter().all(|mapping| mapping.covered),
+            "every mapped family is published today, so all of them must read covered"
+        );
+
+        // Take one family out of the rendered metrics. The mapping that names it has to stop
+        // claiming coverage, and no other mapping may be disturbed.
+        let dropped = live[0].rust_prometheus_family.clone();
+        let without = rendered.replace(
+            &format!("# TYPE {dropped} "),
+            "# TYPE temporalstore_proxy_family_that_is_not_published ",
+        );
+        assert_ne!(without, rendered, "premise: the family was in the render");
+
+        let checked = proxy_metric_mappings_against(&without);
+        let entry = checked
+            .iter()
+            .find(|mapping| mapping.rust_prometheus_family == dropped)
+            .expect("the mapping still exists, it just is not covered");
+        assert!(
+            !entry.covered,
+            "{dropped} is no longer published, so its mapping must not claim coverage"
+        );
+        assert!(
+            checked
+                .iter()
+                .filter(|mapping| mapping.rust_prometheus_family != dropped)
+                .all(|mapping| mapping.covered),
+            "removing one family must not unsettle the others"
+        );
+    }
 
     #[test]
     fn a_heartbeat_that_says_nothing_about_shedding_does_not_lift_a_drain() {

--- a/crates/temporalstore-rust/src/proxy/prometheus.rs
+++ b/crates/temporalstore-rust/src/proxy/prometheus.rs
@@ -164,21 +164,6 @@ impl ProxyService {
             u64::from(options.pin_primary_reads),
         );
 
-        out.push_str("# HELP temporalstore_proxy_metric_family_parity proxy operational metric surface mapped to Rust Prometheus families.\n");
-        out.push_str("# TYPE temporalstore_proxy_metric_family_parity gauge\n");
-        for mapping in proxy_metrics_parity_mappings() {
-            push_proxy_metric(
-                &mut out,
-                "temporalstore_proxy_metric_family_parity",
-                &[
-                    ("native_surface", mapping.native_surface.as_str()),
-                    ("rust_family", mapping.rust_prometheus_family.as_str()),
-                    ("grafana_panel", mapping.grafana_panel.as_str()),
-                ],
-                u64::from(mapping.covered),
-            );
-        }
-
         let service_discovery = self.service_discovery_report_with_options(&options);
         out.push_str("# HELP temporalstore_proxy_service_registry_state Proxy service-discovery registration state.\n");
         out.push_str("# TYPE temporalstore_proxy_service_registry_state gauge\n");
@@ -273,6 +258,25 @@ impl ProxyService {
                 "temporalstore_production_readiness_service_blockers",
                 &[("service", service.service.as_str())],
                 service.blocker_count as u64,
+            );
+        }
+
+        // Last, so every family above has been rendered and this can be answered from them
+        // rather than asserted. A mapping naming a family the proxy no longer publishes
+        // reports 0 here now; it used to report 1 regardless.
+        let mappings = proxy_metric_mappings_against(&out);
+        out.push_str("# HELP temporalstore_proxy_metric_family_parity proxy operational metric surface mapped to Rust Prometheus families.\n");
+        out.push_str("# TYPE temporalstore_proxy_metric_family_parity gauge\n");
+        for mapping in mappings {
+            push_proxy_metric(
+                &mut out,
+                "temporalstore_proxy_metric_family_parity",
+                &[
+                    ("native_surface", mapping.native_surface.as_str()),
+                    ("rust_family", mapping.rust_prometheus_family.as_str()),
+                    ("grafana_panel", mapping.grafana_panel.as_str()),
+                ],
+                u64::from(mapping.covered),
             );
         }
         out

--- a/crates/temporalstore-rust/src/proxy/reports.rs
+++ b/crates/temporalstore-rust/src/proxy/reports.rs
@@ -169,6 +169,7 @@ impl ProxyService {
     }
 
     pub fn metrics_parity_report(&self) -> ProxyMetricsParityReport {
+        let rendered = self.prometheus_metrics();
         ProxyMetricsParityReport {
             status: Status::ok(),
             compared_files: vec![
@@ -178,8 +179,8 @@ impl ProxyService {
                 "<repo>/crates/temporalstore-rust/src/proxy/handle.rs".to_string(),
                 "<repo>/crates/temporalstore-rust/src/proxy/config.rs".to_string(),
             ],
-            rust_prometheus_families: proxy_metric_families_from(&self.prometheus_metrics()),
-            mappings: proxy_metrics_parity_mappings(),
+            rust_prometheus_families: proxy_metric_families_from(&rendered),
+            mappings: proxy_metric_mappings_against(&rendered),
             grafana_panels_ready: true,
             alerts_ready: true,
         }


### PR DESCRIPTION
The proxy publishes a gauge, and a field on its JSON report, saying whether each metric family
it claims to expose is actually being published. Both read `covered`, and `covered` was set to
true where each mapping is constructed. So the gauge read 1 no matter what: rename a family or
stop emitting one, and the dashboard built on it goes quiet while the signal that exists to
notice that goes on reporting health.

The sibling field on the very same report was already fixed this way, and says so in its own
comment -- the list of published families used to be hand-written, had fallen eight families
behind what the proxy emits, and now gets read back off the rendered endpoint so it cannot be
behind by construction. This is the other half of that, left asserting.

So the flag is answered the same way. The block is rendered last, after every other family has
been written, and each mapping is marked by looking for its family in what was actually
produced. Where a mapping is built the flag now starts false: unproven until the metrics prove
it, rather than true until something disproves it, which nothing could.

The test takes one family out of the rendered text and requires the mapping that names it to
stop claiming coverage while no other mapping is disturbed. Watched failing with the old
behaviour put back: it claimed coverage for a family that was no longer there.

    proxy 72 -- 0 failed


