### PR TITLE
Opening or closing a table built every shard and then dropped them

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2423,6 +2423,107 @@ mod tests {
         )
     }
 
+    #[test]
+    fn opening_and_closing_a_table_report_its_version_and_state() {
+        use temporalstore_rust::meta::{
+            AddTableRequest, DeleteTableRequest, GetTableTopologyRequest, RegisterServerRequest,
+            RegisterShardRequest,
+        };
+
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        meta.add_table(AddTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "t".to_string(),
+            first_shard_id: 1,
+            shard_count: 4,
+            replica_count: 1,
+            partition_version: 1,
+            serving_options: Default::default(),
+        });
+        for shard in 1..=4u64 {
+            meta.register(RegisterShardRequest {
+                shard_id: shard,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        let expected_version = meta
+            .get_table_topology(GetTableTopologyRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+                old_topology_version: 0,
+                client_location: String::new(),
+            })
+            .table
+            .expect("the table is there")
+            .topology_version;
+
+        let backend = MetaBackend::Single(meta);
+        let scheduler = MetaTaskScheduler::default();
+        let post = |path: &str, namespace: &str, table_name: &str| {
+            handle(
+                &backend,
+                &scheduler,
+                HttpRequest {
+                    method: "POST".to_string(),
+                    path: path.to_string(),
+                    body: serde_json::to_vec(&serde_json::json!({
+                        "namespace": namespace,
+                        "table_name": table_name,
+                    }))
+                    .unwrap(),
+                },
+            )
+        };
+
+        // Opening reports the version the caller must quote to get a topology.
+        let (code, body) = post("/MasterService/OpenTable", "ns", "t");
+        assert_eq!(code, 200);
+        let opened: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            opened["open_version"].as_u64(),
+            Some(expected_version),
+            "opening a table reported the wrong version: {opened}"
+        );
+        assert_eq!(opened["status"]["ok"].as_bool(), Some(true));
+
+        // Closing reports whether it could be served.
+        let (code, body) = post("/MasterService/CloseTable", "ns", "t");
+        assert_eq!(code, 200);
+        let closed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(closed["status"]["ok"].as_bool(), Some(true));
+
+        // A table that was never created is refused by both, rather than
+        // answered with a zero version.
+        let (_, body) = post("/MasterService/OpenTable", "ns", "absent");
+        let missing: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(missing["status"]["ok"].as_bool(), Some(false));
+        assert_eq!(missing["status"]["code"].as_str(), Some("table_not_found"));
+
+        let (_, body) = post("/MasterService/CloseTable", "ns", "absent");
+        let missing: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(missing["status"]["ok"].as_bool(), Some(false));
+
+        // And a dropped table is refused too, not reported as openable.
+        let dropped = match &backend {
+            MetaBackend::Single(meta) => meta.delete_table(DeleteTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "t".to_string(),
+            }),
+            MetaBackend::Raft(_) => unreachable!("single-node backend"),
+        };
+        assert!(dropped.status.ok);
+        let (_, body) = post("/MasterService/OpenTable", "ns", "t");
+        let gone: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(gone["status"]["ok"].as_bool(), Some(false));
+    }
+
     fn node_body(node_id: u64) -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({ "node_id": node_id })).unwrap()
     }

