### PR TITLE
Drop owner-derivable postings once, for every writer

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -685,6 +685,72 @@ _EMBEDDING_META_SKIP = (
     "storage_part",
 )
 
+try:  # package path
+    from tools.matrixark_mcp_ingest_resource_chunk_records import (
+        INDEX_SKIP_OWNER_DERIVABLE_TERMS,
+    )
+except ImportError:  # top-level path (direct tools/ execution)
+    from matrixark_mcp_ingest_resource_chunk_records import (
+        INDEX_SKIP_OWNER_DERIVABLE_TERMS,
+    )
+
+
+def drop_owner_derivable_postings(records: list[Json], resolve_owner=None) -> list[Json]:
+    """Drop a posting whose term the record it points at can derive for itself.
+
+    `context_index_posting_record` has fourteen call sites; this runs once, on the batch, next to
+    the fold that already resolves owners. A posting survives unless EVERY ref it carries has an
+    owner that both carries a vector -- the condition the retrieve prefilter's owner branch is
+    gated on -- and derives the term.
+
+    Conservative in every direction that matters: an owner that cannot be found, or that carries no
+    vector, keeps its posting.
+    """
+    if not INDEX_SKIP_OWNER_DERIVABLE_TERMS:
+        return records
+    postings = [(i, r) for i, r in enumerate(records)
+                if r.get("record_type") == "context_index"]
+    if not postings:
+        return records
+
+    owners_by_key: dict[tuple[str, Any], Json] = {}
+    for record in records:
+        record_type = record.get("record_type")
+        for ref_type, (owner_type, field) in INLINE_VECTOR_OWNER_BY_REF_TYPE.items():
+            if record_type == owner_type and record.get(field) not in (None, ""):
+                owners_by_key[(ref_type, record[field])] = record
+
+    def owner_for(ref_type, ref_hash):
+        owner = owners_by_key.get((ref_type, ref_hash))
+        if owner is None and resolve_owner is not None:
+            mapped = INLINE_VECTOR_OWNER_BY_REF_TYPE.get(ref_type)
+            if mapped is not None:
+                owner = resolve_owner(mapped[0], mapped[1], ref_hash)
+        return owner
+
+    drop: set[int] = set()
+    for index, record in postings:
+        name = str(record.get("index_name") or "")
+        ref_type = str(record.get("ref_type") or "")
+        refs = context_index_record_ref_hashes(record)
+        if not name or not refs or ref_type not in INLINE_VECTOR_OWNER_BY_REF_TYPE:
+            continue
+        covered = True
+        for ref_hash in refs:
+            owner = owner_for(ref_type, ref_hash)
+            if owner is None or not (owner.get("vector") or owner.get("embedding_meta")):
+                covered = False
+                break
+            if name not in candidate_index_terms(owner, {}, {}):
+                covered = False
+                break
+        if covered:
+            drop.add(index)
+    if not drop:
+        return records
+    return [r for i, r in enumerate(records) if i not in drop]
+
+
 def fold_embedding_records(
     records: list[Json],
     resolve_owner=None,
@@ -4371,6 +4437,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._stamp_ingest_fields(materialize_serving_record_batch([record]))
         )
         records = fold_embedding_records(records, resolve_owner=self._resolve_embedding_owner)
+        records = drop_owner_derivable_postings(
+            records, resolve_owner=self._resolve_embedding_owner
+        )
         if not records:
             return
         if self._queue_batched_records(records):
@@ -4406,6 +4475,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # materialization so the metadata that rides along under embedding_meta is exactly the
         # shape the separate record used to persist in.
         records = fold_embedding_records(records, resolve_owner=self._resolve_embedding_owner)
+        records = drop_owner_derivable_postings(
+            records, resolve_owner=self._resolve_embedding_owner
+        )
         if not records:
             return
         if self._queue_batched_records(records):

