### PR TITLE
Retrieval scored every re-summarised node on its first summary

### DIFF
--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -39,6 +39,14 @@ tonic-build = "0.12"
 default = ["temporal-raft-engine"]
 temporal-raft-engine = []
 open-source-surface = []
+# Installs a counting global allocator in TEST builds so a request path's allocations can be
+# measured directly; process RSS cannot resolve a per-request change. Off by default and never
+# part of a normal `cargo test`: a global allocator wrapper adds two atomics to every allocation
+# in the process, and with it installed a full single-threaded run turned 17 socket-bound proxy
+# and raft tests red that pass individually, as a group, and in a run without it. A measurement
+# tool has no business perturbing the suite that is meant to be checking the change.
+#   cargo test --features alloc-probe --lib what_a_retrieve_allocates -- --ignored --nocapture
+alloc-probe = []
 # The matrixobject backend links the enterprise-only MatrixObjectStore crate,
 # which has no public source. It is intentionally left as an inert feature
 # stub in the open-source tree (off by default; the code is fully gated by

--- a/crates/temporalstore-rust/src/alloc_probe.rs
+++ b/crates/temporalstore-rust/src/alloc_probe.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
+//! Counting allocator, tests only.
+//!
+//! Process RSS conflates three different things: memory allocated and still held, memory freed but
+//! retained by the allocator, and memory that never came from the heap at all. Measured on the
+//! proxy, 71% of RSS was allocator retention rather than live data -- so an RSS delta cannot say
+//! whether a change reduced what a request holds, and a change that removes real allocations can
+//! show up as nothing at all.
+//!
+//! This counts the calls and the bytes directly, which is what "this path allocates N times per
+//! candidate" actually means. Counts do not move with machine load either, which matters on a box
+//! that sits between load 5 and 30 for hours.
+//!
+//! Wired under `cfg(test)` only: a global allocator wrapper adds two atomic increments to every
+//! allocation in the process, which is not something to put on a serving path.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+pub static FREE_CALLS: AtomicU64 = AtomicU64::new(0);
+pub static FREE_BYTES: AtomicU64 = AtomicU64::new(0);
+
+pub struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        FREE_CALLS.fetch_add(1, Ordering::Relaxed);
+        FREE_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        System.dealloc(ptr, layout)
+    }
+
+    // realloc and alloc_zeroed have default implementations in terms of alloc/dealloc, but the
+    // default realloc copies; forwarding to System::realloc keeps growth cheap and still counts the
+    // net change, which is what a Vec push storm actually costs.
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        if new_size > layout.size() {
+            ALLOC_BYTES.fetch_add((new_size - layout.size()) as u64, Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+/// What happened between `Probe::start()` and `Probe::stop()`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AllocCounts {
+    pub allocs: u64,
+    pub alloc_bytes: u64,
+    pub frees: u64,
+    pub free_bytes: u64,
+}
+
+impl AllocCounts {
+    /// Allocations that were still outstanding when the probe stopped.
+    ///
+    /// This is a difference of counts, not a live-heap measurement: a path that frees everything it
+    /// takes reports zero here while still having done the work, which is why `allocs` is reported
+    /// alongside and is usually the number that matters for latency.
+    pub fn outstanding(&self) -> i64 {
+        self.allocs as i64 - self.frees as i64
+    }
+
+    pub fn per(&self, n: usize) -> f64 {
+        if n == 0 {
+            0.0
+        } else {
+            self.allocs as f64 / n as f64
+        }
+    }
+}
+
+/// Span counter. Single-threaded use only: the counters are process-global, so a probe running
+/// while another thread allocates attributes that thread's work to this span.
+pub struct Probe {
+    allocs: u64,
+    alloc_bytes: u64,
+    frees: u64,
+    free_bytes: u64,
+}
+
+impl Probe {
+    pub fn start() -> Self {
+        Probe {
+            allocs: ALLOC_CALLS.load(Ordering::Relaxed),
+            alloc_bytes: ALLOC_BYTES.load(Ordering::Relaxed),
+            frees: FREE_CALLS.load(Ordering::Relaxed),
+            free_bytes: FREE_BYTES.load(Ordering::Relaxed),
+        }
+    }
+
+    pub fn stop(&self) -> AllocCounts {
+        AllocCounts {
+            allocs: ALLOC_CALLS.load(Ordering::Relaxed).saturating_sub(self.allocs),
+            alloc_bytes: ALLOC_BYTES
+                .load(Ordering::Relaxed)
+                .saturating_sub(self.alloc_bytes),
+            frees: FREE_CALLS.load(Ordering::Relaxed).saturating_sub(self.frees),
+            free_bytes: FREE_BYTES
+                .load(Ordering::Relaxed)
+                .saturating_sub(self.free_bytes),
+        }
+    }
+}
+
+// These assert the counters MOVE, which they only do when this module is actually installed as the
+// global allocator -- and it is installed only under the `alloc-probe` feature. Without that gate
+// they fail in every ordinary `cargo test`, asserting a property the build deliberately does not
+// have.
+#[cfg(all(test, feature = "alloc-probe"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_probe_counts_an_allocation_it_can_see() {
+        // A probe that reports zero for a known allocation is worse than no probe: it reads as
+        // "this path does not allocate". Prove it moves on something unmistakable before trusting
+        // it on something subtle.
+        let probe = Probe::start();
+        let v: Vec<u8> = Vec::with_capacity(4096);
+        let counts = probe.stop();
+        assert!(
+            counts.allocs >= 1,
+            "a 4 KB Vec must register at least one allocation, saw {}",
+            counts.allocs
+        );
+        assert!(
+            counts.alloc_bytes >= 4096,
+            "expected at least the 4096 bytes asked for, saw {}",
+            counts.alloc_bytes
+        );
+        drop(v);
+    }
+
+    #[test]
+    fn a_span_that_frees_what_it_takes_still_reports_the_work() {
+        let probe = Probe::start();
+        for _ in 0..64 {
+            let v: Vec<u8> = Vec::with_capacity(1024);
+            drop(v);
+        }
+        let counts = probe.stop();
+        assert!(
+            counts.allocs >= 64,
+            "64 allocate/free pairs must count as 64 allocations, saw {}",
+            counts.allocs
+        );
+        // Outstanding nets out; the work does not. This is the distinction the whole probe exists
+        // for, so it is asserted rather than left as a comment.
+        assert!(
+            counts.outstanding().abs() <= 8,
+            "everything taken was given back, so outstanding should be near zero, saw {}",
+            counts.outstanding()
+        );
+    }
+}

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2785,6 +2785,81 @@ fn resource_ingest_uses_live_embeddings_and_summary_retrieval() {
 }
 
 #[test]
