### PR TITLE
Send a node's embedding text to the encoder once, not twice

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow.rs
+++ b/crates/temporalstore-rust/src/context_workflow.rs
@@ -1497,7 +1497,8 @@ pub fn extract_context(
 /// Extraction with explicit control over L1 gating. The batch ingest path
 /// (`ingest_extract_context`) passes `gate_l1 = false` so bulk resource/skill
 /// docs always produce L1 and keep their fixed fanout contract (2 summaries +
-/// 3 embeddings per extract).
+/// 2 embeddings per extract -- the node and its level-2 summary are built from the
+/// same `l1` text and share the one vector it produces).
 pub(crate) fn extract_context_gated(
     engine: &TemporalEngine,
     request: ContextExtractRequest,
@@ -1675,16 +1676,21 @@ pub(crate) fn extract_context_gated(
     // and hit@5 gains 5.0 points, which is what more signal in the vector buys: the right node
     // is far likelier to be in the set at all.
     //
-    // When L1 is emitted the same string was already being encoded for the level-2 summary, so
-    // the two calls become one and the vector is shared. Embedding is the slowest part of an
-    // ingest, so that is a third of the encoder work on this path.
+    // When L1 is emitted, the string the node embeds is the string the level-2 summary embeds --
+    // both are `l1`. It goes to the provider ONCE and the single vector that comes back is handed
+    // to every owner of it. Listing it twice made the batch carry the same text in two slots, and
+    // `context_embeddings_for_extract` maps inputs to vectors one for one with no dedupe, so a
+    // real OpenAI-compatible provider was asked to encode it twice on every rich ingest and billed
+    // for both. Embedding is the slowest part of an ingest; the second copy bought a vector that
+    // was already in hand.
+    //
+    // So the batch is two texts whether or not L1 is emitted: the text the node is searched by,
+    // and the event body.
     let node_embedding_text = if emit_l1 { l1.as_str() } else { l0.as_str() };
-    let mut embedding_inputs: Vec<(&str, u64, u32, &str)> =
-        vec![("node_l0", node_hash, 1, node_embedding_text)];
-    if emit_l1 {
-        embedding_inputs.push(("node_l1", node_hash, 2, l1.as_str()));
-    }
-    embedding_inputs.push(("event_text", event_id_hash, 3, request.body.as_str()));
+    let embedding_inputs: Vec<(&str, u64, u32, &str)> = vec![
+        ("node_text", node_hash, 1, node_embedding_text),
+        ("event_text", event_id_hash, 3, request.body.as_str()),
+    ];
     // Compute embeddings, trying the fallback provider on error. On total failure
     // the behavior depends on `context_embed_defer_on_failure()`: the default is to
     // DEFER (persist the node/event/summaries without vectors and mark the node
@@ -1734,9 +1740,10 @@ pub(crate) fn extract_context_gated(
     // embedding-dirty and the async drainer attaches vectors later, so an empty vector here
     // means "not yet", never "none". skip_serializing_if keeps that costing nothing on disk.
     if !embedding_deferred {
-        // embedding_inputs order is node_l0, [node_l1], event_text, so the vectors line up
-        // with their owners: index 0 is the L0 summary (and the node), index 1 the L1 summary
-        // when emitted, and the event last.
+        // embedding_inputs order is node text then event text, so the vectors line up with their
+        // owners: index 0 is whatever the node was embedded from -- taken by the node, the L0
+        // summary, and the L1 summary when one is emitted, because one string produced it -- and
+        // index 1 is the event.
         //
         // One encoder produced all of them, so its identity is computed once and stamped on
         // every owner that takes a vector. The summaries need it as much as the node does: the
@@ -1760,14 +1767,17 @@ pub(crate) fn extract_context_gated(
             node.embedding_model_hash = embedding_model_hash;
             node.embedding_updated_at_ms = timestamp_ms;
         }
-        if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.get(1)) {
+        if let (Some(summary), Some(vector)) = (summary_l1.as_mut(), embedding_vectors.first()) {
+            // Index 0, not a slot of its own: this summary's text IS `l1`, and `l1` is what the
+            // node was embedded from, so the vector it wants is the one already returned.
             summary.vector = vector.clone();
             // The one summary vector retrieval actually scores: level 2 is the only level the
             // retrieve pass queries for vectors, so this stamp is what the guard there reads.
             summary.embedding_model_hash = embedding_model_hash;
         }
-        let event_vector_index = if emit_l1 { 2 } else { 1 };
-        if let Some(vector) = embedding_vectors.get(event_vector_index) {
+        // The event is at index 1 either way, because the node now contributes exactly one text
+        // to the batch whether or not L1 was emitted.
+        if let Some(vector) = embedding_vectors.get(1) {
             event.vector = vector.clone();
         }
     }

--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -407,7 +407,9 @@ fn context_extract_gates_l1_for_thin_sources() {
     assert!(thin.node.l1_ref.is_empty());
     assert_eq!(thin.embedding_generation.requested_vector_count, 2);
 
-    // Richer multi-sentence source: L1 is warranted -> L0 + L1, 3 embeddings.
+    // Richer multi-sentence source: L1 is warranted -> L0 + L1, still 2 embeddings. The node
+    // embeds `l1` and the level-2 summary IS `l1`, so that string is encoded once and shared;
+    // the vector count is the same as the thin path and only the summaries differ.
     let rich = extract_context(
         &engine,
         ContextExtractRequest {
@@ -424,7 +426,10 @@ fn context_extract_gates_l1_for_thin_sources() {
     );
     assert!(rich.status.ok, "{:?}", rich.status);
     assert!(!rich.l1.is_empty());
-    assert_eq!(rich.embedding_generation.requested_vector_count, 3);
+    assert_eq!(
+        rich.embedding_generation.requested_vector_count, 2,
+        "emitting L1 must not cost a second encode of the same string"
+    );
 }
 
 #[test]
@@ -449,8 +454,9 @@ fn context_extract_stores_embedding_vectors_on_the_records_themselves() {
         },
     );
     assert!(report.status.ok, "{:?}", report.status);
-    // Rich body -> L1 is warranted, so all three vectors exist: node_l0, node_l1, event_text.
-    assert_eq!(report.embedding_generation.requested_vector_count, 3);
+    // Rich body -> L1 is warranted, so both vectors exist: node text and event text. The L1
+    // summary takes the node's vector rather than asking for one of its own.
+    assert_eq!(report.embedding_generation.requested_vector_count, 2);
 
     let events = match engine
         .execute(ExecuteRequest {
@@ -508,6 +514,68 @@ fn context_extract_stores_embedding_vectors_on_the_records_themselves() {
 }
 
 #[test]
+fn a_node_and_its_level_two_summary_share_one_embedding() {
+    // The node is embedded from `l1`, and the level-2 summary's text IS `l1`. One string, so one
+    // request to the encoder, and both owners take the vector it returns.
+    //
+    // The count is the load-bearing half. Comparing the two vectors alone would pass just as
+    // happily if the provider had been asked twice and answered the same way both times, which is
+    // precisely the duplicate this removes -- so the request count is asserted first, and the
+    // equal vectors afterwards say the shared one actually reached both records.
+    let engine = test_engine();
+    let report = extract_context(
+        &engine,
+        ContextExtractRequest {
+            shard_id: 1,
+            tenant_hash: 81,
+            source_kind: ContextSourceKind::Chat,
+            source_id: "shared-vector".to_string(),
+            title: "note".to_string(),
+            body: "Checkout failed during payment. The risk score spiked sharply. The fraud team paused the account."
+                .to_string(),
+            timestamp_ms: 11,
+            provider: ContextModelProviderConfig::default(),
+        },
+    );
+    assert!(report.status.ok, "{:?}", report.status);
+    assert!(
+        !report.l1.is_empty(),
+        "this body must warrant L1 or the shared case is never reached"
+    );
+    assert_eq!(
+        report.embedding_generation.requested_vector_count, 2,
+        "the node text and the event body; `l1` is encoded once, not once per owner"
+    );
+
+    let summaries = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextQuerySummaries {
+                tenant_hash: 81,
+                node_hash: report.node.node_hash,
+                level: 2,
+                as_of_ms: 4_000_000_000_000,
+                limit: None,
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextSummaries { summaries, .. } => summaries,
+        other => panic!("expected summaries, got {other:?}"),
+    };
+    let summary = summaries.first().expect("the extract wrote a level-2 summary");
+    assert_eq!(summary.text, report.l1, "the summary that embeds the node's own text");
+    assert!(
+        !report.node.vector.is_empty(),
+        "an empty node vector would make the comparison below vacuous"
+    );
+    assert_eq!(
+        summary.vector, report.node.vector,
+        "the one vector `l1` produced belongs to both the node and its level-2 summary"
+    );
+}
+
+#[test]
 fn an_ingested_summary_records_the_encoder_that_embedded_it() {
     // The stamp the summary guard reads. Level 2 is the only summary level retrieval scores, so
     // a vector written there without its encoder recorded is one the guard must wave through --
@@ -543,8 +611,9 @@ fn an_ingested_summary_records_the_encoder_that_embedded_it() {
         },
     );
     assert!(report.status.ok, "{:?}", report.status);
-    // Rich body -> L1 is warranted, so the level-2 summary exists and carries a vector.
-    assert_eq!(report.embedding_generation.requested_vector_count, 3);
+    // Rich body -> L1 is warranted, so the level-2 summary exists and carries a vector -- the
+    // node's own, shared rather than requested a second time.
+    assert_eq!(report.embedding_generation.requested_vector_count, 2);
 
     for level in [1u32, 2] {
         let summaries = match engine
@@ -1906,12 +1975,20 @@ fn context_workflow_extracts_with_openai_compatible_provider() {
                 .to_string()
             } else {
                 assert_eq!(request_body["model"], "context-embedding-live-test");
-                assert_eq!(request_body["input"].as_array().unwrap().len(), 3);
+                // What the provider is actually asked to encode, read off the wire. A rich source
+                // sends the node text and the event body -- two texts. The level-2 summary embeds
+                // the same string as the node, and a third slot repeating it is work and money
+                // spent on a vector the first slot already returns.
+                let inputs = request_body["input"].as_array().unwrap();
+                assert_eq!(inputs.len(), 2, "one text per distinct thing to encode: {inputs:?}");
+                assert_ne!(
+                    inputs[0], inputs[1],
+                    "no text may appear twice in one embedding batch: {inputs:?}"
+                );
                 serde_json::json!({
                     "data": [
                         {"embedding": [1.0, 0.0, 0.0, 0.0]},
-                        {"embedding": [0.0, 1.0, 0.0, 0.0]},
-                        {"embedding": [0.0, 0.0, 1.0, 0.0]}
+                        {"embedding": [0.0, 1.0, 0.0, 0.0]}
                     ]
                 })
                 .to_string()
@@ -1960,8 +2037,8 @@ fn context_workflow_extracts_with_openai_compatible_provider() {
         "context-embedding-live-test"
     );
     assert_eq!(report.embedding_generation.vector_dimension, 4);
-    assert_eq!(report.embedding_generation.requested_vector_count, 3);
-    assert_eq!(report.embedding_generation.generated_vector_count, 3);
+    assert_eq!(report.embedding_generation.requested_vector_count, 2);
+    assert_eq!(report.embedding_generation.generated_vector_count, 2);
     assert_eq!(report.embedding_generation.batch_count, 1);
     assert_eq!(report.embedding_generation.live_call_count, 1);
     assert!(!report.embedding_generation.mock_mode);
@@ -2831,8 +2908,8 @@ fn resource_ingest_uses_live_embeddings_and_summary_retrieval() {
     );
     assert!(report.status.ok, "{:?}", report.status);
     assert_eq!(report.embedding_evidence.extract_count, 1);
-    assert_eq!(report.embedding_evidence.requested_vector_count, 3);
-    assert_eq!(report.embedding_evidence.generated_vector_count, 3);
+    assert_eq!(report.embedding_evidence.requested_vector_count, 2);
+    assert_eq!(report.embedding_evidence.generated_vector_count, 2);
     assert_eq!(report.embedding_evidence.live_call_count, 1);
     assert_eq!(report.embedding_evidence.mock_generation_count, 0);
     assert!(report.embedding_evidence.production_evidence_ready);


### PR DESCRIPTION
`extract_context_gated` built its embedding batch as node text, then level-2 summary text, then event body:

```rust
let node_embedding_text = if emit_l1 { l1.as_str() } else { l0.as_str() };
let mut embedding_inputs = vec![("node_l0", node_hash, 1, node_embedding_text)];
if emit_l1 {
    embedding_inputs.push(("node_l1", node_hash, 2, l1.as_str()));
}
```

When L1 is emitted, entries 0 and 1 are the same string — both are `l1`. `context_embeddings_for_extract` maps inputs to vectors one for one with no dedupe, so a real OpenAI-compatible provider was asked to encode `l1` twice on every rich ingest, was billed for both, and the two identical vectors that came back were written separately to `node.vector` and to the level-2 summary.

The comment above the batch already described the intended behaviour — the two calls become one and the vector is shared — which is what the code was meant to do and did not.

## What changed

`l1` occupies one slot, and the single vector it returns goes to the node, the level-0 summary and the level-2 summary. A rich extract asks the provider for two vectors instead of three, so a third of the encoder work on this path is gone — and embedding is the slowest part of an ingest.

The event vector moves to a fixed index 1, because the node now contributes exactly one text whether or not L1 was emitted.

## Tests

The fake provider in `context_workflow_extracts_with_openai_compatible_provider` now asserts **on the request body itself** that it receives two inputs *and that they differ*. Asserting the count alone would have passed before this change as soon as the number was updated — the duplicate is only visible in the texts.

The new `a_node_and_its_level_two_summary_share_one_embedding` asserts the request count first and only then that the stored level-2 summary's vector equals `node.vector`. Comparing the two vectors alone would pass just as happily if the encoder had been asked twice and answered the same way both times, which is exactly the duplicate being removed.

The five assertions that pinned a rich extract at three vectors now pin it at two, and the fanout contract in the `extract_context_gated` doc comment is corrected to match.

## Verified

```
cargo test -p temporalstore-rust --lib -- --test-threads=1
  1497 passed, 0 failed, 17 ignored

cargo test -p temporalstore-rust --lib what_one_add_costs_end_to_end -- --ignored
  150/300/600 adds, 15.6–17.7ms over the first thirty, unchanged in band
```

The harness cannot show the provider saving, and it is worth being explicit about why: the default provider on this tree is an in-process deterministic hash, so the encode no longer performed costs microseconds against a ~17ms add. What the saving is measured by is the count of texts in the request, which the over-the-wire test now holds at two.
