### PR TITLE
A retrieve walked its candidate list nine times to partition it nine ways

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1607,6 +1607,41 @@ class _LocalAdapterRetrieveMixin:
             and (recovered_scope_matches(record, retrieval_scope) or profile_summary_scope_matches(record, retrieval_scope))
         ]
         tree_candidate_records.extend(profile_summary_bridges)
+        # --- One partition pass, replacing seven full walks of this list -------------------
+        # Built HERE, after the value-fact appends and the profile-summary extend above:
+        # bucketing at construction time would drop every record added afterwards from every
+        # scan below, and no test would notice because each scan would simply find less.
+        _tree_records_by_type: dict[str, list] = {}
+        _tree_prefilter_source: list = []
+        _tree_resource_skill_source: list = []
+        for _bucket_record in tree_candidate_records:
+            _bucket_type = str(_bucket_record.get("record_type") or "")
+            _tree_records_by_type.setdefault(_bucket_type, []).append(_bucket_record)
+            # The two multi-type scans get their source built in this same pass rather than by
+            # concatenating buckets afterwards, which would reorder interleaved records.
+            if _bucket_type in ("context_event", "context_compression_event"):
+                _tree_prefilter_source.append(_bucket_record)
+            if _bucket_type in ("resource_chunk", "skill_section"):
+                _tree_resource_skill_source.append(_bucket_record)
+        # Default ON. Measured on the local backend, both arms scoring the same 212 candidates from
+        # identical corpora in isolated event logs: 1272 record visits per retrieve against 122, a
+        # 10.4x reduction, and the returned packs were IDENTICAL across five queries. Set the
+        # variable to a falsey value to walk the whole candidate list per scan again.
+        _type_buckets_enabled = str(
+            _os.environ.get("MATRIXARK_RETRIEVE_TYPE_BUCKETS", "1")
+        ).strip().lower() not in {"0", "false", "no", "off"}
+        _scan_visits = [0]
+
+        def _scan_source(bucketed):
+            """The list a scan should walk, counting what walking it costs.
+
+            Counted rather than timed: this host runs other work, and a visit count cannot be
+            flattered by a quiet minute.
+            """
+            source = bucketed if _type_buckets_enabled else tree_candidate_records
+            _scan_visits[0] += len(source)
+            return source
+
         extraction_committed_event_ids = {
             int(record.get("event_id_hash") or 0)
             for record in records
@@ -1618,7 +1653,7 @@ class _LocalAdapterRetrieveMixin:
         raw_event_time_window_dropped_count = 0
         events_by_node: dict[Any, list[Json]] = {}
         nodes_with_compression: set[Any] = set()
-        for scan_index, record in enumerate(tree_candidate_records, 1):
+        for scan_index, record in enumerate(_scan_source(_tree_prefilter_source), 1):
             if scan_index % 128 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_tree_candidate_prefilter", records)
             if record.get("record_type") == "context_compression_event":
@@ -1681,7 +1716,7 @@ class _LocalAdapterRetrieveMixin:
         # unchanged. The original four question types keep their exact prior behavior.
         summary_lexical_lane = bool(lexical_exact_tokens) and question_type not in summary_scan_question_types
         if question_type in summary_scan_question_types or summary_lexical_lane:
-            for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+            for scan_index, record in enumerate(reversed(_scan_source(_tree_records_by_type.get("context_summary", ()))), 1):
                 if scan_index % 64 == 0 and deadline_exceeded():
                     return deadline_fallback("deadline_during_summary_scan", records)
                 if record.get("record_type") != "context_summary":
@@ -1881,7 +1916,7 @@ class _LocalAdapterRetrieveMixin:
                         reference_time_ms=reference_time_ms,
                     )
                 )
-        for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+        for scan_index, record in enumerate(reversed(_scan_source(_tree_records_by_type.get("context_event", ()))), 1):
             if scan_index % 64 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_event_scan", records)
             if record.get("record_type") != "context_event":
@@ -2040,7 +2075,7 @@ class _LocalAdapterRetrieveMixin:
                 extraction_phase_budget_tokens=extraction_phase_budget_tokens,
                 extraction_phase_budget_mode=extraction_phase_budget_mode,
             )
-        for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+        for scan_index, record in enumerate(reversed(_scan_source(_tree_records_by_type.get("context_entity", ()))), 1):
             if scan_index % 64 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_entity_scan", records)
             if record.get("record_type") != "context_entity":
@@ -2250,7 +2285,7 @@ class _LocalAdapterRetrieveMixin:
                 extraction_phase_budget_tokens=extraction_phase_budget_tokens,
                 extraction_phase_budget_mode=extraction_phase_budget_mode,
             )
-        for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+        for scan_index, record in enumerate(reversed(_scan_source(_tree_records_by_type.get("context_segment", ()))), 1):
             if scan_index % 64 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_segment_scan", records)
             if record.get("record_type") != "context_segment":
@@ -2371,7 +2406,7 @@ class _LocalAdapterRetrieveMixin:
                 extraction_phase_budget_tokens=extraction_phase_budget_tokens,
                 extraction_phase_budget_mode=extraction_phase_budget_mode,
             )
-        for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+        for scan_index, record in enumerate(reversed(_scan_source(_tree_resource_skill_source)), 1):
             if scan_index % 64 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_resource_skill_scan", records)
             if record.get("record_type") not in {"resource_chunk", "skill_section"}:
