### PR TITLE
Say how long a topology answer took

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -7951,6 +7951,88 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
     }
 
     #[test]
+    fn the_metaserver_says_how_long_a_topology_answer_took() {
+        // Every subsystem reports what it did and how much; none of them
+        // reported how long anything took. A metaserver that has gone slow to
+        // answer looks exactly like one that is fast, until clients time out.
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                registered_at_ms: 0,
+                numa_nodes: Vec::new(),
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "ns".to_string()
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                first_shard_id: 700,
+                shard_count: 1,
+                replica_count: 1,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+
+        // Nothing asked yet, so the histogram is empty rather than absent.
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_topology_query_latency_us_count 0"),
+            "{exported}"
+        );
+
+        for _ in 0..3 {
+            assert!(meta
+                .get_table_topology(GetTableTopologyRequest {
+                    namespace: "ns".to_string(),
+                    table_name: "t".to_string(),
+                    old_topology_version: 0,
+                    client_location: String::new(),
+                })
+                .status
+                .ok);
+        }
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_topology_query_latency_us_count 3"),
+            "three answers were not counted:
+{exported}"
+        );
+        // The buckets are cumulative, so the last one carries every answer.
+        assert!(
+            exported.contains("temporalstore_meta_topology_query_latency_us_bucket{le=\"+Inf\"} 3"),
+            "{exported}"
+        );
+        // A query that is not found is still an answer, and still timed.
+        let missing = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "absent".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert!(!missing.status.ok);
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_topology_query_latency_us_count 4"),
+            "a refused answer was not timed:
+{exported}"
+        );
+    }
+
+    #[test]
     fn metaserver_safe_mode_cooldown_blocks_rejoin_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("safe-mode-mutations.jsonl");

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -30,6 +30,21 @@ fn simple_conviction_round(
 
 impl SingleNodeMeta {
     pub fn get_table_topology(&self, request: GetTableTopologyRequest) -> TableTopologyResponse {
+        // Timed around the whole answer, lock included: a client waiting on a
+        // metaserver that is busy waits for the lock as surely as for the work,
+        // and timing only the work would report the metaserver as fast while
+        // every caller saw it as slow.
+        let started = std::time::Instant::now();
+        let response = self.get_table_topology_timed(request);
+        self.metrics
+            .record_topology_latency(started.elapsed().as_micros() as u64);
+        response
+    }
+
+    fn get_table_topology_timed(
+        &self,
+        request: GetTableTopologyRequest,
+    ) -> TableTopologyResponse {
         self.counters.topology_query_total.fetch_add(1, Ordering::Relaxed);
         // Resolving a topology only reads. It took the exclusive lock solely to
         // count, which serialised every client's and every proxy's hottest call

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -48,6 +48,15 @@ struct SubsystemMetricsState {
     held_total: BTreeMap<(String, String), u64>,
     reboots_detected_total: u64,
     divergences_total: u64,
+    /// How long topology queries took, in microseconds.
+    ///
+    /// Counts per bucket, not cumulative -- the rendering adds them up, because
+    /// that is the shape Prometheus wants and this is the shape that is cheap to
+    /// record.
+    topology_latency_us: [u64; TOPOLOGY_LATENCY_BUCKETS_US.len()],
+    topology_latency_over: u64,
+    topology_latency_sum_us: u64,
+    topology_latency_count: u64,
     /// Bytes of topology handed out, as encoded on the wire.
     topology_query_bytes_total: u64,
     /// Shards a topology answer placed on fewer servers than their table asks
@@ -88,6 +97,14 @@ pub struct SubsystemMetrics {
     inner: Arc<Mutex<SubsystemMetricsState>>,
 }
 
+/// Where the topology-query latency histogram puts things, in microseconds.
+///
+/// An answer served from the metadata already in memory lands in the first few;
+/// the wide ones at the top are there so an answer that waited on the write lock
+/// is visible as itself rather than lost in an overflow bucket.
+const TOPOLOGY_LATENCY_BUCKETS_US: [u64; 9] =
+    [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 50_000];
+
 impl SubsystemMetrics {
     pub fn new() -> Self {
         Self::default()
@@ -124,6 +141,21 @@ impl SubsystemMetrics {
     }
 
     /// Record one shard-divergence reconciliation round.
+    /// Record how long one topology query took.
+    pub fn record_topology_latency(&self, elapsed_us: u64) {
+        self.with(|state| {
+            state.topology_latency_count += 1;
+            state.topology_latency_sum_us += elapsed_us;
+            match TOPOLOGY_LATENCY_BUCKETS_US
+                .iter()
+                .position(|bound| elapsed_us <= *bound)
+            {
+                Some(index) => state.topology_latency_us[index] += 1,
+                None => state.topology_latency_over += 1,
+            }
+        });
+    }
+
     /// Record the encoded size of one topology answer.
     pub fn record_topology_bytes(&self, bytes: usize) {
         self.with(|state| state.topology_query_bytes_total += bytes as u64);
@@ -451,6 +483,39 @@ fn render(state: &SubsystemMetricsState) -> String {
         "temporalstore_meta_placement_short",
         &[],
         state.placement_short_now,
+    );
+
+    out.push_str(
+        "# HELP temporalstore_meta_topology_query_latency_us How long answering a table topology query took.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_topology_query_latency_us histogram\n");
+    let mut cumulative = 0_u64;
+    for (index, bound) in TOPOLOGY_LATENCY_BUCKETS_US.iter().enumerate() {
+        cumulative += state.topology_latency_us[index];
+        push(
+            &mut out,
+            "temporalstore_meta_topology_query_latency_us_bucket",
+            &[("le", &bound.to_string())],
+            cumulative,
+        );
+    }
+    push(
+        &mut out,
+        "temporalstore_meta_topology_query_latency_us_bucket",
+        &[("le", "+Inf")],
+        state.topology_latency_count,
+    );
+    push(
+        &mut out,
+        "temporalstore_meta_topology_query_latency_us_sum",
+        &[],
+        state.topology_latency_sum_us,
+    );
+    push(
+        &mut out,
+        "temporalstore_meta_topology_query_latency_us_count",
+        &[],
+        state.topology_latency_count,
     );
 
     out.push_str("# HELP temporalstore_meta_shard_divergence_total Shards found routed to a server not serving them.\n");


### PR DESCRIPTION
Every background subsystem here reports what it did and how much of it, and
none of them report how long anything took. There is no latency measurement
anywhere in the metaserver.

That matters most for the topology query, because it is the call every
client and every proxy makes and the only one whose slowness a caller feels
directly. A metaserver that has become slow to answer -- a datanode holding
the write lock through a long heartbeat, a table that has grown, a loaded
box -- looks exactly like one that is fast, right up until clients start
timing out, and then nothing says which of those it was.

temporalstore_meta_topology_query_latency_us is a histogram over the whole
answer, in microseconds, with a sum and a count.

Timed around the lock as well as the work. A client waiting on a busy
metaserver waits for the lock as surely as for the placement, and timing
only the placement would report the metaserver as fast while every caller
experienced it as slow.

A query for a table that is not there is an answer too, and is timed.

Buckets are recorded per bucket and added up when rendered, because
cumulative is the shape Prometheus wants and per-bucket is the shape that is
cheap to record on the hot path.