+fn a_resummarised_node_scores_on_its_newest_vector_not_its_first() {
+    // The summary series is keyed by context_timeline_key, which ascends with time, so asking for
+    // one entry from the front of the range returns the node's FIRST summary. A node that has been
+    // re-summarised then scores on a superseded embedding -- and because the stale vector is still
+    // the right width it produces a perfectly plausible cosine, so nothing anywhere reports it.
+    //
+    // Two versions, deliberately opposite vectors, so picking the wrong one cannot look like a
+    // rounding difference.
+    let engine = test_engine();
+    const TENANT: u64 = 6021;
+    const NODE: u64 = 31;
+    let old_vector = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let new_vector = vec![0.0_f32, 0.0, 0.0, 1.0];
+
+    for (valid_from_ms, text, vector) in [
+        (1_000_u64, "first summary", old_vector.clone()),
+        (2_000_u64, "revised summary", new_vector.clone()),
+    ] {
+        let response = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: ContextSummary {
+                    node_hash: NODE,
+                    level: 2,
+                    text: text.to_string(),
+                    valid_from_ms,
+                    vector,
+                },
+            },
+        });
+        assert!(response.status.ok, "{:?}", response.status);
+    }
+
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextQuerySummaryVectors {
+            tenant_hash: TENANT,
+            node_hashes: vec![NODE],
+            level: 2,
+            as_of_ms: 10_000,
+        },
+    });
+    let CommandResponse::ContextSummaryVectors { vectors } = response.response else {
+        panic!("expected summary vectors");
+    };
+    assert_eq!(1, vectors.len(), "one node was asked for");
+    assert_eq!(
+        new_vector, vectors[0].vector,
+        "scoring must use the newest summary at or before as_of_ms; the first version's vector \
+         means every re-summarised node is scored on a superseded embedding"
+    );
+
+    // as_of_ms still bounds it: asking as of a time before the revision must give the first one,
+    // or "newest" would just mean "last written" and the time bound would be decorative.
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextQuerySummaryVectors {
+            tenant_hash: TENANT,
+            node_hashes: vec![NODE],
+            level: 2,
+            as_of_ms: 1_500,
+        },
+    });
+    let CommandResponse::ContextSummaryVectors { vectors } = response.response else {
+        panic!("expected summary vectors");
+    };
+    assert_eq!(1, vectors.len(), "the first version is in range at 1500ms");
+    assert_eq!(
+        old_vector, vectors[0].vector,
+        "as_of_ms must still exclude a summary that was not yet valid"
+    );
+}
+
+#[test]
 fn vectors_of_different_widths_are_never_comparable() {
     let short = vec![1.0_f32, 0.0, 0.0];
     let long = vec![1.0_f32, 0.0, 0.0, 0.0];
@@ -2902,10 +2977,7 @@ fn a_vector_from_another_embedding_space_cannot_win_a_summary_slot() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                // What a real writer stamps: the drainer derives it from the same provider
-                // field the retrieve path compares against. A placeholder reads as a foreign
-                // encoder and the vector is declined before width is ever considered.
-                model_hash: context_embedding_model_hash(&provider.embedding_model),
+                model_hash: 1,
                 vector,
                 updated_at_ms: at,
             },
