### PR TITLE
Hold one allocation of a page-ref key, not three

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 rmp-serde = "1.3"
 hex = "0.4"
 prost = "0.13"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2150,7 +2150,7 @@ fn collect_command_index_items(
             items.push(crate::index_log::IndexItem {
                 kind: crate::index_log::IndexItemKind::Page,
                 routing_bucket,
-                page_ref_key: page_ref_key.clone(),
+                page_ref_key: page_ref_key.to_string(),
                 object_key: page.object_key.clone(),
                 model_id: page.model_id.clone(),
                 component: page.component.clone(),
@@ -2340,7 +2340,9 @@ fn fold_delta_page_items(
             });
         bucket.object_index.insert(item.object_id);
         bucket.page_index.insert(
-            item.page_ref_key.clone(),
+            // The record carries an owned String; the in-memory structures share one allocation,
+            // so it is converted once here as the page is installed.
+            std::sync::Arc::from(item.page_ref_key.as_str()),
             PageIndex {
                 object_key: item.object_key.clone(),
                 model_id: item.model_id.clone(),

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
+use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
@@ -305,7 +306,9 @@ pub(super) struct CoreIndex {
 
 pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
 pub(super) type ObjectIndex = BTreeSet<u64>;
-pub(super) type PageIndexMap = BTreeMap<String, PageIndex>;
+/// Keyed by a SHARED page-ref key: the same allocation is held by the lookups that point at this
+/// page, instead of each of the three keeping its own copy of the same ~117-byte string.
+pub(super) type PageIndexMap = BTreeMap<Arc<str>, PageIndex>;
 pub(super) type ObjectPageLookup = BTreeMap<String, BTreeSet<PageLookupRef>>;
 pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageLookupRef>>;
 
@@ -313,7 +316,7 @@ pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageL
 pub(super) struct PageLookupRef {
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
-    pub(super) page_ref_key: String,
+    pub(super) page_ref_key: Arc<str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -322,7 +325,7 @@ pub(super) struct ComponentPageLookupRef {
     pub(super) component: Option<String>,
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
-    pub(super) page_ref_key: String,
+    pub(super) page_ref_key: Arc<str>,
 }
 
 /// Rust-native core index mirroring the shape:
@@ -394,10 +397,12 @@ impl CoreIndex {
         }
     }
 
+    /// Takes the key by shared pointer: both lookups clone the `Arc`, not the string, so the
+    /// three structures that point at a page hold one allocation between them.
     pub(super) fn insert_object_page_lookup(
         &mut self,
         routing_bucket: u32,
-        page_ref_key: String,
+        page_ref_key: Arc<str>,
         page: &PageIndex,
     ) {
         if page.deleted {
@@ -412,7 +417,7 @@ impl CoreIndex {
             .or_default()
             .insert(PageLookupRef {
                 routing_bucket,
-                page_ref_key: page_ref_key.clone(),
+                page_ref_key: Arc::clone(&page_ref_key),
             });
         let added = self
             .object_component_lookup

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -3,6 +3,7 @@
 
 //! Storage snapshot/sample reporting + bucket-index maintenance internals, split from engine.rs.
 use super::*;
+use std::sync::Arc;
 
 pub(super) fn storage_slab_integrity_report(
     shard_id: ShardId,
@@ -899,14 +900,14 @@ pub(super) fn rebuild_bucket_page_ownership(
             });
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            format!(
+            Arc::from(format!(
                 "{}:{}:{}:{}:{}",
                 entry.kind,
                 entry.object_key,
                 entry.component.clone().unwrap_or_default(),
                 entry.address.page_slab_id,
                 entry.address.offset
-            ),
+            )),
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
@@ -1144,8 +1145,10 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
     entries
 }
 
-pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> String {
-    format!(
+/// The key a page is filed under, as ONE allocation shared by every structure that points at the
+/// page: the bucket's `page_index`, and the two object lookups.
+pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> Arc<str> {
+    Arc::from(format!(
         "{}:{}:{}:{}:{}:{}:{}:{}",
         entry.kind,
         entry.object_key,
@@ -1155,7 +1158,7 @@ pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> String {
         entry.address.length,
         entry.address.page_id.unwrap_or_default(),
         entry.address.generation.unwrap_or_default()
-    )
+    ))
 }
 
 pub(super) fn page_physical_identity_key(

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2320,6 +2320,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 },
             )]
             .into_iter()
+            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
             .collect(),
             ..BucketNode::default()
         },
@@ -2382,6 +2383,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
+            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
             .collect(),
             ..BucketNode::default()
         },
@@ -2443,6 +2445,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
+            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
             .collect(),
             ..BucketNode::default()
         },

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3957,11 +3957,11 @@ fn object_page_lookup_is_derivable_from_object_component_lookup() {
                     page.component.as_deref(),
                 ))
                 .or_default()
-                .insert((*routing_bucket, page_ref_key.clone()));
+                .insert((*routing_bucket, page_ref_key.to_string()));
             from_pages_component_lookup
                 .entry(object_component_lookup_key(&page.model_id, &page.object_key))
                 .or_default()
-                .insert((page.component.clone(), *routing_bucket, page_ref_key.clone()));
+                .insert((page.component.clone(), *routing_bucket, page_ref_key.to_string()));
         }
     }
 
@@ -3974,7 +3974,7 @@ fn object_page_lookup_is_derivable_from_object_component_lookup() {
             (
                 k.clone(),
                 refs.iter()
-                    .map(|r| (r.routing_bucket, r.page_ref_key.clone()))
+                    .map(|r| (r.routing_bucket, r.page_ref_key.to_string()))
                     .collect(),
             )
         })
