### PR TITLE
Counting one namespace's tables walked every table in the cluster

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -5109,7 +5109,84 @@ mod tests {
     }
 
     #[test]
-    fn a_namespace_that_still_holds_a_table_is_not_dropped() {
+fn counting_a_namespace_tables_agrees_with_counting_them_one_by_one() {
+        let meta = SingleNodeMeta::default();
+        // Three namespaces holding different numbers of tables, one holding
+        // none at all, and a dropped table that must not be counted.
+        for (namespace, table_name) in [
+            ("alpha", "a1"),
+            ("alpha", "a2"),
+            ("alpha", "a3"),
+            ("beta", "b1"),
+            ("gamma", "g1"),
+            ("gamma", "dropped"),
+        ] {
+            assert!(meta
+                .add_table(AddTableRequest {
+                    namespace: namespace.to_string(),
+                    table_name: table_name.to_string(),
+                    first_shard_id: 1,
+                    shard_count: 1,
+                    replica_count: 1,
+                    partition_version: 1,
+                    serving_options: Default::default(),
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .add_namespace(AddNamespaceRequest {
+                namespace: "empty".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .delete_table(DeleteTableRequest {
+                namespace: "gamma".to_string(),
+                table_name: "dropped".to_string(),
+            })
+            .status
+            .ok);
+
+        let listed = meta.list_namespaces();
+        assert!(listed.status.ok);
+
+        // Recomputed the long way: for each namespace, walk every table. This
+        // is what the listing used to do, and the tally has to match it.
+        let tables = meta.list_tables().tables;
+        for namespace in &listed.namespaces {
+            let counted_one_by_one = tables
+                .iter()
+                .filter(|table| {
+                    table.namespace == namespace.namespace
+                        && table.state != MetaEntityState::Dropped
+                })
+                .count();
+            assert_eq!(
+                namespace.table_count, counted_one_by_one,
+                "namespace {} was tallied as {} but holds {}",
+                namespace.namespace, namespace.table_count, counted_one_by_one
+            );
+        }
+
+        // And the counts are what they should be, so this is not agreeing on
+        // zero everywhere.
+        let count_of = |wanted: &str| {
+            listed
+                .namespaces
+                .iter()
+                .find(|namespace| namespace.namespace == wanted)
+                .unwrap_or_else(|| panic!("{wanted} is missing from the listing"))
+                .table_count
+        };
+        assert_eq!(count_of("alpha"), 3);
+        assert_eq!(count_of("beta"), 1);
+        assert_eq!(count_of("gamma"), 1, "the dropped table was counted");
+        assert_eq!(count_of("empty"), 0);
+    }
+
+    #[test]
+        fn a_namespace_that_still_holds_a_table_is_not_dropped() {
         // Dropping the namespace out from under a live table would leave the
         // table addressable by name but unreachable through its namespace.
         let meta = namespaced_meta();

--- a/crates/temporalstore-rust/src/meta/lifecycle.rs
+++ b/crates/temporalstore-rust/src/meta/lifecycle.rs
@@ -103,19 +103,29 @@ impl SingleNodeMeta {
 
     pub fn list_namespaces(&self) -> ListNamespacesResponse {
         let state = self.inner.read().expect("meta lock poisoned");
+        // Tally every namespace in one pass. Counting each namespace's tables
+        // by filtering the whole table set cost namespaces times tables, which
+        // a metrics scrape pays on every tick: 151.8us at 32 namespaces of 32
+        // tables, against 0.4us at 4 of 4.
+        let mut table_counts: BTreeMap<&str, usize> = BTreeMap::new();
+        for table in state.tables.values() {
+            if table.info.state != MetaEntityState::Dropped {
+                *table_counts
+                    .entry(table.info.namespace.as_str())
+                    .or_default() += 1;
+            }
+        }
         let namespaces = state
             .namespaces
             .iter()
             .map(|(namespace, state_value)| NamespaceMetaInfo {
                 namespace: namespace.clone(),
-                table_count: state
-                    .tables
-                    .values()
-                    .filter(|table| {
-                        table.info.namespace == *namespace
-                            && table.info.state != MetaEntityState::Dropped
-                    })
-                    .count(),
+                // A namespace holding no table is absent from the tally, not
+                // zero, so it still reports zero here.
+                table_count: table_counts
+                    .get(namespace.as_str())
+                    .copied()
+                    .unwrap_or_default(),
                 state: *state_value,
             })
             .collect();


### PR DESCRIPTION
Listing namespaces reports how many tables each one holds, and it counted them by filtering the whole table set once per namespace. So the cost was the namespaces multiplied by the tables, and a metrics scrape pays it on every tick.

| namespaces | tables | list_namespaces before | after |
|---|---|---|---|
| 32 | 1024 | 171.8us | 39.8us |
| 64 | 4096 | 2824.8us | 384.1us |

One pass over the tables tallies every namespace at once. The whole scrape at the larger size goes from 3639us to 1329us.

## Why it was not caught before

An earlier look at scrape cost varied the number of shards and found it flat. It used one namespace and one table, so it could not have seen a cost that depends on those. The dimension has to be the one the cost is in.

## Behaviour

A namespace holding no table is absent from the tally rather than present with a zero, so it is read back through a lookup that falls back to zero. Dropped tables are excluded when the tally is built, exactly where the filter excluded them before.

## Testing

Three namespaces holding different numbers of tables, one holding none, and a dropped table. Every count is checked against counting that namespace's tables one by one -- which is what the listing used to do -- and then against the four expected counts directly, so it cannot pass by agreeing on zero everywhere.

Checked against a mutation: with the dropped-table exclusion removed the test fails, naming the namespace and both counts.

Measurements were taken with the arms interleaved, on a shared box, and the smaller arm was run twice to bracket the noise.

Suites: 327 metadata tests, 47 metaserver binary tests, 246 consensus tests, all green.
