### PR TITLE
a page digest is 32 bytes, not 64 characters of hex behind a pointer

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -79,11 +79,63 @@ pub struct BlockAddress {
     pub generation: Option<u64>,
     #[serde(default, alias = "extent_id", alias = "zone_id", skip_serializing_if = "Option::is_none")]
     pub band_id: Option<u64>,
-    #[serde(default, alias = "checksum", skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
+    /// The page's digest, as the 32 bytes it is.
+    ///
+    /// It was a hex `String`: 24 bytes inline plus a 64-character allocation, for 32 bytes of
+    /// information, held in the index for every page for the life of the shard. Measured at 100%
+    /// occupancy over 1500 pages, so this is per-page cost and not an occasional one.
+    ///
+    /// The wire form is unchanged -- `hex_digest` writes the same hex string it always did, and
+    /// reads either -- so an index written before this change loads, and one written after is
+    /// readable by anything expecting the old shape.
+    #[serde(
+        default,
+        alias = "checksum",
+        skip_serializing_if = "Option::is_none",
+        with = "hex_digest"
+    )]
+    pub sha256: Option<[u8; 32]>,
+}
+
+/// A digest is 32 bytes in memory and hex on the wire.
+///
+/// Keeping the wire form makes this change invisible to anything that reads a persisted index, in
+/// both directions: the same hex string is written, and a hex string is what is read.
+mod hex_digest {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        value: &Option<[u8; 32]>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(bytes) => serializer.serialize_str(&hex::encode(bytes)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<[u8; 32]>, D::Error> {
+        // A digest that is not 32 bytes of hex is not a digest. Reading it as absent rather than
+        // failing keeps a malformed one from making a whole index unloadable -- the read path
+        // treats a missing digest as "unverified", which is what a corrupt one deserves too.
+        let raw = Option::<String>::deserialize(deserializer)?;
+        Ok(raw.and_then(|text| {
+            let mut bytes = [0u8; 32];
+            hex::decode_to_slice(text.as_bytes(), &mut bytes)
+                .ok()
+                .map(|_| bytes)
+        }))
+    }
 }
 
 impl BlockAddress {
+    /// The digest as the hex text every reporting path quotes.
+    pub fn sha256_hex(&self) -> Option<String> {
+        self.sha256.as_ref().map(hex::encode)
+    }
+
     pub fn compact_slab_id(&self) -> Option<u32> {
         u32::try_from(self.page_slab_id).ok()
     }
@@ -1761,7 +1813,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = LocalBlockStore::new(dir.path());
         let address = store.append(b"verified-page").unwrap();
-        assert_eq!(address.sha256, Some(sha256_hex(b"verified-page")));
+        assert_eq!(address.sha256_hex(), Some(sha256_hex(b"verified-page")));
         assert_eq!(store.read(&address).unwrap(), b"verified-page");
 
         let path = slab_path(dir.path(), address.page_slab_id);
@@ -1788,7 +1840,7 @@ mod tests {
         assert_eq!(address.object_id, Some(4242));
         assert_eq!(address.routing_bucket, Some(17));
         assert_eq!(address.band_id, Some(0));
-        assert_eq!(address.sha256, Some(sha256_hex(b"address-contract")));
+        assert_eq!(address.sha256_hex(), Some(sha256_hex(b"address-contract")));
         assert_eq!(address.compact_slab_id(), Some(0));
         assert_eq!(address.compact_slab_offset(), Some(0));
         assert_eq!(address.compact_slab_address(), Some(0));
@@ -1816,7 +1868,12 @@ mod tests {
             // alias JSON must carry it or the round-trip deserializes to None.
             "generation": address.generation,
             "band_id": address.band_id,
-            "checksum": address.sha256,
+            // The legacy document carries the digest as HEX, which is what the alias means and
+            // what a record written before the digest became bytes actually holds. Passing the
+            // bytes here would build a document no old writer ever produced -- an array where the
+            // alias expects a string -- and test the round-trip against a shape that never
+            // existed.
+            "checksum": address.sha256_hex(),
         });
         let from_checksum_alias: BlockAddress = serde_json::from_value(legacy_alias_json).unwrap();
         assert_eq!(from_checksum_alias, address);
@@ -2514,7 +2571,7 @@ mod tests {
         assert!(!reports[0].block_index_entries[0].dirty);
         assert!(!reports[0].block_index_entries[0].deleted);
         assert!(!reports[0].block_index_entries[0].block_in_log);
-        assert_eq!(reports[0].block_index_entries[0].checksum, first.sha256);
+        assert_eq!(reports[0].block_index_entries[0].checksum, first.sha256_hex());
         assert_eq!(reports[0].block_index_entries[1].offset, second.offset);
         assert_eq!(reports[0].block_index_entries[1].length, second.length);
         assert_eq!(reports[0].block_index_entries[1].block_id, second.page_id);

--- a/crates/temporalstore-rust/src/block_store/append.rs
+++ b/crates/temporalstore-rust/src/block_store/append.rs
@@ -3,6 +3,7 @@
 
 //! LocalBlockStore append/append_batch methods, split from block_store.rs.
 use super::*;
+use super::record::sha256_bytes;
 
 impl LocalBlockStore {
     /// Force durability for writes made under relaxed (bulk) mode: fsync the
@@ -81,7 +82,7 @@ impl LocalBlockStore {
             routing_bucket,
             generation: Some(page_id),
             band_id: Some(band_id),
-            sha256: Some(sha256_hex(bytes)),
+            sha256: Some(sha256_bytes(bytes)),
         };
         file.write_all(&record.bytes)?;
         file.flush()?;
@@ -190,7 +191,7 @@ impl LocalBlockStore {
                 routing_bucket,
                 generation: Some(page_id),
                 band_id: Some(band_id),
-                sha256: Some(sha256_hex(&bytes)),
+                sha256: Some(sha256_bytes(&bytes)),
             };
             if let Some(current) = file.as_mut() {
                 current.write_all(&record.bytes)?;

--- a/crates/temporalstore-rust/src/block_store/read.rs
+++ b/crates/temporalstore-rust/src/block_store/read.rs
@@ -3,6 +3,7 @@
 
 //! LocalBlockStore read/read_range/install_slab methods, split from block_store.rs.
 use super::*;
+use super::record::sha256_bytes;
 
 impl LocalBlockStore {
     pub fn read(&self, address: &BlockAddress) -> Result<Vec<u8>, BlockStoreError> {
@@ -18,14 +19,16 @@ impl LocalBlockStore {
         let decoded = decode_page_record(&bytes, address)?;
         let bytes = decoded.payload;
         if let Some(expected) = &address.sha256 {
-            let actual = sha256_hex(&bytes);
+            // Compare the bytes; render hex only if they differ, which is the path that has a
+            // human on the other end of it.
+            let actual = sha256_bytes(&bytes);
             if &actual != expected {
                 return Err(BlockStoreError::ChecksumMismatch {
                     page_slab_id: address.page_slab_id,
                     offset: address.offset,
                     length: address.length,
-                    expected: expected.clone(),
-                    actual,
+                    expected: hex::encode(expected),
+                    actual: hex::encode(actual),
                 });
             }
         }

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -609,6 +609,14 @@ pub(super) fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(Sha256::digest(bytes))
 }
 
+/// The digest as the 32 bytes it is, for storing.
+///
+/// `sha256_hex` remains for the places that want text -- a report, an error message. What it does
+/// not do any more is decide the in-memory representation of every page in the index.
+pub(super) fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
+    Sha256::digest(bytes).into()
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct SlabSummary {
     pub(super) logical_bytes: u64,

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -259,7 +259,7 @@ pub(super) fn storage_block_address_sample(
         block_id: address.page_slab_id,
         offset: address.offset,
         length: address.length,
-        checksum: address.sha256.clone().unwrap_or_default(),
+        checksum: address.sha256_hex().unwrap_or_default(),
     }
 }
 
@@ -312,7 +312,7 @@ pub(super) fn storage_index_snapshot_with_samples(
                     .address
                     .band_id
                     .unwrap_or(entry.address.page_slab_id),
-                checksum: entry.address.sha256.clone().unwrap_or_default(),
+                checksum: entry.address.sha256_hex().unwrap_or_default(),
                 generation: entry.address.object_id.unwrap_or(0),
                 page_address,
                 block_address,

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -275,7 +275,10 @@ pub(super) fn native_packed_page_index_bytes(
         routing_bucket: Some(page.routing_bucket),
         generation: page.page_id.or(page.object_id),
         band_id: page.zone_id,
-        sha256: page.checksum.clone(),
+        sha256: page.checksum.as_deref().and_then(|text| {
+            let mut bytes = [0u8; 32];
+            hex::decode_to_slice(text.as_bytes(), &mut bytes).ok().map(|_| bytes)
+        }),
     });
     bytes[9..17].copy_from_slice(&address.to_le_bytes());
     bytes
@@ -380,7 +383,7 @@ pub(super) fn storage_physical_index_report(
             page_id: entry.address.page_id,
             object_id: entry.address.object_id,
             zone_id: entry.address.band_id,
-            checksum: entry.address.sha256.clone(),
+            checksum: entry.address.sha256_hex(),
             dirty: entry.dirty,
             deleted: entry.deleted,
             log_backed: entry.log_backed,
@@ -431,7 +434,7 @@ pub(super) fn storage_physical_index_report(
                 page_id: page.address.page_id,
                 object_id: Some(page.object_id),
                 zone_id: page.address.band_id,
-                checksum: page.address.sha256.clone(),
+                checksum: page.address.sha256_hex(),
                 dirty: page.dirty,
                 deleted: page.deleted,
                 log_backed: page.log_backed,
@@ -746,7 +749,7 @@ pub(super) fn bucket_generation_fingerprints_by_bucket(shard: &ShardState) -> BT
             entry.address.object_id.unwrap_or_default(),
             entry.address.routing_bucket.unwrap_or(routing_bucket),
             entry.address.generation.unwrap_or_default(),
-            entry.address.sha256.unwrap_or_default()
+            entry.address.sha256_hex().unwrap_or_default()
         ));
     }
     by_bucket

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -8208,7 +8208,7 @@ fn what_a_live_record_is_made_of() {
                     address.object_id,
                     address.generation,
                     address.band_id,
-                    address.sha256.as_deref().map(str::len).unwrap_or(0),
+                    address.sha256.map(|digest| digest.len()).unwrap_or(0),
                 );
                 println!(
                     "[census]   item.object_id == address.object_id? {}",
@@ -9851,7 +9851,9 @@ fn what_one_page_costs_to_index() {
             heap += page.object_key.len();
             heap += page.model_id.len();
             heap += page.component.as_ref().map_or(0, String::len);
-            heap += page.address.sha256.as_ref().map_or(0, String::len);
+            // The digest is 32 inline bytes now, not a 64-character allocation: it costs
+            // nothing on the heap, which is the whole point of the change.
+            heap += 0;
         }
     }
     assert!(entries > 0, "the workload must produce pages, or this measures nothing");

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -174,10 +174,9 @@ fn address_to_proto(address: &BlockAddress) -> v1::WalBlockAddress {
         band_id: address.band_id,
         // The digest, not its transcription. Half the bytes, same value.
         checksum: None,
-        checksum_raw: address
-            .sha256
-            .as_deref()
-            .and_then(checksum_to_raw),
+        // In memory the digest is already the 32 bytes this field wants, so there is no
+        // transcription left to undo.
+        checksum_raw: address.sha256.map(|digest| digest.to_vec()),
     }
 }
 
@@ -195,8 +194,15 @@ fn address_from_proto(address: v1::WalBlockAddress) -> BlockAddress {
         sha256: address
             .checksum_raw
             .as_deref()
-            .map(checksum_from_raw)
-            .or(address.checksum),
+            .and_then(|raw| <[u8; 32]>::try_from(raw).ok())
+            // A record written before  existed carries the hex instead; decode it
+            // to the same 32 bytes rather than keeping two shapes alive in memory.
+            .or_else(|| {
+                address.checksum.as_deref().and_then(|text| {
+                    let mut bytes = [0u8; 32];
+                    hex::decode_to_slice(text.as_bytes(), &mut bytes).ok().map(|_| bytes)
+                })
+            }),
     }
 }
 /// The numeric key a component is carrying, if it is carrying one.


### PR DESCRIPTION
a page digest is 32 bytes, not 64 characters of hex behind a pointer

    one page's index entry          before      after
      inline struct                  208 B      224 B    (+16, the array)
      heap owned, measured         131.6 B     67.6 B    (-64, the hex string)
      total per page               339.6 B    291.6 B    -14.1%

    and one fewer allocation per page, which that measurement does not count.

`BlockAddress.sha256` was an `Option<String>` holding a 64-character transcription of 32 bytes:
24 bytes inline plus a heap allocation, in the index, for every page, for the life of the shard.
Measured at 100% occupancy over 1500 pages, so it is a per-page cost and not an occasional one.

It is `Option<[u8; 32]>` now. The inline grows by 16 because Rust pads the array to 40 where the
String header was 24; the 64-byte allocation is gone.

THE WIRE FORM DOES NOT CHANGE. A serde shim writes the same hex string it always wrote and reads
either shape, so an index written before this loads, and one written after stays readable by
anything that expects the old form.

THE LOG ALREADY DID THIS. `wal_proto` carries the digest in `checksum_raw` with the comment "The
digest, not its transcription. Half the bytes, same value." The conversions in both directions were
transcribing to hex and back on the way past; they are identity now. The lesson had been learned for
the wire and never followed in memory.

A DIGEST THAT IS NOT 32 BYTES OF HEX READS AS ABSENT rather than failing the load. Deliberate: the
read path treats a missing digest as unverified, and a corrupt one deserves that rather than making
a whole index unloadable.

The surface was small because the digest is PRODUCED in two places and consumed in about seven --
23 `sha256: None` constructions did not change at all. Verification compares bytes and renders hex
only when they differ, which is the path with a human at the end of it.

WHAT IS LEFT of the 136-byte address, measured: 24 bytes restate the surroundings (`routing_slot`
equals the bucket the page is filed under, `object_id` equals the entry's own id, both at 100% with
no partial matches), and 56 bytes are four optionals with no niche to exploit, wrapping values of

🤖 Generated with [Claude Code](https://claude.com/claude-code)
