### PR TITLE
The rule keeping a silent proxy out of a group was never in force

### DIFF
--- a/crates/temporalstore-rust/src/meta.rs
+++ b/crates/temporalstore-rust/src/meta.rs
@@ -554,6 +554,14 @@ pub struct ProxyMetaInfo {
     pub state: MetaEntityState,
     pub config_version: u64,
     pub last_heartbeat_ms: u64,
+    /// How many heartbeats this proxy has sent since it registered.
+    ///
+    /// Separate from `last_heartbeat_ms` because registration stamps that clock, so it cannot
+    /// answer "has this proxy ever reported in" -- every registered proxy reads non-zero from
+    /// the moment it appears. The staleness checks want the timestamp; the question of whether
+    /// a proxy is capacity or merely a registration wants this.
+    #[serde(default)]
+    pub heartbeats_total: u64,
     #[serde(default)]
     pub frozen_since_ms: u64,
     #[serde(default)]
@@ -2152,6 +2160,65 @@ mod tests {
         assert_eq!(server.shard_states[0].serving_state, "serving");
         assert_eq!(server.shard_states[0].wal_sequence, 9);
         assert_eq!(meta.stats().server_heartbeat_total, 1);
+    }
+
+    #[test]
+    fn a_proxy_that_only_registered_is_not_treated_as_capacity() {
+        // `is_idle_candidate` is written to keep a proxy that has never reported in out of a
+        // group -- "a registration, not capacity". It tested `last_heartbeat_ms != 0`, and
+        // registration stamps that clock, so every registered proxy passed and the rule was
+        // never in force. A proxy that registered and died was attached to a group and counted
+        // as serving capacity until the failure detector caught up.
+        let meta = SingleNodeMeta::default();
+        assert!(
+            meta.register_proxy(RegisterProxyRequest {
+                proxy_addr: "silent".to_string(),
+                namespace: "ns".to_string(),
+                location: "zone-a".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok
+        );
+        assert!(
+            meta.put_proxy_group(PutProxyGroupRequest {
+                drop_percent: 0,
+                group: "front".to_string(),
+                namespace: "ns".to_string(),
+                location: String::new(),
+                instance_num: 1,
+            })
+            .status
+            .ok
+        );
+
+        // It has registered and nothing more, so it is not capacity yet.
+        let plan = meta.plan_proxy_calibration_now(ProxyCalibrationOptions::default());
+        assert!(
+            !plan.attach.iter().any(|item| item.proxy_addr == "silent"),
+            "a proxy that has only registered must not be attached, got {:?}",
+            plan.attach
+        );
+
+        // One heartbeat is the difference between a registration and capacity.
+        assert!(
+            meta.proxy_heartbeat(ProxyHeartbeatRequest {
+                boot_time_ms: 1,
+                proxy_addr: "silent".to_string(),
+                namespace: "ns".to_string(),
+                config_version: 1,
+                binary_version: "v1".to_string(),
+            })
+            .status
+            .ok
+        );
+        let plan = meta.plan_proxy_calibration_now(ProxyCalibrationOptions::default());
+        assert!(
+            plan.attach.iter().any(|item| item.proxy_addr == "silent"),
+            "once it has reported in it is capacity and the group should claim it, got {:?}",
+            plan.attach
+        );
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/meta/failure_detector.rs
+++ b/crates/temporalstore-rust/src/meta/failure_detector.rs
@@ -1173,6 +1173,7 @@ mod tests {
 
     fn proxy(addr: &str, location: &str, state: MetaEntityState, heartbeat_ms: u64) -> ProxyMetaInfo {
         ProxyMetaInfo {
+            heartbeats_total: 0,
             group: String::new(),
             freeze_reason: FreezeReason::Unspecified,
             proxy_addr: addr.to_string(),

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -172,7 +172,10 @@ pub struct ProxyCalibrationReport {
 fn is_idle_candidate(proxy: &ProxyMetaInfo) -> bool {
     proxy.state == MetaEntityState::Normal
         && proxy.group.is_empty()
-        && proxy.last_heartbeat_ms != 0
+        // Counted heartbeats, not the timestamp. Registration stamps `last_heartbeat_ms`, so
+        // testing it against zero asked a question every registered proxy answered the same
+        // way -- the rule this line exists to enforce was not in force.
+        && proxy.heartbeats_total != 0
 }
 
 /// Pure planner: bring every group to its declared capacity.
@@ -567,6 +570,9 @@ mod tests {
 
     fn proxy(addr: &str, location: &str, attached: &str) -> ProxyMetaInfo {
         ProxyMetaInfo {
+            // These helpers build proxies that HAVE reported in; the tests that want a silent
+            // one set this back to zero themselves.
+            heartbeats_total: 1,
             proxy_addr: addr.to_string(),
             namespace: String::new(),
             group: attached.to_string(),
@@ -738,8 +744,12 @@ mod tests {
 
     #[test]
     fn a_proxy_that_has_never_heartbeated_is_not_capacity() {
+        // The shape a registration actually has: a heartbeat TIMESTAMP, because registration
+        // stamps one, and no heartbeats counted. This test used to zero the timestamp instead,
+        // which no registered proxy ever does -- so it asserted the right rule against a state
+        // production cannot reach, and the guard it was checking passed everything through.
         let mut silent = proxy("p1", "rack-1", "");
-        silent.last_heartbeat_ms = 0;
+        silent.heartbeats_total = 0;
         let plan = plan_proxy_calibration(
             &[group("orders", "ns", "", 1)],
             &[silent],

--- a/crates/temporalstore-rust/src/meta/registration.rs
+++ b/crates/temporalstore-rust/src/meta/registration.rs
@@ -306,6 +306,7 @@ impl SingleNodeMeta {
         state.proxies.insert(
             request.proxy_addr.clone(),
             ProxyMetaInfo {
+                heartbeats_total: 0,
                 freeze_reason: FreezeReason::Unspecified,
                 group: String::new(),
                 proxy_addr: request.proxy_addr,
@@ -368,6 +369,7 @@ impl SingleNodeMeta {
             };
         }
         proxy.last_heartbeat_ms = now_ms();
+        proxy.heartbeats_total = proxy.heartbeats_total.saturating_add(1);
         // A changed boot time on an address we already know means the proxy restarted
         // in place. Heartbeats never stopped, so this is the only signal that its route
         // cache and config were reset underneath us.


### PR DESCRIPTION
`is_idle_candidate` refuses to hand a group a proxy that has not reported in, and says why:
"a proxy that has never heartbeated is a registration, not capacity". It tested
`last_heartbeat_ms != 0`. Registration stamps that clock, so every proxy the metaserver has ever
held reads non-zero from the moment it appears and the condition was true for all of them.

Everything around it looked right, which is why it lasted. The guard exists. The comment
explains the intent. A test named `a_proxy_that_has_never_heartbeated_is_not_capacity` asserts
it and passes. It passes because it sets `last_heartbeat_ms = 0` by hand -- a state no
registration produces -- so it exercised a path that existed only inside the test while
production sent everything through.

What that costs: a proxy that registers and then dies is attached to a group, counted toward its
instance target, and named to callers as serving capacity, until the failure detector gets
round to freezing it. The group meanwhile believes it is at strength and asks for nothing more.

So the two questions get two fields. `last_heartbeat_ms` goes on answering staleness, which is
what the detector wants and what it is good at. `heartbeats_total` answers whether the proxy has
ever reported at all: registration leaves it zero, the heartbeat path increments it, and the
guard reads that instead.

The old test now builds the shape a registration really has -- a timestamp, and no heartbeats --
rather than one it cannot have. The new test drives the planner through `register_proxy` and
`proxy_heartbeat` instead of asserting on the field, so the only way it can pass is if those two
genuinely differ to the guard. Watched failing with the old condition put back.

    meta 297, proxy 74 -- 0 failed


