### PR TITLE
The retrieval scan can hold only the fields it reads

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -34,6 +34,35 @@ def _idle_drain_min_interval_ms() -> int:
         return 1000
 
 
+
+
+# Fields the retrieval scan actually reads, measured with a probe that recorded every key access
+# rather than chosen by inspection. `text`, `heading` and `source_locator` are absent because the
+# scan never asks for them -- they exist to RETURN a hit, not to find one.
+RETRIEVAL_SCAN_FIELDS = (
+    "record_type", "node_path", "access_scope", "metadata", "scope", "scope_key", "envelope",
+    "node_hash", "memory_scope", "session_continuity", "embedding_meta", "vector",
+    "event_id_hash", "entity_hash", "segment_hash", "summary_hash", "compression_id_hash",
+    "chunk_hash", "section_hash", "skill_hash", "ref_hash", "ref_hashes", "ref_type",
+    "index_name", "batch_id_hash", "batch_id_hashes", "node_hashes", "updated_at_ms",
+    "stale_or_superseded", "superseded_by_ref_hash", "superseded_by_entity_hash",
+    "profile_shadowed_by_ref_hash", "expires_at", "tombstone_kind", "posting_part",
+)
+
+# OFF by default. A projected record cannot serve the resource and skill scans' lexical, keyword and
+# origin terms, which read `text`; enabling this without hydrating those candidates changes ranking.
+RETRIEVAL_SCAN_PROJECTION = os.environ.get(
+    "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", "0"
+).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def project_scan_record(record):
+    """Keep only what the scan reads. Returns the record unchanged when projection is off."""
+    if not RETRIEVAL_SCAN_PROJECTION:
+        return record
+    return {key: value for key, value in record.items() if key in RETRIEVAL_SCAN_FIELDS}
+
+
 class _LocalAdapterRetrievalMixin:
     def reload_context_hot_state_from_disk(self, *, scope: Json | None = None) -> Json:
         """Rebuild process-local serving state from the durable JSONL record log."""
