### PR TITLE
A replaced encoder still reached the ranking through a summary vector

### DIFF
--- a/crates/temporalstore-rust/src/bin/native_persistence_workflow.rs
+++ b/crates/temporalstore-rust/src/bin/native_persistence_workflow.rs
@@ -367,6 +367,7 @@ fn write_context_records(engine: &TemporalEngine) -> usize {
                 valid_from_ms: 2_020,
                 // No vector on this fixture; empty is what a record without one holds.
                 vector: Vec::new(),
+                embedding_model_hash: 0,
             },
         },
     }));
@@ -452,6 +453,7 @@ fn append_context_records_after_restart(engine: &TemporalEngine) -> usize {
                 valid_from_ms: 3_300,
                 // No vector on this fixture; empty is what a record without one holds.
                 vector: Vec::new(),
+                embedding_model_hash: 0,
             },
         },
     }));

--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1645,6 +1645,7 @@ pub(crate) fn extract_context_gated(
         text: l0.clone(),
         valid_from_ms: timestamp_ms,
         vector: Vec::new(),
+        embedding_model_hash: 0,
     };
     let mut summary_l1 = emit_l1.then(|| ContextSummary {
         node_hash,
@@ -1652,6 +1653,7 @@ pub(crate) fn extract_context_gated(
         text: l1.clone(),
         valid_from_ms: timestamp_ms,
         vector: Vec::new(),
+        embedding_model_hash: 0,
     });
     // What the node is SEARCHED by is not what it is SHOWN as. `l0` is the routing preview --
     // title plus one sentence, 18 words -- and embedding it gave the node a vector built from
@@ -1735,6 +1737,12 @@ pub(crate) fn extract_context_gated(
         // embedding_inputs order is node_l0, [node_l1], event_text, so the vectors line up
         // with their owners: index 0 is the L0 summary (and the node), index 1 the L1 summary
         // when emitted, and the event last.
+        //
+        // One encoder produced all of them, so its identity is computed once and stamped on
+        // every owner that takes a vector. The summaries need it as much as the node does: the
+        // retrieve pass scores an L1 summary vector too, and an unstamped one cannot be told
+        // apart from one the encoder in use wrote.
+        let embedding_model_hash = context_embedding_model_hash(&provider.embedding_model);
         if let Some(vector) = embedding_vectors.first() {
             // The level-1 summary carries its own vector because that is the only place a
             // summary's vector lives -- the embedding fold moved vectors off separate rows and
@@ -1743,16 +1751,20 @@ pub(crate) fn extract_context_gated(
             // write on that basis is the exact mistake
             // context_extract_stores_embedding_vectors_on_the_records_themselves exists to catch.
             summary_l0.vector = vector.clone();
+            summary_l0.embedding_model_hash = embedding_model_hash;
             // The node itself carries its L0 vector too: the traversal scores children from
             // node.vector first, and without this the happy path would leave it empty on every
             // fresh ingest -- only the drainer's deferred path would ever fill it, so the
             // fallback to the separate record could never be retired.
             node.vector = vector.clone();
-            node.embedding_model_hash = context_embedding_model_hash(&provider.embedding_model);
+            node.embedding_model_hash = embedding_model_hash;
             node.embedding_updated_at_ms = timestamp_ms;
         }
         if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.get(1)) {
             summary.vector = vector.clone();
+            // The one summary vector retrieval actually scores: level 2 is the only level the
+            // retrieve pass queries for vectors, so this stamp is what the guard there reads.
+            summary.embedding_model_hash = embedding_model_hash;
         }
         let event_vector_index = if emit_l1 { 2 } else { 1 };
         if let Some(vector) = embedding_vectors.get(event_vector_index) {
@@ -2036,6 +2048,19 @@ pub fn retrieve_context(
                     // Same reasoning as the node pass: skip entirely rather than record a zero,
                     // so the count stays at zero and the lexical pass still owns this node.
                     width_conflict_nodes = width_conflict_nodes.saturating_add(1);
+                    continue;
+                }
+                if context_embedding_model_conflicts(
+                    entry.embedding_model_hash,
+                    active_embedding_model_hash,
+                ) {
+                    // The node's own vector is declined above when its encoder was replaced,
+                    // which removed only ONE of this node's two routes into the ranking. Both
+                    // passes fill THIS map, so scoring the summary here would rank the node on a
+                    // cosine taken across two vector spaces AND mark it scored -- withdrawing the
+                    // lexical fallback the other guard deliberately handed it to. Skip without
+                    // recording, exactly as there.
+                    model_conflict_nodes = model_conflict_nodes.saturating_add(1);
                     continue;
                 }
                 let score =

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -507,6 +507,79 @@ fn context_extract_stores_embedding_vectors_on_the_records_themselves() {
     }
 }
 
+#[test]
+fn an_ingested_summary_records_the_encoder_that_embedded_it() {
+    // The stamp the summary guard reads. Level 2 is the only summary level retrieval scores, so
+    // a vector written there without its encoder recorded is one the guard must wave through --
+    // and the check quietly stops applying to everything written from then on. Asserted on the
+    // records as they come back off the engine, not on the report, because the record is what a
+    // later retrieve actually reads.
+    let engine = test_engine();
+    let provider = ContextModelProviderConfig {
+        model: "deepseek-chat".to_string(),
+        embedding_model: "intfloat/multilingual-e5-large".to_string(),
+        ..ContextModelProviderConfig::default()
+    };
+    let expected = context_embedding_model_hash(&provider.embedding_model);
+    assert_ne!(
+        expected,
+        context_embedding_model_hash(&provider.model),
+        "chat and embedding models must hash apart, or a chat-model stamp would pass this"
+    );
+    assert_ne!(0, expected, "an unknown stamp would be waved through, not checked");
+
+    let report = extract_context(
+        &engine,
+        ContextExtractRequest {
+            shard_id: 1,
+            tenant_hash: 79,
+            source_kind: ContextSourceKind::Chat,
+            source_id: "summary-encoder".to_string(),
+            title: "note".to_string(),
+            body: "Checkout failed during payment. The risk score spiked sharply.                    The fraud team paused the account."
+                .to_string(),
+            timestamp_ms: 7,
+            provider: provider.clone(),
+        },
+    );
+    assert!(report.status.ok, "{:?}", report.status);
+    // Rich body -> L1 is warranted, so the level-2 summary exists and carries a vector.
+    assert_eq!(report.embedding_generation.requested_vector_count, 3);
+
+    for level in [1u32, 2] {
+        let summaries = match engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ContextQuerySummaries {
+                    tenant_hash: 79,
+                    node_hash: report.node.node_hash,
+                    level,
+                    as_of_ms: 4_000_000_000_000,
+                    limit: None,
+                },
+            })
+            .response
+        {
+            CommandResponse::ContextSummaries { summaries, .. } => summaries,
+            other => panic!("expected summaries, got {other:?}"),
+        };
+        assert!(
+            !summaries.is_empty(),
+            "the extract wrote no level {level} summary"
+        );
+        for summary in &summaries {
+            assert!(
+                !summary.vector.is_empty(),
+                "level {level} summary has no vector, so there is nothing to identify"
+            );
+            assert_eq!(
+                expected, summary.embedding_model_hash,
+                "level {level} summary must record the encoder that produced its vector"
+            );
+        }
+    }
+}
+
 // shared-corpus: context_compression_secondary_index_query_debug_flow
 #[test]
 fn context_workflow_extracts_retrieves_and_injects_mock_context() {
@@ -2813,6 +2886,7 @@ fn a_resummarised_node_scores_on_its_newest_vector_not_its_first() {
                     text: text.to_string(),
                     valid_from_ms,
                     vector,
+                    embedding_model_hash: 0,
                 },
             },
         });