--- a/tools/test_matrixark_owner_derivable_postings_choke_point.py
+++ b/tools/test_matrixark_owner_derivable_postings_choke_point.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Postings the owner can derive are dropped once, for every writer.
+
+`context_index_posting_record` has fourteen call sites across five modules. Editing one moved a
+100-event store's index by 0.1 KB of 120.2, because a normal ingest takes a different branch than
+the one edited. So the decision is made where every write already passes: beside the fold, which
+already resolves owners.
+
+The negative cases are the ones worth testing. A skip that fired unconditionally would delete
+postings nothing can replace, and that failure is silent -- the query simply matches nothing.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core
+from matrixark_mcp_local_adapter import drop_owner_derivable_postings
+
+
+def _owner(**over):
+    record = {
+        "record_type": "context_event",
+        "event_id_hash": 42,
+        "event_type": "status_update",
+        "classification": "operational",
+        "status": "observed",
+        "source_role": "assistant",
+        "text": "restarted the worker",
+        "vector": [0.5, 0.5],
+    }
+    record.update(over)
+    return record
+
+
+def _posting(name, refs=(42,), ref_type="event"):
+    return {"record_type": "context_index", "index_name": name,
+            "ref_type": ref_type, "ref_hashes": list(refs)}
+
+
+def _derivable_term(owner):
+    terms = sorted(core.candidate_index_terms(owner, {}, {}))
+    assert terms, "the fixture owner derives no terms"
+    return terms[0]
+
+
+class PostingsTheOwnerCanDeriveAreDropped(unittest.TestCase):
+    def test_a_derivable_posting_is_dropped(self):
+        owner = _owner()
+        term = _derivable_term(owner)
+        out = drop_owner_derivable_postings([owner, _posting(term)])
+        self.assertEqual([owner], out, "the owner derives %s for itself" % term)
+
+    def test_a_term_the_owner_cannot_derive_survives(self):
+        owner = _owner()
+        out = drop_owner_derivable_postings([owner, _posting("skill_trigger:refund_flow")])
+        self.assertEqual(2, len(out), "a term no owner can derive must keep its posting")
+
+    def test_an_owner_without_a_vector_keeps_its_postings(self):
+        """The prefilter skips such an owner, so the posting is the only route to it."""
+        owner = _owner()
+        owner.pop("vector")
+        term = _derivable_term(owner)
+        out = drop_owner_derivable_postings([owner, _posting(term)])
+        self.assertEqual(2, len(out))
+
+    def test_an_unresolvable_owner_keeps_its_posting(self):
+        out = drop_owner_derivable_postings([_posting("event_type:status_update", refs=(999,))])
+        self.assertEqual(1, len(out), "no owner in the batch and none resolvable")
+
+    def test_a_multi_ref_posting_needs_every_owner_to_cover_it(self):
+        """One uncovered ref keeps the whole row -- dropping it would strand that ref."""
+        covered = _owner()
+        term = _derivable_term(covered)
+        out = drop_owner_derivable_postings([covered, _posting(term, refs=(42, 4242))])
+        self.assertEqual(2, len(out), "ref 4242 has no owner here, so the row must stay")
+
+    def test_a_ref_type_with_no_owner_mapping_is_untouched(self):
+        out = drop_owner_derivable_postings(
+            [_posting("entity_type:person", ref_type="batch_commit")])
+        self.assertEqual(1, len(out))
+
+    def test_the_escape_hatch_keeps_everything(self):
+        import importlib
+        import matrixark_mcp_local_adapter as adapter
+        os.environ["MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS"] = "0"
+        try:
+            sys.modules.pop("matrixark_mcp_ingest_resource_chunk_records", None)
+            reloaded = importlib.reload(adapter)
+            owner = _owner()
+            out = reloaded.drop_owner_derivable_postings(
+                [owner, _posting(_derivable_term(owner))])
+            self.assertEqual(2, len(out))
+        finally:
+            os.environ.pop("MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS", None)
+            sys.modules.pop("matrixark_mcp_ingest_resource_chunk_records", None)
+            importlib.reload(adapter)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A posting whose term the record it points at can derive restates that record. The resource path
already skips those; every other path still wrote them.

## Why this is not a per-call-site change

`context_index_posting_record` has **fourteen call sites across five modules**. I edited the event
one first, and it moved a 100-event store's index by **0.1 KB of 120.2** — a normal ingest takes the
`hot_path` branch, not the `pending_async` branch I had edited. The measurement caught a no-op that
would otherwise have shipped looking like a fix.

The decision now happens where every write already passes: beside `fold_embedding_records`, which
already runs on `append`/`append_many` and already resolves owners.

## Measured

100-event store, entity + event + segment + summary postings, all at once:

| | before | after |
|---|---|---|
| `context_index` records | 52 | **7** |
| index bytes | 120.2 KB (15.0%) | **12.7 KB (1.8%)** |
| store | 798.7 KB | **691.2 KB** |

### On the embedding share

This environment's default embedder is a **32-dimension token hash**, so vectors read as 6.0% here
and that number means little. At the configured **512 dimensions**:

| vector width | store | vectors | index |
|---|---|---|---|
| 32 (this env) | 691 KB | 6.0% | 1.8% |
| **512 (shipped)** | 1,316 KB | **50.6%** | 1.0% |
| 1024 (e5-large native) | 1,982 KB | 67.2% | 0.6% |

Before this change, vectors at 512 dims were **46.8%**. Dropping these postings is what puts
embeddings in the majority.

## Safety — each measured, not argued

- gated on the owner **carrying a vector**, the same condition the retrieve prefilter's owner branch
  is gated on; without it the owner is skipped and the posting is the only route
- gated on the owner being **found**, in this batch or through the durable view; unresolvable owner
  keeps its posting
- a **multi-ref** posting survives unless every ref is covered, so no ref is stranded
- a `ref_type` with **no owner mapping** is untouched — which is why seven `context_batch_commit`
  rows remain
- derived terms are **monotone**: `stale_or_superseded`, `superseded_by_ref_hash` and
  `profile_shadowed_by_ref_hash` each *add* a marker and remove nothing, so a term skipped today is
  still derivable once the record is superseded. That property also underwrites the resource-path
  skip already in `main`, which shipped without it being checked.

7 tests pin the negative cases; the positive one is the easy half.

## Checks

`*index*` 13, `*retriev*` 6, `*posting*` 14, `test_delete_membership_index` 14, `*embedding*` 25,
`*chunk*` 6, `test_mem0_*` 88, new suite 7. `test_backend_policy_part1` errors identically on `main`.
