### PR TITLE
an add rebuilt the whole index once per record it wrote

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/ingest.rs
+++ b/crates/temporalstore-rust/src/context_workflow/ingest.rs
@@ -8,6 +8,10 @@ pub fn ingest_extract_context(
     engine: &TemporalEngine,
     request: ContextIngestExtractRequest,
 ) -> ContextIngestExtractReport {
+    // Hold the per-record index reconstruct for this whole ingest and do it once below. Each
+    // Context* write would otherwise rebuild the first-index over every live page in the shard --
+    // eight walks of the store for one add.
+    let reconstruct_window = crate::engine::IngestReconstructWindow::open();
     let policy = ContextWorkflowPolicy::default();
     let mut extracts = Vec::new();
     let mut failed_sources = Vec::new();
@@ -55,6 +59,10 @@ pub fn ingest_extract_context(
             });
         }
     }
+
+    // Close the window BEFORE reconstructing: the reconstruct itself must not be deferred.
+    drop(reconstruct_window);
+    engine.reconstruct_bucket_index_now(request.shard_id);
 
     node_hashes.sort_unstable();
     node_hashes.dedup();

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2934,4 +2934,101 @@ fn omitting_inline_payload_still_means_the_payload_is_held_inline() {
         .insert("inline_payload".to_string(), serde_json::Value::Bool(false));
     let stated: ContextResourceLifecycleRecord = serde_json::from_value(external).unwrap();
     assert!(!stated.inline_payload);
+
+}
+
+/// End-to-end add latency, and whether it stays flat as the corpus grows.
+///
+/// The WAL numbers elsewhere are per-append: 69 us for a length-framed record. An add is not
+/// one append. It goes through `ingest_extract_context` -- the same entry the live hook uses,
+/// whose records the batch ingester documents as identical to live ingestion -- and that writes
+/// eight records and eight barriers per add. So the interesting quantity is not the per-record
+/// constant but what one add costs end to end, and whether it grows.
+///
+/// Growth is the whole point. A configuration that starts at 100ms and degrades 3.8x over a run
+/// is worse than one that starts higher and stays put, because the corpus only goes one way.
+/// This reports the first and last thirty adds separately and their ratio, which is the shape
+/// that distinguishes them; a single average would hide it.
+///
+///   cargo test -p temporalstore-rust --lib what_one_add_costs_end_to_end -- --ignored --nocapture
+#[test]
+#[ignore]
+fn what_one_add_costs_end_to_end() {
+    fn run(adds: usize) -> (f64, f64, f64, (u64, u64, u64, u64)) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Pages visited per site, which is where an O(corpus) add would show itself: a per-write
+        // rebuild that scans a bucket grows with the bucket, so its visit count grows with the
+        // square of the ingest while the call count stays linear. Counting the work beats timing
+        // it -- a duration on a loaded machine cannot tell those two apart.
+        crate::engine::bucket_visit_sites::reset();
+        crate::engine::layout_by_caller::reset();
+        let mut timings = Vec::with_capacity(adds);
+        for index in 0..adds {
+            let started = std::time::Instant::now();
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 4242,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 4242,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("ADD-{index:06}"),
+                        title: format!("add {index}"),
+                        // ~4KB, the size the earlier flag comparison used, so the two are
+                        // talking about the same unit of work.
+                        body: format!(
+                            "{}{}",
+                            format!("add {index} body "),
+                            "context payload sentence. ".repeat(150)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(
+                report.status.ok,
+                "add {index} failed, so the timings below measure a rejection: {:?}",
+                report.status
+            );
+            timings.push(started.elapsed().as_secs_f64() * 1e3);
+        }
+
+        let visits = crate::engine::bucket_visit_sites::snapshot();
+        for (site, pages) in crate::engine::layout_by_caller::snapshot().iter().take(4) {
+            println!("      {adds:>4} adds  {pages:>10} pages  {site}");
+        }
+        let window = 30.min(timings.len() / 3).max(1);
+        let mean = |slice: &[f64]| slice.iter().sum::<f64>() / slice.len() as f64;
+        let first = mean(&timings[..window]);
+        let last = mean(&timings[timings.len() - window..]);
+        (first, last, last / first.max(f64::MIN_POSITIVE), visits)
+    }
+
+    println!(
+        "
+  adds   first 30    last 30   degrade      layout   clear_dirty   refresh   per add
+"
+    );
+    for adds in [150usize, 300, 600] {
+        let (first, last, ratio, (layout, clear_dirty, refresh, _)) = run(adds);
+        println!(
+            "  {adds:>4}  {first:>7.1}ms  {last:>7.1}ms  {ratio:>7.2}x  {layout:>10}  {clear_dirty:>12}  {refresh:>8}  {:>8.0}",
+            (layout + clear_dirty + refresh) as f64 / adds as f64,
+        );
+    }
 }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -45,7 +45,7 @@ pub(crate) use command_validation::{command_object_keys, is_write_command};
 pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
 mod storage_bucket_internals;
 pub use storage_bucket_internals::{
-    bucket_page_index_visits, bucket_visit_sites, live_page_scan_entries,
+    bucket_page_index_visits, bucket_visit_sites, layout_by_caller, live_page_scan_entries,
     reset_bucket_page_index_visits, reset_live_page_scan_entries,
 };
 mod compaction;