--- a/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/service_routes.rs
@@ -410,15 +410,12 @@ fn handle_master_service_route(
         }
         ("POST", "/MasterService/OpenTable") => {
             parse_or(&request.body, |req: MasterTableRequest| {
+                // Only the version is read out of this, so it does not ask
+                // for the shard list.
                 let topology = backend_call!(
                     meta,
                     get_table_topology,
-                    GetTableTopologyRequest {
-                        client_location: String::new(),
-                        namespace: req.namespace,
-                        table_name: req.table_name,
-                        old_topology_version: 0,
-                    }
+                    GetTableTopologyRequest::status_only(req.namespace, req.table_name)
                 );
                 MasterOpenTableResponse {
                     open_version: topology
@@ -432,15 +429,12 @@ fn handle_master_service_route(
         }
         ("POST", "/MasterService/CloseTable") => {
             parse_or(&request.body, |req: MasterTableRequest| {
+                // Only the status is read out of this, so it does not ask
+                // for the shard list.
                 let topology = backend_call!(
                     meta,
                     get_table_topology,
-                    GetTableTopologyRequest {
-                        client_location: String::new(),
-                        namespace: req.namespace,
-                        table_name: req.table_name,
-                        old_topology_version: 0,
-                    }
+                    GetTableTopologyRequest::status_only(req.namespace, req.table_name)
                 );
                 AckResponse {
                     status: topology.status,

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -787,6 +787,31 @@ pub struct GetTableTopologyRequest {
     pub client_location: String,
 }
 
+impl GetTableTopologyRequest {
+    /// Ask only whether a table can be served, and at what version.
+    ///
+    /// A caller that wants the version or just the status does not need the
+    /// shard list, and building one is the whole cost of the answer. Measured
+    /// through the open-table route, the cost was the size of the table --
+    /// 28.9us at 50 shards, 114.6us at 200, 434.9us at 800 -- and asking this
+    /// way is 0.5us at every one of them.
+    ///
+    /// This is the ordinary request with the version set past anything a table
+    /// can hold, which is the existing answer for a caller that is already
+    /// current: every missing, dropped and frozen check still runs and still
+    /// returns exactly what it returned before, and the answer stops before the
+    /// shard list. Written this way so the status cannot drift from the status
+    /// the full answer gives -- it is the same code producing it.
+    pub fn status_only(namespace: String, table_name: String) -> Self {
+        Self {
+            namespace,
+            table_name,
+            old_topology_version: u64::MAX,
+            client_location: String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TableMetaInfo {
     pub table_id: u64,
@@ -7068,6 +7093,110 @@ mod tests {
         assert_eq!(
             topo.shards[0].replicas,
             vec!["cool".to_string(), "busy".to_string()]
+        );
+    }
+
+    #[test]
+    fn asking_only_for_status_gives_the_same_answer_without_the_shards() {
+        let meta = SingleNodeMeta::default();
+        meta.register_server(RegisterServerRequest {
+            numa_nodes: Vec::new(),
+            server_addr: "node-a".to_string(),
+            node_id: 1,
+            location: "rack-1".to_string(),
+            binary_version: "v1".to_string(),
+        });
+        for (namespace, table_name) in [
+            ("ns", "normal"),
+            ("ns", "frozen"),
+            ("ns", "dropped"),
+            ("frozen-ns", "in-frozen-ns"),
+        ] {
+            meta.add_table(AddTableRequest {
+                namespace: namespace.to_string(),
+                table_name: table_name.to_string(),
+                first_shard_id: 1,
+                shard_count: 4,
+                replica_count: 1,
+                partition_version: 1,
+                serving_options: Default::default(),
+            });
+        }
+        for shard in 1..=4u64 {
+            meta.register(RegisterShardRequest {
+                shard_id: shard,
+                server_addr: "node-a".to_string(),
+            });
+        }
+        meta.freeze_table(DeleteTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "frozen".to_string(),
+        });
+        meta.delete_table(DeleteTableRequest {
+            namespace: "ns".to_string(),
+            table_name: "dropped".to_string(),
+        });
+        meta.freeze_namespace(AddNamespaceRequest {
+            namespace: "frozen-ns".to_string(),
+        });
+
+        for (namespace, table_name) in [
+            ("ns", "normal"),
+            ("ns", "frozen"),
+            ("ns", "dropped"),
+            ("frozen-ns", "in-frozen-ns"),
+            ("ns", "never-created"),
+            ("no-such-ns", "never-created"),
+        ] {
+            let full = meta.get_table_topology(GetTableTopologyRequest {
+                namespace: namespace.to_string(),
+                table_name: table_name.to_string(),
+                old_topology_version: 0,
+                client_location: String::new(),
+            });
+            let cheap = meta.get_table_topology(GetTableTopologyRequest::status_only(
+                namespace.to_string(),
+                table_name.to_string(),
+            ));
+
+            // Whatever the full answer says about whether this table can be
+            // served, the cheap one says the same. Opening and closing a table
+            // report this status straight back to the caller.
+            assert_eq!(
+                cheap.status.ok, full.status.ok,
+                "{namespace}.{table_name}: the two answers disagree on ok"
+            );
+            assert_eq!(
+                cheap.status.code, full.status.code,
+                "{namespace}.{table_name}: the two answers disagree on the code"
+            );
+            // And the version, which is what opening a table reads.
+            assert_eq!(
+                cheap.table.as_ref().map(|table| table.topology_version),
+                full.table.as_ref().map(|table| table.topology_version),
+                "{namespace}.{table_name}: the two answers disagree on the version"
+            );
+            // The point of asking this way: no shard list is built. If this
+            // ever carries shards again the saving is gone, and that is not
+            // something a timing assertion could tell you reliably.
+            assert!(
+                cheap.shards.is_empty(),
+                "{namespace}.{table_name}: the cheap answer built a shard list"
+            );
+        }
+
+        // The full answer really does carry shards for a servable table, so the
+        // check above is not passing because there was nothing to build.
+        let full = meta.get_table_topology(GetTableTopologyRequest {
+            namespace: "ns".to_string(),
+            table_name: "normal".to_string(),
+            old_topology_version: 0,
+            client_location: String::new(),
+        });
+        assert_eq!(
+            full.shards.len(),
+            4,
+            "the full answer stopped carrying shards, so this test proves nothing"
         );
     }
 


### PR DESCRIPTION
Opening a table reads one number out of the answer -- the version a caller must quote to be given a topology. Closing one reads only whether the table could be served at all. Both asked for the whole topology, so both paid to build a shard list that neither looked at, and the cost was the size of the table:

| shards | OpenTable | CloseTable |
|---|---|---|
| 50 | 28.9us | 31.5us |
| 200 | 114.6us | 113.6us |
| 800 | 434.9us | 435.7us |

Now 0.5us at every one of them, and flat rather than growing with the table.

## Why it is written this way

The cheap answer already existed inside the same call. A caller that is already current is given the status and the table back and stops before the shard list is built, and every missing, dropped and frozen check -- including the namespace ones -- runs before that point.

So this asks for the topology with the version set past anything a table can hold, rather than repeating those checks somewhere new where they could drift from the originals. The status these routes report is the same status because it is the same code producing it.

## Nothing observable changes

Opening reads the version, which the early answer carries. Closing reads the status, which is identical in every case. Neither route exposes the flag that says the answer was unchanged.

The route just below these two, which serves topologies to proxies, was already passing the caller's version through and is untouched.

## Testing

Neither route had a test. They have one now, covering the version, the refusals for a table that was never created and for one that has been dropped.

There is also a test that the cheap answer agrees with the full one on status and version across a normal table, a frozen table, a dropped table, a table in a frozen namespace, and two that do not exist -- and that it carries no shards while the full answer still carries four. The saving is asserted by counting what was built rather than by timing it, so it holds on a loaded machine.

Both tests were checked against a mutation: made to build the shard list again, and made to report the version as zero. Each fails.

Measurements were taken with the arms interleaved, because the box is shared.

Suites: 327 metadata tests and 48 metaserver binary tests, all green.
