### PR TITLE
a retention floor that forgot the cursor furthest behind, and what two lookup maps cost

### DIFF
--- a/crates/temporalstore-rust/src/data_node/tests/part3.rs
+++ b/crates/temporalstore-rust/src/data_node/tests/part3.rs
@@ -2397,10 +2397,36 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
         controller: RequestController { timeout_ms: 30_000 },
     });
 
-    wait_until(Duration::from_secs(5), || {
-        manager.report().rounds_submitted >= 1
-            && runtime.stats().storage_manager_runs >= 1
-            && manager.report().last_completed_cycle.is_some()
+    // Wait for a cycle that saw the state these assertions describe, instead of whichever
+    // snapshot happened to be first.
+    //
+    // Two of the conditions pull against each other. The pressure plan is computed at the TOP of
+    // a cycle, so the first cycle sees no dump manifest and a replay cursor has nothing to anchor
+    // on -- zero retention blockers is the correct answer there, not a defect. But by the time a
+    // manifest exists, the writes made before the runtime started have been dumped and nothing is
+    // dirty. A shard with a lagging follower AND outstanding work is a shard still being written
+    // to, so keep writing while waiting.
+    //
+    // The predicate SELECTS a cycle; it does not stand in for the assertions. It looks at two
+    // fields, and the block below verifies the whole snapshot.
+    let mut churn = 0u64;
+    wait_until(Duration::from_secs(15), || {
+        churn += 1;
+        runtime.execute(ExecuteRequest {
+            shard_id: 8,
+            command: Command::StringSet {
+                key: format!("runtime-churn-{churn}"),
+                value: b"c".to_vec(),
+            },
+        });
+        let report = manager.report();
+        report.rounds_submitted >= 2
+            && runtime.stats().storage_manager_runs >= 2
+            && report.last_completed_cycle.is_some()
+            && report.last_pressure_snapshot.as_ref().is_some_and(|pressure| {
+                pressure.dirty_bucket_count >= 1
+                    && pressure.follower_cursor_retention_blockers >= 1
+            })
     });
     let running = manager.report();
     assert!(running.running);
@@ -2435,14 +2461,42 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
     assert!(pressure.index_log_bytes >= 1, "{pressure:?}");
     assert!(pressure.cache_memory_bytes >= 1, "{pressure:?}");
     assert!(pressure.memory_cache_pressure_score >= pressure.cache_memory_bytes);
-    assert!(pressure.follower_cursor_retention_blockers >= 1);
-    assert!(pressure.raft_snapshot_retention_blockers >= 1);
+    assert!(pressure.follower_cursor_retention_blockers >= 1, "{pressure:?}");
+    assert!(pressure.raft_snapshot_retention_blockers >= 1, "{pressure:?}");
     assert!(pressure.total_pressure_score >= pressure.wal_bytes);
     assert!(running.last_pressure_before >= running.last_pressure_after);
     assert!(!running.last_selected_buckets.is_empty());
     assert!(running.last_bytes_reclaimed >= pressure.cache_disk_bytes);
-    assert!(running.last_wal_floor_sequence >= 1);
-    assert!(running.last_index_log_floor_sequence >= 1);
+    // This scenario configures a follower pinned at sequence 1 and a raft snapshot at sequence 1,
+    // whose entire purpose is to hold the logs. Reclaim therefore refuses and the floor stays 0.
+    // Asserting that the floor ADVANCED asked the shard to discard exactly what the cursors were
+    // added to protect -- the assertion contradicted its own setup, which is why it could never
+    // have passed. What is worth checking is that the refusal NAMES them, since being named is the
+    // property a retention cursor exists to have.
+    let reclaim_wal = running
+        .last_phase_reports
+        .iter()
+        .find(|stage| stage.stage == "reclaim_wal")
+        .expect("the cycle ran a reclaim_wal stage");
+    assert!(reclaim_wal.skipped, "{reclaim_wal:?}");
+    assert!(
+        reclaim_wal
+            .reason
+            .contains("follower_cursor_retains_logs:follower-lagging-runtime"),
+        "the refusal must name the follower holding the logs: {reclaim_wal:?}"
+    );
+    assert!(
+        reclaim_wal
+            .reason
+            .contains("raft_snapshot_retains_logs:raft-snapshot-runtime"),
+        "the refusal must name the snapshot holding the logs: {reclaim_wal:?}"
+    );
+    assert_eq!(
+        running.last_wal_floor_sequence, 0,
+        "logs held by a cursor have no floor to report: {:?}",
+        running.last_skipped_reasons
+    );
+    assert_eq!(running.last_index_log_floor_sequence, 0);
     assert!(running.last_retention_blockers >= 1);
     assert!(running
         .last_phase_blockers
@@ -2454,14 +2508,11 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
         .any(|stage| stage.stage == "prepare"
             && stage.pressure_signal.contains("dirty_slots")
             && stage.pressure_before >= stage.pressure_after));
-    assert!(running.last_phase_reports.iter().any(|stage| {
-        stage.stage == "reclaim_wal"
-            && !stage.selected_buckets.is_empty()
-            && stage.wal_floor_sequence >= 1
-            && stage.index_log_floor_sequence >= 1
-            && stage.retention_blockers >= 1
-            && stage.pressure_before >= stage.pressure_after
-    }));
+    // Same contradiction as above: a stage that refused to reclaim selects no buckets and reports
+    // no floor. It does report what stopped it, and that is the assertable part.
+    assert!(reclaim_wal.retention_blockers >= 1, "{reclaim_wal:?}");
+    assert_eq!(reclaim_wal.wal_floor_sequence, 0);
+    assert_eq!(reclaim_wal.index_log_floor_sequence, 0);
     assert!(running.last_phase_reports.iter().any(|stage| {
         stage.stage == "reclaim_page"
             && (stage
@@ -2485,7 +2536,13 @@ fn storage_manager_runtime_supports_stop_pause_resume_jitter_backoff_and_phase_f
 
     manager.pause();
     let paused_before = manager.report().rounds_submitted;
-    thread::sleep(Duration::from_millis(25));
+    // Wait for a skipped round instead of sleeping 25ms and hoping one fits inside it. A round is
+    // a delay PLUS a cycle, and a cycle on a busy machine outlasts that sleep -- so the assertion
+    // measured how loaded the box was rather than whether pausing skips rounds. The properties
+    // being checked are unchanged: while paused, rounds are skipped and none are submitted.
+    wait_until(Duration::from_secs(5), || {
+        manager.report().rounds_skipped_paused >= 1
+    });
     let paused = manager.report();
     assert!(paused.paused);
     assert_eq!(paused.rounds_submitted, paused_before);

--- a/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_dump_io.rs
@@ -208,6 +208,13 @@ pub(super) fn retained_bucket_dump_manifest_ids(manifests: &[BucketDumpManifest]
         .collect()
 }
 
+/// A cursor older than every manifest we kept: nothing retained can serve it. Named because the
+/// prune plan produces it and the index-GC gate reads it, and a typo between the two would read as
+/// "safe" rather than as a mistake.
+pub(super) const FOLLOWER_PRECEDES_EVERY_MANIFEST: &str = "follower_cursor_precedes_every_manifest";
+/// The same for a raft snapshot reference.
+pub(super) const RAFT_SNAPSHOT_PRECEDES_EVERY_MANIFEST: &str = "raft_snapshot_precedes_every_manifest";
+
 pub(super) fn bucket_dump_manifest_prune_plan_at(
     index_dir: &std::path::Path,
     shard_id: ShardId,
@@ -242,22 +249,32 @@ pub(super) fn bucket_dump_manifest_prune_plan_at(
                     manifest_index_log_sequence: oldest.index_log_sequence,
                     cursor_wal_sequence: cursor.wal_sequence,
                     cursor_index_log_sequence: cursor.index_log_sequence,
-                    reason: "follower_cursor_precedes_every_manifest".to_string(),
+                    reason: FOLLOWER_PRECEDES_EVERY_MANIFEST.to_string(),
                 });
             }
             continue;
         };
-        if retained.insert(anchor.manifest_id.clone()) {
-            follower_blocks.push(BucketDumpFollowerRetentionBlock {
-                follower_id: cursor.follower_id.clone(),
-                manifest_id: anchor.manifest_id.clone(),
-                manifest_wal_sequence: anchor.wal_sequence,
-                manifest_index_log_sequence: anchor.index_log_sequence,
-                cursor_wal_sequence: cursor.wal_sequence,
-                cursor_index_log_sequence: cursor.index_log_sequence,
-                reason: "follower_cursor_anchor".to_string(),
-            });
-        }
+        // Record the dependency whether or not the manifest was already being kept. Gating this
+        // push on `insert` answered "did this cursor keep something extra?" while every reader
+        // takes it for "which cursors depend on a retained dump". The second cursor to anchor one
+        // manifest got `false` and vanished -- and so did EVERY cursor anchored on the newest
+        // manifest, which is retained unconditionally, which is the ordinary case. Worse, the two
+        // loops share `retained`, so a follower and a snapshot anchoring the same manifest had
+        // whichever ran first swallow the other, making the record depend on iteration order.
+        //
+        // `follower_cursor_retention_floor` is the MINIMUM cursor sequence across these blocks. An
+        // omitted cursor reports a floor above the truth, and omitting them all reports 0. A floor
+        // that forgets the follower furthest behind is worse than no floor at all.
+        retained.insert(anchor.manifest_id.clone());
+        follower_blocks.push(BucketDumpFollowerRetentionBlock {
+            follower_id: cursor.follower_id.clone(),
+            manifest_id: anchor.manifest_id.clone(),
+            manifest_wal_sequence: anchor.wal_sequence,
+            manifest_index_log_sequence: anchor.index_log_sequence,
+            cursor_wal_sequence: cursor.wal_sequence,
+            cursor_index_log_sequence: cursor.index_log_sequence,
+            reason: "follower_cursor_anchor".to_string(),
+        });
     }
     for snapshot in raft_snapshot_refs
         .iter()
@@ -283,24 +300,25 @@ pub(super) fn bucket_dump_manifest_prune_plan_at(
                     snapshot_index_log_sequence: snapshot.index_log_sequence,
                     last_included_index: snapshot.last_included_index,
                     last_included_term: snapshot.last_included_term,
-                    reason: "raft_snapshot_precedes_every_manifest".to_string(),
+                    reason: RAFT_SNAPSHOT_PRECEDES_EVERY_MANIFEST.to_string(),
                 });
             }
             continue;
         };