@@ -2968,6 +3042,7 @@ fn a_vector_from_another_embedding_space_cannot_win_a_summary_slot() {
                     text: summary.clone(),
                     valid_from_ms: at,
                     vector: Vec::new(),
+                    embedding_model_hash: 0,
                 },
             },
         });
@@ -3086,6 +3161,7 @@ fn retrieval_ranks_by_vectors_that_live_only_on_the_nodes() {
                     text: summary.clone(),
                     valid_from_ms: at,
                     vector: Vec::new(),
+                    embedding_model_hash: 0,
                 },
             },
         });
@@ -3697,6 +3773,7 @@ fn a_vector_from_another_encoder_at_the_same_width_is_declined_and_counted() {
                     text: summary.clone(),
                     valid_from_ms: at,
                     vector: Vec::new(),
+                    embedding_model_hash: 0,
                 },
             },
         });
@@ -3753,5 +3830,243 @@ fn a_vector_from_another_encoder_at_the_same_width_is_declined_and_counted() {
     assert_eq!(
         0, retrieve.fanout_plan.embedding_width_conflict_nodes,
         "these vectors are the same width -- charging this to the width counter would tell an          operator to look for a provider outage that did not happen"
+    );
+}
+
+/// Builds a store in which the ONLY vector a node owns sits on its level-2 summary: the node
+/// record itself carries none. That is what isolates this to the summary pass -- the node pass
+/// can decline nothing here, because there is nothing there to decline.
+fn seed_summary_only_vector_node(
+    engine: &TemporalEngine,
+    tenant_hash: u64,
+    node_hash: u64,
+    name: &str,
+    text: &str,
+    at: u64,
+    vector: Vec<f32>,
+    model_hash: u64,
+) {
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertNode {
+            tenant_hash,
+            node: ContextNode {
+                node_hash,
+                parent_hash: 0,
+                kind: 1,
+                canonical_name: name.to_string(),
+                l0: text.to_string(),
+                status: 0,
+                last_event_time_ms: at,
+                l1_ref: String::new(),
+                raw_metadata_ref: String::new(),
+                // Deliberately un-embedded: no ContextSetNodeEmbedding follows.
+                vector: Vec::new(),
+                embedding_model_hash: 0,
+                embedding_updated_at_ms: 0,
+            },
+        },
+    });
+    assert!(response.status.ok, "{:?}", response.status);
+    // Level 1 carries the display text the L0 block is packed from.
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertSummary {
+            tenant_hash,
+            summary: ContextSummary {
+                node_hash,
+                level: 1,
+                text: text.to_string(),
+                valid_from_ms: at,
+                vector: Vec::new(),
+                embedding_model_hash: 0,
+            },
+        },
+    });
+    assert!(response.status.ok, "{:?}", response.status);
+    // Level 2 is the only level retrieval queries for summary vectors.
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ContextUpsertSummary {
+            tenant_hash,
+            summary: ContextSummary {
+                node_hash,
+                level: 2,
+                text: text.to_string(),
+                valid_from_ms: at,
+                vector,
+                embedding_model_hash: model_hash,
+            },
+        },
+    });
+    assert!(response.status.ok, "{:?}", response.status);
+}
+
+#[test]
+fn a_summary_vector_from_another_encoder_is_declined_and_counted() {
+    // The node pass declines a node whose OWN vector came from a replaced encoder, but a node is
+    // scored twice in one retrieve and the second route ran unguarded: the level-2 summary vector
+    // is scored into the SAME map. A model swap still reached the ranking through the summary.
+    //
+    // Neither node here carries a vector of its own, so the node pass cannot be what decides the
+    // outcome. The impostor's summary carries the query vector verbatim -- a perfect cosine, at
+    // the same width, so the width check passes it -- and its text cannot win the lexical pass.
+    // If it takes the single summary slot, it was scored across two vector spaces.
+    let engine = test_engine();
+    const TENANT: u64 = 6031;
+    const EVENT_TIME: u64 = 1_781_700_000_000;
+    let provider = ContextModelProviderConfig::default();
+    let query = "how do we deploy the ingest service";
+    let query_vector = query::context_query_embedding(&provider, query).unwrap();
+    let ours = context_embedding_model_hash(&provider.embedding_model);
+    let theirs = context_embedding_model_hash("some-other-encoder");
+    assert_ne!(ours, theirs, "the two encoders must hash apart, or this proves nothing");
+
+    // Close to the query but not identical, so a perfect cosine would outrank it.
+    let mut near = query_vector.clone();
+    near[0] += 0.35;
+    near[1] -= 0.15;
+
+    for (node_hash, name, text, at, vector, model_hash) in [
+        (
+            41u64,
+            "matching",
+            "release runbook notes",
+            EVENT_TIME,
+            near.clone(),
+            ours,
+        ),
+        (
+            42u64,
+            "impostor",
+            "totally unrelated wording",
+            EVENT_TIME + 500,
+            query_vector.clone(),
+            theirs,
+        ),
+    ] {
+        assert_eq!(
+            query_vector.len(),
+            vector.len(),
+            "both vectors must be the same width, or this tests the width check instead"
+        );
+        seed_summary_only_vector_node(
+            &engine, TENANT, node_hash, name, text, at, vector, model_hash,
+        );
+    }
+
+    let retrieve = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: TENANT,
+            node_hashes: vec![41, 42],
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: EVENT_TIME + 1_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider,
+        },
+    );
+    assert!(retrieve.status.ok, "{:?}", retrieve.status);
+    let summary_nodes: Vec<u64> = retrieve
+        .blocks
+        .iter()
+        .filter(|block| block.tier == ContextTier::L0)
+        .map(|block| block.node_hash)
+        .collect();
+    assert_eq!(
+        vec![41u64], summary_nodes,
+        "a summary vector from another encoder must not take the slot on a perfect but meaningless cosine"
+    );
+    assert_eq!(
+        1, retrieve.fanout_plan.embedding_model_conflict_nodes,
+        "the declined summary vector has to be COUNTED, and counted as a MODEL conflict"
+    );
+    assert_eq!(
+        0, retrieve.fanout_plan.embedding_width_conflict_nodes,
+        "these vectors are the same width -- charging this to the width counter would send an operator hunting a provider outage that did not happen"
+    );
+}
+
+#[test]
+fn a_summary_vector_with_no_recorded_encoder_is_still_scored() {
+    // Every summary already on disk decodes with a zero hash, because the field did not exist
+    // when it was written. Zero means unknown, and unknown must keep scoring: tightening this
+    // check to refuse it would take the summary pass dark for every existing store at once --
+    // silently, since an unscored node just falls through to the lexical pass and still returns
+    // SOMETHING. Same store as the test above with both hashes left unrecorded, and here the
+    // perfect cosine is SUPPOSED to win.
+    let engine = test_engine();
+    const TENANT: u64 = 6032;
+    const EVENT_TIME: u64 = 1_781_700_000_000;
+    let provider = ContextModelProviderConfig::default();
+    let query = "how do we deploy the ingest service";
+    let query_vector = query::context_query_embedding(&provider, query).unwrap();
+
+    let mut near = query_vector.clone();
+    near[0] += 0.35;
+    near[1] -= 0.15;
+
+    for (node_hash, name, text, at, vector) in [
+        (
+            41u64,
+            "matching",
+            "release runbook notes",
+            EVENT_TIME,
+            near.clone(),
+        ),
+        (
+            42u64,
+            "impostor",
+            "totally unrelated wording",
+            EVENT_TIME + 500,
+            query_vector.clone(),
+        ),
+    ] {
+        seed_summary_only_vector_node(&engine, TENANT, node_hash, name, text, at, vector, 0);
+    }
+
+    let retrieve = retrieve_context(
+        &engine,
+        ContextRetrieveRequest {
+            shard_id: 1,
+            tenant_hash: TENANT,
+            node_hashes: vec![41, 42],
+            query: query.to_string(),
+            start_time_ms: 0,
+            end_time_ms: EVENT_TIME + 1_000,
+            max_events: 8,
+            min_confidence: 0.0,
+            min_importance: 0.0,
+            tiers: default_tiers(),
+            max_summary_nodes: 1,
+            max_event_nodes: 4,
+            prefer_current_agent: false,
+            current_agent_scope_key: "agent:test".to_string(),
+            provider,
+        },
+    );
+    assert!(retrieve.status.ok, "{:?}", retrieve.status);
+    let summary_nodes: Vec<u64> = retrieve
+        .blocks
+        .iter()
+        .filter(|block| block.tier == ContextTier::L0)
+        .map(|block| block.node_hash)
+        .collect();
+    assert_eq!(
+        vec![42u64], summary_nodes,
+        "an unrecorded encoder is unknown, and unknown must keep being scored"
+    );
+    assert_eq!(
+        0, retrieve.fanout_plan.embedding_model_conflict_nodes,
+        "a zero hash is not a conflict and must not be counted as one"
     );
 }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -3378,6 +3378,7 @@ pub(crate) fn execute_on_shard(
                     .filter(|summary| !summary.vector.is_empty())
                     .map(|summary| ContextSummaryVector {
                         node_hash,
+                        embedding_model_hash: summary.embedding_model_hash,
                         vector: summary.vector,
                     })
                 })

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -833,6 +833,7 @@ fn context_tree_embedding_summary_and_compression_match_round_trip() {
                     text: text.to_string(),
                     valid_from_ms,
                     vector: Vec::new(),
+                    embedding_model_hash: 0,
                 },
             },
         });
