### PR TITLE
An encoder swap at the same width was undetectable

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1116,6 +1116,11 @@ pub struct ContextFanoutPlanReport {
     // across embedding spaces raises no error on its own.
     #[serde(default)]
     pub embedding_width_conflict_nodes: usize,
+    /// Nodes declined because their vector was written by a DIFFERENT ENCODER at the same
+    /// width. Separate from the width count on purpose: two widths means a provider outage
+    /// seeded fallback vectors, while two encoders at one width means a model swap. Same
+    /// symptom, different cause, different fix.
+    pub embedding_model_conflict_nodes: usize,
     #[serde(default)]
     pub event_query_budget: usize,
     #[serde(default)]
@@ -1713,7 +1718,7 @@ pub(crate) fn extract_context_gated(
             // fresh ingest -- only the drainer's deferred path would ever fill it, so the
             // fallback to the separate record could never be retired.
             node.vector = vector.clone();
-            node.embedding_model_hash = context_embedding_model_hash(&provider.model);
+            node.embedding_model_hash = context_embedding_model_hash(&provider.embedding_model);
             node.embedding_updated_at_ms = timestamp_ms;
         }
         if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.get(1)) {
@@ -1910,6 +1915,13 @@ pub fn retrieve_context(
         }
     };
     trace_stage("query_embedding");
+    // The encoder that produced the query vector, read from the RAW request rather than the
+    // normalized provider: normalisation substitutes a mock sentinel for an absent
+    // embedding_model, and hashing that would conflict with everything a real ingest wrote,
+    // skipping every stored vector for any caller that carries no provider config. An unnamed
+    // encoder is unknown, and unknown never conflicts.
+    let active_embedding_model_hash =
+        context_embedding_model_hash(request.provider.embedding_model.trim());
     let mut summary_scores_by_node = BTreeMap::<u64, (i64, usize)>::new();
     // node_l0 comes from the node records themselves: the vector lives on the node, which is
     // addressable by the hash already in hand -- no one-way ref hash to reconstruct, and no