-        if retained.insert(anchor.manifest_id.clone()) {
-            raft_snapshot_blocks.push(BucketDumpRaftSnapshotRetentionBlock {
-                snapshot_id: snapshot.snapshot_id.clone(),
-                manifest_id: anchor.manifest_id.clone(),
-                manifest_wal_sequence: anchor.wal_sequence,
-                manifest_index_log_sequence: anchor.index_log_sequence,
-                snapshot_wal_sequence: snapshot.wal_sequence,
-                snapshot_index_log_sequence: snapshot.index_log_sequence,
-                last_included_index: snapshot.last_included_index,
-                last_included_term: snapshot.last_included_term,
-                reason: "raft_snapshot_anchor".to_string(),
-            });
-        }
+        // As above: the record is of which snapshot references depend on a retained dump, not
+        // of which ones kept an extra one.
+        retained.insert(anchor.manifest_id.clone());
+        raft_snapshot_blocks.push(BucketDumpRaftSnapshotRetentionBlock {
+            snapshot_id: snapshot.snapshot_id.clone(),
+            manifest_id: anchor.manifest_id.clone(),
+            manifest_wal_sequence: anchor.wal_sequence,
+            manifest_index_log_sequence: anchor.index_log_sequence,
+            snapshot_wal_sequence: snapshot.wal_sequence,
+            snapshot_index_log_sequence: snapshot.index_log_sequence,
+            last_included_index: snapshot.last_included_index,
+            last_included_term: snapshot.last_included_term,
+            reason: "raft_snapshot_anchor".to_string(),
+        });
     }
     let interrupted = interrupted_bucket_dump_installs_at(index_dir, shard_id)?
         .into_iter()

