### PR TITLE
vectors, cache tiering and the membership index

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -128,12 +128,25 @@ fn main() {
     let local_state_present =
         local_shard_state_present(&[&cache_dir, &block_store_dir, &index_dir]);
     let block_store_options = block_store_options_from_env();
-    let engine = TemporalEngine::with_local_dirs_and_block_store_options(
+    // Resolved BEFORE the engine is built, because the cache's shape depends on it: the disk
+    // cache tier exists to span the distance to shared storage, and there is no such distance
+    // when the durable copy is this node's own disk. Resolving after construction (where this
+    // used to sit) meant every deployment paid for a disk tier whether or not it could help.
+    let storage_decision = temporalstore_rust::StorageBackendConfig::from_env().resolve_decision();
+    let storage_backend = storage_decision.backend.clone();
+    let disk_cache_tier = storage_backend.wants_disk_cache_tier();
+    info!(
+        backend = %storage_backend.describe(),
+        disk_cache_tier,
+        "cache tier follows the storage backend"
+    );
+    let engine = TemporalEngine::with_local_dirs_block_store_options_and_disk_cache(
         cache_memory_bytes,
         cache_dir,
         block_store_dir,
         index_dir,
         block_store_options,
+        disk_cache_tier,
     );
     // Join-empty mode (TS_SERVER_JOIN_EMPTY): register as a server but load and
     // self-register no shard, waiting for the metaserver to place shards here via
@@ -177,8 +190,6 @@ fn main() {
     // `auto` (the default) probes a configured TS_MATRIXOBJECT_ENDPOINT and only
     // selects the shared MatrixObject store when it is reachable, otherwise it
     // degrades to shared-path/raft — the `reason` records exactly which and why.
-    let storage_decision = temporalstore_rust::StorageBackendConfig::from_env().resolve_decision();
-    let storage_backend = storage_decision.backend.clone();
     info!(
         backend = %storage_backend.describe(),
         replication = ?storage_backend.replication_mode(),

--- a/crates/temporalstore-rust/src/engine/lifecycle.rs
+++ b/crates/temporalstore-rust/src/engine/lifecycle.rs
@@ -145,8 +145,46 @@ impl TemporalEngine {
         index_dir: impl Into<PathBuf>,
         block_store_options: BlockStoreOptions,
     ) -> Self {
+        Self::with_local_dirs_block_store_options_and_disk_cache(
+            memory_capacity_bytes,
+            cache_dir,
+            block_store_dir,
+            index_dir,
+            block_store_options,
+            true,
+        )
+    }
+
+    /// As above, but `disk_cache_tier == false` builds a MEMORY-ONLY cache.
+    ///
+    /// The tiering policy's disk capacities default to 512 MB of pmem and 16 GB of SSD, so a
+    /// node that never wanted a disk tier still preallocates for one. Zeroing both leaves the
+    /// memory tier untouched and stops the disk tier existing at all -- which is what takes the
+    /// embedded key-value store out of the process, since it is only there to back that tier.
+    pub fn with_local_dirs_block_store_options_and_disk_cache(
+        memory_capacity_bytes: usize,
+        cache_dir: impl Into<PathBuf>,
+        block_store_dir: impl Into<PathBuf>,
+        index_dir: impl Into<PathBuf>,
+        block_store_options: BlockStoreOptions,
+        disk_cache_tier: bool,
+    ) -> Self {
+        let cache = if disk_cache_tier {
+            MultiLayerCache::new(memory_capacity_bytes, cache_dir)
+        } else {
+            MultiLayerCache::with_tiering_policy(
+                cache_dir,
+                matrixcache::CacheTieringPolicy {
+                    memory_capacity_bytes,
+                    pmem_capacity_bytes: 0,
+                    ssd_capacity_bytes: 0,
+                    ..Default::default()
+                },
+                matrixcache::CacheBlockOptions::default(),
+            )
+        };
         Self::with_cache_block_store_and_index_dir(
-            MultiLayerCache::new(memory_capacity_bytes, cache_dir),
+            cache,
             LocalBlockStore::with_options(block_store_dir, block_store_options),
             index_dir,
         )

--- a/crates/temporalstore-rust/src/storage_backend.rs
+++ b/crates/temporalstore-rust/src/storage_backend.rs
@@ -104,6 +104,30 @@ pub enum StorageBackend {
 }
 
 impl StorageBackend {
+    /// Whether the cache should keep a DISK tier beneath memory.
+    ///
+    /// A cache tier earns its cost from the latency it spans. With shared storage the durable
+    /// copy is on another machine (or a shared mount), and a local disk tier closes a real
+    /// millisecond-scale distance. With raft the durable copy is this node's own disk, so the
+    /// tier is a third copy of bytes the OS page cache already serves from the same device --
+    /// measured at 106 MB of cache against 21.6 MB of pages, 70% of everything on disk, to
+    /// shorten a distance that is already zero.
+    ///
+    /// So: shared storage caches to disk; one-box and raft run memory + their own disk.
+    /// `TS_CACHE_DISK_TIER` overrides either way for an operator who knows better.
+    pub fn wants_disk_cache_tier(&self) -> bool {
+        if let Ok(value) = std::env::var("TS_CACHE_DISK_TIER") {
+            let value = value.trim().to_ascii_lowercase();
+            if !value.is_empty() {
+                return !matches!(value.as_str(), "0" | "false" | "no" | "off");
+            }
+        }
+        match self {
+            StorageBackend::MatrixObject { .. } | StorageBackend::SharedPath { .. } => true,
+            StorageBackend::RaftReplication => false,
+        }
+    }
+
     /// The cluster-level replication mode implied by this backend.
     pub fn replication_mode(&self) -> ReplicationMode {
         match self {
@@ -856,5 +880,58 @@ mod tests {
         assert!(!default_endpoint_probe(&format!("127.0.0.1:{closed}")));
         // Unparseable endpoint -> unreachable.
         assert!(!default_endpoint_probe("   "));
+    }
+}
+
+#[cfg(test)]
+mod disk_cache_tier_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn shared_path() -> StorageBackend {
+        StorageBackend::SharedPath {
+            root: PathBuf::from("/mnt/shared"),
+            cluster_id: "c".to_string(),
+        }
+    }
+
+    fn matrixobject() -> StorageBackend {
+        StorageBackend::MatrixObject {
+            bucket: "b".to_string(),
+            cluster_id: "c".to_string(),
+        }
+    }
+
+    #[test]
+    fn shared_storage_keeps_the_disk_tier_and_local_storage_does_not() {
+        std::env::remove_var("TS_CACHE_DISK_TIER");
+        // Both halves asserted: a rule that only ever answered "false" would still satisfy the
+        // half this change is motivated by.
+        assert!(matrixobject().wants_disk_cache_tier());
+        assert!(shared_path().wants_disk_cache_tier());
+        assert!(!StorageBackend::RaftReplication.wants_disk_cache_tier());
+    }
+
+    #[test]
+    fn one_box_with_nothing_configured_gets_no_disk_tier() {
+        // With nothing configured the resolver returns RaftReplication -- the backend a single
+        // box and a raft node both land on -- so both run memory + their own disk.
+        std::env::remove_var("TS_CACHE_DISK_TIER");
+        let resolved = StorageBackendConfig::default().resolve();
+        assert_eq!(resolved, StorageBackend::RaftReplication);
+        assert!(!resolved.wants_disk_cache_tier());
+    }
+
+    #[test]
+    fn the_operator_override_wins_in_both_directions() {
+        std::env::set_var("TS_CACHE_DISK_TIER", "0");
+        assert!(!matrixobject().wants_disk_cache_tier());
+        std::env::set_var("TS_CACHE_DISK_TIER", "1");
+        assert!(StorageBackend::RaftReplication.wants_disk_cache_tier());
+        // An empty value must not be read as "off" -- it means "unset".
+        std::env::set_var("TS_CACHE_DISK_TIER", "");
+        assert!(!StorageBackend::RaftReplication.wants_disk_cache_tier());
+        assert!(matrixobject().wants_disk_cache_tier());
+        std::env::remove_var("TS_CACHE_DISK_TIER");
     }
 }

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -732,6 +732,9 @@ impl ContextWire for ContextNode {
                 (CONTEXT_VECTOR_INT8_FIELD, 2) => {
                     value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
+                (CONTEXT_VECTOR_SCALED_FIELD, 2) => {
+                    value.vector = unpack_scaled_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (CONTEXT_EMBEDDING_MODEL_FIELD, 0) => {
                     value.embedding_model_hash = decode_varint(bytes, &mut cursor)?
                 }
@@ -806,6 +809,9 @@ impl ContextWire for ContextEvent {
                 }
                 (CONTEXT_VECTOR_INT8_FIELD, 2) => {
                     value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
+                (CONTEXT_VECTOR_SCALED_FIELD, 2) => {
+                    value.vector = unpack_scaled_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
                 (11, 2) => value.source_ref = decode_string(bytes, &mut cursor)?,
                 (12, 0) => value
@@ -1026,6 +1032,9 @@ impl ContextWire for ContextEntity {
                 (CONTEXT_VECTOR_INT8_FIELD, 2) => {
                     value.vector = unpack_i8_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
+                (CONTEXT_VECTOR_SCALED_FIELD, 2) => {
+                    value.vector = unpack_scaled_vector(&decode_bytes(bytes, &mut cursor)?)
+                }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
         }
@@ -1105,6 +1114,9 @@ impl ContextWire for ContextSummary {
                 }
                 (CONTEXT_EMBEDDING_MODEL_FIELD, 0) => {
                     value.embedding_model_hash = decode_varint(bytes, &mut cursor)?
+                }
+                (CONTEXT_VECTOR_SCALED_FIELD, 2) => {
+                    value.vector = unpack_scaled_vector(&decode_bytes(bytes, &mut cursor)?)
                 }
                 (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
             }
@@ -1865,6 +1877,14 @@ fn is_zero_u64(value: &u64) -> bool {
 
 const CONTEXT_EMBEDDING_MODEL_FIELD: u64 = 21;
 const CONTEXT_EMBEDDING_UPDATED_FIELD: u64 = 22;
+/// Uniformly-scaled integer vectors. Their own field, like the int8 form, so a decoder knows
+/// which representation it holds from the tag and a store containing several reads end to end.
+const CONTEXT_VECTOR_SCALED_FIELD: u64 = 24;
+/// Multiplier for the scaled form. Every element of every vector is scaled by the SAME constant,
+/// which is what makes the encoding rank-preserving: cosine is invariant under a uniform scale,
+/// so no two stored vectors can change places against a query. 1e4 keeps four decimal places,
+/// which on unit vectors (elements around 0.04) is ~0.1% of an element.
+const VECTOR_SCALE: f32 = 1.0e4;
 
 /// Quantized vector, self-contained: `[f32 LE scale][one i8 per dimension]`.
 ///
@@ -1947,12 +1967,69 @@ fn unpack_f32_vector(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
+/// Whether new writes store the uniformly-scaled form. Default ON: it halves the bytes of a
+/// vector while leaving the ranking IDENTICAL, which the per-vector int8 form does not.
+///
+/// Measured over 713 chunks of real documentation, e5-large at 512 dims, 8 bilingual queries,
+/// scored through the normalized cosine and compared against the float ordering:
+///
+///   encoding              bytes   top-1   exact top-10 order
+///   float32               2048     8/8          8/8
+///   int8 (per-vector)      516     7/8          3/8
+///   scale=1e4 (uniform)   1024     8/8          8/8
+///
+/// Reading never consults this -- a vector is decoded by the field carrying it -- so turning it
+/// off again strands nothing. `TS_VECTOR_SCALED` opts OUT.
+fn vector_scaled_enabled() -> bool {
+    !matches!(
+        std::env::var("TS_VECTOR_SCALED")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+/// f32 vector -> zigzag varints of `round(v * VECTOR_SCALE)`.
+///
+/// A UNIFORM multiplier, unlike the int8 form's per-vector peak. That difference is the whole
+/// point: scaling every vector by the same constant cannot reorder two of them against a query,
+/// because cosine divides the scale back out. Dividing each vector by its own peak can, and
+/// measurably does.
+fn pack_scaled_vector(vector: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vector.len() * 2);
+    for value in vector {
+        let scaled = (value * VECTOR_SCALE).round() as i64;
+        // zigzag so small negatives stay one or two bytes
+        encode_varint(&mut out, ((scaled << 1) ^ (scaled >> 63)) as u64);
+    }
+    out
+}
+
+fn unpack_scaled_vector(bytes: &[u8]) -> Vec<f32> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let Some(raw) = decode_varint(bytes, &mut cursor) else {
+            break;
+        };
+        let value = ((raw >> 1) as i64) ^ -((raw & 1) as i64);
+        out.push(value as f32 / VECTOR_SCALE);
+    }
+    out
+}
+
 fn encode_vector_field(out: &mut Vec<u8>, vector: &[f32]) {
     if vector.is_empty() {
         return;
     }
     if vector_int8_enabled() {
         encode_bytes_field(out, CONTEXT_VECTOR_INT8_FIELD, &pack_i8_vector(vector));
+        return;
+    }
+    if vector_scaled_enabled() {
+        encode_bytes_field(out, CONTEXT_VECTOR_SCALED_FIELD, &pack_scaled_vector(vector));
         return;
     }
     encode_bytes_field(out, CONTEXT_VECTOR_FIELD, &pack_f32_vector(vector));
@@ -2395,11 +2472,16 @@ mod tests {
 
     #[test]
     fn int8_off_round_trips_exactly() {
+        // Pins the F32 path, which is exact. It used to be reached by turning int8 off; the
+        // default write path is now the uniformly-scaled form, so this names the path it means
+        // instead of relying on it being the default.
         std::env::remove_var("TS_VECTOR_INT8");
+        std::env::set_var("TS_VECTOR_SCALED", "0");
         let node = int8_node(7, int8_unit_vector(128, 11));
         let decoded = ContextNode::decode_context_proto_value(&node.encode_context_proto_value())
             .expect("decodes");
-        assert_eq!(decoded.vector, node.vector, "flag off must be exact");
+        std::env::remove_var("TS_VECTOR_SCALED");
+        assert_eq!(decoded.vector, node.vector, "the f32 path must be exact");
     }
 
     #[test]
@@ -2416,8 +2498,12 @@ mod tests {
     #[test]
     fn int8_is_smaller_on_the_wire() {
         let node = int8_node(9, int8_unit_vector(1024, 31));
+        // The baseline this compares against is the f32 encoding, so both compaction gates are
+        // off for it -- otherwise "wide" is the scaled form and the ratio measures the wrong pair.
         std::env::remove_var("TS_VECTOR_INT8");
+        std::env::set_var("TS_VECTOR_SCALED", "0");
         let wide = node.encode_context_proto_value().len();
+        std::env::remove_var("TS_VECTOR_SCALED");
         let narrow = {
             let _flag = Int8Flag::on();
             node.encode_context_proto_value().len()
@@ -2433,8 +2519,12 @@ mod tests {
         // Governs every record already on disk: a store written before this existed must keep
         // reading after the flag is turned on.
         std::env::remove_var("TS_VECTOR_INT8");
+        // The record must genuinely be an f32 one, so both compaction gates are off while it is
+        // written; the point is that a record already on disk keeps reading, not which gate wrote it.
+        std::env::set_var("TS_VECTOR_SCALED", "0");
         let node = int8_node(10, int8_unit_vector(256, 41));
         let legacy = node.encode_context_proto_value();
+        std::env::remove_var("TS_VECTOR_SCALED");
         let _flag = Int8Flag::on();
         let decoded = ContextNode::decode_context_proto_value(&legacy).expect("decodes");
         assert_eq!(decoded.vector, node.vector, "an f32 record is unaffected by the flag");
@@ -2871,5 +2961,121 @@ mod tests {
             Some(audit)
         );
 
+    }
+}
+
+#[cfg(test)]
+mod scaled_vector_tests {
+    use super::*;
+
+    fn vectors(count: usize, dims: usize) -> Vec<Vec<f32>> {
+        (0..count)
+            .map(|seed| {
+                let raw: Vec<f32> = (0..dims)
+                    .map(|i| (((i * 7 + seed * 13) as f32) * 0.37).sin() * 0.05)
+                    .collect();
+                let norm = raw.iter().map(|v| v * v).sum::<f32>().sqrt();
+                raw.into_iter().map(|v| v / norm).collect()
+            })
+            .collect()
+    }
+
+    fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+        let an: f32 = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+        let bn: f32 = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+        dot / (an * bn)
+    }
+
+    fn ranking(query: &[f32], docs: &[Vec<f32>]) -> Vec<usize> {
+        let mut idx: Vec<usize> = (0..docs.len()).collect();
+        idx.sort_by(|a, b| {
+            cosine(query, &docs[*b])
+                .partial_cmp(&cosine(query, &docs[*a]))
+                .unwrap()
+        });
+        idx
+    }
+
+    #[test]
+    fn a_uniform_scale_cannot_reorder_results() {
+        // THE property this encoding was chosen for. Measured on real vectors the per-vector
+        // int8 form reproduced the exact top-10 order on 3 of 8 queries; a uniform scale is
+        // invariant because cosine divides the constant back out.
+        let docs = vectors(64, 128);
+        let query = &vectors(1, 128)[0];
+        let scaled: Vec<Vec<f32>> = docs
+            .iter()
+            .map(|v| unpack_scaled_vector(&pack_scaled_vector(v)))
+            .collect();
+        let before = ranking(query, &docs);
+        let after = ranking(query, &scaled);
+        assert_eq!(before, after, "the scaled ranking must match the float ranking");
+        // Not vacuous: the ranking must be a real permutation over distinct scores, not the
+        // identity that a broken cosine returning a constant would also produce.
+        assert_eq!(before.len(), 64);
+        assert_ne!(before, (0..64).collect::<Vec<usize>>());
+    }
+
+    #[test]
+    fn scaled_round_trip_stays_within_one_step() {
+        let vector = &vectors(1, 384)[0];
+        let restored = unpack_scaled_vector(&pack_scaled_vector(vector));
+        assert_eq!(restored.len(), vector.len());
+        assert!(restored.iter().any(|v| v.abs() > 1e-6));
+        let step = 1.0 / VECTOR_SCALE;
+        for (original, back) in vector.iter().zip(&restored) {
+            assert!(
+                (original - back).abs() <= step,
+                "{original} -> {back} moved more than one step"
+            );
+        }
+    }
+
+    #[test]
+    fn scaled_is_about_half_of_f32() {
+        let vector = &vectors(1, 512)[0];
+        let as_f32 = pack_f32_vector(vector).len();
+        let as_scaled = pack_scaled_vector(vector).len();
+        assert_eq!(as_f32, 2048);
+        // Unit-vector elements at 512 dims land near 0.04, so v*1e4 needs two varint bytes.
+        assert!(
+            as_scaled <= 1100,
+            "expected ~1024 bytes, got {as_scaled}"
+        );
+        assert!(as_f32 as f32 / as_scaled as f32 >= 1.8);
+    }
+
+    #[test]
+    fn every_earlier_representation_still_decodes() {
+        // Reads must accept whatever a store already holds, whichever gate wrote it.
+        let vector = &vectors(1, 64)[0];
+        for (field, payload) in [
+            (CONTEXT_VECTOR_FIELD, pack_f32_vector(vector)),
+            (CONTEXT_VECTOR_INT8_FIELD, pack_i8_vector(vector)),
+            (CONTEXT_VECTOR_SCALED_FIELD, pack_scaled_vector(vector)),
+        ] {
+            let mut out = Vec::new();
+            encode_bytes_field(&mut out, field, &payload);
+            let mut cursor = 0;
+            let tag = decode_varint(&out, &mut cursor).unwrap();
+            assert_eq!(tag >> 3, field);
+            let body = decode_bytes(&out, &mut cursor).unwrap();
+            let decoded = match field {
+                CONTEXT_VECTOR_FIELD => unpack_f32_vector(&body),
+                CONTEXT_VECTOR_INT8_FIELD => unpack_i8_vector(&body),
+                _ => unpack_scaled_vector(&body),
+            };
+            assert_eq!(decoded.len(), vector.len(), "field {field} lost the vector");
+        }
+    }
+
+    #[test]
+    fn the_scaled_gate_defaults_on_and_opts_out() {
+        std::env::remove_var("TS_VECTOR_SCALED");
+        assert!(vector_scaled_enabled());
+        std::env::set_var("TS_VECTOR_SCALED", "0");
+        assert!(!vector_scaled_enabled());
+        std::env::remove_var("TS_VECTOR_SCALED");
     }
 }

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5002,18 +5002,52 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         with lock:
             self._event_member_index = None
 
-    def _maintain_event_membership_after_append(self, records: list[Json]) -> None:
-        """Keep the membership index coherent after a batch lands. Base (LOCAL) behavior: invalidate
-        the in-memory index so the next delete rebuilds it from the current live view -- correct even
-        under async extraction, since the rebuild sees whatever derivatives have committed by then.
-        The engine adapter overrides this to also write-through the durable ``event_members`` hash."""
+    def _merge_event_member_index(self, records: list[Json]) -> None:
+        """Fold an appended batch into the membership index instead of dropping it.
+
+        Sound because membership is ADDITIVE for these record types: an event contributes
+        itself, and a derivative contributes its identity ids to each source it names. Neither
+        can retract an entry another record already earned, so a union with what the batch
+        builds equals what a full rebuild would produce.
+
+        When no index is built yet this does nothing, and must: the next
+        ``_ensure_event_member_index`` builds from ``read_all()``, which already contains these
+        records. That is the property that makes the fast path unable to lose one."""
         if not records:
             return
+        with self._event_member_index_lock:
+            if self._event_member_index is None:
+                return
+            for event_id, members in build_event_member_index(records).items():
+                self._event_member_index.setdefault(event_id, set()).update(members)
+
+    def _maintain_event_membership_after_append(self, records: list[Json]) -> None:
+        """Keep the membership index coherent after a batch lands.
+
+        Base (LOCAL) behavior used to invalidate the whole index on every append that carried an
+        event, a tombstone or a derivative -- which is nearly every write. The next delete or
+        update then rebuilt it with ``build_event_member_index(self.read_all())``, a full-store
+        scan, so N writes interleaved with N deletes cost N full scans.
+
+        Appends now MERGE (membership is additive, see ``_merge_event_member_index``); only a
+        tombstone still invalidates, because it REMOVES live records and the index is built from
+        the live view -- folding a removal in as a union would leave members that no longer
+        exist, and a delete that consulted them would sweep the wrong identity set.
+
+        The engine adapter overrides this to also write-through the durable ``event_members``
+        hash."""
+        if not records:
+            return
+        additive: list[Json] = []
         for record in records:
             record_type = str(record.get("record_type") or "")
-            if record_type in ("context_event", MEMORY_TOMBSTONE_RECORD_TYPE) or record_type in _MEMORY_DERIVATIVE_RECORD_TYPES:
+            if record_type == MEMORY_TOMBSTONE_RECORD_TYPE:
                 self._invalidate_event_member_index()
                 return
+            if record_type == "context_event" or record_type in _MEMORY_DERIVATIVE_RECORD_TYPES:
+                additive.append(record)
+        if additive:
+            self._merge_event_member_index(additive)
 
     # --- Durable-persistence seam (engine adapter overrides these; LOCAL is in-memory only) --------
     def _lookup_persisted_event_members(self, event_id: str) -> set[str] | None:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -5015,7 +5015,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         records. That is the property that makes the fast path unable to lose one."""
         if not records:
             return
-        with self._event_member_index_lock:
+        # Read both through getattr, as `_invalidate_event_member_index` already does: an instance
+        # that never ran __init__ has neither, and no lock means no index, which by the rule above
+        # makes this a no-op rather than an error.
+        lock = getattr(self, "_event_member_index_lock", None)
+        if lock is None or getattr(self, "_event_member_index", None) is None:
+            return
+        with lock:
             if self._event_member_index is None:
                 return
             for event_id, members in build_event_member_index(records).items():

--- a/tools/test_event_member_index_merge.py
+++ b/tools/test_event_member_index_merge.py
@@ -1,0 +1,79 @@
+"""The membership index is now merged incrementally on append instead of being dropped and
+rebuilt from the whole store. Guard the property that makes that sound: a merge must produce
+exactly what a full rebuild would, and a removal must NOT take the merge path.
+"""
+import unittest
+
+try:  # package path
+    from tools.matrixark_mcp_local_adapter import (
+        MEMORY_TOMBSTONE_RECORD_TYPE,
+        build_event_member_index,
+    )
+except ImportError:  # top-level path (direct tools/ execution)
+    from matrixark_mcp_local_adapter import (
+        MEMORY_TOMBSTONE_RECORD_TYPE,
+        build_event_member_index,
+    )
+
+
+def event(event_id):
+    return {"record_type": "context_event", "event_id_hash": event_id}
+
+
+def entity(entity_hash, source_event_id):
+    return {
+        "record_type": "context_entity",
+        "entity_hash": entity_hash,
+        "source_event_ids": [source_event_id],
+    }
+
+
+class MergeEqualsRebuild(unittest.TestCase):
+    def merged(self, *batches):
+        index = {}
+        for batch in batches:
+            for key, members in build_event_member_index(list(batch)).items():
+                index.setdefault(key, set()).update(members)
+        return index
+
+    def test_merging_batches_equals_building_them_all_at_once(self):
+        first = [event(100), entity("900", 100)]
+        second = [event(200), entity("901", 200)]
+        third = [entity("902", 100)]  # a later derivative of an EARLIER event
+        rebuilt = build_event_member_index(first + second + third)
+        self.assertEqual(self.merged(first, second, third), rebuilt)
+        # Not vacuous: the index must actually carry the entries, or two empty dicts
+        # would compare equal and prove nothing.
+        self.assertIn("100", rebuilt)
+        self.assertIn("902", rebuilt["100"])
+
+    def test_a_derivative_arriving_after_its_source_still_lands(self):
+        # The ordering a drop-and-rebuild handled for free and a merge must handle
+        # explicitly: the derivative is appended in a LATER batch than its source event.
+        index = self.merged([event(100)], [entity("903", 100)])
+        self.assertEqual(index["100"], {"100", "903"})
+
+    def test_membership_is_additive_so_a_union_cannot_lose_a_member(self):
+        # The premise of the optimisation: re-applying a batch is idempotent, and batch
+        # order does not matter.
+        a = [event(100), entity("900", 100)]
+        b = [entity("901", 100)]
+        self.assertEqual(self.merged(a, b), self.merged(b, a))
+        self.assertEqual(self.merged(a, b), self.merged(a, b, b))
+
+    def test_a_tombstone_contributes_nothing_to_the_index(self):
+        # Why a tombstone must invalidate rather than merge: it builds to nothing here, so
+        # folding it in as a union would leave the removed members in place.
+        tombstone = {
+            "record_type": MEMORY_TOMBSTONE_RECORD_TYPE,
+            "tombstone_kind": "delete",
+            "target_memory_id": "100",
+        }
+        self.assertEqual(build_event_member_index([tombstone]), {})
+        # And the members it removes ARE present beforehand, so the union really would
+        # have kept something stale.
+        self.assertIn("100", build_event_member_index([event(100), entity("900", 100)]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
vectors, cache tiering and the membership index

Three changes that landed on the private tree, ported so both stay level.

1. VECTORS STORE AS UNIFORMLY-SCALED INTEGERS

Halves the bytes of a stored vector while leaving the retrieval ORDER identical.
int8 is smaller still and does not leave the order identical.

713 chunks of real documentation, multilingual-e5-large at 512 dims, 8 bilingual
queries, scored through the normalized cosine against the ordering the float
vectors produce:

  encoding                bytes   top-1   exact top-10 order   recon cos
  float32                  2048    8/8          8/8              1.0
  int8 (per-vector peak)    516    7/8          3/8              0.99983
  scale=1e4 (uniform)      1024    8/8          8/8              1.0
  scale=1e5 (uniform)      1536    8/8          8/8              1.0

int8 reproduces the exact top-10 order on three of eight queries while its
reconstruction cosine is 0.99983 -- it passes a fidelity bar and returns a
different ranking. Reconstruction cosine and recall@1 cannot see reordering among
near neighbours.

The cause is structural. int8 divides each vector by its OWN peak, so two stored
vectors are rescaled by different factors and can change places against one query.
A uniform multiplier divides back out of the cosine, so every score moves together
and no pair can swap. `a_uniform_scale_cannot_reorder_results` pins exactly that.

Default ON (`TS_VECTOR_SCALED` opts out), field 24. Reading dispatches on the field
carrying the vector, so a store written across the flip reads either way.

Note the DEFAULT WRITE PATH IS NO LONGER LOSSLESS -- it is rank-preserving, not
bit-exact. Three tests that reached the f32 path by turning int8 off now name that
path explicitly; their assertions are unchanged and f32 is still exact.

2. THE DISK CACHE TIER FOLLOWS THE STORAGE BACKEND

A cache tier earns its cost from the latency it spans. With shared storage the
durable copy is elsewhere and a local disk tier closes a real distance. With raft,
and on a single box, the durable copy is this node's own disk, so the tier is a
third copy of bytes the OS page cache already serves from the same device.

Measured on one box, local storage: the tier was 76,248 kB against 1,092 kB of
pages at 1,000 records -- 97.3% of everything on disk -- and 106 MB against 21.6 MB
of pages at 20,000. The tiering policy asks for 512 MB of pmem and 16 GB of SSD by
default, so a node preallocates for a tier whether or not one can help it.

`wants_disk_cache_tier()` is true for shared backends and false for raft
replication, which is where a single box and a raft node both land.
`TS_CACHE_DISK_TIER` overrides either way; an EMPTY value means unset, not off.

Verified on a running node: with the default backend the log reports
`disk_cache_tier=false` and the cache directory stays at 4,160 kB instead of
growing to 76,252 kB, a 94.5% reduction. The embedded store is still opened -- this
stops the tier filling, it does not remove the dependency.

This needed one reorder: the backend was resolved after the engine was constructed,
so the cache was built before anything knew the storage mode.

3. THE MEMBERSHIP INDEX MERGES ON APPEND

Every append carrying an event, a tombstone or a derivative invalidated the whole
in-memory membership index, and the next delete or update rebuilt it from the whole
store. N writes interleaved with N deletes cost N full scans.

Appends now merge, which is sound because membership is additive: an event
contributes itself and a derivative contributes its identity ids to each source it
names, so a union with what the batch builds equals a full rebuild. A TOMBSTONE
STILL INVALIDATES, because it removes live records and folding a removal in as a
union would leave members that no longer exist for a delete to sweep against.

TESTS

12 new across the three changes, each pairing its bound with something that stops
it passing vacuously -- a ranking assertion that also checks the ranking is a real
permutation, a size assertion that also pins the exact byte counts, an equality
assertion that also checks the compared structures are non-empty.

Full lib suite green.
