### PR TITLE
Ask the metaserver which node leads, and where it is

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -1487,6 +1487,7 @@ fn handle(
                 &Status::error("raft_disabled", "meta raft is disabled"),
             ),
         },
+        ("GET", "/meta/raft/leader") => json_response(200, &meta.raft_leader()),
         ("GET", "/meta/raft/ready") => json_response(200, &meta.raft_ready()),
         ("GET", "/meta/raft/membership") => json_response(200, &meta.raft_membership()),
         ("POST", "/meta/raft/add_node") => parse_or(&request.body, |req: MetaRaftNodeRequest| {
@@ -2344,6 +2345,18 @@ fn unreplicated_meta_raft_warning(nodes: &[ProductionRaftNode]) -> Option<String
     ))
 }
 
+/// Which node leads the metaserver's raft group, and the address it was
+/// configured with.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct MetaRaftLeaderResponse {
+    status: Status,
+    leader_id: RaftNodeId,
+    /// Empty when there is no leader, or none with a configured address.
+    addr: String,
+    /// Whether this process is that node, so a caller can tell it has arrived.
+    is_local: bool,
+}
+
 fn parse_meta_raft_node(index: usize, value: &str) -> Option<ProductionRaftNode> {
     if let Some((id, addr)) = value.split_once('=') {
         return Some(ProductionRaftNode {
@@ -2736,6 +2749,33 @@ mod tests {
             warning.contains("diverge"),
             "it should say what goes wrong: {warning}"
         );
+    }
+
+    #[test]
+    fn the_metaserver_says_which_node_leads_and_where() {
+        // The raft status answers with a leader id and no address, and the
+        // addresses are configured and then reported nowhere -- so nothing
+        // could work out where to send a change. A number is not an endpoint.
+        let raft = with_scheduler_env(
+            &[(
+                "TS_META_RAFT_NODES",
+                "7=10.0.0.7:17001,8=10.0.0.8:17001,9=10.0.0.9:17001",
+            ), ("TS_META_RAFT_NODE_ID", "7")],
+            MetaBackend::from_env,
+        )
+        .expect("raft backend starts");
+        let leader = raft.raft_leader();
+        assert!(leader.status.ok, "{:?}", leader.status);
+        assert_eq!(leader.leader_id, 7, "the first node listed leads");
+        assert_eq!(leader.addr, "10.0.0.7:17001", "and it says where that is");
+        assert!(leader.is_local, "this process is that node");
+
+        // A metaserver that is not raft-backed has no leader to name, and says
+        // so rather than inventing one.
+        let single = MetaBackend::Single(SingleNodeMeta::default()).raft_leader();
+        assert!(!single.status.ok);
+        assert_eq!(single.status.code, "raft_disabled");
+        assert!(single.addr.is_empty());
     }
 
     #[test]

--- a/crates/temporalstore-rust/src/bin/metaserver/backend.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver/backend.rs
@@ -54,6 +54,35 @@ impl MetaBackend {
         }
     }
 
+    /// Who leads this metaserver's raft group, and where.
+    fn raft_leader(&self) -> MetaRaftLeaderResponse {
+        match self {
+            Self::Single(_) => MetaRaftLeaderResponse {
+                status: Status::error("raft_disabled", "meta raft is disabled"),
+                leader_id: 0,
+                addr: String::new(),
+                is_local: false,
+            },
+            Self::Raft(runtime) => match runtime.leader_endpoint() {
+                Some((leader_id, addr)) => MetaRaftLeaderResponse {
+                    status: Status::ok(),
+                    leader_id,
+                    addr,
+                    is_local: leader_id == runtime.local_node_id(),
+                },
+                None => MetaRaftLeaderResponse {
+                    status: Status::error(
+                        "leader_unavailable",
+                        "meta raft has no leader with a configured address",
+                    ),
+                    leader_id: 0,
+                    addr: String::new(),
+                    is_local: false,
+                },
+            },
+        }
+    }
+
     fn raft_status(&self) -> Option<RaftClusterStatus> {
         match self {
             Self::Single(_) => None,

--- a/crates/temporalstore-rust/src/raft/production_runtime.rs
+++ b/crates/temporalstore-rust/src/raft/production_runtime.rs
@@ -785,6 +785,26 @@ impl ProductionMetaRaftRuntime {
         self.cluster.clone()
     }
 
+    /// Which node leads, and the address it was configured with.
+    ///
+    /// `RaftClusterStatus` carries the leader's id and no address, and the
+    /// addresses live only in the options -- so nothing could answer "where do
+    /// I send a change" without them.
+    pub fn leader_endpoint(&self) -> Option<(RaftNodeId, String)> {
+        let leader_id = self.status().leader_id;
+        self.options
+            .nodes
+            .iter()
+            .find(|node| node.node_id == leader_id)
+            .map(|node| (leader_id, node.addr.clone()))
+    }
+
+    /// The node this process is, which is what makes the answer above useful:
+    /// a caller can tell whether it is already talking to the leader.
+    pub fn local_node_id(&self) -> RaftNodeId {
+        self.options.local_node_id
+    }
+
     pub fn status(&self) -> RaftClusterStatus {
         self.cluster.status()
     }


### PR DESCRIPTION
Rebuilt on current main.

A raft-backed metaserver knew its leader internally but had no way to be asked, so a caller could not tell which node leads or whether it is the local one. Single-node backends answer `raft_disabled` rather than inventing a leader.

Verified: `cargo check --all-targets` clean; `cargo test --bin metaserver` 52 passed, 0 failed -- including both the existing topology-bytes test and the new leader test, which sit adjacent in the file.