### PR TITLE
Drop the placement and storage keys nothing reads from embedding_meta

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -658,6 +658,21 @@ _EMBEDDING_META_SKIP = (
     "vector",
     "storage_route",
     "storage_options",
+    # The placement/storage half of the same routing blob, inherited the same way and read by
+    # nobody. Measured over 400 memories: placement_key 182.9 KB, scope_key 125.1 KB,
+    # storage_record_kind 64.5 KB, placement_hash 56.3 KB, storage_part 50.8 KB -- 479.6 KB of
+    # embedding_meta's 1,703.4 KB (28.2%), every one of them a single distinct value across the
+    # whole store. Checked for readers rather than assumed: no read of any of them across 101
+    # `embedding_meta` sites, and the native layer never reads `embedding_meta` at all.
+    #
+    # `model` / `model_ref` are deliberately NOT here despite also scanning clean: a mis-set model
+    # path falls back to a different vector dimension, and the model identity on an embedding is
+    # what makes that detectable.
+    "placement_key",
+    "placement_hash",
+    "scope_key",
+    "storage_record_kind",
+    "storage_part",
 )
 
 def fold_embedding_records(


### PR DESCRIPTION
`embedding_meta` is the embedding record copied wholesale minus a few keys, so it inherits whatever
the record happened to carry. `_EMBEDDING_META_SKIP` already drops `storage_route` and
`storage_options` from it, on the argument that nothing reads them.

Five more keys are the same routing/placement blob, arrive the same way, and are read by nobody.
Measured across 400 memories:

| key | KB | distinct values |
|---|---:|---:|
| `placement_key` | 182.9 | 1 |
| `scope_key` | 125.1 | 1 |
| `storage_record_kind` | 64.5 | 1 |
| `placement_hash` | 56.3 | 1 |
| `storage_part` | 50.8 | 1 |

Every one holds a **single distinct value across the whole store**.

### Measured

| | before | after |
|---|---:|---:|
| `embedding_meta` total | 1,703.4 KB | **1,223.8 KB** |
| per record | 872 B | **626 B** |
| keys carried | 45 | 40 |
| size vs the vector it describes | 4.9x | **3.5x** |

**&minus;479.6 KB, &minus;28.2%**, matching the prediction to the kilobyte.

### Checked for readers, not inferred from the writer

- No read of any of the five across **101 `embedding_meta` sites** in `tools/`.
- The native layer never reads `embedding_meta` at all.

### What this does NOT do

**Durable disk does not move measurably.** Two rounds each way: 263,820 / 264,932 KB before against
264,052 / 264,824 KB after — fully overlapping. The store is ~264 MB for 300 memories, so 480 KB is
0.18% of it, well under the ~1,100 KB round-to-round spread. Reported as unmeasurable rather than
quoted as a win, and the record-level number above is the one this change is claimed on.

### Deliberately kept

`model` and `model_ref` (178 KB) scan equally clean, and stay. A mis-set embedding model path falls
back to a different vector dimension, and the model identity on an embedding is what makes that
detectable — worth more than the bytes.

`node_path`, `source_memory_layers`, `source_profile_memory_kinds` and
`source_profile_memory_classes` are genuinely read by the retrieve path and are untouched.

### Tests

`test_inline_embedding_vectors`, `test_intern_record_metadata` (recall 5/5), and
`test_engine_purge_on_delete` all pass. `test_backend_policy_part1` fails identically on an
unmodified tree — a missing `run_matrixark_rust_scale_report` module, pre-existing and unrelated.
