### PR TITLE
Intern the largest record field on the backend write path, gated off

### DIFF
--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -64,6 +64,110 @@ def _placement_is_derivable(record: Json) -> bool:
         return False
 
 
+# --------------------------------------------------------------------------------------------- #
+# Backend metadata interning (write side gated, read side always on).
+#
+# `storage_options` is the largest field in the store -- 2,139 KB, 13.2% of all record bytes, with
+# NINE distinct values across 3,610 rows. `INTERN_METADATA_FIELDS` already names it and the local
+# JSONL codec already tokenises it; the primary store does not, so the optimisation landed on the
+# 4-copy/7-day mirror instead of the durable store.
+#
+# The write side is gated OFF. The read side always expands, so a store written with the flag ON
+# still reads correctly if the flag is later turned OFF -- the same asymmetry the JSONL codec uses.
+#
+# NOT yet established, which is why the default is OFF: the JSONL codec's crash-safety argument is
+# "the dict record precedes the data record under the event-log lock". The backend has no such
+# ordering; it would rely on the engine's batch append being atomic, which is a different claim and
+# is unverified. Do not flip this default until that is settled.
+# --------------------------------------------------------------------------------------------- #
+BACKEND_INTERN_METADATA = os.environ.get(
+    "MATRIXARK_INTERN_BACKEND_METADATA", "0").strip().lower() in {"1", "true", "yes", "on"}
+BACKEND_INTERN_FIELDS = ("storage_options",)
+BACKEND_INTERN_TOKEN_KEY = "_bi"
+BACKEND_INTERN_DICT_RECORD_TYPE = "matrixark_backend_intern_dict"
+
+
+def _backend_intern_token(value: Any) -> str:
+    return str(stable_hash(json.dumps(value, sort_keys=True, separators=(",", ":"))))
+
+
+def backend_intern_records(records: list[Json], emitted: set[str]) -> list[Json]:
+    """Replace the interned fields with a token, emitting any new sidecar record FIRST.
+
+    Returns the input unchanged when the flag is off, so the write path is byte-identical to today.
+    """
+    if not BACKEND_INTERN_METADATA:
+        return records
+    dict_records: list[Json] = []
+    encoded: list[Json] = []
+    for record in records:
+        if not isinstance(record, dict) or record.get("record_type") == BACKEND_INTERN_DICT_RECORD_TYPE:
+            encoded.append(record)
+            continue
+        present = {f: record[f] for f in BACKEND_INTERN_FIELDS if f in record}
+        if not present:
+            encoded.append(record)
+            continue
+        out = dict(record)
+        tokens: Json = {}
+        for field, value in present.items():
+            token = _backend_intern_token(value)
+            tokens[field] = token
+            if token not in emitted:
+                emitted.add(token)
+                dict_records.append({
+                    "record_type": BACKEND_INTERN_DICT_RECORD_TYPE,
+                    "bi_field": field,
+                    "bi_token": token,
+                    "bi_value": value,
+                })
+            out.pop(field, None)
+        out[BACKEND_INTERN_TOKEN_KEY] = tokens
+        encoded.append(out)
+    return dict_records + encoded
+
+
+_BACKEND_INTERN_TABLE: dict[str, Any] = {}
+
+
+def backend_intern_learn(records: list[Json]) -> None:
+    """Absorb any sidecar records into the token table."""
+    for record in records:
+        if isinstance(record, dict) and record.get("record_type") == BACKEND_INTERN_DICT_RECORD_TYPE:
+            token = record.get("bi_token")
+            if isinstance(token, str):
+                _BACKEND_INTERN_TABLE[token] = record.get("bi_value")
+
+
+def backend_expand_records(records: list[Json]) -> list[Json]:
+    """Put the interned fields back. ALWAYS runs, flag or no flag.
+
+    A record with no token key is returned untouched, so a store written before this existed -- or
+    with the flag off -- expands as a no-op.
+    """
+    if not records:
+        return records
+    backend_intern_learn(records)
+    out: list[Json] = []
+    for record in records:
+        if not isinstance(record, dict):
+            out.append(record)
+            continue
+        if record.get("record_type") == BACKEND_INTERN_DICT_RECORD_TYPE:
+            continue        # sidecars are storage, not data
+        tokens = record.get(BACKEND_INTERN_TOKEN_KEY)
+        if not isinstance(tokens, dict) or not tokens:
+            out.append(record)
+            continue
+        expanded = dict(record)
+        expanded.pop(BACKEND_INTERN_TOKEN_KEY, None)
+        for field, token in tokens.items():
+            if token in _BACKEND_INTERN_TABLE:
+                expanded[field] = _BACKEND_INTERN_TABLE[token]
+        out.append(expanded)
+    return out
+
+
 def slim_persisted_storage_route(record: Json) -> Json:
     """Persist the placement half of `storage_route`, not the derived half.
 

--- a/tools/test_backend_intern_metadata.py
+++ b/tools/test_backend_intern_metadata.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for the backend interning codec.
+
+A codec that loses a field on a crash is worse than the bytes it saves, so these check the
+properties the JSONL codec claims and that this one must also hold:
+
+  1. flag OFF  -> input returned unchanged (byte-identical to today)
+  2. flag ON   -> the field is replaced by a token and a sidecar carries the value
+  3. round-trip -> encode then expand yields the ORIGINAL record
+  4. sidecar FIRST -> the dict record precedes every record referencing it
+  5. dedup -> one sidecar per distinct value, not per record
+  6. expansion is unconditional -> a token written while ON still expands after the flag goes OFF
+  7. no-op on old data -> a record with no token key is untouched
+  8. sidecars are storage -> they never surface as data records
+"""
+import io
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def fresh(flag):
+    """Reimport the module with the flag set, since it is read at import time."""
+    os.environ["MATRIXARK_INTERN_BACKEND_METADATA"] = flag
+    for mod in list(sys.modules):
+        if "matrixark_mcp_temporal_append" in mod:
+            del sys.modules[mod]
+    import matrixark_mcp_temporal_append as m
+    return m
+
+
+OPTS = {"route": "shared_store_async", "tier": "hot", "replicas": 3}
+
+
+class BackendInternTest(unittest.TestCase):
+
+    def test_flag_off_is_identity(self):
+        m = fresh("0")
+        records = [{"record_type": "context_entity", "storage_options": dict(OPTS)}]
+        self.assertEqual(m.backend_intern_records(records, set()), records)
+
+    def test_flag_on_replaces_field_with_token(self):
+        m = fresh("1")
+        out = m.backend_intern_records(
+            [{"record_type": "context_entity", "storage_options": dict(OPTS)}], set())
+        sidecars = [r for r in out if r["record_type"] == m.BACKEND_INTERN_DICT_RECORD_TYPE]
+        data = [r for r in out if r["record_type"] != m.BACKEND_INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(len(sidecars), 1)
+        self.assertEqual(sidecars[0]["bi_value"], OPTS)
+        self.assertNotIn("storage_options", data[0])
+        self.assertIn(m.BACKEND_INTERN_TOKEN_KEY, data[0])
+
+    def test_round_trip_restores_the_original(self):
+        m = fresh("1")
+        original = {"record_type": "context_entity", "entity_hash": 7,
+                    "storage_options": dict(OPTS)}
+        encoded = m.backend_intern_records([dict(original)], set())
+        expanded = m.backend_expand_records(encoded)
+        self.assertEqual(expanded, [original])
+
+    def test_sidecar_precedes_every_referencing_record(self):
+        m = fresh("1")
+        out = m.backend_intern_records(
+            [{"record_type": "context_entity", "storage_options": dict(OPTS)} for _ in range(5)],
+            set())
+        first_data = next(i for i, r in enumerate(out)
+                          if r["record_type"] != m.BACKEND_INTERN_DICT_RECORD_TYPE)
+        last_sidecar = max(i for i, r in enumerate(out)
+                           if r["record_type"] == m.BACKEND_INTERN_DICT_RECORD_TYPE)
+        self.assertLess(last_sidecar, first_data)
+
+    def test_one_sidecar_per_distinct_value(self):
+        m = fresh("1")
+        out = m.backend_intern_records(
+            [{"record_type": "context_entity", "storage_options": dict(OPTS)} for _ in range(20)],
+            set())
+        sidecars = [r for r in out if r["record_type"] == m.BACKEND_INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(len(sidecars), 1, "20 identical values must share ONE sidecar")
+
+    def test_expansion_still_works_after_the_flag_goes_off(self):
+        m_on = fresh("1")
+        encoded = m_on.backend_intern_records(
+            [{"record_type": "context_entity", "storage_options": dict(OPTS)}], set())
+        m_off = fresh("0")
+        expanded = m_off.backend_expand_records(encoded)
+        self.assertEqual(expanded[0].get("storage_options"), OPTS)
+
+    def test_records_without_a_token_are_untouched(self):
+        m = fresh("1")
+        old = [{"record_type": "context_entity", "storage_options": dict(OPTS)}]
+        self.assertEqual(m.backend_expand_records([dict(old[0])]), old)
+
+    def test_sidecars_never_surface_as_data(self):
+        m = fresh("1")
+        encoded = m.backend_intern_records(
+            [{"record_type": "context_entity", "storage_options": dict(OPTS)}], set())
+        expanded = m.backend_expand_records(encoded)
+        self.assertTrue(all(r["record_type"] != m.BACKEND_INTERN_DICT_RECORD_TYPE
+                            for r in expanded))
+        self.assertEqual(len(expanded), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`storage_options` is the single largest field in the store: **2,139 KB, 13.2% of all record bytes,
with nine distinct values across 3,610 rows**. Within `context_entity` it is 468.8 KB with exactly
**one** distinct value.

`INTERN_METADATA_FIELDS` already names it and the codec already tokenizes it — but only on the local
JSONL log. Both `append()` and `append_many()` call `_encode_records_for_log(...)` **inside**
`if self._local_jsonl_enabled:`, so the records handed to TemporalStore keep the value inline. The
JSONL mirror is retention-capped at 4 copies / 7 days; the engine is the primary store. **The
optimization landed on the smaller of the two.**

This adds the backend half, **gated OFF**.

### Why the stated blocker does not apply

The exclusion is documented as: *"the native backend consumes storage_route / placement_key for real
routing and placement decisions ... the inverse expansion would have to live inside the native layer
(out of scope; do not touch crates)."*

Checked against the Rust tree:

| field | occurrences in `crates/` |
|---|---:|
| `storage_options` | **0** |
| `storage_route` | **0** |
| `placement_key` | 5 — a test helper, two metric label strings, one report contract name |

The engine reads none of them as record fields. And `native_serving` builds each output item field
by field from a fixed list, so it never passes a stored record through wholesale — no expansion is
needed in the native layer, and no crate is touched here.

Python reads of the persisted field are two, both write-side derivation
(`matrixark_mcp_core_compact.py:259`, `matrixark_mcp_storage_options.py:375`). Of ~50 mentions, 43
are `envelope.get("storage_options")` — reading the value off an **inbound request** and writing it
onto a record, which is a write, not a read of stored state.

### Shape

Copied deliberately from the existing codec:

- **write side gated** (`MATRIXARK_INTERN_BACKEND_METADATA`, default **OFF**) — flag off is
  byte-identical to today, so this ships dark;
- **read side always expands**, so a store written with the flag on still reads correctly after the
  flag is turned off. That asymmetry is what makes the switch safe in both directions.

### Why it ships OFF, and what has to be settled before it goes on

The JSONL codec's crash-safety argument is *"the dict record is emitted in the SAME append batch, on
lines that PRECEDE the first data record referencing it (sequential writes under the event-log
lock)"*. **The backend path has no such ordering** — bundles become `{key, field, value}` hash
entries with no "precedes" relation.

If a data record carrying a token becomes durable and its sidecar does not, that field is
permanently lost — worse than the bytes it saves. This is survivable only if the engine's batch
append is atomic, which is *probably* true (a batch goes through one durable barrier) but is a
**different argument than the one written down**, and it has not been verified. Hence the default.

### Tests

`tools/test_backend_intern_metadata.py`, 8 tests, all passing:

| property | why it matters |
|---|---|
| flag OFF is identity | shipping dark must change nothing |
| flag ON replaces the field with a token + sidecar | the mechanism works |
| round-trip restores the **original** record | no silent field loss |
| the sidecar **precedes** every record naming it | ordering within a batch |
| 20 identical values emit **one** sidecar | dedup, not per-record |
| expansion works **after the flag goes OFF** | the safe-rollback property |
| records with no token are untouched | old data reads as a no-op |
| sidecars never surface as data | they are storage, not records |

`test_mem0_complete`, `test_pipeline_task_slim`, `test_engine_purge_on_delete`,
`test_inline_embedding_vectors` and `test_intern_record_metadata` (recall 5/5) all pass.
