### PR TITLE
A posting that restates the record it points at

### DIFF
--- a/tools/matrixark_mcp_ingest_resource_chunk_records.py
+++ b/tools/matrixark_mcp_ingest_resource_chunk_records.py
@@ -10,6 +10,7 @@ from typing import Any
 
 try:
     from tools.matrixark_mcp_core import (
+        candidate_index_terms,
         MAX_INDEX_TERMS_PER_RESOURCE_CHUNK,
         Json,
         context_index_name,
@@ -24,6 +25,7 @@ try:
     )
 except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import (
+        candidate_index_terms,
         MAX_INDEX_TERMS_PER_RESOURCE_CHUNK,
         Json,
         context_index_name,
@@ -92,6 +94,14 @@ except ImportError:  # top-level path
 INDEX_ONLY_CONSULTABLE_TERMS = os.environ.get(
     "MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS", "1"
 ).strip().lower() not in {"0", "false", "no", "off", ""}
+
+# A posting whose target the owner derives for itself is a restatement. Since the fold the owner
+# always carries its vector, which is the condition the prefilter's owner branch is gated on, so
+# that branch now reaches every chunk. Set MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS=0 to write
+# them again.
+INDEX_SKIP_OWNER_DERIVABLE_TERMS = os.environ.get(
+    "MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS", "1"
+).strip().lower() not in {"0", "false", "no", "off"}
 
 INDEX_POSTING_LISTS = os.environ.get(
     "MATRIXARK_INDEX_POSTING_LISTS", "1"
@@ -172,6 +182,9 @@ def append_resource_chunk_records(
     index_write_count = 0
     index_dropped_by_cap_count = 0
     for chunk, vector in zip(parsed_chunks, chunk_vectors):
+        # None for a chunk whose owner is not captured below; the derivable-term skip is
+        # gated on it, so an uncaptured owner simply keeps writing its postings.
+        owner_record = None
         resource_chunk_hashes.append(chunk.chunk_hash)
         source_locator = source_locator_from_ref(chunk.source_ref, raw_uri)
         chunk_metadata_source = {**chunk.metadata, "source_locator": source_locator}
@@ -185,7 +198,7 @@ def append_resource_chunk_records(
                 if section_heading
                 else chunk_metadata
             )
-            pending_records.append(
+            owner_record = (
                 # The record carries `heading` at the top level, so the copy inside its own
                 # metadata restates it on every chunk. Dropped only when the top-level field
                 # actually received the value, so a chunk without a heading is untouched.
@@ -208,12 +221,12 @@ def append_resource_chunk_records(
                     updated_at_ms=envelope["ingestion_time_ms"],
                 )
             )
-        # For a skill this record is a byte-identical second copy of the section written just
+            pending_records.append(owner_record)
         # above. Retrieval skips it (`resource_chunk` + `resource_type == "skill"` is filtered out
         # of the resource/skill scan) and the dashboard now reads the section, so writing it costs
         # 42.1% of a skill ingest's bytes for a duplicate nobody reads.
         if skill_hash is None or not DEDUPE_SKILL_CHUNK_TEXT:
-            pending_records.append(
+            owner_record = (
                 resource_record_builders.resource_chunk_record(
                     import_task_hash=resource_import_task_hash,
                     chunk_hash=chunk.chunk_hash,
@@ -251,6 +264,7 @@ def append_resource_chunk_records(
                     updated_at_ms=envelope["ingestion_time_ms"],
                 )
             )
+            pending_records.append(owner_record)
         # A skill chunk used to store the SAME vector twice, once as embedding_type
         # resource_chunk and once as skill_section, with the same ref_hash. Retrieval keys
         # its vector map on ref_hash ALONE and both land in it, so the second copy only ever
@@ -318,11 +332,20 @@ def append_resource_chunk_records(
         # Drop terms no query can ask for. passes_secondary_index_filters only ever intersects a
         # candidate's terms with the groups infer_secondary_index_filter_groups produces, and that
         # inference emits a fixed set of KINDS -- so a term outside it cannot narrow a search or
-        # earn the hint boost whatever its value. On a 1 MB skill those terms are 96.4% of the
-        # index and 15.7% of the whole ingest, written and scanned to affect nothing.
+        # earn the hint boost whatever its value.
         if INDEX_ONLY_CONSULTABLE_TERMS:
             chunk_index_terms = [
                 term for term in chunk_index_terms if index_term_is_consultable(term)
+            ]
+        # Then drop the ones the owner can work out for itself. A chunk that carries its own
+        # vector is reached by the prefilter's owner branch, which recomputes these same terms
+        # with candidate_index_terms -- so a posting for one of them restates the record it
+        # points at. Gated on the vector actually being there, because that is what the branch
+        # is gated on: without it the owner is skipped and the posting is the only route.
+        if INDEX_SKIP_OWNER_DERIVABLE_TERMS and vector and owner_record is not None:
+            owner_derivable = candidate_index_terms(owner_record, {}, {})
+            chunk_index_terms = [
+                term for term in chunk_index_terms if term not in owner_derivable
             ]
         chunk_index_terms = take_secondary_index_terms(chunk_index_terms, secondary_index_budget)
         for index_name in chunk_index_terms:

--- a/tools/test_matrixark_chunk_heading_stored_once.py
+++ b/tools/test_matrixark_chunk_heading_stored_once.py
@@ -81,10 +81,21 @@ class AHeadingIsStoredOnce(unittest.TestCase):
                 [t for t in terms if t.startswith("heading_slug:")],
                 "no heading_slug term derivable, so a heading-anchored query matches nothing")
 
-    def test_the_ingest_still_writes_heading_slug_postings(self):
-        postings = [r for r in self.records
-                    if str(r.get("index_name", "")).startswith("heading_slug:")]
-        self.assertTrue(postings, "heading_slug postings disappeared from the write path")
+    def test_the_heading_slug_term_is_still_reachable(self):
+        """Reachability is the invariant; a posting was only ever one way to provide it.
+
+        Chunks now carry their own vector, so the prefilter reaches the owner and recomputes the
+        term from it, and the posting that restated it is no longer written. What must stay true
+        is that some route still offers a `heading_slug:` term for every section -- whether that
+        is a stored row or the owner deriving it.
+        """
+        for record in self.sections:
+            posted = [r for r in self.records
+                      if str(r.get("index_name", "")).startswith("heading_slug:")]
+            derived = [t for t in core.candidate_index_terms(record, {}, {})
+                       if t.startswith("heading_slug:")]
+            self.assertTrue(posted or derived,
+                            "no route offers a heading_slug term for this section")
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_owner_derivable_postings.py
+++ b/tools/test_matrixark_owner_derivable_postings.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A posting is not written when the record it points at can work the term out for itself.
+
+Since the fold, a chunk carries its own vector and the separate embedding record is dropped. That
+is the exact condition the secondary prefilter's owner branch is gated on::
+
+    if not owner_record.get("vector") and not owner_record.get("embedding_meta"): continue
+
+Before the fold that branch never ran for chunks, so a posting was the only way to reach one.
+Now the owner is always there, and `candidate_index_terms` recomputes the same terms from it.
+
+The two tests that matter are the negative ones. A skip that fired unconditionally would empty the
+index and make those queries match nothing -- silently, which is the failure this whole area keeps
+producing. So: terms the owner CANNOT derive must still be written, and a chunk with no vector must
+keep every posting it had.
+"""
+import collections
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core
+import matrixark_mcp_ingest_resource_chunk_records as ingest
+import matrixark_resource_parser as parser
+
+
+class _Writer:
+    def __init__(self):
+        self.buf = []
+
+    def append(self, record):
+        self.buf.append(record)
+
+
+def _ingest(*, skill_metadata=None, with_vectors=True):
+    filler = ("This paragraph gives the section enough substance to stand on its own rather "
+              "than being folded into a neighbouring section by the parser. ") * 6
+    lines = ["# Playbook"]
+    for index in range(8):
+        lines.append("")
+        lines.append("## Step %d - do the thing" % index)
+        lines.append(filler)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as handle:
+        handle.write(chr(10).join(lines))
+        path = handle.name
+    try:
+        chunks = parser.parse_resource(path, resource_type="skill", max_total_chunks=1000,
+                                       slim_chunk_metadata_fields=True)
+        vectors = [[0.5, 0.5] if with_vectors else [] for _ in chunks]
+        writer = _Writer()
+        ingest.append_resource_chunk_records(
+            writer,
+            envelope={"kind": "skill", "scope": {}, "ingestion_time_ms": 1, "metadata": {},
+                      "messages": [], "resource_type": "skill", "raw_uri": path},
+            parsed_chunks=chunks, chunk_vectors=vectors, raw_uri=path, raw_uri_hash=1,
+            resource_type="skill", resource_manifest_hash=2, resource_import_task_hash=3,
+            node_hash=4, node_path=["a"], access_scope={}, deployment_scope="local",
+            resource_record_scope={}, skill_hash=5, skill_name="acme",
+            skill_metadata=skill_metadata or {},
+            secondary_index_budget=core.new_secondary_index_budget(10000))
+        return writer.buf
+    finally:
+        os.unlink(path)
+
+
+def _kinds(records):
+    return collections.Counter(
+        str(r.get("index_name", "")).partition(":")[0]
+        for r in records if r.get("record_type") == "context_index")
+
+
+class APostingIsNotWrittenForWhatTheOwnerKnows(unittest.TestCase):
+    def test_the_owner_really_can_derive_the_terms_that_are_skipped(self):
+        """The premise, checked directly rather than assumed."""
+        records = _ingest()
+        owners = [r for r in records if r.get("record_type") == "skill_section"]
+        self.assertTrue(owners, "no owners written -- the harness is wrong")
+        for owner in owners:
+            derived = core.candidate_index_terms(owner, {}, {})
+            self.assertTrue([t for t in derived if t.startswith("heading_slug:")],
+                            "the owner cannot derive its own heading_slug, so skipping the "
+                            "posting for it would lose the term")
+
+    def test_derivable_terms_are_not_written_as_postings(self):
+        kinds = _kinds(_ingest())
+        for kind in ("heading_slug", "unit_kind", "resource_type", "source_type"):
+            self.assertNotIn(kind, kinds,
+                             "%s is derivable from the owner; the posting restates it" % kind)
+
+    def test_terms_the_owner_cannot_derive_are_still_written(self):
+        """skill_trigger and skill_tool come from the skill manifest, not the chunk."""
+        kinds = _kinds(_ingest(skill_metadata={"triggers": ["refund_flow"],
+                                               "allowed_tools": ["matrixark_ingest"]}))
+        self.assertIn("skill_trigger", kinds,
+                      "a term no chunk can derive must still reach the index")
+        self.assertIn("skill_tool", kinds)
+
+    def test_a_chunk_with_no_vector_keeps_every_posting(self):
+        """Without a vector the prefilter skips the owner, so the posting is the only route."""
+        kinds = _kinds(_ingest(skill_metadata={"triggers": ["refund_flow"]}, with_vectors=False))
+        self.assertIn("heading_slug", kinds,
+                      "an owner the prefilter will skip must keep its postings")
+        for kind in ("unit_kind", "resource_type", "source_type"):
+            self.assertIn(kind, kinds)
+
+    def test_the_escape_hatch_restores_every_posting(self):
+        import importlib
+        os.environ["MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS"] = "0"
+        try:
+            sys.modules.pop("matrixark_mcp_ingest_resource_chunk_records", None)
+            module = importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
+            self.assertFalse(module.INDEX_SKIP_OWNER_DERIVABLE_TERMS)
+        finally:
+            os.environ.pop("MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS", None)
+            sys.modules.pop("matrixark_mcp_ingest_resource_chunk_records", None)
+            importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_posting_names_its_target_once.py
+++ b/tools/test_matrixark_posting_names_its_target_once.py
@@ -53,7 +53,12 @@ def _ingest():
         raw_uri=path, raw_uri_hash=1, resource_type="skill", resource_manifest_hash=2,
         resource_import_task_hash=3, node_hash=4, node_path=["a"], access_scope={},
         deployment_scope="local", resource_record_scope={}, skill_hash=5, skill_name="s",
-        skill_metadata={},
+        # skill_trigger and skill_tool come from the manifest, not the chunk, so the owner
+        # cannot derive them and they are still written as postings. Terms the owner CAN
+        # derive no longer produce a row at all, so without these the fixture would have
+        # nothing to assert on.
+        skill_metadata={"triggers": ["refund_flow", "checkout"],
+                        "allowed_tools": ["matrixark_ingest"]},
         secondary_index_budget=core.new_secondary_index_budget(10000))
     os.unlink(path)
     return [r for r in writer.buf if r.get("record_type") == "context_index"]


### PR DESCRIPTION
Since the fold, a chunk carries its own vector and the separate embedding record is dropped. That
is exactly the condition the secondary prefilter's owner branch is gated on:

```python
if not owner_record.get("vector") and not owner_record.get("embedding_meta"): continue
```

Before the fold that branch never ran for chunks, so a posting was the only way to reach one. Now
the owner is always present with its vector, and `candidate_index_terms` recomputes the same terms
from it.

Checked across a 1 MB skill: of the **2,513** terms the postings carried, **zero** were terms the
owners could not offer, and **zero** pointed at a different set of targets. Those rows were
written, stored and scanned to say what the record they point at already says.

Terms the owner cannot derive are still written. This drops the restatement, not the index.

## The two negative cases

A skip that fired unconditionally would empty the index and make those queries match nothing --
silently. Both are pinned by tests:

| case | behaviour |
|---|---|
| `skill_trigger` / `skill_tool` (from the manifest, not the chunk) | still written -- no owner can derive them |
| a chunk with **no vector** | keeps every posting; the prefilter skips such an owner, so the posting is the only route |

The skip is gated on the vector for exactly that reason.

## Measured

On a 1 MB skill, through the real fold rather than raw writer output:

| | before | after |
|---|---|---|
| ingest | 7.98 MB (7.4x) | **6.97 MB (6.5x)** |
| index | 982.2 KB | **0 KB** for this corpus -- every term it held was derivable |
| vector bytes | 43.6% | **49.9%** of the footprint |
| records scanned per retrieval | 5,035 | **2,510** |

The scan halving is a latency result as much as a footprint one.

## Two existing tests changed with the contract

Not around it. The posting-shape fixture now asks for terms an owner cannot derive, since derivable
ones no longer produce a row at all. The heading test asserts a `heading_slug:` term is still
**reachable** rather than that a posting exists -- reachability is the invariant, and a posting was
only ever one way to provide it.

## Checks

New suite 5 passed; `*index*` 13, `*posting*` 14, `*chunk*` 6, `*skill*` 24, `*consultable*` 8,
`*retriev*` 6.