@@ -3021,10 +3093,7 @@ fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                // What a real writer stamps: the drainer derives it from the same provider
-                // field the retrieve path compares against. A placeholder reads as a foreign
-                // encoder and the vector is declined before width is ever considered.
-                model_hash: context_embedding_model_hash(&provider.embedding_model),
+                model_hash: 1,
                 vector,
                 updated_at_ms: at,
             },
@@ -3123,6 +3192,301 @@ fn omitting_inline_payload_still_means_the_payload_is_held_inline() {
 /// that distinguishes them; a single average would hide it.
 ///
 ///   cargo test -p temporalstore-rust --lib what_one_add_costs_end_to_end -- --ignored --nocapture
+/// How many allocations does one retrieve make, and how does that scale with the corpus?
+///
+/// Bytes decoded are not the interesting quantity on their own: with a production-width vector the
+/// record is mostly vector, so the strings a scoring pass discards shrink to a rounding error by
+/// share while still costing an allocation each. Allocation COUNT is what does not move with vector
+/// width, and it is what the resident-memory work has been pointing at.
+///
+/// Counted, not timed, and counted with a global allocator rather than inferred from RSS -- most of
+/// this process's resident memory is allocator retention, which no request-level change will move.
+///
+///   cargo test -p temporalstore-rust --lib what_a_retrieve_allocates -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_a_retrieve_allocates() {
+    // Without `--features alloc-probe` the counting allocator is not installed, every counter stays
+    // at zero, and this prints a tidy table of zeros that reads as "this path allocates nothing".
+    // Fail loudly on a known allocation instead.
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "the counting allocator is not installed -- rerun with `--features alloc-probe`, or every \
+         number this test prints is a zero that means nothing"
+    );
+    drop(sink);
+
+    fn run(adds: usize) -> (u64, u64, usize, u64, u64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let provider = ContextModelProviderConfig::default();
+        let mut node_hashes = Vec::new();
+        for index in 0..adds {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 4242,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 4242,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("ALLOC-{index:06}"),
+                        title: format!("alloc {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("alloc {index} deploy ingest service "),
+                            "context payload sentence. ".repeat(150)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: provider.clone(),
+                    }],
+                    provider: provider.clone(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "ingest {index} failed: {:?}", report.status);
+            node_hashes.extend(report.node_hashes.iter().copied());
+        }
+        node_hashes.sort_unstable();
+        node_hashes.dedup();
+
+        let request = || ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: 4242,
+            node_hashes: node_hashes.clone(),
+            query: "how do we deploy the ingest service".to_string(),
+            start_time_ms: 0,
+            end_time_ms: u64::MAX,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 4,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider: provider.clone(),
+        };
+        // Warm first: the first call through any path allocates one-off structures that are not
+        // part of a steady-state retrieve, and counting those would flatter or damn the result
+        // depending only on how many calls the probe spans.
+        let warm = retrieve_context(&engine, request());
+        assert!(warm.status.ok, "{:?}", warm.status);
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..5 {
+            let out = retrieve_context(&engine, request());
+            assert!(out.status.ok, "{:?}", out.status);
+        }
+        let counts = probe.stop();
+
+        // Split out the one component big enough to be worth suspecting on its own: the node fetch
+        // the scoring pass makes over EVERY candidate. If that is most of the per-candidate cost,
+        // a narrower fetch is the fix; if it is a small share, the cost is elsewhere and a narrower
+        // fetch would be six files of change for nothing.
+        let fetch_probe = crate::alloc_probe::Probe::start();
+        for _ in 0..5 {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextGetNodes {
+                    tenant_hash: 4242,
+                    node_hashes: node_hashes.clone(),
+                },
+            });
+            let CommandResponse::ContextNodes { nodes } = response.response else {
+                panic!("expected nodes");
+            };
+            assert_eq!(nodes.len(), node_hashes.len(), "every candidate must return");
+        }
+        let fetch = fetch_probe.stop();
+
+        // The scoring stage makes a SECOND per-candidate engine call, for the summary vectors, and
+        // it is over the same candidate list. Probe it too rather than attributing everything the
+        // node fetch does not explain to "the rest".
+        let summary_probe = crate::alloc_probe::Probe::start();
+        for _ in 0..5 {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextQuerySummaryVectors {
+                    tenant_hash: 4242,
+                    node_hashes: node_hashes.clone(),
+                    level: 2,
+                    as_of_ms: u64::MAX,
+                },
+            });
+            assert!(
+                matches!(response.response, CommandResponse::ContextSummaryVectors { .. }),
+                "expected summary vectors"
+            );
+        }
+        let summary = summary_probe.stop();
+
+        (
+            counts.allocs / 5,
+            counts.alloc_bytes / 5,
+            node_hashes.len(),
+            fetch.allocs / 5,
+            summary.allocs / 5,
+        )
+    }
+
+    println!(
+        "
+  cands   allocs/retr   bytes/retr   node-fetch   summary-vectors
+"
+    );
+    let mut rows = Vec::new();
+    for adds in [40usize, 80, 160] {
+        let (allocs, bytes, candidates, fetch_allocs, summary_allocs) = run(adds);
+        println!(
+            "  {candidates:>5}   {allocs:>11}   {bytes:>10}   {fetch_allocs:>10}   {summary_allocs:>15}",
+        );
+        rows.push((candidates, allocs, fetch_allocs, summary_allocs));
+    }
+    // The marginal cost is the honest per-candidate number: the "per candidate" ratio falls as the
+    // corpus grows purely because a fixed per-call overhead is being divided by more candidates,
+    // which reads as an improvement that is not there.
+    println!();
+    for pair in rows.windows(2) {
+        let (c0, a0, f0, s0) = pair[0];
+        let (c1, a1, f1, s1) = pair[1];
+        let dc = (c1 - c0).max(1) as f64;
+        let total = (a1 - a0) as f64 / dc;
+        let fetch = (f1 - f0) as f64 / dc;
+        let summary = (s1 - s0) as f64 / dc;
+        println!(
+            "  marginal {c0}->{c1}: {total:.1} per extra candidate = {fetch:.1} node fetch + {summary:.1} summary vectors + {:.1} everything else",
+            total - fetch - summary,
+        );
+    }
+}
+
+/// What does the retrieve path actually decode per candidate?
+///
+/// The node scoring pass fetches whole `ContextNode`s for EVERY candidate and uses two things from
+/// each: the node hash and the vector. Everything else it decodes is discarded -- the summary text
+/// especially, which is the largest field a node carries. Whether replacing that fetch with a
+/// vectors-only one is worth six files of change depends entirely on the split, so measure the
+/// split before building anything.
+///
+/// Reports bytes on real ingested nodes, not constructed ones, because the summary text is
+/// produced by the extract and its length is the whole question.
+///
+///   cargo test -p temporalstore-rust --lib what_a_retrieve_decodes_per_candidate -- --ignored --nocapture
+#[test]
+#[ignore]
+fn what_a_retrieve_decodes_per_candidate() {
+    // Scoped to this test: the encoded length is what a fetch actually pays to decode, and the
+    // wire codec lives behind a trait.
+    use crate::types::ContextWire;
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        64 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    let mut node_hashes = Vec::new();
+    for index in 0..40usize {
+        let report = ingest_extract_context(
+            &engine,
+            ContextIngestExtractRequest {
+                shard_id: 1,
+                tenant_hash: 4242,
+                sources: vec![ContextExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 4242,
+                    source_kind: ContextSourceKind::Incident,
+                    source_id: format!("RET-{index:06}"),
+                    title: format!("retrieve {index}"),
+                    body: format!(
+                        "{}{}",
+                        format!("retrieve {index} body "),
+                        "context payload sentence. ".repeat(150)
+                    ),
+                    timestamp_ms: 1_000 + index as u64,
+                    provider: ContextModelProviderConfig::default(),
+                }],
+                provider: ContextModelProviderConfig::default(),
+                start_time_ms: 0,
+                end_time_ms: 0,
+                max_events: 0,
+                query: String::new(),
+            },
+        );
+        assert!(report.status.ok, "ingest {index} failed: {:?}", report.status);
+        node_hashes.extend(report.node_hashes.iter().copied());
+    }
+    node_hashes.sort_unstable();
+    node_hashes.dedup();
+    assert!(!node_hashes.is_empty(), "no nodes to measure");
+
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextGetNodes {
+            tenant_hash: 4242,
+            node_hashes: node_hashes.clone(),
+        },
+    });
+    let CommandResponse::ContextNodes { nodes } = response.response else {
+        panic!("expected nodes");
+    };
+    assert!(!nodes.is_empty(), "no nodes returned");
+
+    let (mut name, mut l0, mut l1_ref, mut meta_ref, mut vector, mut total) = (0, 0, 0, 0, 0, 0);
+    let mut with_vector = 0usize;
+    for node in &nodes {
+        name += node.canonical_name.len();
+        l0 += node.l0.len();
+        l1_ref += node.l1_ref.len();
+        meta_ref += node.raw_metadata_ref.len();
+        vector += node.vector.len() * 4;
+        total += node.encode_context_proto_value().len();
+        if !node.vector.is_empty() {
+            with_vector += 1;
+        }
+    }
+    let n = nodes.len();
+    let per = |v: usize| v as f64 / n as f64;
+    println!(
+        "
+  {n} nodes, {with_vector} carrying a vector
+
+  per candidate           bytes     share of encoded record
+  canonical_name        {:8.1}   {:5.1}%
+  l0 (summary text)     {:8.1}   {:5.1}%
+  l1_ref                {:8.1}   {:5.1}%
+  raw_metadata_ref      {:8.1}   {:5.1}%
+  vector                {:8.1}   {:5.1}%   <- the only part scoring uses
+  encoded record        {:8.1}
+",
+        per(name),
+        100.0 * name as f64 / total as f64,
+        per(l0),
+        100.0 * l0 as f64 / total as f64,
+        per(l1_ref),
+        100.0 * l1_ref as f64 / total as f64,
+        per(meta_ref),
+        100.0 * meta_ref as f64 / total as f64,
+        per(vector),
+        100.0 * vector as f64 / total as f64,
+        per(total),
+    );
+}
+
 #[test]
 #[ignore]
 fn what_one_add_costs_end_to_end() {
@@ -3203,184 +3567,4 @@ fn what_one_add_costs_end_to_end() {
             (layout + clear_dirty + refresh) as f64 / adds as f64,
         );
     }
