### PR TITLE
The tenant policy registry existed twice, and half the writes went to the wrong one

### DIFF
--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -515,3 +515,20 @@ def describe_effective_policy(scope: Any = None) -> Json:
             source = "default"
         out["knobs"][name] = {"value": resolve(name, scope), "source": source, "env": knob.env}
     return out
+
+
+# One registry, whichever name imported this module first.
+#
+# This file is reachable as ``matrixark_tenant_policy`` (running from tools/) and as
+# ``tools.matrixark_tenant_policy`` (imported as part of the package). Python treats those as two
+# modules and gives each its own ``_RECORD_POLICIES`` and ``_FILE_CACHE``, so a policy set through
+# one name is invisible to a reader that arrived through the other -- the cap silently does not
+# apply, and nothing says so.
+#
+# Aliasing both names to the module object that loaded first means there is one registry however
+# it was reached. ``setdefault`` so the first loader wins and a second import finds it rather than
+# re-executing this file.
+import sys as _sys
+
+_sys.modules.setdefault("matrixark_tenant_policy", _sys.modules[__name__])
+_sys.modules.setdefault("tools.matrixark_tenant_policy", _sys.modules[__name__])


### PR DESCRIPTION
The python suite check has been failing on **every** open pull request, reporting the same two tests as new failures:

```
NEW failures (2):
   test_a_busy_tenant_cannot_evict_a_quiet_tenants_index
   test_each_tenant_is_capped_by_its_own_policy
```

They are not flaky and they are not any branch's fault. They fail deterministically on main.

## What is actually wrong

`tools/matrixark_tenant_policy.py` is reachable under two names: `matrixark_tenant_policy` when something runs from `tools/`, and `tools.matrixark_tenant_policy` when it is imported as part of the package. Python treats those as two modules and gives each its own `_RECORD_POLICIES` and `_FILE_CACHE`.

So the registry splits. `matrixark_index_growth_bound` reaches the policy as `tools.matrixark_tenant_policy`; the per-tenant budget tests set policy on `matrixark_tenant_policy`. The cap is written to one registry and read from the other, so it simply does not apply -- and nothing reports that it did not.

That is why it looked like flakiness: both tests **pass** when that file is run on its own from `tools/`, because then only one of the two names is ever used. Running them as part of the suite is what splits it.

## The change

Alias both names to whichever module object loaded first, so there is one registry however it was reached. `setdefault`, so the first loader wins and a second import finds it rather than executing the file again.

## Verified

| | before | after |
|---|---|---|
| as a package module | FAILED (2) | OK |
| run directly from tools/ | OK | OK |

The one test still failing in that file, `test_two_tenants_one_store_get_different_storage`, is in the recorded baseline of 124 and is untouched by this. The two this fixes are **not** in the baseline, which is precisely why they fail the check.

## What this does not do

Nothing outside tests calls `register_tenant_policy_records`, and both copies read the same file and environment, so they agree on everything that is configured rather than set at runtime. This is not a live defect today. It becomes one the moment runtime registration is wired to anything.

## Worth knowing: it is not one module

Loading every test module the way the ratchet does, then asking `sys.modules` which base names map to two different objects: **92 modules load twice**, including `matrixark_mcp_core` (8 module-level state variables), `matrixark_v1_gateway` (14), `matrixark_mcp_local_adapter` (4).

This change fixes the one that is failing the check. Making all imports consistent, or aliasing centrally in `tools/__init__.py`, is a real refactor across 92 modules and a separate decision -- flagging it rather than doing it here.
