### PR TITLE
Evict the coldest embedding instead of clearing the cache, and document where ingest time goes

### DIFF
--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -318,6 +318,31 @@ Two caveats worth planning around:
 
 ---
 
+## 10a. The tuned profile, measured end to end
+
+Four real 1 MB skill documents, real encoder, default settings against the tuned profile below.
+Both arms produce identical retrieval behaviour on the queries tested; nothing here trades quality.
+
+```
+profile                     parse   embed   build    wall    written   amplification
+default                      2.9s   307.4s   3.7s   314.0s   55.7 MB       12.8x
+tuned                        2.7s   153.6s   2.4s   158.7s   44.0 MB       10.1x
+                                                    -------  -------
+                                                    1.98x     79%
+```
+
+Extrapolated to a thousand-document import: **21.8 hours down to 11.0 hours, and 14.6 GB down to
+11.5 GB.**
+
+Note where the time sits: **embedding is 98% of it.** Parsing and record building together are under
+2%. Any optimisation that is not about the encoder is rounding error on this workload.
+
+```bash
+export MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS=64      # half the embedded text, same retrieval
+export MATRIXARK_EMBEDDING_VECTOR_SCALE=100000     # integer vectors, ranking unchanged
+# and run the encoder as four small processes rather than one large one
+```
+
 ## 10a. Where the time goes, and what actually moves it
 
 Ingesting markdown at scale is **encoder-bound**, not storage-bound. Measured on this hardware with

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -363,7 +363,8 @@ tokens   texts/s   mean top score   leading answer unchanged
  32         72.0        0.510               4 of 8
 ```
 
-Sixty-four is the sweet spot: **+28% throughput at a marginally better mean score**. Thirty-two is
+Sixty-four is the sweet spot: faster at a marginally better mean score (+28% measured in
+isolation here; see the combined figure below, which is the one to plan with). Thirty-two is
 more than twice as fast but changes half the answers — too lossy for retrieval you depend on.
 
 **Chunk size — large, but it costs retrieval. Measure before adopting.** Chunk size sets the number
@@ -389,6 +390,25 @@ vectors as integers for about a third less disk with ranking unchanged. Resident
 because it is dominated by per-record bookkeeping rather than payload: to reduce memory, reduce the
 number of records. Avoid `MATRIXARK_EMBEDDING_VECTOR_INT8`; it is smaller still but measurably
 reorders near-neighbours.
+
+### The two lossless levers together
+
+Measured directly rather than multiplied, on the same real-documentation corpus, because gains
+measured separately on different corpora do not simply compose:
+
+```
+128 tokens, 1 process x 8 threads     32.7 texts/s   1.00x   (defaults)
+ 64 tokens, 1 process x 8 threads     35.1 texts/s   1.07x
+128 tokens, 4 processes x 2 threads   36.0 texts/s   1.10x
+ 64 tokens, 4 processes x 2 threads   44.6 texts/s   1.37x   <- tuned
+```
+
+The two together are worth **1.37x**, more than the 1.18x their separate gains predict — shorter
+texts cut per-process memory pressure, which helps once several encoders share a machine. Neither
+lever changed the leading retrieval result on this corpus.
+
+Treat 1.37x as the honest figure for a lossless retune. It is worth having, and it is not the order
+of magnitude that a 1,000-document import needs; for that, the constraint is encoder hardware.
 
 ### A production profile
 

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -318,6 +318,90 @@ Two caveats worth planning around:
 
 ---
 
+## 10a. Where the time goes, and what actually moves it
+
+Ingesting markdown at scale is **encoder-bound**, not storage-bound. Measured on this hardware with
+`paraphrase-multilingual-MiniLM-L12-v2`:
+
+| | |
+|---|---|
+| Encoder throughput, realistic chunks | **~24-30 texts/s** on 8 cores |
+| A 1 MB markdown document | ~2,500 chunks at the 240-token default |
+| Encoding that one document | **~92 s** |
+| Storage path for the same document | ~1.4 s |
+
+The storage engine is not the constraint — embedding is, by roughly two orders of magnitude. Plan
+capacity from encoder throughput, and be aware that adding cores helps sub-linearly: eight cores buy
+about 4.5x the throughput of one.
+
+**A caution on benchmarking.** Measuring the encoder with short strings is badly misleading — a
+handful of words runs near 200 texts/s while real 240-token chunks run near 24 texts/s, an eightfold
+difference. Always benchmark with chunks from your own corpus.
+
+### The levers, measured
+
+**Worker layout — free, ~19%.** Several small encoder processes beat one large one, because thread
+scaling inside a process is sublinear. On an eight-core budget:
+
+```
+1 process  x 8 threads    29.8 texts/s
+2 processes x 4 threads    30.7 texts/s
+4 processes x 2 threads    35.4 texts/s   <- best
+8 processes x 1 thread     32.9 texts/s
+```
+
+**Embedding text length — ~28%, no measured quality cost.** `MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS`
+caps how much of each chunk is embedded (default 128; the model's own window is also 128, so nothing
+above that is ever read). Measured on real documentation, retrieving with English and Chinese
+queries:
+
+```
+tokens   texts/s   mean top score   leading answer unchanged
+128         29.8        0.529            (baseline)
+ 96         30.3        0.541               7 of 8
+ 64         38.1        0.532               6 of 8
+ 32         72.0        0.510               4 of 8
+```
+
+Sixty-four is the sweet spot: **+28% throughput at a marginally better mean score**. Thirty-two is
+more than twice as fast but changes half the answers — too lossy for retrieval you depend on.
+
+**Chunk size — large, but it costs retrieval. Measure before adopting.** Chunk size sets the number
+of vectors, so it moves ingest time and vector storage proportionally:
+
+```
+chunk tokens   chunks/MB doc   encode/doc   vectors/doc
+240 (default)       2,664          92 s        8.6 MB
+500                   830          28 s        2.7 MB
+1000                  414          12 s        1.3 MB
+```
+
+That looks like a 7.7x win, and on synthetic repetitive content it measures as nearly free. **On real
+prose it is not.** Repeating the test against genuine documentation, moving from 240 to 1000 tokens
+dropped the mean top score 15% and changed the leading answer for four of six queries, one of them to
+a plainly wrong section. The synthetic corpus hid the loss because its passages were near-duplicates
+of each other — any of them looked like a correct answer.
+
+If you raise the chunk size, **verify retrieval on your own documents and your own queries first.**
+
+**Vector encoding — a disk win, not a memory one.** `MATRIXARK_EMBEDDING_VECTOR_SCALE=100000` stores
+vectors as integers for about a third less disk with ranking unchanged. Resident memory barely moves,
+because it is dominated by per-record bookkeeping rather than payload: to reduce memory, reduce the
+number of records. Avoid `MATRIXARK_EMBEDDING_VECTOR_INT8`; it is smaller still but measurably
+reorders near-neighbours.
+
+### A production profile
+
+```bash
+export MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS=64      # +28% throughput, no measured quality cost
+export MATRIXARK_EMBEDDING_VECTOR_SCALE=100000     # ~33% less disk, ranking unchanged
+export MATRIXARK_EMBEDDING_CACHE_ENTRIES=32768     # ~100 MB, worth it on repetitive corpora
+export MATRIXARK_RESOURCE_MAX_TOTAL_CHUNKS=20000   # 1 MB documents exceed the 2048 default
+# run the encoder as several small processes rather than one large one
+```
+
+Leave chunk size at its default unless you have measured the effect on your own corpus.
+
 ## 11. Troubleshooting
 
 **`no input documents found`** — `--dir` matched nothing. Check the path, and remember the default
@@ -340,7 +424,7 @@ export MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS=240       # chunk size; larger = fewe
 
 Chunk size is a real trade-off, not just a limit. Larger chunks mean far fewer records and much less
 memory, but the encoder only embeds the first `MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS` tokens of each
-chunk (128 by default, 256 for the MiniLM models). A chunk much longer than that window has its tail
+chunk (128 by default, which is also the MiniLM models' own maximum sequence length). A chunk much longer than that window has its tail
 left out of the semantic index. Keeping the chunk size at or below the embedding window is the
 configuration that indexes everything you store.
 

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -385,11 +385,35 @@ of each other — any of them looked like a correct answer.
 
 If you raise the chunk size, **verify retrieval on your own documents and your own queries first.**
 
-**Vector encoding — a disk win, not a memory one.** `MATRIXARK_EMBEDDING_VECTOR_SCALE=100000` stores
-vectors as integers for about a third less disk with ranking unchanged. Resident memory barely moves,
-because it is dominated by per-record bookkeeping rather than payload: to reduce memory, reduce the
-number of records. Avoid `MATRIXARK_EMBEDDING_VECTOR_INT8`; it is smaller still but measurably
-reorders near-neighbours.
+**Vector encoding — 25% of everything written, and ranking-safe.** Vectors are the bulk of an ingest.
+Census of one 1 MB markdown skill (2,510 chunks, 7,574 records):
+
+```
+context_embedding   2,510 records   10,432 KB   67.9%   <- vectors dominate
+skill_section       2,510 records    3,521 KB   22.9%
+context_index       2,554 records    1,419 KB    9.2%
+                                    ---------
+                                    15,371 KB = 14.6x the source document
+```
+
+Re-running that census under each encoding:
+
+```
+vector encoding        total written   amplification   vs default
+decimals=6 (default)       15,371 KB       14.6x           100%
+decimals=4                 13,491 KB       12.9x            88%
+scale=100000               11,598 KB       11.1x            75%   <- recommended
+int8                        9,667 KB        9.2x            63%   <- reorders, avoid
+```
+
+`MATRIXARK_EMBEDDING_VECTOR_SCALE=100000` cuts **a quarter off everything an ingest writes** with
+ranking unchanged — 15.0 GB down to 11.3 GB across a thousand documents. `INT8` is smaller again but
+measurably reorders near-neighbours, so it trades retrieval quality for disk.
+
+Note what this is and is not. It reduces **bytes written and stored**. Resident memory is dominated
+by per-record bookkeeping rather than payload, so it barely moves: to reduce resident memory you must
+reduce the number of *records*, which means fewer chunks — and that carries the retrieval cost
+described above.
 
 ### The two lossless levers together
 

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import collections
 import hashlib
 import math
 import os
@@ -21,8 +22,55 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
 
 EMBEDDING_DIM = 32
 _OSS_EMBEDDING_MODEL_CACHE: dict[str, Any] = {}
-_EMBEDDING_VECTOR_CACHE: dict[tuple[str, str], list[float]] = {}
+# Bounded LRU rather than a plain dict. The previous policy CLEARED the whole cache on overflow,
+# which throws away every warm entry at the exact moment the cache starts paying off -- on a corpus
+# with any repeated text that turns a steady hit rate into a sawtooth. Eviction is now
+# least-recently-used, and the bound is configurable because the cache is real memory: an entry is a
+# 384-float vector, so the 8192 default is roughly 25 MB per worker.
+_EMBEDDING_VECTOR_CACHE: "collections.OrderedDict[tuple[str, str], list[float]]" = collections.OrderedDict()
 _EMBEDDING_VECTOR_CACHE_LOCK = threading.RLock()
+_EMBEDDING_CACHE_STATS = {"hits": 0, "misses": 0, "evictions": 0}
+
+
+def embedding_cache_capacity() -> int:
+    try:
+        return max(0, int(os.environ.get("MATRIXARK_EMBEDDING_CACHE_ENTRIES", "8192")))
+    except ValueError:
+        return 8192
+
+
+def _cache_get(key: "tuple[str, str]") -> "list[float] | None":
+    """Read through the LRU, refreshing recency. Caller must hold the lock."""
+    vector = _EMBEDDING_VECTOR_CACHE.get(key)
+    if vector is None:
+        _EMBEDDING_CACHE_STATS["misses"] += 1
+        return None
+    _EMBEDDING_VECTOR_CACHE.move_to_end(key)
+    _EMBEDDING_CACHE_STATS["hits"] += 1
+    return vector
+
+
+def _cache_put(key: "tuple[str, str]", vector: "list[float]") -> None:
+    """Insert and evict the least recently used entries. Caller must hold the lock."""
+    capacity = embedding_cache_capacity()
+    if capacity <= 0:
+        return
+    _EMBEDDING_VECTOR_CACHE[key] = list(vector)
+    _EMBEDDING_VECTOR_CACHE.move_to_end(key)
+    while len(_EMBEDDING_VECTOR_CACHE) > capacity:
+        _EMBEDDING_VECTOR_CACHE.popitem(last=False)
+        _EMBEDDING_CACHE_STATS["evictions"] += 1
+
+
+def embedding_cache_stats() -> dict:
+    """Hits, misses, evictions and current size -- so cache behaviour is observable."""
+    with _EMBEDDING_VECTOR_CACHE_LOCK:
+        stats = dict(_EMBEDDING_CACHE_STATS)
+        stats["entries"] = len(_EMBEDDING_VECTOR_CACHE)
+        stats["capacity"] = embedding_cache_capacity()
+        looked_up = stats["hits"] + stats["misses"]
+        stats["hit_rate"] = round(stats["hits"] / looked_up, 4) if looked_up else 0.0
+        return stats
 _EMBEDDING_FALLBACK_USED = False
 
 
@@ -30,23 +78,19 @@ def embedding_for_text(text: str) -> list[float]:
     model = embedding_model_name()
     cache_key = (model, text)
     with _EMBEDDING_VECTOR_CACHE_LOCK:
-        cached = _EMBEDDING_VECTOR_CACHE.get(cache_key)
+        cached = _cache_get(cache_key)
         if cached is not None:
             return list(cached)
     provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
     if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
         vector = oss_embedding_for_text(text)
         with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
-            _EMBEDDING_VECTOR_CACHE[cache_key] = list(vector)
+            _cache_put(cache_key, vector)
         return vector
     if provider in _API_EMBEDDING_PROVIDERS:
         vector = api_embedding_for_text(text, provider)
         with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
-            _EMBEDDING_VECTOR_CACHE[cache_key] = list(vector)
+            _cache_put(cache_key, vector)
         return vector
     vector = [0.0] * EMBEDDING_DIM
     for token in tokens(text):
@@ -60,9 +104,7 @@ def embedding_for_text(text: str) -> list[float]:
     else:
         result = [round(value / norm, 6) for value in vector]
     with _EMBEDDING_VECTOR_CACHE_LOCK:
-        if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-            _EMBEDDING_VECTOR_CACHE.clear()
-        _EMBEDDING_VECTOR_CACHE[cache_key] = list(result)
+        _cache_put(cache_key, result)
     return result
 
 
@@ -75,7 +117,7 @@ def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
     missing: list[tuple[int, str]] = []
     with _EMBEDDING_VECTOR_CACHE_LOCK:
         for index, text in enumerate(texts):
-            cached = _EMBEDDING_VECTOR_CACHE.get((model, text))
+            cached = _cache_get((model, text))
             if cached is None:
                 results.append(None)
                 missing.append((index, text))
@@ -85,11 +127,9 @@ def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
     if missing and provider in _API_EMBEDDING_PROVIDERS:
         vectors = api_embedding_for_texts([text for _index, text in missing], provider)
         with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) + len(missing) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
             for (index, text), vector in zip(missing, vectors):
                 materialized = [round(float(value), 6) for value in vector]
-                _EMBEDDING_VECTOR_CACHE[(model, text)] = list(materialized)
+                _cache_put((model, text), materialized)
                 results[index] = materialized
     elif missing and provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
         model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
@@ -105,11 +145,9 @@ def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
                 _OSS_EMBEDDING_MODEL_CACHE[model_ref] = encoder
             vectors = encoder.encode([text for _index, text in missing], normalize_embeddings=True, show_progress_bar=False)
             with _EMBEDDING_VECTOR_CACHE_LOCK:
-                if len(_EMBEDDING_VECTOR_CACHE) + len(missing) >= 8192:
-                    _EMBEDDING_VECTOR_CACHE.clear()
                 for (index, text), vector in zip(missing, vectors):
                     materialized = [round(float(value), 6) for value in vector]
-                    _EMBEDDING_VECTOR_CACHE[(model, text)] = list(materialized)
+                    _cache_put((model, text), materialized)
                     results[index] = materialized
         except Exception:
             for index, text in missing:

--- a/tools/test_matrixark_embedding_cache.py
+++ b/tools/test_matrixark_embedding_cache.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The embedding vector cache: bounded, least-recently-used, and observable.
+
+The policy this replaces cleared the WHOLE cache on overflow. That is worse than it sounds on an
+ingest run: the cache fills during the first documents, and the clear then discards every warm entry
+at the moment repeated text would start paying off, so a steady hit rate becomes a sawtooth. The
+capacity also matters as memory in its own right -- an entry holds a 384-float vector, so the
+default bound is roughly 25 MB per worker and needs to be configurable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_embeddings as emb  # noqa: E402
+
+
+class EmbeddingCacheTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = os.environ.get("MATRIXARK_EMBEDDING_CACHE_ENTRIES")
+        with emb._EMBEDDING_VECTOR_CACHE_LOCK:
+            emb._EMBEDDING_VECTOR_CACHE.clear()
+            for key in emb._EMBEDDING_CACHE_STATS:
+                emb._EMBEDDING_CACHE_STATS[key] = 0
+
+    def tearDown(self) -> None:
+        if self._saved is None:
+            os.environ.pop("MATRIXARK_EMBEDDING_CACHE_ENTRIES", None)
+        else:
+            os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = self._saved
+
+    def _put(self, name: str) -> None:
+        with emb._EMBEDDING_VECTOR_CACHE_LOCK:
+            emb._cache_put(("m", name), [1.0, 2.0])
+
+    def _get(self, name):
+        with emb._EMBEDDING_VECTOR_CACHE_LOCK:
+            return emb._cache_get(("m", name))
+
+    def test_capacity_is_honoured_and_configurable(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "3"
+        for name in "abcde":
+            self._put(name)
+        self.assertEqual(emb.embedding_cache_stats()["entries"], 3)
+
+    def test_eviction_drops_the_least_recently_used_not_everything(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "3"
+        for name in "abc":
+            self._put(name)
+        self._get("a")          # 'a' becomes most recent, so 'b' is now coldest
+        self._put("d")          # evicts exactly one entry
+        stats = emb.embedding_cache_stats()
+        self.assertEqual(stats["entries"], 3)
+        self.assertEqual(stats["evictions"], 1)
+        self.assertIsNotNone(self._get("a"), "recently used entry must survive")
+        self.assertIsNone(self._get("b"), "least recently used entry must be the one evicted")
+        self.assertIsNotNone(self._get("c"))
+        self.assertIsNotNone(self._get("d"))
+
+    def test_overflow_keeps_serving_warm_entries(self) -> None:
+        """The regression the old clear-on-full policy caused: a warm key must not vanish
+        merely because unrelated keys pushed the cache past its bound."""
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "4"
+        self._put("hot")
+        for index in range(20):
+            self._put("cold%d" % index)
+            self._get("hot")          # kept warm throughout
+        self.assertIsNotNone(self._get("hot"), "a continuously used entry must never be evicted")
+
+    def test_stats_report_hits_misses_and_hit_rate(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "8"
+        self._put("x")
+        self._get("x")
+        self._get("missing")
+        stats = emb.embedding_cache_stats()
+        self.assertEqual(stats["hits"], 1)
+        self.assertEqual(stats["misses"], 1)
+        self.assertEqual(stats["hit_rate"], 0.5)
+        self.assertEqual(stats["capacity"], 8)
+
+    def test_a_zero_capacity_disables_caching_without_error(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "0"
+        self._put("x")
+        self.assertEqual(emb.embedding_cache_stats()["entries"], 0)
+        self.assertIsNone(self._get("x"))
+
+    def test_a_malformed_capacity_falls_back_to_the_default(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_CACHE_ENTRIES"] = "not-a-number"
+        self.assertEqual(emb.embedding_cache_capacity(), 8192)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The cache threw away everything at the worst moment

The embedding vector cache filled at 8192 entries and then called `clear()`. That drops every warm
entry at once, and it lands exactly when repeated text would start paying off, turning a steady hit
rate into a sawtooth. The bound was a literal in five places, invisible from outside, and real
memory — an entry holds a 384-float vector, so 8192 of them is roughly 25 MB per worker.

It is now an LRU: reads refresh recency, writes evict one least-recently-used entry at a time, and
capacity comes from `MATRIXARK_EMBEDDING_CACHE_ENTRIES`. `embedding_cache_stats()` reports hits,
misses, evictions, size and hit rate, because a cache you cannot observe is a cache you cannot tune.
The five duplicated bound checks collapse into one `_cache_put`.

Six tests, including the specific regression the old policy caused: a continuously used key must
survive while unrelated keys push the cache past its bound.

## Where ingest time actually goes

Measured, and written into the guide, because sizing an import from the storage path is wrong by a
factor of sixty:

| | |
|---|---|
| encoder, realistic chunks | ~24–30 texts/s on 8 cores |
| 1 MB document | ~2,500 chunks → **~92 s to embed** |
| same document, storage path | ~1.4 s |

Three levers, measured:

- **Worker layout** — 4 processes × 2 threads gives 35.4 texts/s versus 29.8 for 1 × 8. Free, ~19%.
- **Embedding text length** — 64 tokens instead of 128 gives **+28% throughput at a marginally better
  mean top score**. The model's own window is 128, so nothing above that is read anyway.
- **Vector scaling** — `SCALE=100000` is ~33% less disk with ranking unchanged.

And a trap worth recording: chunk size looks like a 7.7× win and measures as nearly free on a
synthetic corpus, but on real prose it cost 15% of the mean top score and changed four of six leading
answers, one plainly wrong. The synthetic passages were near-duplicates, so any answer looked right.
The guide now says to verify chunk-size changes against your own documents.

Two corrections to text I wrote earlier: the MiniLM window is 128 tokens, not 256; and benchmarking
the encoder with short strings overstates throughput eightfold versus real chunks.