### PR TITLE
embedding_meta repeated three fields of the record it rides on

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -656,6 +656,11 @@ INLINE_VECTOR_OWNER_BY_REF_TYPE = {
 # budgeting and recovery need; a search for a read of the nested route or options finds none. The
 # record's own top-level `storage_route` is kept and already slimmed to its placement half by
 # `slim_persisted_storage_route`, which is where a reader that wants placement looks.
+# Fields the owner record carries in its own right. They are stripped from `embedding_meta` when
+# they match the owner's, which they do for every writer today -- an embedding is addressed by the
+# owner's hash, so it inherits the owner's node and timestamp. Kept when they differ.
+_EMBEDDING_META_SAME_AS_OWNER = ("node_path", "updated_at_ms", "node_hash")
+
 _EMBEDDING_META_SKIP = (
     "record_type",
     "ref_type",
@@ -744,6 +749,13 @@ def fold_embedding_records(
             if key not in _EMBEDDING_META_SKIP
             and value not in (None, "", [], {})
         }
+        # Three of what survives are fields the owner already carries itself, and the embedding is
+        # addressed by the owner's own hash, so they arrive identical: 137.2 KB per 1 MB skill
+        # restating the record the meta rides on. Dropped only where they MATCH -- a differing
+        # value is the interesting case and is kept.
+        for key in _EMBEDDING_META_SAME_AS_OWNER:
+            if key in meta and key in owner and owner[key] == meta[key]:
+                del meta[key]
         if meta:
             owner.setdefault("embedding_meta", meta)
         if index not in replace:

--- a/tools/test_matrixark_embedding_meta_restates_its_owner.py
+++ b/tools/test_matrixark_embedding_meta_restates_its_owner.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`embedding_meta` does not repeat fields the owner it rides on already carries.
+
+The fold copies the retired embedding record wholesale minus a skip list. Three survivors --
+`node_path`, `updated_at_ms`, `node_hash` -- are fields the owner has in its own right, and since
+an embedding is addressed by the owner's own hash they arrive identical: 137.2 KB per 1 MB skill
+restating the record they are attached to.
+
+Two things have to hold, and the second is the one worth testing. A DIFFERING value is kept, because
+"they always match" is a property of today's writers rather than a guarantee, and a mismatch is
+exactly what nobody would want silently discarded. And the guard fields stay: `dim` feeds the
+width-conflict check and `model` the model-hash check, which are what stop a swapped encoder from
+scoring across two vector spaces.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from matrixark_mcp_local_adapter import fold_embedding_records
+
+
+def _pair(*, meta_node_hash=7, meta_updated=111):
+    owner = {
+        "record_type": "skill_section",
+        "section_hash": 42,
+        "node_hash": 7,
+        "node_path": ["a", "b"],
+        "updated_at_ms": 111,
+        "text": "body",
+    }
+    embedding = {
+        "record_type": "context_embedding",
+        "ref_type": "skill_section",
+        "ref_hash": 42,
+        "vector": [0.5, 0.5],
+        "model": "e5-small",
+        "embedding_type": "skill_section",
+        "dim": 2,
+        "node_hash": meta_node_hash,
+        "node_path": ["a", "b"],
+        "updated_at_ms": meta_updated,
+    }
+    return [owner, embedding]
+
+
+def _folded(records):
+    out = fold_embedding_records(records)
+    owners = [r for r in out if r.get("record_type") == "skill_section"]
+    assert owners, "the fold produced no owner -- the fixture is wrong"
+    return owners[0]
+
+
+class EmbeddingMetaDoesNotRestateItsOwner(unittest.TestCase):
+    def test_the_vector_still_lands_on_the_owner(self):
+        owner = _folded(_pair())
+        self.assertEqual([0.5, 0.5], owner.get("vector"))
+
+    def test_matching_fields_are_not_repeated(self):
+        meta = _folded(_pair()).get("embedding_meta") or {}
+        for key in ("node_path", "updated_at_ms", "node_hash"):
+            self.assertNotIn(key, meta, "the owner already carries %s" % key)
+
+    def test_a_differing_value_is_kept(self):
+        """The case that makes the skip safe: only equal values are dropped."""
+        meta = _folded(_pair(meta_node_hash=999, meta_updated=222)).get("embedding_meta") or {}
+        self.assertEqual(999, meta.get("node_hash"),
+                         "a node_hash that disagrees with the owner must not be discarded")
+        self.assertEqual(222, meta.get("updated_at_ms"),
+                         "an updated_at_ms that disagrees with the owner must not be discarded")
+
+    def test_the_guard_fields_survive(self):
+        """dim and model identify the vector space; losing them is how retrieval goes to noise."""
+        meta = _folded(_pair()).get("embedding_meta") or {}
+        self.assertEqual("e5-small", meta.get("model"))
+        self.assertEqual(2, meta.get("dim"))
+        self.assertEqual("skill_section", meta.get("embedding_type"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The fold copies the retired embedding record wholesale minus a skip list. Three of the survivors --
`node_path`, `updated_at_ms` and `node_hash` -- are fields the **owner** carries in its own right,
and since an embedding is addressed by the owner's own hash they arrive identical. On a 1 MB skill
that is **137.2 KB** restating the record the metadata is attached to.

## Dropped only where they match

"They always match" is a property of today's writers, not a guarantee. A value that disagrees with
the owner is exactly the thing nobody would want silently discarded, so a differing one is kept --
and that is the case the test pins, not the easy one.

## What deliberately stays

`model`, `embedding_type` and `dim` are constant per document and are **not** dropped. `dim` feeds
the width-conflict check and `model` the model-hash check. They identify which vector space a
vector belongs to, and losing them is how retrieval degrades to noise across an encoder change --
with no length mismatch to raise an error, because candidate encoders are frequently the same
width.

## Measured

On a 1 MB skill, through the fold:

| | before | after |
|---|---|---|
| ingest | 6.97 MB (6.5x) | **6.83 MB (6.4x)** |
| vectors | 49.9% | **50.9%** |

## Checks

New suite 4 passed; `*embedding*` 25, `*index*` 13, `*chunk*` 6, `*retriev*` 6.