@@ -1919,6 +1931,7 @@ pub fn retrieve_context(
     // node silently collapses to the lexical/recency fallback.
     let mut l0_row_fallback: Vec<u64> = Vec::new();
     let mut width_conflict_nodes = 0usize;
+    let mut model_conflict_nodes = 0usize;
     for chunk in node_hashes.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
         if chunk.is_empty() {
             continue;
@@ -1937,12 +1950,21 @@ pub fn retrieve_context(
                 if node.vector.is_empty() {
                     l0_row_fallback.push(node.node_hash);
                 } else if context_embedding_width_conflicts(&query_embedding, &node.vector) {
-                    // Written in a different embedding space. Hand it to the hybrid lexical pass
-                    // exactly as an un-embedded node is handed over -- which means NOT recording
-                    // a score here, because that pass selects on the score COUNT being zero, not
-                    // on the score value. Recording a zero would mark the node as scored and
-                    // strand it at the bottom of the ranking with no second chance.
                     width_conflict_nodes = width_conflict_nodes.saturating_add(1);
+                    l0_row_fallback.push(node.node_hash);
+                } else if context_embedding_model_conflicts(
+                    node.embedding_model_hash,
+                    active_embedding_model_hash,
+                ) {
+                    // Same width, different encoder: no length mismatch and no error, so this
+                    // branch is the only thing standing between a model swap and a plausible
+                    // cosine computed across two vector spaces. Hand it to the lexical pass.
+                    //
+                    // Handed over exactly as an un-embedded node is, which means NOT recording a
+                    // score: the lexical pass selects on the score COUNT being zero, not on the
+                    // score value, so a zero would mark the node scored and strand it at the
+                    // bottom of the ranking with no second chance.
+                    model_conflict_nodes = model_conflict_nodes.saturating_add(1);
                     l0_row_fallback.push(node.node_hash);
                 } else {
                     let score =
@@ -1997,6 +2019,7 @@ pub fn retrieve_context(
     // Set after BOTH vector passes -- the node pass and the summary pass each contribute, and the
     // node pass alone would under-report.
     fanout_plan.embedding_width_conflict_nodes = width_conflict_nodes;
+    fanout_plan.embedding_model_conflict_nodes = model_conflict_nodes;
     trace_stage("summary_embedding_lookup");
     // Hybrid lexical fallback: nodes with NO stored summary embedding used to score
     // a flat 0 here (missing-embedding -> unwrap_or_default), so a freshly

--- a/crates/temporalstore-rust/src/context_workflow/query.rs
+++ b/crates/temporalstore-rust/src/context_workflow/query.rs
@@ -1221,6 +1221,19 @@ pub(super) fn context_embedding_width_conflicts(left: &[f32], right: &[f32]) -> 
     !left.is_empty() && !right.is_empty() && left.len() != right.len()
 }
 
+/// Whether a stored vector was written by a different encoder than the one asking.
+///
+/// Width conflicts are already refused, but two encoders of the SAME width -- and candidates
+/// routinely are, since any model truncated to 512 looks alike -- produce no width signal and no
+/// error. The recorded hash is the only thing separating them.
+///
+/// Zero on either side means "unknown" and never conflicts: a stored zero predates the hash being
+/// recorded, and an active zero means the caller named no encoder. Treating either as a conflict
+/// would blank retrieval for every existing store and every providerless request.
+pub(super) fn context_embedding_model_conflicts(stored_hash: u64, active_hash: u64) -> bool {
+    stored_hash != 0 && active_hash != 0 && stored_hash != active_hash
+}
+
 pub(super) fn context_embedding_similarity_micros(left: &[f32], right: &[f32]) -> i64 {
     if left.is_empty() || right.is_empty() {
         return 0;

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2902,7 +2902,10 @@ fn a_vector_from_another_embedding_space_cannot_win_a_summary_slot() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                model_hash: 1,
+                // What a real writer stamps: the drainer derives it from the same provider
+                // field the retrieve path compares against. A placeholder reads as a foreign
+                // encoder and the vector is declined before width is ever considered.
+                model_hash: context_embedding_model_hash(&provider.embedding_model),
                 vector,
                 updated_at_ms: at,
             },
@@ -3018,7 +3021,10 @@ fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                model_hash: 1,
+                // What a real writer stamps: the drainer derives it from the same provider
+                // field the retrieve path compares against. A placeholder reads as a foreign
+                // encoder and the vector is declined before width is ever considered.
+                model_hash: context_embedding_model_hash(&provider.embedding_model),
                 vector,
                 updated_at_ms: at,
             },
@@ -3197,4 +3203,184 @@ fn what_one_add_costs_end_to_end() {
             (layout + clear_dirty + refresh) as f64 / adds as f64,
         );
     }
+}
+
+// --- an encoder swap at the SAME width ------------------------------------------------------
+//
+// Width conflicts are covered above. These cover the case width cannot see: two encoders that
+// produce vectors of identical length, which is routine once any model is truncated to a common
+// width. Nothing but the recorded hash separates them, and no error is raised either way.
+
+#[test]
+fn a_different_encoder_at_the_same_width_conflicts() {
+    let e5 = context_embedding_model_hash("intfloat/multilingual-e5-large");
+    let bge = context_embedding_model_hash("BAAI/bge-m3");
+    assert_ne!(e5, bge, "distinct encoders must hash differently");
+    assert!(context_embedding_model_conflicts(bge, e5));
+    assert!(!context_embedding_model_conflicts(e5, e5));
+}
+
+#[test]
+fn an_unknown_hash_never_conflicts_on_either_side() {
+    let e5 = context_embedding_model_hash("intfloat/multilingual-e5-large");
+    // A stored zero predates the hash being recorded. Refusing those would take every existing
+    // store dark on the first deploy of this guard.
+    assert!(!context_embedding_model_conflicts(0, e5));
+    // An active zero means the caller named no encoder. normalize_provider would have substituted
+    // a mock sentinel, whose hash conflicts with everything a real ingest wrote -- which is why
+    // the active hash is read from the raw request.
+    assert!(!context_embedding_model_conflicts(e5, 0));
+    assert!(!context_embedding_model_conflicts(0, 0));
+}
+
+#[test]
+fn the_mock_sentinel_would_have_conflicted_with_everything() {
+    // The bug this arrangement avoids: hashing the normalized provider.
+    let sentinel = context_embedding_model_hash("mock-context-embedding");
+    let real = context_embedding_model_hash("intfloat/multilingual-e5-large");
+    assert_ne!(0, sentinel, "the sentinel is a real name and hashes to a real value");
+    assert!(
+        context_embedding_model_conflicts(real, sentinel),
+        "hashing the normalized provider would skip every genuinely embedded vector"
+    );
+}
+
+#[test]
+fn ingest_and_the_drainer_identify_the_same_model() {
+    // Ingest used to hash provider.model -- the CHAT model -- while the drainer hashed
+    // provider.embedding_model, so the value stamped on a node did not identify its encoder.
+    let config = ContextModelProviderConfig {
+        model: "deepseek-chat".to_string(),
+        embedding_model: "intfloat/multilingual-e5-large".to_string(),
+        ..ContextModelProviderConfig::default()
+    };
+    assert_ne!(
+        context_embedding_model_hash(&config.model),
+        context_embedding_model_hash(&config.embedding_model),
+        "chat and embedding models must not hash alike, or this proves nothing"
+    );
+    assert_eq!(
+        context_embedding_model_hash(&config.embedding_model),
+        context_embedding_model_hash("intfloat/multilingual-e5-large")
+    );
+}
+
+#[test]
+fn a_vector_from_another_encoder_at_the_same_width_is_declined_and_counted() {
+    // The case width cannot see. Both vectors here are the SAME length as the query, so the
+    // width check passes them both; only the recorded model hash separates them. The impostor
+    // carries the query's own vector verbatim -- a perfect cosine -- and its text is chosen so it
+    // cannot win the lexical pass. If it takes the slot, it was scored across two vector spaces.
+    let engine = test_engine();
+    const TENANT: u64 = 6021;
+    const EVENT_TIME: u64 = 1_781_700_000_000;
+    let provider = ContextModelProviderConfig::default();
+    let query = "how do we deploy the ingest service";
+    let query_vector = query::context_query_embedding(&provider, query).unwrap();
+    let ours = context_embedding_model_hash(&provider.embedding_model);
+    let theirs = context_embedding_model_hash("some-other-encoder");
+    assert_ne!(ours, theirs);
+
+    let mut near = query_vector.clone();
+    near[0] += 0.35;
+    near[1] -= 0.15;
+
+    for (node_hash, name, summary, at, vector, model_hash) in [
+        (31u64, "matching", "release runbook notes".to_string(),
+         EVENT_TIME, near.clone(), ours),
+        (32u64, "impostor", "totally unrelated wording".to_string(),
+         EVENT_TIME + 500, query_vector.clone(), theirs),
+    ] {
+        assert_eq!(
+            query_vector.len(), vector.len(),
+            "both vectors must be the same width, or this tests the width check instead"
+        );
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: name.to_string(),
+                    l0: summary.clone(),
+                    status: 0,
+                    last_event_time_ms: at,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+        assert!(response.status.ok);
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: ContextSummary {
+                    node_hash,
+                    level: 1,
+                    text: summary.clone(),
+                    valid_from_ms: at,
+                    vector: Vec::new(),
+                },
+            },
+        });
+        assert!(response.status.ok);
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: TENANT,
+                node_hash,
+                model_hash,
+                vector,
+                updated_at_ms: at,
+            },
+        });
+        assert!(response.status.ok);
+    }
+
+    let retrieve = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: TENANT,
+            node_hashes: vec![31, 32],
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: EVENT_TIME + 1_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider,
+        },
+    );
+    assert!(retrieve.status.ok, "{:?}", retrieve.status);
+    let summary_nodes: Vec<u64> = retrieve
+        .blocks
+        .iter()
+        .filter(|block| block.tier == ContextTier::L0)
+        .map(|block| block.node_hash)
+        .collect();
+    assert_eq!(
+        vec![31u64],
+        summary_nodes,
+        "a vector from another encoder must not take the slot on a perfect but meaningless cosine"
+    );
+    assert_eq!(
+        1, retrieve.fanout_plan.embedding_model_conflict_nodes,
+        "the declined vector has to be COUNTED, and counted as a MODEL conflict"
+    );
+    assert_eq!(
+        0, retrieve.fanout_plan.embedding_width_conflict_nodes,
+        "these vectors are the same width -- charging this to the width counter would tell an          operator to look for a provider outage that did not happen"
+    );
 }

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -3150,6 +3150,28 @@ def _env_int(name: str, default: int) -> int:
 
 EMBEDDING_VECTOR_DECIMALS = _env_int("MATRIXARK_EMBEDDING_VECTOR_DECIMALS", 6)
 EMBEDDING_VECTOR_SCALE = _env_int("MATRIXARK_EMBEDDING_VECTOR_SCALE", 0)
