### PR TITLE
Choose a deployment shape, and see what it will actually be

### DIFF
--- a/docs/CUSTOMER_PORTAL.md
+++ b/docs/CUSTOMER_PORTAL.md
@@ -791,6 +791,56 @@ every fifteen seconds is a self-inflicted load on the store it is meant to be wa
 
 ---
 
+## Deployment
+
+The storage directories, the metaserver address and the topology are **not** editable from the
+settings form, and that is deliberate: repointing a running deployment's storage from a browser does
+not reconfigure it, it strands its data. But "cannot be changed here" and "cannot be chosen at all"
+are different things, and only the first was ever true. Choosing happens when a deployment is
+*launched*, so that is where the chooser lives.
+
+| Shape | What it is | Storage |
+| --- | --- | --- |
+| One box | Everything in a single process, no metaserver, no peers. The default, and it needs no configuration to work. | Local disk: EBS, instance SSD, or whatever the machine has |
+| Replicated (Raft) | An odd number of nodes replicating through Raft, each with its own disk. | Local disk, plus a separate Raft write-ahead log directory |
+| Shared storage | Nodes are stateless in front of one shared store. | MatrixObject by default, or a shared filesystem path |
+
+`GET /v1/admin/deployment` lists the shapes and reports the backend this deployment is **actually
+running**, read from the datanode's own `temporalstore_storage_backend` metric rather than derived
+from configuration. `POST /v1/admin/deployment/plan` composes a choice and returns the environment,
+an env file, what is blocked, and what will differ from what was asked. Neither route changes this
+process.
+
+### Why the plan reports a resolved backend and not just the requested one
+
+Three choices produce a deployment that starts, serves, and is not the one that was selected — with
+no error raised anywhere:
+
+* `TS_STORAGE_BACKEND=shared` with no `TS_SHARED_STORE_DIR` **falls through to auto-detection**
+  rather than failing. Ask for shared storage, get whatever auto picks.
+* `TS_STORAGE_BACKEND=matrixobject` on a build without that feature compiled in takes the same
+  fall-through, reached a different way.
+* Standalone is **derived**, not defaulted: `!(meta_addr_is_real || TS_DISTRIBUTED)`. A metaserver
+  address arriving from a config file or a systemd drop-in is enough on its own to turn a one-box
+  deployment into a distributed one. A one-box plan therefore pins `TS_STANDALONE=1` rather than
+  leaving it to the default, so that cannot happen quietly.
+
+The engine records **why** it chose a backend in a startup log line and nowhere else, so the portal
+reports the outcome and says plainly that the reason is not readable over HTTP.
+
+The chooser also never asserts that MatrixObject is unavailable. A live backend of `matrixobject`
+proves the feature is compiled in; anything else is silence, because auto reaches other backends for
+several reasons on a build that has it. Turning a missing datanode into a claim about the build
+would print a false statement next to a storage choice.
+
+### Keys
+
+Key **names** are part of a plan; key **values** never are. The plan document can be shown, copied,
+exported and diffed without carrying a credential through any of those. Values are entered in the
+settings form above, which stores them owner-only and never returns them from any read.
+
+---
+
 ## Metrics
 
 ### The scrape

