### PR TITLE
the benchmark that measures what the footer is for had stopped running

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4267,18 +4267,32 @@ mod tests {
             elapsed
         }
 
+        /// Read a log's end with the footer setting it was WRITTEN with. Reading a log without
+        /// footers while footers are enabled walks into a slot that was never reserved and tries
+        /// to parse padding as a record, which is what made this benchmark die with a decode
+        /// error rather than report a number.
+        fn read_end(path: &std::path::Path, footers: bool) -> u64 {
+            let previous = std::env::var("TS_WAL_BLOCK_FOOTER").ok();
+            std::env::set_var("TS_WAL_BLOCK_FOOTER", if footers { "1" } else { "0" });
+            let end = last_wal_sequence_in(path).map(|(_, end)| end);
+            match previous {
+                Some(value) => std::env::set_var("TS_WAL_BLOCK_FOOTER", value),
+                None => std::env::remove_var("TS_WAL_BLOCK_FOOTER"),
+            }
+            end.unwrap()
+        }
+
+        // Rolling off for the WHOLE benchmark, before anything is built. The segment threshold is
+        // a thread-local override and these tests share a thread, so whatever a previous test left
+        // is inherited; a log that rolls mid-build splits across files this never looks at. It was
+        // being set after both logs were already written, which is too late to matter.
+        set_wal_segment_bytes_for_test(None);
+
         for records in [4_000usize, 16_000] {
             let (_keep_a, with) = build(records, true);
             let (_keep_b, without) = build(records, false);
-            let (_, end_with) = {
-                // rolling is off for this test. The segment threshold is a THREAD-LOCAL override and
-        // these tests share a thread, so whatever the previous test left is inherited -- and a
-        // log that rolls mid-test splits across files the assertions never look at.
-        set_wal_segment_bytes_for_test(None);
-        let _flag = FooterFlag::on();
-                last_wal_sequence_in(&with).unwrap()
-            };
-            let (_, end_without) = last_wal_sequence_in(&without).unwrap();
+            let end_with = read_end(&with, true);
+            let end_without = read_end(&without, false);
             let footer = time_tail(&with, true, 20);
             let walk = time_tail(&without, false, 20);
             println!(


### PR DESCRIPTION
the benchmark that measures what the footer is for had stopped running

     4000 records (~32 blocks)    footer  2848.8 us   walk  142781.0 us    50.1x
    16000 records (~130 blocks)   footer   494.6 us   walk  427180.3 us   863.6x

It died with `Json(Error("expected value", line: 1, column: 1))` and had done for some time. Being
`#[ignore]`d, nothing ran it, so nothing said so.

Two faults, both from an edit that landed inside a block expression:

    let (_, end_with) = {
        // rolling is off for this test...
        set_wal_segment_bytes_for_test(None);
        let _flag = FooterFlag::on();
        last_wal_sequence_in(&with).unwrap()
    };
    let (_, end_without) = last_wal_sequence_in(&without).unwrap();

`build()` and `time_tail()` each save, set and restore TS_WAL_BLOCK_FOOTER around their own work.
The two reads between them did not. So the log written WITHOUT footers was read while footers were
enabled, which walks into a slot that was never reserved and parses padding as a record -- the
decode error. Each log is now read with the setting it was written with, through a helper that does
the same save-set-restore as its neighbours.

And the segment-rolling override was being cleared after both logs had already been written, which
is too late for it to prevent anything. It is set once, before either build.

WHAT IT MEASURES, now that it runs: the walk grows with the log and the footer does not. Four times
the records costs the walk 3.0x, and the ratio moves from 50x to 864x. That shape is the whole
argument for the footer -- not that it is faster at one size, but that the alternative is a cost
that scales with the log while the log is what keeps growing.

An `#[ignore]`d test is excluded from the gate by design, which is the right call for a measurement
that takes fifteen seconds -- and it means these rot silently. A sweep of the ignored set is worth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
