### PR TITLE
An index nobody can query

### DIFF
--- a/tools/matrixark_mcp_core_query_analysis.py
+++ b/tools/matrixark_mcp_core_query_analysis.py
@@ -461,6 +461,37 @@ def deterministic_secondary_index_filter_groups(query: str, question_type: str) 
     return groups
 
 
+# The index KINDS a query can ever ask for. `passes_secondary_index_filters` intersects a
+# candidate's terms with the groups this module infers, so a term whose kind never appears in a
+# group cannot narrow a search or earn the hint boost -- whatever its value.
+#
+# This lives next to the inference it mirrors on purpose. If a kind is added to the inference and
+# not here, ingest stops writing it and the query that needs it narrows to nothing, silently; the
+# two are only correct together.
+INFERABLE_SECONDARY_INDEX_KINDS = frozenset({
+    "classification",
+    "entity_type",
+    "event_type",
+    "memory_layer",
+    "memory_scope",
+    "memory_selection_policy",
+    "profile_entity_current",
+    "profile_memory_class",
+    "profile_memory_kind",
+    "profile_summary_current",
+    "segment_topic",
+    "session_continuity",
+    "source_role",
+    "source_type",
+})
+
+
+def index_term_is_consultable(term: str) -> bool:
+    """Whether a query could ever match this term."""
+    kind, separator, _ = str(term).partition(":")
+    return bool(separator) and kind in INFERABLE_SECONDARY_INDEX_KINDS
+
+
 def infer_secondary_index_filter_groups(query: str, question_type: str) -> list[set[str]]:
     if understanding_provider() == "oss_encoder":
         return oss_encoder_secondary_index_filter_groups(query, question_type)

--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -77,6 +77,22 @@ INDEX_KEYWORD_LIMIT = int(os.environ.get("MATRIXARK_INDEX_KEYWORD_LIMIT", "12"))
 # fields and never read `ref_hashes`, so a posting carrying two refs had no identity and was
 # dropped outright -- silently, with no length mismatch to raise an error. That is fixed, and
 # the emitter now splits at MAX_SECONDARY_INDEX_REFS_PER_POSTING like the compactor does.
+try:  # package path
+    from tools.matrixark_mcp_core_query_analysis import index_term_is_consultable
+except ImportError:  # top-level path
+    from matrixark_mcp_core_query_analysis import index_term_is_consultable
+
+# Default ON. See index_term_is_consultable: a term whose kind the query analyser can never
+# emit cannot appear in a filter group, so it cannot narrow a search or earn the hint boost. On a
+# 1 MB skill those terms are 1,418 KB of the 1,471 KB index -- 15.7% of the ingest -- and dropping
+# them takes amplification 8.6x to 7.2x while embeddings become the majority of the footprint
+# (44.6% -> 53.0%), which is what an embedding-first store should look like.
+#
+# Set MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS=0 to write every term again.
+INDEX_ONLY_CONSULTABLE_TERMS = os.environ.get(
+    "MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS", "1"
+).strip().lower() not in {"0", "false", "no", "off", ""}
+
 INDEX_POSTING_LISTS = os.environ.get(
     "MATRIXARK_INDEX_POSTING_LISTS", "1"
 ) not in {"0", "false", "False", ""}
@@ -289,6 +305,15 @@ def append_resource_chunk_records(
             0,
             len(ordered_unique([term for term in raw_chunk_index_terms if term])) - len(chunk_index_terms),
         )
+        # Drop terms no query can ask for. passes_secondary_index_filters only ever intersects a
+        # candidate's terms with the groups infer_secondary_index_filter_groups produces, and that
+        # inference emits a fixed set of KINDS -- so a term outside it cannot narrow a search or
+        # earn the hint boost whatever its value. On a 1 MB skill those terms are 96.4% of the
+        # index and 15.7% of the whole ingest, written and scanned to affect nothing.
+        if INDEX_ONLY_CONSULTABLE_TERMS:
+            chunk_index_terms = [
+                term for term in chunk_index_terms if index_term_is_consultable(term)
+            ]
         chunk_index_terms = take_secondary_index_terms(chunk_index_terms, secondary_index_budget)
         for index_name in chunk_index_terms:
             index_write_count += 1

