### PR TITLE
A chunk stored the resource type it already announces

### DIFF
--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2035,7 +2035,15 @@ def ordered_unique(values: list[str]) -> list[str]:
 
 RAW_BYTE_METADATA_FIELDS = {"raw_bytes", "file_bytes", "bytes", "binary", "payload_bytes", "data_url", "base64"}
 SERVING_RESOURCE_METADATA_FIELDS = {
-    "resource_type",
+    # `resource_type` is not carried: it restates what the record already says it is.
+    # candidate_index_terms derives both `resource_type:` and `source_type:` from the
+    # record_type -- a skill_section is a skill -- and dropping this copy loses no terms,
+    # checked against the derivation. 63.7 KB per 1 MB skill, identical on every row.
+    #
+    # `unit_kind` and `heading_slug` are NOT droppable with it: the same check shows each is
+    # the only source of its own term. `resource_version` produces no term, but the retrieve
+    # path compares it against the manifest's latest to decide version_state, and a manifest
+    # holding only the latest cannot supply a record's own ingested version.
     "resource_version",
     "unit_kind",
     "relative_path",


### PR DESCRIPTION
`metadata.resource_type` is the same string on every row of a document, and
`candidate_index_terms` derives **both** `resource_type:` and `source_type:` from the record's own
`record_type` — a `skill_section` is a skill.

Dropping the stored copy loses **no terms**, checked against the derivation rather than argued:

```
with metadata.resource_type : heading_slug:step-1, resource_type:skill, source_type:skill, unit_kind:markdown_section
without it                  : heading_slug:step-1, resource_type:skill, source_type:skill, unit_kind:markdown_section
terms lost                  : none
```

63.7 KB per 1 MB skill.

## What is deliberately kept

The same check run against the neighbours gives the opposite answer, which is why they stay:

| key | dropping it loses |
|---|---|
| `unit_kind` | `unit_kind:markdown_section` |
| `heading_slug` | `heading_slug:step-1` |
| `resource_type` | **nothing** |

`resource_version` yields no term either, but it is still kept: the retrieve path compares it
against the manifest's latest to decide `version_state` for resource chunks, and a manifest holding
only the *latest* cannot supply a record's own *ingested* version.

## Measured

| | before | after |
|---|---|---|
| ingest | 6.56 MB (6.1x) | **6.49 MB (6.0x)** |
| vectors | 53.1% | **53.6%** |

## Checks

`*chunk*`, `*index*`, `*document*`, `*embedding*`, `*skill*`, `*posting*` all pass.
