### PR TITLE
One vector, compared two ways

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -568,12 +568,35 @@ fn a_node_and_its_level_two_summary_share_one_embedding() {
     };
     let summary = summaries.first().expect("the extract wrote a level-2 summary");
     assert_eq!(summary.text, report.l1, "the summary that embeds the node's own text");
+
+    // The NODE as stored, not as reported. The summary above came back through a page, and every
+    // stored vector form rounds -- four decimal places for the uniformly-scaled encoding that is
+    // on by default, a per-vector scale for the int8 one -- so the value in the report is not the
+    // value on disk. Comparing the two would not be asserting that one vector reached both
+    // owners; it would be asserting that the encoding is lossless, which it is not and is not
+    // meant to be.
+    //
+    // Reading the node back is also the stronger claim of the two: it says the shared vector
+    // reached the durable record, not merely the report that the extract returned.
+    let node = match engine
+        .execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextGetNode {
+                tenant_hash: 81,
+                node_hash: report.node.node_hash,
+            },
+        })
+        .response
+    {
+        CommandResponse::ContextNode { node: Some(node), .. } => node,
+        other => panic!("expected the node back, got {other:?}"),
+    };
     assert!(
-        !report.node.vector.is_empty(),
+        !node.vector.is_empty(),
         "an empty node vector would make the comparison below vacuous"
     );
     assert_eq!(
-        summary.vector, report.node.vector,
+        summary.vector, node.vector,
         "the one vector `l1` produced belongs to both the node and its level-2 summary"
     );
 }


### PR DESCRIPTION
`a_node_and_its_level_two_summary_share_one_embedding` fails on main. It reads the
level-2 summary back through ContextQuerySummaries -- so that vector has been through a
page -- and compares it against `report.node.vector`, which is the value still in
memory:

    left:  [-0.2513,     0.0072,      -0.3175,     ...]
    right: [-0.25133738, 0.007248736, -0.31754488, ...]

Every stored vector form rounds. The uniformly-scaled encoding is on by default and
keeps four decimal places; the int8 form rounds to a per-vector scale. So the two sides
can never be equal, and what the assertion actually demands is that the encoding be
lossless -- which it is not, and is not meant to be.

Both sides now come off a page: the node is read back with ContextGetNode. That is also
the stronger of the two claims, because it says the shared vector reached the durable
record rather than only the report the extract returned.

The test's two halves both still bite, checked by breaking each one:

  * give the node a vector the summary did not get -> the comparison fails, with both
    sides rounded, so it is comparing like with like rather than passing on a
    technicality;
  * put the duplicate encoder request back -> the requested-vector count fails at 3
    against 2, which is the half that distinguishes "one request, shared" from "asked
    twice, answered the same way".

Nothing in CI reports this: the Rust workflow is a compile check and does not run the
library suite, so the whole of `cargo test --lib` is only ever seen locally. Run it
single-threaded -- the crate has around 180 std::env::set_var sites and races otherwise:

    cargo test -p temporalstore-rust --lib -- --test-threads=1

