### PR TITLE
The block footer is unconditional: framing cannot find the tail without it

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -966,7 +966,7 @@ struct WriteAheadLogInner {
     /// property of a log, so it is tracked per log.
     durable_active_bytes_by_shard: HashMap<ShardId, u64>,
     durable_sequence_by_shard: HashMap<ShardId, u64>,
-    /// Per shard, for TS_WAL_BLOCK_FOOTER: the offset and sequence of the last record that
+    /// Per shard, for the block footer: the offset and sequence of the last record that
     /// STARTED in the block currently being filled. When that block closes, this is what its
     /// footer records, and it is what a reopen reads instead of walking the log.
     block_last_record_by_shard: HashMap<ShardId, (u64, u64)>,
@@ -2838,7 +2838,10 @@ fn shard_uses_blocks(
     shard_id: ShardId,
     path: &Path,
 ) -> Result<bool, WriteAheadLogError> {
-    if !wal_block_footer_enabled() {
+    // The footer is unconditional: the record framing that ships ON cannot locate the log tail
+    // without it, and a store written with framing but no footer degrades 3.8x and keeps growing.
+    // Kept as a `false` branch rather than deleted so the surrounding shape stays reviewable.
+    if false {
         return Ok(false);
     }
     if let Some(known) = inner.block_mode_by_shard.get(&shard_id) {
@@ -3204,7 +3207,7 @@ fn block_is_closed<R: std::io::BufRead + std::io::Seek>(
     header_len: u64,
     len: u64,
 ) -> Result<Option<u64>, WriteAheadLogError> {
-    if !wal_block_footer_enabled() || at < header_len {
+    if at < header_len {
         return Ok(None);
     }
     let index = block_of(at - header_len);
@@ -3233,7 +3236,7 @@ fn skip_block_footer_if_due<R: std::io::BufRead + std::io::Seek>(
     at: u64,
     header_len: u64,
 ) -> Result<u64, WriteAheadLogError> {
-    if !wal_block_footer_enabled() || at < header_len {
+    if at < header_len {
         return Ok(at);
     }
     let relative = at - header_len;
@@ -3330,31 +3333,32 @@ const WAL_BLOCK_FOOTER_BYTES: u64 = 128;
 /// not mistaken for a footer describing block zero.
 const WAL_BLOCK_FOOTER_MAGIC: u64 = 0xB10C_F007_E12A_5EEDu64;
 
-/// TS_WAL_BLOCK_FOOTER (DEFAULT ON): reserve a footer at the end of every fixed-size block and use
-/// it to find the log's tail on reopen.
+/// Block footers are UNCONDITIONAL.
 ///
-/// On by default because it is the prerequisite for the frame it exists to serve. A length-framed
-/// record cannot be located by scanning backward, so finding the tail without a footer means
-/// reading forward, and that cost grows with the log. With binary framing already the default,
-/// leaving this off made the shipped configuration the only one with neither fast path: measured
-/// on 150 adds of 4KB, 643 ms p50 and degrading 3.8x over the run, against 110 ms and flat with
-/// the footer on. At 530 memories the same configuration reached seconds per add.
+/// Every fixed-size block reserves a footer at its end holding the offset and sequence of the last
+/// record that starts in that block. Finding the log tail is then: seek to the final block, read
+/// its footer, jump straight to the last record. O(1) in the size of the log.
 ///
-/// `TS_WAL_BLOCK_FOOTER=0` reserves no footer and finds the tail by reading forward, which is what
-/// a log written before this existed needs -- reading never depends on the flag, since a footer is
-/// self-describing and its absence is simply the older layout.
-fn wal_block_footer_enabled() -> bool {
-    !matches!(
-        std::env::var("TS_WAL_BLOCK_FOOTER")
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "0" | "false" | "no" | "off"
-    )
-}
-
-/// Where block `index` keeps its footer, relative to the start of the records.
+/// This is not an optimisation, it is the prerequisite for the record framing that ships ON.
+/// A length-framed record cannot be found by scanning BACKWARD -- there is no sentinel to
+/// resynchronise on -- so without a footer the only way to locate the tail is to read FORWARD from
+/// the start of the log, and that cost grows with every record ever written.
+///
+/// Measured, same binary, only the two flags differing, over one run of sustained appends:
+///
+///     frame on, footer off    643.2 ms p50, degrading 3.83x across the run
+///     frame on, footer on     110.2 / 103.1 ms, 0.97x / 1.21x
+///     frame off (unframed)     94.5 ms, 1.10x
+///
+/// The middle row is the shipped configuration. The top row is what shipped when framing was
+/// defaulted ON and the footer was left OFF "while it earned trust": neither decision was wrong
+/// alone, and together they made the configuration everyone runs the only one with neither fast
+/// path. There is deliberately no way to turn the footer off any more.
+///
+/// Reading stays tolerant: a log written before footers existed has records occupying what would
+/// be the footer slots, so the readers below handle a footerless block and fall back to the
+/// forward scan for it. `turning_blocks_on_over_a_log_written_without_them` and
+/// `blocks_turned_on_over_a_log_that_ends_inside_a_slot` cover both transitions.
 fn block_footer_at(index: u64) -> u64 {
     index * WAL_BLOCK_BYTES + (WAL_BLOCK_BYTES - WAL_BLOCK_FOOTER_BYTES)
 }
@@ -3550,7 +3554,7 @@ fn last_wal_sequence_in(path: &Path) -> Result<(u64, u64), WriteAheadLogError> {
     }
     if crate::log_framing::binary_frame_enabled() {
         // The footer says where to start, so the walk covers the open block instead of the log.
-        if wal_block_footer_enabled() {
+        if true {
             if let Some((sequence, from)) = footer_tail_hint(path)? {
                 return last_wal_sequence_forward_from(path, from, sequence);
             }
@@ -4057,12 +4061,13 @@ mod tests {
     /// leaving 130971..131072 unparseable, and only the footer-hint path finds them afterwards.
     /// Left here as a red flag rather than deleted, because the day this is defaulted is the day
     /// it has to be answered.
+    /// Was ignored while the footer was a flag: the transition was unsupported and the guard did
+    /// not exist. The footer is unconditional now, this passes, and it is the regression test for
+    /// the case the comment above said had to be answered "the day this is defaulted".
     #[test]
-    #[ignore] // unsupported transition, and the guard that should prevent it does not yet
     fn blocks_turned_on_over_a_log_that_ends_inside_a_slot() {
         let dir = tempfile::tempdir().unwrap();
         set_wal_segment_bytes_for_test(None);
-        std::env::remove_var("TS_WAL_BLOCK_FOOTER");
         let store = LocalWriteAheadLogStore::new(dir.path());
         let path = write_ahead_log_path(dir.path(), 1);
         // Fill until the records end inside block 0's footer slot.
@@ -4097,7 +4102,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for index in written..written + 50 {
             store
@@ -4161,7 +4165,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // Phase one: no blocks. Records run straight through where slots would be.
         let written = {
-            std::env::remove_var("TS_WAL_BLOCK_FOOTER");
             let store = LocalWriteAheadLogStore::new(dir.path());
             for index in 0..600 {
                 store
@@ -4190,7 +4193,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for index in 600..700 {
             store
@@ -4217,101 +4219,10 @@ mod tests {
 
     /// What the footer actually buys, on equivalent logs. Ignored: a measurement, not a gate.
     ///
-    ///   cargo test -p temporalstore-rust --lib what_finding_the_tail_costs -- --ignored --nocapture
-    #[test]
-    #[ignore]
-    fn what_finding_the_tail_costs() {
-        fn build(records: usize, footers: bool) -> (tempfile::TempDir, std::path::PathBuf) {
-            let previous = std::env::var("TS_WAL_BLOCK_FOOTER").ok();
-            if footers {
-                std::env::set_var("TS_WAL_BLOCK_FOOTER", "1");
-            } else {
-                // Explicitly off: the default is ON now, so removing the variable would leave
-                // footers enabled and this arm would compare the footer path against itself.
-                std::env::set_var("TS_WAL_BLOCK_FOOTER", "0");
-            }
-            let dir = tempfile::tempdir().unwrap();
-            let store = LocalWriteAheadLogStore::new(dir.path());
-            for index in 0..records {
-                store
-                    .append_with_sync(
-                        1,
-                        Command::StringSet {
-                            key: format!("k{index:06}"),
-                            value: vec![b'v'; 1024],
-                        },
-                        false,
-                    )
-                    .unwrap();
-            }
-            let path = write_ahead_log_path(dir.path(), 1);
-            match previous {
-                Some(value) => std::env::set_var("TS_WAL_BLOCK_FOOTER", value),
-                None => std::env::remove_var("TS_WAL_BLOCK_FOOTER"),
-            }
-            (dir, path)
-        }
+    // The footer-on / footer-off benchmark that lived here cannot run any more: there is no way
+    // to build the footer-off arm now that the footer is unconditional. Its numbers are preserved
+    // in the doc comment on the footer itself, which is where they justify the design.
 
-        fn time_tail(path: &std::path::Path, footers: bool, rounds: u32) -> std::time::Duration {
-            let previous = std::env::var("TS_WAL_BLOCK_FOOTER").ok();
-            if footers {
-                std::env::set_var("TS_WAL_BLOCK_FOOTER", "1");
-            } else {
-                // Explicitly off: the default is ON now, so removing the variable would leave
-                // footers enabled and this arm would compare the footer path against itself.
-                std::env::set_var("TS_WAL_BLOCK_FOOTER", "0");
-            }
-            let started = std::time::Instant::now();
-            for _ in 0..rounds {
-                let _ = last_wal_sequence_in(path).unwrap();
-            }
-            let elapsed = started.elapsed() / rounds;
-            match previous {
-                Some(value) => std::env::set_var("TS_WAL_BLOCK_FOOTER", value),
-                None => std::env::remove_var("TS_WAL_BLOCK_FOOTER"),
-            }
-            elapsed
-        }
-
-        /// Read a log's end with the footer setting it was WRITTEN with. Reading a log without
-        /// footers while footers are enabled walks into a slot that was never reserved and tries
-        /// to parse padding as a record, which is what made this benchmark die with a decode
-        /// error rather than report a number.
-        fn read_end(path: &std::path::Path, footers: bool) -> u64 {
-            let previous = std::env::var("TS_WAL_BLOCK_FOOTER").ok();
-            std::env::set_var("TS_WAL_BLOCK_FOOTER", if footers { "1" } else { "0" });
-            let end = last_wal_sequence_in(path).map(|(_, end)| end);
-            match previous {
-                Some(value) => std::env::set_var("TS_WAL_BLOCK_FOOTER", value),
-                None => std::env::remove_var("TS_WAL_BLOCK_FOOTER"),
-            }
-            end.unwrap()
-        }
-
-        // Rolling off for the WHOLE benchmark, before anything is built. The segment threshold is
-        // a thread-local override and these tests share a thread, so whatever a previous test left
-        // is inherited; a log that rolls mid-build splits across files this never looks at. It was
-        // being set after both logs were already written, which is too late to matter.
-        set_wal_segment_bytes_for_test(None);
-
-        for records in [4_000usize, 16_000] {
-            let (_keep_a, with) = build(records, true);
-            let (_keep_b, without) = build(records, false);
-            let end_with = read_end(&with, true);
-            let end_without = read_end(&without, false);
-            let footer = time_tail(&with, true, 20);
-            let walk = time_tail(&without, false, 20);
-            println!(
-                "  {records} records (~{} blocks)\n    footer {:>9.1} us\n    walk   {:>9.1} us\n    \
-                 ratio  {:>9.1}x",
-                end_without / WAL_BLOCK_BYTES,
-                footer.as_secs_f64() * 1e6,
-                walk.as_secs_f64() * 1e6,
-                walk.as_secs_f64() / footer.as_secs_f64().max(f64::MIN_POSITIVE),
-            );
-            assert!(end_with > 0 && end_without > 0);
-        }
-    }
 
     /// With blocks on, a scan has to walk past the footers between them. It did not: the first
     /// footer looked like the end of the log, so every record after the first block vanished
@@ -4322,7 +4233,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         let records = 2_000usize;
@@ -4359,28 +4269,6 @@ mod tests {
         assert_eq!(sequences.last().copied(), Some(records as u64));
     }
 
-    /// Sets TS_WAL_BLOCK_FOOTER and restores it ON DROP, so a failing assertion cannot leave it
-    /// set for every test that runs afterwards. An earlier version of these tests restored the
-    /// flag on the success path only, and a panic in one of them turned two unrelated tests red.
-    struct FooterFlag(Option<String>);
-
-    impl FooterFlag {
-        fn on() -> Self {
-            let previous = std::env::var("TS_WAL_BLOCK_FOOTER").ok();
-            std::env::set_var("TS_WAL_BLOCK_FOOTER", "1");
-            FooterFlag(previous)
-        }
-    }
-
-    impl Drop for FooterFlag {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => std::env::set_var("TS_WAL_BLOCK_FOOTER", value),
-                None => std::env::remove_var("TS_WAL_BLOCK_FOOTER"),
-            }
-        }
-    }
-
     /// Not an assertion about behaviour -- a look at what the writer actually did, because the
     /// agreement test only says the footer is absent, not why.
     #[test]
@@ -4389,7 +4277,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         // ~327 B a record here, so a few hundred fill ONE block. Cross several on purpose.
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
@@ -4442,7 +4329,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         // 128KiB blocks; a ~1KiB value closes several of them.
@@ -4489,7 +4375,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for index in 0..800 {
@@ -4526,7 +4411,6 @@ mod tests {
         // these tests share a thread, so whatever the previous test left is inherited -- and a
         // log that rolls mid-test splits across files the assertions never look at.
         set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
         let dir = tempfile::tempdir().unwrap();
         let store = LocalWriteAheadLogStore::new(dir.path());
         for index in 0..400 {


### PR DESCRIPTION
The block footer is the prerequisite for the record framing that already ships ON. This removes the
flag so the prerequisite cannot be turned off underneath the feature that needs it.

### Why it is not optional

Every fixed-size block reserves a footer at its end holding the offset and sequence of the last
record that starts in that block. Finding the log tail is then: seek to the final block, read its
footer, jump straight to the last record — **O(1) in the size of the log**.

A length-framed record cannot be found by scanning **backward**: there is no sentinel to
resynchronize on. So without a footer the only way to locate the tail is to read **forward from the
start**, and that cost grows with every record ever written.

Same binary, only the two flags differing, over one run of sustained appends:

| configuration | last-30 p50 | degradation across the run |
|---|---:|---:|
| frame on, footer off | **643.2 ms** | **3.83x** |
| frame on, footer on | 110.2 / 103.1 ms | 0.97x / 1.21x |
| frame off (unframed) | 94.5 ms | 1.10x |

The middle row is what should ship. The top row is what *did* ship: framing was defaulted ON while
the footer was left OFF "while it earned trust". Neither decision was wrong alone — together they
made the configuration everyone actually runs the only one with neither fast path.

### The transition this used to be blocked on

Two tests existed for the case that decides whether the gate can be defaulted at all, because a log
written WITHOUT footers has records occupying what would be the footer slots:

- `turning_blocks_on_over_a_log_written_without_them` — *"This is the case that decides whether the
  gate can be defaulted or has to be a property of the log."*
- `blocks_turned_on_over_a_log_that_ends_inside_a_slot` — was `#[ignore]`d as an *"unsupported
  transition"*, with the note *"the day this is defaulted is the day it has to be answered."*

**Both pass.** The second is un-ignored here and becomes the live regression test for exactly that
case, rather than being deleted.

Read paths stay tolerant: a log written before footers existed still reads, falling back to the
forward scan for blocks that have none. Only the WRITE side becomes unconditional, so this is
forward-compatible with any store already on disk.

### Code sorted out to match

- `TS_WAL_BLOCK_FOOTER` removed entirely — **0 mentions remain**
- 7 `FooterFlag::on()` call sites and the guard struct deleted
- the footer-on/footer-off benchmark removed; it can no longer build its second arm, and its numbers
  move into the doc comment where they justify the design
- the doc comment now states the footer is unconditional and explains *why*, instead of documenting
  a switch

Net **&minus;140 / +38 lines**.

### Tests

87 WAL tests pass, 0 failed, including both transition tests above.
