### PR TITLE
A metrics scrape cloned every resource to read a few fields off it

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1724,11 +1724,14 @@ fn handle(
 
 fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskScheduler) -> String {
     let stats = backend_call!(meta, stats);
-    let servers = backend_call!(meta, list_servers).servers;
-    let proxies = backend_call!(meta, list_proxies).proxies;
-    // Counts only: these three are reported by number and by state, never
-    // itemised, so they are counted in place rather than cloned out first.
-    let tallies = backend_call!(meta, resource_tallies);
+    // One pass, one acquisition of the read lock. Tables, namespaces and proxy
+    // groups are reported by number and by state and never itemised, so they
+    // are counted in place; servers and proxies are itemised, but only by a few
+    // fields each, so they arrive without the per-shard lists a server record
+    // carries.
+    let report = backend_call!(meta, metrics_report);
+    let servers = &report.servers;
+    let proxies = &report.proxies;
     let reserved = backend_call!(meta, reserved_names).reserved;
     let scheduler_snapshot = scheduler.snapshot();
     let scheduler_executions = scheduler.executions();
@@ -1762,12 +1765,12 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     out.push_str("# HELP temporalstore_meta_inventory Current metaserver inventory counts.\n");
     out.push_str("# TYPE temporalstore_meta_inventory gauge\n");
     for (kind, value) in [
-        ("namespace", tallies.namespaces.total()),
-        ("table", tallies.tables.total()),
+        ("namespace", report.namespaces.total()),
+        ("table", report.tables.total()),
         ("server", servers.len() as u64),
         ("proxy", proxies.len() as u64),
         ("shard", stats.shard_count as u64),
-        ("proxy_group", tallies.proxy_groups.total()),
+        ("proxy_group", report.proxy_groups.total()),
         ("reserved_namespace", reserved.namespaces.len() as u64),
         ("reserved_table", reserved.tables.len() as u64),
     ] {
@@ -1806,7 +1809,7 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "table"), ("state", state)],
-            tallies.tables.in_state(state),
+            report.tables.in_state(state),
         );
         // A namespace has had a state since it became something an operator can
         // freeze and drop; nothing reported it.
@@ -1814,13 +1817,13 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "namespace"), ("state", state)],
-            tallies.namespaces.in_state(state),
+            report.namespaces.in_state(state),
         );
         push_meta_metric(
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "proxy_group"), ("state", state)],
-            tallies.proxy_groups.in_state(state),
+            report.proxy_groups.in_state(state),
         );
     }
     // The size of what each node is holding, which every heartbeat has carried