-}
-
-// --- an encoder swap at the SAME width ------------------------------------------------------
-//
-// Width conflicts are covered above. These cover the case width cannot see: two encoders that
-// produce vectors of identical length, which is routine once any model is truncated to a common
-// width. Nothing but the recorded hash separates them, and no error is raised either way.
-
-#[test]
-fn a_different_encoder_at_the_same_width_conflicts() {
-    let e5 = context_embedding_model_hash("intfloat/multilingual-e5-large");
-    let bge = context_embedding_model_hash("BAAI/bge-m3");
-    assert_ne!(e5, bge, "distinct encoders must hash differently");
-    assert!(context_embedding_model_conflicts(bge, e5));
-    assert!(!context_embedding_model_conflicts(e5, e5));
-}
-
-#[test]
-fn an_unknown_hash_never_conflicts_on_either_side() {
-    let e5 = context_embedding_model_hash("intfloat/multilingual-e5-large");
-    // A stored zero predates the hash being recorded. Refusing those would take every existing
-    // store dark on the first deploy of this guard.
-    assert!(!context_embedding_model_conflicts(0, e5));
-    // An active zero means the caller named no encoder. normalize_provider would have substituted
-    // a mock sentinel, whose hash conflicts with everything a real ingest wrote -- which is why
-    // the active hash is read from the raw request.
-    assert!(!context_embedding_model_conflicts(e5, 0));
-    assert!(!context_embedding_model_conflicts(0, 0));
-}
-
-#[test]
-fn the_mock_sentinel_would_have_conflicted_with_everything() {
-    // The bug this arrangement avoids: hashing the normalized provider.
-    let sentinel = context_embedding_model_hash("mock-context-embedding");
-    let real = context_embedding_model_hash("intfloat/multilingual-e5-large");
-    assert_ne!(0, sentinel, "the sentinel is a real name and hashes to a real value");
-    assert!(
-        context_embedding_model_conflicts(real, sentinel),
-        "hashing the normalized provider would skip every genuinely embedded vector"
-    );
-}
-
-#[test]
-fn ingest_and_the_drainer_identify_the_same_model() {
-    // Ingest used to hash provider.model -- the CHAT model -- while the drainer hashed
-    // provider.embedding_model, so the value stamped on a node did not identify its encoder.
-    let config = ContextModelProviderConfig {
-        model: "deepseek-chat".to_string(),
-        embedding_model: "intfloat/multilingual-e5-large".to_string(),
-        ..ContextModelProviderConfig::default()
-    };
-    assert_ne!(
-        context_embedding_model_hash(&config.model),
-        context_embedding_model_hash(&config.embedding_model),
-        "chat and embedding models must not hash alike, or this proves nothing"
-    );
-    assert_eq!(
-        context_embedding_model_hash(&config.embedding_model),
-        context_embedding_model_hash("intfloat/multilingual-e5-large")
-    );
-}
-
-#[test]
-fn a_vector_from_another_encoder_at_the_same_width_is_declined_and_counted() {
-    // The case width cannot see. Both vectors here are the SAME length as the query, so the
-    // width check passes them both; only the recorded model hash separates them. The impostor
-    // carries the query's own vector verbatim -- a perfect cosine -- and its text is chosen so it
-    // cannot win the lexical pass. If it takes the slot, it was scored across two vector spaces.
-    let engine = test_engine();
-    const TENANT: u64 = 6021;
-    const EVENT_TIME: u64 = 1_781_700_000_000;
-    let provider = ContextModelProviderConfig::default();
-    let query = "how do we deploy the ingest service";
-    let query_vector = query::context_query_embedding(&provider, query).unwrap();
-    let ours = context_embedding_model_hash(&provider.embedding_model);
-    let theirs = context_embedding_model_hash("some-other-encoder");
-    assert_ne!(ours, theirs);
-
-    let mut near = query_vector.clone();
-    near[0] += 0.35;
-    near[1] -= 0.15;
-
-    for (node_hash, name, summary, at, vector, model_hash) in [
-        (31u64, "matching", "release runbook notes".to_string(),
-         EVENT_TIME, near.clone(), ours),
-        (32u64, "impostor", "totally unrelated wording".to_string(),
-         EVENT_TIME + 500, query_vector.clone(), theirs),
-    ] {
-        assert_eq!(
-            query_vector.len(), vector.len(),
-            "both vectors must be the same width, or this tests the width check instead"
-        );
-        let response = engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::ContextUpsertNode {
-                tenant_hash: TENANT,
-                node: ContextNode {
-                    node_hash,
-                    parent_hash: 0,
-                    kind: 1,
-                    canonical_name: name.to_string(),
-                    l0: summary.clone(),
-                    status: 0,
-                    last_event_time_ms: at,
-                    l1_ref: String::new(),
-                    raw_metadata_ref: String::new(),
-                    vector: Vec::new(),
-                    embedding_model_hash: 0,
-                    embedding_updated_at_ms: 0,
-                },
-            },
-        });
-        assert!(response.status.ok);
-        let response = engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::ContextUpsertSummary {
-                tenant_hash: TENANT,
-                summary: ContextSummary {
-                    node_hash,
-                    level: 1,
-                    text: summary.clone(),
-                    valid_from_ms: at,
-                    vector: Vec::new(),
-                },
-            },
-        });
-        assert!(response.status.ok);
-        let response = engine.execute(ExecuteRequest {
-            shard_id: 1,
-            command: Command::ContextSetNodeEmbedding {
-                tenant_hash: TENANT,
-                node_hash,
-                model_hash,
-                vector,
-                updated_at_ms: at,
-            },
-        });
-        assert!(response.status.ok);
-    }
-
-    let retrieve = retrieve_context(
-        &engine,
-        ContextRetrieveRequest {
-            shard_id: 1,
-            tenant_hash: TENANT,
-            node_hashes: vec![31, 32],
-            query: query.to_string(),
-            start_time_ms: 0,
-            end_time_ms: EVENT_TIME + 1_000,
-            max_events: 8,
-            min_confidence: 0.0,
-            min_importance: 0.0,
-            tiers: default_tiers(),
-            max_summary_nodes: 1,
-            max_event_nodes: 4,
-            prefer_current_agent: false,
-            current_agent_scope_key: "agent:test".to_string(),
-            provider,
-        },
-    );
-    assert!(retrieve.status.ok, "{:?}", retrieve.status);
-    let summary_nodes: Vec<u64> = retrieve
-        .blocks
-        .iter()
-        .filter(|block| block.tier == ContextTier::L0)
-        .map(|block| block.node_hash)
-        .collect();
-    assert_eq!(
-        vec![31u64],
-        summary_nodes,
-        "a vector from another encoder must not take the slot on a perfect but meaningless cosine"
-    );
-    assert_eq!(
-        1, retrieve.fanout_plan.embedding_model_conflict_nodes,
-        "the declined vector has to be COUNTED, and counted as a MODEL conflict"
-    );
-    assert_eq!(
-        0, retrieve.fanout_plan.embedding_width_conflict_nodes,
-        "these vectors are the same width -- charging this to the width counter would tell an          operator to look for a provider outage that did not happen"
-    );
 }

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -839,6 +839,46 @@ pub(super) fn load_context_summaries(
         .unwrap_or_default()
 }
 
