### PR TITLE
A bucket-index reconstruct scanned every page twice

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -200,7 +200,11 @@ impl TemporalEngine {
             start_routing_bucket,
             end_routing_bucket,
         );
-        storage_bucket_internals::refresh_bucket_runtime_flags(shard);
+        // The rebuild above just recomputed every bucket's object index by scanning that bucket's
+        // page index. The full sweep's own rebuild would scan the same pages again, from the same
+        // source, with nothing in between that could change the answer -- so the flags refresh,
+        // and the duplicate scan does not.
+        storage_bucket_internals::refresh_bucket_runtime_flags_after_reconstruct(shard);
     }
 
     /// Mirror the deletions this engine emits on its own -- eviction drops, expiry sweeps --

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1523,6 +1523,11 @@ pub mod layout_by_caller {
     }
 }
 
+// `Location::caller()` in a function that is not `#[track_caller]` returns the location of the
+// `caller()` call itself, so the by-caller breakdown below reported this one line for all ten
+// callers -- it looked like attribution and was not. Applied only under `cfg(test)`, because the
+// attribute adds a hidden location argument at every call site and this is a write path.
+#[cfg_attr(test, track_caller)]
 pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
     note_site(&bucket_visit_sites::LAYOUT, bucket.page_index.len());
     // Tests only: this takes a lock, and `update_bucket_layout` is on a write path. It exists