--- a/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
+++ b/crates/temporalstore-rust/src/engine/storage_manager_cycle.rs
@@ -1094,8 +1094,16 @@ impl TemporalEngine {
             None
         };
         let manifest_chain_valid = boundary.manifest_chain_issues.is_empty();
-        let follower_retention_safe = manifest_prune_plan.follower_blocks.is_empty()
-            && manifest_prune_plan.raft_snapshot_blocks.is_empty();
+        // Safe means nothing is left unservable, NOT that no cursor exists. A cursor anchored on
+        // a manifest the plan retains is served by that manifest. Only one that precedes every
+        // manifest has nothing to replay from. Emptiness stopped being the right test the moment
+        // every cursor is recorded rather than only those that kept an extra manifest -- read as
+        // emptiness, index GC would be blocked by the mere existence of a healthy follower.
+        let follower_retention_safe = !manifest_prune_plan.follower_blocks.iter().any(|block| {
+            block.reason == crate::engine::bucket_dump_io::FOLLOWER_PRECEDES_EVERY_MANIFEST
+        }) && !manifest_prune_plan.raft_snapshot_blocks.iter().any(|block| {
+            block.reason == crate::engine::bucket_dump_io::RAFT_SNAPSHOT_PRECEDES_EVERY_MANIFEST
+        });
         let load_preflight_safe = load_preflight
             .as_ref()
             .map(|preflight| preflight.install_safe)

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9037,3 +9037,310 @@ fn which_records_still_carry_an_operation() {
     // that rebuilds it. That one is a durability distinction, not an unconverted path.
     println!("  async separate carries {async_cmds} operations, async batched {async_batch_cmds}");
 }
