### PR TITLE
A scan its byte budget cut short reported the stream as ended

### DIFF
--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -64,7 +64,7 @@ impl TemporalEngine {
             let records = match request.stream_kind {
                 StreamKind::Wal => self
                     .wal_store
-                    .scan(
+                    .scan_bounded(
                         request.shard_id,
                         request.start_offset,
                         request.end_offset,
@@ -73,7 +73,7 @@ impl TemporalEngine {
                     .map_err(|err| err.to_string()),
                 StreamKind::IndexLog => self
                     .index_log_store
-                    .scan(
+                    .scan_bounded(
                         request.shard_id,
                         request.start_offset,
                         request.end_offset,
@@ -83,13 +83,17 @@ impl TemporalEngine {
                 StreamKind::Index | StreamKind::Block | StreamKind::Page => unreachable!(),
             };
             return match records {
-                Ok(records) => ScanStreamResponse {
+                // `truncated` is the whole point of asking: the walk stops both when the window
+                // ends and when max_bytes runs out, and this used to answer "end of stream" for
+                // either. A caller reading a range larger than its budget was handed a prefix
+                // and told it had the lot.
+                Ok((records, truncated)) => ScanStreamResponse {
                     status: Status::ok(),
                     records: records
                         .into_iter()
                         .map(|(offset, data)| StreamRecord { offset, data })
                         .collect(),
-                    end_of_stream: true,
+                    end_of_stream: !truncated,
                 },
                 Err(err) => ScanStreamResponse {
                     status: Status::error("stream_scan_failed", err.to_string()),
@@ -105,6 +109,13 @@ impl TemporalEngine {
             offset: request.start_offset,
             size,
         });
+        // A byte-addressed read is capped the same way -- `size` above is the window clamped to
+        // max_bytes -- so it ends the stream only when it reached the offset that was asked for.
+        let end_of_stream = !read.status.ok
+            || request
+                .start_offset
+                .saturating_add(read.data.len() as u64)
+                >= request.end_offset;
         ScanStreamResponse {
             status: read.status.clone(),
             records: if read.status.ok && !read.data.is_empty() {
@@ -115,7 +126,7 @@ impl TemporalEngine {
             } else {
                 Vec::new()
             },
-            end_of_stream: true,
+            end_of_stream,
         }
     }
 

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -66,6 +66,72 @@ fn control_api_reads_page_and_index_streams() {
 }
 
 #[test]
+fn a_scan_cut_short_by_its_budget_does_not_claim_the_stream_ended() {
+    // scan_stream stops walking for two unrelated reasons -- the window ended, or max_bytes ran
+    // out -- and it answered end_of_stream: true for both. So a caller reading a range larger
+    // than its budget was handed a prefix and told it had the whole thing, with nothing in the
+    // response to suggest otherwise.
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for i in 0..8 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("k{i}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+
+    let all = engine.scan_stream(ScanStreamRequest {
+        shard_id: 1,
+        stream_kind: StreamKind::Wal,
+        page_slab_id: 0,
+        start_offset: 0,
+        end_offset: u64::MAX,
+        max_bytes: u64::MAX,
+    });
+    assert!(all.status.ok);
+    assert!(
+        all.records.len() >= 4,
+        "premise: there are several records to walk, got {}",
+        all.records.len()
+    );
+    assert!(
+        all.end_of_stream,
+        "a scan with no budget to run out of did reach the end of the window"
+    );
+
+    // A budget that fits the first record and not the second.
+    let budget = all.records[0].data.len() as u64 + 1;
+    let cut = engine.scan_stream(ScanStreamRequest {
+        shard_id: 1,
+        stream_kind: StreamKind::Wal,
+        page_slab_id: 0,
+        start_offset: 0,
+        end_offset: u64::MAX,
+        max_bytes: budget,
+    });
+    assert!(cut.status.ok);
+    assert!(
+        cut.records.len() < all.records.len(),
+        "premise: the budget cut this scan short, got {} of {}",
+        cut.records.len(),
+        all.records.len()
+    );
+    assert!(
+        !cut.end_of_stream,
+        "the budget stopped this scan with records still in the window, so it must not report          the stream as ended"
+    );
+}
+
+#[test]
 fn control_api_reads_and_scans_wal_stream() {
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -711,6 +711,8 @@ impl LocalIndexLogStore {
         Ok(bytes)
     }
 
+    /// The records in the window. Says nothing about whether the window was exhausted, which
+    /// is why anything reporting completeness to a caller wants `scan_bounded` instead.
     pub fn scan(
         &self,
         shard_id: ShardId,
@@ -718,11 +720,27 @@ impl LocalIndexLogStore {
         end_offset: u64,
         max_bytes: u64,
     ) -> Result<Vec<(u64, Vec<u8>)>, IndexLogError> {
+        self.scan_bounded(shard_id, start_offset, end_offset, max_bytes)
+            .map(|(records, _)| records)
+    }
+
+    /// The records in the window, and whether `max_bytes` cut the scan short.
+    ///
+    /// The walk below stops for two unrelated reasons: the window ended, or the byte budget ran
+    /// out. Returning only the records conflates them, and a caller that cannot tell them apart
+    /// reports a truncated read as a complete one.
+    pub fn scan_bounded(
+        &self,
+        shard_id: ShardId,
+        start_offset: u64,
+        end_offset: u64,
+        max_bytes: u64,
+    ) -> Result<(Vec<(u64, Vec<u8>)>, bool), IndexLogError> {
         let mut inner = self.inner.lock().expect("index log lock poisoned");
         let path = index_log_path(&inner.root, shard_id);
         if !path.exists() {
             inner.stats.scans += 1;
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
         let _ = last_sequence_at(&inner.root, shard_id)?;
         let mut file = File::open(&path)?;
@@ -730,6 +748,7 @@ impl LocalIndexLogStore {
         let mut reader = BufReader::new(file);
         let mut offset = start_offset;
         let mut total = 0;
+        let mut truncated = false;
         let mut records = Vec::new();
         loop {
             let mut line = Vec::new();
@@ -738,7 +757,12 @@ impl LocalIndexLogStore {
                 break;
             }
             let next_offset = offset.saturating_add(read as u64);
-            if next_offset > end_offset || total + read as u64 > max_bytes {
+            if next_offset > end_offset {
+                break;
+            }
+            if total + read as u64 > max_bytes {
+                // Out of budget with the window not yet walked: there is more to read.
+                truncated = true;
                 break;
             }
             records.push((offset, line));
@@ -747,7 +771,7 @@ impl LocalIndexLogStore {
         }
         inner.stats.scans += 1;
         inner.stats.bytes_read += total;
-        Ok(records)
+        Ok((records, truncated))
     }
 
     pub fn gc_before_sequence(

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -1523,6 +1523,8 @@ impl LocalWriteAheadLogStore {
         Ok(bytes)
     }
 
+    /// The records in the window. Says nothing about whether the window was exhausted, which
+    /// is why anything reporting completeness to a caller wants `scan_bounded` instead.
     pub fn scan(
         &self,
         shard_id: ShardId,
@@ -1530,6 +1532,22 @@ impl LocalWriteAheadLogStore {
         end_offset: u64,
         max_bytes: u64,
     ) -> Result<Vec<(u64, Vec<u8>)>, WriteAheadLogError> {
+        self.scan_bounded(shard_id, start_offset, end_offset, max_bytes)
+            .map(|(records, _)| records)
+    }
+
+    /// The records in the window, and whether `max_bytes` cut the scan short.
+    ///
+    /// The walk below stops for two unrelated reasons: the window ended, or the byte budget ran
+    /// out. Returning only the records conflates them, and a caller that cannot tell them apart
+    /// reports a truncated read as a complete one.
+    pub fn scan_bounded(
+        &self,
+        shard_id: ShardId,
+        start_offset: u64,
+        end_offset: u64,
+        max_bytes: u64,
+    ) -> Result<(Vec<(u64, Vec<u8>)>, bool), WriteAheadLogError> {
         let mut inner = self.inner.lock().expect("write-ahead log lock poisoned");
         let segments = wal_segment_paths(&inner.root, shard_id)
             .into_iter()
@@ -1540,10 +1558,11 @@ impl LocalWriteAheadLogStore {
         // (corruption) as data loss (see engine::lifecycle replay).
         if segments.is_empty() {
             inner.stats.scans += 1;
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
         let _ = last_wal_sequence_at(&inner.root, shard_id)?;
         let mut total = 0;
+        let mut truncated = false;
         let mut records = Vec::new();
         'segments: for path in segments {
             // Each piece says where in the log's history its contents begin, so a record's position
@@ -1600,7 +1619,12 @@ impl LocalWriteAheadLogStore {
                     log_id = next_log_id;
                     continue;
                 }
-                if next_log_id > end_offset || total + read as u64 > max_bytes {
+                if next_log_id > end_offset {
+                    break 'segments;
+                }
+                if total + read as u64 > max_bytes {
+                    // Out of budget with the window not yet walked: there is more to read.
+                    truncated = true;
                     break 'segments;
                 }
                 // Refuse a corrupt record here, where it is being read. This used to happen only as
@@ -1617,7 +1641,7 @@ impl LocalWriteAheadLogStore {
         }
         inner.stats.scans += 1;
         inner.stats.bytes_read += total;
-        Ok(records)
+        Ok((records, truncated))
     }
 
     /// Where reading can start, to see every record after `sequence` and no whole piece before it.


### PR DESCRIPTION
/scan_stream walks a window of the write-ahead log or the index log and says whether the stream
ended. It said yes every time, on every path, including the one where max_bytes stopped the walk
with records still inside the window. A caller reading a range larger than its budget was handed
a prefix and told it had the whole thing.

The walk stops for two unrelated reasons and one line conflated them:

    if next_log_id > end_offset || total + read as u64 > max_bytes { break }

The left half means the window ended, which really is the end of the stream. The right half
means the budget ran out, which means there is more. Both answered the same way, and the answer
they gave was the reassuring one.

Only the loop knows which happened, so the loop now says. `scan_bounded` returns the records and
whether it was cut short; `scan` stays as it was, delegating and dropping the flag, so nothing
that just wants records had to change. The byte-addressed branch answers the same question from
the offset it actually reached.

Two cheaper answers were tried first and are worth recording as wrong. Comparing the last
record's position against the window reports "not ended" for a COMPLETE scan of a sparse range,
which is worse than the defect. Comparing bytes returned against the budget does not work either:
the loop breaks BEFORE adding the record that would not fit, so a truncated scan can end well
under its budget.

Scope, stated plainly: this endpoint is reachable at POST /scan_stream and nothing inside the
tree pages through it, so this is a control surface telling an external caller something untrue
rather than a live loss of data.

Watched failing with the old answer put back: the scan the budget cut short went on reporting the
stream as ended.

    wal 86, index_log 20, engine 287 -- 0 failed, serialized


