### PR TITLE
A registration built in a test still needs the time it was first seen

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2645,6 +2645,7 @@ mod tests {
         let scheduler = MetaTaskScheduler::default();
         assert!(meta
             .register_server(RegisterServerRequest {
+                registered_at_ms: 0,
                 numa_nodes: Vec::new(),
                 server_addr: "node-a".to_string(),
                 node_id: 1,

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -612,6 +612,7 @@ mod tests {
         // One idle proxy for a group that wants three.
         assert!(meta
             .register_proxy(RegisterProxyRequest {
+                registered_at_ms: 0,
                 proxy_addr: "p1".to_string(),
                 namespace: "ns".to_string(),
                 location: "rack-1".to_string(),
@@ -662,6 +663,7 @@ mod tests {
             .ok);
         assert!(meta
             .register_proxy(RegisterProxyRequest {
+                registered_at_ms: 0,
                 proxy_addr: "p1".to_string(),
                 namespace: "ns".to_string(),
                 location: "rack-1".to_string(),
@@ -989,6 +991,7 @@ mod tests {
             .ok);
         assert!(meta
             .register_proxy(RegisterProxyRequest {
+                registered_at_ms: 0,
                 proxy_addr: "p1".to_string(),
                 namespace: String::new(),
                 location: "us-east/dc1/az1".to_string(),
@@ -1113,6 +1116,7 @@ mod tests {
         let meta = SingleNodeMeta::default();
         assert!(meta
             .register_proxy(RegisterProxyRequest {
+                registered_at_ms: 0,
                 proxy_addr: "p1".to_string(),
                 namespace: String::new(),
                 location: "rack-1".to_string(),
@@ -1177,6 +1181,7 @@ mod tests {
         for addr in ["p1", "p2"] {
             assert!(meta
                 .register_proxy(RegisterProxyRequest {
+                    registered_at_ms: 0,
                     proxy_addr: addr.to_string(),
                     namespace: String::new(),
                     location: "rack-1".to_string(),


### PR DESCRIPTION
Six constructions of RegisterProxyRequest / RegisterServerRequest predate the registered_at_ms field, so `cargo check --all-targets` fails on main. The metaserver stamps the field and overwrites any caller value, so these pass 0, matching every other construction in the tree.

Verified: `cargo check --all-targets` is clean with this, and fails without it.