### PR TITLE
Count the answers that were refused and the changes that would not apply

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2255,6 +2255,18 @@ impl SingleNodeMeta {
     }
 
     pub(crate) fn apply_mutation_at(&self, mutation: MetaMutation, at_ms: u64) -> Status {
+        let status = self.apply_mutation_at_inner(mutation, at_ms);
+        if !status.ok {
+            // Worth counting wherever it happens, but it is replay this is for:
+            // there, a mutation that will not apply means the recorded history
+            // and the state it should have produced have parted company, and
+            // nothing else would say so.
+            self.metrics.record_mutation_apply_failed();
+        }
+        status
+    }
+
+    fn apply_mutation_at_inner(&self, mutation: MetaMutation, at_ms: u64) -> Status {
         match mutation {
             MetaMutation::RegisterShard(request) => self.apply_register(request).status,
             MetaMutation::PublishShardSnapshot(request) => {
@@ -8030,6 +8042,75 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
             "a refused answer was not timed:
 {exported}"
         );
+    }
+
+    #[test]
+    fn a_refused_answer_and_a_change_that_would_not_apply_are_counted() {
+        let meta = SingleNodeMeta::default();
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "ns".to_string()
+            })
+            .status
+            .ok);
+
+        // A query for a table that is not there is refused. The request counter
+        // counts it as a query like any other, so without this a client looping
+        // against a name that does not exist looks like one being served.
+        let missing = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "absent".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert!(!missing.status.ok);
+
+        // A recorded change that will not apply: dropping a table that was
+        // never created. During replay this is the log and the state parting
+        // company, and nothing else would say so.
+        let failed = meta.apply_mutation(MetaMutation::DeleteTable(DeleteTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "never-existed".to_string(),
+        }));
+        assert!(!failed.ok, "the apply should have been refused");
+
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains("temporalstore_meta_topology_query_failed_total 1"),
+            "a refused answer was not counted:
+{exported}"
+        );
+        assert!(
+            exported.contains("temporalstore_meta_mutation_apply_failed_total 1"),
+            "a change that would not apply was not counted:
+{exported}"
+        );
+
+        // And an answer that succeeds does not move either of them.
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "real".to_string(),
+                first_shard_id: 800,
+                shard_count: 1,
+                replica_count: 1,
+                partition_version: 0,
+                serving_options: TableServingOptions::default(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .get_table_topology(GetTableTopologyRequest {
+                namespace: "ns".to_string(),
+                table_name: "real".to_string(),
+                old_topology_version: 0,
+                client_location: String::new(),
+            })
+            .status
+            .ok);
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(exported.contains("temporalstore_meta_topology_query_failed_total 1"), "{exported}");
+        assert!(exported.contains("temporalstore_meta_mutation_apply_failed_total 1"), "{exported}");
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -30,6 +30,20 @@ fn simple_conviction_round(
 
 impl SingleNodeMeta {
     pub fn get_table_topology(&self, request: GetTableTopologyRequest) -> TableTopologyResponse {
+        let response = self.get_table_topology_answered(request);
+        if !response.status.ok {
+            // The request counter counts a refusal as a query like any other, so
+            // a client looping against a name that is not there looked exactly
+            // like one being served.
+            self.metrics.record_topology_query_failed();
+        }
+        response
+    }
+
+    fn get_table_topology_answered(
+        &self,
+        request: GetTableTopologyRequest,
+    ) -> TableTopologyResponse {
         // Timed around the whole answer, lock included: a client waiting on a
         // metaserver that is busy waits for the lock as surely as for the work,
         // and timing only the work would report the metaserver as fast while

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -48,6 +48,11 @@ struct SubsystemMetricsState {
     held_total: BTreeMap<(String, String), u64>,
     reboots_detected_total: u64,
     divergences_total: u64,
+    /// Topology queries answered with an error rather than a topology.
+    topology_query_failed_total: u64,
+    /// Recorded mutations that would not apply. During replay this means the
+    /// log and the state have parted company.
+    mutation_apply_failed_total: u64,
     /// How long topology queries took, in microseconds.
     ///
     /// Counts per bucket, not cumulative -- the rendering adds them up, because
@@ -108,6 +113,16 @@ const TOPOLOGY_LATENCY_BUCKETS_US: [u64; 9] =
 impl SubsystemMetrics {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Record a topology query that was refused rather than answered.
+    pub fn record_topology_query_failed(&self) {
+        self.with(|state| state.topology_query_failed_total += 1);
+    }
+
+    /// Record a recorded mutation that would not apply.
+    pub fn record_mutation_apply_failed(&self) {
+        self.with(|state| state.mutation_apply_failed_total += 1);
     }
 
     fn with<R>(&self, f: impl FnOnce(&mut SubsystemMetricsState) -> R) -> R {
@@ -516,6 +531,27 @@ fn render(state: &SubsystemMetricsState) -> String {
         "temporalstore_meta_topology_query_latency_us_count",
         &[],
         state.topology_latency_count,
+    );
+
+    out.push_str(
+        "# HELP temporalstore_meta_topology_query_failed_total Topology queries answered with an error.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_topology_query_failed_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_topology_query_failed_total",
+        &[],
+        state.topology_query_failed_total,
+    );
+    out.push_str(
+        "# HELP temporalstore_meta_mutation_apply_failed_total Recorded mutations that would not apply.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_mutation_apply_failed_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_mutation_apply_failed_total",
+        &[],
+        state.mutation_apply_failed_total,
     );
 
     out.push_str("# HELP temporalstore_meta_shard_divergence_total Shards found routed to a server not serving them.\n");


### PR DESCRIPTION
Two things the metaserver does can fail without anything saying so.

A topology query can be answered with an error: the table is gone, or
frozen, or was never there. The request counter counts that as a query like
any other, so a client looping against a name that does not exist looks
exactly like one being served.

A recorded mutation can fail to apply. That is the more serious of the two.
Applying is how replay rebuilds the state from the log, so a mutation that
will not apply means the recorded history and the state it should have
produced have parted company -- and the metaserver carries on without
mentioning it. That is the kind of thing that is only ever noticed later,
from the wrong end.

temporalstore_meta_topology_query_failed_total and
temporalstore_meta_mutation_apply_failed_total.

Counted around the whole answer and the whole apply, so every refusal
reaches them however the call returns.

Test: a query for a table that is not there, and dropping a table that was
never created, each move their counter once; an answer that succeeds moves
neither. Removing the apply counter fails it.