@@ -1832,7 +1835,7 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     );
     out.push_str("# TYPE temporalstore_meta_server_records gauge
 ");
-    for server in &servers {
+    for server in servers {
         push_meta_metric(
             &mut out,
             "temporalstore_meta_server_records",
@@ -1846,7 +1849,7 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     );
     out.push_str("# TYPE temporalstore_meta_server_storage_bytes gauge
 ");
-    for server in &servers {
+    for server in servers {
         push_meta_metric(
             &mut out,
             "temporalstore_meta_server_storage_bytes",
@@ -1869,12 +1872,12 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     );
     out.push_str("# TYPE temporalstore_meta_server_applied_topology gauge
 ");
-    for server in &servers {
+    for server in servers {
         push_meta_metric(
             &mut out,
             "temporalstore_meta_server_applied_topology",
             &[("server", server.server_addr.as_str())],
-            server.runtime_load.last_meta_topology_version,
+            server.last_meta_topology_version,
         );
     }
 
@@ -1890,11 +1893,11 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
 # TYPE temporalstore_meta_server_{name}_total counter
 "
         ));
-        for server in &servers {
+        for server in servers {
             let value = match name {
-                "rejected" => server.runtime_load.rejected_total,
-                "timed_out" => server.runtime_load.timed_out_total,
-                _ => server.runtime_load.canceled_total,
+                "rejected" => server.rejected_total,
+                "timed_out" => server.timed_out_total,
+                _ => server.canceled_total,
             };
             push_meta_metric(
                 &mut out,
@@ -1915,7 +1918,7 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     );
     out.push_str("# TYPE temporalstore_meta_proxy_restarts gauge
 ");
-    for proxy in &proxies {
+    for proxy in proxies {
         push_meta_metric(
             &mut out,
             "temporalstore_meta_proxy_restarts",

--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1726,9 +1726,9 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     let stats = backend_call!(meta, stats);
     let servers = backend_call!(meta, list_servers).servers;
     let proxies = backend_call!(meta, list_proxies).proxies;
-    let namespaces = backend_call!(meta, list_namespaces).namespaces;
-    let tables = backend_call!(meta, list_tables).tables;
-    let proxy_groups = backend_call!(meta, list_proxy_groups).groups;
+    // Counts only: these three are reported by number and by state, never
+    // itemised, so they are counted in place rather than cloned out first.
+    let tallies = backend_call!(meta, resource_tallies);
     let reserved = backend_call!(meta, reserved_names).reserved;
     let scheduler_snapshot = scheduler.snapshot();
     let scheduler_executions = scheduler.executions();
@@ -1762,12 +1762,12 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
     out.push_str("# HELP temporalstore_meta_inventory Current metaserver inventory counts.\n");
     out.push_str("# TYPE temporalstore_meta_inventory gauge\n");
     for (kind, value) in [
-        ("namespace", namespaces.len() as u64),
-        ("table", tables.len() as u64),
+        ("namespace", tallies.namespaces.total()),
+        ("table", tallies.tables.total()),
         ("server", servers.len() as u64),
         ("proxy", proxies.len() as u64),
         ("shard", stats.shard_count as u64),
-        ("proxy_group", proxy_groups.len() as u64),
+        ("proxy_group", tallies.proxy_groups.total()),
         ("reserved_namespace", reserved.namespaces.len() as u64),
         ("reserved_table", reserved.tables.len() as u64),
     ] {
@@ -1806,10 +1806,7 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "table"), ("state", state)],
-            tables
-                .iter()
-                .filter(|table| table.state.as_str() == state)
-                .count() as u64,
+            tallies.tables.in_state(state),
         );
         // A namespace has had a state since it became something an operator can
         // freeze and drop; nothing reported it.
@@ -1817,19 +1814,13 @@ fn metaserver_prometheus_metrics(meta: &MetaBackend, scheduler: &MetaTaskSchedul
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "namespace"), ("state", state)],
-            namespaces
-                .iter()
-                .filter(|namespace| namespace.state.as_str() == state)
-                .count() as u64,
+            tallies.namespaces.in_state(state),
         );
         push_meta_metric(
             &mut out,
             "temporalstore_meta_resource_state",
             &[("resource", "proxy_group"), ("state", state)],
-            proxy_groups
-                .iter()
-                .filter(|group| group.state.as_str() == state)
-                .count() as u64,
+            tallies.proxy_groups.in_state(state),
         );
     }
     // The size of what each node is holding, which every heartbeat has carried

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -774,6 +774,56 @@ pub struct TableServingOptionsPatch {
     pub connect_timeout_ms: Option<u64>,
 }
 
+/// How many resources there are, and how many are in each state.
+///
+/// A scrape reports exactly this about tables, namespaces and proxy groups and
+/// nothing else, but it was cloning every one of them -- names and serving
+/// options included -- to call `.len()` and filter on the state field.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StateTally {
+    pub normal: u64,
+    pub frozen: u64,
+    pub dropped: u64,
+}
+
+impl StateTally {
+    fn record(&mut self, state: MetaEntityState) {
+        match state {
+            MetaEntityState::Normal => self.normal += 1,
+            MetaEntityState::Frozen => self.frozen += 1,
+            MetaEntityState::Dropped => self.dropped += 1,
+        }
+    }
+
+    /// Every resource counted, whatever state it is in.
+    ///
+    /// The three states are the whole of `MetaEntityState`, so this is the
+    /// count the listing's `.len()` used to give.
+    pub fn total(&self) -> u64 {
+        self.normal + self.frozen + self.dropped
+    }
+
+    /// How many are in the state of this name, named as
+    /// [`MetaEntityState::as_str`] names it.
+    pub fn in_state(&self, state: &str) -> u64 {
+        match state {
+            "normal" => self.normal,
+            "frozen" => self.frozen,
+            "dropped" => self.dropped,
+            _ => 0,
+        }
+    }
+}
+
+/// The counts a scrape needs, taken in one pass under the read lock.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceTalliesResponse {
+    pub status: Status,
+    pub tables: StateTally,
+    pub namespaces: StateTally,
+    pub proxy_groups: StateTally,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GetTableTopologyRequest {
     pub namespace: String,
@@ -5174,7 +5224,142 @@ mod tests {
     }
 
     #[test]
-    fn namespace_state_survives_snapshot_and_replay() {
+fn counting_resources_agrees_with_listing_them_and_counting_those() {
+        let meta = SingleNodeMeta::default();
+
+        // Tables in all three states.
+        for table_name in ["kept", "frozen", "dropped"] {
+            assert!(meta
+                .add_table(AddTableRequest {
+                    namespace: "ns".to_string(),
+                    table_name: table_name.to_string(),
+                    first_shard_id: 1,
+                    shard_count: 1,
+                    replica_count: 1,
+                    partition_version: 1,
+                    serving_options: Default::default(),
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .freeze_table(DeleteTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "frozen".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .delete_table(DeleteTableRequest {
+                namespace: "ns".to_string(),
+                table_name: "dropped".to_string(),
+            })
+            .status
+            .ok);
+
+        // Namespaces in all three states.
+        for namespace in ["kept-ns", "frozen-ns", "dropped-ns"] {
+            assert!(meta
+                .add_namespace(AddNamespaceRequest {
+                    namespace: namespace.to_string(),
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .freeze_namespace(AddNamespaceRequest {
+                namespace: "frozen-ns".to_string(),
+            })
+            .status
+            .ok);
+        assert!(meta
+            .drop_namespace(AddNamespaceRequest {
+                namespace: "dropped-ns".to_string(),
+            })
+            .status
+            .ok);
+
+        // Proxy groups, one kept and one dropped.
+        for group in ["kept-group", "dropped-group"] {
+            assert!(meta
+                .put_proxy_group(PutProxyGroupRequest {
+                    group: group.to_string(),
+                    namespace: "ns".to_string(),
+                    location: String::new(),
+                    instance_num: 1,
+                    drop_percent: 0,
+                })
+                .status
+                .ok);
+        }
+        assert!(meta
+            .drop_proxy_group(DropProxyGroupRequest {
+                group: "dropped-group".to_string(),
+            })
+            .status
+            .ok);
+
+        let tallies = meta.resource_tallies();
+        assert!(tallies.status.ok);
+
+        // Counted against listing them and counting those, which is what the
+        // scrape did before -- for every state, and for the total.
+        let tables = meta.list_tables().tables;
+        let namespaces = meta.list_namespaces().namespaces;
+        let proxy_groups = meta.list_proxy_groups().groups;
+        assert_eq!(tallies.tables.total(), tables.len() as u64, "table total");
+        assert_eq!(
+            tallies.namespaces.total(),
+            namespaces.len() as u64,
+            "namespace total"
+        );
+        assert_eq!(
+            tallies.proxy_groups.total(),
+            proxy_groups.len() as u64,
+            "proxy group total"
+        );
+        for state in ["normal", "frozen", "dropped"] {
+            assert_eq!(
+                tallies.tables.in_state(state),
+                tables
+                    .iter()
+                    .filter(|table| table.state.as_str() == state)
+                    .count() as u64,
+                "tables in state {state}"
+            );
+            assert_eq!(
+                tallies.namespaces.in_state(state),
+                namespaces
+                    .iter()
+                    .filter(|namespace| namespace.state.as_str() == state)
+                    .count() as u64,
+                "namespaces in state {state}"
+            );
+            assert_eq!(
+                tallies.proxy_groups.in_state(state),
+                proxy_groups
+                    .iter()
+                    .filter(|group| group.state.as_str() == state)
+                    .count() as u64,
+                "proxy groups in state {state}"
+            );
+        }
+
+        // And the states are actually spread, so the agreement above is not
+        // every count being equal to zero.
+        assert_eq!(tallies.tables.normal, 1);
+        assert_eq!(tallies.tables.frozen, 1);
+        assert_eq!(tallies.tables.dropped, 1);
+        assert_eq!(tallies.namespaces.frozen, 1);
+        assert_eq!(tallies.namespaces.dropped, 1);
+
+        // A name nothing uses counts as nothing, rather than falling into one
+        // of the three.
+        assert_eq!(tallies.tables.in_state("loading"), 0);
+    }
+
+    #[test]
+        fn namespace_state_survives_snapshot_and_replay() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("namespace-mutations.jsonl");
         {

--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -815,13 +815,43 @@ impl StateTally {
     }
 }
 
-/// The counts a scrape needs, taken in one pass under the read lock.
+/// One server, reduced to what a scrape reports about it.
+///
+/// A server record carries its shard loads, its stat loads and its shard
+/// serving states -- one entry per shard it holds, and the serving states carry
+/// strings. A scrape reads none of them, so none of them are here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerScrapeRow {
+    pub server_addr: String,
+    pub state: MetaEntityState,
+    pub reported_record_count: u64,
+    pub reported_storage_bytes: u64,
+    pub last_meta_topology_version: u64,
+    pub rejected_total: u64,
+    pub timed_out_total: u64,
+    pub canceled_total: u64,
+}
+
+/// One proxy, reduced the same way.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProxyScrapeRow {
+    pub proxy_addr: String,
+    pub state: MetaEntityState,
+    pub restart_count: u64,
+}
+
+/// Everything a scrape needs, taken in one pass under one read lock.
+///
+/// The scrape used to make five separate listing calls, each taking the lock
+/// again, so its numbers described five consecutive moments rather than one.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ResourceTalliesResponse {
+pub struct MetaMetricsReport {
     pub status: Status,
     pub tables: StateTally,
     pub namespaces: StateTally,
     pub proxy_groups: StateTally,
+    pub servers: Vec<ServerScrapeRow>,
+    pub proxies: Vec<ProxyScrapeRow>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -5227,6 +5257,55 @@ mod tests {
 fn counting_resources_agrees_with_listing_them_and_counting_those() {
         let meta = SingleNodeMeta::default();
 
+        // A server that has heartbeated, so its row has something in it, and a
+        // frozen one so the states are spread.
+        for node in 0..2u64 {
+            assert!(meta
+                .register_server(RegisterServerRequest {
+                    numa_nodes: Vec::new(),
+                    server_addr: format!("node-{node}"),
+                    node_id: node + 1,
+                    location: "rack-1".to_string(),
+                    binary_version: "v1".to_string(),
+                })
+                .status
+                .ok);
+            meta.server_heartbeat(ServerHeartbeatRequest {
+                server_addr: format!("node-{node}"),
+                boot_time_ms: 1,
+                binary_version: "v1".to_string(),
+                shard_loads: vec![ShardLoad {
+                    shard_id: node + 1,
+                    key_count: 7 + node,
+                    memory_bytes: 4096,
+                }],
+                shard_stat_loads: Vec::new(),
+                runtime_load: ServerRuntimeLoad {
+                    rejected_total: 3 + node,
+                    timed_out_total: 1,
+                    canceled_total: 2,
+                    last_meta_topology_version: 9,
+                    ..Default::default()
+                },
+                // The record and storage counters a scrape reports are summed
+                // from these, not from the loads above.
+                shard_states: vec![ServerShardServingState {
+                    shard_id: node + 1,
+                    total_records: 11 + node as usize,
+                    storage_bytes: 2048,
+                    ..Default::default()
+                }],
+            });
+        }
+        assert!(meta
+            .freeze_server(StateChangeRequest {
+                endpoint: "node-1".to_string(),
+                freeze_cooldown_ms: 0,
+                reason: FreezeReason::Unresponsive,
+            })
+            .status
+            .ok);
+
         // Tables in all three states.
         for table_name in ["kept", "frozen", "dropped"] {
             assert!(meta
@@ -5299,7 +5378,7 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
             .status
             .ok);
 
-        let tallies = meta.resource_tallies();
+        let tallies = meta.metrics_report();
         assert!(tallies.status.ok);
 
         // Counted against listing them and counting those, which is what the
@@ -5356,6 +5435,73 @@ fn counting_resources_agrees_with_listing_them_and_counting_those() {
         // A name nothing uses counts as nothing, rather than falling into one
         // of the three.
         assert_eq!(tallies.tables.in_state("loading"), 0);
+
+        // The server and proxy rows carry what the scrape reports, for every
+        // server and proxy there is, and they agree with the full records.
+        let full_servers = meta.list_servers().servers;
+        let full_proxies = meta.list_proxies().proxies;
+        assert_eq!(tallies.servers.len(), full_servers.len(), "a server is missing");
+        assert_eq!(tallies.proxies.len(), full_proxies.len(), "a proxy is missing");
+        for full in &full_servers {
+            let row = tallies
+                .servers
+                .iter()
+                .find(|row| row.server_addr == full.server_addr)
+                .unwrap_or_else(|| panic!("{} has no row", full.server_addr));
+            assert_eq!(row.state, full.state, "{} state", full.server_addr);
+            assert_eq!(
+                row.reported_record_count, full.reported_record_count,
+                "{} record count",
+                full.server_addr
+            );
+            assert_eq!(
+                row.reported_storage_bytes, full.reported_storage_bytes,
+                "{} storage bytes",
+                full.server_addr
+            );
+            assert_eq!(
+                row.last_meta_topology_version, full.runtime_load.last_meta_topology_version,
+                "{} topology version",
+                full.server_addr
+            );
+            assert_eq!(
+                row.rejected_total, full.runtime_load.rejected_total,
+                "{} rejected",
+                full.server_addr
+            );
+            assert_eq!(
+                row.timed_out_total, full.runtime_load.timed_out_total,
+                "{} timed out",
+                full.server_addr
+            );
+            assert_eq!(
+                row.canceled_total, full.runtime_load.canceled_total,
+                "{} canceled",
+                full.server_addr
+            );
+        }
+        for full in &full_proxies {
+            let row = tallies
+                .proxies
+                .iter()
+                .find(|row| row.proxy_addr == full.proxy_addr)
+                .unwrap_or_else(|| panic!("{} has no row", full.proxy_addr));
+            assert_eq!(row.state, full.state, "{} state", full.proxy_addr);
+            assert_eq!(
+                row.restart_count, full.restart_count,
+                "{} restart count",
+                full.proxy_addr
+            );
+        }
+        // The counters are not all zero, so the agreement above means
+        // something.
+        assert!(
+            tallies
+                .servers
+                .iter()
+                .any(|row| row.reported_record_count > 0),
+            "no server reported a record count, so the row check proves nothing"
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -101,29 +101,53 @@ impl SingleNodeMeta {
         stats_from_state(&state, &self.counters)
     }
 
-    /// Count the tables, namespaces and proxy groups by state.
+    /// Everything a metrics scrape reports, in one pass under one read lock.
     ///
-    /// A scrape wants these counts and nothing else about those resources, and
-    /// listing them to count them meant cloning every one: 648.5us for 4096
-    /// tables and 292.3us for their namespaces, out of a 1093.3us scrape.
-    pub fn resource_tallies(&self) -> ResourceTalliesResponse {
+    /// The scrape reports tables, namespaces and proxy groups by count alone,
+    /// and servers and proxies by a handful of fields each. Getting there by
+    /// listing all five cloned every resource whole -- including each server's
+    /// per-shard loads and serving states, which the scrape never reads. On
+    /// 4096 tables that was 940us of a 1093us scrape; on 32 servers holding
+    /// 1000 shards each it was most of 6.1ms.
+    pub fn metrics_report(&self) -> MetaMetricsReport {
         let state = self.inner.read().expect("meta lock poisoned");
-        let mut tallies = ResourceTalliesResponse {
+        let mut report = MetaMetricsReport {
             status: Status::ok(),
             tables: StateTally::default(),
             namespaces: StateTally::default(),
             proxy_groups: StateTally::default(),
+            servers: Vec::with_capacity(state.servers.len()),
+            proxies: Vec::with_capacity(state.proxies.len()),
         };
         for table in state.tables.values() {
-            tallies.tables.record(table.info.state);
+            report.tables.record(table.info.state);
         }
         for namespace_state in state.namespaces.values() {
-            tallies.namespaces.record(*namespace_state);
+            report.namespaces.record(*namespace_state);
         }
         for group in state.proxy_groups.values() {
-            tallies.proxy_groups.record(group.state);
+            report.proxy_groups.record(group.state);
         }
-        tallies
+        for server in state.servers.values() {
+            report.servers.push(ServerScrapeRow {
+                server_addr: server.server_addr.clone(),
+                state: server.state,
+                reported_record_count: server.reported_record_count,
+                reported_storage_bytes: server.reported_storage_bytes,
+                last_meta_topology_version: server.runtime_load.last_meta_topology_version,
+                rejected_total: server.runtime_load.rejected_total,
+                timed_out_total: server.runtime_load.timed_out_total,
+                canceled_total: server.runtime_load.canceled_total,
+            });
+        }
+        for proxy in state.proxies.values() {
+            report.proxies.push(ProxyScrapeRow {
+                proxy_addr: proxy.proxy_addr.clone(),
+                state: proxy.state,
+                restart_count: proxy.restart_count,
+            });
+        }
+        report
     }
 
     pub fn preflight_report(&self) -> MetaPreflightReport {

--- a/crates/temporalstore-rust/src/meta/node_reports.rs
+++ b/crates/temporalstore-rust/src/meta/node_reports.rs
@@ -101,6 +101,31 @@ impl SingleNodeMeta {
         stats_from_state(&state, &self.counters)
     }
 
+    /// Count the tables, namespaces and proxy groups by state.
+    ///
+    /// A scrape wants these counts and nothing else about those resources, and
+    /// listing them to count them meant cloning every one: 648.5us for 4096
+    /// tables and 292.3us for their namespaces, out of a 1093.3us scrape.
+    pub fn resource_tallies(&self) -> ResourceTalliesResponse {
+        let state = self.inner.read().expect("meta lock poisoned");
+        let mut tallies = ResourceTalliesResponse {
+            status: Status::ok(),
+            tables: StateTally::default(),
+            namespaces: StateTally::default(),
+            proxy_groups: StateTally::default(),
+        };
+        for table in state.tables.values() {
+            tallies.tables.record(table.info.state);
+        }
+        for namespace_state in state.namespaces.values() {
+            tallies.namespaces.record(*namespace_state);
+        }
+        for group in state.proxy_groups.values() {
+            tallies.proxy_groups.record(group.state);
+        }
+        tallies
+    }
+
     pub fn preflight_report(&self) -> MetaPreflightReport {
         let state = self.inner.read().expect("meta lock poisoned");
         let normal_servers = state

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -25,6 +25,7 @@ use crate::http::{
 use crate::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, DeleteTableRequest, GetShardResponse,
     GetTableTopologyRequest, ListNamespacesResponse, ListProxiesResponse, ListServersResponse,
+    ResourceTalliesResponse, StateTally,
     ListShardsResponse,
     ListTablesResponse, LoadFinishRequest, MetaEntityState, MetaInfo, MetaMutation,
     MetaPreflightReport, MetaSnapshot, MetaStats, ProxyHeartbeatRequest, ProxyHeartbeatResponse,

--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -25,7 +25,7 @@ use crate::http::{
 use crate::meta::{
     AckResponse, AddNamespaceRequest, AddTableRequest, DeleteTableRequest, GetShardResponse,
     GetTableTopologyRequest, ListNamespacesResponse, ListProxiesResponse, ListServersResponse,
-    ResourceTalliesResponse, StateTally,
+    MetaMetricsReport, StateTally,
     ListShardsResponse,
     ListTablesResponse, LoadFinishRequest, MetaEntityState, MetaInfo, MetaMutation,
     MetaPreflightReport, MetaSnapshot, MetaStats, ProxyHeartbeatRequest, ProxyHeartbeatResponse,

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -502,6 +502,18 @@ impl MetaRaftCluster {
         )
     }
 
+    pub fn resource_tallies(&self) -> ResourceTalliesResponse {
+        self.read_meta().map_or_else(
+            |status| ResourceTalliesResponse {
+                status,
+                tables: StateTally::default(),
+                namespaces: StateTally::default(),
+                proxy_groups: StateTally::default(),
+            },
+            |meta| meta.resource_tallies(),
+        )
+    }
+
     pub fn list_namespaces(&self) -> ListNamespacesResponse {
         self.read_meta().map_or_else(
             |status| ListNamespacesResponse {

--- a/crates/temporalstore-rust/src/raft/cluster_meta.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_meta.rs
@@ -502,15 +502,17 @@ impl MetaRaftCluster {
         )
     }
 
-    pub fn resource_tallies(&self) -> ResourceTalliesResponse {
+    pub fn metrics_report(&self) -> MetaMetricsReport {
         self.read_meta().map_or_else(
-            |status| ResourceTalliesResponse {
+            |status| MetaMetricsReport {
                 status,
                 tables: StateTally::default(),
                 namespaces: StateTally::default(),
                 proxy_groups: StateTally::default(),
+                servers: Vec::new(),
+                proxies: Vec::new(),
             },
-            |meta| meta.resource_tallies(),
+            |meta| meta.metrics_report(),
         )
     }
 


### PR DESCRIPTION
A metrics scrape reports five kinds of resource. Tables, namespaces and proxy groups it reports only by number and by state. Servers and proxies it reports one by one, but by a handful of fields each.

It got all of that by listing every resource in full: cloning each table with its name and serving options, and each server with its shard loads, its stat loads and its shard serving states -- one entry per shard the node holds, with strings inside. Then it counted them, or read three fields off them.

So the scrape cost what the cluster was holding.

| | before | after |
|---|---|---|
| 4096 tables | 1093.3us | 18.4us |
| 8 servers, 250 shards each | 256.1us | 11.6us |
| 32 servers, 250 shards each | 1026.0us | 29.8us |
| 32 servers, 1000 shards each | 4714.8us | 30.4us |

It is now close to flat in the size of the cluster, which matters because it runs on a timer.

## One pass, one lock

The scrape made five separate listing calls, each taking the read lock again, so its numbers described five consecutive moments. It now takes one report under one acquisition.

## What is still reported per resource

Servers and proxies, one by one, exactly as before. Only the fields nothing reads are gone: the per-shard loads, stat loads and serving states, and the numa nodes.

The three states are the whole of `MetaEntityState`, so a tally's total is the count the listing's `.len()` used to give. A state name that is not one of the three counts as none, which is what filtering for it used to produce.

## Verification

The entire scrape was generated for a cluster with four servers that have heartbeated with shard loads and serving states, three proxies, twelve tables, two proxy groups, and resources in all three states -- before and after. 136 lines, 27 of them naming a server or a proxy, identical.

The equivalence test checks every tally against listing that resource and counting it, and every server and proxy row against the full record field by field.

It is guarded by a check that some server actually reported a non-zero count. That guard caught the first version of this test, where the records were being reported through the wrong field and every counter was zero -- the test would otherwise have passed by comparing zeros.

Both behaviours were also checked against mutations: counting frozen resources as normal, and forcing the counts to be taken the old way. Each fails.

Measurements were taken with the arms interleaved and the changed arm run twice.

## Relationship to the namespace listing

This removes the scrape's call to `list_namespaces` entirely. That listing counts each namespace's tables, which is fixed separately in #523 -- still worth having, because the `/namespaces` route does read those counts. The scrape never did.

Suites: 327 metadata tests, 47 metaserver binary tests, 246 consensus tests, and `cargo check --all-targets` clean.
