### PR TITLE
a dump walked every dirty object once per bucket it dumped

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -307,12 +307,6 @@ pub(super) type ObjectIndex = BTreeSet<u64>;
 /// Keyed by a SHARED page-ref key: the same allocation is held by the lookups that point at this
 /// page, instead of each of the three keeping its own copy of the same ~117-byte string.
 pub(super) type PageIndexMap = BTreeMap<Arc<str>, PageIndex>;
-/// A sorted, deduplicated vector rather than a set: measured, 100% of these entries hold exactly
-/// one ref, and a B-tree node costs its full size whether it holds one element or eleven.
-/// Insertion goes through `insert_page_lookup_ref`, which keeps both invariants.
-///
-/// Serializes identically -- both a `Vec` and a `BTreeSet` encode as a sequence -- which matters
-/// because this map is part of the serialized index.
 /// One entry per OBJECT, with its components nested inside.
 ///
 /// This replaced two maps keyed by overlapping composites -- (model, object) and
@@ -343,6 +337,12 @@ pub(super) struct ObjectPageRefs {
 pub(super) struct ComponentPages {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) component: Option<String>,
+    /// A sorted, deduplicated vector rather than a set: measured, 100% of these hold exactly one
+    /// ref, and a B-tree node costs its full size whether it holds one element or eleven.
+    /// Insertion goes through `insert_page_lookup_ref`, which keeps both invariants.
+    ///
+    /// Serializes identically -- a `Vec` and a `BTreeSet` both encode as a sequence -- which
+    /// matters because this is part of the serialized index.
     #[serde(default)]
     pub(super) refs: Vec<PageLookupRef>,
 }

--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -4,6 +4,15 @@
 //! Storage lifecycle / WAL-reclaim / eviction methods for TemporalEngine, split from engine.rs.
 use super::*;
 
