### PR TITLE
Vectors of different widths were compared on their shared prefix

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1108,6 +1108,14 @@ pub struct ContextFanoutPlanReport {
     // counted; the rows are gone, so any nonzero here means the backfill has work to do.)
     #[serde(default)]
     pub l0_row_fallback_nodes: usize,
+    // Candidate vectors declined because their width did not match the query's, i.e. they were
+    // written in a different embedding space. Counted separately from the un-embedded ones above
+    // because the two ask for different repairs: an un-embedded node needs the backfill to run,
+    // whereas a width conflict means the store holds vectors from two encoders and re-embedding
+    // is the only fix. Nonzero here is the signal that would otherwise not exist -- comparing
+    // across embedding spaces raises no error on its own.
+    #[serde(default)]
+    pub embedding_width_conflict_nodes: usize,
     #[serde(default)]
     pub event_query_budget: usize,
     #[serde(default)]
@@ -1910,6 +1918,7 @@ pub fn retrieve_context(
     // because a single oversized command is rejected outright, not truncated, and an unscored
     // node silently collapses to the lexical/recency fallback.
     let mut l0_row_fallback: Vec<u64> = Vec::new();
+    let mut width_conflict_nodes = 0usize;
     for chunk in node_hashes.chunks(CONTEXT_EMBEDDING_QUERY_CHUNK) {
         if chunk.is_empty() {
             continue;
@@ -1926,6 +1935,14 @@ pub fn retrieve_context(
             for node in nodes {
                 returned.insert(node.node_hash);
                 if node.vector.is_empty() {
+                    l0_row_fallback.push(node.node_hash);
+                } else if context_embedding_width_conflicts(&query_embedding, &node.vector) {
+                    // Written in a different embedding space. Hand it to the hybrid lexical pass
+                    // exactly as an un-embedded node is handed over -- which means NOT recording
+                    // a score here, because that pass selects on the score COUNT being zero, not
+                    // on the score value. Recording a zero would mark the node as scored and
+                    // strand it at the bottom of the ranking with no second chance.
+                    width_conflict_nodes = width_conflict_nodes.saturating_add(1);
                     l0_row_fallback.push(node.node_hash);
                 } else {
                     let score =
@@ -1963,6 +1980,12 @@ pub fn retrieve_context(
         });
         if let CommandResponse::ContextSummaryVectors { vectors } = response.response {
             for entry in vectors {
+                if context_embedding_width_conflicts(&query_embedding, &entry.vector) {
+                    // Same reasoning as the node pass: skip entirely rather than record a zero,
+                    // so the count stays at zero and the lexical pass still owns this node.
+                    width_conflict_nodes = width_conflict_nodes.saturating_add(1);
+                    continue;
+                }
                 let score =
                     context_embedding_similarity_micros(&query_embedding, &entry.vector);
                 let scores = summary_scores_by_node.entry(entry.node_hash).or_default();
@@ -1971,6 +1994,9 @@ pub fn retrieve_context(
             }
         }
     }
+    // Set after BOTH vector passes -- the node pass and the summary pass each contribute, and the
+    // node pass alone would under-report.
+    fanout_plan.embedding_width_conflict_nodes = width_conflict_nodes;
     trace_stage("summary_embedding_lookup");
     // Hybrid lexical fallback: nodes with NO stored summary embedding used to score
     // a flat 0 here (missing-embedding -> unwrap_or_default), so a freshly

--- a/crates/temporalstore-rust/src/context_workflow/query.rs
+++ b/crates/temporalstore-rust/src/context_workflow/query.rs
@@ -1206,11 +1206,32 @@ pub(super) fn context_query_embedding(
     }
 }
 
+/// Two vectors are comparable only when they are the same width.
+///
+/// A different width means a different embedding space. This system can hold both at once: the
+/// embedding path falls back to a 32-dimension deterministic token-hash vector whenever the
+/// configured provider raises, so one store can carry 32-dimension and 384-dimension vectors with
+/// nothing marking them apart. Scoring the shared prefix of two such vectors returns a perfectly
+/// plausible cosine computed across two unrelated spaces -- there is no length error to raise and
+/// nothing appears in the logs, so the only symptom is ranking that has quietly become noise.
+///
+/// An empty vector on either side is a different condition (un-embedded, not mis-embedded) and is
+/// deliberately not folded in here, so that case keeps behaving exactly as it did.
+pub(super) fn context_embedding_width_conflicts(left: &[f32], right: &[f32]) -> bool {
+    !left.is_empty() && !right.is_empty() && left.len() != right.len()
+}
+
 pub(super) fn context_embedding_similarity_micros(left: &[f32], right: &[f32]) -> i64 {
     if left.is_empty() || right.is_empty() {
         return 0;
     }
-    let len = left.len().min(right.len());
+    // Refuse, rather than score the shared prefix. The callers route a conflict to the lexical
+    // pass before reaching here; this is the backstop that stops any future caller from comparing
+    // across two embedding spaces just by passing two vectors in.
+    if context_embedding_width_conflicts(left, right) {
+        return 0;
+    }
+    let len = left.len();
     let mut dot = 0.0_f32;
     let mut left_norm = 0.0_f32;
     let mut right_norm = 0.0_f32;

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2785,6 +2785,172 @@ fn resource_ingest_uses_live_embeddings_and_summary_retrieval() {
 }
 
 #[test]
+fn vectors_of_different_widths_are_never_comparable() {
+    let short = vec![1.0_f32, 0.0, 0.0];
+    let long = vec![1.0_f32, 0.0, 0.0, 0.0];
+    assert!(context_embedding_width_conflicts(&short, &long));
+    assert!(context_embedding_width_conflicts(&long, &short));
+    assert!(!context_embedding_width_conflicts(&short, &short));
+    // An empty side is un-embedded, not mis-embedded, and stays the caller's business.
+    assert!(!context_embedding_width_conflicts(&short, &[]));
+    assert!(!context_embedding_width_conflicts(&[], &long));
+}
+
+#[test]
+fn a_perfect_prefix_match_across_two_widths_scores_nothing() {
+    // The exact shape that makes this failure silent: `long` begins with `short`, so scoring the
+    // shared prefix returns 1.0 -- the strongest score the system can produce -- for two vectors
+    // that came out of different encoders and mean nothing to each other. There is no length
+    // error to raise, so a prefix-scoring implementation reports maximum confidence and nothing
+    // anywhere says otherwise.
+    let short = vec![0.6_f32, 0.8, 0.0];
+    let mut long = short.clone();
+    long.extend_from_slice(&[5.0, -3.0, 2.5]);
+    assert_eq!(
+        0,
+        context_embedding_similarity_micros(&short, &long),
+        "a cross-width comparison must score nothing, not the cosine of the shared prefix"
+    );
+    // The same vector against itself still scores, so the guard has not disabled scoring.
+    assert!(context_embedding_similarity_micros(&short, &short) > 900_000);
+}
+
+#[test]
+fn a_vector_from_another_embedding_space_cannot_win_a_summary_slot() {
+    // A store can hold two embedding widths at once: the embedding path falls back to a
+    // 32-dimension deterministic token-hash vector whenever the configured provider raises, so a
+    // single provider outage seeds records that no later read can tell apart.
+    //
+    // The impostor below carries the query's own vector as its PREFIX plus extra dimensions. Under
+    // prefix scoring it earns a perfect cosine -- beating the genuinely matching node, which is
+    // deliberately a little off-query -- and takes the single summary slot. Its text is chosen so
+    // it cannot win the lexical pass either, so if it appears in the result at all, it got there
+    // by being scored across two embedding spaces.
+    let engine = test_engine();
+    const TENANT: u64 = 6011;
+    const EVENT_TIME: u64 = 1_781_700_000_000;
+    let provider = ContextModelProviderConfig::default();
+    let query = "how do we deploy the ingest service";
+    let query_vector = query::context_query_embedding(&provider, query).unwrap();
+    assert!(
+        query_vector.len() >= 2,
+        "the impostor construction below needs at least two dimensions to perturb"
+    );
+
+    // Close to the query but not identical, so a perfect prefix score would outrank it.
+    let mut near = query_vector.clone();
+    near[0] += 0.35;
+    near[1] -= 0.15;
+
+    // Same opening dimensions as the query, then more of them: a different space entirely.
+    let mut wider = query_vector.clone();
+    wider.extend_from_slice(&[0.9, -0.4, 0.7, 0.2]);
+
+    for (node_hash, name, summary, at, vector) in [
+        (
+            21u64,
+            "matching",
+            "release runbook notes".to_string(),
+            EVENT_TIME,
+            near.clone(),
+        ),
+        (
+            22u64,
+            "impostor",
+            "totally unrelated wording".to_string(),
+            EVENT_TIME + 500,
+            wider.clone(),
+        ),
+    ] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: name.to_string(),
+                    l0: summary.clone(),
+                    status: 0,
+                    last_event_time_ms: at,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: Vec::new(),
+                    embedding_model_hash: 0,
+                    embedding_updated_at_ms: 0,
+                },
+            },
+        });
+        assert!(response.status.ok);
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: ContextSummary {
+                    node_hash,
+                    level: 1,
+                    text: summary.clone(),
+                    valid_from_ms: at,
+                    vector: Vec::new(),
+                },
+            },
+        });
+        assert!(response.status.ok);
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextSetNodeEmbedding {
+                tenant_hash: TENANT,
+                node_hash,
+                model_hash: 1,
+                vector,
+                updated_at_ms: at,
+            },
+        });
+        assert!(response.status.ok);
+    }
+
+    let retrieve = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: TENANT,
+            node_hashes: vec![21, 22],
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: EVENT_TIME + 1_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider,
+        },
+    );
+    assert!(retrieve.status.ok, "{:?}", retrieve.status);
+    let summary_nodes: Vec<u64> = retrieve
+        .blocks
+        .iter()
+        .filter(|block| block.tier == ContextTier::L0)
+        .map(|block| block.node_hash)
+        .collect();
+    assert_eq!(
+        vec![21u64],
+        summary_nodes,
+        "the wider vector came from another embedding space and must not take the slot on the \
+         strength of its prefix"
+    );
+    assert_eq!(
+        1, retrieve.fanout_plan.embedding_width_conflict_nodes,
+        "the declined vector has to be COUNTED -- an operator has no other signal that this \
+         store holds two embedding widths"
+    );
+}
+
+#[test]
 fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
     // No separate embedding rows exist anywhere in this store. If the summary-scoring pass
     // still read node_l0 through the rows, every node here would score zero, selection would


