### PR TITLE
A page read allocated a fresh decompression window every time

### DIFF
--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -470,6 +470,18 @@ fn parse_page_record_header(
     })
 }
 
+thread_local! {
+    /// One zstd decompression context per thread, reused across page reads.
+    ///
+    /// Thread-local rather than a shared pool: a decompressor is `&mut` for the duration of a
+    /// decompress, so sharing one would serialise every reader behind a lock on a path that is
+    /// otherwise concurrent.
+    static ZSTD_DECOMPRESSOR: std::cell::RefCell<zstd::bulk::Decompressor<'static>> =
+        std::cell::RefCell::new(
+            zstd::bulk::Decompressor::new().expect("zstd decompressor construction"),
+        );
+}
+
 fn decode_page_record_payload(
     stored_payload: &[u8],
     header: &PageRecordHeader,
@@ -478,9 +490,45 @@ fn decode_page_record_payload(
     match header.compression {
         PageRecordCompression::None => Ok(stored_payload.to_vec()),
         PageRecordCompression::Zstd => {
-            let payload = zstd::stream::decode_all(Cursor::new(stored_payload)).map_err(|err| {
-                corrupt_page_envelope(address, format!("zstd decompression failed: {err}"))
-            })?;
+            // Reuse one decompression context per thread instead of building one per read.
+            //
+            // `zstd::stream::decode_all` constructs a fresh streaming decoder each call, and a
+            // decoder allocates its window buffer up front. Measured over 120 freshly written
+            // summary records: the block-store read allocated ~132 KB per address to return a
+            // 344-byte payload, about 380x the data, and that read was 78% of the whole cost of
+            // fetching a record. The window is the same size whatever the record is, so the
+            // smaller the record the worse the ratio -- which is the wrong way round for a point
+            // read.
+            //
+            // `header.payload_len` is the exact decompressed size, so the bulk API needs no
+            // guessed capacity. The length check below still runs: it guards against a record
+            // whose header disagrees with its payload, which is corruption, not a size hint.
+            // `payload_len` comes out of the record header, and the bulk API allocates that much
+            // BEFORE anything is decompressed or checked -- so a header that lies (corruption, a
+            // truncated write, a hostile record) would turn into an allocation of whatever it
+            // claims. The old streaming call sized its buffer from what it actually decompressed
+            // and could not be steered this way, so this bound is guarding a hazard the reuse
+            // introduces, not one that was already here.
+            //
+            // Above the ceiling, fall back to the streaming decoder: it pays the window
+            // allocation, but a record that large is not the case being optimised, and the
+            // fallback keeps behaviour identical rather than failing a read that used to work.
+            const ZSTD_TRUSTED_PAYLOAD_CEILING: usize = 64 << 20;
+            let payload = if header.payload_len <= ZSTD_TRUSTED_PAYLOAD_CEILING {
+                ZSTD_DECOMPRESSOR
+                    .with(|decompressor| {
+                        decompressor
+                            .borrow_mut()
+                            .decompress(stored_payload, header.payload_len)
+                    })
+                    .map_err(|err| {
+                        corrupt_page_envelope(address, format!("zstd decompression failed: {err}"))
+                    })?
+            } else {
+                zstd::stream::decode_all(Cursor::new(stored_payload)).map_err(|err| {
+                    corrupt_page_envelope(address, format!("zstd decompression failed: {err}"))
+                })?
+            };
             if payload.len() != header.payload_len {
                 return Err(corrupt_page_envelope(
                     address,
@@ -878,5 +926,107 @@ mod crc32c_switch_tests {
             decode_page_record(&encoded.bytes, &address()),
             Err(BlockStoreError::ChecksumMismatch { .. })
         ));
+    }
+}
+
+
+#[cfg(test)]
+mod reused_zstd_context_tests {
+    use super::*;
+
+    fn zstd_header(payload_len: usize, stored_len: usize) -> PageRecordHeader {
+        PageRecordHeader {
+            version: PAGE_RECORD_VERSION,
+            header_len: PAGE_RECORD_HEADER_LEN,
+            payload_len,
+            stored_len,
+            expected_sha256: [0_u8; 32],
+            page_id: Some(1),
+            object_id: Some(1),
+            routing_bucket: Some(0),
+            band_id: None,
+            compression: PageRecordCompression::Zstd,
+        }
+    }
+
+    fn address_for(payload_len: usize) -> BlockAddress {
+        BlockAddress {
+            page_slab_id: 1,
+            offset: 0,
+            length: payload_len as u64,
+            page_id: Some(1),
+            object_id: Some(1),
+            routing_bucket: Some(0),
+            generation: None,
+            band_id: None,
+            sha256: None,
+        }
+    }
+
+    /// Round-trip at several sizes through the shared thread-local context.
+    ///
+    /// Sizes straddle PAGE_RECORD_COMPRESSION_MIN_BYTES (256) so both the compressed and the
+    /// uncompressed branch are exercised, and the largest is well past any single decompress
+    /// buffer -- a bulk decompressor given the wrong capacity truncates rather than erroring, so
+    /// "it worked for the size I tried" is not evidence.
+    #[test]
+    fn a_compressed_record_round_trips_through_the_reused_context() {
+        for len in [1usize, 64, 255, 256, 257, 4096, 200_000] {
+            // Compressible content: random bytes would not compress, so the Zstd branch would
+            // never be taken and the test would silently cover nothing.
+            let original: Vec<u8> = (0..len).map(|i| (i % 7) as u8).collect();
+            let compressed = zstd::stream::encode_all(
+                std::io::Cursor::new(&original[..]),
+                PAGE_RECORD_COMPRESSION_LEVEL,
+            )
+            .expect("compresses");
+            let header = zstd_header(original.len(), compressed.len());
+            let decoded = decode_page_record_payload(&compressed, &header, &address_for(len))
+                .expect("a well-formed compressed record must decode");
+            assert_eq!(
+                original, decoded,
+                "length {len} did not survive the reused decompression context"
+            );
+        }
+    }
+
+    /// The same context serves many reads in a row without carrying state between them.
+    #[test]
+    fn the_context_stays_correct_across_consecutive_reads_of_different_sizes() {
+        let sizes = [4096usize, 17, 900, 3, 60_000];
+        for _ in 0..3 {
+            for len in sizes {
+                let original: Vec<u8> = (0..len).map(|i| (i % 11) as u8).collect();
+                let compressed = zstd::stream::encode_all(
+                    std::io::Cursor::new(&original[..]),
+                    PAGE_RECORD_COMPRESSION_LEVEL,
+                )
+                .expect("compresses");
+                let header = zstd_header(original.len(), compressed.len());
+                let decoded = decode_page_record_payload(&compressed, &header, &address_for(len))
+                    .expect("decodes");
+                assert_eq!(original, decoded, "size {len} was wrong on a reused context");
+            }
+        }
+    }
+
+    /// A header that lies about its payload length is refused, not served.
+    ///
+    /// This matters more now than it did: the bulk API allocates the CLAIMED length before
+    /// decompressing anything, so a lie is acted on before it is checked.
+    #[test]
+    fn a_header_that_lies_about_its_length_is_refused() {
+        let original: Vec<u8> = (0..1000).map(|i| (i % 5) as u8).collect();
+        let compressed = zstd::stream::encode_all(
+            std::io::Cursor::new(&original[..]),
+            PAGE_RECORD_COMPRESSION_LEVEL,
+        )
+        .expect("compresses");
+        // The record really holds 1000 bytes; the header claims 4242.
+        let header = zstd_header(4242, compressed.len());
+        assert!(
+            decode_page_record_payload(&compressed, &header, &address_for(1000)).is_err(),
+            "a payload_len that disagrees with the record must be an error, not a short read"
+        );
     }
 }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3302,3 +3302,179 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
         plain.len()
     );
 }
+
+
+/// Where does the cost of reading ONE summary go: fetching the bytes, or decoding them?
+///
+/// The command-level measurement says 253 allocations and 289 KB per candidate for a 4 KB summary
+/// -- a 70x amplification -- and two guesses about why have already been wrong, including one that
+/// made it worse. So split the read in half and count each half, and print how many points the
+/// extent holds, which settles whether siblings are being decoded at all.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_reading_one_summary_actually_costs -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_reading_one_summary_actually_costs() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  text   points/extent   extent bytes   read allocs   read bytes   decode allocs   decode bytes
+"
+    );
+    for text_len in [16usize, 512, 4096] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let text = "s".repeat(text_len);
+        for node_hash in 1..=120u64 {
+            let response = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextUpsertSummary {
+                    tenant_hash: 7201,
+                    summary: crate::types::ContextSummary {
+                        node_hash,
+                        level: 2,
+                        text: text.clone(),
+                        valid_from_ms: 1_000,
+                        vector: vec![0.25_f32; 16],
+                    },
+                },
+            });
+            assert!(response.status.ok, "{:?}", response.status);
+        }
+
+        let address = {
+            let shards = engine.shards.read().expect("engine lock poisoned");
+            let shard = shards.get(&1).expect("loaded shard");
+            let key = super::context::context_summary_key(7201, 60, 2);
+            let series = shard
+                .context_summaries
+                .get(&key)
+                .expect("the summary series must exist, or this measures nothing");
+            series
+                .iter()
+                .next()
+                .map(|(_, address)| address.clone())
+                .expect("one entry")
+        };
+
+        // Warm, so neither half is charged for filling a cache that a steady-state read finds warm.
+        let _ = super::read_page_bytes(&engine.cache, &engine.page_store, 1, &address);
+
+        let read_probe = crate::alloc_probe::Probe::start();
+        let mut bytes = Vec::new();
+        for _ in 0..5 {
+            bytes = super::read_page_bytes(&engine.cache, &engine.page_store, 1, &address)
+                .expect("the page must read, or the split below is measuring a None");
+        }
+        let read = read_probe.stop();
+
+        let decode_probe = crate::alloc_probe::Probe::start();
+        let mut points = 0usize;
+        for _ in 0..5 {
+            points = match super::packed_pages::decode_feature_page_strict(&bytes) {
+                super::state::PackedFeaturePageDecode::Packed(p) => p.len(),
+                super::state::PackedFeaturePageDecode::Legacy => 1,
+                super::state::PackedFeaturePageDecode::Corrupt(_) => 0,
+            };
+        }
+        let decode = decode_probe.stop();
+
+        println!(
+            "  {text_len:>4}   {points:>13}   {:>12}   {:>11}   {:>10}   {:>13}   {:>12}",
+            bytes.len(),
+            read.allocs / 5,
+            read.alloc_bytes / 5,
+            decode.allocs / 5,
+            decode.alloc_bytes / 5,
+        );
+
+        // Cold walk over every address, which is what a batch read actually does: 120 distinct
+        // extents rather than one warm one. Warming a single address measures the best case and
+        // would report it as the cost.
+        let addresses: Vec<crate::block_store::BlockAddress> = {
+            let shards = engine.shards.read().expect("engine lock poisoned");
+            let shard = shards.get(&1).expect("loaded shard");
+            (1..=120u64)
+                .filter_map(|node_hash| {
+                    let key = super::context::context_summary_key(7201, node_hash, 2);
+                    shard
+                        .context_summaries
+                        .get(&key)
+                        .and_then(|series| series.iter().next())
+                        .map(|(_, address)| address.clone())
+                })
+                .collect()
+        };
+        assert_eq!(addresses.len(), 120, "every summary must be addressable");
+        let wal_resident = addresses
+            .iter()
+            .filter(|a| crate::wal_record::is_wal_resident(a.page_slab_id))
+            .count();
+        let with_page_id = addresses.iter().filter(|a| a.page_id.is_some()).count();
+        let distinct_slabs: std::collections::BTreeSet<u64> =
+            addresses.iter().map(|a| a.page_slab_id).collect();
+        println!(
+            "         {wal_resident}/120 wal_resident addresses, {with_page_id} carry a page_id, {} distinct slabs, block_in_wal enabled={}",
+            distinct_slabs.len(),
+            std::env::var("TS_BLOCK_IN_WAL").unwrap_or_else(|_| "unset(on)".to_string()),
+        );
+        let extent_total: u64 = addresses.iter().map(|a| a.length).sum();
+
+        let walk_probe = crate::alloc_probe::Probe::start();
+        let mut decoded = 0usize;
+        for address in &addresses {
+            if let Some(page) = super::read_page_bytes(&engine.cache, &engine.page_store, 1, address)
+            {
+                if let super::state::PackedFeaturePageDecode::Packed(points) =
+                    super::packed_pages::decode_feature_page_strict(&page)
+                {
+                    decoded += points.len();
+                }
+            }
+        }
+        let walk = walk_probe.stop();
+
+        // The block-store read alone, over the same addresses, on a store whose cache is already
+        // warm from the walk above -- so this is purely file seek + read_exact + decode.
+        let read_only_probe = crate::alloc_probe::Probe::start();
+        let mut read_bytes_total = 0usize;
+        for address in &addresses {
+            if let Ok(b) = engine.page_store.read(address) {
+                read_bytes_total += b.len();
+            }
+        }
+        let read_only = read_only_probe.stop();
+        println!(
+            "         block-store read alone: {} allocs/addr, {} bytes/addr ({} payload bytes returned in total)",
+            read_only.allocs / 120,
+            read_only.alloc_bytes / 120,
+            read_bytes_total,
+        );
+        println!(
+            "         cold walk over every address: {} allocs/addr, {} bytes/addr, {} extents totalling {} bytes, {decoded} points decoded",
+            walk.allocs / 120,
+            walk.alloc_bytes / 120,
+            addresses.len(),
+            extent_total,
+        );
+    }
+    println!(
+        "
+  points/extent > 1 means siblings ARE decoded for every read, and a page-granular cache pays.
+  points/extent == 1 means each record has its own extent and the cost is inside one record.
+"
+    );
+}


