### PR TITLE
Two chunk fields that restate what the record already says

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -1995,7 +1995,9 @@ SERVING_RESOURCE_METADATA_FIELDS = {
     "unit_kind",
     "relative_path",
     "heading",
-    "heading_slug",
+    # `heading_slug` is slugify(heading) and heading is right here. Its readers try `heading`
+    # first and only fall through to the slug, and the parser builds the source locator from its
+    # own metadata before any record exists. 153.6 KB per 1 MB skill to restate one field.
     "heading_path",
     # `source_locator` is deliberately absent: every chunk record carries it at the TOP level
     # (both resource_chunk_record and skill_section_record set it unconditionally), and storing
@@ -2052,7 +2054,9 @@ def serving_resource_metadata(metadata: Json) -> Json:
         if key in sanitized and sanitized[key] not in (None, "", [], {})
     }
     serving["raw_storage_policy"] = sanitized.get("raw_storage_policy", "raw_uri_only")
-    serving["raw_bytes_stored"] = False
+    # `raw_bytes_stored` is a per-document fact and the manifest record already carries it. Every
+    # actual read takes the top-level field; the metadata mentions are assignments in the parser
+    # and resource IO, not reads of a stored record. 66.2 KB per 1 MB skill for a constant False.
     parse_warnings = normalize_parse_warnings(sanitized)
     if parse_warnings:
         serving["parse_warning_count"] = len(parse_warnings)


### PR DESCRIPTION
`heading_slug` is `slugify(heading)`, and `heading` sits beside it in the same dict. Its readers try `heading` first and only fall through to the slug; the one place reading the slug directly is the **parser**, building a source locator from its own metadata before any record exists. **153.6 KB** per 1 MB skill to restate one field.

`raw_bytes_stored` is a per-document fact the **manifest already carries**, written as a constant `False` on every chunk. Every actual read takes the top-level field — the mentions inside metadata are *assignments* in the parser and resource IO, not reads of a stored record. **66.2 KB** for a constant.

### Three neighbours deliberately left alone

| field | why it stays |
|---|---|
| `content_hash` | **Not a duplicate.** It varies per chunk, and the manifest's `content_hash` is the *document's* — a different value that would have been silently substituted. |
| `resource_type`, `resource_version`, `raw_storage_policy` | Per-document and on the manifest, but their readers fall back *through* the metadata copy to a top-level field that doesn't exist on every record type. Needs those readers pointed at the manifest first. |
| `unit_kind` | Constant on the document measured and **not constant in general** — a mixed document has sections, tables and code blocks. The sample says nothing. |

### Effect

A 1 MB skill now stores **7.3 MB** where this session started at 27.9 MB — amplification **26.0x → 6.8x**, and embeddings are **56.8%** of what is written.

For reference, 4.4x is the floor where a record carries *only* its text and its vector — no `record_type`, no hashes, nothing addressable. The remaining 39% is record identity, most of which has to exist.