+# Default OFF, and two independent reasons keep it there.
+#
+# The ranking reason is the decisive one and predates this note: measured over 500 candidate
+# chunks with six CN/EN queries against the float ranking, int8 got top-1 right 1/6, exact
+# top-10 order 0/6, mean overlap 4.8/10. A reconstruction cosine of 0.9999 is NOT evidence of
+# safety here -- the margins between competing near-neighbours in a real corpus are smaller
+# than that error, so a near-perfect cosine coexists with a reordered top-10.
+#
+# A 2026-08-31 re-measurement with multilingual-e5-large @512 over 2,753 chunks / 298 queries
+# put reconstruction cosine at min 0.999816 and recall@1 at 0.7617 -> 0.7584. That does NOT
+# overturn the above: needle-match recall tolerates reordering among similarly relevant chunks,
+# whereas agreement with the float ranking does not. Two metrics, two questions.
+#
+# The second reason is the consumer. matrixark_mcp_scoring.cosine is a bare dot product over
+# assumed-unit inputs, and normalized_dense_score clamps (v + 1) / 2 into [0, 1]; at int8
+# magnitudes every positive match saturates to 1.0 and every negative to 0.0, so the dense term
+# degenerates to a binary signal and 0.72 * dense + 0.28 * sparse is decided by the lexical term
+# alone. This also means EMBEDDING_VECTOR_SCALE cannot simply be turned on either: a uniform
+# rescale preserves dot ORDER but still saturates that clamp, which is why it is 0.
+#
+# int8 remains legitimate where ranking does not matter -- bulk archival, or a coarse prefilter
+# re-scored at full precision. It must not be the retrieval path.
 EMBEDDING_VECTOR_INT8 = os.environ.get("MATRIXARK_EMBEDDING_VECTOR_INT8", "0") not in {"0", "false", "False", ""}
 
 

