### PR TITLE
A chunk stored its heading twice

### DIFF
--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -179,7 +179,17 @@ def append_resource_chunk_records(
         chunk_debug_metadata = debug_resource_metadata(chunk.metadata)
         chunk_resource_hash = resource_manifest_hash if skill_hash is None else skill_hash
         if skill_hash is not None:
+            section_heading = str(chunk_metadata.get("heading", ""))
+            section_metadata = (
+                {key: value for key, value in chunk_metadata.items() if key != "heading"}
+                if section_heading
+                else chunk_metadata
+            )
             pending_records.append(
+                # The record carries `heading` at the top level, so the copy inside its own
+                # metadata restates it on every chunk. Dropped only when the top-level field
+                # actually received the value, so a chunk without a heading is untouched.
+                # `heading_slug` stays: it is the only source of the heading_slug: index terms.
                 resource_record_builders.skill_section_record(
                     import_task_hash=resource_import_task_hash,
                     skill_hash=skill_hash,
@@ -188,10 +198,10 @@ def append_resource_chunk_records(
                     node_path=node_path,
                     raw_uri_hash=raw_uri_hash,
                     source_locator=source_locator,
-                    heading=str(chunk_metadata.get("heading", "")),
+                    heading=section_heading,
                     text=chunk.text,
                     token_estimate=chunk.token_estimate,
-                    metadata=chunk_metadata,
+                    metadata=section_metadata,
                     access_scope=access_scope,
                     deployment_scope=deployment_scope,
                     scope=resource_record_scope,

--- a/tools/test_matrixark_chunk_heading_stored_once.py
+++ b/tools/test_matrixark_chunk_heading_stored_once.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A chunk carries its heading once, and still carries the slug the index is built from.
+
+`heading` was stored twice on every chunk -- once at the top level, once inside `metadata` -- and
+the two were byte-identical on all 2,510 chunks of a 1 MB skill. The copy is gone.
+
+`heading_slug` LOOKS like the better candidate for removal, since it is slugify(heading) and the
+heading is right there. It is not. It is the only source of the `heading_slug:` index terms: drop
+it and `candidate_index_terms` derives nothing for that kind, so a query narrowing on a heading
+anchor intersects against a term no candidate can offer and matches nothing. Both halves are
+pinned here so the pair cannot be swapped by someone reading only the first line of the reasoning.
+"""
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core
+import matrixark_mcp_ingest_resource_chunk_records as ingest
+import matrixark_resource_parser as parser
+
+
+class _Writer:
+    def __init__(self):
+        self.buf = []
+
+    def append(self, record):
+        self.buf.append(record)
+
+
+def _sections():
+    filler = ("This paragraph gives the section enough substance to stand on its own rather "
+              "than being folded into a neighbouring section by the parser. ") * 6
+    lines = ["# Playbook"]
+    for index in range(10):
+        lines.append("")
+        lines.append("## Step %d - do the thing" % index)
+        lines.append(filler)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as handle:
+        handle.write(chr(10).join(lines))
+        path = handle.name
+    chunks = parser.parse_resource(path, resource_type="skill", max_total_chunks=1000,
+                                   slim_chunk_metadata_fields=True)
+    writer = _Writer()
+    ingest.append_resource_chunk_records(
+        writer,
+        envelope={"kind": "skill", "scope": {}, "ingestion_time_ms": 1, "metadata": {},
+                  "messages": [], "resource_type": "skill", "raw_uri": path},
+        parsed_chunks=chunks, chunk_vectors=[[0.5, 0.5] for _ in chunks],
+        raw_uri=path, raw_uri_hash=1, resource_type="skill", resource_manifest_hash=2,
+        resource_import_task_hash=3, node_hash=4, node_path=["a"], access_scope={},
+        deployment_scope="local", resource_record_scope={}, skill_hash=5, skill_name="s",
+        skill_metadata={},
+        secondary_index_budget=core.new_secondary_index_budget(10000))
+    os.unlink(path)
+    return writer.buf
+
+
+class AHeadingIsStoredOnce(unittest.TestCase):
+    def setUp(self):
+        self.records = _sections()
+        self.sections = [r for r in self.records
+                         if r.get("record_type") == "skill_section" and r.get("heading")]
+        self.assertTrue(self.sections, "no sections with a heading -- the harness is wrong")
+
+    def test_the_metadata_no_longer_repeats_the_heading(self):
+        for record in self.sections:
+            self.assertNotIn("heading", record.get("metadata") or {},
+                             "the row already carries `heading` at the top level")
+            self.assertTrue(record.get("heading"), "the top-level heading must survive")
+
+    def test_the_slug_survives_and_still_yields_its_index_terms(self):
+        for record in self.sections:
+            self.assertIn("heading_slug", record.get("metadata") or {},
+                          "heading_slug is the only source of heading_slug: index terms")
+            terms = core.candidate_index_terms(record, {}, {})
+            self.assertTrue(
+                [t for t in terms if t.startswith("heading_slug:")],
+                "no heading_slug term derivable, so a heading-anchored query matches nothing")
+
+    def test_the_ingest_still_writes_heading_slug_postings(self):
+        postings = [r for r in self.records
+                    if str(r.get("index_name", "")).startswith("heading_slug:")]
+        self.assertTrue(postings, "heading_slug postings disappeared from the write path")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`skill_section_record` takes `heading` and `metadata` as separate arguments. The call site filled
the first from `chunk_metadata["heading"]` and then handed over the whole dict, so the value landed
twice -- byte-identical on all 2,510 chunks of a 1 MB skill, 65 B at a time, **158.5 KB**.

The copy is dropped at the call site, and only when the top-level field actually received it, so a
chunk with no heading is untouched.

## Where it must NOT be dropped

`SERVING_RESOURCE_METADATA_FIELDS` looks like the natural place and is the wrong one. The top-level
field is populated **from** that metadata, so removing the key there does not deduplicate the
heading -- it empties it. Measured: 2,510 sections with a heading become **0**.

`heading_slug` is left in place for the mirror-image reason. It reads like a restatement of
`heading`, being `slugify(heading)`, but it is the only source of the `heading_slug:` index terms.
Without it `candidate_index_terms` derives nothing for that kind, so a heading-anchored query
intersects against a term no candidate can offer and matches nothing.

Both traps are pinned by the new test, and both were confirmed to turn it red:

| mutation | result |
|---|---|
| drop `heading` from the field list | test **red** |
| drop `heading_slug` from the field list | test **red** |

## Measured

On a 1 MB skill (2,510 chunks), against `main`:

| | ingest | amplification | sections with a heading |
|---|---|---|---|
| before | 8.60 MB | 8.0x | 2,510 |
| after | **8.44 MB** | **7.9x** | 2,510 |

## Checks

`test_matrixark_*index*` 13 passed, `test_matrixark_*skill*` 24 passed, new suite 3 passed.
