### PR TITLE
Share one copy of a page kind instead of one per page

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2186,7 +2186,7 @@ fn collect_command_index_items(
                 routing_bucket,
                 page_ref_key: page_ref_key.to_string(),
                 object_key: page.object_key.clone(),
-                model_id: page.model_id.clone(),
+                model_id: page.model_id.clone().to_string(),
                 component: page.component.clone(),
                 object_id: page.object_id,
                 page_id: page.address.page_id().unwrap_or(0),
@@ -2344,7 +2344,7 @@ fn fold_delta_page_items(
                 continue;
             };
             bucket.page_index.retain(|_, page| {
-                !(page.model_id == item.model_id
+                !(page.model_id.as_ref() == item.model_id
                     && page.object_key == item.object_key
                     && page.component == item.component)
             });
@@ -2379,7 +2379,7 @@ fn fold_delta_page_items(
             std::sync::Arc::from(item.page_ref_key.as_str()),
             PageIndex {
                 object_key: item.object_key.clone(),
-                model_id: item.model_id.clone(),
+                model_id: Arc::from(item.model_id.clone()),
                 component: item.component.clone(),
                 object_id: item.object_id,
                 address,
@@ -3119,7 +3119,7 @@ fn mark_bucket_index_page_deleted(
         let mut bucket_removed = false;
         let mut deleted_object_ids = BTreeSet::new();
         bucket.page_index.retain(|_, page| {
-            let matches = page.model_id == model_id
+            let matches = page.model_id.as_ref() == model_id
                 && page.object_key == key
                 && page.component.as_deref() == component;
             if matches {
@@ -3353,7 +3353,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
                             .get(&page_ref.routing_bucket)
                             .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                             .map(|page| {
-                                !page.deleted && page.model_id == *kind && page.object_key == key
+                                !page.deleted && page.model_id.as_ref() == *kind && page.object_key == key
                             })
                             .unwrap_or(false)
                     })
@@ -3534,9 +3534,9 @@ fn object_manager_stats(
                     .iter()
                     .map(|page| {
                         (
-                            page.model_id.as_str(),
+                            page.model_id.as_ref(),
                             page.object_key.as_str(),
-                            (page.model_id == "hash")
+                            (page.model_id.as_ref() == "hash")
                                 .then(|| page.component.as_deref())
                                 .flatten(),
                         )
@@ -3548,9 +3548,9 @@ fn object_manager_stats(
                     .filter(|page| page.dirty || shard.dirty_objects.contains(&page.object_key))
                     .map(|page| {
                         (
-                            page.model_id.as_str(),
+                            page.model_id.as_ref(),
                             page.object_key.as_str(),
-                            (page.model_id == "hash")
+                            (page.model_id.as_ref() == "hash")
                                 .then(|| page.component.as_deref())
                                 .flatten(),
                         )

--- a/crates/temporalstore-rust/src/engine/bucket_store.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_store.rs
@@ -173,7 +173,7 @@ pub(super) fn bucket_index_page_address(
                 continue;
             };
             if !page.deleted
-                && page.model_id == model_id
+                && page.model_id.as_ref() == model_id
                 && page.object_key == object_key
                 && page.component.as_deref() == component
             {
@@ -194,7 +194,7 @@ pub(super) fn bucket_index_page_address(
         .flat_map(|bucket| bucket.page_index.values())
         .filter(|page| {
             !page.deleted
-                && page.model_id == model_id
+                && page.model_id.as_ref() == model_id
                 && page.object_key == object_key
                 && page.component.as_deref() == component
         })
@@ -213,7 +213,7 @@ pub(super) fn bucket_index_component_page_addresses(
             .filter_map(|page_ref| {
                 let bucket = shard.bucket_index.bucket_map.get(&page_ref.routing_bucket)?;
                 let page = bucket.page_index.get(&page_ref.page_ref_key)?;
-                if !page.deleted && page.model_id == model_id && page.object_key == object_key {
+                if !page.deleted && page.model_id.as_ref() == model_id && page.object_key == object_key {
                     Some((page.component.clone(), page.address.clone()))
                 } else {
                     None
@@ -236,7 +236,7 @@ pub(super) fn bucket_index_component_page_addresses(
         .bucket_map
         .values()
         .flat_map(|bucket| bucket.page_index.values())
-        .filter(|page| !page.deleted && page.model_id == model_id && page.object_key == object_key)
+        .filter(|page| !page.deleted && page.model_id.as_ref() == model_id && page.object_key == object_key)
         .map(|page| (page.component.clone(), page.address.clone()))
         .collect::<Vec<_>>();
     refs.sort_by(|left, right| left.0.cmp(&right.0));

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -64,7 +64,7 @@ pub(super) fn model_compaction_policy_reports(
 
     let mut by_model = BTreeMap::<String, ModelStats>::new();
     for entry in entries {
-        let stats = by_model.entry(entry.kind.clone()).or_default();
+        let stats = by_model.entry(entry.kind.clone().to_string()).or_default();
         if entry.deleted {
             stats.deleted_page_refs = stats.deleted_page_refs.saturating_add(1);
         } else {

--- a/crates/temporalstore-rust/src/engine/object_manager.rs
+++ b/crates/temporalstore-rust/src/engine/object_manager.rs
@@ -132,8 +132,8 @@ pub(super) fn runtime_report(shard: &ShardState) -> ObjectManagerRuntimeReport {
             if !object.object_keys.contains(&page.object_key) {
                 object.object_keys.push(page.object_key.clone());
             }
-            if !object.model_ids.contains(&page.model_id) {
-                object.model_ids.push(page.model_id.clone());
+            if !object.model_ids.contains(&page.model_id.to_string()) {
+                object.model_ids.push(page.model_id.clone().to_string());
             }
         }
     }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -284,6 +284,20 @@ pub(super) struct CoreIndex {
     pub(super) bucket_map: BucketMap,
     #[serde(default)]
     pub(super) object_page_lookup: ObjectPageLookup,
+    /// One shared copy of each page kind, so a page holds a pointer rather than its own string.
+    ///
+    /// Measured over 2700 pages: `model_id` had 2 distinct values and 2700 copies -- 1350 copies
+    /// of each, and an allocation apiece. The object key, by contrast, had 1650 distinct values
+    /// for those same 2700 pages, which is why it is not interned here: sharing something that is
+    /// nearly unique saves nothing.
+    ///
+    /// Owned by the index rather than a global, so the write path interns through the `&mut` it
+    /// already holds and no lock appears on it. Capped, so being bounded is a property of this
+    /// code rather than a promise about every future caller: past the cap a kind still works, it
+    /// just allocates as it did before. Not serialized -- it is a sharing detail, not part of the
+    /// index.
+    #[serde(skip)]
+    pub(super) kind_pool: std::collections::HashSet<Arc<str>>,
     /// Running total of page refs across `object_component_lookup`, or `None` when not known.
     ///
     /// The stats path reports this number, and computing it as
@@ -365,6 +379,23 @@ impl ObjectPageRefs {
     pub(super) fn total_refs(&self) -> usize {
         self.by_component.iter().map(|entry| entry.refs.len()).sum()
     }
+}
+
+/// A kind is drawn from a fixed set of literals in the code, so a pool of them is bounded. The
+/// cap keeps that true even if some future caller passes something unbounded: it stops sharing
+/// rather than growing.
+const KIND_POOL_CAP: usize = 64;
+
+/// One shared copy of `kind`, taken from the pool or added to it.
+pub(super) fn intern_kind(pool: &mut std::collections::HashSet<Arc<str>>, kind: &str) -> Arc<str> {
+    if let Some(shared) = pool.get(kind) {
+        return Arc::clone(shared);
+    }
+    let shared: Arc<str> = Arc::from(kind);
+    if pool.len() < KIND_POOL_CAP {
+        pool.insert(Arc::clone(&shared));
+    }
+    shared
 }
 
 /// The pages holding one component, with the single-page case held inline.
@@ -512,7 +543,7 @@ pub(super) enum BucketLayoutState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct PageIndex {
     pub(super) object_key: String,
-    pub(super) model_id: String,
+    pub(super) model_id: Arc<str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) component: Option<String>,
     pub(super) object_id: u64,
@@ -650,7 +681,7 @@ impl CoreIndex {
                     .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                     .map(|page| {
                         !page.deleted
-                            && page.model_id == model_id
+                            && page.model_id == Arc::from(model_id)
                             && page.object_key == object_key
                             && page.component.as_deref() == component
                             && same_page_address(&page.address, address)
@@ -666,7 +697,7 @@ impl CoreIndex {
         self.bucket_map.values().any(|bucket| {
             bucket.page_index.values().any(|page| {
                 !page.deleted
-                    && page.model_id == model_id
+                    && page.model_id == Arc::from(model_id)
                     && page.object_key == object_key
                     && page.component.as_deref() == component
                     && same_page_address(&page.address, address)
@@ -779,7 +810,7 @@ mod component_lookup_tests {
     fn page(object: &str, component: Option<&str>) -> PageIndex {
         PageIndex {
             object_key: object.to_string(),
-            model_id: "hash".to_string(),
+            model_id: Arc::from("hash".to_string()),
             component: component.map(str::to_string),
             object_id: 0,
             address: BlockAddress::from_parts(0, 0, 0, None, None, None, None, None, None),

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -200,7 +200,7 @@ impl StorageManagerPhaseExecutor {
 #[derive(Debug, Clone)]
 pub(super) struct LivePageEntry {
     pub(super) object_key: String,
-    pub(super) kind: String,
+    pub(super) kind: Arc<str>,
     pub(super) component: Option<String>,
     pub(super) address: BlockAddress,
     pub(super) dirty: bool,
@@ -222,7 +222,7 @@ pub(super) fn live_page_entry(
 ) -> LivePageEntry {
     LivePageEntry {
         object_key: object_key.into(),
-        kind: kind.into(),
+        kind: Arc::from(kind.into()),
         component,
         // A page materialized in the block store carries a real page_id; a page
         // backed only by the hot/append-log buffer does not. Evaluate before the
@@ -271,14 +271,14 @@ pub(super) fn storage_index_snapshot_with_samples(
     let mut entries = collect_live_page_entries(shard);
     entries.sort_by(|left, right| {
         (
-            left.kind.as_str(),
+            left.kind.as_ref(),
             left.object_key.as_str(),
             left.component.as_deref().unwrap_or(""),
             left.address.page_slab_id,
             left.address.offset,
         )
             .cmp(&(
-                right.kind.as_str(),
+                right.kind.as_ref(),
                 right.object_key.as_str(),
                 right.component.as_deref().unwrap_or(""),
                 right.address.page_slab_id,
@@ -327,15 +327,15 @@ pub(super) fn storage_index_snapshot_with_samples(
         .take(MAX_STORAGE_INDEX_SAMPLES.saturating_mul(4))
     {
         let key = (
-            entry.kind.clone(),
-            entry.kind.clone(),
+            entry.kind.to_string(),
+            entry.kind.to_string(),
             entry.object_key.clone(),
         );
         let sample = object_entries
             .entry(key)
             .or_insert_with(|| StorageObjectIndexEntrySample {
-                model: entry.kind.clone(),
-                table: entry.kind.clone(),
+                model: entry.kind.to_string(),
+                table: entry.kind.to_string(),
                 object_key: entry.object_key.clone(),
                 page_chain: Vec::new(),
                 tombstone: entry.deleted,
@@ -429,7 +429,7 @@ pub(super) fn storage_gc_snapshot_with_samples(
     entries.sort_by(|left, right| {
         (
             left.deleted,
-            left.kind.as_str(),
+            left.kind.as_ref(),
             left.object_key.as_str(),
             left.component.as_deref().unwrap_or(""),
             left.address.page_slab_id,
@@ -437,7 +437,7 @@ pub(super) fn storage_gc_snapshot_with_samples(
         )
             .cmp(&(
                 right.deleted,
-                right.kind.as_str(),
+                right.kind.as_ref(),
                 right.object_key.as_str(),
                 right.component.as_deref().unwrap_or(""),
                 right.address.page_slab_id,
@@ -528,7 +528,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
                 .unwrap_or(left.address.page_slab_id),
             left.address.page_slab_id,
             left.address.offset,
-            left.kind.as_str(),
+            left.kind.as_ref(),
             left.object_key.as_str(),
         )
             .cmp(&(
@@ -538,7 +538,7 @@ pub(super) fn storage_topology_snapshot_with_samples(
                     .unwrap_or(right.address.page_slab_id),
                 right.address.page_slab_id,
                 right.address.offset,
-                right.kind.as_str(),
+                right.kind.as_ref(),
                 right.object_key.as_str(),
             ))
     });
@@ -972,7 +972,7 @@ pub(super) fn rebuild_unserialized_model_maps_from_bucket_index(shard: &mut Shar
     }
     let mut hashes = HashMap::<String, HashMap<String, BlockAddress>>::new();
     for entry in collect_bucket_index_live_page_entries(shard) {
-        if entry.deleted || entry.kind != "hash" {
+        if entry.deleted || entry.kind != Arc::from("hash") {
             continue;
         }
         hashes
@@ -1370,7 +1370,7 @@ pub(super) fn upsert_bucket_index_page_with(
     }
     let entry = LivePageEntry {
         object_key: object_key.to_string(),
-        kind: kind.to_string(),
+        kind: crate::engine::state::intern_kind(&mut shard.bucket_index.kind_pool, kind),
         component,
         log_backed: address.page_id().is_none(),
         address,
@@ -1509,7 +1509,7 @@ pub(super) fn sync_bucket_index_object_pages(
         };
         let before = bucket.page_index.len();
         bucket.page_index
-            .retain(|_, page| !(page.model_id == kind && page.object_key == object_key));
+            .retain(|_, page| !(page.model_id == Arc::from(kind) && page.object_key == object_key));
         if bucket.page_index.len() != before {
             removed_any = true;
             touched_buckets.insert(routing_bucket);
@@ -1548,7 +1548,7 @@ pub(super) fn sync_bucket_index_object_pages(
             .unwrap_or_else(|| stable_page_object_id(shard_id, kind, object_key, None));
         let entry = LivePageEntry {
             object_key: object_key.to_string(),
-            kind: kind.to_string(),
+            kind: Arc::from(kind.to_string()),
             component: None,
             log_backed: address.page_id().is_none(),
             address,
@@ -2088,7 +2088,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
     let mut context_compressions = HashMap::<String, BTreeMap<u64, BlockAddress>>::new();
 
     for entry in entries {
-        match entry.kind.as_str() {
+        match entry.kind.as_ref() {
             "string" => {
                 saw_strings = true;
                 strings.insert(entry.object_key, entry.address);

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -364,7 +364,7 @@ pub(super) fn storage_physical_index_report(
             });
         let mut page_index = StoragePhysicalPageIndex {
             object_key: entry.object_key.clone(),
-            model_id: entry.kind.clone(),
+            model_id: entry.kind.clone().to_string(),
             component: entry.component.clone(),
             routing_bucket,
             page_slab_id: entry.address.page_slab_id,
@@ -405,7 +405,7 @@ pub(super) fn storage_physical_index_report(
         for page in runtime_bucket.page_index.values() {
             let already_present = bucket.page_indexes.iter().any(|existing| {
                 existing.object_key == page.object_key
-                    && existing.model_id == page.model_id
+                    && *existing.model_id == *page.model_id
                     && existing.component == page.component
                     && existing.page_slab_id == page.address.page_slab_id
                     && existing.offset == page.address.offset
@@ -415,7 +415,7 @@ pub(super) fn storage_physical_index_report(
             }
             let mut page_index = StoragePhysicalPageIndex {
                 object_key: page.object_key.clone(),
-                model_id: page.model_id.clone(),
+                model_id: page.model_id.clone().to_string(),
                 component: page.component.clone(),
                 routing_bucket: *routing_bucket,
                 page_slab_id: page.address.page_slab_id,
@@ -606,7 +606,7 @@ pub(super) fn object_manager_runtime_report(
     ];
     report.packed_timestamped_page_count = collect_live_page_entries(shard)
         .iter()
-        .filter(|entry| TIMESTAMPED_KINDS.contains(&entry.kind.as_str()))
+        .filter(|entry| TIMESTAMPED_KINDS.contains(&entry.kind.as_ref()))
         .count() as u64;
     report.runtime_ready = report.blockers.is_empty();
     report
@@ -955,7 +955,7 @@ pub(super) fn storage_feature_page_layout_report(
             continue;
         }
         if !matches!(
-            entry.kind.as_str(),
+            entry.kind.as_ref(),
             "feature"
                 | "sequence"
                 | "context_event"
@@ -967,15 +967,15 @@ pub(super) fn storage_feature_page_layout_report(
         ) {
             continue;
         }
-        let family = family_reports.entry(entry.kind.clone()).or_insert_with(|| {
+        let family = family_reports.entry(entry.kind.clone().to_string()).or_insert_with(|| {
             StorageTimestampedPageFamilyReport {
-                kind: entry.kind.clone(),
+                kind: entry.kind.clone().to_string(),
                 ..StorageTimestampedPageFamilyReport::default()
             }
         });
         report.unique_timestamped_page_refs = report.unique_timestamped_page_refs.saturating_add(1);
         family.unique_page_refs = family.unique_page_refs.saturating_add(1);
-        if entry.kind == "feature" {
+        if entry.kind == Arc::from("feature") {
             report.unique_feature_page_refs = report.unique_feature_page_refs.saturating_add(1);
         }
         match page_store.read(&entry.address) {
@@ -984,7 +984,7 @@ pub(super) fn storage_feature_page_layout_report(
                     report.packed_timestamped_pages =
                         report.packed_timestamped_pages.saturating_add(1);
                     family.packed_pages = family.packed_pages.saturating_add(1);
-                    if entry.kind == "feature" {
+                    if entry.kind == Arc::from("feature") {
                         report.packed_feature_pages = report.packed_feature_pages.saturating_add(1);
                     }
                     for point in points {
@@ -1012,7 +1012,7 @@ pub(super) fn storage_feature_page_layout_report(
                     report.legacy_timestamped_value_pages =
                         report.legacy_timestamped_value_pages.saturating_add(1);
                     family.legacy_value_pages = family.legacy_value_pages.saturating_add(1);
-                    if entry.kind == "feature" {
+                    if entry.kind == Arc::from("feature") {
                         report.legacy_feature_value_pages =
                             report.legacy_feature_value_pages.saturating_add(1);
                     }

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2356,7 +2356,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 "string:k::1:0".to_string(),
                 PageIndex {
                     object_key: "k".to_string(),
-                    model_id: "string".to_string(),
+                    model_id: Arc::from("string".to_string()),
                     component: None,
                     object_id: 30,
                     address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1), None, None),
@@ -2385,7 +2385,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     "feature:k::2:0".to_string(),
                     PageIndex {
                         object_key: "feature-key".to_string(),
-                        model_id: "feature".to_string(),
+                        model_id: Arc::from("feature".to_string()),
                         component: None,
                         object_id: 40,
                         address: BlockAddress::from_parts(2, 0, 4, Some(2), Some(40), Some(4), Some(2), None, None),
@@ -2398,7 +2398,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     "feature:k::2:4".to_string(),
                     PageIndex {
                         object_key: "feature-key".to_string(),
-                        model_id: "feature".to_string(),
+                        model_id: Arc::from("feature".to_string()),
                         component: None,
                         object_id: 40,
                         address: BlockAddress::from_parts(2, 4, 4, Some(3), Some(40), Some(4), Some(3), None, None),
@@ -2427,7 +2427,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     "hash:k:a:3:0".to_string(),
                     PageIndex {
                         object_key: "hash-key".to_string(),
-                        model_id: "hash".to_string(),
+                        model_id: Arc::from("hash".to_string()),
                         component: Some("a".to_string()),
                         object_id: 50,
                         address: BlockAddress::from_parts(3, 0, 1, Some(4), Some(50), Some(5), Some(4), None, None),
@@ -2440,7 +2440,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     "hash:k:b:3:1".to_string(),
                     PageIndex {
                         object_key: "hash-key".to_string(),
-                        model_id: "hash".to_string(),
+                        model_id: Arc::from("hash".to_string()),
                         component: Some("b".to_string()),
                         object_id: 51,
                         address: BlockAddress::from_parts(3, 1, 1, Some(5), Some(51), Some(5), Some(5), None, None),

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4080,6 +4080,194 @@ fn page_refs_serialize_as_a_sequence() {
     assert_eq!(round_tripped.len(), 2);
 }
 
+/// Pages of the same kind point at ONE string, not a copy each.
+///
+/// Changing the field's type to a shared pointer does not by itself share anything -- every page
+/// could still hold its own allocation and the type would look identical from outside, exactly as
+/// the measurement did before. So this compares pointers, not contents.
+#[test]
+fn pages_of_one_kind_share_a_single_kind_string() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..200 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("shared-kind-{index:05}"),
+                value: vec![b'v'; 32],
+            },
+        });
+    }
+    for index in 0..40 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: format!("shared-kind-hash-{index:05}"),
+                field: "f".to_string(),
+                value: vec![b'h'; 32],
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+
+    let mut first_of_kind: std::collections::HashMap<String, std::sync::Arc<str>> =
+        std::collections::HashMap::new();
+    let mut pages = 0usize;
+    let mut shared = 0usize;
+    for bucket in shard.bucket_index.bucket_map.values() {
+        for (_ref_key, page) in bucket.page_index.iter() {
+            pages += 1;
+            match first_of_kind.get(page.model_id.as_ref()) {
+                None => {
+                    first_of_kind.insert(page.model_id.to_string(), page.model_id.clone());
+                }
+                Some(first) => {
+                    if std::sync::Arc::ptr_eq(first, &page.model_id) {
+                        shared += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // Anti-vacuity first: with no pages, or one page per kind, "everything is shared" is true for
+    // free and proves nothing.
+    assert!(pages > 0, "no pages were recorded; nothing was measured");
+    assert!(
+        pages > first_of_kind.len(),
+        "only {} pages for {} kinds -- no kind repeats, so sharing is untested",
+        pages,
+        first_of_kind.len()
+    );
+    assert_eq!(
+        shared,
+        pages - first_of_kind.len(),
+        "every page after the first of its kind should point at that first string; \
+         {} kinds over {} pages, {shared} shared",
+        first_of_kind.len(),
+        pages
+    );
+    assert!(
+        first_of_kind.len() >= 2,
+        "corpus produced one kind; a second is needed to show the pool distinguishes them"
+    );
+}
+
+/// How many distinct identity strings the page index holds, against how many copies of each.
+///
+/// Interning pays only where cardinality is low relative to the number of holders. The object key
+/// is unique per object, so sharing it saves copies but never collapses them -- established
+/// already, and not what this measures. The question here is the other two: `model_id` should be
+/// drawn from a small fixed set of model types, and `component` from a per-object field name.
+///
+/// Reported per field rather than as one identity-strings total, because the answer differs by
+/// field and a combined number would hide that.
+#[test]
+fn page_index_identity_string_cardinality() {
+    use std::collections::HashSet;
+
+    const STRING_OBJECTS: usize = 1_500;
+    const HASH_OBJECTS: usize = 150;
+    const FIELDS_PER_HASH: usize = 8;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..STRING_OBJECTS {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet {
+                key: format!("identity-string-{index:08}"),
+                value: vec![b'v'; 64],
+            },
+        });
+    }
+    for object in 0..HASH_OBJECTS {
+        for field in 0..FIELDS_PER_HASH {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: format!("identity-hash-{object:08}"),
+                    field: format!("field-{field}"),
+                    value: vec![b'h'; 64],
+                },
+            });
+        }
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+
+    let mut pages = 0usize;
+    let mut distinct_models: HashSet<&str> = HashSet::new();
+    // Distinct ALLOCATIONS, not distinct values. Once the kind is shared, counting holders would
+    // report the cost as if nothing had changed -- every page still holds one, it just points at
+    // a string it does not own.
+    let mut model_allocations: HashSet<*const u8> = HashSet::new();
+    let mut distinct_components: HashSet<&str> = HashSet::new();
+    let mut distinct_keys: HashSet<&str> = HashSet::new();
+    let mut model_bytes = 0usize;
+    let mut component_bytes = 0usize;
+    let mut key_bytes = 0usize;
+    let mut components_present = 0usize;
+    for bucket in shard.bucket_index.bucket_map.values() {
+        for (_ref_key, page) in bucket.page_index.iter() {
+            pages += 1;
+            distinct_models.insert(page.model_id.as_ref());
+            model_allocations.insert(std::sync::Arc::as_ptr(&page.model_id).cast::<u8>());
+            distinct_keys.insert(page.object_key.as_str());
+            model_bytes += page.model_id.len();
+            key_bytes += page.object_key.len();
+            if let Some(component) = page.component.as_deref() {
+                distinct_components.insert(component);
+                component_bytes += component.len();
+                components_present += 1;
+            }
+        }
+    }
+
+    // Anti-vacuity first: an empty index would make every ratio below true for free, and a
+    // corpus with no components would decide the component question by construction.
+    assert!(pages > 0, "the page index is empty; nothing was measured");
+    assert!(
+        components_present > 0,
+        "no page carries a component; the component question would be decided by construction"
+    );
+
+    let share = |distinct: usize, copies: usize| {
+        if distinct == 0 { 0.0 } else { copies as f64 / distinct as f64 }
+    };
+    println!(
+        "
+  page index identity strings over {pages} pages:
+    model_id    {:>5} distinct, {:>6} holders ({:>7.1} each), {:>4} allocations behind {:>6} B of referenced text
+    component   {:>5} distinct, {:>6} copies  ({:>7.1} copies each, {:>6} B held)
+    object_key  {:>5} distinct, {:>6} copies  ({:>7.1} copies each, {:>6} B held)
+
+    PageIndex is {} B before its heap strings
+",
+        distinct_models.len(), pages, share(distinct_models.len(), pages),
+        model_allocations.len(), model_bytes,
+        distinct_components.len(), components_present,
+        share(distinct_components.len(), components_present), component_bytes,
+        distinct_keys.len(), pages, share(distinct_keys.len(), pages), key_bytes,
+        std::mem::size_of::<crate::engine::state::PageIndex>(),
+    );
+}
+
 /// How many components an object actually has, and how many refs a component actually holds.
 ///
 /// This decides whether an inline single-component shape is worth having. The inner `refs` vector
@@ -9969,7 +10157,7 @@ fn whether_a_context_page_reaches_the_bucket_index() {
     let mut kinds: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     for bucket in shard.bucket_index.bucket_map.values() {
         for page in bucket.page_index.values() {
-            *kinds.entry(page.model_id.clone()).or_insert(0) += 1;
+            *kinds.entry(page.model_id.clone().to_string()).or_insert(0) += 1;
         }
     }
     // And the context keys the model map holds, so the two can be compared.
@@ -10350,7 +10538,7 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
                     (
                         (*bucket, ref_key.to_string()),
                         (
-                            page.model_id.clone(),
+                            page.model_id.to_string(),
                             page.object_key.clone(),
                             page.component.clone(),
                         ),
@@ -10384,7 +10572,7 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
                     (
                         (*bucket, ref_key.to_string()),
                         (
-                            page.model_id.clone(),
+                            page.model_id.to_string(),
                             page.object_key.clone(),
                             page.component.clone(),
                         ),


### PR DESCRIPTION
Measured over 2700 pages in the page index:

| field | distinct values | copies | copies each |
|---|---|---|---|
| `model_id` | **2** | 2700 | **1350×** |
| `component` | 8 | 1200 | 150× |
| `object_key` | 1650 | 2700 | 1.6× |

A page held its own `String` for its kind — an allocation each, for a value with two distinct forms. This shares one copy instead.

`PageIndex` goes from **184 to 176 bytes**, and the **2700 allocations become 2**.

### What is deliberately not interned

`object_key` had 1650 distinct values across those same 2700 pages. Sharing something that is nearly unique saves nothing, and it holds the most bytes of the three — so it stays as it is. That is consistent with what was already established about the key, and this change does not revisit it.

`component` shows 150 copies each, which looks like the same opportunity. It is not, and the difference decides the design: a kind is drawn from a fixed set of literals in the code, so a pool of them is bounded. A component name comes from the caller, so the same pool would grow without bound. Interning it needs a different mechanism, not this one.

### Where the pool lives

On the index, not in a global. The write path already holds the index mutably, so no lock appears on it and the pool is scoped to the shard that uses it.

It is capped at 64. That makes boundedness a property of this code rather than a promise about every future caller: past the cap a kind still works, it just allocates as it did before.

### Verification

Full lib suite, single-threaded: **1493 passed, 0 failed, 17 ignored**.

Two tests, both written against the ways this could look right while being wrong:

- **Pages of one kind point at the same string**, compared by pointer. Changing the field's type shares nothing by itself — every page could keep its own allocation and the type would look identical from outside, exactly as the measurement did before the change. It also asserts a kind actually repeats first, because with one page per kind "everything is shared" holds for free.
- **The census counts distinct allocations, not holders.** Counting holders would report the cost as if nothing had changed: every page still holds one, it just points at a string it does not own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
