### PR TITLE
Retire two rollout gates whose off path is the behavior they replaced

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -429,11 +429,13 @@ INTERN_BUNDLE_EMIT_KEY = "__bundle__"  # emitted-token namespace for bundle side
 # records (model_ref/model_name/model_hash/provider/execution_mode) re-emitted on every serving batch
 # that carries a context_embedding, yet only a handful of distinct models exist per store. The read
 # path already latest-state-compacts them (compact_latest_context_state_records), so the duplicates are
-# pure durable-log bloat. With MATRIXARK_DEDUP_MODEL_REGISTRY ON we append at most one registry record
-# per distinct semantic identity (timestamp excluded); a genuine change to any model field is a new
-# identity and is still recorded. Serving/retrieval that reads model info still resolves it (>=1 record
-# per model survives). Flag OFF re-emits every batch (prior behaviour).
-DEDUP_MODEL_REGISTRY = bool_env("MATRIXARK_DEDUP_MODEL_REGISTRY", True)
+# pure durable-log bloat. At most one registry record is appended per distinct semantic identity
+# (timestamp excluded); a genuine change to any model field is a new identity and is still recorded.
+# Serving/retrieval that reads model info still resolves it (>=1 record per model survives).
+#
+# This was gated behind MATRIXARK_DEDUP_MODEL_REGISTRY during its rollout. The gate is gone: its OFF
+# path was the superseded behavior -- re-emitting every batch -- and keeping a switch for it only
+# preserved the option of choosing the worse one.
 
 # Phase-2 -- coalesce transient summary-dirty markers. A context_summary_dirty (status="pending")
 # marker means "this node's summary needs regeneration". One is emitted per (node prefix) on EVERY
@@ -441,13 +443,16 @@ DEDUP_MODEL_REGISTRY = bool_env("MATRIXARK_DEDUP_MODEL_REGISTRY", True)
 # though the refresh reconciliation only ever acts on the LATEST uncompleted pending marker per node
 # (it regenerates the node summary from all current events regardless of which marker triggered it) and
 # resolves a marker by matching a status="completed" marker on the same dirty_hash. With
-# MATRIXARK_COALESCE_SUMMARY_DIRTY ON we keep at most ONE outstanding (uncompleted) pending marker per
+# coalescing ON we keep at most ONE outstanding (uncompleted) pending marker per
 # (scope, node): a new pending marker is skipped while an uncompleted one is already durable, so the
 # node stays flagged for regen. CRASH-SAFE -- the one outstanding marker is durable, so a crash before
 # regen still triggers the refresh on recovery; once the summary regenerates (completion marker with
 # that dirty_hash) the next event re-marks the node afresh. Completion/refreshed markers are never
-# dropped. Flag OFF emits a marker per event (prior behaviour).
-COALESCE_SUMMARY_DIRTY = bool_env("MATRIXARK_COALESCE_SUMMARY_DIRTY", True)
+# dropped.
+#
+# This was gated behind MATRIXARK_COALESCE_SUMMARY_DIRTY during its rollout. The gate is gone: its
+# OFF path was the superseded behavior -- a marker per event, measured at ~5% of on-disk memory --
+# and a switch whose only setting anyone would choose is ON is not a switch.
 
 
 def _canonical_scope_key_of(record: Json) -> str:
@@ -4225,10 +4230,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
 
     def _filter_duplicate_model_registry(self, records: list[Json]) -> list[Json]:
         """Drop context_model_registry records whose semantic identity is already durably present.
-        Keeps at least one record per distinct model; a changed field is a new identity. No-op when the
-        flag is OFF."""
-        if not DEDUP_MODEL_REGISTRY:
-            return records
+        Keeps at least one record per distinct model; a changed field is a new identity."""
         if not any(isinstance(r, dict) and r.get("record_type") == "context_model_registry" for r in records):
             return records
         if not getattr(self, "_model_registry_seeded", False):
@@ -4282,9 +4284,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
     def _coalesce_summary_dirty(self, records: list[Json]) -> list[Json]:
         """Drop redundant pending summary-dirty markers for a (scope, node) that already has an
         outstanding uncompleted marker. Completion / non-pending markers pass through. No-op when the
