### PR TITLE
A posting carrying several refs had no identity, and serving dropped it

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1406,6 +1406,25 @@ fn record_ref_hash(record: &Value) -> Option<String> {
             }
         }
     }
+    // `ref_hashes` fallback, last so nothing that resolves today changes branch.
+    //
+    // The posting builder writes the singular `ref_hash` ONLY when the posting carries exactly one
+    // ref; a multi-ref posting has the array and no singular field. Without this a posting like
+    // that returns None here, and two serving sites drop the record outright rather than score it
+    // (`let Some(profile_hash) = record_ref_hash(..) else { continue; }`), with nothing logged.
+    //
+    // No caller passes more than one ref today, which is precisely why the day one does the loss
+    // would be silent.
+    if let Some(Value::Array(refs)) = record.get("ref_hashes") {
+        for value in refs {
+            if let Some(number) = value.as_u64() {
+                return Some(number.to_string());
+            }
+            if let Some(text) = value.as_str().filter(|text| !text.is_empty()) {
+                return Some(text.to_string());
+            }
+        }
+    }
     None
 }
 
@@ -7113,6 +7132,40 @@ mod tests {
             Some(7),
             "sibling bundle metadata is preserved on rewrite"
         );
+    }
+
+
+    /// A posting carrying SEVERAL refs has no singular `ref_hash` -- the builder only writes that
+    /// when there is exactly one -- so before the `ref_hashes` fallback this returned None and two
+    /// serving sites dropped the record instead of scoring it.
+    #[test]
+    fn a_multi_ref_posting_still_has_an_identity() {
+        let single = json!({
+            "record_type": "context_index",
+            "ref_hash": 4242_u64,
+            "ref_hashes": [4242_u64],
+        });
+        assert_eq!(record_ref_hash(&single).as_deref(), Some("4242"),
+                   "a single-ref posting keeps resolving through the singular field");
+
+        let multi = json!({
+            "record_type": "context_index",
+            "ref_hashes": [7001_u64, 7002_u64, 7003_u64],
+        });
+        assert_eq!(record_ref_hash(&multi).as_deref(), Some("7001"),
+                   "a multi-ref posting resolves through the array");
+
+        let identity_wins = json!({
+            "record_type": "context_entity",
+            "entity_hash": 900_u64,
+            "ref_hashes": [111_u64],
+        });
+        assert_eq!(record_ref_hash(&identity_wins).as_deref(), Some("900"),
+                   "an identity field still takes precedence over the array");
+
+        let neither = json!({"record_type": "context_index"});
+        assert_eq!(record_ref_hash(&neither), None,
+                   "a record with no identity at all is still unidentified");
     }
 
     #[test]


### PR DESCRIPTION
`record_ref_hash` cannot identify a posting that carries more than one ref.

It reads `ref_hash`, `chunk_hash`, `section_hash`, `skill_hash`, `event_id_hash`, `entity_hash` and
`summary_hash` — but never `ref_hashes`, the array the posting builder actually populates. And the
builder writes the singular field **only** when there is exactly one ref:

```python
if len(refs) == 1:
    record["ref_hash"] = refs[0]      # "Compatibility for native readers"
```

So a posting with two refs has the array and no singular field, `record_ref_hash` returns `None`,
and of its nine consumers **two serving sites drop the record outright**:

```rust
let Some(profile_hash) = record_ref_hash(record) else {
    continue;                         // native_serving.rs:618 and :683
};
```

Two more emit an empty string (`unwrap_or_default()`).

### Why it has not bitten yet, and why that is the problem

All 21 ref-passing call sites pass a single-element literal, so no multi-ref posting exists today
and this path never runs. That is exactly what makes it dangerous: `MAX_SECONDARY_INDEX_REFS_PER_POSTING`
is **512**, the compactor is built to merge refs into one posting, and the docstring describes "a
compact posting list of the hashes it names". The first caller to pass two refs starts **silently
losing records from serving**, with nothing in the logs and no length mismatch to raise an error.

### The fix

Read `ref_hashes` as a **last** resort, after every identity field. Nothing that resolves today
changes branch — a record with any identity field takes the path it always did — and a multi-ref
posting stops being anonymous.

### Tests

`a_multi_ref_posting_still_has_an_identity` covers four cases:

| case | expectation |
|---|---|
| single-ref posting (`ref_hash` + one-element array) | resolves through the singular field, unchanged |
| **multi-ref posting (array only)** | **resolves through the array** — this is the defect |
| identity field present alongside the array | the identity field still wins |
| neither present | still `None`; the fallback invents nothing |

**Mutation-tested.** Removing only the fallback block and keeping the test turns it red; restoring
it turns it green, and the file returns byte-identical. A test that passes on correct code proves
nothing until it has been shown to fail on broken code.