@@ -1569,6 +1574,7 @@ pub(super) fn note_bucket_flags_stale(shard: &mut ShardState, routing_bucket: u3
 /// from page entries, where the set has NOT been maintained and must be derived. Those keep the
 /// scan. `bucket_object_index_already_matches_a_from_scratch_recompute` is the evidence for
 /// dropping it everywhere else.
+#[cfg_attr(test, track_caller)]
 fn refresh_one_bucket_runtime_flags(
     bucket: &mut BucketNode,
     now: u64,
@@ -1617,12 +1623,30 @@ fn refresh_one_bucket_runtime_flags(
 /// set of changed buckets is not known. On the per-write path use
 /// [`refresh_pending_bucket_runtime_flags`] instead -- this sweep on every write is what made
 /// ingestion quadratic in the corpus.
+#[cfg_attr(test, track_caller)]
 pub(super) fn refresh_bucket_runtime_flags(shard: &mut ShardState) {
     refresh_all_bucket_runtime_flags(shard, true);
 }
 
+/// The sweep, for a caller that has just rebuilt the bucket index from the page entries.
+///
+/// [`rebuild_bucket_first_index`] recomputes every bucket's object index and layout by scanning
+/// that bucket's page index. Running the full sweep with the rebuild still switched on immediately
+/// afterwards scans exactly the same pages a second time, from the same source, with nothing in
+/// between that could change the answer. The two showed up in the per-add attribution as a pair of
+/// counters that were equal at every corpus size -- 45 300 each over 150 adds, 180 600 each over
+/// 300, 721 200 each over 600 -- which is what the same scan run twice looks like.
+///
+/// The flags themselves (dirty, deleted, in_memory, ttl) are still refreshed; only the redundant
+/// object-index rescan is skipped.
+#[cfg_attr(test, track_caller)]
+pub(super) fn refresh_bucket_runtime_flags_after_reconstruct(shard: &mut ShardState) {
+    refresh_all_bucket_runtime_flags(shard, false);
+}
+
 /// The sweep, with the object-index rebuild made optional. See
 /// [`refresh_one_bucket_runtime_flags`] for when it can be skipped.
+#[cfg_attr(test, track_caller)]
 fn refresh_all_bucket_runtime_flags(shard: &mut ShardState, rebuild_object_index: bool) {
     let now = now_ms();
     for bucket in shard.bucket_index.bucket_map.values_mut() {
@@ -1644,6 +1668,7 @@ fn refresh_all_bucket_runtime_flags(shard: &mut ShardState, rebuild_object_index
 /// function of its own pages plus the two shard-wide maps, and both of those are noted against the
 /// buckets they affect. `bucket_runtime_flags_match_full_sweep` in the engine tests checks that
 /// equivalence against a real workload rather than leaving it as an argument.
+#[cfg_attr(test, track_caller)]
 pub(super) fn refresh_pending_bucket_runtime_flags(shard: &mut ShardState) {
     if shard.buckets_pending_flag_refresh.is_empty() {
         return;

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -392,7 +392,10 @@ impl TemporalEngine {
         }
         if mutated_any {
             if rebuilt_bucket_index {
-                refresh_bucket_runtime_flags(shard);
+                // The reconstruct on the line above already recomputed every bucket's object
+                // index from its page index, so the sweep's own rebuild would redo that identical
+                // scan. Flags still refresh; only the duplicate scan is dropped.
+                refresh_bucket_runtime_flags_after_reconstruct(shard);
             } else {
                 // Refresh only the buckets this batch disturbed. The full sweep is
                 // O(total pages), so running it per batch left bulk ingest quadratic in the


### PR DESCRIPTION
A bucket-index reconstruct scanned every page twice. Per-add bucket work is now half what it was,
measured by count.

### What the attribution showed

The in-tree harness `what_one_add_costs_end_to_end` counts pages visited per add, which is the
right unit here — a duration on a loaded machine cannot tell "slower machine" apart from "more
work", and this machine sits at a load average of 20 to 30 for hours at a time.

At 150, 300 and 600 adds, the work split evenly between two sites, and both quadrupled every time
the corpus doubled:

| adds | site A | site B | total | per add |
|---:|---:|---:|---:|---:|
| 150 | 45,300 | 45,300 | 90,600 | 604 |
| 300 | 180,600 | 180,600 | 361,200 | 1,204 |
| 600 | 721,200 | 721,200 | 1,442,400 | 2,404 |

Two counters equal to the digit at every corpus size is what the *same scan run twice* looks like.

### The instrumentation was lying first

The breakdown that names the caller was built on

```rust
layout_by_caller::note(std::panic::Location::caller(), bucket.page_index.len());
```

inside `update_bucket_layout`. That function was not `#[track_caller]`, so `Location::caller()`
returned the location of the `caller()` call itself — one fixed line — for all ten of its callers.
It looked like attribution and was not, and the comment above it says the whole reason it exists is
that the counter "reports how much work happened without saying who asked for it".

`#[track_caller]` also *chains*: a location passes through annotated frames untouched. Annotating
only `update_bucket_layout` named its immediate caller, which was still an inner frame. Annotating
the whole refresh chain named the real origin — `reconstruct_bucket_index_now`. All annotations are
`#[cfg_attr(test, track_caller)]`, because the attribute adds a hidden argument at every call site
and this is a write path.

### The duplicate

```rust
rebuild_bucket_first_index(shard_id, shard, start, end);   // rebuilds every bucket's object index
refresh_bucket_runtime_flags(shard);                       // rebuilds every bucket's object index
```

Back to back, from the same source (`page_index`), with nothing in between that can change the
answer. `refresh_bucket_runtime_flags_after_reconstruct` refreshes the flags — dirty, deleted,
in_memory, ttl — and skips the second rebuild.

### Result

| adds | before | after |
|---:|---:|---:|
| 150 | 604 / add | **302 / add** |
| 300 | 1,204 / add | **602 / add** |
| 600 | 2,404 / add | **1,202 / add** |

Exactly half, and the duplicate site disappears from the breakdown entirely rather than shrinking,
which is the result the diagnosis predicted.

### One behavioural change, deliberately

The skipped rebuild is also what *removed* object ids whose every page is deleted. Skipping it
preserves the tombstone ids that `rebuild_bucket_first_index` re-attaches immediately above — the
ids the deserialize and reconcile load path has always kept. So the reconstruct path now agrees
with the load path instead of disagreeing with it. The full suite covers object counts across both
paths: **1,448 passed, 0 failed**, run with `--test-threads=1` because this crate has around 180
`std::env::set_var` sites and races through process globals under parallel threads.

### What is still there

The remaining 1,202 pages per add is one full-store walk per logical ingest, so ingest is still
quadratic in the corpus overall, with half the constant. Removing that means letting `Context*`
writes update the bucket index directly instead of triggering a reconstruct — none of them appear
in `command_updates_bucket_index_directly`, which is why the reconstruct fires at all. That is a
larger change and is not attempted here.

### What was dropped

I also hoisted `update_bucket_layout` out of the per-entry loop inside `rebuild_bucket_first_index`
and measured it at **exactly zero** — at default routing every key lands in its own bucket, so the
loop was already running once per bucket. The narrow-routing A/B that would have justified it came
back with both arms equal to the default-routing counts, meaning the setting never took effect and
the run proved nothing. It is not in this change: an unmeasured edit riding along with a measured
one makes the measured one harder to trust.
