### PR TITLE
A posting named what it points at three times

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2521,10 +2521,13 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             record = dict(base)
             record["ref_hashes"] = ref_chunk
             record["posting_part"] = part
-            if len(ref_chunk) == 1:
-                record["ref_hash"] = ref_chunk[0]
-            else:
-                record.pop("ref_hash", None)
+            # `ref_hashes` is the one place a posting names what it points at. The singular
+            # `ref_hash` restated it on every single-ref row, and `chunk_hash` restated it again;
+            # the serving accessor reads neither when the list is present, and `index_hash` is
+            # derived from the list, so both are dropped rather than written three ways. Older
+            # rows still resolve -- the fallbacks that read them are unchanged.
+            record.pop("ref_hash", None)
+            record.pop("chunk_hash", None)
             if len(record.get("node_hashes", [])) == 1:
                 record["node_hash"] = record["node_hashes"][0]
             else:

--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -482,10 +482,13 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             record = dict(base)
             record["ref_hashes"] = ref_chunk
             record["posting_part"] = part
-            if len(ref_chunk) == 1:
-                record["ref_hash"] = ref_chunk[0]
-            else:
-                record.pop("ref_hash", None)
+            # `ref_hashes` is the one place a posting names what it points at. The singular
+            # `ref_hash` restated it on every single-ref row, and `chunk_hash` restated it again;
+            # the serving accessor reads neither when the list is present, and `index_hash` is
+            # derived from the list, so both are dropped rather than written three ways. Older
+            # rows still resolve -- the fallbacks that read them are unchanged.
+            record.pop("ref_hash", None)
+            record.pop("chunk_hash", None)
             if len(record.get("node_hashes", [])) == 1:
                 record["node_hash"] = record["node_hashes"][0]
             else:

