### PR TITLE
ingestion stops being quadratic: 9604 index-rebuild visits per add become 3

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/ingest.rs
+++ b/crates/temporalstore-rust/src/context_workflow/ingest.rs
@@ -60,9 +60,11 @@ pub fn ingest_extract_context(
         }
     }
 
-    // Close the window BEFORE reconstructing: the reconstruct itself must not be deferred.
+    // No reconstruct: the writes above maintain the index themselves now, so the window has
+    // nothing to catch up on. It stays open across the ingest only to keep the per-record
+    // fallback rebuild from firing for a write maintenance does not cover -- and if one is not
+    // covered, the fallback runs at that write, not here.
     drop(reconstruct_window);
-    engine.reconstruct_bucket_index_now(request.shard_id);
 
     node_hashes.sort_unstable();
     node_hashes.dedup();

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -43,6 +43,8 @@ pub(crate) mod eviction_sampler;
 // as reads -> lifecycle-write-barrier bypass + missing dump scheduling).
 pub(crate) use command_validation::{command_object_keys, is_write_command};
 pub(crate) use storage_manager_cycle::cross_shard_reclaim_guard_enabled;
+#[cfg(test)]
+pub(crate) use storage_bucket_internals::uncovered_maintenance;
 mod storage_bucket_internals;
 pub use storage_bucket_internals::{
     bucket_page_index_visits, bucket_visit_sites, layout_by_caller, live_page_scan_entries,

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1044,6 +1044,39 @@ pub(super) fn shard_has_model_entries(shard: &ShardState) -> bool {
 ///
 /// Returns whether anything was synced, so the caller can fall back to a rebuild for a write this
 /// does not cover rather than silently leaving the index stale.
+/// Keys `sync_context_pages_for_object` found nothing for, recorded so they can be named.
+///
+/// One uncovered key forces a rebuild for the whole write, so what matters is WHICH keys are
+/// uncovered, not how many. Reading the command list to guess at them has already been wrong more
+/// than once in this area.
+#[cfg(test)]
+pub mod uncovered_maintenance {
+    use std::collections::BTreeSet;
+    use std::sync::Mutex;
+
+    pub(super) static UNCOVERED_MAINTENANCE_KEYS: Mutex<Option<BTreeSet<String>>> =
+        Mutex::new(None);
+
+    pub(super) fn note(object_key: &str) {
+        let mut guard = UNCOVERED_MAINTENANCE_KEYS.lock().expect("uncovered key tally poisoned");
+        guard.get_or_insert_with(BTreeSet::new).insert(object_key.to_string());
+    }
+
+    pub fn reset() {
+        *UNCOVERED_MAINTENANCE_KEYS.lock().expect("uncovered key tally poisoned") =
+            Some(BTreeSet::new());
+    }
+
+    pub fn snapshot() -> Vec<String> {
+        UNCOVERED_MAINTENANCE_KEYS
+            .lock()
+            .expect("uncovered key tally poisoned")
+            .as_ref()
+            .map(|set| set.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
 pub(super) fn sync_context_pages_for_object(
     shard: &mut ShardState,
     shard_id: ShardId,
@@ -1082,7 +1115,38 @@ pub(super) fn sync_context_pages_for_object(
         }
     }
 
-    if groups.is_empty() {
+    // A context node's page lives in `shard.hashes` under a single field, so the rebuild derives
+    // it as kind "hash" with that field as the component -- a different shape from the kinds
+    // above, which carry no component. It is filed here the same way the rebuild would file it.
+    let hash_fields: Vec<(String, BlockAddress)> = shard
+        .hashes
+        .get(object_key)
+        .map(|fields| {
+            fields
+                .iter()
+                .map(|(field, address)| (field.clone(), address.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let had_hash_pages = !hash_fields.is_empty();
+    for (field, address) in hash_fields {
+        // `stage: false` -- the write staged its own outcome under its own kind already, and a
+        // second one would have replay install the same page twice.
+        upsert_bucket_index_page_with(
+            shard,
+            shard_id,
+            "hash",
+            object_key,
+            Some(field),
+            address,
+            true,
+            false,
+        );
+    }
+
+    if groups.is_empty() && !had_hash_pages {
+        #[cfg(test)]
+        uncovered_maintenance::note(object_key);
         return false;
     }
     for (kind, key, live) in groups {
@@ -1258,6 +1322,29 @@ pub(super) fn upsert_bucket_index_page(
     address: BlockAddress,
     dirty: bool,
 ) {
+    upsert_bucket_index_page_with(shard, shard_id, kind, object_key, component, address, dirty, true)
+}
+
+/// The same, with a say over whether an outcome is staged for the record.
+///
+/// A page write produces an outcome, and this is where that outcome is produced -- so a caller
+/// that WRITES a page wants `stage: true`, which is every existing caller.
+///
+/// Maintenance is different: the context write has already staged its own outcome, under its own
+/// kind. Registering the page it produced must not put a SECOND outcome in the log, because replay
+/// would then install the same page twice under two kinds. `stage: false` says "file this page in
+/// the index; the record already knows about it".
+#[allow(clippy::too_many_arguments)]
+pub(super) fn upsert_bucket_index_page_with(
+    shard: &mut ShardState,
+    shard_id: ShardId,
+    kind: &str,
+    object_key: &str,
+    component: Option<String>,
+    address: BlockAddress,
+    dirty: bool,
+    stage: bool,
+) {
     let routing_bucket = address
         .routing_bucket
         .unwrap_or_else(|| page_routing_bucket(object_key, 0, u32::MAX));
@@ -1267,7 +1354,7 @@ pub(super) fn upsert_bucket_index_page(
     // This IS the outcome: an object, its identity, and where its page ended up. Put it aside
     // for the record, so replay has the option of installing it instead of re-running the
     // command that produced it.
-    if crate::wal::wal_outcome_items_enabled() {
+    if stage && crate::wal::wal_outcome_items_enabled() {
         super::block_in_wal::stage_outcome(crate::wal::WalOutcomeItem {
             kind: kind.to_string(),
             object_key: object_key.to_string(),

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -349,6 +349,9 @@ impl TemporalEngine {
                     (Some(collected), Some(components)) => collected.extend(components),
                     (state, _) => *state = None,
                 }
+                // The keys this write touched, for the maintenance below. `object_keys` is
+                // consumed by the loop, so they are kept as they go past.
+                let mut object_keys_for_maintenance: Vec<String> = Vec::new();
                 if object_keys.is_empty() {
                     rebuild_bucket_page_ownership(
                         request.shard_id,
@@ -358,6 +361,7 @@ impl TemporalEngine {
                     );
                 } else {
                     for object_key in object_keys {
+                        object_keys_for_maintenance.push(object_key.clone());
                         shard.dirty_objects.insert(object_key.clone());
                         mark_async_dirty_object(
                             shard,
@@ -367,7 +371,25 @@ impl TemporalEngine {
                         );
                     }
                 }
-                if !defer_bucket_index_reconstruct()
+                // The same maintenance the single-command path does. An ingest's writes are
+                // split across both paths, which is why covering only the other one removed
+                // exactly half the rebuild work and left the rest: 2404 page visits per add
+                // became 1205, and stayed there until this site was covered too.
+                //
+                // Same two guards: every touched key must report that it synced, or the rebuild
+                // still runs; and an empty bucket_map still rebuilds, because maintenance updates
+                // an index rather than constructing one.
+                let maintained_bucket_index = !shard.bucket_index.bucket_map.is_empty()
+                    && !object_keys_for_maintenance.is_empty()
+                    && object_keys_for_maintenance.iter().all(|object_key| {
+                        crate::engine::storage_bucket_internals::sync_context_pages_for_object(
+                            shard,
+                            request.shard_id,
+                            object_key,
+                        )
+                    });
+                if !maintained_bucket_index
+                    && !defer_bucket_index_reconstruct()
                     && (!command_updates_bucket_index_directly(&command_for_post_write)
                         || shard.bucket_index.bucket_map.is_empty())
                 {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -10154,6 +10154,12 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
         !held.is_empty(),
         "the ingests must populate the index, or the comparison below compares nothing"
     );
+    let uncovered = crate::engine::uncovered_maintenance::snapshot();
+    println!("
+  keys maintenance found nothing for ({}):", uncovered.len());
+    for key in uncovered.iter().take(10) {
+        println!("    {key}");
+    }
 
     // And what a rebuild from the model maps would hold.
     engine.reconstruct_bucket_index_now(1);


### PR DESCRIPTION
ingestion stops being quadratic: 9604 index-rebuild visits per add become 3

    index-rebuild page visits per add
      originally              2404 at 150 adds    4804 at 300    9604 at 600   -- doubling
      coalesced to one/add     604                1204           2404          -- still doubling
      maintained, both paths     3                   3              3          -- flat

    total visits 450 / 900 / 1800: linear in adds, where it was linear in adds TIMES corpus.

    equivalence, with no reconstruct at all: 160 pages held after the ingests, 160 a rebuild
    produces, 0 either side has that the other does not, 0 keys maintenance found nothing for.

A context write did not register its page, so the write path rebuilt the whole first-index for
every one -- a walk of every live page in the store, several times per add. Feature and Sequence
writes have always maintained the index on the write path, and replay already maintained these
very kinds. The context write path was the one doing neither, and the rebuild stood in for it.

`sync_context_pages_for_object` mirrors `collect_model_live_page_entries` arm for arm rather than
mapping commands to kinds by hand, so maintenance and rebuild derive from the same source and
cannot disagree about which kind a page belongs to. That mattered: a hand-written mapping would
have missed that `context_entity` composes its key from the collection key and the entity hash, and
that a context node's page lives in `shard.hashes` and is derived as kind "hash" with the field as
its component -- a different shape from the eight kinds that carry no component at all.

BOTH WRITE PATHS. An ingest splits its writes between `execute` and `batch_execute`. Covering only
the first removed EXACTLY half the work -- 2404 visits per add became 1205 and stayed there, which
is a strange number for "some kinds missed" and a natural one for "one of two paths". The
uncovered-key tally reporting ZERO while the rebuilds continued is what ruled out the kinds and
pointed at the second site.

AND THE RECONSTRUCT THIS REPLACES. Coalescing the per-record rebuild into one per ingest was the
right change when nothing maintained the index; maintenance makes that one unnecessary too, so it
is gone. The window stays, because it still keeps the per-record fallback from firing for a write
maintenance does not cover.

TWO GUARDS, unchanged at both sites: every touched key must report that it synced or the rebuild
still runs, and an empty bucket_map still rebuilds -- maintenance updates an index, it does not
construct one. An uncovered write is slow, not wrong.

STAGING IS NOW A PARAMETER. `upsert_bucket_index_page` files a page AND stages an outcome, because
its caller is normally the thing that wrote the page. Maintenance is not: the context write already
staged its own outcome under its own kind, and a second one would have replay install the same page
twice under two kinds. Every existing caller keeps `stage: true`.

The wall-clock column in that table is noisy -- the machine has other work on it and the remaining
per-add cost is extraction and WAL, not index maintenance. The visit count is what does not depend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