### PR DESCRIPTION
Two vectors of different widths were compared on their shared prefix. They are now declined and
routed to the lexical pass, and the decline is counted.

### The failure

`context_embedding_similarity_micros` took `len = left.len().min(right.len())` and scored that
many dimensions. Two vectors of different widths came from different encoders, so the number it
returned was a cosine computed across two unrelated spaces.

Nothing about this is loud. There is no length mismatch to raise, nothing reaches the logs, and a
wider vector whose opening dimensions happen to track the query earns a **perfect** score — the
strongest the system can produce — and outranks every genuinely matching record. The only symptom
is ranking that has quietly become noise.

This is reachable in a normal deployment, not just in theory. The embedding path falls back to a
32-dimension deterministic token-hash vector whenever the configured provider raises — a bad model
path, a missing dependency, a CPU OOM. One outage seeds 32-dimension records into a store of
384-dimension ones, and no later read can tell them apart. The only dimension check in the engine
is an upper bound (`CONTEXT_MAX_EMBEDDING_DIM`); there was never an equality check.

### The fix

`context_embedding_width_conflicts(left, right)` is true when both vectors are non-empty and their
widths differ. Both scoring call sites consult it and hand a conflicting vector to the hybrid
lexical pass, exactly as an un-embedded node is handed over. The similarity function refuses
unequal widths as well, so a future caller cannot reintroduce this by passing two vectors in.

