### PR TITLE
Wire the audit-payload slimmer into the serving pipeline it was written for

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -3361,6 +3361,21 @@ def compact_and_apply_tombstones(records: list[Json]) -> list[Json]:
     A tombstone-free log short-circuits ``apply_memory_tombstones`` unchanged, so the middle step is a
     no-op for the overwhelmingly common no-tombstone case (and ``compact_latest_value`` then
     ``compact_latest_context_state`` is exactly the historical composition)."""
+    # Audit/pipeline-task footprint bounding runs FIRST. It was written as this pipeline's entry
+    # (`bound_pipeline_task_footprint`, "Lever A, lever B, audit-payload retention, then value
+    # sharing") and was reachable from nowhere -- while a comment in matrixark_mcp_summary_runtime
+    # states serving already applies it. Its knob is defaulted, not off: audit payloads are retained
+    # for the newest 20 rows per scope and aged out beyond that.
+    #
+    # Safe at this position: it touches only pipeline-task and audit rows, never context_index
+    # postings and never memory records, so neither load-bearing boundary above is disturbed. The
+    # audit ROW always survives (retrieval and session-commit look it up by record_type + scope);
+    # only the diagnostic payload ages out.
+    try:
+        from tools.matrixark_pipeline_task_slim import bound_pipeline_task_footprint
+    except ImportError:  # Direct script execution from tools/.
+        from matrixark_pipeline_task_slim import bound_pipeline_task_footprint
+    records = bound_pipeline_task_footprint(records)
     return compact_latest_context_state_records(apply_memory_tombstones(compact_latest_value_records(records)))
 
 


### PR DESCRIPTION
`tools/matrixark_pipeline_task_slim.py` implements `bound_pipeline_task_footprint` — "Lever A,
lever B, audit-payload retention, then value sharing" — and describes itself as **"the serving
pipeline's entry"**.

**It is called from nowhere.** A repo-wide search for the name outside its defining file returns
nothing; the module is imported only by its own test. Its **10 tests pass**. Its retention knob is
defaulted, not disabled: `audit_payload_retain_per_scope` = 20 per scope.

Meanwhile `matrixark_mcp_summary_runtime.py:665` states *"Serving already collapses them
(matrixark_pipeline_task_slim, Lever A)"*. It does not — so code elsewhere is being reasoned about
on the assumption this runs.

This wires it into `compact_and_apply_tombstones`, the serving pipeline every read path calls.

### Why this position

It runs **first**, ahead of `compact_latest_value_records`. That function documents two load-bearing
boundaries — tombstones after latest-value, tombstones before the posting rebuild — and this stage
disturbs neither: it touches only pipeline-task and audit rows, never `context_index` postings and
never memory records. Running first also means the later stages carry fewer bytes.

Confirmed live on the backend path, not only local-JSONL mode: the backend adapter's
`_read_all_compacted` calls `compact_and_apply_tombstones`
(`matrixark_mcp_temporal_adapters.py:542`).

### Measured

The mechanism, directly:

```
rows in:                       60
rows stamped payload_slimmed:  40
rows still carrying `outputs`: 20     (retention default is 20/scope)
payload bytes:      50,800 -> 24,660  (51.5% smaller)
```

The audit ROW always survives — retrieval and session-commit look it up by `record_type` + scope —
and only the diagnostic payload ages out beyond the newest 20.

Context for the size: `context_extraction_audit` is 1,826 KB of ~16 MB of records in a 400-memory
store (11.3%), and `outputs` alone is 5.6%. The module's own docstring cites the same two figures
from an independent census.

### What this does NOT show

**Gateway resident memory does not separate cleanly.** Two rounds each way: 50.1 / 50.2 MB before
against 50.0 / 47.5 MB after — a &minus;1.4 MB mean, but the after arm spans 2.5 MB where the before
arm spans 0.1 MB. The expected saving is ~0.9 MB of served bytes, roughly 1.7% of a 50 MB process,
which is at the noise floor. Reported as unresolved rather than quoted as a win; the mechanism
numbers above are what this is claimed on.

### Tests

`test_pipeline_task_slim`, `test_mem0_complete` (full API), `test_engine_purge_on_delete`,
`test_inline_embedding_vectors`, `test_intern_record_metadata` (recall 5/5) all pass.

Two pre-existing reds, both verified to fail identically on an unmodified tree:
`test_matrixark_debug_trace_compaction` (a `tokens` field in pack compaction) and
`test_backend_policy_part1` (missing `run_matrixark_rust_scale_report` module).