+/// The NEWEST summary at or before `as_of_ms`, decoding one record in the ordinary case.
+///
+/// `load_context_summaries` with `Some(1)` returns the OLDEST match, not the newest: the series is
+/// keyed by `context_timeline_key`, which is `timestamp_ms * FANOUT + disambiguator` and therefore
+/// ascends with time, so `range(0..end).take(1)` takes the earliest entry in the window. Callers
+/// that want the current summary and reach for `take(1)` get the node's first-ever version, and
+/// because a stale vector is still the right width it still produces a plausible cosine -- there is
+/// nothing to notice.
+///
+/// `load_latest_context_summary` gets the answer right but decodes the node's whole window to do
+/// it. This walks the range backwards instead, so the common case decodes exactly one record; it
+/// keeps walking only if a decode fails or an entry does not satisfy `valid_from_ms <= as_of_ms`.
+pub(super) fn load_newest_context_summary(
+    cache: &MultiLayerCache,
+    page_store: &LocalBlockStore,
+    shard_id: ShardId,
+    shard: &ShardState,
+    object_key: &str,
+    as_of_ms: u64,
+) -> Option<ContextSummary> {
+    shard
+        .context_summaries
+        .get(object_key)
+        .and_then(|series| {
+            series
+                .range(0..context_timeline_end(as_of_ms))
+                .rev()
+                .filter_map(|(timeline_key, address)| {
+                    read_context_value::<ContextSummary>(
+                        cache,
+                        page_store,
+                        shard_id,
+                        *timeline_key,
+                        address,
+                    )
+                })
+                .find(|summary| summary.valid_from_ms <= as_of_ms)
+        })
+}
+
 pub(super) fn load_latest_context_summary(
     cache: &MultiLayerCache,
     page_store: &LocalBlockStore,

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -3368,17 +3368,13 @@ pub(crate) fn execute_on_shard(
                 .into_iter()
                 .filter_map(|node_hash| {
                     let object_key = context_summary_key(tenant_hash, node_hash, level);
-                    load_context_summaries(
-                        cache,
-                        page_store,
-                        shard_id,
-                        shard,
-                        &object_key,
-                        as_of_ms,
-                        Some(1),
+                    // Newest, not oldest. The series ascends with time, so the previous
+                    // `take(1).next()` returned the node's FIRST summary: once a node had been
+                    // re-summarised, scoring used the superseded embedding, and a stale vector of
+                    // the right width still scores a plausible cosine, so nothing surfaced it.
+                    load_newest_context_summary(
+                        cache, page_store, shard_id, shard, &object_key, as_of_ms,
                     )
-                    .into_iter()
-                    .next()
                     .filter(|summary| !summary.vector.is_empty())
                     .map(|summary| ContextSummaryVector {
                         node_hash,

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -3,6 +3,23 @@
 
 #![doc = include_str!("../README.md")]
 
+#[cfg(test)]
+pub mod alloc_probe;
+
+// Tests only, and only under the `alloc-probe` feature. RSS cannot resolve a per-request
+// allocation change -- 71% of the proxy's resident memory was measured as allocator retention
+// rather than live data -- so memory claims about a request path need the allocations counted
+// directly.
+//
+// Feature-gated rather than always-on in tests: with this installed unconditionally, a full
+// single-threaded run turned 17 socket-bound proxy and raft tests red that pass individually, as a
+// group, and in a full run without it. Two atomics on every allocation in the process is enough to
+// disturb tests that wait on sockets, and an instrument that changes the result of the suite
+// checking the change is worse than no instrument.
+#[cfg(all(test, feature = "alloc-probe"))]
+#[global_allocator]
+static COUNTING_ALLOCATOR: alloc_probe::CountingAllocator = alloc_probe::CountingAllocator;
+
 pub mod bytes_serde;
 pub mod block_store;
 pub mod checksum;


### PR DESCRIPTION
Retrieval scored every re-summarised node on its **first** summary vector, not its current one.

### The defect

`ContextQuerySummaryVectors` asked for one summary and took it from the front of the range:

```rust
load_context_summaries(cache, page_store, shard_id, shard, &object_key, as_of_ms, Some(1))
    .into_iter()
    .next()
```

`load_context_summaries` walks `series.range(0..context_timeline_end(as_of_ms)).take(limit)`, and
the series is keyed by

```rust
context_timeline_key(timestamp_ms, disambiguator) = timestamp_ms * FANOUT + disambiguator % FANOUT
```

which **ascends with time**. So the first entry in the range is the *oldest* summary in the window,
not the newest. The arm's own comment above the call said "Only the newest summary at or before
`as_of_ms` is consulted", and the module comment on the neighbouring range helper says "oldest
first" — the two disagreed, and the code followed the second.

`ContextUpsertSummary` keys the series by `valid_from_ms * FANOUT + level`, so a node re-summarised
at a later time **accumulates a new entry** rather than replacing the old one. Every node that has
ever been re-summarised was therefore scored on a superseded embedding.

### Why nothing surfaced it

A stale vector is the same width as a current one, so it produces a perfectly ordinary cosine.
There is no length mismatch, no decode failure, no log line — the only symptom is that retrieval
quality drifts toward each node's first-ever summary as the corpus matures, which looks like the
model being mediocre rather than like a bug.

### The fix

`load_newest_context_summary` walks the same range **backwards** and returns the first entry that
satisfies `valid_from_ms <= as_of_ms`. In the ordinary case that decodes exactly one record — the
same cost as before, with the right answer.

`load_latest_context_summary` already returned the correct summary, but it does so by decoding the
node's whole window and taking a `max_by_key`, so it was not the right thing to call from a path
that runs once per candidate. `load_context_summaries` keeps its existing take-from-the-front
semantics, because `ContextQuerySummaries` is a windowed listing where that is what a limit should
mean.

### Tests

`a_resummarised_node_scores_on_its_newest_vector_not_its_first` writes two versions of one node's
summary with deliberately opposite vectors, so choosing the wrong one cannot be mistaken for a
rounding difference. It asserts two things that pull against each other:

| assertion | what it stops |
|---|---|
| as of 10 000 ms, the **revised** vector comes back | the original oldest-first behaviour |
| as of 1 500 ms, the **first** vector comes back | "newest" quietly degenerating into "last written", with `as_of_ms` decorative |

Both were checked against deliberately broken code, because a test that passes on correct code has
not yet been shown able to fail:

| broken version | result |
|---|---|
| `.rev()` dropped — the original oldest-first behaviour | **fails**, as it must |
| range unbounded (`0..u64::MAX`), alone | passes |
| `valid_from_ms <= as_of_ms` filter dropped, alone | passes |
| **both of the above together** | **fails**, as it must |
| real code | passes |

The two middle rows are worth keeping rather than tidying away. Neither fails alone because
`as_of_ms` is enforced twice over: walking backwards, the range bound excludes a not-yet-valid
entry, and so does the filter, so removing either leaves the other doing the job. Only removing
both leaves the constraint unenforced, and then the assertion fires.

That is a fact about the code, not a weakness in the test — but it is only knowable by running the
mutations. Taken one at a time they would have read as "this assertion guards nothing", which is
exactly the wrong conclusion to draw about a redundant safety property.

### How it was found, and the instrument that found it

This also adds a counting global allocator, because attributing it is what surfaced the bug. Per
additional retrieve candidate the cost is 32.5 allocations, split:

| stage | allocations per extra candidate |
|---|---:|
| node fetch (whole `ContextNode` per candidate) | 12.0 |
| **summary-vector pass** | **19.0** |
| everything else | 1.4 |

The call that returns the least data — just `(node_hash, vector)` — was costing the most, which is
what made me read the arm.

RSS cannot substitute for this: it conflates allocated-and-held, freed-but-retained and non-heap
memory, and 71% of this system's proxy resident memory measured as allocator retention rather than
live data. Counts also do not move with machine load, which matters on a host that sits between
load 5 and 30.

**It is behind the `alloc-probe` feature and off by default**, which is not incidental. Installed
unconditionally in test builds, a wrapper adding two atomics to every allocation in the process
turned socket-bound proxy and raft tests red in a full single-threaded run — tests that pass
individually, as a group, and in a run without it. An instrument that changes the outcome of the
suite verifying the change is worse than no instrument.

The gate then creates its own trap: with the feature off every counter reads zero, and the harness
would print a tidy table of zeros that looks exactly like "this path allocates nothing". So the
harness allocates something known first and asserts the counter moved, and the probe's own
self-tests are gated on the feature too rather than asserting a property the default build
deliberately does not have.