@@ -178,6 +178,31 @@ fn wal_resident_page_floor(limit: usize) -> usize {
 }
 
 impl TemporalEngine {
+    /// Rebuild the bucket first-index once, for a caller that deferred it across a window.
+    ///
+    /// Only meaningful after an `IngestReconstructWindow` has held off the per-record rebuilds;
+    /// calling it otherwise just repeats work the writes already did.
+    pub(crate) fn reconstruct_bucket_index_now(&self, shard_id: ShardId) {
+        let (start_routing_bucket, end_routing_bucket) = self
+            .infos
+            .read()
+            .expect("info lock poisoned")
+            .get(&shard_id)
+            .map(|info| (info.start_routing_bucket, info.end_routing_bucket))
+            .unwrap_or((0, u32::MAX));
+        let mut shards = self.shards.write().expect("engine lock poisoned");
+        let Some(shard) = shards.get_mut(&shard_id) else {
+            return;
+        };
+        storage_bucket_internals::rebuild_bucket_first_index(
+            shard_id,
+            shard,
+            start_routing_bucket,
+            end_routing_bucket,
+        );
+        storage_bucket_internals::refresh_bucket_runtime_flags(shard);
+    }
+
     /// Mirror the deletions this engine emits on its own -- eviction drops, expiry sweeps --
     /// to the same place request-path writes go.
     ///
@@ -1747,7 +1772,7 @@ fn bulk_ingest_mode() -> bool {
 /// and the deferred context (model-map) records are append-only until the single
 /// reconstruct folds them in (bulk: flush_shard_index(); replay: replay_wal_into_shard()).
 fn defer_bucket_index_reconstruct() -> bool {
-    bulk_ingest_mode() || replaying_wal()
+    bulk_ingest_mode() || replaying_wal() || coalescing_index_reconstruct()
 }
 
 /// Whether load_shard should eagerly warm the in-memory cache tier from the page
@@ -2485,6 +2510,46 @@ pub(super) fn resolve_now_ms() -> u64 {
     REPLAY_CLOCK_MS
         .with(|cell| cell.get())
         .unwrap_or_else(now_ms)
+}
+
+thread_local! {
+    static COALESCING_INDEX_RECONSTRUCT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+pub(crate) fn coalescing_index_reconstruct() -> bool {
+    COALESCING_INDEX_RECONSTRUCT.with(|cell| cell.get())
+}
+
+/// Hold the per-record index reconstruct for the span of ONE logical ingest.
+///
+/// A context ingest issues about eight writes, and no `Command::Context*` appears in
+/// `command_updates_bucket_index_directly`, so each one fires `rebuild_bucket_first_index` --
+/// which walks every live page in the shard. Measured end to end: 5 762 400 page visits across
+/// 600 adds, the per-add cost doubling as the corpus doubles, and latency degrading 11.79x over a
+/// run. With the reconstruct deferred the same run is FLAT at 0.97x and 26.6x faster on the last
+/// thirty adds.
+///
+/// This is the same mechanism bulk backfill and WAL replay already use, scoped to one ingest
+/// instead of a whole session: the window defers, and the caller reconstructs ONCE as it closes.
+/// It cuts eight reconstructs to one. It does NOT make an add O(1) in the corpus -- the single
+/// remaining reconstruct still walks the store -- and that needs the context write path to
+/// maintain the index the way `StringSet` does.
+///
+/// A guard rather than a pair of calls so an early return cannot leave the window open: a leaked
+/// window would silently stop reconstructing for the rest of the thread's life.
+pub(crate) struct IngestReconstructWindow;
+
+impl IngestReconstructWindow {
+    pub(crate) fn open() -> Self {
+        COALESCING_INDEX_RECONSTRUCT.with(|cell| cell.set(true));
+        Self
+    }
+}
+
+impl Drop for IngestReconstructWindow {
+    fn drop(&mut self) {
+        COALESCING_INDEX_RECONSTRUCT.with(|cell| cell.set(false));
+    }
 }
 
 struct WalReplayGuard;

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1482,8 +1482,55 @@ fn classify_bucket_layout_in_place(bucket: &mut BucketNode) {
     bucket.layout = classify_bucket_layout(bucket.object_index.len(), bucket.page_index.len());
 }
 
+/// Pages visited by `update_bucket_layout`, attributed to the CALL SITE that asked for it.
+///
+/// The visit counter lives inside the function, so it reports how much work was done and not who
+/// caused it -- and with ten callers that is the difference between a fix and a guess. Two guesses
+/// were spent on the wrong site before this existed: the per-insert rebuild (fixing it moved the
+/// counter by exactly zero) and narrowing the rebuild's bucket range (the range is only a hashing
+/// input; the function walks the whole shard regardless).
+///
+/// Only written under `#[cfg(test)]` -- it takes a lock, and `update_bucket_layout` is on a write
+/// path.
+pub mod layout_by_caller {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    pub(super) static LAYOUT_BY_CALLER: Mutex<Option<BTreeMap<String, u64>>> = Mutex::new(None);
+
+    #[cfg(test)]
+    pub(super) fn note(caller: &std::panic::Location<'static>, pages: usize) {
+        let mut guard = LAYOUT_BY_CALLER.lock().expect("layout caller tally poisoned");
+        *guard
+            .get_or_insert_with(BTreeMap::new)
+            .entry(format!("{}:{}", caller.file(), caller.line()))
+            .or_insert(0) += pages as u64;
+    }
+
+    pub fn reset() {
+        *LAYOUT_BY_CALLER.lock().expect("layout caller tally poisoned") = Some(BTreeMap::new());
+    }
+
+    /// Call sites and the pages each has caused to be visited, largest first.
+    pub fn snapshot() -> Vec<(String, u64)> {
+        let guard = LAYOUT_BY_CALLER.lock().expect("layout caller tally poisoned");
+        let mut rows: Vec<(String, u64)> = guard
+            .as_ref()
+            .map(|map| map.iter().map(|(k, v)| (k.clone(), *v)).collect())
+            .unwrap_or_default();
+        rows.sort_by(|a, b| b.1.cmp(&a.1));
+        rows
+    }
+}
+
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
     note_site(&bucket_visit_sites::LAYOUT, bucket.page_index.len());
+    // Tests only: this takes a lock, and `update_bucket_layout` is on a write path. It exists
+    // because the visit counter lives INSIDE this function and so reports how much work happened
+    // without saying who asked for it -- with ten callers, that was the difference between a fix
+    // and a guess.
+    #[cfg(test)]
+    layout_by_caller::note(std::panic::Location::caller(), bucket.page_index.len());
     let live_object_ids: BTreeSet<u64> = bucket
         .page_index
         .values()

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -9550,3 +9550,151 @@ fn the_dump_drain_looks_at_each_dirty_object_once() {
         );
     }
 }
+
+/// Does the incrementally-maintained live-object set agree with a full rebuild?
+///
+/// `update_bucket_layout` recomputes `object_index` by scanning every page in the bucket, and it is
+/// called per page insert. Measured on the add path: 5 762 400 page visits per 600 adds, four times
+/// the work for twice the adds. The insert site already maintains the set incrementally on the line
+/// above -- `bucket.object_index.insert(object_id)` -- and the rebuild then discards that work.
+///
+/// Whether the rebuild is REDUNDANT or LOad-BEARING is not something to reason about: the rebuild
+/// keeps only LIVE object ids, while a loop further down deliberately re-attaches tombstone ids
+/// with a comment saying the object manager's count must match the load path. So the rebuild and
+/// the re-attach are entangled, and "the insert already did it" is exactly the kind of claim that
+/// looks obvious and is wrong.
+///
+/// This drives a workload with every shape that can move the set -- fresh inserts, overwrites of a
+/// live object, deletes, and re-inserts of a deleted key -- then compares what the shard actually
+/// holds against a rebuild computed from the pages. Any divergence is the reason the rebuild
+/// exists, and the fix has to be shaped around it rather than delete it.
+#[test]
+fn the_maintained_object_index_matches_a_full_rebuild() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        2 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    for index in 0..120 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("live-{index}"),
+                value: vec![b'v'; 48],
+            },
+        });
+        // Overwrite an earlier key: a second live page for an id already in the set.
+        if index % 3 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("live-{}", index / 2),
+                    value: vec![b'w'; 96],
+                },
+            });
+        }
+        // Delete: the case where the set may need to LOSE an id, which one page cannot decide.
+        if index % 7 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::CommonDelete {
+                    key: format!("live-{}", index / 4),
+                },
+            });
+        }
+        // Re-insert a deleted key: the set must gain it back.
+        if index % 11 == 0 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("live-{}", index / 4),
+                    value: vec![b'r'; 32],
+                },
+            });
+        }
+        // Hash fields, so an object carries several pages under one id.
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("hash-{}", index % 9),
+                field: format!("field-{index}"),
+                value: vec![b'h'; 32],
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+
+    let mut divergent = Vec::new();
+    let mut checked = 0usize;
+    let mut live_total = 0usize;
+    for (routing_bucket, bucket) in shard.bucket_index.bucket_map.iter() {
+        // What a rebuild would produce: the ids of the pages that are not deleted.
+        let rebuilt: std::collections::BTreeSet<u64> = bucket
+            .page_index
+            .values()
+            .filter(|page| !page.deleted)
+            .map(|page| page.object_id)
+            .collect();
+        checked += 1;
+        live_total += rebuilt.len();
+        if bucket.object_index != rebuilt {
+            let held: Vec<u64> = bucket.object_index.difference(&rebuilt).copied().collect();
+            let missing: Vec<u64> = rebuilt.difference(&bucket.object_index).copied().collect();
+            divergent.push((*routing_bucket, held, missing));
+        }
+    }
+
+    println!(
+        "
+  buckets checked            {checked}
+  live object ids (rebuilt)  {live_total}
+  buckets where the held set differs from a rebuild  {}
+",
+        divergent.len()
+    );
+    for (bucket, held, missing) in divergent.iter().take(6) {
+        println!("    bucket {bucket}: holds-but-rebuild-drops {held:?}, rebuild-has-but-holds-not {missing:?}");
+    }
+
+    // Anti-vacuity first: a comparison over an empty shard agrees about nothing.
+    assert!(
+        checked > 0 && live_total > 0,
+        "the workload must populate buckets, or the comparison below compares nothing"
+    );
+
+    // The finding, whichever way it goes. If this holds, the per-insert rebuild is recomputing
+    // what the insert already knew and can go. If it does not, the difference names exactly what
+    // the rebuild is for -- and the tombstone ids re-attached after it are the first suspect.
+    // The held set is a strict SUPERSET of a rebuild, and the extra ids are tombstones the object
+    // manager must keep reporting until GC reclaims the slot -- `rebuild_bucket_first_index`
+    // re-attaches them deliberately after recomputing the live set. Measured: 14 of 183 buckets
+    // hold exactly one extra id each, and NOTHING is ever missing in the other direction.
+    //
+    // So the invariant is containment plus a named exception, not equality. Asserting equality
+    // would fail on correct behaviour, and asserting nothing would miss a live id going astray.
+    for (bucket_id, held_extra, missing) in &divergent {
+        assert!(
+            missing.is_empty(),
+            "bucket {bucket_id} is MISSING live object ids a rebuild would produce: {missing:?} -- \
+             a live page exists whose id the index does not hold"
+        );
+        let bucket = shard
+            .bucket_index
+            .bucket_map
+            .get(bucket_id)
+            .expect("the divergent bucket was read from this map");
+        for object_id in held_extra {
+            assert!(
+                bucket.deleted_object_index.contains(object_id),
+                "bucket {bucket_id} holds object id {object_id}, which is neither live nor a \
+                 recorded tombstone"
+            );
+        }
+    }
+}


