### PR TITLE
A write refused while its shard was loading reached the caller as a failure

### DIFF
--- a/crates/temporalstore-rust/src/client/retry.rs
+++ b/crates/temporalstore-rust/src/client/retry.rs
@@ -89,6 +89,15 @@ pub(super) fn status_is_retryable(status: &Status) -> bool {
             | "shard_not_found"
             | "loadversionmismatch"
             | "load_version_mismatch"
+            // A foreground write refused while its shard is loading, reloading or unloading.
+            // Every one of those states ends on its own, and the data node refuses the write
+            // BEFORE executing it, so asking again cannot duplicate anything. Not topology
+            // retryable: the shard has not moved, so re-resolving the route names the same
+            // node. Without this a rebalance, a restart or a dump/load cycle reached the
+            // caller as failed writes, while the two conditions directly above -- which say
+            // the same thing about the same shard -- were retried.
+            | "lifecyclewriteblocked"
+            | "lifecycle_write_blocked"
     )
 }
 

--- a/crates/temporalstore-rust/src/client/tests/part3.rs
+++ b/crates/temporalstore-rust/src/client/tests/part3.rs
@@ -209,6 +209,49 @@ fn client_does_not_retry_write_status_without_write_retry_budget() {
 }
 
 #[test]
+fn a_write_refused_while_its_shard_is_loading_is_worth_asking_again() {
+    // The data node refuses a foreground write while its shard is loading, reloading or
+    // unloading and answers lifecycle_write_blocked. Each of those states ends on its own --
+    // the shard finishes and serves -- and the write is refused BEFORE it executes, so asking
+    // again cannot duplicate anything. The client treated it as fatal, so a rebalance, a
+    // restart or a dump/load cycle surfaced to the caller as failed writes, while the sibling
+    // conditions it already retries (partition_loading, shard_not_loaded) say the same thing.
+    let blocked = classify_retry_decision(
+        &Status::error("lifecycle_write_blocked", "shard 1 is reloading for dump"),
+        true,
+        0,
+        2,
+        false,
+    );
+    assert!(
+        blocked.retryable,
+        "a shard that is loading will finish loading"
+    );
+    assert!(
+        blocked.would_retry,
+        "with retry budget in hand the client should ask again"
+    );
+    assert!(
+        !blocked.topology_retry,
+        "the shard has not moved, so re-resolving the route would name the same node"
+    );
+
+    // Budget still governs it. The budget-free retry is only for rejections that prove the
+    // write never reached the shard, and this one is not routed through that path.
+    let no_budget = classify_retry_decision(
+        &Status::error("lifecycle_write_blocked", "shard 1 is reloading for dump"),
+        true,
+        0,
+        1,
+        false,
+    );
+    assert!(
+        !no_budget.would_retry,
+        "a write with no budget left must not repeat itself"
+    );
+}
+
+#[test]
 fn client_retry_classifier_separates_safe_topology_retry_from_unsafe_write_retry() {
     let unsafe_write_retry = classify_retry_decision(
         &Status::error("retry_later", "possibly applied"),


### PR DESCRIPTION
The data node refuses a foreground write while its shard is loading, reloading or unloading, and
answers lifecycle_write_blocked. The client did not count that among the answers worth asking
again, so it handed the caller an error.

Each of those states ends on its own -- the shard finishes and serves -- and the refusal happens
BEFORE the write executes, so asking again cannot duplicate anything. Those states are also what
a rebalance, a restart and a dump/load cycle look like from outside, which is to say the ordinary
operation of the cluster. Writes failed during all of them.

The two conditions listed directly above it in the same match say the same thing about the same
shard and were already retried: partition_loading, shard_not_loaded. This one was added to the
data node later and never reached the list.

Deliberately NOT topology retryable. The shard has not moved -- it is the same node, busy -- so
re-resolving the route would name that node again and spend a metaserver round trip to learn
nothing. Plain retryable means backoff and ask the same node, which is what the situation calls
for.

Budget still governs it, and the test says so. The budget-free retry exists for rejections that
prove the write never reached the shard's log and is reached through the topology path; a write
whose retries are configured away must still not repeat itself.

Watched failing first: the classifier did not consider it retryable at all.

    client 35 -- 0 failed, serialized
    data_node 49 -- 1 failed, the storage-manager jitter_backoff red that is already on main


