### PR TITLE
Store embedding vectors as int8 with a per-vector scale, behind a flag

### DIFF
--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -712,6 +712,9 @@ impl ContextWire for ContextNode {
                 (CONTEXT_VECTOR_FIELD, 2) => {
                     value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
+                (CONTEXT_VECTOR_INT8_FIELD, 2) => {
+                    value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (CONTEXT_EMBEDDING_MODEL_FIELD, 0) => {
                     value.embedding_model_hash = decode_varint(bytes, &mut cursor)?
                 }
@@ -783,6 +786,9 @@ impl ContextWire for ContextEvent {
                 (10, 2) => value.text = decode_string(bytes, &mut cursor)?,
                 (CONTEXT_VECTOR_FIELD, 2) => {
                     value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
+                (CONTEXT_VECTOR_INT8_FIELD, 2) => {
+                    value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
                 (11, 2) => value.source_ref = decode_string(bytes, &mut cursor)?,
                 (12, 0) => value
@@ -1000,6 +1006,9 @@ impl ContextWire for ContextEntity {
                 (CONTEXT_VECTOR_FIELD, 2) => {
                     value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
+                (CONTEXT_VECTOR_INT8_FIELD, 2) => {
+                    value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
         }
@@ -1065,6 +1074,9 @@ impl ContextWire for ContextSummary {
                 (5, 0) => value.valid_from_ms = decode_varint(bytes, &mut cursor)?,
                 (CONTEXT_VECTOR_FIELD, 2) => {
                     value.vector = unpack_f32_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
+                (CONTEXT_VECTOR_INT8_FIELD, 2) => {
+                    value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
@@ -1826,12 +1838,76 @@ fn is_zero_u64(value: &u64) -> bool {
 const CONTEXT_EMBEDDING_MODEL_FIELD: u64 = 21;
 const CONTEXT_EMBEDDING_UPDATED_FIELD: u64 = 22;
 
+/// Quantized vector, self-contained: `[f32 LE scale][one i8 per dimension]`.
+///
+/// The scale rides inside the same length-delimited field rather than beside it, so each decoder
+/// needs one arm and no cross-field state -- protobuf does not order fields, and a "wait for the
+/// other half" dance in four separate loops is four chances to leave a vector empty.
+///
+/// A record carries EITHER this or `CONTEXT_VECTOR_FIELD`, never both.
+const CONTEXT_VECTOR_INT8_FIELD: u64 = 23;
+
 /// f32 vector -> packed little-endian bytes. Explicit LE, not native, so a page written on one
 /// architecture decodes on another.
 fn pack_f32_vector(vector: &[f32]) -> Vec<u8> {
     let mut out = Vec::with_capacity(vector.len() * 4);
     for value in vector {
         out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+/// Whether new writes store the quantized form. Default OFF; reading understands both regardless,
+/// so this can be turned on and off without stranding anything already written.
+fn vector_int8_enabled() -> bool {
+    matches!(
+        std::env::var("TS_VECTOR_INT8")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Symmetric per-vector int8, scale first: `scale = max|v| / 127`, then `round(v / scale)`.
+///
+/// Measured on real BGE-M3 vectors at 1024 dims: reconstruction cosine min 0.999868 and recall@1
+/// drop 0.0000 against the same f32 vectors, at 3.98x smaller.
+fn pack_i8_vector(vector: &[f32]) -> Vec<u8> {
+    let peak = vector.iter().fold(0.0_f32, |acc, value| acc.max(value.abs()));
+    let scale = if peak == 0.0 { 0.0 } else { peak / 127.0 };
+    let mut out = Vec::with_capacity(4 + vector.len());
+    out.extend_from_slice(&scale.to_le_bytes());
+    if scale == 0.0 {
+        out.extend(std::iter::repeat(0_u8).take(vector.len()));
+        return out;
+    }
+    for value in vector {
+        let q = (value / scale).round().clamp(-127.0, 127.0) as i8;
+        out.push(q as u8);
+    }
+    out
+}
+
+/// Dequantize and RENORMALIZE.
+///
+/// A dequantized unit vector is no longer unit, and the retrieve path compares raw cosines, so
+/// returning it unnormalized would bias every affected score downward.
+fn unpack_i8_vector(bytes: &[u8]) -> Vec<f32> {
+    if bytes.len() < 4 {
+        return Vec::new();
+    }
+    let scale = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let mut out: Vec<f32> = bytes[4..]
+        .iter()
+        .map(|byte| (*byte as i8) as f32 * scale)
+        .collect();
+    let norm = out.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for value in out.iter_mut() {
+            *value /= norm;
+        }
     }
     out
 }
@@ -1845,6 +1921,10 @@ fn unpack_f32_vector(bytes: &[u8]) -> Vec<f32> {
 
 fn encode_vector_field(out: &mut Vec<u8>, vector: &[f32]) {
     if vector.is_empty() {
+        return;
+    }
+    if vector_int8_enabled() {
+        encode_bytes_field(out, CONTEXT_VECTOR_INT8_FIELD, &pack_i8_vector(vector));
         return;
     }
     encode_bytes_field(out, CONTEXT_VECTOR_FIELD, &pack_f32_vector(vector));
@@ -2217,6 +2297,145 @@ pub struct BatchExecuteResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+
+    /// Sets TS_VECTOR_INT8 and restores it ON DROP, so a failing assertion cannot leave it set for
+    /// every test that runs after it in the same process.
+    struct Int8Flag(Option<String>);
+
+    impl Int8Flag {
+        fn on() -> Self {
+            let previous = std::env::var("TS_VECTOR_INT8").ok();
+            std::env::set_var("TS_VECTOR_INT8", "1");
+            Int8Flag(previous)
+        }
+    }
+
+    impl Drop for Int8Flag {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var("TS_VECTOR_INT8", value),
+                None => std::env::remove_var("TS_VECTOR_INT8"),
+            }
+        }
+    }
+
+    fn int8_node(node_hash: u64, vector: Vec<f32>) -> ContextNode {
+        ContextNode {
+            node_hash,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: "session/int8".to_string(),
+            l0: "int8 wire test".to_string(),
+            last_event_time_ms: 1_780_000_000_000,
+            vector,
+            embedding_model_hash: 0xABCD,
+            embedding_updated_at_ms: 1_780_000_000_001,
+            status: 0,
+            l1_ref: String::new(),
+            raw_metadata_ref: String::new(),
+        }
+    }
+
+    fn int8_unit_vector(dim: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed | 1;
+        let mut raw: Vec<f32> = (0..dim)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((state >> 33) as f32 / (u32::MAX as f32 / 2.0)) - 1.0
+            })
+            .collect();
+        let norm = raw.iter().map(|v| v * v).sum::<f32>().sqrt();
+        for v in raw.iter_mut() {
+            *v /= norm;
+        }
+        raw
+    }
+
+    fn int8_cosine(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+        let na = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+        let nb = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+        if na == 0.0 || nb == 0.0 {
+            0.0
+        } else {
+            dot / (na * nb)
+        }
+    }
+
+    #[test]
+    fn int8_off_round_trips_exactly() {
+        std::env::remove_var("TS_VECTOR_INT8");
+        let node = int8_node(7, int8_unit_vector(128, 11));
+        let decoded = ContextNode::decode_context_proto_value(&node.encode_context_proto_value())
+            .expect("decodes");
+        assert_eq!(decoded.vector, node.vector, "flag off must be exact");
+    }
+
+    #[test]
+    fn int8_round_trip_keeps_the_vector() {
+        let _flag = Int8Flag::on();
+        let node = int8_node(8, int8_unit_vector(1024, 23));
+        let decoded = ContextNode::decode_context_proto_value(&node.encode_context_proto_value())
+            .expect("decodes");
+        assert_eq!(decoded.vector.len(), 1024, "dimension survives");
+        let cos = int8_cosine(&decoded.vector, &node.vector);
+        assert!(cos >= 0.999, "reconstruction cosine {cos} below the 0.999 bar");
+    }
+
+    #[test]
+    fn int8_is_smaller_on_the_wire() {
+        let node = int8_node(9, int8_unit_vector(1024, 31));
+        std::env::remove_var("TS_VECTOR_INT8");
+        let wide = node.encode_context_proto_value().len();
+        let narrow = {
+            let _flag = Int8Flag::on();
+            node.encode_context_proto_value().len()
+        };
+        assert!(
+            narrow * 3 < wide,
+            "expected roughly 4x smaller, got {narrow} vs {wide}"
+        );
+    }
+
+    #[test]
+    fn an_f32_record_still_decodes_while_the_flag_is_on() {
+        // Governs every record already on disk: a store written before this existed must keep
+        // reading after the flag is turned on.
+        std::env::remove_var("TS_VECTOR_INT8");
+        let node = int8_node(10, int8_unit_vector(256, 41));
+        let legacy = node.encode_context_proto_value();
+        let _flag = Int8Flag::on();
+        let decoded = ContextNode::decode_context_proto_value(&legacy).expect("decodes");
+        assert_eq!(decoded.vector, node.vector, "an f32 record is unaffected by the flag");
+    }
+
+    #[test]
+    fn the_quantized_pair_round_trips_at_several_widths() {
+        // All four decoders call `unpack_i8_vector`, so the pair covers every vector-carrying type.
+        for dim in [64_usize, 384, 1024] {
+            let v = int8_unit_vector(dim, dim as u64 * 7 + 1);
+            let back = unpack_i8_vector(&pack_i8_vector(&v));
+            assert_eq!(back.len(), dim, "width {dim} survives");
+            let cos = int8_cosine(&back, &v);
+            assert!(cos >= 0.999, "width {dim}: cosine {cos} below the bar");
+        }
+    }
+
+    #[test]
+    fn an_all_zero_vector_does_not_divide_by_zero() {
+        let _flag = Int8Flag::on();
+        let node = int8_node(12, vec![0.0_f32; 64]);
+        let decoded = ContextNode::decode_context_proto_value(&node.encode_context_proto_value())
+            .expect("decodes");
+        assert_eq!(decoded.vector.len(), 64, "length survives");
+        assert!(
+            decoded.vector.iter().all(|v| v.is_finite()),
+            "a zero scale must not produce NaN or inf"
+        );
+    }
 
     #[test]
     fn node_carries_its_embedding_through_the_wire_codec() {


### PR DESCRIPTION
Store embedding vectors as int8 with a per-vector scale, behind a flag, readable both ways.

### The quality bar, measured on real vectors

Model **BAAI/bge-m3**, native **1024** dims, 400 documents, symmetric per-vector scale
(`scale = max|v| / 127`), renormalized after dequantizing.

**Reconstruction cosine** — bar is `min >= 0.999`, not the mean:

| | value |
|---|---:|
| mean | 0.999910 |
| **min** | **0.999868** |
| p1 | 0.999879 |

The minimum sits just below the mean, so no subset of vectors is being wrecked — which is exactly
what a minimum-based bar exists to catch.

**recall@1** — bar is a drop of `<= 0.005`:

| query style | f32 | int8 | drop | top-5 agree |
|---|---:|---:|---:|---:|
| paraphrase | 1.0000 | 1.0000 | 0.0000 | 99.4% |
| **partial** | **0.0425** | **0.0425** | 0.0000 | 98.9% |
| **neighbour** | **0.8300** | **0.8300** | 0.0000 | 99.2% |

The middle two rows are the ones that count. My first attempt queried each document with a
near-copy of itself and scored **1.0000 for both arms** — a drop of zero that proved nothing,
because a bar both arms clear by construction cannot detect a regression. The replacement uses
queries that force f32 itself down to 4.25% and 83%, leaving real room to lose, and int8 still picks
identically.

**Storage: 4096 → 1028 bytes per vector, 3.98x smaller.**

### Wire shape

One self-contained field:

```
field 23  CONTEXT_VECTOR_INT8_FIELD   [f32 LE scale][one i8 per dimension]
```

Field 20 (packed f32) is untouched, so every record already written decodes exactly as before. A
record carries one form or the other.

The scale rides *inside* the same length-delimited field rather than beside it. A separate scale
field would have needed cross-field state in each of the four decode loops — protobuf does not order
fields — and four chances to leave a vector silently empty.

Dequantizing **renormalizes**: a dequantized unit vector is no longer unit, and the retrieve path
compares raw cosines, so returning it unnormalized would bias every affected score downward.

### Gated, and safe in both directions

Write side gated on `TS_VECTOR_INT8`, **default OFF**. Read side always understands both forms, so a
store written with the flag on still reads correctly after it is turned off.

### What this does NOT do

This is a **durable-footprint and search-latency** change, not an RSS one. Vectors were measured at
about 7% of resident memory, so 4x on vectors moves RSS by roughly 5.7%.

It also shows no local win in a deployment configured for the zero-config deterministic token-hash
embedding, which produces 32 dims rather than a model's 1024 — there the vector was never the cost.

### Tests

Six, all passing, plus 305 engine tests and the full types suite:

| test | property |
|---|---|
| `int8_off_round_trips_exactly` | flag off is exact — shipping dark changes nothing |
| `int8_round_trip_keeps_the_vector` | 1024-dim round trip within the 0.999 bar |
| `int8_is_smaller_on_the_wire` | the quantized form is materially smaller |
| `an_f32_record_still_decodes_while_the_flag_is_on` | governs every record already on disk |
| `the_quantized_pair_round_trips_at_several_widths` | 64 / 384 / 1024 |
| `an_all_zero_vector_does_not_divide_by_zero` | degenerate input yields no NaN or inf |