-        flag is OFF or the batch carries no pending markers."""
-        if not COALESCE_SUMMARY_DIRTY:
-            return records
+        batch carries no pending markers."""
         pending_in_batch = [
             r for r in records
             if isinstance(r, dict) and str(r.get("record_type") or "") == "context_summary_dirty"


### PR DESCRIPTION
Audited all **617 environment flags** in the repo. Twenty default ON; **eighteen of those are never
set to off anywhere**, in source or in tests.

That is not sufficient grounds to remove them. A durable-format switch or a recall rollback is also
never set to 0 — right up until the day it is needed. The bar applied here is the one the block
footer met: **the OFF path is the superseded behavior, kept for a rollout that is over, and nothing
can want it back.**

Exactly two meet it, and both say so in their own comments.

### Retired

| flag | what OFF meant | measured cost of OFF |
|---|---|---|
| `MATRIXARK_COALESCE_SUMMARY_DIRTY` | *"emits a marker per event (prior behaviour)"* | ~5% of on-disk memory |
| `MATRIXARK_DEDUP_MODEL_REGISTRY` | *"re-emits every batch (prior behaviour)"* | pure durable-log bloat |

A summary-dirty marker means "this node needs regeneration". One was emitted per node **per event**,
while the refresh only ever acts on the latest uncompleted marker. The registry rows are pure model
metadata re-appended on every serving batch carrying an embedding, when a handful of distinct models
exist per store and the read path already latest-state-compacts them.

Each had exactly **one** use site — an `if not FLAG: return records` early-out — and no test
used either. The rationale stays in the code; only the switch goes, plus a note saying it was
a rollout gate and why it is gone.

### Deliberately left alone

The other sixteen are configuration or real rollback valves, not rollout gates:

- `MATRIXARK_INTERN_RECORD_METADATA` / `MATRIXARK_INTERN_METADATA_BUNDLE` — a **durable storage
  format**. OFF is byte-identical to the pre-codec log, which is exactly the rollback you want if a
  format problem appears.
- `MATRIXARK_PRUNE_INTERNAL_INDEX_DIMENSIONS` — its own comment says any dimension whose removal
  drops recall must come off the list; the flag is the rollback for a recall regression.
- `TS_SCRATCH_SWEEP` — OFF leaves abandoned scratch directories in place, which is a debugging aid.
- `MATRIXARK_METADATA_AUTO_INIT`, `MATRIXARK_RUST_PROXY_SHARED_PROCESS`,
  `MATRIXARK_TEMPORALSTORE_SHADOW_LOCAL_STORE`, `MATRIXARK_LOCAL_JSONL_ENABLED`,
  `MATRIXARK_RESOURCE_*` — deployment configuration.

`MATRIXARK_LOCAL_JSONL_ENABLED` is worth a note: it reads as "never disabled" because backend
adapters turn it off through a sentinel path rather than the environment variable. The audit's
"never set to 0" signal is necessary but not sufficient, and that is one of the cases that shows why.

### Behavior is preserved by construction, not by benchmark

The only executable lines this changes are the two constants and the two branches they guarded:



Everything else in the diff is comments. Both constants defaulted to , so  was unreachable and its removal cannot change what the code does.

That is worth stating precisely because a benchmark CANNOT establish it. Ingest timing and durable
record counts vary several percent run to run on this workload -- enough to swamp the difference
being looked for, and enough to invent one that is not there. A static argument about an unreachable
branch is the stronger evidence here.

**The one real behavior change**: a deployment that had explicitly set either variable to  gets
the ON behavior after this. The audit found no such setting anywhere in the repo or its tests, but an
operator could have set it in an environment. That is the intended consequence -- the OFF path is the
superseded behavior -- and it is stated here rather than left implicit.

### Tests

`test_mem0_complete` (full API), `test_pipeline_task_slim`, `test_engine_purge_on_delete`,
`test_inline_embedding_vectors`, `test_intern_record_metadata` (recall 5/5) all pass.
