### PR TITLE
Test servers bound hand-assigned ports and collided across processes

### DIFF
--- a/crates/temporalstore-rust/src/http.rs
+++ b/crates/temporalstore-rust/src/http.rs
@@ -265,7 +265,39 @@ where
     S: Fn(&RequestHead, &mut StreamTransfer) -> StreamAction + Send + Sync + 'static,
     H: Fn(HttpRequest) -> (u16, Vec<u8>) + Send + Sync + 'static,
 {
-    let listener = TcpListener::bind(addr)?;
+    serve_listener_with_stream_handler(TcpListener::bind(addr)?, stream_handler, handler)
+}
+
+/// Like [`serve`], but on a listener the caller has already bound.
+///
+/// Choosing a port by binding, reading the address back, dropping the listener
+/// and handing the address on leaves the port owned by nobody until the server
+/// binds it again. On a machine running more than one server process, something
+/// else can take it inside that window, and the server then fails on `AddrInUse`
+/// long after the address was decided -- far from where the address was chosen,
+/// and usually reported as whatever the missing server broke downstream. Handing
+/// the bound listener straight over closes the window: the port is never unowned.
+pub fn serve_listener(
+    listener: TcpListener,
+    handler: impl Fn(HttpRequest) -> (u16, Vec<u8>) + Send + Sync + 'static,
+) -> Result<(), HttpError> {
+    serve_listener_with_stream_handler(
+        listener,
+        |_head, _transfer| StreamAction::Declined,
+        handler,
+    )
+}
+
+/// [`serve_with_stream_handler`] on an already-bound listener. See [`serve_listener`].
+pub fn serve_listener_with_stream_handler<S, H>(
+    listener: TcpListener,
+    stream_handler: S,
+    handler: H,
+) -> Result<(), HttpError>
+where
+    S: Fn(&RequestHead, &mut StreamTransfer) -> StreamAction + Send + Sync + 'static,
+    H: Fn(HttpRequest) -> (u16, Vec<u8>) + Send + Sync + 'static,
+{
     let stream_handler = Arc::new(stream_handler);
     let handler = Arc::new(handler);
     for stream in listener.incoming() {
@@ -942,5 +974,97 @@ mod tests {
             pool.borrow_mut().remove(&pool_key);
         });
         server.join().unwrap();
+    }
+}
+
+/// Loopback ports for tests that stand a real server up.
+///
+/// The crate's test binary is regularly running in more than one copy at a time:
+/// several worktrees share one machine, and a test run in one of them overlaps a
+/// test run in another. Ports written into the tests as literals collide across
+/// those processes -- whichever binary binds first wins, the other's server
+/// thread dies with `AddrInUse`, and the test that needed that server reports
+/// something else entirely: a counter that reads 0, a route that never resolves.
+/// The bind error is inside a spawned thread, so the failure libtest prints names
+/// only the consequence.
+///
+/// Ports here come from the OS instead, and the listener that reserved one is
+/// kept and handed to [`serve_listener`], so a reserved port is owned by this
+/// process from the moment it is chosen until the server accepts on it.
+#[cfg(test)]
+pub(crate) mod test_ports {
+    use super::{serve_listener, HttpError, HttpRequest};
+    use std::collections::HashMap;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Mutex, OnceLock};
+
+    struct Reservation {
+        addr: String,
+        /// Taken by the first [`serve_reserved`] on this address; `None` after.
+        listener: Option<TcpListener>,
+    }
+
+    fn table() -> &'static Mutex<HashMap<u64, Reservation>> {
+        static TABLE: OnceLock<Mutex<HashMap<u64, Reservation>>> = OnceLock::new();
+        TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// The address reserved for `key` in this process.
+    ///
+    /// Stable for the life of the process, so a test can name one address in as
+    /// many places as it likes -- the way a literal port number used to read --
+    /// while the port itself is whatever the OS had free.
+    pub(crate) fn reserved_addr(key: u64) -> String {
+        table()
+            .lock()
+            .unwrap()
+            .entry(key)
+            .or_insert_with(|| {
+                let listener =
+                    TcpListener::bind("127.0.0.1:0").expect("reserve a loopback port");
+                let addr = listener
+                    .local_addr()
+                    .expect("read the reserved port")
+                    .to_string();
+                Reservation {
+                    addr,
+                    listener: Some(listener),
+                }
+            })
+            .addr
+            .clone()
+    }
+
+    /// A reserved address no other caller will be handed.
+    ///
+    /// For a test that needs an address but has no reason to name it twice.
+    pub(crate) fn unique_addr() -> String {
+        static NEXT: AtomicU64 = AtomicU64::new(1 << 32);
+        reserved_addr(NEXT.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Serve on `addr`, taking over the listener that reserved it.
+    ///
+    /// An address this table did not reserve -- or one already being served -- is
+    /// bound afresh, which is exactly what plain `serve` would have done.
+    pub(crate) fn serve_reserved(
+        addr: &str,
+        handler: impl Fn(HttpRequest) -> (u16, Vec<u8>) + Send + Sync + 'static,
+    ) -> Result<(), HttpError> {
+        serve_listener(claim(addr)?, handler)
+    }
+
+    fn claim(addr: &str) -> Result<TcpListener, HttpError> {
+        if let Some(reserved) = table()
+            .lock()
+            .unwrap()
+            .values_mut()
+            .find(|reservation| reservation.addr == addr)
+            .and_then(|reservation| reservation.listener.take())
+        {
+            return Ok(reserved);
+        }
+        Ok(TcpListener::bind(addr)?)
     }
 }

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -2108,6 +2108,7 @@ fn proxy_addr_port(addr: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::test_ports::{reserved_addr, serve_reserved, unique_addr};
 
     #[test]
     fn a_config_push_reaches_a_thread_that_already_cached_the_options() {
@@ -4057,7 +4058,7 @@ mod tests {
         let h = heartbeats.clone();
         let addr_for_thread = addr.clone();
         std::thread::spawn(move || {
-            serve(&addr_for_thread, move |request| {
+            serve_reserved(&addr_for_thread, move |request| {
                 match request.path.as_str() {
                     "/proxies/heartbeat" => {
                         h.fetch_add(1, Ordering::SeqCst);
@@ -4796,7 +4797,7 @@ mod tests {
         let calls = stats_calls.clone();
         let addr_for_thread = addr.clone();
         std::thread::spawn(move || {
-            serve(&addr_for_thread, move |request| match request.path.as_str() {
+            serve_reserved(&addr_for_thread, move |request| match request.path.as_str() {
                 "/shards" => {
                     calls.fetch_add(1, Ordering::SeqCst);
                     crate::http::json_response(
@@ -4885,7 +4886,7 @@ mod tests {
         let gapped = test_addr(18_406);
         let gapped_for_thread = gapped.clone();
         std::thread::spawn(move || {
-            serve(&gapped_for_thread, move |request| match request.path.as_str() {
+            serve_reserved(&gapped_for_thread, move |request| match request.path.as_str() {
                 "/shards" => crate::http::json_response(
                     200,
                     &crate::meta::ListShardsResponse {
@@ -6084,7 +6085,7 @@ mod tests {
         std::thread::spawn({
             let meta = meta.clone();
             move || {
-                serve(&meta_addr, move |request| {
+                serve_reserved(&meta_addr, move |request| {
                     match (request.method.as_str(), request.path.as_str()) {
                         ("POST", "/proxies/heartbeat") => {
                             let req = parse_json::<ProxyHeartbeatRequest>(&request.body).unwrap();
@@ -6148,7 +6149,7 @@ mod tests {
         std::thread::spawn({
             let meta = meta.clone();
             move || {
-                serve(&meta_addr, move |request| {
+                serve_reserved(&meta_addr, move |request| {
                     match (request.method.as_str(), request.path.as_str()) {
                         ("POST", "/proxies/heartbeat") => {
                             let req = parse_json::<ProxyHeartbeatRequest>(&request.body).unwrap();
@@ -6203,7 +6204,7 @@ mod tests {
         std::thread::spawn({
             let meta = meta.clone();
             move || {
-                serve(&meta_addr, move |request| {
+                serve_reserved(&meta_addr, move |request| {
                     match (request.method.as_str(), request.path.as_str()) {
                         ("POST", "/proxies/heartbeat") => {
                             let req = parse_json::<ProxyHeartbeatRequest>(&request.body).unwrap();
@@ -6248,7 +6249,7 @@ mod tests {
         std::thread::spawn({
             let meta = meta.clone();
             move || {
-                serve(&meta_addr, move |request| {
+                serve_reserved(&meta_addr, move |request| {
                     match (request.method.as_str(), request.path.as_str()) {
                         ("POST", "/proxies/heartbeat") => {
                             let req = parse_json::<ProxyHeartbeatRequest>(&request.body).unwrap();
@@ -6286,7 +6287,7 @@ mod tests {
 
     fn start_server(addr: String, engine: TemporalEngine) {
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("POST", "/execute") => {
                         let req = parse_json::<ExecuteRequest>(&request.body).unwrap();
@@ -6305,7 +6306,7 @@ mod tests {
 
     fn start_meta(addr: String, server_addr: String) {
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("GET", "/shards/1") => json_response(
                         200,
@@ -6342,7 +6343,7 @@ mod tests {
         let h = hits.clone();
         let addr_for_thread = addr.clone();
         std::thread::spawn(move || {
-            serve(&addr_for_thread, move |_request| {
+            serve_reserved(&addr_for_thread, move |_request| {
                 // First exchange answers immediately, so the socket lands in the pool.
                 // Everything after that accepts the request and goes quiet.
                 if h.fetch_add(1, Ordering::SeqCst) > 0 {
@@ -6399,7 +6400,7 @@ mod tests {
         let slow = test_addr(18_402);
         let slow_for_thread = slow.clone();
         std::thread::spawn(move || {
-            serve(&slow_for_thread, move |_request| {
+            serve_reserved(&slow_for_thread, move |_request| {
                 std::thread::sleep(Duration::from_millis(500));
                 crate::http::json_response(200, &Status::ok())
             })
@@ -6462,7 +6463,7 @@ mod tests {
         let slow = test_addr(18_396);
         let slow_for_thread = slow.clone();
         std::thread::spawn(move || {
-            serve(&slow_for_thread, move |_request| {
+            serve_reserved(&slow_for_thread, move |_request| {
                 std::thread::sleep(Duration::from_millis(500));
                 crate::http::json_response(200, &Status::ok())
             })
@@ -6530,7 +6531,7 @@ mod tests {
         let h = hits.clone();
         let slow_for_thread = slow.clone();
         std::thread::spawn(move || {
-            serve(&slow_for_thread, move |_request| {
+            serve_reserved(&slow_for_thread, move |_request| {
                 h.fetch_add(1, Ordering::SeqCst);
                 std::thread::sleep(Duration::from_millis(500));
                 json_response(200, &Status::ok())
@@ -6616,7 +6617,7 @@ mod tests {
         let tp = topo_posts.clone();
         let m = meta.clone();
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("GET", path) if path.starts_with("/shards/") => {
                         let shard_id =
@@ -6725,7 +6726,7 @@ mod tests {
         let tp = topo_posts.clone();
         let m = meta.clone();
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("GET", path) if path.starts_with("/shards/") => {
                         sg.fetch_add(1, Ordering::SeqCst);
@@ -6791,7 +6792,7 @@ mod tests {
 
     fn start_meta_service(addr: String, meta: crate::meta::SingleNodeMeta) {
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("GET", path) if path.starts_with("/shards/") => {
                         let shard_id = path
@@ -6825,13 +6826,18 @@ mod tests {
         panic!("no key found for shard {shard_id}");
     }
 
+    /// The address these tests use where a literal port number used to be.
+    ///
+    /// `port` is no longer a port: it is the name of one address, and every call
+    /// with the same name in one process answers with the same OS-assigned
+    /// address. Fixed ports collided with the other copies of this test binary
+    /// that run on the same machine -- see `crate::http::test_ports`.
     fn test_addr(port: u16) -> String {
-        format!("127.0.0.1:{port}")
+        reserved_addr(u64::from(port))
     }
 
     fn free_local_addr() -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        listener.local_addr().unwrap().to_string()
+        unique_addr()
     }
 
     fn wait_for_http(addr: &str) {
@@ -6855,7 +6861,7 @@ mod tests {
         };
         use crate::ingestion::IngestionBatchRequest;
         std::thread::spawn(move || {
-            serve(&addr, move |request| {
+            serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("POST", "/ingest/batch") => {
                         let req = parse_json::<IngestionBatchRequest>(&request.body).unwrap();

--- a/crates/temporalstore-rust/src/raft/tests/helpers.rs
+++ b/crates/temporalstore-rust/src/raft/tests/helpers.rs
@@ -269,8 +269,7 @@ pub(super) fn wait_for_replica_value(
 }
 
 pub(super) fn free_local_addr() -> String {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.local_addr().unwrap().to_string()
+    crate::http::test_ports::unique_addr()
 }
 
 pub(super) fn topology_for_shard(

--- a/crates/temporalstore-rust/src/raft/tests/part2.rs
+++ b/crates/temporalstore-rust/src/raft/tests/part2.rs
@@ -10,11 +10,16 @@ use super::helpers::*;
 #[test]
 fn http_raft_transport_sends_append_vote_and_snapshot_over_tcp() {
     let cluster = RaftCluster::new_single_shard(11, [1, 2, 3]);
-    let addr = "127.0.0.1:18431".to_string();
+    let addr = free_local_addr();
     std::thread::spawn({
         let cluster = cluster.clone();
         let addr = addr.clone();
-        move || serve(&addr, move |request| handle_raft_http(&cluster, request)).unwrap()
+        move || {
+            crate::http::test_ports::serve_reserved(&addr, move |request| {
+                handle_raft_http(&cluster, request)
+            })
+            .unwrap()
+        }
     });
     wait_for_http(&addr);
 
@@ -1528,7 +1533,7 @@ fn production_raft_runtime_replicates_over_separate_http_nodes() {
         let addr = node.addr.clone();
         let runtime_for_server = runtime.clone();
         thread::spawn(move || {
-            serve(&addr, move |request| {
+            crate::http::test_ports::serve_reserved(&addr, move |request| {
                 match (request.method.as_str(), request.path.as_str()) {
                     ("POST", "/raft/propose") => {
                         match parse_json::<DistributedRaftProposeRequest>(&request.body) {


### PR DESCRIPTION
## What was wrong

The proxy tests stood their servers up on port numbers written into the tests:
137 call sites of `test_addr` passed literals in the `18_310..18_406` range, and
one raft test bound `127.0.0.1:18431`. Two helpers already asked the OS for a
free port, and only two call sites used them.

Those literals are per-machine, not per-process. Several worktrees share one box
here, so the same test binary runs in more than one copy at a time and both
copies want the same port. The second one loses: `TcpListener::bind` fails with
`AddrInUse` inside a spawned server thread, where nothing reports it. What
libtest prints is the consequence instead — a counter that reads 0 instead of 1,
a route that never resolves — so the failure names a test with nothing wrong
with it, and the same tests pass when the module is run alone, because the
collision window is short.

## What changed

- `test_addr(n)` no longer builds an address out of `n`. It looks `n` up in a
  per-process table that assigns one OS-chosen port the first time each `n` is
  seen, so a test can still name one address in as many places as it likes.
- The listener that reserved the port is kept and handed to the server through a
  new `http::serve_listener`. That closes the window `free_local_addr` left
  open: it bound `:0`, read the address back, dropped the listener, and let the
  caller bind again later, so the port belonged to nobody in between.
- All 17 server sites in the proxy tests and both in the raft tests now serve
  their reserved listener.

Test-harness only — no engine or storage code is touched.

## How it was checked

Measured the way the problem was found: two copies of the same test binary
running at once, `--test-threads=1`.

| | `proxy::tests` copy A | copy B |
|---|---|---|
| before | FAILED — 15 failed, 23 × `AddrInUse` | FAILED — 5 failed, 6 × `AddrInUse` |
| after | ok — 74 passed, 0 failed, 0 × `AddrInUse` | ok — 74 passed, 0 failed, 0 × `AddrInUse` |

Four concurrent rounds: `AddrInUse` was 0 in all eight runs, and both copies
came back fully green together in rounds 3 and 4. The single test that dropped
out in rounds 1 and 2 was a different one each time, and a lone copy dropped a
different one again — that is CPU starvation from unrelated load on the box (16
cores at load 9–19), not a port collision.

Alongside, both copies concurrently: `raft::tests` 235 passed / 0 failed, and
`client::tests` 33 passed / 0 failed, `AddrInUse` 0 throughout.
