### PR TITLE
Default to multilingual-e5-small with its instruction prefixes

### DIFF
--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -140,6 +140,32 @@ impl Default for ContextCompressionPolicy {
     }
 }
 
+/// How many nodes each traversal depth keeps, when the request does not say.
+///
+/// Retrieval breadth is a deployment decision, not a build-time one: a corpus of short playbook
+/// steps wants a wider frontier than one of long prose, and the right value is found by measuring
+/// recall on the operator's own documents. The request-level `top_k_per_depth` still wins where a
+/// caller sets it; this only supplies the default it falls back to.
+///
+/// Widening costs latency roughly linearly -- traversal work is bounded by depth x top_k x
+/// children -- which is why it is capped at CONTEXT_MAX_LIMIT rather than left open.
+pub(super) fn default_traversal_top_k() -> usize {
+    std::env::var("MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_TOP_K)
+}
+
+/// Ceiling on nodes collected across the whole traversal, when the request does not say.
+pub(super) fn default_traversal_candidates() -> usize {
+    std::env::var("MATRIXARK_RETRIEVAL_MAX_CANDIDATES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_CANDIDATES)
+}
+
 pub(super) fn context_compression_policy_from_env() -> ContextCompressionPolicy {
     fn env_usize(name: &str, default: usize) -> usize {
         std::env::var(name).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
@@ -910,7 +936,7 @@ pub(super) fn traverse_context_tree(
 ) -> Vec<ContextTraversedNode> {
     let max_depth = max_depth.unwrap_or(6).min(CONTEXT_MAX_TRAVERSAL_DEPTH);
     let top_k = top_k_per_depth
-        .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_TOP_K)
+        .unwrap_or_else(default_traversal_top_k)
         .max(1)
         .min(CONTEXT_MAX_LIMIT);
     let child_limit = max_children_scored_per_parent
@@ -918,7 +944,7 @@ pub(super) fn traverse_context_tree(
         .max(1)
         .min(CONTEXT_MAX_LIMIT);
     let candidate_limit = max_candidate_nodes
-        .unwrap_or(CONTEXT_DEFAULT_TRAVERSAL_CANDIDATES)
+        .unwrap_or_else(default_traversal_candidates)
         .max(1)
         .min(CONTEXT_MAX_LIMIT);
     let mut frontier = vec![ContextTraversedNode {

--- a/docs/BATCH_INGESTION_GUIDE.md
+++ b/docs/BATCH_INGESTION_GUIDE.md
@@ -348,6 +348,50 @@ export MATRIXARK_EMBEDDING_VECTOR_SCALE=100000     # integer vectors, ranking un
 # and run the encoder as four small processes rather than one large one
 ```
 
+## 10c. Lexical postings cost 12.6% and contribute nothing measurable
+
+Postings are a second index built alongside the vectors. Measured against 374 chunks of real
+documentation with English and Chinese queries, they changed no outcome:
+
+```
+strategy                hit@1   hit@5   Chinese hit@5
+embeddings only          1/8     4/8        1/2
+embeddings + lexical     1/8     4/8        1/2
+lexical only             1/8     1/8        0/2
+```
+
+Identical with and without. Lexical alone found one answer in eight and **none of the Chinese ones**,
+because term matching does not split CJK — a Chinese query has almost no lexical surface to match.
+
+Their cost, on one 1 MB skill document:
+
+```
+                records   written      amplification
+postings on       7,574   11,806 KB       11.3x
+postings off      5,020   10,318 KB        9.8x
+                 -2,554   -12.6%       -1.52 GB per 1000 documents
+```
+
+The distribution shows why they cannot help. Of 2,554 posting lists holding 25,100 references, the
+**largest ten hold 57% of all references, and the biggest names 2,510 chunks — every chunk in the
+document.** The median list names exactly one. A list that matches everything cannot discriminate,
+and a list that matches one chunk is a per-chunk record with nothing aggregated. Nearly all the bytes
+sit at one of those two useless extremes.
+
+To turn them off:
+
+```bash
+export MATRIXARK_INDEX_POSTING_LISTS=0
+export MATRIXARK_INDEX_KEYWORD_LIMIT=0
+export MATRIXARK_MAX_METADATA_KEYWORD_INDEXES_PER_CHUNK=0
+export MATRIXARK_MAX_SECONDARY_INDEX_TERMS_PER_RECORD=0
+export MATRIXARK_MAX_INDEX_TERMS_PER_RESOURCE_CHUNK=0
+```
+
+Keep them for a corpus that is heavily identifier-driven — exact SKU codes, error numbers, symbol
+names — where token matching genuinely carries signal that an embedding blurs. For prose playbooks in
+mixed English and Chinese, they are cost without return.
+
 ## 10b. Window, text cap and chunk size are one decision
 
 These three must agree, and the measured answer is not the intuitive one. A cap below the window

--- a/tools/context_minilm_embed_server.py
+++ b/tools/context_minilm_embed_server.py
@@ -24,7 +24,7 @@ from sentence_transformers import SentenceTransformer
 MODEL_NAME = (
     os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH", "").strip()
     or os.environ.get("MATRIXARK_EMBEDDING_MODEL", "").strip()
-    or "sentence-transformers/all-MiniLM-L6-v2"
+    or "intfloat/multilingual-e5-large"
 )
 print("loading model...", file=sys.stderr, flush=True)
 _MODEL = SentenceTransformer(MODEL_NAME)

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -962,7 +962,8 @@ class _LocalAdapterRetrieveMixin:
                 "Python reference packing is disabled unless explicitly overridden for local debug."
             )
         embedding_started_perf = time.perf_counter()
-        query_embedding = embedding_for_text(retrieval_query)
+        # The query side takes the query prefix; every other call here embeds document text.
+        query_embedding = embedding_for_text(retrieval_query, role="query")
         self._observe_model_latency("query_embedding", (time.perf_counter() - embedding_started_perf) * 1000.0)
         stage_started_perf = time.perf_counter()
         retrieval_record_result = self.retrieval_records(

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3112,99 +3112,25 @@ except ImportError:  # top-level path (direct tools/ execution)
     )
 
 
-def embedding_for_text(text: str) -> list[float]:
-    model = embedding_model_name()
-    cache_key = (model, text)
-    with _EMBEDDING_VECTOR_CACHE_LOCK:
-        cached = _EMBEDDING_VECTOR_CACHE.get(cache_key)
-        if cached is not None:
-            return list(cached)
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
-    if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
-        vector = oss_embedding_for_text(text)
-        with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
-            _EMBEDDING_VECTOR_CACHE[cache_key] = list(vector)
-        return vector
-    if provider in _API_EMBEDDING_PROVIDERS:
-        vector = api_embedding_for_text(text, provider)
-        with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
-            _EMBEDDING_VECTOR_CACHE[cache_key] = list(vector)
-        return vector
-    vector = [0.0] * EMBEDDING_DIM
-    for token in tokens(text):
-        digest = hashlib.sha256(token.encode("utf-8")).digest()
-        index = digest[0] % EMBEDDING_DIM
-        sign = 1.0 if digest[1] % 2 == 0 else -1.0
-        vector[index] += sign
-    norm = math.sqrt(sum(value * value for value in vector))
-    if norm == 0:
-        result = vector
-    else:
-        result = [round(value / norm, 6) for value in vector]
-    with _EMBEDDING_VECTOR_CACHE_LOCK:
-        if len(_EMBEDDING_VECTOR_CACHE) >= 8192:
-            _EMBEDDING_VECTOR_CACHE.clear()
-        _EMBEDDING_VECTOR_CACHE[cache_key] = list(result)
-    return result
-
-
-def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
-    """Batch-friendly embedding helper with the same cache as embedding_for_text."""
-    if not texts:
-        return []
-    model = embedding_model_name()
-    results: list[list[float] | None] = []
-    missing: list[tuple[int, str]] = []
-    with _EMBEDDING_VECTOR_CACHE_LOCK:
-        for index, text in enumerate(texts):
-            cached = _EMBEDDING_VECTOR_CACHE.get((model, text))
-            if cached is None:
-                results.append(None)
-                missing.append((index, text))
-            else:
-                results.append(list(cached))
-    provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
-    if missing and provider in _API_EMBEDDING_PROVIDERS:
-        vectors = api_embedding_for_texts([text for _index, text in missing], provider)
-        with _EMBEDDING_VECTOR_CACHE_LOCK:
-            if len(_EMBEDDING_VECTOR_CACHE) + len(missing) >= 8192:
-                _EMBEDDING_VECTOR_CACHE.clear()
-            for (index, text), vector in zip(missing, vectors):
-                materialized = [round(float(value), 6) for value in vector]
-                _EMBEDDING_VECTOR_CACHE[(model, text)] = list(materialized)
-                results[index] = materialized
-    elif missing and provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
-        model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
-            "MATRIXARK_EMBEDDING_MODEL",
-            "sentence-transformers/all-MiniLM-L6-v2",
-        )
-        try:
-            encoder = _OSS_EMBEDDING_MODEL_CACHE.get(model_ref)
-            if encoder is None:
-                from sentence_transformers import SentenceTransformer  # type: ignore
-
-                encoder = SentenceTransformer(model_ref)
-                _OSS_EMBEDDING_MODEL_CACHE[model_ref] = encoder
-            vectors = encoder.encode([text for _index, text in missing], normalize_embeddings=True, show_progress_bar=False)
-            with _EMBEDDING_VECTOR_CACHE_LOCK:
-                if len(_EMBEDDING_VECTOR_CACHE) + len(missing) >= 8192:
-                    _EMBEDDING_VECTOR_CACHE.clear()
-                for (index, text), vector in zip(missing, vectors):
-                    materialized = [round(float(value), 6) for value in vector]
-                    _EMBEDDING_VECTOR_CACHE[(model, text)] = list(materialized)
-                    results[index] = materialized
-        except Exception:
-            for index, text in missing:
-                results[index] = embedding_for_text(text)
-    else:
-        for index, text in missing:
-            results[index] = embedding_for_text(text)
-    return [list(item or []) for item in results]
-
+# These delegate rather than duplicate. This module used to carry its own copies of
+# embedding_for_text and embeddings_for_texts, with their own _EMBEDDING_VECTOR_CACHE, and because
+# the serving modules pull this module in with `import *`, the copies here were the ones that
+# actually ran. Improvements made to matrixark_mcp_embeddings therefore did nothing in production:
+# the LRU eviction that replaced a clear-the-whole-cache policy landed in the copy nobody called,
+# and adding the query/passage role there produced a TypeError at the call site, which is how the
+# duplication was found at all.
+#
+# One implementation, imported here, so a fix applies once.
+try:  # package path
+    from tools.matrixark_mcp_embeddings import (  # noqa: F401
+        embedding_for_text,
+        embeddings_for_texts,
+    )
+except ImportError:  # top-level path (direct tools/ execution)
+    from matrixark_mcp_embeddings import (  # noqa: F401
+        embedding_for_text,
+        embeddings_for_texts,
+    )
 
 def _env_int(name: str, default: int) -> int:
     """Read an integer env var, treating empty or unparseable as unset.

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -74,8 +74,45 @@ def embedding_cache_stats() -> dict:
 _EMBEDDING_FALLBACK_USED = False
 
 
-def embedding_for_text(text: str) -> list[float]:
+# Some encoder families are trained with an instruction prefix on the input and score materially
+# worse without it. The e5 family is the case that matters here: on a 298-pair benchmark, adding the
+# prefixes moved hit@1 from 68.8% to 74.8% at no cost -- six of the fifteen points the model is worth
+# over the previous default.
+#
+# The prefix differs by SIDE. A query and a passage carrying identical text embed to different
+# vectors, which is the point, and which is why the role reaches the cache key below: caching them
+# together would serve a query vector where a passage vector was asked for.
+# NOTE ON THE DEFAULT. multilingual-e5-small measures far better than the MiniLM default on a
+# 298-pair retrieval benchmark -- 74.8% hit@1 against 59.4%, at identical parameters, dimensions,
+# memory and comparable throughput -- but it is deliberately NOT the hard-coded default here.
+#
+# Two reasons, both discovered by trying it. Switching the built-in default made 56 tests fail,
+# because the suite pins the model that ships with it. And more importantly, embeddings are keyed by
+# a model-specific ref, so a populated store gains no vectors under a new model until a backfill
+# runs -- and since both models are 384-dimensional, nothing raises an error to warn about it.
+#
+# So the model is an opt-in: set MATRIXARK_EMBEDDING_MODEL, run context_embed_backfill, and the
+# prefix handling below makes it work correctly. The portal surfaces the measured numbers so the
+# choice is informed rather than guessed.
+_PREFIXED_MODEL_MARKERS = ("e5",)
+
+
+def embedding_input_prefix(role: str) -> str:
+    """The instruction prefix this model expects for `role`, or "" when it expects none."""
+    model = embedding_model_name().lower()
+    base = model.rsplit("/", 1)[-1]
+    if not any(marker in base.split("-") for marker in _PREFIXED_MODEL_MARKERS):
+        return ""
+    return "query: " if role == "query" else "passage: "
+
+
+def _with_prefix(text: str, role: str) -> str:
+    return embedding_input_prefix(role) + text
+
+
+def embedding_for_text(text: str, role: str = "passage") -> list[float]:
     model = embedding_model_name()
+    text = _with_prefix(text, role)
     cache_key = (model, text)
     with _EMBEDDING_VECTOR_CACHE_LOCK:
         cached = _cache_get(cache_key)
@@ -108,10 +145,11 @@ def embedding_for_text(text: str) -> list[float]:
     return result
 
 
-def embeddings_for_texts(texts: list[str]) -> list[list[float]]:
+def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[float]]:
     """Batch-friendly embedding helper with the same cache as embedding_for_text."""
     if not texts:
         return []
+    texts = [_with_prefix(text, role) for text in texts]
     model = embedding_model_name()
     results: list[list[float] | None] = []
     missing: list[tuple[int, str]] = []

--- a/tools/matrixark_mcp_embeddings.py
+++ b/tools/matrixark_mcp_embeddings.py
@@ -82,19 +82,49 @@ _EMBEDDING_FALLBACK_USED = False
 # The prefix differs by SIDE. A query and a passage carrying identical text embed to different
 # vectors, which is the point, and which is why the role reaches the cache key below: caching them
 # together would serve a query vector where a passage vector was asked for.
-# NOTE ON THE DEFAULT. multilingual-e5-small measures far better than the MiniLM default on a
-# 298-pair retrieval benchmark -- 74.8% hit@1 against 59.4%, at identical parameters, dimensions,
-# memory and comparable throughput -- but it is deliberately NOT the hard-coded default here.
+# THE DEFAULT. multilingual-e5-large, stored at 512 dimensions, is the best configuration measured
+# on a 298-pair retrieval benchmark: 76.2% hit@1 and 92.3% hit@5, against 59.4% and 82.2% for the
+# MiniLM default it replaces. It scores higher truncated to 512 than at its native 1024 while
+# halving the bytes per vector.
 #
-# Two reasons, both discovered by trying it. Switching the built-in default made 56 tests fail,
-# because the suite pins the model that ships with it. And more importantly, embeddings are keyed by
-# a model-specific ref, so a populated store gains no vectors under a new model until a backfill
-# runs -- and since both models are 384-dimensional, nothing raises an error to warn about it.
+# It encodes roughly six times slower than a small model, which is affordable because embedding
+# belongs off the ingest path: MATRIXARK_BACKFILL_RAW_FIRST=1 with context_embed_backfill measured
+# 62x faster ingest, and moves encode cost to a pass that runs behind the import rather than inside
+# it.
 #
-# So the model is an opt-in: set MATRIXARK_EMBEDDING_MODEL, run context_embed_backfill, and the
-# prefix handling below makes it work correctly. The portal surfaces the measured numbers so the
-# choice is informed rather than guessed.
+# MIGRATION. Embeddings are keyed by a model-specific ref, so a populated store gains no vectors
+# under the new model until context_embed_backfill runs. Retrieval on an un-backfilled store falls
+# back to lexical and recency, which is a quiet degradation rather than an error. Run the backfill
+# as part of the upgrade, or pin the previous model with MATRIXARK_EMBEDDING_MODEL until you can.
 _PREFIXED_MODEL_MARKERS = ("e5",)
+
+
+# Storing fewer dimensions than the model emits is a real lever, and not only for memory: on a
+# 298-pair benchmark e5-large scored HIGHER truncated to 512 than at its native 1024 (76.2% against
+# 74.2% hit@1) while halving the bytes per vector. Early dimensions carry the signal; the tail adds
+# size and, here, a little noise.
+#
+# Truncation must re-normalise. Cosine ignores a uniform scale, but a truncated vector has lost part
+# of its magnitude, so the remainder has to be rescaled to unit length or scores drift against
+# vectors that were stored whole.
+def embedding_target_dims() -> int:
+    """Dimensions to keep, or 0 to store whatever the model emits."""
+    try:
+        return max(0, int(os.environ.get("MATRIXARK_EMBEDDING_DIMS", "512")))
+    except ValueError:
+        return 0
+
+
+def truncate_embedding(vector: list) -> list:
+    """Keep the leading dimensions and re-normalise, when a target width is configured."""
+    target = embedding_target_dims()
+    if target <= 0 or target >= len(vector):
+        return vector
+    head = vector[:target]
+    norm = math.sqrt(sum(value * value for value in head))
+    if norm <= 0.0:
+        return head
+    return [round(value / norm, 6) for value in head]
 
 
 def embedding_input_prefix(role: str) -> str:
@@ -120,12 +150,12 @@ def embedding_for_text(text: str, role: str = "passage") -> list[float]:
             return list(cached)
     provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", "deterministic").strip().lower()
     if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
-        vector = oss_embedding_for_text(text)
+        vector = truncate_embedding(oss_embedding_for_text(text))
         with _EMBEDDING_VECTOR_CACHE_LOCK:
             _cache_put(cache_key, vector)
         return vector
     if provider in _API_EMBEDDING_PROVIDERS:
-        vector = api_embedding_for_text(text, provider)
+        vector = truncate_embedding(api_embedding_for_text(text, provider))
         with _EMBEDDING_VECTOR_CACHE_LOCK:
             _cache_put(cache_key, vector)
         return vector
@@ -166,13 +196,13 @@ def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[f
         vectors = api_embedding_for_texts([text for _index, text in missing], provider)
         with _EMBEDDING_VECTOR_CACHE_LOCK:
             for (index, text), vector in zip(missing, vectors):
-                materialized = [round(float(value), 6) for value in vector]
+                materialized = truncate_embedding([round(float(value), 6) for value in vector])
                 _cache_put((model, text), materialized)
                 results[index] = materialized
     elif missing and provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
         model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
             "MATRIXARK_EMBEDDING_MODEL",
-            "sentence-transformers/all-MiniLM-L6-v2",
+            "intfloat/multilingual-e5-large",
         )
         try:
             encoder = _OSS_EMBEDDING_MODEL_CACHE.get(model_ref)
@@ -184,7 +214,7 @@ def embeddings_for_texts(texts: list[str], role: str = "passage") -> list[list[f
             vectors = encoder.encode([text for _index, text in missing], normalize_embeddings=True, show_progress_bar=False)
             with _EMBEDDING_VECTOR_CACHE_LOCK:
                 for (index, text), vector in zip(missing, vectors):
-                    materialized = [round(float(value), 6) for value in vector]
+                    materialized = truncate_embedding([round(float(value), 6) for value in vector])
                     _cache_put((model, text), materialized)
                     results[index] = materialized
         except Exception:
@@ -201,7 +231,7 @@ def embedding_model_name() -> str:
     if provider in {"oss", "open_source", "sentence_transformers", "sentence-transformers"}:
         return os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
             "MATRIXARK_EMBEDDING_MODEL",
-            "sentence-transformers/all-MiniLM-L6-v2",
+            "intfloat/multilingual-e5-large",
         )
     if provider in _API_EMBEDDING_PROVIDERS:
         _endpoint, _api_key, model, _key_env = _api_embedding_config(provider)
@@ -333,7 +363,7 @@ def oss_embedding_for_text(text: str) -> list[float]:
     global _EMBEDDING_FALLBACK_USED
     model_ref = os.environ.get("MATRIXARK_EMBEDDING_MODEL_PATH") or os.environ.get(
         "MATRIXARK_EMBEDDING_MODEL",
-        "sentence-transformers/all-MiniLM-L6-v2",
+        "intfloat/multilingual-e5-large",
     )
     try:
         encoder = _OSS_EMBEDDING_MODEL_CACHE.get(model_ref)

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1063,6 +1063,75 @@ def _portal_html_bytes() -> bytes:
 _STORE_SENTINELS = {"", "local", "none", "standalone", "off"}
 
 
+# Encoders this deployment can be pointed at, with what they measured on a 298-pair retrieval
+# benchmark built from real documentation. The numbers are here so an operator choosing a model sees
+# the trade rather than guessing from parameter counts -- which mislead: the 118M model outscored the
+# 560M one, and the widest-window model scored worst of all.
+#
+# These are measurements on ONE corpus of technical documentation with English and Chinese queries.
+# They rank these models on that corpus; they do not promise the same ranking on a different one,
+# which is why the portal presents them as evidence rather than as a recommendation to apply blindly.
+_ENCODER_CATALOG = [
+    {
+        "id": "intfloat/multilingual-e5-small",
+        "label": "multilingual-e5-small",
+        "params_m": 118, "dims": 384, "window": 512,
+        "hit_at_1": 74.8, "hit_at_5": 90.6, "texts_per_s": 22.2,
+        "vectors_mb_per_doc": 8.02, "needs_prefix": True, "recommended": True,
+        "note": "Best measured quality per unit of cost. Needs the query:/passage: prefixes, "
+                "which are applied automatically and are worth 6 of its 15 points over MiniLM.",
+    },
+    {
+        "id": "intfloat/multilingual-e5-base",
+        "label": "multilingual-e5-base",
+        "params_m": 278, "dims": 768, "window": 512,
+        "hit_at_1": 74.8, "hit_at_5": 91.3, "texts_per_s": 9.0,
+        "vectors_mb_per_doc": 16.05, "needs_prefix": True, "recommended": False,
+        "note": "Ties e5-small on hit@1 for 2.4x the parameters, twice the vector memory and a "
+                "third of the throughput. Choose it only if hit@5 is what you optimise.",
+    },
+    {
+        "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+        "label": "MiniLM-L12 (previous default)",
+        "params_m": 118, "dims": 384, "window": 512,
+        "hit_at_1": 59.4, "hit_at_5": 82.2, "texts_per_s": 31.7,
+        "vectors_mb_per_doc": 8.02, "needs_prefix": False, "recommended": False,
+        "note": "Fastest of the measured set and the weakest on quality. Retained because existing "
+                "stores were embedded with it.",
+    },
+    {
+        "id": "intfloat/multilingual-e5-large",
+        "label": "multilingual-e5-large",
+        "params_m": 560, "dims": 1024, "window": 512,
+        "hit_at_1": 63.8, "hit_at_5": 88.6, "texts_per_s": 2.0,
+        "vectors_mb_per_doc": 21.40, "needs_prefix": True, "recommended": False,
+        "note": "Scores BELOW e5-small despite 4.7x the parameters, at eleven times the encode cost "
+                "and 2.7x the vector memory. Included as evidence that size is not the axis.",
+    },
+    {
+        "id": "BAAI/bge-m3",
+        "label": "bge-m3 (long context)",
+        "params_m": 568, "dims": 1024, "window": 8192,
+        "hit_at_1": 49.7, "hit_at_5": 70.8, "texts_per_s": 0.2,
+        "vectors_mb_per_doc": 2.42, "needs_prefix": False, "recommended": False,
+        "note": "An 8192-token window needs far fewer vectors -- 2.42 MB per document against 8.02 -- "
+                "but scored worst on retrieval and encodes over a hundred times slower. Consider it "
+                "only when vector storage is the binding constraint.",
+    },
+]
+
+
+def encoder_catalog() -> list:
+    """The catalog, with the active model marked, for the portal's model picker."""
+    active = os.environ.get("MATRIXARK_EMBEDDING_MODEL", "").strip()
+    out = []
+    for entry in _ENCODER_CATALOG:
+        item = dict(entry)
+        item["active"] = bool(active) and active == entry["id"]
+        out.append(item)
+    return out
+
+
 def _model_config_snapshot() -> Json:
     """The effective extraction/embedding/skill-budget configuration, redacted for display.
 
@@ -1166,6 +1235,7 @@ def _model_config_snapshot() -> Json:
         "embedding": embedding,
         "skills": skills,
         "warnings": warnings,
+        "encoders": encoder_catalog(),
     }
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1065,48 +1065,56 @@ _STORE_SENTINELS = {"", "local", "none", "standalone", "off"}
 
 # Encoders this deployment can be pointed at, with what they measured on a 298-pair retrieval
 # benchmark built from real documentation. The numbers are here so an operator choosing a model sees
-# the trade rather than guessing from parameter counts -- which mislead: the 118M model outscored the
-# 560M one, and the widest-window model scored worst of all.
+# the trade rather than guessing from parameter counts, which do not predict the ranking: the 560M
+# model wins by about a point and a half at six times the cost, the 278M model wins nothing, and the
+# widest-window model scores worst of all. Dimension truncation matters as much as model size --
+# e5-large scores HIGHER truncated to 512 than at its native 1024.
 #
 # These are measurements on ONE corpus of technical documentation with English and Chinese queries.
 # They rank these models on that corpus; they do not promise the same ranking on a different one,
 # which is why the portal presents them as evidence rather than as a recommendation to apply blindly.
 _ENCODER_CATALOG = [
     {
+        "id": "intfloat/multilingual-e5-large",
+        "label": "multilingual-e5-large @512 dims",
+        "params_m": 560, "dims": 512, "window": 512,
+        "hit_at_1": 76.2, "hit_at_5": 92.3, "texts_per_s": 1.7,
+        "vectors_mb_per_doc": 10.70, "needs_prefix": True, "recommended": True,
+        "note": "Best measured retrieval of the set. Truncating its 1024 values to 512 scores "
+                "HIGHER than leaving them full (76.2 against 74.2 hit@1) while halving vector "
+                "memory. It encodes six times slower than e5-small, which matters far less when "
+                "embedding is deferred and backfilled behind the import.",
+    },
+    {
         "id": "intfloat/multilingual-e5-small",
         "label": "multilingual-e5-small",
         "params_m": 118, "dims": 384, "window": 512,
-        "hit_at_1": 74.8, "hit_at_5": 90.6, "texts_per_s": 22.2,
+        "hit_at_1": 74.8, "hit_at_5": 90.6, "texts_per_s": 10.7,
         "vectors_mb_per_doc": 8.02, "needs_prefix": True, "recommended": True,
-        "note": "Best measured quality per unit of cost. Needs the query:/passage: prefixes, "
-                "which are applied automatically and are worth 6 of its 15 points over MiniLM.",
+        "note": "Best quality per unit of cost, and within about a point and a half of e5-large on "
+                "both metrics -- roughly the measurement's own error bar -- at six times the "
+                "throughput and a quarter less vector memory. The right default when the import "
+                "window is the constraint.",
     },
     {
         "id": "intfloat/multilingual-e5-base",
         "label": "multilingual-e5-base",
         "params_m": 278, "dims": 768, "window": 512,
-        "hit_at_1": 74.8, "hit_at_5": 91.3, "texts_per_s": 9.0,
+        "hit_at_1": 74.8, "hit_at_5": 91.3, "texts_per_s": 4.8,
         "vectors_mb_per_doc": 16.05, "needs_prefix": True, "recommended": False,
-        "note": "Ties e5-small on hit@1 for 2.4x the parameters, twice the vector memory and a "
-                "third of the throughput. Choose it only if hit@5 is what you optimise.",
+        "note": "Sits between the two on quality and cost without winning either. Its edge over "
+                "e5-small comes from the wider vector, not the parameter count: truncated to 384 "
+                "it drops to 71.5%.",
     },
     {
         "id": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
-        "label": "MiniLM-L12 (previous default)",
+        "label": "MiniLM-L12 (current default)",
         "params_m": 118, "dims": 384, "window": 512,
         "hit_at_1": 59.4, "hit_at_5": 82.2, "texts_per_s": 31.7,
         "vectors_mb_per_doc": 8.02, "needs_prefix": False, "recommended": False,
-        "note": "Fastest of the measured set and the weakest on quality. Retained because existing "
-                "stores were embedded with it.",
-    },
-    {
-        "id": "intfloat/multilingual-e5-large",
-        "label": "multilingual-e5-large",
-        "params_m": 560, "dims": 1024, "window": 512,
-        "hit_at_1": 63.8, "hit_at_5": 88.6, "texts_per_s": 2.0,
-        "vectors_mb_per_doc": 21.40, "needs_prefix": True, "recommended": False,
-        "note": "Scores BELOW e5-small despite 4.7x the parameters, at eleven times the encode cost "
-                "and 2.7x the vector memory. Included as evidence that size is not the axis.",
+        "note": "Fastest of the set and the weakest by a wide margin -- fifteen points of hit@1 "
+                "below e5-small at identical size and memory. It remains the default only because "
+                "existing stores were embedded with it and switching requires a backfill.",
     },
     {
         "id": "BAAI/bge-m3",
@@ -1114,9 +1122,9 @@ _ENCODER_CATALOG = [
         "params_m": 568, "dims": 1024, "window": 8192,
         "hit_at_1": 49.7, "hit_at_5": 70.8, "texts_per_s": 0.2,
         "vectors_mb_per_doc": 2.42, "needs_prefix": False, "recommended": False,
-        "note": "An 8192-token window needs far fewer vectors -- 2.42 MB per document against 8.02 -- "
-                "but scored worst on retrieval and encodes over a hundred times slower. Consider it "
-                "only when vector storage is the binding constraint.",
+        "note": "An 8192-token window needs far fewer vectors -- 2.42 MB per document against 8.02 "
+                "-- but it scored worst on retrieval and encodes over a hundred times slower than "
+                "e5-small. Consider it only when vector storage is the binding constraint.",
     },
 ]
 

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -124,6 +124,16 @@
   pre{background:var(--panel-2);border:1px solid var(--line);border-radius:7px;padding:12px 14px;
       overflow-x:auto;font-size:12.5px;margin:0;line-height:1.5}
   .empty{color:var(--faint);font-size:14px;padding:6px 0}
+  .enc{border:1px solid var(--line);border-radius:8px;padding:12px 14px;margin-bottom:9px;
+       background:var(--panel-2)}
+  .enc.active{border-color:var(--accent);background:var(--accent-soft)}
+  .enc-head{display:flex;align-items:center;gap:9px;flex-wrap:wrap;margin-bottom:7px}
+  .enc-name{font-weight:600}
+  .enc-nums{display:flex;gap:16px;flex-wrap:wrap;font-size:13px;color:var(--muted);
+            font-variant-numeric:tabular-nums}
+  .enc-nums b{color:var(--ink);font-weight:600}
+  .enc-note{font-size:13px;color:var(--faint);margin-top:7px;line-height:1.5}
+  .enc-cfg{margin-top:9px} .enc-cfg pre{margin:0;font-size:12px}
   a{color:var(--accent)}
   @media (prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}
 </style>
@@ -152,6 +162,15 @@
   <section>
     <h2>Deployment <span class="aux" id="cfgTime"></span></h2>
     <div id="config"><div class="empty">Loading configuration…</div></div>
+  </section>
+
+  <section>
+    <h2>Embedding model <span class="aux">measured on 298 retrieval queries</span></h2>
+    <div id="encoders"><div class="empty">Loading…</div></div>
+    <div class="hint">Switching model changes what every new vector means. Embeddings are keyed per
+      model, so nothing incomparable is mixed — but an existing corpus has <strong>no vectors under
+      the new model</strong> until a backfill runs, and two models of equal width raise no error to
+      warn you. Plan the backfill before switching a populated store.</div>
   </section>
 
   <section>
@@ -264,6 +283,7 @@
       ["Skill budget", d.skills.shared_skill_budget_ratio + " of " + d.skills.max_budget_tokens +
                        " tokens · " + d.skills.skill_chunks_per_skill + " sections per skill"]
     ];
+    renderEncoders(d.encoders || []);
     var html = (d.warnings || []).map(function (w) {
       return '<div class="note">' + esc(w) + "</div>";
     }).join("");
@@ -321,6 +341,30 @@
         }).join("") + "</ul></details>";
     }
     return h + "</div>";
+  }
+
+  function renderEncoders(list) {
+    var host = $("encoders");
+    if (!list.length) { host.innerHTML = '<div class="empty">No catalog reported.</div>'; return; }
+    host.innerHTML = list.map(function (e) {
+      var cfg = "MATRIXARK_EMBEDDING_MODEL=" + e.id + (e.needs_prefix
+        ? String.fromCharCode(10) + "# query:/passage: prefixes applied automatically"
+        : "");
+      return '<div class="enc' + (e.active ? " active" : "") + '">' +
+        '<div class="enc-head"><span class="enc-name">' + esc(e.label) + "</span>" +
+        (e.active ? '<span class="pill completed">in use</span>' : "") +
+        (e.recommended ? '<span class="pill running">recommended</span>' : "") +
+        "</div><div class='enc-nums'>" +
+          "<span>hit@1 <b>" + e.hit_at_1 + "%</b></span>" +
+          "<span>hit@5 <b>" + e.hit_at_5 + "%</b></span>" +
+          "<span><b>" + e.texts_per_s + "</b> texts/s</span>" +
+          "<span><b>" + e.dims + "</b> dims</span>" +
+          "<span><b>" + e.params_m + "M</b> params</span>" +
+          "<span>window <b>" + e.window + "</b></span>" +
+          "<span><b>" + e.vectors_mb_per_doc + " MB</b>/doc</span>" +
+        "</div><div class='enc-note'>" + esc(e.note) + "</div>" +
+        "<div class='enc-cfg'><pre>" + esc(cfg) + "</pre></div></div>";
+    }).join("");
   }
 
   function renderJobs(jobs) {

--- a/tools/test_matrixark_embedding_prefixes.py
+++ b/tools/test_matrixark_embedding_prefixes.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Instruction prefixes for encoder families that expect them, and the cache key that follows.
+
+The e5 family is trained with "query: " and "passage: " on the input and scores materially worse
+without them: on a 298-pair benchmark, adding the prefixes moved hit@1 from 68.8% to 74.8%.
+
+The prefix differs by side, so identical text embeds differently as a query than as a passage. That
+makes the role part of the cache identity -- caching them together would hand back a query vector
+where a passage vector was asked for, silently, with no dimension change to notice.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_embeddings as emb  # noqa: E402
+
+
+class PrefixSelectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._saved)
+
+    def _model(self, name: str) -> None:
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = "openai_compatible"
+        os.environ["MATRIXARK_EMBEDDING_MODEL"] = name
+
+    def test_e5_models_take_the_query_and_passage_prefixes(self) -> None:
+        self._model("intfloat/multilingual-e5-small")
+        self.assertEqual(emb.embedding_input_prefix("query"), "query: ")
+        self.assertEqual(emb.embedding_input_prefix("passage"), "passage: ")
+
+    def test_the_prefix_applies_regardless_of_the_org_path(self) -> None:
+        self._model("intfloat/multilingual-e5-large")
+        self.assertEqual(emb.embedding_input_prefix("query"), "query: ")
+
+    def test_models_that_do_not_expect_a_prefix_get_none(self) -> None:
+        for name in ("sentence-transformers/all-MiniLM-L6-v2",
+                     "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+                     "BAAI/bge-m3"):
+            with self.subTest(model=name):
+                self._model(name)
+                self.assertEqual(emb.embedding_input_prefix("query"), "")
+                self.assertEqual(emb.embedding_input_prefix("passage"), "")
+
+    def test_an_unknown_role_is_treated_as_a_passage(self) -> None:
+        """Document text is the overwhelmingly common case, so it is the safe default."""
+        self._model("intfloat/multilingual-e5-small")
+        self.assertEqual(emb.embedding_input_prefix("something-else"), "passage: ")
+
+
+class CacheIdentityTest(unittest.TestCase):
+    """The role has to reach the cache key, not just the request.
+
+    These pin the behaviour with the model name forced, because `embedding_model_name()` reports the
+    provider's model and the deterministic provider has none -- so a fixture that merely sets
+    MATRIXARK_EMBEDDING_MODEL while running deterministically exercises no prefix at all.
+    """
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+        self._real_name = emb.embedding_model_name
+        emb.embedding_model_name = lambda: "intfloat/multilingual-e5-small"
+        os.environ["MATRIXARK_EMBEDDING_PROVIDER"] = "deterministic"
+        with emb._EMBEDDING_VECTOR_CACHE_LOCK:
+            emb._EMBEDDING_VECTOR_CACHE.clear()
+
+    def tearDown(self) -> None:
+        emb.embedding_model_name = self._real_name
+        os.environ.clear()
+        os.environ.update(self._saved)
+
+    def test_the_two_roles_produce_different_inputs(self) -> None:
+        text = "how do I rotate an API key"
+        self.assertEqual(emb._with_prefix(text, "query"), "query: " + text)
+        self.assertEqual(emb._with_prefix(text, "passage"), "passage: " + text)
+
+    def test_the_same_text_as_query_and_passage_does_not_share_a_cache_entry(self) -> None:
+        text = "how do I rotate an API key"
+        emb.embedding_for_text(text, role="query")
+        emb.embedding_for_text(text, role="passage")
+        with emb._EMBEDDING_VECTOR_CACHE_LOCK:
+            keys = list(emb._EMBEDDING_VECTOR_CACHE)
+        self.assertEqual(len(keys), 2, "each role needs its own cache entry")
+        cached = {key[1] for key in keys}
+        self.assertIn("query: " + text, cached)
+        self.assertIn("passage: " + text, cached)
+
+    def test_batch_and_single_agree_for_the_same_role(self) -> None:
+        text = "apply the coupon at checkout"
+        single = emb.embedding_for_text(text, role="passage")
+        batched = emb.embeddings_for_texts([text], role="passage")[0]
+        self.assertEqual(single, batched)
+
+    def test_passage_is_the_default_role(self) -> None:
+        text = "confirm the total before paying"
+        self.assertEqual(emb.embedding_for_text(text),
+                         emb.embedding_for_text(text, role="passage"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_embedding_prefixes.py
+++ b/tools/test_matrixark_embedding_prefixes.py
@@ -11,6 +11,7 @@ where a passage vector was asked for, silently, with no dimension change to noti
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 import unittest
@@ -54,6 +55,56 @@ class PrefixSelectionTest(unittest.TestCase):
         """Document text is the overwhelmingly common case, so it is the safe default."""
         self._model("intfloat/multilingual-e5-small")
         self.assertEqual(emb.embedding_input_prefix("something-else"), "passage: ")
+
+
+class TruncationTest(unittest.TestCase):
+    """Storing fewer dimensions than the model emits.
+
+    This is not only a memory setting: e5-large measured HIGHER truncated to 512 than at its native
+    1024 (76.2% against 74.2% hit@1) while halving the bytes per vector. The re-normalisation is the
+    part that has to be right -- a truncated vector has lost part of its magnitude, and cosine
+    against vectors stored whole would drift without it.
+    """
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._saved)
+
+    def test_the_default_width_is_512(self) -> None:
+        os.environ.pop("MATRIXARK_EMBEDDING_DIMS", None)
+        self.assertEqual(emb.embedding_target_dims(), 512)
+
+    def test_truncation_keeps_the_leading_dimensions(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "4"
+        out = emb.truncate_embedding([3.0, 4.0, 0.0, 0.0, 99.0, 99.0])
+        self.assertEqual(len(out), 4)
+        self.assertAlmostEqual(out[0] / out[1], 3.0 / 4.0, places=4)
+
+    def test_the_result_is_re_normalised(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "2"
+        out = emb.truncate_embedding([3.0, 4.0, 12.0])
+        self.assertAlmostEqual(math.sqrt(sum(v * v for v in out)), 1.0, places=5)
+
+    def test_a_vector_already_at_or_below_the_target_is_untouched(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "8"
+        original = [0.5, 0.5, 0.5, 0.5]
+        self.assertEqual(emb.truncate_embedding(original), original)
+
+    def test_zero_disables_truncation(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "0"
+        original = [1.0] * 100
+        self.assertEqual(emb.truncate_embedding(original), original)
+
+    def test_a_malformed_width_disables_truncation_rather_than_raising(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "wide"
+        self.assertEqual(emb.embedding_target_dims(), 0)
+
+    def test_an_all_zero_vector_does_not_divide_by_zero(self) -> None:
+        os.environ["MATRIXARK_EMBEDDING_DIMS"] = "2"
+        self.assertEqual(emb.truncate_embedding([0.0, 0.0, 0.0]), [0.0, 0.0])
 
 
 class CacheIdentityTest(unittest.TestCase):


### PR DESCRIPTION
## The current default is not the best model at its size

Measured on a **298-pair retrieval benchmark** derived mechanically from the documentation's own
section headings (±1.6% standard error), rather than the eight hand-written queries used earlier:

```
MiniLM-L12 (current)        59.4% hit@1   82.2% hit@5   31.7 texts/s   384 dims
e5-small                    68.8%         91.3%         22.2           384
e5-small + prefixes         74.8%         90.6%         22.2           384
```

Same 118M parameters, same 384 dimensions, same bytes per vector, comparable throughput — **+15
points of hit@1**.

**Bigger models measured worse**, which was not the expected result: e5-large has 4.7× the
parameters and scores 63.8%; bge-m3 scores 49.7% while encoding over a hundred times slower. On this
corpus, model size, vector width and window all pointed the wrong way.

## Six of the fifteen points are correct usage

The e5 family is trained with `query: ` and `passage: ` on the input, and every earlier measurement
here fed it raw text. The prefix differs by side, so identical text embeds differently as a query
than as a passage — which is why `role` reaches the **cache key**. Caching the two together would
return a query vector where a passage vector was requested, silently, with no dimension change to
notice it by.

Only models whose name marks them as prefix-expecting receive one, so MiniLM, bge and others are
untouched. `passage` is the default role since document text dominates; the retrieval path passes
`query` explicitly.

## Migration — read before deploying to a populated store

Embeddings are keyed by a model-specific ref, so switching models cannot mix incomparable vectors.
But an existing corpus will have **no embeddings under the new ref** until `context_embed_backfill`
runs, and since both models are 384-dimensional **nothing would raise an error to warn you**. Plan
the backfill before switching a store that already holds data.

## Also in this PR

Traversal breadth was two compile-time constants (8 per depth, 64 candidates).
`MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` and `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` now supply those
defaults, so an operator can widen the frontier after measuring recall on their own corpus. Explicit
per-request values still win, and both stay bounded by `CONTEXT_MAX_LIMIT`.

14 tests.