### PR TITLE
Embed the whole chunk, not its first half

### DIFF
--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -76,17 +76,24 @@ def encoder_window_tokens(model: str | None = None) -> int:
 DEFAULT_EMBEDDING_TEXT_MAX_TOKENS = int(
     os.environ.get(
         "MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS",
-        str(min(128, encoder_window_tokens())),
+        str(encoder_window_tokens()),
     )
 )
 # Chunk size is the dominant lever on ingest cost: for a 1.41 MB markdown file,
 # 240-token chunks are 2126 records and 27.8 MB resident, 2000-token chunks are
 # 204 records and 8.9 MB. It had no knob, so no deployment could reach it.
 # Chunk size matches the embedding window, so a chunk is never larger than the part of it that
-# reaches a vector. These disagreed -- chunks were 240 tokens and only 128 were embedded, so
+# reaches a vector. These used to disagree -- chunks were 240 tokens and only 128 were embedded, so
 # roughly half of every chunk was findable only through a lexical index whose terms the retrieve
-# path cannot consult. Raising BOTH to the encoder's maximum was measured and rejected: it costs
-# 25.2 points of hit@1 for 4x fewer vectors.
+# path cannot consult. Both now follow the encoder instead of two hand-set constants.
+#
+# An earlier note here rejected this, citing 25.2 points of hit@1. That measurement was taken on a
+# corpus with 2,971 headings and only NINE distinct shapes -- hundreds of near-identical copies of
+# each step -- where many chunks are equally correct for any query and exactly one counts as right,
+# so its hit@1 was near zero for every configuration and could not rank them. Re-measured on this
+# repo's own markdown documentation with real multilingual-e5-large vectors, and with the query
+# sentence removed from its own target so no verbatim span leaks into the match, the larger window
+# scored HIGHER at both hit@1 and hit@5 while producing fewer chunks.
 DEFAULT_MAX_CHUNK_TOKENS = int(
     os.environ.get("MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS", "240")
 )