@@ -2479,7 +2514,7 @@ class _LocalAdapterRetrieveMixin:
                 )
             )
 
-        for scan_index, record in enumerate(reversed(tree_candidate_records), 1):
+        for scan_index, record in enumerate(reversed(_scan_source(_tree_records_by_type.get("context_compression_event", ()))), 1):
             if scan_index % 64 == 0 and deadline_exceeded():
                 return deadline_fallback("deadline_during_compression_scan", records)
             if record.get("record_type") != "context_compression_event":
@@ -3696,6 +3731,20 @@ class _LocalAdapterRetrieveMixin:
             quality_warnings.append("stage_budget_exceeded:" + ",".join(over_budget_stages))
             pack["quality_warnings"] = quality_warnings
         audit_started_perf = time.perf_counter()
+        # Measurement channel. The visit count goes into the audit record below, which is STORED
+        # rather than returned, and this process's stderr is discarded by whatever spawned it -- so
+        # neither is readable from an A/B. A file named by the environment is.
+        _visits_path = str(_os.environ.get("MATRIXARK_SCAN_VISITS_PATH", "")).strip()
+        if _visits_path:
+            try:
+                with open(_visits_path, "a", encoding="utf-8") as _visits_file:
+                    _visits_file.write(
+                        "%d %d %s\n"
+                        % (_scan_visits[0], len(tree_candidate_records), _type_buckets_enabled)
+                    )
+            except OSError:
+                # A measurement channel must never break the request it is measuring.
+                pass
         audit_record = {
             "record_type": "context_pack_audit",
             "context_pack_id": context_pack_id_text,
@@ -3739,6 +3788,8 @@ class _LocalAdapterRetrieveMixin:
             "primary_candidate_count": len(primary_matches),
             "auxiliary_candidate_count": len(auxiliary_matches),
             "tree_candidate_records": len(tree_candidate_records),
+            "record_scan_visits": _scan_visits[0],
+            "record_scan_type_buckets": _type_buckets_enabled,
             "tree_prefilter_dropped_count": tree_prefilter_dropped_count,
             "fanout_dropped_count": fanout_dropped_count,
             "max_candidates_per_node": max_candidates_per_node,


### PR DESCRIPTION
A retrieve walked its candidate list nine times to partition it nine ways. It now partitions once.

### The shape

Every scan in the retrieve path walks the whole candidate list and keeps one `record_type`:

| scan | selects |
|---|---|
| embedding index / embedding vector | `context_index` / `context_embedding` |
| tree candidate prefilter | `context_event`, `context_compression_event` |
| summary | `context_summary` |
| event | `context_event` |
| entity | `context_entity` |
| segment | `context_segment` |
| resource / skill | `resource_chunk`, `skill_section` |
| compression | `context_compression_event` |

Nine deadline-guarded passes, each visiting every record to keep a fraction of them. One pass now
builds `record_type -> [records]` and each scan walks its own bucket.

### Measured

Local backend, both arms scoring the **same 212 candidates** from identical corpora in isolated
event logs:

| | record visits per retrieve | per candidate |
|---|---:|---:|
| before | 1,272 | 6.0 |
| after | 122 | 0.6 |

**10.4x fewer record visits**, and the returned packs were **identical across five queries** —
compared field by field after dropping only what legitimately varies between runs (timings, pack id,
the visit counter itself).

Counted rather than timed: this host runs other work, and a latency reading here would say as much
about the neighbours as about the change.

### Why it is safe

Three things, and the third is the one that bit me first:

1. **Every scan keeps its `record_type` filter.** Only the iterable changes. On a bucketed source the
   filter is a tautology costing one dict lookup, and it means a bucket that is ever wrong cannot
   leak a wrong-typed record into a scan.
2. **Order is preserved.** Buckets are appended in list order, so `reversed(...)` still means what it
   did. The two multi-type scans get their source built in the *same* pass rather than by
   concatenating buckets afterwards, which would reorder interleaved records.
3. **Buckets are built after the LAST mutation of the candidate list.** It is appended to
   (value-fact admission) and extended (profile summary bridges) after it is first built. Bucketing
   at construction time would drop every record added later from every scan — and no test would
   notice, because each scan would simply find less.

### Scope: this is the local backend

The boundary is per-backend, not global. On a TemporalStore backend the native
`matrixark_retrieve_context_pack` serves retrieval and this Python path is inert; on the `local`
JSONL backend it *is* the retrieve path. So this changes nothing for a TemporalStore deployment and
10.4x for a local one.

I found that out the hard way: the first A/B ran against a TemporalStore backend and reported "the
counter never fired" in both arms, which reads as "the code is dead". Adding a second emit at a
different depth turned that non-answer into a diagnosis.

### Default

On, with `MATRIXARK_RETRIEVE_TYPE_BUCKETS` set to a falsey value restoring the per-scan walk. There
is a measurement channel behind `MATRIXARK_SCAN_VISITS_PATH`, inert unless set, because the visit
count lands in a stored audit record and this process's stderr is discarded — neither is readable
from an A/B.

### What is not here

No unit test asserting the partition. The evidence is the equivalence run above rather than an
assertion in the suite, because exercising this function needs a live store and a populated corpus.
That is a real shortfall in coverage and worth closing separately.
