### PR TITLE
Hold a component's single page ref inline instead of behind a vector

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -337,14 +337,10 @@ pub(super) struct ObjectPageRefs {
 pub(super) struct ComponentPages {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) component: Option<String>,
-    /// A sorted, deduplicated vector rather than a set: measured, 100% of these hold exactly one
-    /// ref, and a B-tree node costs its full size whether it holds one element or eleven.
-    /// Insertion goes through `insert_page_lookup_ref`, which keeps both invariants.
-    ///
-    /// Serializes identically -- a `Vec` and a `BTreeSet` both encode as a sequence -- which
-    /// matters because this is part of the serialized index.
+    /// Sorted and deduplicated, and held inline when there is only one -- which is all of them.
+    /// Insertion goes through `PageRefs::insert`, which keeps both invariants.
     #[serde(default)]
-    pub(super) refs: Vec<PageLookupRef>,
+    pub(super) refs: PageRefs,
 }
 
 impl ObjectPageRefs {
@@ -371,11 +367,103 @@ impl ObjectPageRefs {
     }
 }
 
-/// Insert keeping the vector sorted and free of duplicates, which is what the set it replaced did.
-pub(super) fn insert_page_lookup_ref(refs: &mut Vec<PageLookupRef>, value: PageLookupRef) {
-    match refs.binary_search(&value) {
-        Ok(_) => {}
-        Err(at) => refs.insert(at, value),
+/// The pages holding one component, with the single-page case held inline.
+///
+/// Measured over a corpus mixing single-value objects and multi-field ones: 3600 of 3600
+/// components hold exactly one ref. That is not a property of the workload mix the way the
+/// component count per object is -- it held for both object shapes -- so the single case is worth
+/// having a shape for.
+///
+/// A `Vec` for one element costs a 24-byte header and, more expensively, its own heap allocation
+/// to hold a single 24-byte value. Inline costs 8 bytes more inside the enclosing vector and no
+/// allocation at all. The spilled arm keeps the behaviour unchanged for a component that does span
+/// several pages -- nothing in the measured corpus does, but the format allows it, so it stays
+/// representable rather than being asserted away.
+///
+/// Serializes as a sequence exactly as the vector did, so the on-disk index is unchanged.
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
+#[serde(from = "Vec<PageLookupRef>", into = "Vec<PageLookupRef>")]
+pub(super) enum PageRefs {
+    One(PageLookupRef),
+    Many(Vec<PageLookupRef>),
+}
+
+impl PageRefs {
+    pub(super) fn as_slice(&self) -> &[PageLookupRef] {
+        match self {
+            Self::One(value) => std::slice::from_ref(value),
+            Self::Many(values) => values.as_slice(),
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        match self {
+            Self::One(_) => 1,
+            Self::Many(values) => values.len(),
+        }
+    }
+
+    pub(super) fn iter(&self) -> std::slice::Iter<'_, PageLookupRef> {
+        self.as_slice().iter()
+    }
+
+    /// Insert keeping the refs sorted and free of duplicates, which is what the set this replaced
+    /// did. Reports whether anything was added, which is what the ref counter is kept from.
+    pub(super) fn insert(&mut self, value: PageLookupRef) -> bool {
+        match self {
+            Self::One(existing) => match value.cmp(existing) {
+                std::cmp::Ordering::Equal => false,
+                std::cmp::Ordering::Less => {
+                    *self = Self::Many(vec![value, existing.clone()]);
+                    true
+                }
+                std::cmp::Ordering::Greater => {
+                    *self = Self::Many(vec![existing.clone(), value]);
+                    true
+                }
+            },
+            Self::Many(values) => match values.binary_search(&value) {
+                Ok(_) => false,
+                Err(at) => {
+                    values.insert(at, value);
+                    true
+                }
+            },
+        }
+    }
+}
+
+impl Default for PageRefs {
+    fn default() -> Self {
+        Self::Many(Vec::new())
+    }
+}
+
+/// Compared by contents, so a one-element spilled arm and an inline one are the same refs. Without
+/// this, a value read back from an index written before this change could compare unequal to the
+/// identical value built in memory.
+impl PartialEq for PageRefs {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl From<Vec<PageLookupRef>> for PageRefs {
+    fn from(mut refs: Vec<PageLookupRef>) -> Self {
+        if refs.len() == 1 {
+            Self::One(refs.pop().expect("length just checked"))
+        } else {
+            Self::Many(refs)
+        }
+    }
+}
+
+impl From<PageRefs> for Vec<PageLookupRef> {
+    fn from(refs: PageRefs) -> Self {
+        match refs {
+            PageRefs::One(value) => vec![value],
+            PageRefs::Many(values) => values,
+        }
     }
 }
 
@@ -470,29 +558,25 @@ impl CoreIndex {
                 .object_page_lookup
                 .entry(object_component_lookup_key(&page.model_id, &page.object_key))
                 .or_default();
-            let at = match entry.position(page.component.as_deref()) {
-                Ok(at) => at,
+            let value = PageLookupRef {
+                routing_bucket,
+                page_ref_key,
+            };
+            match entry.position(page.component.as_deref()) {
+                Ok(at) => entry.by_component[at].refs.insert(value),
                 Err(at) => {
+                    // A component's first page. Build the entry already holding it, so the common
+                    // case never allocates and there is no empty state in between.
                     entry.by_component.insert(
                         at,
                         ComponentPages {
                             component: page.component.clone(),
-                            refs: Vec::new(),
+                            refs: PageRefs::One(value),
                         },
                     );
-                    at
+                    true
                 }
-            };
-            let refs = &mut entry.by_component[at].refs;
-            let before = refs.len();
-            insert_page_lookup_ref(
-                refs,
-                PageLookupRef {
-                    routing_bucket,
-                    page_ref_key,
-                },
-            );
-            refs.len() != before
+            }
         };
         if added {
             if let Some(total) = self.object_component_page_refs.as_mut() {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3983,6 +3983,213 @@ fn components_of_one_object_stay_separate() {
     );
 }
 
+/// The common case takes the inline arm, and the spilled arm still behaves.
+///
+/// Measuring that 100% of components hold one ref only justifies the shape; it does not show the
+/// shape is being used. A structure that silently spilled every time would measure identically
+/// from the outside and cost an allocation each, so the arm is asserted directly.
+#[test]
+fn single_page_components_are_held_inline() {
+    use crate::engine::state::{PageLookupRef, PageRefs};
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..64 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("inline-{index:04}"),
+                value: vec![b'v'; 48],
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let mut inline = 0usize;
+    let mut spilled = 0usize;
+    for entry in shard.bucket_index.object_page_lookup.values() {
+        for component in &entry.by_component {
+            match component.refs {
+                PageRefs::One(_) => inline += 1,
+                PageRefs::Many(_) => spilled += 1,
+            }
+        }
+    }
+    assert!(inline + spilled > 0, "no components were recorded; nothing was measured");
+    assert_eq!(
+        spilled, 0,
+        "{spilled} of {} components allocated for a single ref",
+        inline + spilled
+    );
+
+    // The spilled arm has to keep working: sorted, deduplicated, and reporting what it added.
+    let first = PageLookupRef { routing_bucket: 7, page_ref_key: Arc::from("bbb") };
+    let second = PageLookupRef { routing_bucket: 7, page_ref_key: Arc::from("aaa") };
+    let mut refs = PageRefs::One(first.clone());
+    assert!(!refs.insert(first.clone()), "re-inserting the same ref adds nothing");
+    assert_eq!(refs.len(), 1);
+    assert!(refs.insert(second.clone()), "a second ref is an addition");
+    assert_eq!(refs.len(), 2);
+    assert_eq!(
+        refs.as_slice(),
+        &[second, first],
+        "promotion must land sorted -- removal binary-searches these"
+    );
+}
+
+/// The index on disk does not change shape.
+///
+/// This is held inline in memory but has to serialize as the sequence it always was, or an index
+/// written before this stops loading. Both directions are checked, including a spilled arm read
+/// back as an inline one.
+#[test]
+fn page_refs_serialize_as_a_sequence() {
+    use crate::engine::state::{PageLookupRef, PageRefs};
+
+    let single = PageRefs::One(PageLookupRef {
+        routing_bucket: 3,
+        page_ref_key: Arc::from("page-a"),
+    });
+    let json = serde_json::to_value(&single).unwrap();
+    assert!(json.is_array(), "must encode as a sequence, got {json}");
+    assert_eq!(json.as_array().unwrap().len(), 1);
+    assert_eq!(json[0]["routing_slot"], 3);
+
+    // A one-element sequence written by the previous shape comes back inline, not spilled.
+    let restored: PageRefs = serde_json::from_value(json).unwrap();
+    assert!(
+        matches!(restored, PageRefs::One(_)),
+        "a one-element sequence should load into the inline arm"
+    );
+    assert_eq!(restored, single);
+
+    let mut pair = single.clone();
+    pair.insert(PageLookupRef {
+        routing_bucket: 4,
+        page_ref_key: Arc::from("page-b"),
+    });
+    let round_tripped: PageRefs = serde_json::from_value(serde_json::to_value(&pair).unwrap()).unwrap();
+    assert_eq!(round_tripped, pair);
+    assert_eq!(round_tripped.len(), 2);
+}
+
+/// How many components an object actually has, and how many refs a component actually holds.
+///
+/// This decides whether an inline single-component shape is worth having. The inner `refs` vector
+/// already carries a measured note that 100% of them hold exactly one ref; the outer
+/// `by_component` vector has no such measurement, and it is the one that costs an allocation per
+/// object.
+///
+/// The corpus is deliberately mixed. A string object is one componentless entry and a hash object
+/// is one entry per field, so a corpus of only one kind would decide the question by construction
+/// rather than by measurement. Both kinds are asserted present before any number is read.
+#[test]
+fn object_page_lookup_occupancy_census() {
+    const STRING_OBJECTS: usize = 2_000;
+    const HASH_OBJECTS: usize = 200;
+    const FIELDS_PER_HASH: usize = 8;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..STRING_OBJECTS {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("occupancy-string-{index:08}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+    for object in 0..HASH_OBJECTS {
+        for field in 0..FIELDS_PER_HASH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("occupancy-hash-{object:08}"),
+                    field: format!("field-{field}"),
+                    value: vec![b'h'; 64],
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let lookup = &shard.bucket_index.object_page_lookup;
+
+    let mut single_component = 0usize;
+    let mut multi_component = 0usize;
+    let mut single_ref_components = 0usize;
+    let mut multi_ref_components = 0usize;
+    let mut components_total = 0usize;
+    let mut refs_total = 0usize;
+    for entry in lookup.values() {
+        if entry.by_component.len() == 1 {
+            single_component += 1;
+        } else {
+            multi_component += 1;
+        }
+        components_total += entry.by_component.len();
+        for component in &entry.by_component {
+            if component.refs.len() == 1 {
+                single_ref_components += 1;
+            } else {
+                multi_ref_components += 1;
+            }
+            refs_total += component.refs.len();
+        }
+    }
+    let objects = lookup.len();
+
+    // Anti-vacuity, asserted before any ratio is read: an empty or one-sided corpus would make
+    // every claim below true for free.
+    assert!(objects > 0, "the lookup is empty; nothing was measured");
+    assert!(refs_total > 0, "no refs were recorded; nothing was measured");
+    assert!(
+        single_component > 0 && multi_component > 0,
+        "corpus is one-sided ({single_component} single, {multi_component} multi) -- \
+         the occupancy question would be decided by construction, not measurement"
+    );
+
+    let pct = |n: usize, d: usize| 100.0 * n as f64 / d as f64;
+    println!(
+        "
+  object page lookup occupancy ({objects} objects, {components_total} components, {refs_total} refs):
+    objects with exactly one component  {single_component:>6}  ({:>5.1}%)
+    objects with more than one          {multi_component:>6}  ({:>5.1}%)
+    components holding exactly one ref  {single_ref_components:>6}  ({:>5.1}%)
+    components holding more             {multi_ref_components:>6}  ({:>5.1}%)
+
+    sizes: ObjectPageRefs {:>3} B, ComponentPages {:>3} B, PageRefs {:>3} B, PageLookupRef {:>3} B
+    a one-component one-ref object: {:>3} B inline + {:>3} B for the component vector,
+    and the ref itself rides inside the component rather than in an allocation of its own
+",
+        pct(single_component, objects),
+        pct(multi_component, objects),
+        pct(single_ref_components, components_total),
+        pct(multi_ref_components, components_total),
+        std::mem::size_of::<crate::engine::state::ObjectPageRefs>(),
+        std::mem::size_of::<crate::engine::state::ComponentPages>(),
+        std::mem::size_of::<crate::engine::state::PageRefs>(),
+        std::mem::size_of::<crate::engine::state::PageLookupRef>(),
+        std::mem::size_of::<crate::engine::state::ObjectPageRefs>(),
+        std::mem::size_of::<crate::engine::state::ComponentPages>(),
+    );
+}
+
 /// Which structures hold an entry per record, and how many.
 ///
 /// Resident memory is ~2.8-3.9 KB per record depending on key length, and a key byte costs 14.1


### PR DESCRIPTION
A component's page refs were a `Vec`. Measured over a corpus mixing single-value objects and multi-field ones, **3600 of 3600 components hold exactly one ref** — so that vector was, in every case, a 24-byte header plus its own heap allocation to hold a single 24-byte value.

This holds the single case inline:

```rust
enum PageRefs {
    One(PageLookupRef),
    Many(Vec<PageLookupRef>),
}
```

| | before | after |
|---|---|---|
| `ComponentPages` | 48 B | 56 B |
| refs storage | +24 B heap, own allocation | inline |

8 bytes more inside the enclosing vector, and the allocation is gone — net ~32 B and one allocation saved per component. In the census corpus that is 3600 allocations removed.

### Why this one and not the object-level equivalent

The same corpus shows 90.9% of *objects* hold exactly one component, which looks like the bigger prize. It was not taken, because that number is an artifact of the workload mix: a single-value object is one component by construction and a multi-field object is one per field, so the ratio tracks how many of each you write. Inlining there would also cost every multi-component object 40 bytes.

The refs measurement is different in kind — it held at 100% for *both* object shapes, so it is a property of how pages are assigned rather than of the mix. That is the one worth building a shape around.

### The spilled arm is real, not decorative

Nothing in the measured corpus has a component spanning several pages, but the format allows it, so it stays representable rather than being asserted away. `insert` promotes inline → spilled, keeping the refs sorted and deduplicated: removal binary-searches them, so that order is load-bearing.

Equality compares contents, so a one-element spilled arm and an inline one are equal. Without that, a value read back from an index written before this change could compare unequal to the identical value built in memory.

### The on-disk index does not change

`PageRefs` converts through `Vec<PageLookupRef>` both ways, so it still encodes as the sequence it always was. A one-element sequence written by the previous shape loads into the inline arm.

### Verification

Full lib suite, single-threaded: **1491 passed, 0 failed, 17 ignored** (1508 total = 1505 pre-existing + 3 new).

Three new tests:
- the inline arm is actually taken — 0 spilled of 3600. Measuring that 100% of components hold one ref only justifies the shape; a structure that silently spilled every time would measure identically from outside, so the arm is asserted directly.
- promotion to the spilled arm lands sorted, refuses duplicates, and reports what it added
- the serialized form is still a sequence, in both directions

The occupancy census that motivated the change is included, and asserts its corpus is two-sided before reading any ratio from it — a one-sided corpus would decide the question by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
