### PR TITLE
Report a shard served with fewer replicas than its table asks for

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -9911,4 +9911,76 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
             .unwrap()
             .is_empty());
     }
+
+    #[test]
+    fn a_shard_served_short_of_replicas_is_reported() {
+        // Placement is worked out per request, so a table asking for three
+        // replicas on a cluster that can only offer one is answered with one
+        // and nothing says so. The readiness flag named after this is a
+        // hardcoded true.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                registered_at_ms: 0,
+                numa_nodes: Vec::new(),
+                server_addr: "only-node".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "ns".to_string()
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "wants_three".to_string(),
+                first_shard_id: 500,
+                shard_count: 2,
+                replica_count: 3,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+
+        let response = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "wants_three".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert_eq!(response.shards.len(), 2);
+        for shard in &response.shards {
+            assert_eq!(shard.replicas.len(), 1, "one server can only be one replica");
+        }
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_placement_short 2"),
+            "both shards were served short and nothing said so:
+{exported}"
+        );
+        assert!(
+            exported.contains("temporalstore_meta_placement_short_total 2"),
+            "{exported}"
+        );
+
+        // A second answer keeps the running total moving and reports the same
+        // shortfall now, rather than accumulating into the gauge.
+        let _ = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "wants_three".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(exported.contains("temporalstore_meta_placement_short 2"), "{exported}");
+        assert!(exported.contains("temporalstore_meta_placement_short_total 4"), "{exported}");
+    }
 }

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -93,6 +93,18 @@ impl SingleNodeMeta {
             };
         }
         let shards = build_shards(&state, &table.info, &request.client_location);
+        // A shard that is serving but holds fewer servers than the table asks
+        // for is under-replicated, and the answer goes out saying so without
+        // anything noticing. A shard with no primary is out of service on
+        // purpose and is not short, it is stopped.
+        let short = shards
+            .iter()
+            .filter(|shard| {
+                shard.primary.is_some()
+                    && (shard.replicas.len() as u64) < table.info.replica_count
+            })
+            .count();
+        self.metrics.record_placement(short);
         TableTopologyResponse {
             status: Status::ok(),
             table: Some(table.info.clone()),

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -50,6 +50,11 @@ struct SubsystemMetricsState {
     divergences_total: u64,
     /// Bytes of topology handed out, as encoded on the wire.
     topology_query_bytes_total: u64,
+    /// Shards a topology answer placed on fewer servers than their table asks
+    /// for, counted as the answers go out, and how many the last answer was
+    /// short of.
+    placement_short_total: u64,
+    placement_short_now: u64,
     reassigned_total: BTreeMap<String, u64>,
     purged_total: BTreeMap<String, u64>,
     aged_total: BTreeMap<String, u64>,
@@ -122,6 +127,19 @@ impl SubsystemMetrics {
     /// Record the encoded size of one topology answer.
     pub fn record_topology_bytes(&self, bytes: usize) {
         self.with(|state| state.topology_query_bytes_total += bytes as u64);
+    }
+
+    /// Record what one topology answer could not place.
+    ///
+    /// `short` counts the shards in that answer which are serving but hold
+    /// fewer replicas than their table asks for. Recorded where the answer is
+    /// built, because placement is worked out per request and there is no
+    /// round anywhere that would otherwise notice.
+    pub fn record_placement(&self, short: usize) {
+        self.with(|state| {
+            state.placement_short_total += short as u64;
+            state.placement_short_now = short as u64;
+        });
     }
 
     pub fn record_divergence(&self, report: &ShardCheckReport) {
@@ -413,6 +431,26 @@ fn render(state: &SubsystemMetricsState) -> String {
         "temporalstore_meta_topology_query_bytes_total",
         &[],
         state.topology_query_bytes_total,
+    );
+    out.push_str(
+        "# HELP temporalstore_meta_placement_short_total Shards served with fewer replicas than their table asks for.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_placement_short_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_placement_short_total",
+        &[],
+        state.placement_short_total,
+    );
+    out.push_str(
+        "# HELP temporalstore_meta_placement_short Shards the last topology answer could not fill.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_placement_short gauge\n");
+    push(
+        &mut out,
+        "temporalstore_meta_placement_short",
+        &[],
+        state.placement_short_now,
     );
 
     out.push_str("# HELP temporalstore_meta_shard_divergence_total Shards found routed to a server not serving them.\n");


### PR DESCRIPTION
Placement is worked out per request: a topology answer names whatever
servers could be found for each shard. When there are not enough -- too few
live ones, or none the separation rules will accept -- the answer is simply
shorter, and the caller uses it.

Nothing counted that. A table configured for three replicas can be served
with one indefinitely, and the only place it shows is a client noticing it
was handed fewer endpoints than it asked for. There is a readiness field
called under_replicated_repair_ready and it is a hardcoded true; nothing
measured the thing it is named after.

temporalstore_meta_placement_short_total counts the shards each answer could
not fill, and temporalstore_meta_placement_short is what the last answer was
short of. Counted where the answer is built, because placement happens per
request and no background round would otherwise notice.

A shard with no primary is out of service deliberately -- frozen, or its
owner not serving -- so it is not counted as short. It is stopped, not
under-replicated.

Test: one server, a table asking for three replicas, two shards. Both are
served with one replica and both are reported; a second answer moves the
total and leaves the gauge where it was.