@@ -4002,7 +4002,7 @@ fn object_page_lookup_is_derivable_from_object_component_lookup() {
             derived
                 .entry(format!("{component_key}|{}", component.as_deref().unwrap_or("")))
                 .or_default()
-                .insert((*routing_bucket, page_ref_key.clone()));
+                .insert((*routing_bucket, page_ref_key.to_string()));
         }
     }
 
@@ -4021,7 +4021,7 @@ fn object_page_lookup_is_derivable_from_object_component_lookup() {
                     page.component.as_deref().unwrap_or("")
                 ))
                 .or_default()
-                .insert((*routing_bucket, page_ref_key.clone()));
+                .insert((*routing_bucket, page_ref_key.to_string()));
         }
     }
 


### PR DESCRIPTION
A page's key is held in three places at once. This makes it one allocation.

Every page in the bucket index is filed under a `page_ref_key` — a string of about 117 bytes built
from the page's identity and address. The same key is then stored again in `object_page_lookup`,
and again in `object_component_lookup`, because both point back at the page. Three copies of the
same bytes, per page.

They are the same string by construction: both lookups are built from the page index and key their
entries by the page they point at. So the map key and the two ref structs now share one `Arc<str>`,
built once where the key is made and cloned by pointer into the lookups.

### Measured

Resident memory of the proxy, 400 memories, arms alternating:

| round | arm | proxy RSS |
|---|---|---:|
| 1 | main | 348.7 MB |
| 1 | **this branch** | **329.8 MB** |
| 2 | **this branch** | **336.8 MB** |
| 2 | main | 341.4 MB |

**&minus;11.8 MB, about &minus;3.4%**, with the arms not overlapping — the larger of the two
"after" readings is below the smaller "before". The saving is per page, so it grows with the store.

That is in the range the arithmetic predicts: roughly 22 000 pages at this corpus, two allocations
removed each, at an allocator rounding a 117-byte request up to 128 — about 5.6 MB — plus the
inline shrink from `String` (24 bytes) to `Arc<str>` (16) in two fields.

**Latency was measured and shows nothing.** Add p50 at the same corpus, arms alternating: 112.1 ms
on `main` against 116.6 and 102.7 ms on this branch. The arms are indistinguishable, so removing two
allocations per page write does not move the write path at this size &mdash; it is a memory change,
not a latency one. (A third reading of 7 999 ms on the `main` arm was discarded as an outlier: the
box was loaded by another session at that moment, and the same binary read 112.1 ms in the other
round. Alternating the arms is what made that visible, and it is why they alternate.)

### A note on how NOT to measure it

An index census that sums string lengths per occurrence cannot see this change at all, and reported
1.3% — which is only the inline shrink. Sharing does not change a length; it removes an allocation.
Anyone re-checking this should measure resident memory, not content bytes.

### On the wire

`serde` gains its `rc` feature so `Arc<str>` can round-trip. The encoded form is unchanged: an
`Arc<str>` encodes exactly as the string it holds. Decoding does not restore the sharing — each
field decodes into its own allocation — but the lookup rebuild re-shares them, so a reloaded index
converges back on one copy.

### Tests

`upsert_reload_equality`, `storage_migration_corpus`, `bulk_install_index_durability`,
`storage_crash_harness`, `delta_index_log_gc` and `delta_index_cost` all pass — the first of those
matters most here, since it writes state and reads it back through the type that changed.

`cargo check --all-targets` clean on both repos. Every source file is byte-identical between them;
`Cargo.toml` differs only by the private dependency seam that already differed.

Three test fixtures that built a page index from owned strings, and a comparison harness that
collected ref keys into `String` sets, were adapted rather than the production type softened —
accepting a `String` at the map would put the third allocation straight back.

### Not done

Interning `object_key` and `model_id` was measured alongside this and is **not** worth it: 1.67 MB
and 0.13 MB respectively at 600 memories, against 3.88 MB for each copy of the ref key, and their
values are nearly all distinct so there is little to share.