--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -358,12 +358,13 @@ def append_resource_chunk_records(
             # in for every posting of the term that falls in this part.
             record["ref_hashes"] = ref_chunk
             record["posting_part"] = part
-            # Same singular/plural rule as the compactor: the scalar exists only when the
-            # posting carries exactly one ref, so the two producers agree on the shape.
-            if len(ref_chunk) == 1:
-                record["ref_hash"] = ref_chunk[0]
-            else:
-                record.pop("ref_hash", None)
+            # `ref_hashes` is the one place a posting names what it points at. The singular
+            # `ref_hash` restated it on every single-ref row, and `chunk_hash` restated it again;
+            # the serving accessor reads neither when the list is present, and `index_hash` is
+            # derived from the list, so both are dropped rather than written three ways. Older
+            # rows still resolve -- the fallbacks that read them are unchanged.
+            record.pop("ref_hash", None)
+            record.pop("chunk_hash", None)
             pending_records.append(record)
             if len(pending_records) >= RESOURCE_APPEND_BATCH_RECORDS:
                 pending_records = _flush_pending_records(adapter, pending_records)

--- a/tools/test_matrixark_index_posting_coalescing.py
+++ b/tools/test_matrixark_index_posting_coalescing.py
@@ -25,6 +25,8 @@ import os
 import sys
 import unittest
 
+import matrixark_mcp_core as core
+
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -145,14 +147,26 @@ class CoalescedPostingsKeepEveryReference(unittest.TestCase):
             self.assertIsNone(record.get("ref_hash"),
                               "a multi-ref posting must not carry a singular ref_hash")
 
-    def test_a_single_ref_posting_keeps_its_scalar(self):
+    def test_a_single_ref_posting_names_its_target_once(self):
+        """`ref_hashes` is the only place a posting names what it points at.
+
+        Single-ref rows used to repeat that value into a singular `ref_hash`, and the row also
+        carried `chunk_hash` holding it a third time. Nothing read either when the list was
+        present -- `context_index_record_ref_hashes` takes the list whenever it is a list -- so
+        both are gone from what is written. What matters is that the row still resolves, which is
+        asserted here rather than the shape it used to have.
+        """
         records, _, _ = _emit(True)
         singles = [r for r in records
                    if r.get("record_type") == "context_index"
                    and len(r.get("ref_hashes", []) or []) == 1]
         self.assertTrue(singles, "no single-ref posting produced")
         for record in singles:
-            self.assertEqual(record["ref_hashes"][0], record.get("ref_hash"))
+            self.assertNotIn("ref_hash", record)
+            self.assertNotIn("chunk_hash", record)
+            self.assertEqual(record["ref_hashes"],
+                             core.context_index_record_ref_hashes(record),
+                             "a single-ref posting no longer resolves to what it points at")
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_posting_names_its_target_once.py
+++ b/tools/test_matrixark_posting_names_its_target_once.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A posting names what it points at once, and everything that reads it still resolves.
+
+Rows used to carry the same 64-bit value in `ref_hashes: [x]`, `chunk_hash: x` and `ref_hash: x`.
+On a skill nearly every row is a single-ref row -- heading_slug is unique per chunk -- so two of
+the three copies were pure restatement.
+
+These tests go through the REAL writer rather than reading the source. The builder exists in three
+copies and a resource ingest runs the one in `matrixark_mcp_ingest_resource_chunk_records`; a test
+that inspected `matrixark_mcp_core` would have passed while the rows on disk were unchanged.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core
+import matrixark_mcp_ingest_resource_chunk_records as ingest
+
+
+class _Writer:
+    def __init__(self):
+        self.buf = []
+
+    def append(self, record):
+        self.buf.append(record)
+
+
+def _ingest():
+    """Drive the real resource path over a real parsed document, and hand back what it wrote."""
+    import tempfile
+    import matrixark_resource_parser as parser
+
+    body = ["# Playbook"]
+    for index in range(6):
+        body.append("")
+        body.append("## Step %d - do the thing" % index)
+        body.append("Body text for step %d, long enough to be its own section." % index)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as handle:
+        handle.write(chr(10).join(body))
+        path = handle.name
+
+    chunks = parser.parse_resource(path, resource_type="skill", max_total_chunks=1000,
+                                   slim_chunk_metadata_fields=True)
+    writer = _Writer()
+    ingest.append_resource_chunk_records(
+        writer,
+        envelope={"kind": "skill", "scope": {}, "ingestion_time_ms": 1, "metadata": {},
+                  "messages": [], "resource_type": "skill", "raw_uri": path},
+        parsed_chunks=chunks, chunk_vectors=[[0.5, 0.5] for _ in chunks],
+        raw_uri=path, raw_uri_hash=1, resource_type="skill", resource_manifest_hash=2,
+        resource_import_task_hash=3, node_hash=4, node_path=["a"], access_scope={},
+        deployment_scope="local", resource_record_scope={}, skill_hash=5, skill_name="s",
+        skill_metadata={},
+        secondary_index_budget=core.new_secondary_index_budget(10000))
+    os.unlink(path)
+    return [r for r in writer.buf if r.get("record_type") == "context_index"]
+
+
+class APostingNamesItsTargetOnce(unittest.TestCase):
+    def setUp(self):
+        self.postings = _ingest()
+        # Guard the harness itself: an empty result would pass every assertion below.
+        self.assertTrue(self.postings, "the ingest wrote no postings -- the harness is wrong")
+
+    def test_the_written_rows_carry_no_restated_target(self):
+        for record in self.postings:
+            self.assertNotIn("ref_hash", record,
+                             "`ref_hashes` already names it: %s" % record.get("index_name"))
+            self.assertNotIn("chunk_hash", record,
+                             "`ref_hashes` already names it: %s" % record.get("index_name"))
+
+    def test_every_posting_still_resolves_what_it_points_at(self):
+        seen = 0
+        for record in self.postings:
+            refs = core.context_index_record_ref_hashes(record)
+            self.assertTrue(refs, "posting %s resolved to nothing" % record.get("index_name"))
+            self.assertEqual(refs, [r for r in record["ref_hashes"] if r is not None])
+            seen += len(refs)
+        self.assertGreater(seen, 0, "no refs resolved at all")
+
+    def test_rows_written_before_this_still_resolve(self):
+        """The singular field stays READABLE; only new rows stop writing it."""
+        self.assertEqual([77], core.context_index_record_ref_hashes({"ref_hash": 77}))
+        self.assertEqual([88], core.context_index_record_ref_hashes({"ref_hashes": [88]}))
+
+    def test_the_identity_does_not_depend_on_the_dropped_fields(self):
+        """`index_hash` is derived from `ref_hashes`, so dropping the copies cannot move it."""
+        for record in self.postings:
+            self.assertIsNotNone(record.get("index_hash"))
+            self.assertIn("ref_hashes", record)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every single-ref posting carried the same 64-bit value three times: in `ref_hashes`, in
`chunk_hash`, and in `ref_hash`. On a skill almost every row is a single-ref row -- `heading_slug`
is unique per chunk, so 2,510 of 2,525 rows carry exactly one -- and two of the three copies are
read by nothing the first cannot serve.

## Why dropping two of them is safe

- `context_index_record_ref_hashes`, the accessor the serving scan uses, takes `ref_hashes`
  whenever it is a list, and falls back to the scalar only for rows written before the list
  existed.
- The rust `record_ref_hash` tries the scalar, then `chunk_hash`, then `ref_hashes`. That last arm
  already has its own test.
- `chunk_hash` is never consulted on a posting at all. The dashboard reader that takes it is gated
  to `resource_chunk`, `resource_manifest` and `resource_import_task` rows.
- `index_hash` is derived from an identity naming `ref_hashes` and neither of these, so the value
  does not move and nothing needs rebuilding.

Both fields stay **readable**. Only what new rows write changes, so rows already on disk keep
resolving through the same fallbacks.

## Measured

On a 1 MB skill (2,510 chunks):

| | index | ingest | per target |
|---|---|---|---|
| before | 1,148.8 KB | 8.60 MB (8.0x) | 404.2 B |
| after | **982.2 KB** | **8.43 MB (7.8x)** | **336.4 B** |

## The test drives the writer, not the source

This builder exists in **three** copies -- `matrixark_mcp_core`, `matrixark_mcp_indexing` and
`matrixark_mcp_ingest_resource_chunk_records` -- and a resource ingest runs the third. All three
change together here.

That is also why the new test goes through the real writer instead of reading source, and the
choice is load-bearing: putting the restatement back into `matrixark_mcp_core` leaves the test
**green**, because that copy is not on this path, while putting it back into the ingest copy turns
it **red**. A test that inspected the first copy would have passed while the rows on disk were
unchanged.

The coalescing test that pinned the old singular/plural shape now asserts the row still resolves to
what it points at, which is the property that actually mattered.

## Checks

`test_matrixark_*index*` 12 passed, `test_matrixark_*posting*` 9 passed, new suite 4 passed, and
the revert-one-producer mutation behaves as described above.
