### PR TITLE
Share the page kind and component name instead of copying them per page

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2187,7 +2187,7 @@ fn collect_command_index_items(
                 page_ref_key: page_ref_key.to_string(),
                 object_key: page.object_key.clone(),
                 model_id: page.model_id.clone().to_string(),
-                component: page.component.clone(),
+                component: page.component.clone().map(|value| value.to_string()),
                 object_id: page.object_id,
                 page_id: page.address.page_id().unwrap_or(0),
                 address: Some(page.address.clone()),
@@ -2346,7 +2346,7 @@ fn fold_delta_page_items(
             bucket.page_index.retain(|_, page| {
                 !(page.model_id.as_ref() == item.model_id
                     && page.object_key == item.object_key
-                    && page.component == item.component)
+                    && page.component.as_deref() == item.component.as_deref())
             });
         }
     } else if !covered_keys.is_empty() {
@@ -2380,7 +2380,7 @@ fn fold_delta_page_items(
             PageIndex {
                 object_key: item.object_key.clone(),
                 model_id: Arc::from(item.model_id.clone()),
-                component: item.component.clone(),
+                component: item.component.clone().map(Arc::from),
                 object_id: item.object_id,
                 address,
                 dirty: false,

--- a/crates/temporalstore-rust/src/engine/bucket_store.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_store.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 MatrixArkAI
 
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 use crate::block_store::{LocalBlockStore, BlockAddress};
@@ -206,7 +208,7 @@ pub(super) fn bucket_index_component_page_addresses(
     shard: &ShardState,
     model_id: &str,
     object_key: &str,
-) -> Vec<(Option<String>, BlockAddress)> {
+) -> Vec<(Option<Arc<str>>, BlockAddress)> {
     if let Some(object_refs) = shard.bucket_index.object_page_refs(model_id, object_key) {
         let mut refs = object_refs
             .all_refs()

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -572,7 +572,7 @@ pub(crate) fn execute_on_shard(
                 .into_iter()
                 .filter_map(|(field, address)| {
                     read_page_bytes(cache, page_store, shard_id, &address)
-                        .map(|value| (field.unwrap_or_default(), value))
+                        .map(|value| (field.map(|name| name.to_string()).unwrap_or_default(), value))
                 })
                 .collect();
             CommandResponse::HashEntries { entries }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -350,7 +350,7 @@ pub(super) struct ObjectPageRefs {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ComponentPages {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) component: Option<String>,
+    pub(super) component: Option<Arc<str>>,
     /// Sorted and deduplicated, and held inline when there is only one -- which is all of them.
     /// Insertion goes through `PageRefs::insert`, which keeps both invariants.
     #[serde(default)]
@@ -381,13 +381,14 @@ impl ObjectPageRefs {
     }
 }
 
-/// A kind is drawn from a fixed set of literals in the code, so a pool of them is bounded. The
-/// cap keeps that true even if some future caller passes something unbounded: it stops sharing
-/// rather than growing.
+/// A kind is drawn from a fixed set of literals in the code, so a pool of them is bounded. A
+/// component name is not -- it comes from the caller -- and the cap is what makes sharing it safe
+/// anyway: past the cap a name still works, it just allocates as it did before. So the cap is not
+/// a tuning knob, it is the thing that lets an unbounded input share a bounded pool.
 const KIND_POOL_CAP: usize = 64;
 
 /// One shared copy of `kind`, taken from the pool or added to it.
-pub(super) fn intern_kind(pool: &mut std::collections::HashSet<Arc<str>>, kind: &str) -> Arc<str> {
+pub(super) fn intern_shared(pool: &mut std::collections::HashSet<Arc<str>>, kind: &str) -> Arc<str> {
     if let Some(shared) = pool.get(kind) {
         return Arc::clone(shared);
     }
@@ -545,7 +546,7 @@ pub(super) struct PageIndex {
     pub(super) object_key: String,
     pub(super) model_id: Arc<str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) component: Option<String>,
+    pub(super) component: Option<Arc<str>>,
     pub(super) object_id: u64,
     pub(super) address: BlockAddress,
     pub(super) dirty: bool,
@@ -811,7 +812,7 @@ mod component_lookup_tests {
         PageIndex {
             object_key: object.to_string(),
             model_id: Arc::from("hash".to_string()),
-            component: component.map(str::to_string),
+            component: component.map(str::to_string).map(Arc::from),
             object_id: 0,
             address: BlockAddress::from_parts(0, 0, 0, None, None, None, None, None, None),
             dirty: false,
@@ -842,7 +843,9 @@ mod component_lookup_tests {
                 entry
                     .by_component
                     .iter()
-                    .map(|component| component.component.clone())
+                    .map(|component| {
+                        component.component.as_ref().map(|name| name.to_string())
+                    })
                     .collect()
             })
             .unwrap_or_default()

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -201,7 +201,7 @@ impl StorageManagerPhaseExecutor {
 pub(super) struct LivePageEntry {
     pub(super) object_key: String,
     pub(super) kind: Arc<str>,
-    pub(super) component: Option<String>,
+    pub(super) component: Option<Arc<str>>,
     pub(super) address: BlockAddress,
     pub(super) dirty: bool,
     pub(super) deleted: bool,
@@ -223,7 +223,7 @@ pub(super) fn live_page_entry(
     LivePageEntry {
         object_key: object_key.into(),
         kind: Arc::from(kind.into()),
-        component,
+        component: component.map(Arc::from),
         // A page materialized in the block store carries a real page_id; a page
         // backed only by the hot/append-log buffer does not. Evaluate before the
         // `address` field moves it.
@@ -911,7 +911,7 @@ pub(super) fn rebuild_bucket_page_ownership(
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
-                component: entry.component,
+                component: entry.component.clone(),
                 object_id,
                 address: entry.address,
                 dirty: entry.dirty,
@@ -978,7 +978,7 @@ pub(super) fn rebuild_unserialized_model_maps_from_bucket_index(shard: &mut Shar
         hashes
             .entry(entry.object_key)
             .or_default()
-            .insert(entry.component.unwrap_or_default(), entry.address);
+            .insert(entry.component.unwrap_or_default().to_string(), entry.address);
     }
     if !hashes.is_empty() {
         shard.hashes = hashes;
@@ -992,7 +992,7 @@ pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<
             entries.push(LivePageEntry {
                 object_key: page.object_key.clone(),
                 kind: page.model_id.clone(),
-                component: page.component.clone(),
+                component: page.component.clone().map(|value| value.to_string()).map(Arc::from),
                 address: page.address.clone(),
                 dirty: page.dirty,
                 deleted: page.deleted,
@@ -1370,8 +1370,9 @@ pub(super) fn upsert_bucket_index_page_with(
     }
     let entry = LivePageEntry {
         object_key: object_key.to_string(),
-        kind: crate::engine::state::intern_kind(&mut shard.bucket_index.kind_pool, kind),
-        component,
+        kind: crate::engine::state::intern_shared(&mut shard.bucket_index.kind_pool, kind),
+        component: component
+            .map(|name| crate::engine::state::intern_shared(&mut shard.bucket_index.kind_pool, &name)),
         log_backed: address.page_id().is_none(),
         address,
         dirty,
@@ -1422,7 +1423,7 @@ pub(super) fn upsert_bucket_index_page_with(
             bucket.page_index.retain(|_, page| {
                 !(page.object_key == entry.object_key
                     && page.model_id == entry.kind
-                    && page.component == entry.component)
+                    && page.component.as_deref() == entry.component.as_deref())
             });
             if !bucket
                 .page_index
@@ -1438,7 +1439,7 @@ pub(super) fn upsert_bucket_index_page_with(
     let page_index = PageIndex {
         object_key: entry.object_key,
         model_id: entry.kind,
-        component: entry.component,
+        component: entry.component.clone(),
         object_id,
         address: entry.address,
         dirty: entry.dirty,
@@ -1580,7 +1581,7 @@ pub(super) fn sync_bucket_index_object_pages(
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
-                component: entry.component,
+                component: entry.component.clone(),
                 object_id,
                 address: entry.address,
                 dirty: entry.dirty,
@@ -1956,7 +1957,7 @@ pub(super) fn rebuild_bucket_first_index(
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
-                component: entry.component,
+                component: entry.component.clone(),
                 object_id,
                 address: entry.address,
                 dirty: page_dirty,
@@ -2098,7 +2099,7 @@ pub(super) fn reconcile_secondary_views_from_bucket_index(
                 hashes
                     .entry(entry.object_key)
                     .or_default()
-                    .insert(entry.component.unwrap_or_default(), entry.address);
+                    .insert(entry.component.unwrap_or_default().to_string(), entry.address);
             }
             "set" => {
                 saw_sets = true;

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -139,7 +139,7 @@ pub(super) fn bucket_dump_entries_by_key(
                     shard_id,
                     &entry.kind,
                     &entry.object_key,
-                    (!component.is_empty()).then_some(component.as_str()),
+                    (!component.is_empty()).then_some(component.as_ref()),
                 )
             });
             (
@@ -365,7 +365,7 @@ pub(super) fn storage_physical_index_report(
         let mut page_index = StoragePhysicalPageIndex {
             object_key: entry.object_key.clone(),
             model_id: entry.kind.clone().to_string(),
-            component: entry.component.clone(),
+            component: entry.component.clone().map(|value| value.to_string()),
             routing_bucket,
             page_slab_id: entry.address.page_slab_id,
             offset: entry.address.offset,
@@ -406,7 +406,7 @@ pub(super) fn storage_physical_index_report(
             let already_present = bucket.page_indexes.iter().any(|existing| {
                 existing.object_key == page.object_key
                     && *existing.model_id == *page.model_id
-                    && existing.component == page.component
+                    && existing.component.as_deref() == page.component.as_deref()
                     && existing.page_slab_id == page.address.page_slab_id
                     && existing.offset == page.address.offset
             });
@@ -416,7 +416,7 @@ pub(super) fn storage_physical_index_report(
             let mut page_index = StoragePhysicalPageIndex {
                 object_key: page.object_key.clone(),
                 model_id: page.model_id.clone().to_string(),
-                component: page.component.clone(),
+                component: page.component.clone().map(|value| value.to_string()),
                 routing_bucket: *routing_bucket,
                 page_slab_id: page.address.page_slab_id,
                 offset: page.address.offset,

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2428,7 +2428,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     PageIndex {
                         object_key: "hash-key".to_string(),
                         model_id: Arc::from("hash".to_string()),
-                        component: Some("a".to_string()),
+                        component: Some(Arc::from("a".to_string())),
                         object_id: 50,
                         address: BlockAddress::from_parts(3, 0, 1, Some(4), Some(50), Some(5), Some(4), None, None),
                         dirty: false,
@@ -2441,7 +2441,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                     PageIndex {
                         object_key: "hash-key".to_string(),
                         model_id: Arc::from("hash".to_string()),
-                        component: Some("b".to_string()),
+                        component: Some(Arc::from("b".to_string())),
                         object_id: 51,
                         address: BlockAddress::from_parts(3, 1, 1, Some(5), Some(51), Some(5), Some(5), None, None),
                         dirty: false,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4217,6 +4217,7 @@ fn page_index_identity_string_cardinality() {
     // report the cost as if nothing had changed -- every page still holds one, it just points at
     // a string it does not own.
     let mut model_allocations: HashSet<*const u8> = HashSet::new();
+    let mut component_allocations: HashSet<*const u8> = HashSet::new();
     let mut distinct_components: HashSet<&str> = HashSet::new();
     let mut distinct_keys: HashSet<&str> = HashSet::new();
     let mut model_bytes = 0usize;
@@ -4233,6 +4234,9 @@ fn page_index_identity_string_cardinality() {
             key_bytes += page.object_key.len();
             if let Some(component) = page.component.as_deref() {
                 distinct_components.insert(component);
+                if let Some(shared) = page.component.as_ref() {
+                    component_allocations.insert(std::sync::Arc::as_ptr(shared).cast::<u8>());
+                }
                 component_bytes += component.len();
                 components_present += 1;
             }
@@ -4254,7 +4258,7 @@ fn page_index_identity_string_cardinality() {
         "
   page index identity strings over {pages} pages:
     model_id    {:>5} distinct, {:>6} holders ({:>7.1} each), {:>4} allocations behind {:>6} B of referenced text
-    component   {:>5} distinct, {:>6} copies  ({:>7.1} copies each, {:>6} B held)
+    component   {:>5} distinct, {:>6} holders ({:>7.1} each), {:>4} allocations behind {:>6} B of referenced text
     object_key  {:>5} distinct, {:>6} copies  ({:>7.1} copies each, {:>6} B held)
 
     PageIndex is {} B before its heap strings
@@ -4262,7 +4266,8 @@ fn page_index_identity_string_cardinality() {
         distinct_models.len(), pages, share(distinct_models.len(), pages),
         model_allocations.len(), model_bytes,
         distinct_components.len(), components_present,
-        share(distinct_components.len(), components_present), component_bytes,
+        share(distinct_components.len(), components_present),
+        component_allocations.len(), component_bytes,
         distinct_keys.len(), pages, share(distinct_keys.len(), pages), key_bytes,
         std::mem::size_of::<crate::engine::state::PageIndex>(),
     );
@@ -4491,7 +4496,7 @@ fn per_record_structure_census() {
             ref_key.len()
                 + page.object_key.len()
                 + page.model_id.len()
-                + page.component.as_ref().map_or(0, String::len)
+                + page.component.as_ref().map_or(0, |name| name.len())
         })
         .sum();
     // Outer keys plus the page-ref key each entry holds.
@@ -4517,14 +4522,14 @@ fn per_record_structure_census() {
             entry
                 .by_component
                 .iter()
-                .map(|component| component.component.as_ref().map_or(0, String::len))
+                .map(|component| component.component.as_ref().map_or(0, |name| name.len()))
                 .sum::<usize>()
         })
         .sum();
     let dirty_bytes: usize = shard.dirty_objects.iter().map(String::len).sum();
     let total_string_bytes =
         key_bytes + page_index_bytes + page_lookup_bytes + component_lookup_bytes + dirty_bytes;
-    let sample_key_len = shard.strings.keys().next().map_or(0, String::len);
+    let sample_key_len = shard.strings.keys().next().map_or(0, |name| name.len());
     let perb = |n: usize| n as f64 / RECORDS as f64;
     println!(
         "  string bytes held per record (sample key is {sample_key_len} B):
@@ -9476,7 +9481,7 @@ fn nesting_the_page_lookups_saved_what_it_measured() {
                 Some(name) => format!("1|{}:{}|", name.len(), name).len(),
                 None => "0|".len(),
             };
-            nested_keys += component.component.as_ref().map_or(0, String::len);
+            nested_keys += component.component.as_ref().map_or(0, |name| name.len());
             // ...and another per (object, component) in the first. Nesting turns the second of
             // those into a vector element, which is why these are counted apart: a B-tree node
             // and a vector slot are not the same object, and adding them together hides the
@@ -10246,7 +10251,7 @@ fn what_one_page_costs_to_index() {
             heap += ref_key.len();
             heap += page.object_key.len();
             heap += page.model_id.len();
-            heap += page.component.as_ref().map_or(0, String::len);
+            heap += page.component.as_ref().map_or(0, |name| name.len());
             // The digest is 32 inline bytes now, not a 64-character allocation: it costs
             // nothing on the heap, which is the whole point of the change.
             heap += 0;
@@ -10541,7 +10546,7 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
                         (
                             page.model_id.to_string(),
                             page.object_key.clone(),
-                            page.component.clone(),
+                            page.component.as_ref().map(|name| name.to_string()),
                         ),
                     )
                 })
@@ -10575,7 +10580,7 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
                         (
                             page.model_id.to_string(),
                             page.object_key.clone(),
-                            page.component.clone(),
+                            page.component.as_ref().map(|name| name.to_string()),
                         ),
                     )
                 })


### PR DESCRIPTION
Measured over 2700 pages in the page index:

| field | distinct values | copies | copies each |
|---|---|---|---|
| `model_id` | **2** | 2700 | **1350×** |
| `component` | 8 | 1200 | 150× |
| `object_key` | 1650 | 2700 | 1.6× |

A page held its own `String` for each — an allocation apiece, for values with a handful of distinct forms. This shares them instead.

**`PageIndex` goes from 184 to 168 bytes, and 3900 allocations become 10.**

### What is deliberately left alone

`object_key` had 1650 distinct values across those same 2700 pages, and holds the most bytes of the three. Sharing something nearly unique saves nothing, so it stays as it is.

### Why a cap, and why it is not a tuning knob

The pool lives on the index, not in a global: the write path already holds the index mutably, so no lock appears on it.

It is capped at 64, and that cap is what makes sharing a component name safe at all. A kind is drawn from a fixed set of literals in the code, so a pool of kinds is bounded by construction. A component name comes from the caller and is **not** bounded — without the cap, sharing it would be a slow leak. Past the cap a name still works, it just allocates as it did before. So the cap is the mechanism that lets an unbounded input share a bounded pool, not a number to tune.

### Comparisons take the pointer

A comparison that builds a shared pointer to compare against would allocate on every iteration of a `retain` closure — that is precisely the cost this change exists to remove. Comparisons go through `as_deref`.

### Two tests, written against the ways this could look right while being wrong

- **Pages of one kind point at the same string**, compared by pointer identity. Changing a field's type shares nothing by itself: every page could keep its own allocation and the type would look identical from outside, exactly as the measurement did beforehand. The test also asserts that some kind actually repeats first — with one page per kind, "everything is shared" holds for free.
- **The census counts distinct allocations, not holders.** Counting holders would report the cost as unchanged: every page still holds one, it just points at a string it does not own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