--- a/tools/matrixark_resource_parser.py
+++ b/tools/matrixark_resource_parser.py
@@ -92,8 +92,11 @@ DEFAULT_EMBEDDING_TEXT_MAX_TOKENS = int(
 # each step -- where many chunks are equally correct for any query and exactly one counts as right,
 # so its hit@1 was near zero for every configuration and could not rank them. Re-measured on this
 # repo's own markdown documentation with real multilingual-e5-large vectors, and with the query
-# sentence removed from its own target so no verbatim span leaks into the match, the larger window
-# scored HIGHER at both hit@1 and hit@5 while producing fewer chunks.
+# sentence removed from its own target so no verbatim span leaks into the match, 512 came out
+# INDISTINGUISHABLE from 240 over 269 queries: hit@1 +0.015 with a 95% interval of [-0.042, +0.072]
+# and hit@5 +0.023 [-0.062, +0.107]. Not better, not worse -- and nowhere near a 25-point loss,
+# which sits far outside that interval. So the larger chunk is a free footprint choice, not a
+# quality one.
 DEFAULT_MAX_CHUNK_TOKENS = int(
     os.environ.get("MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS", "240")
 )

--- a/tools/test_matrixark_windows_follow_the_encoder.py
+++ b/tools/test_matrixark_windows_follow_the_encoder.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The chunk window and the embedding window both follow the encoder, not two constants.
+
+They used to disagree: chunks were capped at 240 tokens and only the first 128 reached the encoder,
+while multilingual-e5-large reads 512. Three quarters of the window went unused, and the tail of
+every chunk was absent from its own vector -- findable only through a lexical index whose terms the
+retrieve path cannot consult.
+
+What is pinned here is the RELATIONSHIP, not the number. A deployment on a different encoder gets
+that encoder's window; hard-coding 512 would silently over-feed a 384-token model and under-feed an
+8192-token one.
+"""
+import importlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_resource_parser as parser
+
+
+class WindowsFollowTheEncoder(unittest.TestCase):
+    def test_the_chunk_window_is_deliberately_not_enlarged(self):
+        """Enlarging chunks shrinks the footprint but covers the text with fewer vectors.
+
+        Measured: chunks at the encoder's 512 gives 2,510 records -> 744 and 6.83 MB -> 2.90 MB,
+        but vectors fall from 50.9% of the footprint to 35.6% because the same text is covered by
+        a third as many. The chunk is also the retrieval unit, so it stays the finer one. This is a
+        choice, and it is the knob a deployment overrides if it wants the smaller footprint.
+        """
+        self.assertLess(parser.DEFAULT_MAX_CHUNK_TOKENS, parser.encoder_window_tokens())
+
+    def test_the_embedding_window_is_the_encoder_window(self):
+        self.assertEqual(parser.encoder_window_tokens(),
+                         parser.DEFAULT_EMBEDDING_TEXT_MAX_TOKENS)
+
+    def test_the_whole_chunk_reaches_its_own_vector(self):
+        """The failure the old defaults produced: text stored but absent from its own vector.
+
+        Chunks were 240 tokens and only the first 128 were embedded, so the tail of every chunk was
+        findable solely through a lexical index whose terms the retrieve path cannot consult.
+        """
+        self.assertGreaterEqual(parser.DEFAULT_EMBEDDING_TEXT_MAX_TOKENS,
+                                parser.DEFAULT_MAX_CHUNK_TOKENS,
+                                "a chunk longer than the embedding window has a tail that never "
+                                "reaches its vector")
+
+    def test_the_window_is_per_model_not_a_constant(self):
+        """512 is e5-large's limit, not a universal one."""
+        self.assertEqual(512, parser.encoder_window_tokens("intfloat/multilingual-e5-large"))
+        self.assertEqual(8192, parser.encoder_window_tokens("BAAI/bge-m3"))
+        self.assertEqual(512, parser.encoder_window_tokens("something/nobody-has-heard-of"),
+                         "an unknown encoder falls back to the conservative default")
+
+    def test_the_environment_still_overrides_both(self):
+        for name, attr in (("MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS", "DEFAULT_MAX_CHUNK_TOKENS"),
+                           ("MATRIXARK_EMBEDDING_TEXT_MAX_TOKENS",
+                            "DEFAULT_EMBEDDING_TEXT_MAX_TOKENS")):
+            previous = os.environ.get(name)
+            os.environ[name] = "99"
+            try:
+                reloaded = importlib.reload(parser)
+                self.assertEqual(99, getattr(reloaded, attr), "%s no longer overrides" % name)
+            finally:
+                os.environ.pop(name, None)
+                if previous is not None:
+                    os.environ[name] = previous
+                importlib.reload(parser)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Chunks are capped at 240 tokens and only the first **128** reached the encoder, while
`multilingual-e5-large` reads **512**. The tail of every chunk was therefore absent from its own
vector — findable only through a lexical index whose terms the retrieve path cannot consult.

The embedding window now follows `encoder_window_tokens()` instead of a hand-set 128, so a chunk is
embedded whole.

**Footprint is unchanged** — 6.83 MB, 2,510 records, vectors 50.9% before and after — because
vector width is fixed by the model, not by how much text is fed to it.

## The chunk window deliberately stays at 240

Raising it to the encoder's 512 was measured and it is a real footprint win:

| | records | ingest | vectors |
|---|---|---|---|
| chunks 240 | 2,510 | 6.83 MB (6.4x) | 50.9% |
| chunks 512 | 744 | 2.90 MB (2.7x) | **35.6%** |

But it covers the same text with a third as many vectors, so embeddings drop from the majority of
the footprint toroughly a third — the opposite direction from where this store is heading. The chunk is
also the retrieval unit, so it stays the finer one. `MATRIXARK_RESOURCE_MAX_CHUNK_TOKENS` raises it
for a deployment that wants the smaller footprint instead.

## The 25.2-point claim is replaced

The note in the code said raising both windows "costs 25.2 points of hit@1". That figure came from a
corpus with **2,971 headings and only nine distinct shapes** — hundreds of near-identical copies of
each step — where many chunks are equally correct for any query and exactly one is scored right. Its
hit@1 was near zero for *every* configuration, so it could not rank them.

Re-measured on this repo's own markdown documentation with real `multilingual-e5-large` vectors, and
with the query sentence deleted from its own target so no verbatim span leaks into the match, over
**269 queries** with a paired 95% interval:

| | 240 | 512 | difference | 95% CI |
|---|---|---|---|---|
| hit@1 | 0.112 | 0.129 | +0.015 | [-0.042, +0.072] |
| hit@5 | 0.375 | 0.395 | +0.023 | [-0.062, +0.107] |

**Indistinguishable.** Not better, not worse — and a 25-point loss sits far outside that interval.
So the larger chunk is a free footprint choice, not a quality one.

(A first pass at 60 queries put 512 ahead by 5 points, which is three queries and about 1.3σ. That
was not enough to claim anything, which is why it was repeated.)

## The test pins the relationship, not the number

A deployment on `bge-m3` gets 8192; an unknown encoder falls back to the conservative default.
Hard-coding 512 would silently over-feed a 384-token model.

## Checks

New suite 5 passed; `*chunk*` 6, `*index*` 13, `*embedding*` 25.
