### PR TITLE
main does not build: six register-request initializers predate the field they need

### DIFF
--- a/crates/temporalstore-rust/src/bin/metaserver.rs
+++ b/crates/temporalstore-rust/src/bin/metaserver.rs
@@ -2650,6 +2650,7 @@ mod tests {
                 node_id: 1,
                 location: "rack-1".to_string(),
                 binary_version: "v1".to_string(),
+                registered_at_ms: 0,
             })
             .status
             .ok);

--- a/crates/temporalstore-rust/src/meta/proxy_groups.rs
+++ b/crates/temporalstore-rust/src/meta/proxy_groups.rs
@@ -617,6 +617,7 @@ mod tests {
                 location: "rack-1".to_string(),
                 config_version: 1,
                 binary_version: "v1".to_string(),
+                registered_at_ms: 0,
             })
             .status
             .ok);
@@ -667,6 +668,7 @@ mod tests {
                 location: "rack-1".to_string(),
                 config_version: 1,
                 binary_version: "v1".to_string(),
+                registered_at_ms: 0,
             })
             .status
             .ok);
@@ -994,6 +996,7 @@ mod tests {
                 location: "us-east/dc1/az1".to_string(),
                 config_version: 0,
                 binary_version: "v1".to_string(),
+                registered_at_ms: 0,
             })
             .status
             .ok);
@@ -1118,6 +1121,7 @@ mod tests {
                 location: "rack-1".to_string(),
                 config_version: 0,
                 binary_version: "v1".to_string(),
+                registered_at_ms: 0,
             })
             .status
             .ok);
@@ -1182,6 +1186,7 @@ mod tests {
                     location: "rack-1".to_string(),
                     config_version: 0,
                     binary_version: "v1".to_string(),
+                    registered_at_ms: 0,
                 })
                 .status
                 .ok);


### PR DESCRIPTION
`main` does not compile.

`RegisterProxyRequest` and `RegisterServerRequest` gained `registered_at_ms` in #219. Six
initializers written on branches cut before that merge do not set it, so the build fails with
`E0063` — five in `meta/proxy_groups` tests and one in the `metaserver` tests.

## Per-PR CI structurally cannot catch this

Neither side is wrong alone. The branch adding the field is complete; the branch adding an
initializer is complete against the field set it was written against. Only the **merge** is broken,
and nothing builds that combination until it has already landed.

Worth noting alongside: mx#560 merged while its ratchet was failing, so red changes can reach `main`
here.

## The fix

`registered_at_ms: 0`, matching every existing initializer in these files.

`cargo check --all-targets` is clean.

## A trap I hit while writing it

My first pass added the field to every `Register*Request {` match — which also matches
`struct MasterRegisterServerRequest {`, a **declaration**. In a definition the syntax is
`name: Type`, not `name: value`, so that produced `expected type, found 0` and broke the serde
derive as well. A brace-matching scan cannot tell an initializer from a definition; only the six
initializers are touched here.
