### PR TITLE
Writers waiting on the metadata log share a barrier

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1159,7 +1159,16 @@ pub struct MetaMutationRecord {
 #[derive(Debug, Clone)]
 pub struct LocalMetaMutationLog {
     path: PathBuf,
-    write_lock: Arc<Mutex<()>>,
+    /// The handle records are appended through, opened once.
+    ///
+    /// Opening the file per record cost more than it looked like: with the
+    /// barrier split out so writers can share one, a record was opening it
+    /// twice.
+    write_lock: Arc<Mutex<Option<File>>>,
+    /// A second handle for the barrier, so it can run without the write lock
+    /// and let the next writer get its bytes down meanwhile. Syncing is per
+    /// file, not per handle, so this covers what the other one wrote.
+    sync_file: Arc<Mutex<Option<File>>>,
     /// How many records have been written to the file.
     ///
     /// Written under `write_lock`, so it counts the records whose bytes have
@@ -1181,6 +1190,7 @@ impl LocalMetaMutationLog {
         Ok(Self {
             path,
             write_lock: Arc::default(),
+            sync_file: Arc::default(),
             written: Arc::default(),
             synced: Arc::default(),
         })
@@ -1190,19 +1200,21 @@ impl LocalMetaMutationLog {
         // The bytes reach the file in the order the write lock grants, and the
         // record is numbered by that order.
         let mine = {
-            let _guard = self
+            let mut handle = self
                 .write_lock
                 .lock()
                 .expect("meta mutation log lock poisoned");
-            let mut file = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&self.path)?;
+            let file = match handle.as_mut() {
+                Some(file) => file,
+                None => handle.insert(
+                    OpenOptions::new().create(true).append(true).open(&self.path)?,
+                ),
+            };
             let record = MetaMutationRecord {
                 at_ms,
                 mutation: mutation.clone(),
             };
-            serde_json::to_writer(&mut file, &record).map_err(io::Error::other)?;
+            serde_json::to_writer(&mut *file, &record).map_err(io::Error::other)?;
             file.write_all(b"\n")?;
             self.written.fetch_add(1, Ordering::SeqCst) + 1
         };
@@ -1226,7 +1238,16 @@ impl LocalMetaMutationLog {
         // Read before the barrier, published after it. The other order would
         // tell a writer its bytes were durable while the sync was still running.
         let covered = self.written.load(Ordering::SeqCst);
-        let file = OpenOptions::new().create(true).append(true).open(&self.path)?;
+        let mut handle = self
+            .sync_file
+            .lock()
+            .expect("meta mutation log sync handle poisoned");
+        let file = match handle.as_mut() {
+            Some(file) => file,
+            None => handle.insert(
+                OpenOptions::new().create(true).append(true).open(&self.path)?,
+            ),
+        };
         crate::durability_metrics::record_barrier("meta_log_append");
         file.sync_data()?;
         *synced = (*synced).max(covered);

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -1160,6 +1160,16 @@ pub struct MetaMutationRecord {
 pub struct LocalMetaMutationLog {
     path: PathBuf,
     write_lock: Arc<Mutex<()>>,
+    /// How many records have been written to the file.
+    ///
+    /// Written under `write_lock`, so it counts the records whose bytes have
+    /// reached the file in the order the lock granted.
+    written: Arc<AtomicU64>,
+    /// How many records a completed sync has covered.
+    ///
+    /// Guarded by its own lock rather than `write_lock`, so a writer waiting for
+    /// durability is not holding up the writer behind it.
+    synced: Arc<Mutex<u64>>,
 }
 
 impl LocalMetaMutationLog {
@@ -1171,26 +1181,55 @@ impl LocalMetaMutationLog {
         Ok(Self {
             path,
             write_lock: Arc::default(),
+            written: Arc::default(),
+            synced: Arc::default(),
         })
     }
 
     pub fn append(&self, mutation: &MetaMutation, at_ms: u64) -> io::Result<()> {
-        let _guard = self
-            .write_lock
-            .lock()
-            .expect("meta mutation log lock poisoned");
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
-        let record = MetaMutationRecord {
-            at_ms,
-            mutation: mutation.clone(),
+        // The bytes reach the file in the order the write lock grants, and the
+        // record is numbered by that order.
+        let mine = {
+            let _guard = self
+                .write_lock
+                .lock()
+                .expect("meta mutation log lock poisoned");
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)?;
+            let record = MetaMutationRecord {
+                at_ms,
+                mutation: mutation.clone(),
+            };
+            serde_json::to_writer(&mut file, &record).map_err(io::Error::other)?;
+            file.write_all(b"\n")?;
+            self.written.fetch_add(1, Ordering::SeqCst) + 1
         };
-        serde_json::to_writer(&mut file, &record).map_err(io::Error::other)?;
-        file.write_all(b"\n")?;
+        self.sync_through(mine)
+    }
+
+    /// Return once a sync that began after record `mine` was written has
+    /// completed.
+    ///
+    /// The barrier a writer needs is not its own: any sync beginning after its
+    /// bytes reached the file covers them, because the file is append-only and
+    /// the writes are ordered. So a writer that finds its record already covered
+    /// has nothing to do, and one that does not takes the barrier for everything
+    /// written so far -- including the writers still queued behind it.
+    fn sync_through(&self, mine: u64) -> io::Result<()> {
+        let mut synced = self.synced.lock().expect("meta mutation log sync poisoned");
+        if *synced >= mine {
+            // Somebody else's barrier already covered this record.
+            return Ok(());
+        }
+        // Read before the barrier, published after it. The other order would
+        // tell a writer its bytes were durable while the sync was still running.
+        let covered = self.written.load(Ordering::SeqCst);
+        let file = OpenOptions::new().create(true).append(true).open(&self.path)?;
         crate::durability_metrics::record_barrier("meta_log_append");
         file.sync_data()?;
+        *synced = (*synced).max(covered);
         Ok(())
     }
 
@@ -6360,6 +6399,77 @@ mod tests {
             .is_empty(),
             "the routes are still in the state"
         );
+    }
+
+    #[test]
+    fn writers_share_a_barrier_without_losing_a_record() {
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = Arc::new(LocalMetaMutationLog::new(dir.path().join("meta.log")).unwrap());
+
+        // One writer on its own is covered by its own barrier, and its record is
+        // readable the moment append returns.
+        log.append(
+            &MetaMutation::RegisterShard(RegisterShardRequest {
+                shard_id: 1,
+                server_addr: "solo".to_string(),
+            }),
+            10,
+        )
+        .unwrap();
+        assert_eq!(log.load().unwrap().len(), 1, "the first record is not there");
+
+        let writers = 8usize;
+        let each = 12usize;
+        let mut handles = Vec::new();
+        for w in 0..writers {
+            let log = Arc::clone(&log);
+            handles.push(std::thread::spawn(move || {
+                for i in 0..each {
+                    log.append(
+                        &MetaMutation::RegisterShard(RegisterShardRequest {
+                            shard_id: (w * each + i) as u64 + 100,
+                            server_addr: format!("node-{w}"),
+                        }),
+                        i as u64,
+                    )
+                    .unwrap();
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Every record every writer was told was durable is in the log, once.
+        let records = log.load().unwrap();
+        assert_eq!(
+            records.len(),
+            writers * each + 1,
+            "a record a writer was told had landed is missing"
+        );
+        let mut shard_ids = records
+            .iter()
+            .filter_map(|record| match &record.mutation {
+                MetaMutation::RegisterShard(request) => Some(request.shard_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        shard_ids.sort_unstable();
+        shard_ids.dedup();
+        assert_eq!(
+            shard_ids.len(),
+            writers * each + 1,
+            "a record was written twice or read back wrong"
+        );
+
+        // How many barriers this took is deliberately not asserted. The
+        // barrier counter is process-wide and every other test in the binary
+        // adds to it, so a count read here says nothing about this log -- and a
+        // test that passes alone and fails in the suite is worse than no test.
+        // What matters is above: every record a writer was told had landed is
+        // in the log, exactly once.
     }
 
     #[test]


### PR DESCRIPTION
Every recorded change to the metadata takes a durability barrier, and the barrier is nearly the whole cost. Of the 2.6ms an append takes, 2.1ms is the write and the sync; opening the file is 5us and copying the change is 0.2us.

So writers did not go faster together than alone. Measured end to end -- registering shards through the metaserver, not appending to the log directly:

| writers | before | after |
|---|---|---|
| 1 | 499/s | 490/s |
| 4 | 467/s | 858/s |
| 16 | 478/s | 1941/s |

Flat before, because each writer took its own barrier and the next one waited. A cluster coming back -- every datanode registering every shard it holds -- paid one barrier per shard however many datanodes were doing it.

## Why it is safe

The barrier a writer needs is not its own. The file is append-only and the writes are ordered by the write lock, so any sync beginning after a writer's bytes reached the file covers them. Numbering the records lets a writer notice that somebody else's sync already covered it and return without taking another.

The part that is easy to get wrong, and the reason it is written this way: how far the log has been written is read BEFORE the sync and published only AFTER it returns. The other order would tell a writer its bytes were durable while the sync was still running.

## The first version of this was slower for one writer

Splitting the write from the sync meant a record opened the file twice where it used to open it once. End to end that cost a lone writer more than sharing saved it -- 499 registrations a second became 363 -- and one writer is the ordinary case for a metaserver.

Both handles are now opened once and kept, which is what the write-ahead log next door already does. Syncing is per file rather than per handle, so the barrier handle still covers what the write handle wrote, and the barrier still runs outside the write lock.

Nothing in the tree rewrites this file: the only nearby truncate belongs to snapshot export, which writes a temporary file and renames it.

## Testing

Eight writers, twelve records each, and every record every writer was told had landed is in the log exactly once.

How many barriers that took is deliberately not asserted. The barrier counter is process-wide and every other test in the binary adds to it, so a count read in a test says nothing about this log -- and a test that passes alone and fails in the suite is worse than no test. That is how the first version of this test behaved.

Measurements were taken twice with the arms interleaved, because the box is shared. The second pair ran under load 12.4 and the absolute numbers moved together while the shape held.

Suites: 327 metadata tests, 246 consensus tests, 47 metaserver binary tests, all green.