**A conflicting vector must not record a score of zero.** The hybrid lexical pass picks its
candidates with

```rust
summary_scores_by_node.get(node_hash).map(|(_, found)| *found == 0).unwrap_or(true)
```

— it selects on the *count* of scores recorded, not on their value. Writing a zero therefore marks
the node as scored and strands it at the bottom of the ranking with no second chance, which is a
quieter version of the bug being fixed. So the node pass pushes to the fallback list and the
summary pass `continue`s; neither touches the score map.

This is reasoning from the selection predicate, not from a test: the shipped behaviour is covered,
but there is no test in which a width-conflicting node legitimately *wins* on its text. That test
is worth adding and is noted below.

An empty vector on either side is left exactly as it was. That is un-embedded, a different
condition with a different repair, and folding the two together would have changed behaviour on a
path this change has no business touching.

### Making it visible

New report field `embedding_width_conflict_nodes`, counted across both vector passes and set after
both — the node pass alone under-reports. It is separate from `l0_row_fallback_nodes` because the
two ask for different repairs: an un-embedded node needs the backfill to run, whereas a width
conflict means the store holds vectors from two encoders and re-embedding is the only fix. Nonzero
here is the signal that did not previously exist.

### Tests

| test | property |
|---|---|
| `vectors_of_different_widths_are_never_comparable` | the predicate, both orders, and that an empty side is *not* a conflict |
| `a_perfect_prefix_match_across_two_widths_scores_nothing` | the silent case: `long` starts with `short`, so prefix scoring returns maximum confidence for two unrelated vectors |
| `a_vector_from_another_embedding_space_cannot_win_a_summary_slot` | end to end — an impostor carrying the query vector as its prefix plus extra dimensions cannot take the single summary slot, and is counted |

The third test is built so it cannot pass by accident: the impostor's text is chosen so it loses
the lexical pass too, and the genuinely matching node is deliberately a little off-query, so under
prefix scoring the impostor wins outright.

Each test was then checked against deliberately broken code, because a test that passes on correct
code has not yet been shown capable of failing:

| broken version | end-to-end test | unit test |
|---|---|---|
| counter dropped, routing kept | fails | — |
| call-site check disabled | fails | — |
| scorer's `min` restored, call site left intact | **passes** | fails |
| **both guards removed — the code as it was** | fails | fails |

The third row is worth stating plainly, because it corrects the obvious assumption: restoring the
`min` on its own does *not* fail the end-to-end test. The call-site check declines the vector
before it can reach the scorer, so the two tests cover two different guards rather than one guard
twice. Only removing both — the code exactly as it stood before this change — fails both.

### What this deliberately does not change

Two related properties are still outstanding and are **not** safe to fix in this change:

- ingest stamps `embedding_model_hash` from `provider.model`, which is annotated
  `default_chat_model` — the chat model, a different field from `embedding_model`, which is what
  the drainer hashes. The two paths therefore disagree.
- no read path consults `embedding_model_hash` at all.

They have to land in that order and separately. Correcting the stamped value while also adding
"skip on hash mismatch" would make every already-written node mismatch at once and drop out of
vector scoring — mass silent recall loss, which is a worse version of the problem being fixed
here. A hash of `0` means "unknown" and must keep being scored, or existing stores break.
