### PR TITLE
A document fact written onto every chunk of the document

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2096,7 +2096,14 @@ def serving_resource_metadata(metadata: Json) -> Json:
         for key in SERVING_RESOURCE_METADATA_FIELDS
         if key in sanitized and sanitized[key] not in (None, "", [], {})
     }
-    serving["raw_storage_policy"] = sanitized.get("raw_storage_policy", "raw_uri_only")
+    # `raw_storage_policy` is not carried per chunk: it is a document fact, identical on every
+    # chunk, and no reader takes it from a stored chunk. The dashboard reads the TOP-level
+    # field on manifest rows, ingest reads the live storage_resolution, and resource IO reads
+    # the ENVELOPE metadata while deciding where raw bytes go. 93.1 KB per 1 MB skill.
+    #
+    # `resource_version` stays, though it is the same shape: the retrieve path reads it from a
+    # stored record to decide version_state, falling back to a top-level field sections do not
+    # carry, so dropping it would make every chunk look current.
     # `raw_bytes_stored` is a per-document fact and a constant False on every chunk of a
     # document, 27 B a row -- 66.2 KB per 1 MB skill. It is not carried here because
     # nothing reads it from a chunk: every mention inside a metadata dict is an

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -661,6 +661,13 @@ INLINE_VECTOR_OWNER_BY_REF_TYPE = {
 # owner's hash, so it inherits the owner's node and timestamp. Kept when they differ.
 _EMBEDDING_META_SAME_AS_OWNER = ("node_path", "updated_at_ms", "node_hash")
 
+# `embedding_type` repeats the owner's record_type whenever the fold's owner map is identity, which
+# it is for chunks: skill_section -> skill_section, resource_chunk -> resource_chunk. It is NOT
+# identity for the other six -- event -> context_event, summary -> context_summary -- and there the
+# value says something the owner cannot (`node_l0` is not `context_summary`). So it is compared
+# against record_type rather than assumed equal to it.
+_EMBEDDING_META_SAME_AS_RECORD_TYPE = "embedding_type"
+
 _EMBEDDING_META_SKIP = (
     "record_type",
     "ref_type",
@@ -756,6 +763,8 @@ def fold_embedding_records(
         for key in _EMBEDDING_META_SAME_AS_OWNER:
             if key in meta and key in owner and owner[key] == meta[key]:
                 del meta[key]
+        if meta.get(_EMBEDDING_META_SAME_AS_RECORD_TYPE) == owner.get("record_type"):
+            del meta[_EMBEDDING_META_SAME_AS_RECORD_TYPE]
         if meta:
             owner.setdefault("embedding_meta", meta)
         if index not in replace:

--- a/tools/matrixark_mcp_resources.py
+++ b/tools/matrixark_mcp_resources.py
@@ -102,7 +102,14 @@ def serving_resource_metadata(metadata: Json) -> Json:
         for key in SERVING_RESOURCE_METADATA_FIELDS
         if key in sanitized and sanitized[key] not in (None, "", [], {})
     }
-    serving["raw_storage_policy"] = sanitized.get("raw_storage_policy", "raw_uri_only")
+    # `raw_storage_policy` is not carried per chunk: it is a document fact, identical on every
+    # chunk, and no reader takes it from a stored chunk. The dashboard reads the TOP-level
+    # field on manifest rows, ingest reads the live storage_resolution, and resource IO reads
+    # the ENVELOPE metadata while deciding where raw bytes go. 93.1 KB per 1 MB skill.
+    #
+    # `resource_version` stays, though it is the same shape: the retrieve path reads it from a
+    # stored record to decide version_state, falling back to a top-level field sections do not
+    # carry, so dropping it would make every chunk look current.
     # `raw_bytes_stored` is a per-document fact and a constant False on every chunk of a
     # document, 27 B a row -- 66.2 KB per 1 MB skill. It is not carried here because
     # nothing reads it from a chunk: every mention inside a metadata dict is an

--- a/tools/test_matrixark_document_facts_are_not_per_chunk.py
+++ b/tools/test_matrixark_document_facts_are_not_per_chunk.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A document fact is not repeated onto every chunk of the document.
+
+`raw_storage_policy` is decided once for a document and was written into every chunk's serving
+metadata -- 93.1 KB per 1 MB skill for a value identical on all of them. No reader takes it from a
+stored chunk: the dashboard reads the TOP-level field on manifest rows, ingest reads the live
+`storage_resolution`, and resource IO reads the ENVELOPE's metadata while deciding where raw bytes
+go.
+
+The second test is the important one. `resource_version` looks like exactly the same kind of
+per-document constant, and dropping it would be wrong: the retrieve path reads it from a stored
+record to decide `version_state`, falling back to a top-level field that sections do not carry, so
+removing it would make every chunk look current. Two fields, same shape, opposite answers -- so the
+test pins both directions.
+"""
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_core as core
+import matrixark_mcp_ingest_resource_chunk_records as ingest
+import matrixark_resource_parser as parser
+
+
+class _Writer:
+    def __init__(self):
+        self.buf = []
+
+    def append(self, record):
+        self.buf.append(record)
+
+
+def _sections():
+    filler = ("This paragraph gives the section enough substance to stand on its own rather "
+              "than being folded into a neighbouring section by the parser. ") * 6
+    lines = ["# Playbook"]
+    for index in range(6):
+        lines += ["", "## Step %d - do the thing" % index, filler]
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as handle:
+        handle.write(chr(10).join(lines))
+        path = handle.name
+    try:
+        chunks = parser.parse_resource(path, resource_type="skill", max_total_chunks=1000,
+                                       slim_chunk_metadata_fields=True)
+        writer = _Writer()
+        ingest.append_resource_chunk_records(
+            writer,
+            envelope={"kind": "skill", "scope": {}, "ingestion_time_ms": 1, "metadata": {},
+                      "messages": [], "resource_type": "skill", "raw_uri": path},
+            parsed_chunks=chunks, chunk_vectors=[[0.5, 0.5] for _ in chunks],
+            raw_uri=path, raw_uri_hash=1, resource_type="skill", resource_manifest_hash=2,
+            resource_import_task_hash=3, node_hash=4, node_path=["a"], access_scope={},
+            deployment_scope="local", resource_record_scope={}, skill_hash=5, skill_name="s",
+            skill_metadata={},
+            secondary_index_budget=core.new_secondary_index_budget(10000))
+        return [r for r in writer.buf if r.get("record_type") == "skill_section"]
+    finally:
+        os.unlink(path)
+
+
+class DocumentFactsAreNotRepeatedPerChunk(unittest.TestCase):
+    def setUp(self):
+        self.sections = _sections()
+        self.assertTrue(self.sections, "no sections written -- the harness is wrong")
+
+    def test_the_storage_policy_is_not_on_every_chunk(self):
+        for record in self.sections:
+            self.assertNotIn("raw_storage_policy", record.get("metadata") or {})
+
+    def test_the_resource_version_IS_still_on_every_chunk(self):
+        """Same shape, opposite answer: version_state is decided from this stored copy."""
+        for record in self.sections:
+            self.assertIn("resource_version", record.get("metadata") or {},
+                          "the retrieve path reads this from the stored record to decide "
+                          "version_state; without it every chunk looks current")
+
+    def test_a_reader_asking_a_chunk_for_the_policy_gets_the_documented_default(self):
+        """How the remaining readers ask, all of which default rather than require."""
+        for record in self.sections:
+            metadata = record.get("metadata") or {}
+            self.assertEqual("raw_uri_only",
+                             metadata.get("raw_storage_policy", "raw_uri_only"))
+
+    def test_the_index_terms_a_chunk_offers_are_unchanged(self):
+        """The scan derives terms from metadata; dropping a key must not change them."""
+        for record in self.sections:
+            terms = core.candidate_index_terms(record, {}, {})
+            self.assertTrue([t for t in terms if t.startswith("resource_type:")])
+            self.assertTrue([t for t in terms if t.startswith("unit_kind:")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_embedding_meta_restates_its_owner.py
+++ b/tools/test_matrixark_embedding_meta_restates_its_owner.py
@@ -76,7 +76,16 @@ class EmbeddingMetaDoesNotRestateItsOwner(unittest.TestCase):
         meta = _folded(_pair()).get("embedding_meta") or {}
         self.assertEqual("e5-small", meta.get("model"))
         self.assertEqual(2, meta.get("dim"))
-        self.assertEqual("skill_section", meta.get("embedding_type"))
+
+    def test_embedding_type_is_not_repeated_when_it_is_the_owners_record_type(self):
+        """For a chunk the fold's owner map is identity, so this restates record_type.
+
+        It is kept where the map is NOT identity -- summary owners carry node_l0, which
+        context_summary does not say -- and that case is covered in
+        test_matrixark_embedding_type_restates_record_type.
+        """
+        meta = _folded(_pair()).get("embedding_meta") or {}
+        self.assertNotIn("embedding_type", meta)
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_embedding_type_restates_record_type.py
+++ b/tools/test_matrixark_embedding_type_restates_record_type.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`embedding_meta` does not repeat the owner's record_type under another name.
+
+For a chunk the fold's owner map is identity -- `skill_section -> skill_section`,
+`resource_chunk -> resource_chunk` -- so `embedding_type` arrives equal to the owner's
+`record_type`, measured equal on 2510/2510 chunks of a 1 MB skill. 85.8 KB restating it.
+
+The map is NOT identity for the other six owner types: `event -> context_event`,
+`summary -> context_summary`, and so on. There the value says something the owner cannot --
+`node_l0` is not `context_summary` -- so it is compared rather than assumed, and a differing value
+is kept. That mismatch case is the test that matters.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from matrixark_mcp_local_adapter import fold_embedding_records
+
+
+def _folded(owner_type, embedding_type, id_field, ref_type):
+    owner = {"record_type": owner_type, id_field: 42, "text": "body"}
+    embedding = {
+        "record_type": "context_embedding",
+        "ref_type": ref_type,
+        "ref_hash": 42,
+        "vector": [0.5, 0.5],
+        "model": "e5-large",
+        "embedding_type": embedding_type,
+        "dim": 2,
+    }
+    out = fold_embedding_records([owner, embedding])
+    owners = [r for r in out if r.get("record_type") == owner_type]
+    assert owners, "the fold produced no owner -- the fixture is wrong"
+    return owners[0]
+
+
+class EmbeddingTypeIsNotRepeated(unittest.TestCase):
+    def test_a_chunk_does_not_repeat_its_own_record_type(self):
+        for owner_type, id_field, ref_type in (("skill_section", "section_hash", "skill_section"),
+                                               ("resource_chunk", "chunk_hash", "resource_chunk")):
+            meta = _folded(owner_type, owner_type, id_field, ref_type).get("embedding_meta") or {}
+            self.assertNotIn("embedding_type", meta,
+                             "%s already says what it is" % owner_type)
+
+    def test_a_differing_embedding_type_is_kept(self):
+        """The case that makes the drop safe: summary owners carry node_l0, not context_summary."""
+        meta = _folded("context_summary", "node_l0", "summary_hash", "summary").get("embedding_meta") or {}
+        self.assertEqual("node_l0", meta.get("embedding_type"),
+                         "node_l0 is not the owner's record_type and must survive")
+
+    def test_the_guard_fields_survive(self):
+        """dim and model identify the vector space; losing them is how retrieval goes to noise."""
+        meta = _folded("skill_section", "skill_section", "section_hash", "skill_section").get("embedding_meta") or {}
+        self.assertEqual("e5-large", meta.get("model"))
+        self.assertEqual(2, meta.get("dim"))
+
+    def test_the_vector_still_lands_on_the_owner(self):
+        owner = _folded("skill_section", "skill_section", "section_hash", "skill_section")
+        self.assertEqual([0.5, 0.5], owner.get("vector"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`raw_storage_policy` is decided once per document and was copied into every chunk's serving
metadata — **93.1 KB per 1 MB skill** for a value identical on all of them.

## No reader takes it from a stored chunk

- the dashboard reads the **top-level** field on manifest rows
- ingest reads the live `storage_resolution`, not a stored record
- resource IO reads the **envelope's** metadata while deciding where raw bytes go
- the two remaining mentions in the sanitizer are writes

Every reader that could see a chunk without it already defaults to `"raw_uri_only"`.

## resource_version is deliberately kept

It is the same shape and the same size class, and dropping it would be wrong. The retrieve path
reads it from a stored record to decide `version_state`, falling back to a top-level field that
sections do not carry — so removing it would quietly make **every chunk look current**.

Two fields that look alike with opposite answers, so the test pins both directions rather than only
the removal.

## Measured

| | before | after |
|---|---|---|
| ingest | 6.83 MB (6.4x) | **6.73 MB (6.3x)** |
| vectors | 50.9% | **51.7%** |

## Two sanitizer copies

The line exists in `matrixark_mcp_core` and `matrixark_mcp_resources`; both change together.
Patching one would have left half the write path still emitting it — the same shape as the
fourteen-call-site posting emitter earlier in this series.

## Checks

`*chunk*`, `*index*`, `*resource*`, `*skill*` all pass; new suite 4 passed.