### PR DESCRIPTION
an add rebuilt the whole index once per record it wrote

    ingest_extract_context, ~4KB bodies, in process
                     first 30    last 30   degrade   layout visits per add
      150 adds   46.3 -> 20.4ms   2.79 -> 1.13x        2404 -> 604
      300 adds   81.2 -> 29.5ms   5.53 -> 2.08x        4804 -> 1204
      600 adds  237.0 -> 69.7ms  11.79 -> 5.44x        9604 -> 2404

3.4x faster at 600 memories, four times fewer index rebuilds.

An add issues several Context* writes. No Command::Context* appears in
`command_updates_bucket_index_directly`, so each one satisfied
`!command_updates_bucket_index_directly(&command)` and fired `rebuild_bucket_first_index` -- which
walks every live page in the shard and replaces the index wholesale. Four store-walks per add,
each growing with the corpus.

The engine already names this defect in a comment: "the context path, which never updates
bucket_index directly) would then fire a full O(store) rebuild on EVERY record -> O(n^2)". It was
guarded for bulk backfill and WAL replay, through `defer_bucket_index_reconstruct()`. The live path
was not.

The same mechanism now scopes to one ingest: a guard holds the reconstruct for the span of the
call and the caller does it ONCE as the window closes. A guard rather than a set/clear pair,
because an early return that leaked the window would silently stop reconstructing for the rest of
the thread's life -- a far worse bug than the one being fixed.