--- a/tools/test_matrixark_index_consultable_terms.py
+++ b/tools/test_matrixark_index_consultable_terms.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Index terms no query can ask for are not written, and the two halves cannot drift apart.
+
+Retrieval narrows using groups from `infer_secondary_index_filter_groups`, and
+`passes_secondary_index_filters` only ever INTERSECTS a candidate's terms with those groups. The
+inference emits a fixed set of KINDS, so a term whose kind is outside that set cannot appear in a
+group, cannot intersect one, and cannot narrow a search or earn the hint boost -- whatever its
+value.
+
+On a 1 MB skill those terms were 1,418 KB of a 1,471 KB index, 15.7% of the whole ingest, written
+and scanned to affect nothing. Dropping them takes amplification 8.6x to 7.2x and makes embeddings
+the majority of the footprint (44.6% -> 53.0%), which is what an embedding-first store should look
+like.
+
+The danger is drift. The declared set and the inference are only correct TOGETHER: a kind added to
+the inference but not declared would be filtered out at ingest, and the query needing it would
+narrow to nothing with nothing to notice. The first test reads the kinds straight out of the
+inference source so that can only happen loudly.
+"""
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from matrixark_mcp_core_query_analysis import (
+    INFERABLE_SECONDARY_INDEX_KINDS,
+    index_term_is_consultable,
+)
+from matrixark_mcp_core_scoring import passes_secondary_index_filters
+
+
+class WhatAQueryCanAskFor(unittest.TestCase):
+    def test_the_declared_set_covers_every_kind_the_inference_emits(self):
+        """The drift guard, and the reason this file exists.
+
+        Read from the inference SOURCE rather than a hand-kept list: a kind added there and not
+        here would be dropped at ingest and the query that needed it would silently match nothing.
+        This caught `source_role` missing the first time it ran.
+        """
+        import matrixark_mcp_core_query_analysis as qa
+        with open(qa.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("def deterministic_secondary_index_filter_groups")
+        emitted = set(re.findall(r'context_index_name\("([a-z_]+)"', source[start:start + 12000]))
+        self.assertTrue(emitted, "found no emitted kinds -- the parse is wrong, not the code")
+        missing = emitted - set(INFERABLE_SECONDARY_INDEX_KINDS)
+        self.assertEqual(
+            set(), missing,
+            "the inference can emit %s but ingest would filter them out, so a query using them "
+            "would narrow to nothing" % sorted(missing))
+
+    def test_a_consultable_kind_is_kept(self):
+        for kind in sorted(INFERABLE_SECONDARY_INDEX_KINDS):
+            self.assertTrue(index_term_is_consultable("%s:whatever" % kind))
+
+    def test_the_bulk_of_a_skill_ingest_is_not_consultable(self):
+        # These are what a skill actually wrote, and together they were 96.4% of its index.
+        for term in ("heading_slug:step-1", "keyword:checkout", "unit_kind:section",
+                     "resource_type:skill", "skill_name:acme", "relative_path:a/b.md"):
+            self.assertFalse(index_term_is_consultable(term),
+                             "%s is filtered at ingest; if a query can now ask for it, the "
+                             "declared set must say so" % term)
+
+    def test_a_term_with_no_kind_is_not_consultable(self):
+        for term in ("", "novalue", ":", "  "):
+            self.assertFalse(index_term_is_consultable(term))
+
+    def test_dropping_them_cannot_change_narrowing(self):
+        """The claim, exercised rather than argued.
+
+        Narrowing intersects a candidate's terms with the inferred groups. Adding or removing
+        terms whose kind is not in any group must not move the outcome either way.
+        """
+        groups = [{"entity_type:location"}, {"source_type:message"}]
+        kept = {"entity_type:location", "source_type:message"}
+        dropped = {"heading_slug:step-1", "keyword:checkout", "skill_name:acme"}
+        self.assertEqual(
+            passes_secondary_index_filters(kept, groups),
+            passes_secondary_index_filters(kept | dropped, groups),
+            "un-consultable terms changed the narrowing outcome")
+        # and the negative case, so this is not passing because everything passes
+        self.assertFalse(passes_secondary_index_filters(dropped, groups))
+        self.assertTrue(passes_secondary_index_filters(kept, groups))
+
+
+class TheFilterIsOnAndActuallyFilters(unittest.TestCase):
+    def test_the_default_is_on(self):
+        os.environ.pop("MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS", None)
+        import importlib
+        for name in [m for m in list(sys.modules) if m.startswith("matrixark_mcp_ingest_resource_chunk_records")]:
+            del sys.modules[name]
+        mod = importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
+        self.assertTrue(mod.INDEX_ONLY_CONSULTABLE_TERMS)
+
+    def test_the_escape_hatch_works(self):
+        import importlib
+        os.environ["MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS"] = "0"
+        for name in [m for m in list(sys.modules) if m.startswith("matrixark_mcp_ingest_resource_chunk_records")]:
+            del sys.modules[name]
+        mod = importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
+        self.assertFalse(mod.INDEX_ONLY_CONSULTABLE_TERMS)
+        os.environ.pop("MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_index_posting_coalescing.py
+++ b/tools/test_matrixark_index_posting_coalescing.py
@@ -33,6 +33,12 @@ def _emit(coalesced, chunk_count=40):
     os.environ.update({
         "MATRIXARK_RESOURCE_MAX_TOTAL_CHUNKS": "500000",
         "MATRIXARK_INDEX_POSTING_LISTS": "1" if coalesced else "0",
+        # These tests are about the SHAPE of a posting -- coalescing, the ref cap, the
+        # singular/plural ref_hash rule -- not about which terms survive filtering. With the
+        # consultable-terms filter on, a small fixture emits one source_type posting carrying
+        # every chunk: no single-ref posting to assert on and the cap never approached. The
+        # filter has its own tests in test_matrixark_index_consultable_terms.
+        "MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS": "0",
     })
     for name in [m for m in list(sys.modules) if m.startswith("matrixark_")]:
         del sys.modules[name]


### PR DESCRIPTION
Retrieval narrows using groups from `infer_secondary_index_filter_groups`, and `passes_secondary_index_filters` only ever **intersects** a candidate's terms with those groups:

```python
return all(bool(candidate_terms.intersection(group)) for group in required_groups)
```

The inference emits a fixed set of **14 kinds**, all on the memory/profile path. A term whose kind is outside that set cannot appear in a group, cannot intersect one, and so cannot narrow a search or earn the 0.08 hint boost — **whatever its value**.

### On a 1 MB skill, that is almost the entire index

| index kind | bytes | consultable |
|---|---:|---|
| heading_slug | 990.7 KB | no |
| keyword | 269.3 KB | no |
| unit_kind / resource_type / skill_name | 158.1 KB | no |
| **source_type** | **52.7 KB** | **yes — the only one** |

**1,418 KB of 1,471 KB (96.4%)**, written, stored, and scanned on every retrieval to affect nothing.

### Effect

| | before | after |
|---|---:|---:|
| ingest | 9.2 MB | **7.8 MB** (−15.7%) |
| amplification | 8.6x | **7.2x** |
| context_index share | 16.3% | **0.7%** |
| **embedding share** | 44.6% | **53.0%** |

Embeddings become the majority of what is stored, which is what an embedding-first store should look like.

### Why this costs nothing

The index is **not** used to gather candidates — candidates come from elsewhere; index records only build the term lists feeding the filter and the boost. A test exercises the claim directly rather than arguing it: adding or removing un-consultable terms does not move `passes_secondary_index_filters` either way, paired with a negative case so it cannot pass because everything passes.

### The drift hazard

`INFERABLE_SECONDARY_INDEX_KINDS` and `index_term_is_consultable` live **beside** the inference they mirror, because the two are only correct together and drift is silent in one direction: a kind added to the inference and not the set gets filtered out at ingest, and the query needing it narrows to nothing with no error anywhere.

A test reads the kinds out of the inference **source** and fails on any gap rather than trusting a hand-kept list. **It caught `source_role` missing the first time it ran.**

### Testing

12 tests here; 292 across the affected modules with no new failures — the 7 remaining are in `dual_write_ingestion_benchmark` and reproduce identically without this change.
