### PR TITLE
Hold a page lookup refs in a sorted vector, not a b-tree set

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -309,7 +309,21 @@ pub(super) type ObjectIndex = BTreeSet<u64>;
 /// Keyed by a SHARED page-ref key: the same allocation is held by the lookups that point at this
 /// page, instead of each of the three keeping its own copy of the same ~117-byte string.
 pub(super) type PageIndexMap = BTreeMap<Arc<str>, PageIndex>;
-pub(super) type ObjectPageLookup = BTreeMap<String, BTreeSet<PageLookupRef>>;
+/// A sorted, deduplicated vector rather than a set: measured, 100% of these entries hold exactly
+/// one ref, and a B-tree node costs its full size whether it holds one element or eleven.
+/// Insertion goes through `insert_page_lookup_ref`, which keeps both invariants.
+///
+/// Serializes identically -- both a `Vec` and a `BTreeSet` encode as a sequence -- which matters
+/// because this map is part of the serialized index.
+pub(super) type ObjectPageLookup = BTreeMap<String, Vec<PageLookupRef>>;
+
+/// Insert keeping the vector sorted and free of duplicates, which is what the set it replaced did.
+pub(super) fn insert_page_lookup_ref(refs: &mut Vec<PageLookupRef>, value: PageLookupRef) {
+    match refs.binary_search(&value) {
+        Ok(_) => {}
+        Err(at) => refs.insert(at, value),
+    }
+}
 pub(super) type ObjectComponentLookup = BTreeMap<String, BTreeSet<ComponentPageLookupRef>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -408,17 +422,21 @@ impl CoreIndex {
         if page.deleted {
             return;
         }
-        self.object_page_lookup
+        let page_refs = self
+            .object_page_lookup
             .entry(object_page_lookup_key(
                 &page.model_id,
                 &page.object_key,
                 page.component.as_deref(),
             ))
-            .or_default()
-            .insert(PageLookupRef {
+            .or_default();
+        insert_page_lookup_ref(
+            page_refs,
+            PageLookupRef {
                 routing_bucket,
                 page_ref_key: Arc::clone(&page_ref_key),
-            });
+            },
+        );
         let added = self
             .object_component_lookup
             .entry(object_component_lookup_key(

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4105,7 +4105,7 @@ fn per_record_structure_census() {
         .bucket_index
         .object_page_lookup
         .values()
-        .map(std::collections::BTreeSet::len)
+        .map(Vec::len)
         .sum();
     let component_lookup_keys = shard.bucket_index.object_component_lookup.len();
     let strings = shard.strings.len();
@@ -4380,7 +4380,7 @@ fn maintained_component_page_ref_total_matches_the_walk() {
         .bucket_index
         .object_component_lookup
         .values()
-        .map(std::collections::BTreeSet::len)
+        .map(BTreeSet::len)
         .sum();
     let maintained = shard
         .bucket_index


### PR DESCRIPTION
`object_page_lookup` maps a page to the refs that point at it. It held those refs in a `BTreeSet`.
Counted at 600 memories, it has **33,307 entries and 100.0% of them hold exactly one ref**.

A `BTreeSet` node is sized for 11 elements whether it holds one or eleven. A sorted `Vec` holding
one ref allocates exactly one. So this holds the refs in a `Vec`, kept sorted and deduplicated by a
binary-search insert, which preserves both properties the set was providing.

The wire format does not change: a `Vec` and a `BTreeSet` both encode as a sequence.

`object_component_lookup` is deliberately left alone. Its shape is the opposite — 42 of its 658
entries hold 50+ refs, 32,665 refs between them — and a set is the right container there.

### Measured

600 memories, 4 KB payloads, three rounds with the arm order alternating:

| arm | live heap (MB) | live allocations |
|---|---|---|
| before | 177.5, 161.5, 162.2 | ~1,045,533 |
| after | **156.2, 156.5, 156.2** | ~1,045,455 |

**−10.8 MB of live heap, −6.4%**, with every after value below every before value (min-before 161.5
> max-after 156.5).

Two things worth reading off that table:

**Allocation count does not move** (~78 apart, i.e. zero), and it was never going to: a one-element
`BTreeSet` and a one-element `Vec` are one allocation each. The saving is entirely in allocation
*size*.

**The after arm's spread is 0.3 MB against the before arm's 16.0 MB.** A tree node's footprint
varies with capacity and fragmentation; a one-element vector is exact. Less variance is a real
result alongside the smaller mean.

### What this does not do

**Process RSS does not move.** Means differ by 7.8 MB against round-to-round spreads of ~38 MB —
unresolvable, and honestly reported as such. The live-heap numbers above come from a counting
allocator carried by *both* binaries so it cancels between arms, sampled as the minimum over 25
readings after ingest so transient per-request allocation is squeezed out.

This change was measured by RSS first, read as a null result, and set aside. It isn't a null — the
whole index is ~52 MB of a ~455 MB process, so an effect of this size sits under the noise floor of
a process-level measurement. Recording that here because the instrument, not the change, was what
had to improve.

### Tests

`cargo check --release --all-targets` clean. The engine unit tests include a harness that compares
both lookup structures against the pages they describe; the suites that write state and read it
back matter here because this map is serialized.
