### PR TITLE
Say how much topology went out

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1708,9 +1708,12 @@ fn handle(
         }),
         ("GET", "/tables") => json_response(200, &backend_call!(meta, list_tables)),
         ("POST", "/tables/topology") | ("POST", "/table_topology") => {
-            parse_or(&request.body, |req: GetTableTopologyRequest| {
+            let (code, body) = parse_or(&request.body, |req: GetTableTopologyRequest| {
                 backend_call!(meta, get_table_topology, req)
-            })
+            });
+            // Measured here because here is where the answer has a size.
+            meta.record_topology_bytes(body.len());
+            (code, body)
         }
         _ => json_response(
             404,
@@ -2486,6 +2489,88 @@ mod tests {
             std::env::remove_var(key);
         }
         out
+    }
+
+    #[test]
+    fn the_metaserver_says_how_much_topology_went_out() {
+        // A topology answer grows with the table, and every client and proxy
+        // fetches it whenever the version moves. Nothing measured how much was
+        // going out, so a table whose answers had grown large enough to matter
+        // was not visible as bandwidth anywhere.
+        let backend = MetaBackend::Single(SingleNodeMeta::default());
+        let MetaBackend::Single(meta) = &backend else {
+            unreachable!()
+        };
+        let scheduler = MetaTaskScheduler::default();
+        assert!(meta
+            .register_server(RegisterServerRequest {
+                numa_nodes: Vec::new(),
+                server_addr: "node-a".to_string(),
+                node_id: 1,
+                location: "rack-1".to_string(),
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "ns".to_string()
+            })
+            .status
+            .ok);
+        assert!(meta
+            .add_table(AddTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                first_shard_id: 900,
+                shard_count: 4,
+                replica_count: 1,
+                partition_version: 0,
+                serving_options: temporalstore_rust::meta::TableServingOptions::default(),
+            })
+            .status
+            .ok);
+
+        let ask = || {
+            handle(
+                &backend,
+                &scheduler,
+                HttpRequest {
+                    method: "POST".to_string(),
+                    path: "/table_topology".to_string(),
+                    body: serde_json::to_vec(&GetTableTopologyRequest {
+                        namespace: "ns".to_string(),
+                        table_name: "t".to_string(),
+                        old_topology_version: 0,
+                        client_location: String::new(),
+                    })
+                    .unwrap(),
+                },
+            )
+        };
+
+        let (code, body) = ask();
+        assert_eq!(code, 200);
+        let first = body.len() as u64;
+        assert!(first > 0);
+
+        let exported = meta.subsystem_metrics().prometheus();
+        let line = format!("temporalstore_meta_topology_query_bytes_total {first}");
+        assert!(
+            exported.contains(&line),
+            "the size of the answer was not counted, wanted {line}"
+        );
+
+        // A second answer adds its own size rather than replacing it.
+        let (_, body) = ask();
+        let total = first + body.len() as u64;
+        let exported = meta.subsystem_metrics().prometheus();
+        assert!(
+            exported.contains(&format!(
+                "temporalstore_meta_topology_query_bytes_total {total}"
+            )),
+            "the second answer did not add to the total"
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -37,6 +37,16 @@ impl MetaBackend {
         }
     }
 
+    /// Record the encoded size of a topology answer.
+    ///
+    /// Only the single-node backend keeps these: the raft backend drives none of
+    /// the subsystems this recorder belongs to, and reports nothing from it.
+    fn record_topology_bytes(&self, bytes: usize) {
+        if let Self::Single(meta) = self {
+            meta.subsystem_metrics().record_topology_bytes(bytes);
+        }
+    }
+
     fn raft_status(&self) -> Option<RaftClusterStatus> {
         match self {
             Self::Single(_) => None,

--- a/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
+++ b/crates/temporalstore-rust/src/meta/subsystem_metrics.rs
@@ -48,6 +48,8 @@ struct SubsystemMetricsState {
     held_total: BTreeMap<(String, String), u64>,
     reboots_detected_total: u64,
     divergences_total: u64,
+    /// Bytes of topology handed out, as encoded on the wire.
+    topology_query_bytes_total: u64,
     reassigned_total: BTreeMap<String, u64>,
     purged_total: BTreeMap<String, u64>,
     aged_total: BTreeMap<String, u64>,
@@ -107,6 +109,11 @@ impl SubsystemMetrics {
     }
 
     /// Record one shard-divergence reconciliation round.
+    /// Record the encoded size of one topology answer.
+    pub fn record_topology_bytes(&self, bytes: usize) {
+        self.with(|state| state.topology_query_bytes_total += bytes as u64);
+    }
+
     pub fn record_divergence(&self, report: &ShardCheckReport) {
         self.with(|state| {
             *state
@@ -333,6 +340,17 @@ fn render(state: &SubsystemMetricsState) -> String {
             u64::from(*paused),
         );
     }
+
+    out.push_str(
+        "# HELP temporalstore_meta_topology_query_bytes_total Bytes of topology handed out.\n",
+    );
+    out.push_str("# TYPE temporalstore_meta_topology_query_bytes_total counter\n");
+    push(
+        &mut out,
+        "temporalstore_meta_topology_query_bytes_total",
+        &[],
+        state.topology_query_bytes_total,
+    );
 
     out.push_str("# HELP temporalstore_meta_shard_divergence_total Shards found routed to a server not serving them.\n");
     out.push_str("# TYPE temporalstore_meta_shard_divergence_total counter\n");


### PR DESCRIPTION
A topology answer grows with the table: a thousand shards with three
replicas each is a large response, and every client and every proxy fetches
it whenever the version moves. Nothing measured how much of that was going
out, so a table whose answers had grown big enough to matter, or a fleet
re-fetching them far more often than it needed to, was not visible as
bandwidth anywhere.

temporalstore_meta_topology_query_bytes_total counts the encoded size of
each answer.

Measured at the route rather than where the answer is built, because that is
the only place the answer has a size -- the metaserver hands back a
structure, and how many bytes it becomes is decided by encoding it.

The raft backend drives none of the subsystems this recorder belongs to and
reports nothing from it, so it records nothing here either, which is what it
already does for every other subsystem counter.

Test: ask for a table's topology twice through the route and the counter
holds the size of the first answer and then both.
