### PR TITLE
One locator, stored twice

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -1997,7 +1997,15 @@ SERVING_RESOURCE_METADATA_FIELDS = {
     "heading",
     "heading_slug",
     "heading_path",
-    "source_locator",
+    # `source_locator` is deliberately absent: every chunk record carries it at the TOP level
+    # (both resource_chunk_record and skill_section_record set it unconditionally), and storing
+    # it here as well cost 290.8 KB per 1 MB skill -- 3.7% of the ingest -- byte-identical to the
+    # copy beside it. Readers of the metadata copy are all fallbacks of the form
+    # `record.get("source_locator") or metadata.get("source_locator")`, which cannot fire while
+    # the top-level field is present.
+    #
+    # `heading` stays: skill_section_record sets it at the top level but resource_chunk_record
+    # does not, so for a resource chunk this is the only copy.
     "content_hash",
     "token_estimate",
     "row_start",


### PR DESCRIPTION
Every chunk record carries `source_locator` at the top level **and** again inside its own `metadata`, byte-identical. On a 1 MB skill that is **290.8 KB — 3.7% of the ingest** — storing the same string beside itself 2,510 times.

### Why the metadata copy is safe to drop

Both builders set the top-level field unconditionally (`resource_chunk_record`, `skill_section_record`), so the metadata copy never carries anything the record does not already have. Every reader of it is a fallback:

```python
record.get("source_locator") or metadata.get("source_locator")
```

which cannot fire while the top-level field is present. Reads of `chunk_metadata` during ingest see the **parser's** metadata, before a record exists, and are untouched.

### `heading` is deliberately left alone

It looks like the same duplication, and it is not: `skill_section_record` sets it at the top level but `resource_chunk_record` **does not**, so for a resource chunk the metadata copy is the only copy. Removing it would have been the same edit with a different outcome — a field silently absent on one record type. The two were checked separately rather than treated as "the duplicated fields".

### Testing

92 tests across the resource, chunk, skill, retrieval and dashboard modules: OK.