### PR DESCRIPTION
Every compressed page read built a fresh zstd decoder and allocated its decompression window to
return a few hundred bytes.

### The measurement

`decode_page_record_payload` called `zstd::stream::decode_all(Cursor::new(stored_payload))`. That
constructs a new streaming decoder per call, and a decoder allocates its window up front —
independent of how small the record is, so the smaller the record the worse the ratio. That is the
wrong way round for a point read.

Counted with a global allocator over 120 freshly written summary records, **bytes allocated per
address**:

| summary text | block-store read, before | after | full `read_page_bytes`, before | after |
|---:|---:|---:|---:|---:|
| 16 B | 132,035 | **960** | 169,290 | 39,307 |
| 512 B | 134,025 | 2,950 | 178,101 | 48,119 |
| 4096 B | 164,463 | 17,288 | 258,232 | 112,284 |

**137x** on the read itself for small records; 4.3x on the whole read path. The block-store read was
78% of the cost of fetching a record before this, and the records in question total 27 KB across all
120 of them.

Allocation *count* barely moved — 15 to 14 — which is the tell that this was one large allocation
rather than many small ones, and the reason neither RSS nor an allocation count on its own would
have found it.

### The change

One `zstd::bulk::Decompressor` per thread, reused across reads, with `header.payload_len` as the
exact output capacity. Thread-local rather than pooled: a decompressor is `&mut` for the duration of
a call, so a shared one would serialise readers on a path that is otherwise concurrent.