@@ -1409,6 +1410,7 @@ fn page_compaction_reports_model_layouts_tombstones_object_pages_and_density() {
                 text: "compact summary".to_string(),
                 valid_from_ms: 52,
                 vector: Vec::new(),
+                embedding_model_hash: 0,
             },
         },
         Command::CommonDelete {
@@ -3349,6 +3351,7 @@ fn what_reading_one_summary_actually_costs() {
                         text: text.clone(),
                         valid_from_ms: 1_000,
                         vector: vec![0.25_f32; 16],
+                        embedding_model_hash: 0,
                     },
                 },
             });

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5822,6 +5822,7 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
                 text: "a summary".to_string(),
                 valid_from_ms: 1_787_270_073_000,
                 vector: Vec::new(),
+                embedding_model_hash: 0,
             },
         },
         Command::ContextWriteCompressionEvent {

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -467,6 +467,11 @@ pub struct ContextChildRef {
 pub struct ContextSummaryVector {
     pub node_hash: u64,
     pub vector: Vec<f32>,
+    /// Which encoder produced `vector`, carried out alongside it. The retrieve path scores from
+    /// this response alone and never opens the summary record again, so without the hash here
+    /// the model check would have nothing to check.
+    #[serde(default)]
+    pub embedding_model_hash: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -489,6 +494,18 @@ pub struct ContextSummary {
     // vector and simply counts as un-embedded until the backfill re-embeds it.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub vector: Vec<f32>,
+    /// Which encoder produced `vector`, mirroring the field of the same name on `ContextNode`.
+    ///
+    /// A node whose own vector came from a replaced encoder is already declined, but that only
+    /// removed one of the two ways this node gets scored: the same retrieve pass also scores
+    /// this summary's vector, and it had no hash to check. That is worse than being un-embedded
+    /// rather than equal to it -- both passes fill ONE score map, so a summary score marks the
+    /// node scored and withdraws the lexical fallback the declined node was routed to.
+    ///
+    /// Zero means unknown -- a summary written before this field existed, or one carrying no
+    /// vector at all -- and unknown never conflicts, so existing stores keep scoring as they did.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub embedding_model_hash: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1053,6 +1070,13 @@ impl ContextWire for ContextSummary {
         encode_bytes_field(&mut out, 4, self.text.as_bytes());
         encode_varint_field(&mut out, 5, self.valid_from_ms);
         encode_vector_field(&mut out, &self.vector);
+        if self.embedding_model_hash != 0 {
+            encode_varint_field(
+                &mut out,
+                CONTEXT_EMBEDDING_MODEL_FIELD,
+                self.embedding_model_hash,
+            );
+        }
         out
     }
 
@@ -1064,6 +1088,7 @@ impl ContextWire for ContextSummary {
             text: String::new(),
             valid_from_ms: 0,
             vector: Vec::new(),
+            embedding_model_hash: 0,
         };
         while cursor < bytes.len() {
             let tag = decode_varint(bytes, &mut cursor)?;
@@ -1077,6 +1102,9 @@ impl ContextWire for ContextSummary {
                 }
                 (CONTEXT_VECTOR_INT8_FIELD, 2) => {
                     value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
+                (CONTEXT_EMBEDDING_MODEL_FIELD, 0) => {
+                    value.embedding_model_hash = decode_varint(bytes, &mut cursor)?
                 }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
@@ -2757,6 +2785,7 @@ mod tests {
             text: "summary".to_string(),
             valid_from_ms: 1_000,
             vector: Vec::new(),
+            embedding_model_hash: 0x51A7,
         };
         assert_eq!(
             ContextSummary::decode_context_proto_value(&summary.encode_context_proto_value()),


### PR DESCRIPTION
A node is scored twice in one retrieve, and only one of the two routes checked which encoder produced the vector it was scoring.

The node pass declines a node whose own vector was written by an encoder that is no longer the active one, and hands it to the hybrid lexical pass. The level-2 summary pass, forty lines below it, scores that node's summary vector into the **same map** with no such check — because `ContextSummary` had no field to record its encoder in, so there was nothing to check against.

That leaves the node **worse off than being un-embedded, not equal to it**. Both passes fill one score map, and the lexical pass selects on the score *count* being zero. So the summary score marks the node scored, withdraws the fallback the node pass deliberately routed it to, and ranks the node on a cosine taken across two vector spaces. Same width, no error, nothing to notice it by.

### What this changes

- `ContextSummary` carries `embedding_model_hash`, written to the wire only when non-zero, on the field number already set aside for exactly this on the records that had it.
- `ContextSummaryVector` carries it out to the caller: retrieval scores from that response alone and never opens the summary record again, so the hash has to travel with the vector or the check has nothing to read.
- Ingest stamps it on both summaries from the same encoder identity it already stamps on the node — computed once now rather than three times.
- The summary pass declines a mismatch and counts it into `embedding_model_conflict_nodes`, skipping **without recording a score**, so the node keeps the lexical fallback rather than being stranded at the bottom of a ranking it was never really scored for.

### Why recording and enforcing can land together here

They could not for the node-side guard, where stamping a wrong value first would have made every existing node mismatch at once. Here every summary already on disk decodes with a zero hash, zero means unknown, and unknown never conflicts. No record that exists today starts mismatching, so nothing drops out of scoring on deploy.

A test pins that directly, because tightening it later would take every existing store dark and do it silently — an unscored node still returns *something*.

### Tests

Three added. Each was shown able to fail by mutating the code it covers:

| mutation | test turned red |
|---|---|
| remove the summary guard | `a_summary_vector_from_another_encoder_is_declined_and_counted` |
| make the guard refuse an unknown hash too | `a_summary_vector_with_no_recorded_encoder_is_still_scored` |
| drop the ingest stamp on the level-2 summary | `an_ingested_summary_records_the_encoder_that_embedded_it` |
| stop encoding the field on the wire | `an_ingested_summary_records_the_encoder_that_embedded_it` |

`cargo test --lib context_workflow -- --test-threads=1` — 45 passed, 0 failed. Single-threaded because the module mutates process-global env vars.
