### PR TITLE
index log: stop spelling out a field name once per item, forever

### DIFF
--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -74,29 +74,29 @@ impl Default for IndexItemKind {
 /// tombstone: replaying it removes the entry.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IndexItem {
-    #[serde(default)]
+    #[serde(rename = "k", alias = "kind", default)]
     pub kind: IndexItemKind,
-    #[serde(default, rename = "routing_slot")]
+    #[serde(rename = "rb", alias = "routing_bucket", alias = "routing_slot", default)]
     pub routing_bucket: u32,
-    #[serde(default)]
+    #[serde(rename = "pk", alias = "page_ref_key", default)]
     pub page_ref_key: String,
-    #[serde(default)]
+    #[serde(rename = "ok", alias = "object_key", default)]
     pub object_key: String,
-    #[serde(default)]
+    #[serde(rename = "mi", alias = "model_id", default)]
     pub model_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "c", alias = "component", default, skip_serializing_if = "Option::is_none")]
     pub component: Option<String>,
-    #[serde(default)]
+    #[serde(rename = "oi", alias = "object_id", default)]
     pub object_id: u64,
-    #[serde(default)]
+    #[serde(rename = "pi", alias = "page_id", default)]
     pub page_id: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "a", alias = "address", default, skip_serializing_if = "Option::is_none")]
     pub address: Option<BlockAddress>,
-    #[serde(default)]
+    #[serde(rename = "sz", alias = "size", default)]
     pub size: u64,
-    #[serde(default)]
+    #[serde(rename = "il", alias = "in_log", default)]
     pub in_log: bool,
-    #[serde(default)]
+    #[serde(rename = "d", alias = "deleted", default)]
     pub deleted: bool,
 }
 
@@ -1453,6 +1453,66 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn an_index_item_written_with_the_old_field_names_still_loads() {
+        // The names are short now because they repeat once per ITEM for the life of the log.
+        // Every record already on disk spells them out, so each short name keeps its old
+        // spelling as an alias -- including `routing_slot`, which was itself a rename.
+        let legacy = serde_json::json!({
+            "kind": "page",
+            "routing_slot": 545210715_u32,
+            "page_ref_key": "string:m:0::0:0:126:0:0",
+            "object_key": "m:0",
+            "model_id": "string",
+            "object_id": 122110326161599232_u64,
+            "page_id": 0,
+            "size": 126,
+            "in_log": false,
+            "deleted": false
+        });
+        let item: IndexItem = serde_json::from_value(legacy).expect("a legacy item must load");
+        assert_eq!(item.routing_bucket, 545210715);
+        assert_eq!(item.object_key, "m:0");
+        assert_eq!(item.object_id, 122110326161599232);
+        assert_eq!(item.size, 126);
+        assert!(!item.deleted);
+    }
+
+    #[test]
+    fn an_index_item_costs_far_less_than_its_field_names_used_to() {
+        // Field names were 65.3% of a measured 859-byte index-log record: they are written once
+        // per item, forever, and cost more than the addresses they label.
+        let item = IndexItem {
+            kind: IndexItemKind::Page,
+            routing_bucket: 545210715,
+            page_ref_key: "string:m:0::0:0:126:0:0".to_string(),
+            object_key: "m:0".to_string(),
+            model_id: "string".to_string(),
+            component: None,
+            object_id: 122110326161599232,
+            page_id: 0,
+            address: None,
+            size: 126,
+            in_log: false,
+            deleted: false,
+        };
+        let encoded = serde_json::to_string(&item).unwrap();
+        // Not vacuous: the item must still carry its values, so assert the payload is present
+        // before asserting the envelope is small.
+        assert!(encoded.contains("545210715"));
+        assert!(encoded.contains("m:0"));
+        assert!(encoded.contains("122110326161599232"));
+        // The long spellings must be gone from the WRITTEN form.
+        for gone in ["routing_slot", "page_ref_key", "object_key", "model_id", "object_id"] {
+            assert!(!encoded.contains(gone), "{gone} should not be written any more");
+        }
+        assert!(
+            encoded.len() < 150,
+            "expected a compact item, got {} bytes: {encoded}",
+            encoded.len()
+        );
+    }
+
     fn meta_item_without_zones_serializes_byte_identically_to_pre_fold() {
         // Byte-identical-when-off invariant: an anchor whose `zones` is empty (the only state
         // reachable with TS_INDEX_CATALOG_FOLD off) must serialize with NO `zones` key and NO


### PR DESCRIPTION
index log: stop spelling out a field name once per item, forever

An index-log record is mostly the names of its fields. Measured on one 859-byte
record from a 100,000-record store:

  field names   561 B   65.3%
  values        248 B   28.9%
  punctuation    44 B    5.1%

The names are written once per ITEM, for the life of the log, and cost more than
the addresses they label. This shortens the twelve on `IndexItem`, each keeping its
old spelling as an alias -- including `routing_slot`, which was itself a rename, so
both historical spellings still load.

WHAT IS DELIBERATELY NOT RENAMED

`items` and `meta` on the record. They are not labels: whole-index and delta
records are told apart on read BY THE PRESENCE of those keys, so shortening them
breaks record-type detection. Three tests caught that on the first attempt.

`MetaItem`'s fields, which carry an explicit byte-identical-when-off invariant for
the anchor record.

Both exclusions are also the better optimisation: record-level names appear once per
record, an item's appear once per item. The repetition is where the bytes are.

`BlockAddress` is untouched -- private fields, a custom hex wire form, and
block_store.rs is being reworked elsewhere. It is where the remaining bytes are; see
below.

MEASURED ON AWS, 100,000 RECORDS, c7i.2xlarge

  index log / record   962.8 B -> 867.5 B   -9.9%
  index directory      101,708 kB -> 95,168 kB
  stored total         115.4 MB -> 109.0 MB
  amplification        2.39x -> 2.26x
  add p50              1.733 ms -> 1.794 ms  (unchanged)

Deployed sha verified equal to the locally built one before measuring -- the first
attempt hit "Text file busy" and silently kept the old binary, which the sha check
caught.

WHAT THIS DOES NOT FIX, AND WHERE THE REST IS

I expected ~54% and measured 9.9%. The difference is `BlockAddress`: the nested `address`
object still spells out `page_segment_id`, `object_id`, `routing_slot`, `generation`
and the rest, and it carries `object_id`, `routing_slot` and `page_id` a SECOND time
after the item has already stated them. A record now reads:

  {"shard_id":1,"sequence":1,"items":[{"k":"page","rb":545210715,...,"a":{
   "page_segment_id":0,"offset":0,"length":126,"page_id":0,
   "object_id":122110326161599232,"routing_slot":545210715,...

The duplication and the long nested names are the next increment, and they are worth
more than this one.

TESTS

Two new, plus the 28 that already covered this file:

  * an item written with the OLD field names still loads, and its values survive --
    the property the aliases exist for
  * the written form is compact AND still contains its values, so the size assertion
    cannot pass on an empty encoding, and the long spellings are asserted absent

Full lib suite: 1,498 passed, 0 failed.