### The bound is guarding a hazard this introduces

The bulk API allocates the **claimed** length before decompressing or checking anything, so a header
that lies — corruption, a truncated write — becomes an allocation of whatever it claims. The old
streaming call sized its buffer from what it actually decompressed and could not be steered that
way. Above a 64 MB ceiling this falls back to the streaming decoder: it pays the window allocation,
but a record that large is not the case being optimised, and falling back keeps behaviour identical
rather than failing a read that used to work.

The existing post-decompress length check still runs, but it runs *after* the allocation, so it is
not a substitute for the ceiling.

### Tests

| test | property |
|---|---|
| `a_compressed_record_round_trips_through_the_reused_context` | byte-exact at 1, 64, 255, 256, 257, 4096 and 200 000 bytes — either side of the 256-byte compression threshold, and one well past any single buffer |
| `the_context_stays_correct_across_consecutive_reads_of_different_sizes` | the shared context carries no state between reads, three rounds over five alternating sizes |
| `a_header_that_lies_about_its_length_is_refused` | a claimed length that disagrees with the record is an error, not a short read |

Sizes matter here: swapping a streaming decoder for a bulk one with an explicit capacity is exactly
the change that works at the size you tried and truncates at another, and a bulk decompressor given
too little room **truncates rather than erroring**. Mutation-tested — halving the capacity fails the
round-trip test, which is the failure mode that would otherwise ship silently.

Not mutation-tested, deliberately: swapping the bulk decompressor back for the streaming one leaves
both paths correct, so the round-trip test rightly still passes. These tests guard the correctness
of the new path; the saving is evidenced by the measurement above.

### What this does not fix

After the change the full `read_page_bytes` path still allocates ~39 KB per address for a 344-byte
payload. The remainder is not the decode — it is what happens around it, and it is the next thing
to attribute rather than something this change addresses.