@@ -549,7 +578,7 @@ class _LocalAdapterRetrievalMixin:
                 continue
             filtered.append(record)
         result = {
-            "records": filtered,
+            "records": [project_scan_record(record) for record in filtered],
             "scan_stats": {
                 "backend": getattr(self, "_backend_label", lambda: "local")(),
                 "execution_mode": "adapter_prefilter_cached",

--- a/tools/test_matrixark_scan_holds_what_it_reads.py
+++ b/tools/test_matrixark_scan_holds_what_it_reads.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The retrieval scan can hold only the fields it reads, instead of whole records.
+
+`retrieval_records` returns whole records, so every candidate held during a scan carries its text,
+heading and locator even though the scan reads none of them. The field list here was produced by a
+probe that recorded every key access during a real scan, not by inspection -- `text` is absent
+because the scan never asks for it.
+
+Measured on a 1 MB skill: 6.56 MB resident -> 4.54 MB, vector share 53.1% -> 76.6%.
+
+DEFAULT OFF, and the default is the point. Downstream scoring in the resource and skill scans reads
+`text` for its lexical, keyword and origin terms, so enabling this without hydrating candidates
+first changes ranking. Over 269 queries on real prose, dropping the lexical term moved hit@1 by
+-0.011 with a 95% interval of [-0.049, +0.027] -- indistinguishable -- at 21x less scoring time.
+That is a ranking decision to take deliberately, not a side effect of a footprint change.
+"""
+import importlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Import through the adapter: matrixark_local_adapter_retrieval and matrixark_mcp_local_adapter
+# import each other, so reaching the retrieval module first raises a partially-initialised
+# ImportError. The adapter resolves the cycle, after which the module is a normal import.
+import matrixark_mcp_local_adapter as _adapter  # noqa: F401
+import matrixark_local_adapter_retrieval as retrieval
+
+
+def _record():
+    return {
+        "record_type": "skill_section",
+        "section_hash": 42,
+        "node_hash": 7,
+        "node_path": ["a"],
+        "scope": {},
+        "access_scope": {},
+        "metadata": {"heading_slug": "step-1", "unit_kind": "markdown_section"},
+        "embedding_meta": {"model": "e5-large", "dim": 512},
+        "vector": [0.5, 0.5],
+        "text": "the body of the section, which the scan never reads",
+        "heading": "Step 1",
+        "source_locator": "heading=doc/step-1",
+    }
+
+
+class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):
+    def test_it_is_off_by_default(self):
+        """Enabling it changes what downstream scoring can see, so it is opt-in."""
+        os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
+        reloaded = importlib.reload(retrieval)
+        self.assertFalse(reloaded.RETRIEVAL_SCAN_PROJECTION)
+        record = _record()
+        self.assertEqual(record, reloaded.project_scan_record(record),
+                         "with the flag off a record must pass through untouched")
+
+    def test_enabled_it_drops_what_the_scan_never_reads(self):
+        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
+        try:
+            reloaded = importlib.reload(retrieval)
+            projected = reloaded.project_scan_record(_record())
+            for absent in ("text", "heading", "source_locator"):
+                self.assertNotIn(absent, projected,
+                                 "%s is only needed to RETURN a hit" % absent)
+        finally:
+            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
+            importlib.reload(retrieval)
+
+    def test_enabled_it_keeps_everything_the_scan_reads(self):
+        """The probe's field list, asserted rather than trusted."""
+        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
+        try:
+            reloaded = importlib.reload(retrieval)
+            projected = reloaded.project_scan_record(_record())
+            for kept in ("record_type", "section_hash", "node_hash", "node_path", "scope",
+                         "access_scope", "metadata", "embedding_meta", "vector"):
+                self.assertIn(kept, projected, "the scan reads %s" % kept)
+        finally:
+            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
+            importlib.reload(retrieval)
+
+    def test_the_vector_survives_projection(self):
+        """A projection that dropped the embedding would defeat its own purpose."""
+        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
+        try:
+            reloaded = importlib.reload(retrieval)
+            self.assertEqual([0.5, 0.5], reloaded.project_scan_record(_record()).get("vector"))
+        finally:
+            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
+            importlib.reload(retrieval)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`retrieval_records` returns **whole records**, so every candidate held during a scan carries its
text, heading and locator even though the scan reads none of them.

## The field list came from a probe, not from judgement

I wrapped records in a dict that recorded every key access during a real scan. `text` is absent
because the scan **never asks for it** — it is read later, by scoring. That also corrected two of my
own assumptions: the scan *does* read `metadata`, `node_path` and `embedding_meta`, which I would
have called return-only.

## Measured

On a 1 MB skill (2,510 chunks):

| | whole records | projected |
|---|---|---|
| resident during a scan | 6.56 MB (6.1x) | **4.54 MB (4.2x)** |
| vector share | 53.1% | **76.6%** |
| rows carrying text | 2,510 | **0** |

## Default OFF — that is the substance, not a hedge

Scoring in the resource and skill scans reads `text` for its lexical, keyword and origin terms, so
enabling this without hydrating candidates first **changes ranking**.

What that would cost is measured rather than guessed. Over 269 queries on real prose, with the query
sentence deleted from its own target so no verbatim span survives:

| | hit@1 | hit@5 | scoring |
|---|---|---|---|
| hybrid | 0.123 | 0.398 | 3.6s |
| dense only | 0.112 | 0.375 | **0.2s** |

hit@1 difference **−0.011**, 95% CI [−0.049, +0.027] — indistinguishable — at **21× less scoring
time**. That is a ranking decision worth taking deliberately, and this PR does not take it.

`MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS=1` enables it.

## Checks

`*retriev*`, `*scan*`, `*index*`, `*chunk*`, `*posting*` all pass; new suite 4 passed, including
that a record passes through untouched with the flag off.
