### PR TITLE
A test fixture stamped a model hash no encoder produces

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -2977,7 +2977,10 @@ fn a_vector_from_another_embedding_space_cannot_win_a_summary_slot() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                model_hash: 1,
+                // What a real writer stamps: the drainer derives it from the same provider
+                // field the retrieve path compares against. A placeholder reads as a foreign
+                // encoder, so the vector is declined and selection falls to the lexical pass.
+                model_hash: context_embedding_model_hash(&provider.embedding_model),
                 vector,
                 updated_at_ms: at,
             },
@@ -3093,7 +3096,10 @@ fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
             command: Command::ContextSetNodeEmbedding {
                 tenant_hash: TENANT,
                 node_hash,
-                model_hash: 1,
+                // What a real writer stamps: the drainer derives it from the same provider
+                // field the retrieve path compares against. A placeholder reads as a foreign
+                // encoder, so the vector is declined and selection falls to the lexical pass.
+                model_hash: context_embedding_model_hash(&provider.embedding_model),
                 vector,
                 updated_at_ms: at,
             },


### PR DESCRIPTION
Two tests are failing on `main`:

- `retrieval_ranks_by_vectors_that_live_only_on_the_nodes`
- `a_vector_from_another_embedding_space_cannot_win_a_summary_slot`

Both store their vectors with `model_hash: 1`.

### This is the guard working

A stored hash that does not match the active encoder means the vector was written in a different embedding space, so the node is handed to the hybrid lexical pass rather than scored. `1` matches no encoder, so **every** node in these tests is declined, selection falls to the lexical pass, and the decoy — which is built to win exactly that pass — takes the slot.

### Why it regressed

The fixtures stamped the derived hash until #532, which landed from a tree predating that change and carried the older test file. The guard itself is intact on `main`; only the fixtures went backwards.

They now stamp `context_embedding_model_hash(&provider.embedding_model)` — what the drainer stamps, and what the retrieve path compares against.

### Testing

`context_workflow` suite: **37 passed, 0 failed** (was 1 failed). Verified the same failure reproduces on a clean checkout of `main`, so this is not branch-local.
