### PR TITLE
The failover and conviction planners copied out every shard a node holds

### DIFF
--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -485,6 +485,40 @@ impl Default for MetaFailureDetector {
     }
 }
 
+/// A server as the conviction planner sees it.
+///
+/// The planner judges whether a node has gone quiet: it reads the address, the
+/// state, the location it sits in, when it last heartbeated, whether it has
+/// been seen restarting, and which shards it is serving.
+///
+/// The serving shards are reduced to a set of ids here, which is all the
+/// planner ever wanted -- it used to be handed every shard serving state, each
+/// carrying its serving state, table name and uri as strings, and reduce them
+/// itself. On 32 nodes holding 1000 shards each, copying those out first cost
+/// 5.6ms a tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedLiveness {
+    pub server_addr: String,
+    pub state: MetaEntityState,
+    pub location: String,
+    pub last_heartbeat_ms: u64,
+    pub reboot_detected: bool,
+    pub serving_shards: BTreeSet<ShardId>,
+}
+
+impl ObservedLiveness {
+    pub fn of(server: &ServerMetaInfo) -> Self {
+        Self {
+            server_addr: server.server_addr.clone(),
+            state: server.state,
+            location: server.location.clone(),
+            last_heartbeat_ms: server.last_heartbeat_ms,
+            reboot_detected: server.reboot_detected,
+            serving_shards: super::shard_check::serving_shards(server),
+        }
+    }
+}
+
 impl MetaFailureDetector {
     pub fn new(options: FailureDetectorOptions) -> Self {
         Self {
@@ -592,7 +626,7 @@ impl MetaFailureDetector {
     /// metaserver should freeze.
     pub fn plan_round(
         &mut self,
-        servers: &[ServerMetaInfo],
+        servers: &[ObservedLiveness],
         now_ms: u64,
         policy: ConvictionPolicy,
     ) -> ConvictionPlan {
@@ -603,9 +637,8 @@ impl MetaFailureDetector {
                 location: server.location.as_str(),
                 state: server.state,
                 last_heartbeat_ms: server.last_heartbeat_ms,
-                serving_shards: super::shard_check::serving_shards(server)
-                    .into_iter()
-                    .collect(),
+                // Already reduced to ids when the view was taken.
+                serving_shards: server.serving_shards.iter().copied().collect(),
                 // Not gated on the detector being active: a changed boot time is
                 // direct evidence the process restarted, not an inference drawn
                 // from silence, so the stall guard does not apply to it.
@@ -757,7 +790,11 @@ impl SingleNodeMeta {
         let now = now_ms();
         let servers = {
             let state = self.inner.read().expect("meta lock poisoned");
-            state.servers.values().cloned().collect::<Vec<_>>()
+            state
+                .servers
+                .values()
+                .map(ObservedLiveness::of)
+                .collect::<Vec<_>>()
         };
         let plan = detector.plan_round(&servers, now, policy);
         let detector_paused = !detector.is_active(now);
@@ -932,7 +969,21 @@ mod tests {
         }
     }
 
-    fn server(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ServerMetaInfo {
+    fn server(
+        addr: &str,
+        location: &str,
+        state: MetaEntityState,
+        heartbeat_ms: u64,
+    ) -> ObservedLiveness {
+        ObservedLiveness::of(&server_record(addr, location, state, heartbeat_ms))
+    }
+
+    fn server_record(
+        addr: &str,
+        location: &str,
+        state: MetaEntityState,
+        heartbeat_ms: u64,
+    ) -> ServerMetaInfo {
         ServerMetaInfo {
             reported_record_count: 0,
             reported_storage_bytes: 0,
@@ -1495,7 +1546,10 @@ mod tests {
         let policy = orphan_policy(true);
         let mut now = 10_000;
         let with_shard = |addr: &str, heartbeat: u64| {
-            let mut server = server(addr, "rack-1", MetaEntityState::Normal, heartbeat);
+            // Built as a full record and then observed, so this still proves the
+            // serving set is read out of the reported shard states -- that step
+            // now happens when the view is taken rather than inside the planner.
+            let mut server = server_record(addr, "rack-1", MetaEntityState::Normal, heartbeat);
             server.shard_states = vec![ServerShardServingState {
                 shard_id: 1,
                 serving_state: "serving".to_string(),
@@ -1517,7 +1571,7 @@ mod tests {
                 dirty_object_count: 0,
                 dirty_bucket_count: 0,
             }];
-            server
+            ObservedLiveness::of(&server)
         };
         for _ in 0..40 {
             detector.plan_round(&[with_shard("a", now)], now, policy);

--- a/crates/temporalstore-rust/src/meta/raft_failover.rs
+++ b/crates/temporalstore-rust/src/meta/raft_failover.rs
@@ -46,7 +46,30 @@ pub struct RaftFailoverTrigger {
 /// live (Normal) servers to notify. Deterministic — triggers ordered by dead
 /// node id then address; targets ordered by address. Returns an empty plan when
 /// there are no frozen servers or no live targets (nothing safe to drive).
-pub fn compute_raft_failover_triggers(servers: &[ServerMetaInfo]) -> Vec<RaftFailoverTrigger> {
+/// A server as the failover planner sees it.
+///
+/// The planner needs to know which node is which and whether it is serving. A
+/// server record also carries one shard load and one serving state per shard
+/// the node holds, and cloning those to read three fields cost 4.7ms a tick on
+/// 32 nodes holding 1000 shards each.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailoverMember {
+    pub server_addr: String,
+    pub node_id: u64,
+    pub state: MetaEntityState,
+}
+
+impl FailoverMember {
+    pub fn of(server: &ServerMetaInfo) -> Self {
+        Self {
+            server_addr: server.server_addr.clone(),
+            node_id: server.node_id,
+            state: server.state,
+        }
+    }
+}
+
+pub fn compute_raft_failover_triggers(servers: &[FailoverMember]) -> Vec<RaftFailoverTrigger> {
     let mut live_targets: Vec<String> = servers
         .iter()
         .filter(|server| server.state == MetaEntityState::Normal)
@@ -60,7 +83,7 @@ pub fn compute_raft_failover_triggers(servers: &[ServerMetaInfo]) -> Vec<RaftFai
         return Vec::new();
     }
 
-    let mut dead: Vec<&ServerMetaInfo> = servers
+    let mut dead: Vec<&FailoverMember> = servers
         .iter()
         .filter(|server| server.state == MetaEntityState::Frozen)
         .collect();
@@ -85,7 +108,11 @@ impl SingleNodeMeta {
     /// re-elect. Pure read of the shared meta state.
     pub fn plan_raft_failover(&self) -> Vec<RaftFailoverTrigger> {
         let state = self.inner.read().expect("meta lock poisoned");
-        let servers = state.servers.values().cloned().collect::<Vec<_>>();
+        let servers = state
+            .servers
+            .values()
+            .map(FailoverMember::of)
+            .collect::<Vec<_>>();
         compute_raft_failover_triggers(&servers)
     }
 }
@@ -94,7 +121,11 @@ impl SingleNodeMeta {
 mod tests {
     use super::*;
 
-    fn server(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
+    fn server(addr: &str, node_id: u64, state: MetaEntityState) -> FailoverMember {
+        FailoverMember::of(&server_record(addr, node_id, state))
+    }
+
+    fn server_record(addr: &str, node_id: u64, state: MetaEntityState) -> ServerMetaInfo {
         ServerMetaInfo {
             reported_record_count: 0,
             reported_storage_bytes: 0,


### PR DESCRIPTION
Both planners run on a timer when enabled, and both began by cloning every server.

A server record carries one shard load, one stat load and one shard serving state per shard the node holds, and the serving states carry three strings each. The failover planner reads an address, a node id and a state. The conviction planner reads those, plus a location, a heartbeat time, a reboot flag, and which shards the node is serving.

| 32 servers, shards each | failover before | after | conviction before | after |
|---|---|---|---|---|
| 250 | 1029.1us | 3.5us | 1223.3us | 228.6us |
| 1000 | 6131.5us | 2.8us | 9611.3us | 1224.6us |

Failover no longer depends on what the nodes are holding at all.

## Conviction still grows with the shards, and should

It needs the set of shards a node is serving, and that set comes from the reported states. What changed is where the reduction happens: the serving states become a set of shard ids when the view is taken, rather than being copied out whole and reduced afterwards.

7.4x cheaper, still proportional to the shards. That is honest for what it computes -- it is not flat and this does not claim it is.

## Separate views on purpose

Each planner has its own view rather than a shared one. They read different things, and a shared view would hand each of them something it does not use, which is the thing being fixed.

## Testing

`plan_round_reads_the_serving_set_from_the_heartbeat` still builds a full server record with reported shard states on it and goes through the view, so it still proves the planner's serving set comes from what the datanode reported. That step simply moved to where the view is taken.

The test helpers in both modules now hand back the view, so every existing call site and every existing assertion is unchanged.

Suites: 39 failure-detector tests, 6 failover tests, 326 metadata tests, 47 metaserver binary tests, and `cargo check --all-targets` clean.

Measurements were taken with the arms interleaved and the changed arm run twice.

## Note on when this runs

Both paths are opt-in -- `TS_RAFT_AUTO_FAILOVER` and `TS_META_ADAPTIVE_FAILURE_DETECTOR` both default to off. This costs nothing to a deployment that leaves them off, and removes a per-tick cost proportional to the whole cluster's holdings from one that turns them on.