--- a/tools/matrixark_deployment_plan.py
+++ b/tools/matrixark_deployment_plan.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Compose a deployment's shape, storage and keys, and say what the engine will actually do with it.
+
+Why this is a separate surface from the settings registry: the storage directory, the metaserver
+address and the topology are deliberately NOT writable from the portal's settings form, and that is
+the right call -- repointing a running deployment's storage from a browser does not reconfigure it,
+it strands its data. But "you cannot change it here" and "you cannot choose it at all" are different
+things, and only the first was true. Choosing happens when a deployment is *launched*, so that is
+where this lives.
+
+The part worth having is not the form. It is that three of these choices resolve to something other
+than what was asked, with no error anywhere:
+
+* `TS_STORAGE_BACKEND=shared` with no `TS_SHARED_STORE_DIR` falls through to auto. The engine says so
+  in its resolved-backend log line and nowhere else.
+* `TS_STORAGE_BACKEND=matrixobject` on a build without the feature compiled also falls through to
+  auto -- the same silent path, reached a different way.
+* A real `TS_META_ADDR` turns a standalone box into a distributed one on its own, because standalone
+  is derived (`!(meta_addr_is_real || TS_DISTRIBUTED)`) rather than defaulted. A single-box plan that
+  carries a metaserver address is a distributed plan wearing the wrong name.
+
+Each of those produces a deployment that starts, serves, and is not the one that was asked for. So
+`plan()` resolves the choice the same way the engine does and reports the backend that will actually
+be selected, next to the one that was requested.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+Json = Dict[str, Any]
+
+# Values of TS_META_ADDR the engine reads as "no metaserver". Empty is one of them, so a plan can
+# express standalone either by omitting the variable or by pinning a sentinel.
+META_SENTINELS = ("", "local", "none", "standalone", "off")
+
+# The disk a datanode's pages, blobs, index and cache sit on. All three are ordinary filesystem
+# paths to the engine -- it has no notion of which device is underneath -- so the difference is
+# what a customer is choosing operationally, and the durability note is the honest part.
+DISK_TIERS: Tuple[Json, ...] = (
+    {"id": "ebs", "label": "EBS volume", "default_root": "/var/lib/temporalstore",
+     "note": "Survives instance stop/start and can be snapshotted. The default for anything whose "
+             "loss would matter."},
+    {"id": "ssd", "label": "Instance SSD", "default_root": "/mnt/nvme/temporalstore",
+     "note": "Fastest, and erased when the instance stops. Appropriate when the store can be "
+             "rebuilt from somewhere else, and a bad choice when it cannot."},
+    {"id": "local", "label": "Local disk", "default_root": "/var/lib/temporalstore",
+     "note": "Whatever the machine already has. The right answer off AWS and for a laptop."},
+)
+
+SHAPES: Tuple[Json, ...] = (
+    {"id": "onebox", "label": "One box",
+     "summary": "Everything in a single process. No metaserver, no peers.",
+     "when": "Trying it out, a single-tenant deployment, or any load one machine can hold. This is "
+             "the default and it needs no configuration to work.",
+     "nodes": 1, "storage_kinds": ("disk",)},
+    {"id": "raft", "label": "Replicated (Raft)",
+     "summary": "An odd number of nodes replicating through Raft, each with its own disk.",
+     "when": "The store must survive losing a machine. Costs a write barrier per commit and needs a "
+             "majority to serve writes at all.",
+     "nodes": 3, "storage_kinds": ("disk",)},
+    {"id": "shared", "label": "Shared storage",
+     "summary": "Nodes are stateless in front of one shared store; MatrixObject by default.",
+     "when": "Nodes should be replaceable and capacity should grow without moving data between "
+             "them. Durability belongs to the shared store rather than to any node.",
+     "nodes": 2, "storage_kinds": ("matrixobject", "path")},
+)
+
+_SHAPES_BY_ID = {shape["id"]: shape for shape in SHAPES}
+_TIERS_BY_ID = {tier["id"]: tier for tier in DISK_TIERS}
+
+
+def catalogue(matrixobject_available: bool = True) -> Json:
+    """Everything the portal needs to render the chooser, including what this build can honour.
+
+    `matrixobject_available` is reported rather than assumed: the shared shape's default storage is
+    unreachable on a build without that feature compiled, and offering it as the default on such a
+    build is offering a choice that silently becomes something else.
+    """
+    shapes: List[Json] = []
+    for shape in SHAPES:
+        entry = dict(shape)
+        entry["storage"] = [dict(tier) for tier in DISK_TIERS] if "disk" in shape["storage_kinds"] \
+            else _shared_stores(matrixobject_available)
+        shapes.append(entry)
+    return {
+        "shapes": shapes,
+        "matrixobject_available": bool(matrixobject_available),
+        "default_shape": "onebox",
+    }
+
+
+def _shared_stores(matrixobject_available: bool) -> List[Json]:
+    return [
+        {"id": "matrixobject", "label": "MatrixObject", "default_root": "",
+         "available": bool(matrixobject_available),
+         "note": "Content-addressed shared object storage, and the default for this shape. "
+                 + ("" if matrixobject_available else
+                    "This build does not have it compiled in, so selecting it resolves to "
+                    "auto-detection instead -- which is not an error and not logged as a refusal.")},
+        {"id": "path", "label": "Shared filesystem", "default_root": "/srv/temporalstore/shared",
+         "available": True,
+         "note": "A directory every node can reach -- NFS, EFS, or a shared mount. Needs the path "
+                 "to actually be shared; a per-node directory of the same name looks identical at "
+                 "configuration time and diverges silently once nodes write to it."},
+    ]
+
+
+def _clean(value: Optional[str]) -> str:
+    return str(value or "").strip()
+
+
+def resolve_backend(env: Json, matrixobject_available: bool = True,
+                    endpoint_reachable: bool = False) -> Json:
+    """What the engine will select, given this environment.
+
+    Mirrors `StorageBackendConfig::resolve_decision`: raft is forced; matrixobject is forced when
+    compiled; shared is forced only when a directory is configured; everything else -- including a
+    shared or matrixobject request that cannot be honoured -- falls through to auto. The fall-through
+    is the whole reason this function exists, because from the outside it is indistinguishable from
+    having been honoured.
+    """
+    requested = _clean(env.get("TS_STORAGE_BACKEND")).lower()
+    shared_dir = _clean(env.get("TS_SHARED_STORE_DIR"))
+    endpoint = _clean(env.get("MATRIXARK_OBJECT_RPC_URL"))
+
+    if requested in ("raft", "raft_replication", "replication"):
+        return {"backend": "raft", "honoured": True,
+                "reason": "TS_STORAGE_BACKEND=raft forces raft replication."}
+    if requested in ("matrixobject", "matrix_object", "object"):
+        if matrixobject_available:
+            return {"backend": "matrixobject", "honoured": True,
+                    "reason": "TS_STORAGE_BACKEND=matrixobject is forced without probing."}
+        return dict(_auto(matrixobject_available, endpoint, endpoint_reachable, shared_dir),
+                    honoured=False,
+                    reason="TS_STORAGE_BACKEND=matrixobject, but this build has no MatrixObject "
+                           "compiled in, so selection falls through to auto-detection.")
+    if requested in ("shared", "shared_path", "shared_store", "path"):
+        if shared_dir:
+            return {"backend": "shared_path", "honoured": True,
+                    "reason": "TS_STORAGE_BACKEND=shared with a configured directory (%s)."
+                              % shared_dir}
+        return dict(_auto(matrixobject_available, endpoint, endpoint_reachable, shared_dir),
+                    honoured=False,
+                    reason="TS_STORAGE_BACKEND=shared with no TS_SHARED_STORE_DIR set, so selection "
+                           "falls through to auto-detection rather than failing.")
+    return dict(_auto(matrixobject_available, endpoint, endpoint_reachable, shared_dir),
+                honoured=True)
+
+
+def _auto(matrixobject_available: bool, endpoint: str, endpoint_reachable: bool,
+          shared_dir: str) -> Json:
+    """Auto's order: a reachable networked object store, then node-local, then a shared path, then
+    raft."""
+    if matrixobject_available:
+        if endpoint and endpoint_reachable:
+            return {"backend": "matrixobject",
+                    "reason": "auto: the MatrixObject endpoint %s answered." % endpoint}
+        if not endpoint:
+            return {"backend": "matrixobject",
+                    "reason": "auto: node-local MatrixObject, no endpoint configured."}
+    if shared_dir:
+        return {"backend": "shared_path",
+                "reason": "auto: a shared store directory is configured (%s)." % shared_dir}
+    return {"backend": "raft", "reason": "auto: nothing shared is reachable, so raft replication."}
+
+
+def is_standalone(env: Json) -> bool:
+    """The engine's own derivation, which is not "TS_STANDALONE defaults to on"."""
+    forced = _clean(env.get("TS_STANDALONE")).lower()
+    if forced in ("1", "true", "yes", "on"):
+        return True
+    if forced in ("0", "false", "no", "off"):
+        return False
+    meta = _clean(env.get("TS_META_ADDR")).lower()
+    meta_is_real = meta not in META_SENTINELS
+    distributed = _clean(env.get("TS_DISTRIBUTED")).lower() in ("1", "true", "yes", "on")
+    return not (meta_is_real or distributed)
+
+
+_KEY_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,63}$")
+
+
+def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
+         shared_dir: str = "", key_envs: Optional[List[str]] = None,
+         matrixobject_available: bool = True, endpoint_reachable: bool = False) -> Json:
+    """Compose one deployment. Returns the environment, plus what it will really resolve to.
+
+    `blocking` is for choices that cannot produce the deployment asked for at all; `warnings` is for
+    ones that produce a working deployment that differs from the request. They are separate because
+    they need different answers -- a block is a mistake to fix, a warning is a fact to accept.
+    """
+    blocking: List[str] = []
+    warnings: List[str] = []
+    notes: List[str] = []
+
+    spec = _SHAPES_BY_ID.get(shape)
+    if spec is None:
+        return {"ok": False, "env": {}, "blocking": ["Unknown deployment shape %r." % shape],
+                "warnings": [], "notes": [], "shape": shape}
+
+    count = int(nodes or spec["nodes"])
+    env: Json = {}
+
+    if shape == "onebox":
+        if count != 1:
+            blocking.append("A one-box deployment is one node; %d was requested. Pick the "
+                            "replicated shape for more than one." % count)
+        # Pinned rather than omitted. Standalone is DERIVED from the metaserver address, so a
+        # deployment that later inherits a TS_META_ADDR from a shared config file or a systemd
+        # drop-in silently becomes distributed. Pinning it means that cannot happen quietly.
+        env["TS_STANDALONE"] = "1"
+        env["TS_DISTRIBUTED"] = "0"
+        notes.append("TS_STANDALONE is pinned to 1 rather than left to the default. Standalone is "
+                     "derived from whether a metaserver address is set, so an address arriving "
+                     "later from a config file would otherwise flip this box to distributed with "
+                     "nothing said.")
+    elif shape == "raft":
+        if count < 3:
+            blocking.append("Raft needs at least 3 nodes to tolerate losing one; %d was "
+                            "requested." % count)
+        elif count % 2 == 0:
+            blocking.append("Raft needs an odd node count to have a majority; %d gives the same "
+                            "fault tolerance as %d while costing one more machine."
+                            % (count, count - 1))
+        env["TS_STANDALONE"] = "0"
+        env["TS_DISTRIBUTED"] = "1"
+        env["TS_STORAGE_BACKEND"] = "raft"
+        env["TS_META_RAFT"] = "1"
+        env["TS_RAFT_AUTO_FAILOVER"] = "1"
+        notes.append("Writes need a majority: %d nodes serve writes while %d are reachable, and go "
+                     "read-only below that." % (count, count // 2 + 1))
+    elif shape == "shared":
+        if count < 2:
+            blocking.append("Shared storage exists so nodes are replaceable; %d node is a one-box "
+                            "deployment with extra moving parts." % count)
+        env["TS_STANDALONE"] = "0"
+        env["TS_DISTRIBUTED"] = "1"
+
+    kinds = spec["storage_kinds"]
+    choice = _clean(storage) or ("matrixobject" if "matrixobject" in kinds else "ebs")
+
+    if "disk" in kinds:
+        tier = _TIERS_BY_ID.get(choice)
+        if tier is None:
+            blocking.append("Unknown storage tier %r for the %s shape." % (choice, shape))
+        else:
+            base = _clean(root) or tier["default_root"]
+            env["TS_PAGE_STORE_DIR"] = base + "/pages"
+            env["TS_BLOB_STORE_DIR"] = base + "/blobs"
+            env["TS_INDEX_DIR"] = base + "/index"
+            env["TS_CACHE_DIR"] = base + "/cache"
+            if shape == "raft":
+                env["TS_RAFT_WAL_DIR"] = base + "/raft-wal"
+            if choice == "ssd":
+                warnings.append("Instance SSD is erased when the instance stops. Everything under "
+                                "%s goes with it, including the write-ahead log, so this is a "
+                                "choice to make only when the store can be rebuilt from "
+                                "elsewhere." % base)
+            notes.append("%s: %s" % (tier["label"], tier["note"]))
+    else:
+        if choice == "matrixobject":
+            env["TS_STORAGE_BACKEND"] = "matrixobject"
+            if not matrixobject_available:
+                warnings.append("This build has no MatrixObject compiled in. The engine will not "
+                                "refuse the setting -- it falls through to auto-detection, so the "
+                                "deployment starts and serves on a different backend than the one "
+                                "chosen here.")
+        elif choice == "path":
+            directory = _clean(shared_dir)
+            if not directory:
+                blocking.append("A shared filesystem needs a directory every node can reach. "
+                                "Without TS_SHARED_STORE_DIR the engine falls through to "
+                                "auto-detection and quietly selects a different backend.")
+            else:
+                env["TS_STORAGE_BACKEND"] = "shared"
+                env["TS_SHARED_STORE_DIR"] = directory
+                warnings.append("Every node must see %s as the SAME storage. A per-node directory "
+                                "of that name is indistinguishable from a shared one at launch and "
+                                "diverges only once nodes start writing." % directory)
+        else:
+            blocking.append("Unknown shared store %r." % choice)
+
+    for name in (key_envs or []):
+        clean = _clean(name)
+        if not _KEY_NAME.match(clean):
+            blocking.append("%r is not usable as an environment variable name for a key." % name)
+        else:
+            # The NAME is part of the plan; the value never is. Keys are written through the
+            # existing write-only secret path, so a plan can be shown, exported and diffed without
+            # carrying a credential into any of those.
+            notes.append("%s is named by the plan; its value is entered separately and is never "
+                         "part of the plan document." % clean)
+
+    resolved = resolve_backend(env, matrixobject_available, endpoint_reachable)
+    if not resolved.get("honoured", True):
+        warnings.append(resolved["reason"])
+
+    if shape == "onebox":
+        # A one-box plan deliberately names no backend, so the engine auto-selects -- which means
+        # the same plan produces a different backend on a build with MatrixObject compiled in than
+        # on one without. That is fine, and it is not something to discover from a log line after
+        # the fact, so the plan says which one this build will pick and why.
+        notes.append("No storage backend is pinned, so the engine auto-selects. On this build that "
+                     "is %s (%s). The directories above are where the data lands either way."
+                     % (resolved["backend"], resolved["reason"]))
+
+    if shape == "onebox" and not is_standalone(env):
+        blocking.append("This one-box plan does not resolve to standalone.")
+    if shape in ("raft", "shared") and is_standalone(env):
+        blocking.append("This %s plan resolves to standalone, which is not a cluster." % shape)
+
+    return {
+        "ok": not blocking,
+        "shape": shape,
+        "nodes": count,
+        "storage": choice,
+        "env": env,
+        "resolved_backend": resolved["backend"],
+        "backend_reason": resolved["reason"],
+        "blocking": blocking,
+        "warnings": warnings,
+        "notes": notes,
+    }
+
+
+def as_env_file(plan_doc: Json) -> str:
+    """The plan as something that can be pasted into a unit file or an env file."""
+    lines = ["# MatrixArk deployment: %s, %d node(s), %s storage."
+             % (plan_doc.get("shape"), plan_doc.get("nodes", 0), plan_doc.get("storage")),
+             "# Resolves to the %s backend: %s"
+             % (plan_doc.get("resolved_backend"), plan_doc.get("backend_reason"))]
+    for warning in plan_doc.get("warnings") or []:
+        lines.append("# WARNING: " + warning)
+    for name in sorted(plan_doc.get("env") or {}):
+        lines.append("%s=%s" % (name, plan_doc["env"][name]))
+    return "\n".join(lines) + "\n"

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -53,9 +53,11 @@ except ImportError:  # Direct script execution from tools/.
 # edge request metrics. Both are self-contained stdlib modules; a deployment missing them degrades to
 # the previous read-only config surface rather than failing to import.
 try:
+    from tools import matrixark_deployment_plan as _deployment_plan  # type: ignore
     from tools import matrixark_gateway_config as _gwconfig  # type: ignore
     from tools import matrixark_gateway_metrics as _gwmetrics  # type: ignore
 except ImportError:  # Direct script execution from tools/.
+    import matrixark_deployment_plan as _deployment_plan  # type: ignore
     import matrixark_gateway_config as _gwconfig  # type: ignore
     import matrixark_gateway_metrics as _gwmetrics  # type: ignore
 
@@ -1685,6 +1687,21 @@ ROUTE_DOCS: List[Json] = [
                                   "first and last use."},
     {"group": "Administration", "method": "GET", "path": "/v1/admin/ingestion/jobs",
      "scope": "admin", "summary": "Bulk import jobs on this worker."},
+    {"group": "Administration", "method": "GET", "path": "/v1/admin/deployment",
+     "scope": "admin",
+     "summary": "The deployment shapes that can be launched -- one box, replicated with Raft, or "
+                "nodes in front of shared storage -- with the storage each supports, plus the "
+                "backend this deployment is running right now, read from the datanode rather than "
+                "inferred from configuration."},
+    {"group": "Administration", "method": "POST", "path": "/v1/admin/deployment/plan",
+     "scope": "admin",
+     "summary": "Compose a deployment and report what the engine will actually do with it. "
+                "Several choices resolve to something other than what was asked with no error: "
+                "shared storage with no directory, and MatrixObject on a build without it, both "
+                "fall through to auto-detection. Returns the environment, an env file, what is "
+                "blocked, and what will differ from the request. Changes nothing.",
+     "body": {"shape": "raft", "storage": "ebs", "nodes": 3,
+              "root": "/var/lib/temporalstore", "key_envs": ["DEEPSEEK_API_KEY"]}},
     {"group": "Administration", "method": "POST", "path": "/v1/admin/ingestion/jobs",
      "scope": "admin",
      "summary": "Start a bulk import. Every path resolves inside MATRIXARK_INGESTION_ROOT; pass "
@@ -2922,6 +2939,49 @@ def _build_direct_client(cfg: GatewayConfig) -> DirectBackendClient:
     )
 
 
+def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
+    """Which storage backend the datanode actually resolved. None => could not determine.
+
+    Read from the engine instead of re-derived here, because the two can disagree and the engine is
+    the one that is right: `TS_STORAGE_BACKEND=shared` with no directory, or `matrixobject` on a
+    build without the feature, both fall through to auto-detection without erroring, so a
+    deployment routinely runs a backend nobody selected. The engine publishes what it chose as
+    `temporalstore_storage_backend{backend=...}`; the *reason* it chose it exists only in a startup
+    log line, so this reports the outcome and the portal says plainly that the reason is not
+    available over HTTP.
+    """
+    try:
+        conn = cfg.blob_connection_factory(cfg)
+        conn.putrequest("GET", "/metrics")
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = b""
+        try:
+            body = resp.read() or b""
+        except Exception:
+            pass
+        status = int(getattr(resp, "status", 0) or 0)
+        _safe_close(conn)
+        if status >= 400:
+            return None
+        for line in body.decode("utf-8", "replace").splitlines():
+            if not line.startswith("temporalstore_storage_backend{"):
+                continue
+            labels = line[line.find("{") + 1:line.find("}")]
+            parsed: Json = {}
+            for pair in labels.split(","):
+                if "=" in pair:
+                    key, _, value = pair.partition("=")
+                    parsed[key.strip()] = value.strip().strip('"')
+            if parsed.get("backend"):
+                return {"backend": parsed["backend"],
+                        "replication": parsed.get("replication", ""),
+                        "source": "datanode /metrics"}
+        return None
+    except Exception:
+        return None
+
+
 def _probe_datanode(cfg: GatewayConfig) -> Optional[bool]:
     """Best-effort readiness probe against the datanode. None => could not determine (never fatal)."""
     try:
@@ -3179,6 +3239,72 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             except Exception as exc:  # never let the write-side registry break the read
                 snapshot["settings"] = {"status": "unavailable", "detail": str(exc)}
             return await _json(send, 200, snapshot)
+
+        # ---- the deployment chooser (auth + admin scope) --------------------------------------
+        # Separate from the settings registry on purpose. The storage directory, the metaserver
+        # address and the topology are deliberately NOT writable there -- repointing a running
+        # deployment's storage from a browser does not reconfigure it, it strands its data. But
+        # "cannot be changed here" and "cannot be chosen at all" are different, and only the first
+        # was ever true. Choosing happens when a deployment is launched, so this composes a plan and
+        # reports what the engine will actually do with it, without touching this process.
+        if method == "GET" and path == "/v1/admin/deployment":
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _usage_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            live = _probe_storage_backend(cfg)
+            # Only a live backend of matrixobject PROVES the feature is compiled in. Anything else
+            # is silence: auto may have picked another backend on a build that has it. So this
+            # reports confirmation, never absence, and the plan preview stays conditional.
+            confirmed = bool(live and live.get("backend") == "matrixobject")
+            catalogue = _deployment_plan.catalogue(matrixobject_available=True)
+            catalogue["matrixobject_confirmed"] = confirmed
+            return await _json(send, 200, {
+                "status": "ok",
+                "catalogue": catalogue,
+                "live": live,
+                "live_detail": (
+                    "This deployment resolved the %s backend. The engine records WHY in a startup "
+                    "log line only, so the reason is not readable over HTTP."
+                    % live["backend"] if live else
+                    "Could not read the datanode's backend. It publishes "
+                    "temporalstore_storage_backend on /metrics; an unreachable datanode or a "
+                    "gateway pointed at the wrong address both look like this."),
+            })
+
+        if method == "POST" and path == "/v1/admin/deployment/plan":
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _usage_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            raw, too_big = await _read_body_capped(receive, 1 << 16)
+            if too_big or raw is None:
+                return await _json(send, 413, {"error": "body_too_large"})
+            try:
+                payload = json.loads(raw.decode("utf-8") or "{}")
+            except Exception:
+                return await _json(send, 400, {"error": "invalid_json"})
+            live = _probe_storage_backend(cfg)
+            try:
+                plan = _deployment_plan.plan(
+                    shape=str((payload or {}).get("shape", "")),
+                    storage=str((payload or {}).get("storage", "")),
+                    nodes=int((payload or {}).get("nodes", 0) or 0),
+                    root=str((payload or {}).get("root", "")),
+                    shared_dir=str((payload or {}).get("shared_dir", "")),
+                    key_envs=list((payload or {}).get("key_envs", []) or []),
+                    matrixobject_available=bool(
+                        (payload or {}).get("matrixobject_available", True)),
+                )
+            except (TypeError, ValueError) as exc:
+                return await _json(send, 400, {"error": "invalid_plan", "detail": str(exc)})
+            plan["env_file"] = _deployment_plan.as_env_file(plan)
+            plan["live"] = live
+            return await _json(send, 200, plan)
 
         # ---- write the model configuration (auth + admin scope) ------------------------------
         # The customer-facing half of the same surface: a closed registry of settings (see

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -613,6 +613,45 @@ SETUP_BODY = """
   </section>
 
   <section>
+    <h2>Deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
+      topology are not editable above, and that is deliberate — repointing a running deployment's
+      storage from a browser does not reconfigure it, it strands its data. They are chosen when a
+      deployment is <em>launched</em>, which is what this composes.</p>
+    <div id="liveShape" class="hint"></div>
+    <div class="grid2">
+      <label class="field"><span>Shape</span>
+        <select id="depShape"></select>
+        <span class="hint" id="depShapeWhen"></span>
+      </label>
+      <label class="field"><span>Storage</span>
+        <select id="depStorage"></select>
+        <span class="hint" id="depStorageNote"></span>
+      </label>
+      <label class="field"><span>Nodes</span>
+        <input id="depNodes" type="number" min="1" max="99" step="1" value="1">
+        <span class="hint">Raft needs an odd count so a majority exists.</span>
+      </label>
+      <label class="field"><span>Data root</span>
+        <input id="depRoot" type="text" placeholder="/var/lib/temporalstore">
+        <span class="hint">Where pages, blobs, index and cache go.</span>
+      </label>
+      <label class="field" id="depSharedField" hidden><span>Shared directory</span>
+        <input id="depShared" type="text" placeholder="/srv/temporalstore/shared">
+        <span class="hint">Must be the same storage seen by every node, not a per-node path of
+          the same name.</span>
+      </label>
+      <label class="field"><span>Key variables</span>
+        <input id="depKeys" type="text" placeholder="DEEPSEEK_API_KEY, OPENAI_API_KEY">
+        <span class="hint">Names only. Values are entered above and never appear in a plan.</span>
+      </label>
+    </div>
+    <div id="depMsg" role="status" aria-live="polite"></div>
+    <div id="depVerdict"></div>
+    <pre id="depEnv"></pre>
+  </section>
+
+  <section>
     <h2>Grafana <span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></h2>
     <p class="hint" style="margin-top:0">Everything on this page is also exported at
       <span class="mono">/v1/metrics</span> in Prometheus text format — aggregate counters only, no
@@ -1505,6 +1544,7 @@ function liveStream(options) {
         renderHistory(d.settings);
         renderInventory(d.settings);
         renderMonitoring(d);
+        loadDeployment();
         loadEncoding();
         loadModels(false);
         startLive();
@@ -1652,6 +1692,136 @@ function liveStream(options) {
         $("traffic").innerHTML = '<div class="msg err">Could not read /v1/metrics.</div>';
       });
   }
+
+  /* ---------- deployment chooser ---------- */
+  var depCatalogue = null;
+  var depPlanDoc = null;
+
+  function depShape() {
+    if (!depCatalogue) { return null; }
+    var want = $("depShape").value;
+    var found = depCatalogue.shapes.filter(function (s) { return s.id === want; });
+    return found.length ? found[0] : depCatalogue.shapes[0];
+  }
+
+  function renderDeploymentChoices() {
+    if (!depCatalogue) { return; }
+    $("depShape").innerHTML = depCatalogue.shapes.map(function (s) {
+      return "<option value='" + esc(s.id) + "'>" + esc(s.label) + " — " + esc(s.summary) +
+        "</option>";
+    }).join("");
+    $("depShape").value = depCatalogue.default_shape;
+    renderShapeDetail();
+  }
+
+  function renderShapeDetail() {
+    var shape = depShape();
+    if (!shape) { return; }
+    $("depShapeWhen").textContent = shape.when;
+    $("depNodes").value = shape.nodes;
+    $("depStorage").innerHTML = shape.storage.map(function (s) {
+      /* An option that cannot be honoured is still listed rather than hidden: the customer needs
+         to know the choice exists and why this build cannot take it. */
+      var suffix = s.available === false ? " (not in this build)" : "";
+      return "<option value='" + esc(s.id) + "'>" + esc(s.label) + suffix + "</option>";
+    }).join("");
+    if (!$("depRoot").value) {
+      $("depRoot").value = shape.storage[0].default_root || "";
+    }
+    $("depSharedField").hidden = shape.id !== "shared";
+    renderStorageNote();
+  }
+
+  function renderStorageNote() {
+    var shape = depShape();
+    if (!shape) { return; }
+    var want = $("depStorage").value;
+    var found = shape.storage.filter(function (s) { return s.id === want; });
+    $("depStorageNote").textContent = found.length ? found[0].note : "";
+    $("depSharedField").hidden = !(shape.id === "shared" && want === "path");
+  }
+
+  function previewPlan() {
+    if (!depCatalogue) { return; }
+    var keys = $("depKeys").value.split(",").map(function (k) { return k.trim(); })
+      .filter(function (k) { return k.length; });
+    fetch("/v1/admin/deployment/plan", {
+      method: "POST",
+      headers: Object.assign({ "Content-Type": "application/json" }, auth()),
+      body: JSON.stringify({
+        shape: $("depShape").value,
+        storage: $("depStorage").value,
+        nodes: parseInt($("depNodes").value, 10) || 0,
+        root: $("depRoot").value,
+        shared_dir: $("depShared").value,
+        key_envs: keys
+      })
+    })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (plan) {
+        depPlanDoc = plan;
+        /* The requested backend and the resolved one are shown together, because they differ
+           silently: a shared request with no directory, or MatrixObject on a build without it,
+           both fall through to auto-detection and start a deployment nobody chose. */
+        var rows = [];
+        rows.push("<tr><td>Resolves to</td><td><span class='mono'>" +
+          esc(plan.resolved_backend) + "</span><div class='hint' style='margin:2px 0 0'>" +
+          esc(plan.backend_reason) + "</div></td></tr>");
+        (plan.blocking || []).forEach(function (b) {
+          rows.push("<tr><td>Blocked</td><td>" + esc(b) + "</td></tr>");
+        });
+        (plan.warnings || []).forEach(function (w) {
+          rows.push("<tr><td>Warning</td><td>" + esc(w) + "</td></tr>");
+        });
+        (plan.notes || []).forEach(function (n) {
+          rows.push("<tr><td>Note</td><td>" + esc(n) + "</td></tr>");
+        });
+        $("depVerdict").innerHTML = "<table><tbody>" + rows.join("") + "</tbody></table>";
+        $("depEnv").textContent = plan.env_file || "";
+        say($("depMsg"), plan.ok
+          ? "This plan is launchable."
+          : "This plan cannot produce the deployment described. See Blocked above.",
+          plan.ok ? "ok" : "err");
+      })
+      .catch(function (e) {
+        say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+            "err");
+      });
+  }
+
+  function loadDeployment() {
+    fetch("/v1/admin/deployment", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) {
+        depCatalogue = d.catalogue;
+        renderDeploymentChoices();
+        $("liveShape").textContent = d.live
+          ? ("Running now: the " + d.live.backend + " backend (" + d.live.replication +
+             "). " + d.live_detail)
+          : d.live_detail;
+        previewPlan();
+      })
+      .catch(function (e) {
+        if (e !== 401 && e !== 403) {
+          say($("depMsg"), "Could not load the deployment shapes.", "err");
+        }
+      });
+  }
+
+  ["depShape", "depStorage", "depNodes", "depRoot", "depShared", "depKeys"].forEach(function (id) {
+    $(id).addEventListener("change", function () {
+      if (id === "depShape") { renderShapeDetail(); }
+      if (id === "depStorage") { renderStorageNote(); }
+      previewPlan();
+    });
+  });
+
+  $("copyEnv").addEventListener("click", function () {
+    var text = $("depEnv").textContent;
+    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
+    $("copyEnv").textContent = "copied";
+    setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+  });
 
   /* Set once the config lands. Until then only the gateway job is knowable, and printing a
      placeholder engine host would be worse than printing nothing. */

--- a/tools/portal/deployment_chooser_harness.js
+++ b/tools/portal/deployment_chooser_harness.js
@@ -1,0 +1,135 @@
+/* Run the Setup page and drive the deployment chooser the way a customer would.
+ *
+ * The thing worth proving here cannot be read off the source. The chooser's whole purpose is that a
+ * request and its outcome differ -- ask for shared storage with no directory, or MatrixObject on a
+ * build without it, and the engine starts a deployment on something else without erroring. A page
+ * that renders the request back is indistinguishable, in source, from one that renders what the
+ * plan resolved to. Only running it and reading the DOM separates them.
+ *
+ * Element identity is kept per id, and `change` events are dispatched through the real listeners,
+ * so the select-driven reveal of the shared-directory field is exercised rather than assumed.
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const routes = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+const posted = [];
+const byId = new Map();
+
+function makeEl(id) {
+  const listeners = {};
+  const attrs = {};
+  const el = {
+    id: id || "",
+    hidden: false, innerHTML: "", textContent: "", value: "", checked: false, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    removeEventListener() {},
+    dispatch(type, ev) { (listeners[type] || []).forEach((fn) => fn(ev || {})); },
+    appendChild() {}, removeChild() {},
+    setAttribute(k, v) { attrs[k] = v; }, getAttribute(k) { return k in attrs ? attrs[k] : null; },
+    closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+  return el;
+}
+
+function get(id) {
+  if (!byId.has(id)) { byId.set(id, makeEl(id)); }
+  return byId.get(id);
+}
+
+function respond(body) {
+  return Promise.resolve({
+    ok: true, status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  });
+}
+
+const win = {
+  document: {
+    getElementById: get,
+    querySelector: () => makeEl(),
+    querySelectorAll: () => [],
+    createElement: () => makeEl(),
+    addEventListener() {},
+    body: makeEl("body"),
+    hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", host: "gw.example:8080", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0,
+  setInterval: () => 0,
+  clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {},
+  Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url, opts) => {
+    const key = String(url);
+    if (opts && opts.method === "POST") { posted.push({ url: key, body: opts.body }); }
+    if (key.indexOf("/v1/admin/deployment/plan") === 0) { return respond(routes.plan); }
+    if (key.indexOf("/v1/admin/deployment") === 0) { return respond(routes.deployment); }
+    if (key.indexOf("/v1/admin/config") === 0) { return respond(routes.config); }
+    return respond({});
+  },
+  __matrixarkOnFrame() {}
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+const errors = [];
+scripts.forEach((body) => {
+  try { new Function(...names, body)(...values); } catch (e) { errors.push(String(e)); }
+});
+
+/* Microtasks drain before timers, so one real timer is enough for the whole
+   load -> loadDeployment -> previewPlan chain to settle. */
+setTimeout(() => {
+  const shapeOptions = (get("depShape").innerHTML.match(/<option/g) || []).length;
+
+  /* Snapshot before touching anything: a preview that only happens because the harness dispatched
+     a change is not the same feature as one the customer gets on arrival. */
+  const postedOnLoad = posted.map((p) => p.url);
+  const verdictOnLoad = get("depVerdict").innerHTML;
+
+  /* Drive the selects the way the page's own listeners see it. */
+  get("depShape").value = "shared";
+  get("depShape").dispatch("change");
+  const storageAfterShared = get("depStorage").innerHTML;
+  get("depStorage").value = "path";
+  get("depStorage").dispatch("change");
+  const sharedFieldShownForPath = get("depSharedField").hidden === false;
+  get("depStorage").value = "matrixobject";
+  get("depStorage").dispatch("change");
+  const sharedFieldHiddenForObject = get("depSharedField").hidden === true;
+
+  setTimeout(() => {
+    process.stdout.write(JSON.stringify({
+      errors,
+      shapeOptions,
+      postedOnLoad,
+      verdictOnLoad,
+      live: get("liveShape").textContent,
+      verdict: get("depVerdict").innerHTML,
+      envFile: get("depEnv").textContent,
+      storageAfterShared,
+      sharedFieldShownForPath,
+      sharedFieldHiddenForObject,
+      posted: posted.map((p) => ({ url: p.url, body: p.body }))
+    }));
+  }, 0);
+}, 0);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -556,6 +556,45 @@
   </section>
 
   <section>
+    <h2>Deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
+      topology are not editable above, and that is deliberate — repointing a running deployment's
+      storage from a browser does not reconfigure it, it strands its data. They are chosen when a
+      deployment is <em>launched</em>, which is what this composes.</p>
+    <div id="liveShape" class="hint"></div>
+    <div class="grid2">
+      <label class="field"><span>Shape</span>
+        <select id="depShape"></select>
+        <span class="hint" id="depShapeWhen"></span>
+      </label>
+      <label class="field"><span>Storage</span>
+        <select id="depStorage"></select>
+        <span class="hint" id="depStorageNote"></span>
+      </label>
+      <label class="field"><span>Nodes</span>
+        <input id="depNodes" type="number" min="1" max="99" step="1" value="1">
+        <span class="hint">Raft needs an odd count so a majority exists.</span>
+      </label>
+      <label class="field"><span>Data root</span>
+        <input id="depRoot" type="text" placeholder="/var/lib/temporalstore">
+        <span class="hint">Where pages, blobs, index and cache go.</span>
+      </label>
+      <label class="field" id="depSharedField" hidden><span>Shared directory</span>
+        <input id="depShared" type="text" placeholder="/srv/temporalstore/shared">
+        <span class="hint">Must be the same storage seen by every node, not a per-node path of
+          the same name.</span>
+      </label>
+      <label class="field"><span>Key variables</span>
+        <input id="depKeys" type="text" placeholder="DEEPSEEK_API_KEY, OPENAI_API_KEY">
+        <span class="hint">Names only. Values are entered above and never appear in a plan.</span>
+      </label>
+    </div>
+    <div id="depMsg" role="status" aria-live="polite"></div>
+    <div id="depVerdict"></div>
+    <pre id="depEnv"></pre>
+  </section>
+
+  <section>
     <h2>Grafana <span class="aux"><button class="link" id="copyScrape" type="button">copy scrape config</button></span></h2>
     <p class="hint" style="margin-top:0">Everything on this page is also exported at
       <span class="mono">/v1/metrics</span> in Prometheus text format — aggregate counters only, no
@@ -1447,6 +1486,7 @@ function liveStream(options) {
         renderHistory(d.settings);
         renderInventory(d.settings);
         renderMonitoring(d);
+        loadDeployment();
         loadEncoding();
         loadModels(false);
         startLive();
@@ -1594,6 +1634,136 @@ function liveStream(options) {
         $("traffic").innerHTML = '<div class="msg err">Could not read /v1/metrics.</div>';
       });
   }
+
+  /* ---------- deployment chooser ---------- */
+  var depCatalogue = null;
+  var depPlanDoc = null;
+
+  function depShape() {
+    if (!depCatalogue) { return null; }
+    var want = $("depShape").value;
+    var found = depCatalogue.shapes.filter(function (s) { return s.id === want; });
+    return found.length ? found[0] : depCatalogue.shapes[0];
+  }
+
+  function renderDeploymentChoices() {
+    if (!depCatalogue) { return; }
+    $("depShape").innerHTML = depCatalogue.shapes.map(function (s) {
+      return "<option value='" + esc(s.id) + "'>" + esc(s.label) + " — " + esc(s.summary) +
+        "</option>";
+    }).join("");
+    $("depShape").value = depCatalogue.default_shape;
+    renderShapeDetail();
+  }
+
+  function renderShapeDetail() {
+    var shape = depShape();
+    if (!shape) { return; }
+    $("depShapeWhen").textContent = shape.when;
+    $("depNodes").value = shape.nodes;
+    $("depStorage").innerHTML = shape.storage.map(function (s) {
+      /* An option that cannot be honoured is still listed rather than hidden: the customer needs
+         to know the choice exists and why this build cannot take it. */
+      var suffix = s.available === false ? " (not in this build)" : "";
+      return "<option value='" + esc(s.id) + "'>" + esc(s.label) + suffix + "</option>";
+    }).join("");
+    if (!$("depRoot").value) {
+      $("depRoot").value = shape.storage[0].default_root || "";
+    }
+    $("depSharedField").hidden = shape.id !== "shared";
+    renderStorageNote();
+  }
+
+  function renderStorageNote() {
+    var shape = depShape();
+    if (!shape) { return; }
+    var want = $("depStorage").value;
+    var found = shape.storage.filter(function (s) { return s.id === want; });
+    $("depStorageNote").textContent = found.length ? found[0].note : "";
+    $("depSharedField").hidden = !(shape.id === "shared" && want === "path");
+  }
+
+  function previewPlan() {
+    if (!depCatalogue) { return; }
+    var keys = $("depKeys").value.split(",").map(function (k) { return k.trim(); })
+      .filter(function (k) { return k.length; });
+    fetch("/v1/admin/deployment/plan", {
+      method: "POST",
+      headers: Object.assign({ "Content-Type": "application/json" }, auth()),
+      body: JSON.stringify({
+        shape: $("depShape").value,
+        storage: $("depStorage").value,
+        nodes: parseInt($("depNodes").value, 10) || 0,
+        root: $("depRoot").value,
+        shared_dir: $("depShared").value,
+        key_envs: keys
+      })
+    })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (plan) {
+        depPlanDoc = plan;
+        /* The requested backend and the resolved one are shown together, because they differ
+           silently: a shared request with no directory, or MatrixObject on a build without it,
+           both fall through to auto-detection and start a deployment nobody chose. */
+        var rows = [];
+        rows.push("<tr><td>Resolves to</td><td><span class='mono'>" +
+          esc(plan.resolved_backend) + "</span><div class='hint' style='margin:2px 0 0'>" +
+          esc(plan.backend_reason) + "</div></td></tr>");
+        (plan.blocking || []).forEach(function (b) {
+          rows.push("<tr><td>Blocked</td><td>" + esc(b) + "</td></tr>");
+        });
+        (plan.warnings || []).forEach(function (w) {
+          rows.push("<tr><td>Warning</td><td>" + esc(w) + "</td></tr>");
+        });
+        (plan.notes || []).forEach(function (n) {
+          rows.push("<tr><td>Note</td><td>" + esc(n) + "</td></tr>");
+        });
+        $("depVerdict").innerHTML = "<table><tbody>" + rows.join("") + "</tbody></table>";
+        $("depEnv").textContent = plan.env_file || "";
+        say($("depMsg"), plan.ok
+          ? "This plan is launchable."
+          : "This plan cannot produce the deployment described. See Blocked above.",
+          plan.ok ? "ok" : "err");
+      })
+      .catch(function (e) {
+        say($("depMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
+            "err");
+      });
+  }
+
+  function loadDeployment() {
+    fetch("/v1/admin/deployment", { headers: auth() })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (d) {
+        depCatalogue = d.catalogue;
+        renderDeploymentChoices();
+        $("liveShape").textContent = d.live
+          ? ("Running now: the " + d.live.backend + " backend (" + d.live.replication +
+             "). " + d.live_detail)
+          : d.live_detail;
+        previewPlan();
+      })
+      .catch(function (e) {
+        if (e !== 401 && e !== 403) {
+          say($("depMsg"), "Could not load the deployment shapes.", "err");
+        }
+      });
+  }
+
+  ["depShape", "depStorage", "depNodes", "depRoot", "depShared", "depKeys"].forEach(function (id) {
+    $(id).addEventListener("change", function () {
+      if (id === "depShape") { renderShapeDetail(); }
+      if (id === "depStorage") { renderStorageNote(); }
+      previewPlan();
+    });
+  });
+
+  $("copyEnv").addEventListener("click", function () {
+    var text = $("depEnv").textContent;
+    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
+    $("copyEnv").textContent = "copied";
+    setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+  });
 
   /* Set once the config lands. Until then only the gateway job is knowable, and printing a
      placeholder engine host would be worse than printing nothing. */

--- a/tools/test_matrixark_deployment_plan.py
+++ b/tools/test_matrixark_deployment_plan.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A deployment plan has to describe the deployment that will exist, not the one that was asked for.
+
+Every case here is one where the engine accepts a setting and produces something else. None of them
+raise, none are logged as a refusal, and all of them yield a deployment that starts and serves --
+which is exactly why a chooser that only records the request is worse than no chooser at all: it
+puts a confident label on the wrong thing.
+
+The resolution order under test is `StorageBackendConfig::resolve_decision`, and the standalone
+derivation is the datanode's. Both are mirrored here rather than guessed; if either moves, these
+tests are the thing that should break.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_deployment_plan as dp  # noqa: E402
+
+
+class SilentFallthroughTest(unittest.TestCase):
+    """The three ways a choice becomes a different deployment with nothing said."""
+
+    def test_shared_without_a_directory_is_not_shared(self) -> None:
+        # `TS_STORAGE_BACKEND=shared` with no directory falls through to auto rather than failing,
+        # so the deployment comes up on whatever auto picks. Asking for shared storage and getting
+        # single-node raft is the kind of thing that is only noticed under load.
+        plan = dp.plan("shared", "path", nodes=3)
+        self.assertFalse(plan["ok"])
+        self.assertTrue(any("TS_SHARED_STORE_DIR" in b for b in plan["blocking"]),
+                        plan["blocking"])
+
+    def test_matrixobject_without_the_feature_is_not_matrixobject(self) -> None:
+        plan = dp.plan("shared", "matrixobject", nodes=3, matrixobject_available=False)
+        self.assertNotEqual("matrixobject", plan["resolved_backend"])
+        self.assertTrue(any("falls through to auto" in w for w in plan["warnings"]),
+                        plan["warnings"])
+
+    def test_matrixobject_with_the_feature_is_honoured(self) -> None:
+        plan = dp.plan("shared", "matrixobject", nodes=3, matrixobject_available=True)
+        self.assertTrue(plan["ok"], plan["blocking"])
+        self.assertEqual("matrixobject", plan["resolved_backend"])
+        self.assertEqual([], [w for w in plan["warnings"] if "falls through" in w])
+
+    def test_a_metaserver_address_alone_makes_a_box_distributed(self) -> None:
+        # Standalone is derived, not defaulted: !(meta_addr_is_real || TS_DISTRIBUTED). So a
+        # metaserver address arriving from a config file is enough to change the topology of a
+        # deployment nobody meant to change.
+        self.assertTrue(dp.is_standalone({}))
+        self.assertFalse(dp.is_standalone({"TS_META_ADDR": "10.0.0.4:17001"}))
+        # ...unless it is one of the sentinels the engine reads as "no metaserver".
+        for sentinel in dp.META_SENTINELS:
+            with self.subTest(sentinel=sentinel):
+                self.assertTrue(dp.is_standalone({"TS_META_ADDR": sentinel}))
+
+    def test_a_onebox_plan_pins_standalone_rather_than_relying_on_the_default(self) -> None:
+        plan = dp.plan("onebox", "ebs")
+        self.assertTrue(plan["ok"], plan["blocking"])
+        self.assertEqual("1", plan["env"]["TS_STANDALONE"])
+        # The pin has to survive a metaserver address turning up later, which is the whole point.
+        polluted = dict(plan["env"])
+        polluted["TS_META_ADDR"] = "10.0.0.4:17001"
+        self.assertTrue(dp.is_standalone(polluted),
+                        "an inherited metaserver address flipped a one-box deployment")
+
+
+class BackendResolutionTest(unittest.TestCase):
+    """The order auto walks, which decides what every unpinned deployment gets."""
+
+    def test_auto_prefers_a_reachable_endpoint_then_local_then_shared_then_raft(self) -> None:
+        reachable = dp.resolve_backend({"MATRIXARK_OBJECT_RPC_URL": "http://store:9000"},
+                                       matrixobject_available=True, endpoint_reachable=True)
+        self.assertEqual("matrixobject", reachable["backend"])
+
+        # Configured but unreachable degrades rather than wedging the node on a store it cannot
+        # reach -- and lands somewhere other than MatrixObject.
+        unreachable = dp.resolve_backend({"MATRIXARK_OBJECT_RPC_URL": "http://store:9000"},
+                                         matrixobject_available=True, endpoint_reachable=False)
+        self.assertNotEqual("matrixobject", unreachable["backend"])
+
+        shared = dp.resolve_backend({"TS_SHARED_STORE_DIR": "/srv/shared"},
+                                    matrixobject_available=False)
+        self.assertEqual("shared_path", shared["backend"])
+
+        nothing = dp.resolve_backend({}, matrixobject_available=False)
+        self.assertEqual("raft", nothing["backend"])
+
+    def test_raft_is_forced_regardless_of_what_else_is_configured(self) -> None:
+        forced = dp.resolve_backend(
+            {"TS_STORAGE_BACKEND": "raft", "TS_SHARED_STORE_DIR": "/srv/shared"},
+            matrixobject_available=True, endpoint_reachable=True)
+        self.assertEqual("raft", forced["backend"])
+
+    def test_the_spellings_the_engine_accepts_are_accepted_here(self) -> None:
+        for spelling in ("shared", "shared_path", "shared_store", "path"):
+            with self.subTest(spelling=spelling):
+                got = dp.resolve_backend({"TS_STORAGE_BACKEND": spelling,
+                                          "TS_SHARED_STORE_DIR": "/srv/s"})
+                self.assertEqual("shared_path", got["backend"])
+        for spelling in ("raft", "raft_replication", "replication"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual("raft", dp.resolve_backend(
+                    {"TS_STORAGE_BACKEND": spelling})["backend"])
+        # An unknown value is not an error to the engine either: it means auto.
+        self.assertEqual("raft", dp.resolve_backend(
+            {"TS_STORAGE_BACKEND": "nonsense"}, matrixobject_available=False)["backend"])
+
+
+class ShapeTest(unittest.TestCase):
+
+    def test_raft_refuses_an_even_node_count(self) -> None:
+        for count in (2, 4, 6):
+            with self.subTest(nodes=count):
+                plan = dp.plan("raft", "ebs", nodes=count)
+                self.assertFalse(plan["ok"])
+        for count in (3, 5):
+            with self.subTest(nodes=count):
+                self.assertTrue(dp.plan("raft", "ebs", nodes=count)["ok"])
+
+    def test_raft_gets_its_own_wal_directory(self) -> None:
+        plan = dp.plan("raft", "ebs", nodes=3, root="/data")
+        self.assertEqual("/data/raft-wal", plan["env"]["TS_RAFT_WAL_DIR"])
+        self.assertNotIn("TS_RAFT_WAL_DIR", dp.plan("onebox", "ebs")["env"])
+
+    def test_instance_ssd_says_the_store_is_erased_on_stop(self) -> None:
+        plan = dp.plan("onebox", "ssd")
+        self.assertTrue(any("erased" in w for w in plan["warnings"]), plan["warnings"])
+        self.assertEqual([], [w for w in dp.plan("onebox", "ebs")["warnings"] if "erased" in w])
+
+    def test_a_onebox_plan_says_which_backend_this_build_will_pick(self) -> None:
+        # The same plan resolves differently depending on what was compiled in, so leaving it
+        # unstated means the answer is only discoverable from a log line after launch.
+        with_feature = dp.plan("onebox", "ebs", matrixobject_available=True)
+        without = dp.plan("onebox", "ebs", matrixobject_available=False)
+        self.assertNotEqual(with_feature["resolved_backend"], without["resolved_backend"])
+        for plan in (with_feature, without):
+            self.assertTrue(any(plan["resolved_backend"] in n for n in plan["notes"]),
+                            plan["notes"])
+
+    def test_a_key_name_is_planned_but_its_value_never_is(self) -> None:
+        plan = dp.plan("onebox", "ebs", key_envs=["DEEPSEEK_API_KEY"])
+        rendered = dp.as_env_file(plan)
+        self.assertNotIn("DEEPSEEK_API_KEY=", rendered,
+                         "the plan document must never carry a credential")
+        self.assertTrue(any("DEEPSEEK_API_KEY" in n for n in plan["notes"]))
+        self.assertFalse(dp.plan("onebox", "ebs", key_envs=["not a var name"])["ok"])
+
+    def test_the_catalogue_reports_what_this_build_can_honour(self) -> None:
+        available = dp.catalogue(matrixobject_available=True)
+        missing = dp.catalogue(matrixobject_available=False)
+        self.assertTrue(available["matrixobject_available"])
+        self.assertFalse(missing["matrixobject_available"])
+
+        def store(doc, shape_id, store_id):
+            shape = [s for s in doc["shapes"] if s["id"] == shape_id][0]
+            return [s for s in shape["storage"] if s["id"] == store_id][0]
+
+        self.assertTrue(store(available, "shared", "matrixobject")["available"])
+        self.assertFalse(store(missing, "shared", "matrixobject")["available"])
+
+    def test_an_unknown_shape_is_refused_rather_than_guessed(self) -> None:
+        plan = dp.plan("wishful")
+        self.assertFalse(plan["ok"])
+        self.assertEqual({}, plan["env"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_deployment_routes.py
+++ b/tools/test_matrixark_deployment_routes.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The deployment chooser over HTTP: what it offers, what it refuses, and what it claims to know.
+
+The claim that needs guarding is the narrow one. The portal can prove MatrixObject is compiled in --
+a live backend of `matrixobject` says so -- but it can never prove the opposite, because auto picks
+another backend for plenty of reasons on a build that has the feature. Reporting "not available"
+from that silence would turn a missing datanode into a false statement about the build, printed
+next to a storage choice. So absence is never asserted, and that is what these tests hold in place.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import (  # noqa: E402
+    _FakeResponse, _FakeServer, _cfg, _factory_for, drive,
+)
+
+ADMIN = {"Authorization": "Bearer k-acme"}
+
+_METRICS = (
+    b"# HELP temporalstore_storage_backend Selected distributed storage backend (1 = active).\n"
+    b"# TYPE temporalstore_storage_backend gauge\n"
+    b'temporalstore_storage_backend{backend="matrixobject",replication="shared_store"} 1\n'
+    b"temporalstore_data_node_runtime_queue_depth 0\n"
+)
+
+
+def _app(response=None):
+    cfg = _cfg(blob_connection_factory=_factory_for(response or _FakeResponse(200, _METRICS)))
+    return gw.make_v1_app(_FakeServer(), cfg)
+
+
+class DeploymentCatalogueTest(unittest.TestCase):
+
+    def test_it_needs_an_admin_key(self) -> None:
+        status, _h, _b = drive(_app(), method="GET", path="/v1/admin/deployment")
+        self.assertEqual(401, status)
+
+    def test_it_offers_every_shape_with_storage_for_each(self) -> None:
+        status, _h, body = drive(_app(), method="GET", path="/v1/admin/deployment", headers=ADMIN)
+        self.assertEqual(200, status)
+        doc = json.loads(body)
+        shapes = {s["id"]: s for s in doc["catalogue"]["shapes"]}
+        self.assertEqual({"onebox", "raft", "shared"}, set(shapes))
+        for name, shape in shapes.items():
+            with self.subTest(shape=name):
+                self.assertTrue(shape["storage"], "no storage choices offered")
+                self.assertTrue(shape["when"].strip(), "no guidance on when to pick it")
+        # Shared storage defaults to the object store; the disk shapes never offer it.
+        self.assertIn("matrixobject", [s["id"] for s in shapes["shared"]["storage"]])
+        self.assertNotIn("matrixobject", [s["id"] for s in shapes["onebox"]["storage"]])
+
+    def test_a_live_matrixobject_backend_confirms_the_feature(self) -> None:
+        _st, _h, body = drive(_app(), method="GET", path="/v1/admin/deployment", headers=ADMIN)
+        doc = json.loads(body)
+        self.assertEqual("matrixobject", doc["live"]["backend"])
+        self.assertEqual("shared_store", doc["live"]["replication"])
+        self.assertTrue(doc["catalogue"]["matrixobject_confirmed"])
+
+    def test_another_backend_does_not_claim_the_feature_is_absent(self) -> None:
+        # A raft backend is not evidence that MatrixObject is uncompiled -- auto reaches raft for
+        # several reasons on a build that has it. Confirmation goes false; nothing asserts absence.
+        raft = _FakeResponse(200, b'temporalstore_storage_backend{backend="raft",'
+                                  b'replication="raft"} 1\n')
+        _st, _h, body = drive(_app(raft), method="GET", path="/v1/admin/deployment", headers=ADMIN)
+        doc = json.loads(body)
+        self.assertEqual("raft", doc["live"]["backend"])
+        self.assertFalse(doc["catalogue"]["matrixobject_confirmed"])
+        self.assertTrue(doc["catalogue"]["matrixobject_available"],
+                        "absence was asserted from silence")
+
+    def test_an_unreachable_datanode_is_reported_not_fatal(self) -> None:
+        # Every way this can fail has to land on "could not determine", because the alternative is
+        # a 500 on the page that tells an operator what their deployment is doing.
+        #
+        # The third fixture is the one that carries weight. A 503 with an EMPTY body returns None
+        # whether or not the status is checked -- there are no lines to parse either way -- so it
+        # cannot tell a working status check from a missing one. A 503 that still carries a
+        # parseable metric line can, and it is the realistic shape: a datanode in a state where its
+        # own numbers should not be believed can still serve bytes that scan cleanly.
+        fixtures = (
+            _FakeResponse(503, b""),
+            _FakeResponse(200, b"nothing useful\n"),
+            _FakeResponse(503, b'temporalstore_storage_backend{backend="raft",'
+                               b'replication="raft"} 1\n'),
+        )
+        for index, response in enumerate(fixtures):
+            with self.subTest(fixture=index, status=response.status):
+                status, _h, body = drive(_app(response), method="GET",
+                                         path="/v1/admin/deployment", headers=ADMIN)
+                self.assertEqual(200, status)
+                doc = json.loads(body)
+                self.assertIsNone(doc["live"],
+                                  "a failed scrape was reported as a live backend")
+                self.assertIn("temporalstore_storage_backend", doc["live_detail"])
+
+    def test_a_connection_that_raises_is_survived(self) -> None:
+        def explode(_cfg_arg):
+            raise OSError("connection refused")
+        app = gw.make_v1_app(_FakeServer(), _cfg(blob_connection_factory=explode))
+        status, _h, body = drive(app, method="GET", path="/v1/admin/deployment", headers=ADMIN)
+        self.assertEqual(200, status)
+        self.assertIsNone(json.loads(body)["live"])
+
+
+class DeploymentPlanRouteTest(unittest.TestCase):
+
+    def _plan(self, payload, app=None):
+        status, _h, body = drive(app or _app(), method="POST",
+                                 path="/v1/admin/deployment/plan", body=payload, headers=ADMIN)
+        return status, json.loads(body)
+
+    def test_it_needs_an_admin_key(self) -> None:
+        status, _h, _b = drive(_app(), method="POST", path="/v1/admin/deployment/plan",
+                               body={"shape": "onebox"})
+        self.assertEqual(401, status)
+
+    def test_a_onebox_plan_comes_back_with_an_env_file(self) -> None:
+        status, plan = self._plan({"shape": "onebox", "storage": "ebs"})
+        self.assertEqual(200, status)
+        self.assertTrue(plan["ok"], plan["blocking"])
+        self.assertEqual("1", plan["env"]["TS_STANDALONE"])
+        self.assertIn("TS_PAGE_STORE_DIR=", plan["env_file"])
+        self.assertIn("TS_STANDALONE=1", plan["env_file"])
+
+    def test_an_even_raft_count_is_refused_with_the_reason(self) -> None:
+        status, plan = self._plan({"shape": "raft", "storage": "ebs", "nodes": 4})
+        self.assertEqual(200, status)
+        self.assertFalse(plan["ok"])
+        self.assertTrue(any("odd" in b for b in plan["blocking"]), plan["blocking"])
+
+    def test_shared_storage_without_a_directory_is_refused(self) -> None:
+        status, plan = self._plan({"shape": "shared", "storage": "path", "nodes": 3})
+        self.assertEqual(200, status)
+        self.assertFalse(plan["ok"])
+        self.assertTrue(any("TS_SHARED_STORE_DIR" in b for b in plan["blocking"]))
+
+    def test_a_key_name_is_carried_but_never_a_value(self) -> None:
+        status, plan = self._plan({"shape": "onebox", "storage": "ebs",
+                                   "key_envs": ["DEEPSEEK_API_KEY"]})
+        self.assertEqual(200, status)
+        self.assertNotIn("DEEPSEEK_API_KEY=", plan["env_file"])
+        self.assertNotIn("DEEPSEEK_API_KEY", plan["env"])
+
+    def test_a_malformed_body_is_a_400_not_a_500(self) -> None:
+        status, _h, body = drive(_app(), method="POST", path="/v1/admin/deployment/plan",
+                                 raw=b"{not json", headers=ADMIN)
+        self.assertEqual(400, status)
+        self.assertEqual("invalid_json", json.loads(body)["error"])
+
+    def test_an_unknown_shape_is_refused_rather_than_guessed(self) -> None:
+        status, plan = self._plan({"shape": "wishful"})
+        self.assertEqual(200, status)
+        self.assertFalse(plan["ok"])
+        self.assertEqual({}, plan["env"])
+
+
+class ChooserRendersTest(unittest.TestCase):
+    """The page, run against the real route bodies.
+
+    A request and its outcome differ here on purpose, and in page source the two are the same shape
+    of string concatenation. Rendering the resolved backend and rendering the requested one look
+    identical to a grep, so the only way to tell them apart is to run the page and read what landed
+    in the DOM.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+        if not shutil.which("node"):
+            self.skipTest("node is not installed")
+        self.app = _app()
+
+    def _routes(self, plan_payload) -> dict:
+        _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
+        _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
+                                    headers=ADMIN)
+        _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
+                              body=plan_payload, headers=ADMIN)
+        return {
+            "config": json.loads(config),
+            "deployment": json.loads(deployment),
+            "plan": json.loads(plan),
+        }
+
+    def _run(self, plan_payload) -> dict:
+        import subprocess
+        import tempfile
+        page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "portal", "setup_portal.html")
+        harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "portal", "deployment_chooser_harness.js")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(self._routes(plan_payload), handle)
+            fixture = handle.name
+        try:
+            proc = subprocess.run(["node", harness, page, fixture],
+                                  capture_output=True, text=True, timeout=60)
+        finally:
+            os.unlink(fixture)
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertEqual([], result["errors"], "the page's scripts threw")
+        self.assertEqual(3, result["shapeOptions"])
+        self.assertIn("TS_STANDALONE=1", result["envFile"])
+        # The preview happens without the customer pressing anything -- checked against the
+        # snapshot taken before the harness dispatched any change, because a post made in response
+        # to the harness's own interaction proves nothing about what a customer sees on arrival.
+        self.assertTrue(
+            any("/v1/admin/deployment/plan" in url for url in result["postedOnLoad"]),
+            "no plan was previewed until something was touched")
+        self.assertIn("Resolves to", result["verdictOnLoad"])
+
+    def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("Resolves to", result["verdict"])
+        # The live backend read from the engine is stated, not inferred from the form.
+        self.assertIn("matrixobject", result["live"])
+
+    def test_a_blocked_plan_is_shown_as_blocked(self) -> None:
+        result = self._run({"shape": "shared", "storage": "path", "nodes": 3})
+        self.assertIn("Blocked", result["verdict"])
+        self.assertIn("TS_SHARED_STORE_DIR", result["verdict"])
+
+    def test_the_shared_directory_field_follows_the_storage_choice(self) -> None:
+        # It is required for a shared filesystem and meaningless for the object store, and the
+        # difference is a live DOM change no source read can confirm.
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("MatrixObject", result["storageAfterShared"])
+        self.assertTrue(result["sharedFieldShownForPath"],
+                        "a shared filesystem was offered with nowhere to put the directory")
+        self.assertTrue(result["sharedFieldHiddenForObject"],
+                        "a directory field was left showing for the object store")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The settings form deliberately refuses to edit the storage directories, the metaserver
address and the topology: repointing a running deployment's storage from a browser does
not reconfigure it, it strands its data. That reasoning is sound, and it left a hole —
"cannot be changed here" and "cannot be chosen at all" are different things, and only the
first was true. Choosing belongs to *launching* a deployment, which is what this adds:
one box, replicated with Raft, or nodes in front of shared storage.

