### PR TITLE
Build the range sentinel as the type the page-ref key now holds

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -456,7 +456,10 @@ impl CoreIndex {
             let first = ComponentPageLookupRef {
                 component: component.map(str::to_string),
                 routing_bucket: 0,
-                page_ref_key: String::new(),
+                // Only a range START: the empty key sorts below every real page-ref key, so the
+                // seek lands on this component's first ref. It became an `Arc<str>` when the key
+                // was made shared, and the sentinel has to follow the field.
+                page_ref_key: Arc::from(""),
             };
             let doomed: Vec<ComponentPageLookupRef> = component_refs
                 .range(first..)
@@ -628,7 +631,7 @@ mod component_lookup_tests {
             set.insert(ComponentPageLookupRef {
                 component: component.map(str::to_string),
                 routing_bucket: i as u32,
-                page_ref_key: format!("p{i}"),
+                page_ref_key: Arc::from(format!("p{i}").as_str()),
             });
         }
         index
@@ -687,13 +690,13 @@ mod component_lookup_tests {
             set.insert(ComponentPageLookupRef {
                 component: Some("dup".to_string()),
                 routing_bucket: i,
-                page_ref_key: format!("p{i}"),
+                page_ref_key: Arc::from(format!("p{i}").as_str()),
             });
         }
         set.insert(ComponentPageLookupRef {
             component: Some("keep".to_string()),
             routing_bucket: 9,
-            page_ref_key: "p9".to_string(),
+            page_ref_key: Arc::from("p9"),
         });
         index.remove_object_page_lookup_entry("hash", "k", Some("dup"));
         assert_eq!(components_left(&index, "k"), vec![Some("keep".to_string())]);


### PR DESCRIPTION
**`main` does not currently compile.** This fixes it.

Two changes landed that never conflicted textually and are incompatible anyway:

- the range-removal change added a `ComponentPageLookupRef` used purely as a range **start**, with
  `page_ref_key: String::new()`;
- the shared-key change made that field an `Arc<str>`.

Neither diff touches the other's lines, so both read `MERGEABLE/CLEAN` right up until the second
one merged. The breakage exists only once **both** are in the tree, and nothing in the pull-request
view can see that: each PR is compared against `main`, never against its siblings.

```
error[E0308]: mismatched types
   --> crates/temporalstore-rust/src/engine/state.rs:459:31
    |
459 |                 page_ref_key: String::new(),
    |                               ^^^^^^^^^^^^^ expected `Arc<str>`, found `String`
```

The empty key is still exactly right — the sentinel is only a lower bound, sorting below every real
page-ref key so the seek lands on the component's first ref. It just has to be built as the type
the field now holds. Same fix for three test construction sites in the same file.

### Verified

`cargo check --release --all-targets` clean, and **298 engine tests pass** — including the ones
that exercise the range removal the sentinel serves.

### Worth noting for next time

`cargo build --bin` does not compile test code, so a change that moves a field type can pass a
binary build and still leave the test sites broken. `--all-targets` is the gate that catches it.
