### PR TITLE
Rank a shard replicas against locations already parsed

### DIFF
--- a/crates/temporalstore-rust/src/meta/partitioning.rs
+++ b/crates/temporalstore-rust/src/meta/partitioning.rs
@@ -98,6 +98,13 @@ pub(super) fn build_shards(
         .map(|candidate| Location::parse(candidate.location))
         .collect::<Vec<_>>();
     let caller = Location::parse(client_location);
+    // The locations above, reachable by address, so ranking a shard's replicas
+    // does not parse them again for every shard.
+    let location_of = normal_servers
+        .iter()
+        .map(|candidate| candidate.server_addr)
+        .zip(candidate_locations.iter())
+        .collect::<BTreeMap<&str, &Location>>();
     // Derived from the candidate locations alone, so it is the same for every
     // shard of this table. It was being rebuilt per shard.
     let ladder = separation_ladder(&candidate_locations);
@@ -253,11 +260,20 @@ pub(super) fn build_shards(
                 .iter()
                 .enumerate()
                 .map(|(position, server_addr)| {
-                    let distance = state
-                        .servers
-                        .get(server_addr)
-                        .map(|server| caller.shared_prefix_len(&Location::parse(&server.location)))
-                        .unwrap_or(0);
+                    // A replica is normally one of the candidates above, whose
+                    // location is already parsed. A shard whose recorded owner
+                    // is not among them -- a route naming a server the
+                    // metaserver has not heard about -- still has to be parsed.
+                    let distance = match location_of.get(server_addr.as_str()) {
+                        Some(location) => caller.shared_prefix_len(location),
+                        None => state
+                            .servers
+                            .get(server_addr)
+                            .map(|server| {
+                                caller.shared_prefix_len(&Location::parse(&server.location))
+                            })
+                            .unwrap_or(0),
+                    };
                     (distance, position, server_addr.clone())
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
Ordering a shard's replicas nearest-first measures each one's distance from
the caller, and measuring it parsed that replica's location. Per replica,
per shard, on the call every client and proxy makes when a table's topology
moves.

Those same locations are parsed once at the top of the function to size the
separation ladder. The note above the ranking already says the distance has
to be computed once rather than inside sort_by_key, because the key function
is called O(n log n) times -- and it is. The parse simply stayed where the
distance is computed.

Counted rather than timed, because the machine this was measured on is at
load 22 and the timings swing by more than the effect. For one request
against 64 servers and a table of 1024 shards with 3 replicas each:

    Location::parse calls   3 137  ->  65

Sixty-five is the floor: one for each server, one for the caller. The other
3 072 were the same handful of locations parsed again for every shard.

A replica that is not one of those servers -- a route naming a server the
metaserver has not heard about -- is still parsed on the spot.

Four tests cover the ordering this feeds, including that callers equally
close keep the order the load scan chose. Answering a zero distance from the
index fails all four.