## The part worth having is not the form

Three of these choices resolve to something other than what was asked, with nothing
raised anywhere:

- `TS_STORAGE_BACKEND=shared` with no `TS_SHARED_STORE_DIR` falls through to
  auto-detection rather than failing.
- `TS_STORAGE_BACKEND=matrixobject` on a build without that feature compiled in takes the
  same fall-through, reached a different way.
- Standalone is **derived**, not defaulted — `!(meta_addr_is_real || TS_DISTRIBUTED)` — so
  a metaserver address arriving from a config file is on its own enough to turn a one-box
  deployment into a distributed one.

Each produces a deployment that starts, serves, and is not the one selected. So the plan
resolves the choice the same way the engine does and reports the backend that will
actually be used next to the one requested; a one-box plan pins `TS_STANDALONE` rather
than trusting the derivation.

## What is running now is read, not re-derived

The live backend comes from the datanode's own `temporalstore_storage_backend` metric.
The two sources disagree in exactly the cases above, and the engine is the one that is
right. The engine records *why* it chose a backend in a startup log line and nowhere
else, so the portal reports the outcome and says the reason is not readable over HTTP
rather than inventing one.

Availability is never asserted negatively. A live `matrixobject` backend proves the
feature is compiled in; any other backend is silence, since auto reaches others for
several reasons on a build that has it. Reporting absence from that silence would turn an
unreachable datanode into a false claim about the build, printed next to a storage choice.

Key **names** are planned; key **values** never are, so a plan can be shown, copied and
diffed without carrying a credential.

## Tests

45 tests, every one mutation-checked. Two were vacuous when first written and are worth
naming:

- A 503 fixture with an empty body returned "undetermined" whether or not the status was
  checked — there were no lines to parse either way. It now carries a parseable metric
  line, which is the realistic shape and the one that separates the two.
- A page assertion could not tell a preview that happens on arrival from one the test
  harness itself triggered by dispatching a change. The harness now snapshots the state
  before any interaction.

Both fail when the thing they describe is broken.