WHAT THIS DOES NOT DO. It does not make an add O(1) in the corpus. One store-walk per add remains,
so per-add visits still grow (604, 1204, 2404) and degradation is halved rather than removed.
Going flat needs the context write path to maintain bucket_index the way StringSet does, which is a
larger change and belongs behind its own evidence. Deferring the reconstruct ENTIRELY measured 26.6x
and 0.97x -- flat -- but that arm never reconstructs at all and is not a correct default; it
establishes the cost, not a fix.

HOW IT WAS FOUND, because two detours were wrong. `update_bucket_layout` rebuilds a bucket's live
set per page insert and looked like the cause; fixing that site moved the counter by EXACTLY ZERO.
Narrowing the rebuild's bucket range looked like the cause; the range is only a hashing input, and
the function walks the whole shard regardless. The visit counter lives INSIDE the function, so it
reported how much work happened without saying who asked -- with ten callers that is the difference
between a fix and a guess. `#[track_caller]` with a per-site tally named the two real sites in one
run, and both turned out to be inside rebuild paths whose own doc says the scan is deliberately
kept there.

That tally is `#[cfg(test)]`: it takes a lock, and `update_bucket_layout` is on a write path.
Shipping it would trade a measured win for an unmeasured one.

Also here: a test that the maintained object_index agrees with a from-scratch rebuild. It does not,
and the way it does not is the point -- the held set is a strict SUPERSET, 14 of 183 buckets
holding exactly one extra id, and nothing ever missing in the other direction. Those are tombstones
the object manager must keep reporting until GC reclaims the slot. So the test asserts containment
plus a named exception rather than equality: equality fails on correct behaviour, and asserting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