+/// How many dirty-object keys the dump drain has looked at, across every call.
+///
+/// The drain's cost is not visible from outside -- it is a closure inside a `retain` -- and
+/// deriving it as |dirty objects| x |buckets| is arithmetic about the code rather than a
+/// measurement of it. This counts what actually happens, which is the only version that keeps
+/// being true after someone changes the loop.
+pub(crate) static DIRTY_DRAIN_VISITS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 impl TemporalEngine {
     pub fn storage_lifecycle_plan(&self, request: StorageLifecycleRequest) -> StorageLifecyclePlan {
         let bucket_summaries = self.bucket_storage_summaries(request.shard_id);
@@ -424,6 +433,19 @@ impl TemporalEngine {
                 .into_iter()
                 .map(|summary| (summary.routing_bucket, summary.dirty_generation))
                 .collect();
+        // Buckets this dump actually clears. Collected first so the dirty set is walked ONCE.
+        //
+        // The retain used to sit inside this loop, so every qualifying bucket walked every dirty
+        // object and re-hashed its key to recompute a routing bucket -- a bucket the caller
+        // already knew, and one that `mark_async_dirty_object` had computed on the line above the
+        // insert and thrown away. The work was |dirty objects| x |buckets|, to remove at most
+        // |dirty objects| entries: measured at 4 040 000 closure calls to clear 4 000 objects
+        // across 1 010 buckets, a 1010x amplification.
+        //
+        // Nothing in the per-bucket body depends on the dirty set having been cleared, and
+        // `current` was captured before any mutation, so hoisting the walk out is the same answer
+        // in one pass.
+        let mut cleared_buckets: std::collections::HashSet<u32> = std::collections::HashSet::new();
         for bucket_id in manifest.bucket_ids.iter().copied() {
             let Some(&captured_generation) = captured.get(&bucket_id) else {
                 continue;
@@ -431,9 +453,7 @@ impl TemporalEngine {
             if current.get(&bucket_id).copied().unwrap_or_default() != captured_generation {
                 continue;
             }
-            shard.dirty_objects.retain(|key| {
-                page_routing_bucket(key, start_routing_bucket, end_routing_bucket) != bucket_id
-            });
+            cleared_buckets.insert(bucket_id);
             if let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&bucket_id) {
                 // Hold the generation at the captured (derived) value so the reclaim
                 // fingerprint still matches once the dirty objects are cleared.
@@ -445,6 +465,16 @@ impl TemporalEngine {
                     page.dirty = false;
                 }
             }
+        }
+        if !cleared_buckets.is_empty() {
+            shard.dirty_objects.retain(|key| {
+                DIRTY_DRAIN_VISITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                !cleared_buckets.contains(&page_routing_bucket(
+                    key,
+                    start_routing_bucket,
+                    end_routing_bucket,
+                ))
+            });
         }
     }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9436,3 +9436,117 @@ fn a_clamped_reclaim_still_serves_what_it_kept_after_a_restart() {
         );
     }
 }
+
+/// What the dirty-object set costs to drain, as the store grows.
+///
+/// `dirty_objects` is a flat set of object keys, and the dump drain used to sit INSIDE the
+/// per-bucket loop:
+///
+///     for bucket_id in manifest.bucket_ids { ...
+///         shard.dirty_objects.retain(|key| page_routing_bucket(key, ..) != bucket_id)
+///
+/// so every qualifying bucket walked every dirty object, re-hashing each key to recompute a
+/// routing bucket the caller already knew. The work was |dirty objects| x |buckets| to remove at
+/// most |dirty objects| entries.
+///
+/// This counts what the drain ACTUALLY looks at, through a counter inside the closure, rather than
+/// deriving the number as a product. A product is arithmetic about the code; the counter survives
+/// someone moving the loop back.
+#[test]
+fn the_dump_drain_looks_at_each_dirty_object_once() {
+    fn measure(records: usize) -> (usize, usize, u64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        assert!(
+            engine
+                .load_shard_with(crate::control::LoadShardRequest {
+                    shard_id: 1,
+                    table_name: "dirty-drain".to_string(),
+                    shard_uri: "local://dirty-drain/1".to_string(),
+                    start_routing_bucket: 0,
+                    end_routing_bucket: 1023,
+                    readonly: false,
+                    load_version: 1,
+                    local_node_id: Some(1),
+                })
+                .status
+                .ok
+        );
+        for index in 0..records {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("dirty-{index}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let (dirty_before, buckets) = {
+            let shards = engine.shards.read().expect("shards lock poisoned");
+            let shard = shards.get(&1).expect("shard 1 loaded");
+            (shard.dirty_objects.len(), shard.bucket_index.bucket_map.len())
+        };
+
+        // The drain runs from `apply_storage_lifecycle`, NOT from creating or installing a
+        // manifest directly. The first version of this probe called those, measured a drain that
+        // never ran, and passed -- which is why the assertion below insists it ran at all.
+        let selected: Vec<u32> = {
+            let shards = engine.shards.read().expect("shards lock poisoned");
+            shards
+                .get(&1)
+                .expect("shard 1 loaded")
+                .bucket_index
+                .bucket_map
+                .keys()
+                .copied()
+                .collect()
+        };
+        crate::engine::storage_lifecycle_methods::DIRTY_DRAIN_VISITS
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        engine.apply_storage_lifecycle(StorageLifecycleRequest {
+            shard_id: 1,
+            selected_dump_buckets: selected,
+            ..Default::default()
+        });
+        let visits = crate::engine::storage_lifecycle_methods::DIRTY_DRAIN_VISITS
+            .load(std::sync::atomic::Ordering::Relaxed);
+        (dirty_before, buckets, visits)
+    }
+
+    println!(
+        "
+  records   dirty objects   buckets   drain visits   per dirty object   as one-pass-per-bucket
+"
+    );
+    for records in [500usize, 1_000, 2_000, 4_000] {
+        let (dirty, buckets, visits) = measure(records);
+        println!(
+            "  {records:>7}   {dirty:>13}   {buckets:>7}   {visits:>12}   {:>16.2}   {:>21}",
+            visits as f64 / dirty.max(1) as f64,
+            dirty.saturating_mul(buckets),
+        );
+        // The property, not a threshold: one pass over the set, however many buckets a dump
+        // covers. Before the hoist this was `dirty * buckets` -- 4 040 000 visits to clear 4 000
+        // objects across 1 010 buckets.
+        // ANTI-VACUITY FIRST. `visits <= dirty` is trivially true at zero, and the first version
+        // of this probe passed exactly that way: it called an entry point that does not drain, so
+        // the count was 0 and the bound held for the wrong reason. A "no more than X" assertion
+        // needs a companion asserting "at least something", because a broken harness and a fixed
+        // defect both produce zero and only one of them is good news.
+        assert!(
+            visits > 0,
+            "the drain never ran, so the count measures nothing: {dirty} dirty objects, \
+             {buckets} buckets"
+        );
+        assert!(
+            visits <= dirty as u64,
+            "the drain visited {visits} keys for {dirty} dirty objects across {buckets} buckets, \
+             which means it is walking the set once per bucket again"
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -427,9 +427,15 @@ pub(crate) fn record_command(
 /// An outcome states the result instead: this object's page now lives at this address, or this
 /// object is gone. Replay can install that without running anything.
 ///
-/// Default OFF while both are carried, because carrying both makes every record bigger and the
-/// payoff only arrives when replay switches to the outcomes and the command comes out. The flip
-/// belongs with that change, not before it.
+/// DEFAULT ON. The comment here used to say "default OFF while both are carried", and described a
+/// state that no longer exists: records no longer carry both. A mixed workload was walked across
+/// every write shape -- synchronous and asynchronous, separate and batched -- and ZERO records
+/// carry an operation, so the payoff this flag was waiting for has arrived and the command has
+/// come out.
+///
+/// The flip was correct; the comment simply outlived it. A flag comment that states the opposite
+/// default from the code is worse than no comment, because the two are indistinguishable from
+/// outside: a stale note and a default nobody meant to change read exactly alike.
 pub fn wal_outcome_items_enabled() -> bool {
     // Default ON. Recording stopped costing the group-commit coalescing once results travelled
     // through the reserve-only append, and recovery prefers installing them over re-running an


### PR DESCRIPTION
a dump walked every dirty object once per bucket it dumped

    records   dirty objects   buckets   drain visits   per object   before
        500             500       408            500         1.00   204000
       1000            1000       702           1000         1.00   702000
       2000            2000       934           2000         1.00  1868000
       4000            4000      1010           4000         1.00  4040000

The drain sat inside the per-bucket loop:

    for bucket_id in manifest.bucket_ids { ...
        shard.dirty_objects.retain(|key| page_routing_bucket(key, ..) != bucket_id)

so every qualifying bucket walked every dirty object and re-hashed its key to recompute a routing
bucket the caller already knew -- and one that `mark_async_dirty_object` computes on the line above
its insert and throws away. 4 040 000 closure calls to clear 4 000 objects across 1 010 buckets.

Nothing in the per-bucket body depends on the set having been cleared, and the generation snapshot
is taken before any mutation, so the buckets a dump clears are collected first and the set is
walked once. Same answer, 1010x less of it.

NOT quadratic, and the measurement says so: the growth factor per doubling FALLS -- 3.44x, 2.66x,
2.16x -- because buckets saturate against the shard's routing width. It is linear in
records x bucket_count with bucket_count capped by shard width. Wider shards make it worse; calling
it quadratic would have been wrong in a way that mattered for predicting it.

THE COUNT IS OBSERVED, NOT DERIVED. |dirty| x |buckets| is arithmetic about the code; a counter
inside the closure is a measurement of it, and it stays true if someone moves the loop back. There
was precedent for the shape in RESIDENT_SWEEPS.

AND THE FIRST VERSION OF THE PROBE PASSED WHILE MEASURING NOTHING. It called
create_bucket_dump_manifest and install_bucket_dump_manifest; the drain runs from
apply_storage_lifecycle. Visits were 0, and `visits <= dirty` is trivially true at zero. The probe
now asserts it ran BEFORE asserting the bound -- a "no more than X" assertion needs a companion
asserting "at least something", because a broken harness and a fixed defect both produce zero and
only one of them is good news.

Two further changes are deliberately not here, so this number stays attributable: the set holds a
second String per object where the interned key already exists (~9.7 B/record and an allocation per
write), and keying it by bucket would make the drain O(1) rather than one pass -- at the cost of
len() no longer being the object count, which is the same obstacle that blocked the page-lookup map
until it was keyed by object.

AND ONE FLAG COMMENT STATED THE OPPOSITE DEFAULT FROM THE CODE. An audit of all 25 env-var flags
found exactly one: TS_WAL_OUTCOME_ITEMS reads `!matches!(.., "0"|"false"|..)` -- default ON -- while
its comment said "Default OFF while both are carried... the flip belongs with that change, not
before it". That change has landed: a mixed workload across every write shape now shows ZERO records
carrying an operation, so the condition the comment was waiting on is met. The flip was right and
the comment outlived it.

A flag comment that contradicts the code is worse than none, because a stale note and a default
nobody meant to change are indistinguishable from outside.

The audit's first pass reported TWO disagreements and was wrong about one: it read only the
`matches!` inside `group_commit_enabled`, whose default lives in a `match`'s `Err(_) => true` arm.
TS_GROUP_COMMIT is ON and its comment is correct. The tool now reads all three shapes, which is why
the remaining row can be trusted.

Every performance flag is ON: TS_WAL_BINARY_FRAME, TS_WAL_BLOCK_FOOTER, TS_BLOCK_IN_WAL,
TS_GROUP_COMMIT, TS_HOT_PAGE_SPILL, TS_INDEXLOG_UPSERT_DELTAS, TS_INDEX_CATALOG_FOLD,
TS_WAL_OUTCOME_ITEMS, TS_SCRATCH_SWEEP, TS_CROSS_SHARD_RECLAIM_GUARD, TS_RAFT_WAL_DELTA_ENTRIES,
MATRIXARK_EAGER_CACHE_WARM_ON_LOAD. The flags that are off are legacy paths, a bulk-ingest mode and

🤖 Generated with [Claude Code](https://claude.com/claude-code)
