### PR TITLE
Filtering that found nothing to redact reported that it had not run

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -2913,7 +2913,11 @@ fn context_policy_report_for_text(
     } else {
         text.to_string()
     };
-    let pii_filtering_applied = !policy.pii_filtering_enabled || sanitized_text != text;
+    // "Applied" is about whether this text went through the filter, not about whether the
+    // filter found anything. Answering `sanitized_text != text` meant a record with no personal
+    // data in it -- the ordinary case, and the great majority of them -- reported that filtering
+    // had not been applied, so anyone auditing whether it runs read "no" nearly every time.
+    let pii_filtering_applied = policy.pii_filtering_enabled;
     let accepted = provider_allowed
         && model_allowed
         && body_size_allowed

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -1226,6 +1226,64 @@ fn context_management_ingest_extract_builds_retrieval_pipeline() {
 }
 
 #[test]
+fn text_with_nothing_to_redact_still_went_through_the_filter() {
+    // pii_filtering_applied answered "did redaction change the text", not "did this text go
+    // through the filter". With filtering on, most text has no personal data in it, so the flag
+    // read false in the ordinary healthy case: anyone auditing whether filtering ran got "no"
+    // for every clean record, which is the majority of them.
+    let policy = ContextWorkflowPolicy {
+        allowed_provider_kinds: vec![ContextProviderKind::OpenAiCompatible],
+        allowed_models: vec!["context-prod".to_string()],
+        max_extract_body_bytes: 256,
+        max_prompt_tokens: 64,
+        pii_filtering_enabled: true,
+        tenant_isolation_required: true,
+        rate_limit_per_minute: 100,
+        provider_failure_budget: 3,
+    };
+    let request = ContextExtractRequest {
+        shard_id: 1,
+        tenant_hash: 9,
+        source_kind: ContextSourceKind::Ticket,
+        source_id: "T-2".to_string(),
+        title: "Billing".to_string(),
+        body: "Customer asked when the next invoice run happens".to_string(),
+        timestamp_ms: 1,
+        provider: ContextModelProviderConfig {
+            provider_name: "openai-compatible".to_string(),
+            provider_kind: ContextProviderKind::OpenAiCompatible,
+            model: "context-prod".to_string(),
+            mock_mode: false,
+            ..ContextModelProviderConfig::default()
+        },
+    };
+
+    let report = validate_context_extract_policy(&policy, &request);
+    assert!(report.status.ok);
+    assert_eq!(
+        report.sanitized_text, request.body,
+        "premise: this text has nothing in it to redact"
+    );
+    assert!(
+        report.pii_filtering_applied,
+        "the text went through the filter -- it simply had nothing to remove, which is not          the same as the filter not running"
+    );
+
+    // And the other direction, so "applied" cannot quietly come to mean something else: with
+    // filtering switched off, nothing went through the filter and the report has to say so.
+    let unfiltered = ContextWorkflowPolicy {
+        pii_filtering_enabled: false,
+        ..policy
+    };
+    let report = validate_context_extract_policy(&unfiltered, &request);
+    assert!(report.status.ok);
+    assert!(
+        !report.pii_filtering_applied,
+        "filtering is switched off, so it was not applied to this text"
+    );
+}
+
+#[test]
 fn context_workflow_policy_controls_provider_model_and_pii() {
     let policy = ContextWorkflowPolicy {
         allowed_provider_kinds: vec![ContextProviderKind::OpenAiCompatible],


### PR DESCRIPTION
The context policy report carries pii_filtering_applied, and it was answered with

    !policy.pii_filtering_enabled || sanitized_text != text

which is "did redaction change this text", not "did this text go through the filter". Most text
has no personal data in it, so with filtering switched on the flag read false for the ordinary
case and true only for the records that happened to contain something. Anyone reading the report
to see whether filtering runs got "no" for the great majority of records it had in fact run on.

It now answers what it is named: whether the text went through the filter. That also settles the
other end, which nothing had pinned: with filtering switched off the flag is false, where it used
to be true on the grounds that nothing was required. Both directions are asserted now, so the
meaning cannot drift back.

Worth being plain about which way this was wrong. The flag UNDER-claimed -- it said filtering had
not happened when it had -- and it feeds a report rather than the accept decision, which does not
read it. Nothing was admitted that should not have been. What was wrong was the answer given to
someone auditing whether the filter runs.

Watched failing first: text with nothing to redact, filtering on, reported not applied.

    context_workflow 33 -- 0 failed, serialized