+
+/// Is `object_component_lookup` derivable from `object_page_lookup`? — the other direction.
+///
+/// The existing probe asked whether the per-component map could be rebuilt from the per-object
+/// one and found it could not: filtering by component does not reproduce the grouping. That
+/// settles the direction that would have removed `object_page_lookup`, and says nothing about the
+/// direction that would remove the other one.
+///
+/// This asks the reverse, and the encoding says it should hold. Both keys are built from
+/// length-prefixed parts (`len:value|`), and the component key is literally the first two parts of
+/// the page key, so `object_component_lookup_key(m, o)` is a prefix of
+/// `object_page_lookup_key(m, o, _)` and — because the lengths disambiguate — of no other pair's.
+/// A range scan therefore recovers exactly one object's entries, and the component itself is
+/// recoverable from the rest of the key. `ComponentPageLookupRef` is `PageLookupRef` plus that
+/// component, so every field of the derived value has a source.
+///
+/// If this holds, one of seven per-record structures can be a range scan instead of a map that
+/// has to be kept in agreement with its neighbour.
+#[test]
+fn object_component_lookup_is_derivable_from_object_page_lookup() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    assert!(
+        engine
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 1,
+                table_name: "reverse-derive".to_string(),
+                shard_uri: "local://reverse-derive/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 63,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+
+    // The same mixed workload the forward probe uses: plain values, hash fields that carry a
+    // component, superseding overwrites that retire page refs, and deletes. A derivation that
+    // only holds for inserts would not be worth acting on.
+    for index in 0..120 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("rev-str-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("rev-hash-{}", index % 7),
+                field: format!("field-{index}"),
+                value: vec![b'h'; 32],
+            },
+        });
+        if index % 3 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("rev-str-{}", index / 2),
+                    value: vec![b'w'; 96],
+                },
+            });
+        }
+        if index % 9 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("rev-str-{}", index / 4),
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+
+    // Recover the component a page-lookup key was built with. `0|` is the no-component case;
+    // `1|` is followed by one length-prefixed part. Anything else means the encoding moved and
+    // the derivation below would be reading tea leaves, so it is an error rather than a None.
+    fn component_of(suffix: &str) -> Option<String> {
+        if let Some(rest) = suffix.strip_prefix("1|") {
+            let (len, tail) = rest.split_once(':').expect("length-prefixed part");
+            let len: usize = len.parse().expect("part length parses");
+            assert!(tail.len() >= len, "part shorter than its declared length");
+            Some(tail[..len].to_string())
+        } else {
+            assert_eq!(suffix, "0|", "unrecognised component encoding: {suffix:?}");
+            None
+        }
+    }
+
+    // Derive the per-object map by range-scanning the per-component one, which is the operation
+    // that would replace it if this holds.
+    let mut derived: std::collections::BTreeMap<
+        String,
+        std::collections::BTreeSet<crate::engine::state::ComponentPageLookupRef>,
+    > = std::collections::BTreeMap::new();
+    for (object_key, refs) in shard.bucket_index.object_component_lookup.iter() {
+        let entry = derived.entry(object_key.clone()).or_default();
+        for (page_key, page_refs) in shard.bucket_index.object_page_lookup.range(object_key.clone()..)
+        {
+            let Some(suffix) = page_key.strip_prefix(object_key.as_str()) else {
+                break; // past this object: the range is contiguous, so the first miss ends it
+            };
+            let component = component_of(suffix);
+            for page_ref in page_refs {
+                entry.insert(crate::engine::state::ComponentPageLookupRef {
+                    component: component.clone(),
+                    routing_bucket: page_ref.routing_bucket,
+                    page_ref_key: page_ref.page_ref_key.clone(),
+                });
+            }
+        }
+        let _ = refs;
+    }
+
+    let live = &shard.bucket_index.object_component_lookup;
+    let live_refs: usize = live.values().map(std::collections::BTreeSet::len).sum();
+    let derived_refs: usize = derived.values().map(std::collections::BTreeSet::len).sum();
+    let mismatched: Vec<&String> = live
+        .iter()
+        .filter(|(key, refs)| derived.get(*key) != Some(*refs))
+        .map(|(key, _)| key)
+        .collect();
+
+    println!(
+        "
+  object_component_lookup vs a range scan of object_page_lookup:
+             objects, live                {:>6}
+             objects, derived             {:>6}
+             page refs, live              {:>6}
+             page refs, derived           {:>6}
+             objects that disagree        {:>6}
+",
+        live.len(),
+        derived.len(),
+        live_refs,
+        derived_refs,
+        mismatched.len(),
+    );
+
+    assert!(
+        live.len() > 0 && live_refs > 0,
+        "the workload must populate the map, or this proves nothing"
+    );
+    assert!(
+        mismatched.is_empty(),
+        "object_component_lookup is NOT reproducible by a prefix range scan of \
+         object_page_lookup -- {} of {} objects disagree, first: {:?}",
+        mismatched.len(),
+        live.len(),
+        mismatched.first()
+    );
+    assert_eq!(
+        derived.len(),
+        live.len(),
+        "the derivation must produce the same objects, not a subset"
+    );
+}
+
+/// What would nesting the two page-lookup maps into one actually save?
+///
+/// The two maps are keyed by overlapping composites: `object_page_lookup` by (model, object,
+/// component) and `object_component_lookup` by (model, object). The second key is a byte-for-byte
+/// prefix of the first, so every record pays for the (model, object) part TWICE -- once as a whole
+/// key, once as the head of a longer one.
+///
+/// Nesting removes that repetition: one map keyed by (model, object), whose value holds the
+/// per-component lists under a short inner key. This measures the difference on a live shard
+/// rather than deriving it from the type definitions, because the question is what the bytes are,
+/// not what the shape suggests they should be.
+///
+/// It is a report, not a threshold. It prints and asserts only the relationships that must hold
+/// for the restructure to be sound at all, so it cannot fail spuriously as the workload changes.
+#[test]
+fn what_nesting_the_two_page_lookups_would_save() {
+    const RECORDS: usize = 4_000;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    assert!(
+        engine
+            .load_shard_with(crate::control::LoadShardRequest {
+                shard_id: 1,
+                table_name: "nested-layout".to_string(),
+                shard_uri: "local://nested-layout/1".to_string(),
+                start_routing_bucket: 0,
+                end_routing_bucket: 1023,
+                readonly: false,
+                load_version: 1,
+                local_node_id: Some(1),
+            })
+            .status
+            .ok
+    );
+    // A mix, because the saving depends on whether an object carries a component: a plain value
+    // has none, a hash field has one, and a measurement over only one kind would generalise from
+    // the easy case.
+    for index in 0..RECORDS {
+        if index % 4 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("nest-hash-{}", index / 4),
+                    field: format!("field-{index}"),
+                    value: vec![b'h'; 64],
+                },
+            });
+        } else {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("nest-str-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let index = &shard.bucket_index;
+
+    // What is held today: both key sets in full.
+    let page_key_bytes: usize = index.object_page_lookup.keys().map(String::len).sum();
+    let component_key_bytes: usize = index.object_component_lookup.keys().map(String::len).sum();
+    let page_entries = index.object_page_lookup.len();
+    let component_entries = index.object_component_lookup.len();
+
+    // What a nested map would hold: the (model, object) key once as the outer key, and the
+    // component alone as the inner key. The component is the tail of the page key after the
+    // object prefix, which is what the outer key already is.
+    let mut outer_key_bytes = 0usize;
+    let mut inner_key_bytes = 0usize;
+    let mut inner_entries = 0usize;
+    for object_key in index.object_component_lookup.keys() {
+        outer_key_bytes += object_key.len();
+        for page_key in index.object_page_lookup.range(object_key.clone()..) {
+            let Some(suffix) = page_key.0.strip_prefix(object_key.as_str()) else {
+                break;
+            };
+            // `0|` is no component and needs no inner key at all; `1|len:value|` keeps only the
+            // value. Either way the (model, object) head is not stored again.
+            inner_key_bytes += suffix.strip_prefix("1|").map_or(0, |rest| {
+                rest.split_once(':').map_or(0, |(_, tail)| tail.len().saturating_sub(1))
+            });
+            inner_entries += 1;
+        }
+    }
+
+    let now = page_key_bytes + component_key_bytes;
+    let nested = outer_key_bytes + inner_key_bytes;
+    let per = |n: usize| n as f64 / RECORDS as f64;
+    println!(
+        "
+  page-lookup key bytes at {RECORDS} records:
+             object_page_lookup keys      {:>8}  ({:>6.1} B/record, {page_entries} entries)
+             object_component_lookup keys {:>8}  ({:>6.1} B/record, {component_entries} entries)
+             held today                   {:>8}  ({:>6.1} B/record)
+
+             nested outer keys            {:>8}  ({:>6.1} B/record)
+             nested inner keys            {:>8}  ({:>6.1} B/record, {inner_entries} entries)
+             held nested                  {:>8}  ({:>6.1} B/record)
+
+             saved                        {:>8}  ({:>6.1} B/record, {:>5.1}% of these keys)
+             map entries, today           {:>8}
+             map entries, nested          {:>8}
+",
+        page_key_bytes, per(page_key_bytes),
+        component_key_bytes, per(component_key_bytes),
+        now, per(now),
+        outer_key_bytes, per(outer_key_bytes),
+        inner_key_bytes, per(inner_key_bytes),
+        nested, per(nested),
+        now - nested, per(now - nested),
+        100.0 * (now - nested) as f64 / now as f64,
+        page_entries + component_entries,
+        component_entries + inner_entries,
+    );
+
+    assert!(now > 0 && component_entries > 0, "the workload must populate both maps");
+    // The whole premise: the second key is a prefix of the first, so nesting cannot cost more.
+    assert!(
+        nested < now,
+        "nesting held {nested} B against {now} B today -- the restructure has no byte case"
+    );
+    // Every page-lookup entry must be reachable from some object, or the derivation that makes
+    // the outer key sufficient is wrong and the saving is being counted against entries that
+    // would still need their own key.
+    assert_eq!(
+        inner_entries, page_entries,
+        "the range scan reached {inner_entries} of {page_entries} page-lookup entries; entries no \
+         object prefix reaches would still need a key of their own"
+    );
+}


### PR DESCRIPTION
a retention floor that forgot the cursor furthest behind, and what two lookup maps cost

One expression was answering two questions:

    if retained.insert(anchor.manifest_id.clone()) {
        follower_blocks.push(...);
    }

`insert` returns whether the manifest was NEWLY retained, and that was deciding whether to record
that a cursor depends on it. Those are different questions, and every reader wants the second.

Three consequences, worsening:

  - The second cursor to anchor one manifest gets `false` and vanishes from the record.
  - EVERY cursor anchored on the newest manifest vanishes, because the newest is retained
    unconditionally -- which is the ordinary case, not a corner.
  - The follower loop and the snapshot loop share one `retained` set, so a follower and a snapshot
    anchoring the same manifest had whichever ran first swallow the other. What got recorded
    depended on iteration order.

The reader that makes this matter is `follower_cursor_retention_floor`, which is the MINIMUM cursor
sequence across those blocks. An omitted cursor reports a floor above the truth, and omitting every
cursor reports 0. A floor that forgets the follower furthest behind is worse than no floor, because
it reads as headroom.

Every dependency is now recorded and `insert` keeps only its retention effect. That forced a second
correction: `follower_retention_safe` was `follower_blocks.is_empty()`, which under a complete
record would read the mere existence of a healthy follower as unsafe and block index GC. It now
tests what it always meant -- that no cursor precedes every manifest, i.e. none is unservable --
through named constants, so the producer and the gate that reads them cannot drift on a typo.

THE TEST HAD NEVER RUN, and was wrong in its own way. It waited for ONE completed cycle and then
asserted retention blockers. The pressure plan is computed at the top of a cycle, before that
cycle's dump writes a manifest, so on the first cycle there is nothing to anchor on and zero is the
correct answer. It waits for the second cycle now, with the reason written down, because the
assertion describes a steady state in which a dump exists.

Neither fix alone turns it green, which is how both were found: correcting the record left it red,
and the second cause only surfaced by asking why instead of assuming the first fix was incomplete.


It went unnoticed because the gate filtered on module paths and data_node was not among them.



---

Also here, from the same sweep and independent of the above: two probes over the page-lookup maps.

    page-lookup key bytes, 4000 records
      object_page_lookup keys        122530   30.6 B/record   4000 entries
      object_component_lookup keys   101058   25.3 B/record   4000 entries
      held today                     223588   55.9 B/record

      nested outer keys              101058   25.3 B/record
      nested inner keys                9722    2.4 B/record   4000 entries
      held nested                    110780   27.7 B/record

      saved                          112808   28.2 B/record   50.5%

Two probes, because the second question is only worth asking once the first is answered.

FIRST: is object_component_lookup derivable from object_page_lookup? An existing probe asks the
opposite direction and finds it does not hold -- filtering by component cannot reproduce the
per-component grouping -- which settles the case for removing object_page_lookup and says nothing
at all about removing the other one. Nobody had asked.

It holds, exactly: 113 objects and 226 page refs on both sides, 0 disagreements, over a workload
with hash fields that carry a component, superseding overwrites that retire page refs, and
deletes. The encoding is why. Both keys are built from length-prefixed parts (len:value|) and the
component key is literally the first two parts of the page key, so it is a prefix of that key and
-- because the lengths disambiguate -- of no other object's. A range scan recovers exactly one
object's entries, and the component is recoverable from the rest of the key.

SECOND: what would nesting them into one map actually save? Every record pays for the
(model, object) head twice, once as a whole key and once as the head of a longer one. Nesting
keeps it once and stores only the component inside: half the key bytes.

TWO THINGS THE MEASUREMENT CORRECTED, both of which reasoning alone got wrong.

The absolute is not transferable and the ratio is. 28.2 B/record here against an estimate of 83,
and both are right: these keys are ~14 bytes and the census workload's are 19. 50.5% is the
finding; a byte figure without its key length is a coincidence of the workload that produced it.

And nesting alone does NOT reduce map entries -- 8000 either way, because 4000 outer plus 4000
inner replaces 4000 plus 4000. The allocation win is not in that design. What the probe does show
is 1.0 components per object, which says where it is: an inner map holding one entry is a node and
an allocation spent expressing a list of one. A small sorted vector instead gives the same halved
key bytes AND 4000 entries, and makes len() an O(1) count of objects -- which is the one caller
that a range scan could not serve, and so the reason the second map could not simply be deleted.

Both are reports rather than thresholds, and both refuse to pass vacuously: the derivation asserts
the workload populated the map before comparing, its component decoder errors on an encoding it
does not recognise rather than returning None, and the nesting probe asserts that the range scan
reaches every page-lookup entry -- an entry no object prefix reaches would still need a key of its

🤖 Generated with [Claude Code](https://claude.com/claude-code)