--- a/tools/test_matrixark_embedding_int8_default.py
+++ b/tools/test_matrixark_embedding_int8_default.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""int8 stays off on this path, for a ranking reason and a scorer reason.
+
+The ranking reason is decisive and already established: over 500 candidate chunks with six CN/EN
+queries, scored against the float ranking, int8 got top-1 right 1/6 and exact top-10 order 0/6,
+mean overlap 4.8/10. A reconstruction cosine near 0.9999 is not evidence of safety -- the margins
+between competing near-neighbours are smaller than that error.
+
+A 2026-08-31 re-measurement (multilingual-e5-large @512, 2,753 chunks, 298 queries) found
+reconstruction cosine min 0.999816 and recall@1 0.7617 -> 0.7584. That does not overturn it:
+needle-match recall tolerates reordering among similarly relevant chunks; rank agreement does not.
+
+The second reason is downstream. matrixark_mcp_scoring.cosine is a bare dot product over assumed-unit
+inputs, and normalized_dense_score clamps (v + 1) / 2 into [0, 1]. At int8 magnitudes every
+positive match saturates to 1.0 and every negative to 0.0, collapsing the dense term to a binary
+signal so that 0.72 * dense + 0.28 * sparse is decided by the lexical term alone.
+
+These tests exist so the default cannot be flipped on again without the scorer being fixed first:
+the saturation test fails the moment someone enables int8 while cosine() still skips the norms.
+"""
+import importlib
+import math
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from matrixark_mcp_scoring import cosine, normalized_dense_score
+
+
+def _core(**env):
+    """Re-import under a given environment: the flag is read at import time."""
+    saved = {k: os.environ.get(k) for k in env}
+    for k, v in env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    for name in [m for m in list(sys.modules) if m.startswith("matrixark_mcp_core")]:
+        del sys.modules[name]
+    module = importlib.import_module("matrixark_mcp_core")
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    return module
+
+
+def _unit(seed, dims=512):
+    values = [math.sin(seed * 0.7 + i * 0.013) for i in range(dims)]
+    norm = math.sqrt(sum(v * v for v in values))
+    return [v / norm for v in values]
+
+
+class Int8StaysOffOnThisPath(unittest.TestCase):
+    def test_int8_is_off_by_default_here(self):
+        core = _core(MATRIXARK_EMBEDDING_VECTOR_INT8=None)
+        self.assertFalse(
+            core.EMBEDDING_VECTOR_INT8,
+            "int8 saturates this path's dense score; it belongs on the Rust cosine path",
+        )
+
+    def test_the_scorer_skips_the_norms_which_is_why(self):
+        # If this ever starts normalising, int8 becomes safe here and the default can move.
+        big = [2.0, 0.0, 0.0]
+        unit_vector = [1.0, 0.0, 0.0]
+        self.assertEqual(
+            2.0, cosine(unit_vector, big),
+            "cosine() is a bare dot product; a true cosine would return 1.0 for these",
+        )
+
+    def test_quantised_vectors_saturate_the_dense_score(self):
+        core = _core(MATRIXARK_EMBEDDING_VECTOR_INT8="1")
+        query = _unit(11)
+        dense = []
+        for seed in range(1, 9):
+            stored = core.compact_embedding_vector(_unit(seed))
+            dense.append(normalized_dense_score(cosine(query, stored)))
+        # Every value pinned to an endpoint: the dense term carries no gradation left to rank by.
+        self.assertTrue(
+            all(value in (0.0, 1.0) for value in dense),
+            "expected saturation at the clamp endpoints, got %r" % dense,
+        )
+        self.assertIn(1.0, dense)
+        self.assertIn(0.0, dense)
+
+    def test_float_vectors_keep_their_gradation(self):
+        # The contrast that makes the previous test meaningful rather than vacuous.
+        query = _unit(11)
+        dense = [normalized_dense_score(cosine(query, _unit(seed))) for seed in range(1, 9)]
+        interior = [value for value in dense if 0.0 < value < 1.0]
+        self.assertEqual(
+            len(dense), len(interior),
+            "unit vectors must land strictly inside the clamp, got %r" % dense,
+        )
+
+    def test_high_reconstruction_fidelity_is_not_evidence_of_safe_ranking(self):
+        # The trap this pins: reconstruction cosine clears 0.999 comfortably while the measured
+        # top-10 overlap against float ranking is 4.8/10. A passing fidelity number must never be
+        # read as permission to enable int8 for retrieval.
+        core = _core(MATRIXARK_EMBEDDING_VECTOR_INT8="1")
+        for seed in range(1, 12):
+            original = _unit(seed)
+            quantised = core.compact_embedding_vector(original)
+            dot = sum(a * b for a, b in zip(original, quantised))
+            na = math.sqrt(sum(a * a for a in original))
+            nb = math.sqrt(sum(b * b for b in quantised))
+            self.assertGreaterEqual(
+                dot / (na * nb), 0.999,
+                "reconstruction cosine fell below the 0.999 floor at seed %d" % seed,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rebased onto #519, which landed the width refusal. This is what remains: width is not the signal that separates two encoders.

Any model truncated to a common width looks identical to any other, so a model swap produces **no length mismatch and no error**. The recorded model hash is the only thing that can tell them apart — and nothing consulted it.

### What was still wrong on main after #519

| | intended | actual |
|---|---|---|
| ingest and the drainer hash the same field | both `embedding_model` | ingest hashed `provider.model`, the **chat** model |
| retrieve consults the recorded hash | decline on mismatch | never read it — 3 write sites, 0 reads |
| a decline is observable | counted | no counter |

The only apparent read was `types.rs` `if self.embedding_model_hash != 0`, a serializer skip rather than a guard.

### The fix

Ingest stamps the embedding model. Retrieve declines a vector whose recorded encoder differs from the active one and hands it to the hybrid lexical pass — **not** a zero score, which would mark the node scored and strand it at the bottom, since that pass selects on the score *count* being zero.

**Zero on either side means unknown and never conflicts.**

- A **stored** zero predates the hash being recorded. Refusing those would take every existing store dark on first deploy.
- An **active** zero means the caller named no encoder. The active hash is read from the **raw** request, because `normalize_provider` substitutes a `mock-context-embedding` sentinel for an absent `embedding_model` — and hashing that sentinel conflicts with everything a real ingest ever wrote, skipping every stored vector for any caller without a provider config. A test pins that the sentinel *would* have conflicted, so the reasoning can't be quietly undone.

### A separate counter, deliberately

Model conflicts do **not** share `embedding_width_conflict_nodes`. Two widths means a provider outage seeded 32-dim fallback vectors; two encoders at one width means a model swap. Same symptom, different cause, different fix. A test asserts the width counter stays at **0** when only the encoder differs — that assertion caught this branch bumping both counters.

### Known limit

`ContextSummaryVector` carries no model hash, so L1 keeps the width check alone. A same-width swap is not catchable there without a schema change.

### Why int8 stays off for retrieval on the Python path

The docstring previously left this open. The decisive evidence is the existing ranking measurement from #419 — over 500 candidate chunks, six CN/EN queries, scored against the float ranking:

| encoding | top-1 correct | exact top-10 order | mean overlap |
|---|---:|---:|---:|
| scale=100000 | 6/6 | 6/6 | 10.0/10 |
| int8 | 1/6 | 0/6 | 4.8/10 |

**A reconstruction cosine near 0.9999 is not evidence of safety** — the margins between competing near-neighbours are smaller than that error.

A fresh run (multilingual-e5-large @512, 2,753 chunks, 298 queries) gave reconstruction cosine min 0.999816 and recall@1 0.7617 → 0.7584. That does *not* overturn the above: needle-match recall tolerates reordering among similarly relevant chunks; rank agreement does not. Two metrics, two questions.

Separately, that path's scorer could not take a rescale anyway: `cosine()` is a bare dot product over assumed-unit inputs and `normalized_dense_score` clamps into `[0, 1]`, so int8 magnitudes saturate every positive to 1.0 and every negative to 0.0 — the dense term goes binary and `0.72*dense + 0.28*sparse` is decided by the lexical term. This is also why `EMBEDDING_VECTOR_SCALE` cannot simply be enabled.

### Testing

- 38 passed / 0 failed in `context_workflow::tests`, including #519's tests and both repaired fixtures.
- New: same-width encoder conflict declined **and** counted; unknown hash never conflicts on either side; the mock sentinel would have conflicted; ingest/drainer agreement.
- 5 Python tests pinning the saturation, paired with a float control so they cannot pass vacuously.
- The ratchet's `test_tenant_policy` failure is **pre-existing**: it fails identically on a clean checkout of main (10 tests, 1 failure, same assertion, both ways).
