### PR TITLE
Maintain the object page lookup instead of rebuilding all of it per write

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/tests.rs
+++ b/crates/temporalstore-rust/src/context_workflow/tests.rs
@@ -3499,6 +3499,455 @@ fn what_the_discarded_node_text_costs() {
     println!("     candidate for the whole node fetch. Worth building only if it is a real share.");
 }
 
+/// Which of the writes an ingest makes is the one that grows with the store?
+///
+/// One add allocates 5,293 / 13,099 / 32,629 at 40 / 120 / 320 memories, a bare `ContextUpsertNode`
+/// is flat at ~188, bucket-index visits per add are 3 and flat, and the ingest no longer calls the
+/// reconstruct. So the growth is in one of the other writes, and each lands in a different
+/// structure.
+///
+/// Measures each on stores grown by REAL ingests, and reports growth per command. A flat command is
+/// cleared; a rising one is the answer.
+///
+///   cargo test --features alloc-probe --lib which_ingest_write_grows_with_the_store -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn which_ingest_write_grows_with_the_store() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    const TENANT: u64 = 8201;
+
+    fn grown(rung: usize) -> TemporalEngine {
+        let dir = Box::leak(Box::new(tempfile::tempdir().unwrap()));
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: TENANT,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: TENANT,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("CMDB-{index:06}"),
+                        title: format!("cmd {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+        engine
+    }
+
+    fn measure(engine: &TemporalEngine, tag: u64, command: impl Fn(u64) -> Command) -> u64 {
+        // Warm with a different key, then measure a fresh one: the first write of a shape touches
+        // one-off structures that are not part of a steady-state write.
+        let warm = engine.execute(ExecuteRequest { shard_id: 1, command: command(tag) });
+        assert!(warm.status.ok, "warm: {:?}", warm.status);
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest { shard_id: 1, command: command(tag + 1) });
+        assert!(out.status.ok, "measured: {:?}", out.status);
+        probe.stop().allocs
+    }
+
+    let small = grown(40);
+    let large = grown(320);
+
+    println!(
+        "
+  command                     corpus 40   corpus 320   growth
+"
+    );
+
+    let node = |hash: u64| Command::ContextUpsertNode {
+        tenant_hash: TENANT,
+        node: crate::types::ContextNode {
+            node_hash: hash,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: format!("session/probe-{hash}"),
+            l0: "probe node".to_string(),
+            status: 0,
+            last_event_time_ms: 1_781_700_000_000,
+            l1_ref: String::new(),
+            raw_metadata_ref: String::new(),
+            vector: vec![0.25_f32; 16],
+            embedding_model_hash: 7,
+            embedding_updated_at_ms: 1,
+            summary_vector: vec![0.5_f32; 16],
+            summary_vector_valid_from_ms: 1_781_700_000_000,
+            summary_vector_model_hash: 7,
+        },
+    };
+    let summary = |hash: u64| Command::ContextUpsertSummary {
+        tenant_hash: TENANT,
+        summary: crate::types::ContextSummary {
+            node_hash: hash,
+            level: 2,
+            text: "a probe summary of ordinary length for one turn".to_string(),
+            valid_from_ms: 1_781_700_000_000,
+            vector: vec![0.5_f32; 16],
+            embedding_model_hash: 7,
+        },
+    };
+
+    for (label, small_n, large_n) in [
+        ("ContextUpsertNode", measure(&small, 9_100_000, node), measure(&large, 9_200_000, node)),
+        (
+            "ContextUpsertSummary",
+            measure(&small, 9_300_000, summary),
+            measure(&large, 9_400_000, summary),
+        ),
+    ] {
+        println!(
+            "  {label:<26} {small_n:>9}   {large_n:>10}   {:>6.2}x",
+            large_n as f64 / small_n.max(1) as f64,
+        );
+    }
+    println!(
+        "
+  growth ~1x   => that write is not the cost.
+  growth >>1x  => it is, and its structure is where an ingest's corpus-proportional work lives.
+"
+    );
+}
+
+/// Does the per-ingest bucket-index reconstruct explain add's corpus-proportional cost?
+///
+/// One add allocates 5,293 / 13,099 / 32,629 at 40 / 120 / 320 memories while a bare engine write is
+/// flat at 188 / 188 / 190, so the growth sits above the engine inside `ingest_extract_context`.
+/// That function closes its coalescing window and calls `reconstruct_bucket_index_now`, which walks
+/// every live page in the shard.
+///
+/// Measuring the reconstruct alone against the same rungs decides it: growth here means the walk IS
+/// the cost and the remedy is for context writes to maintain the index rather than ask for a
+/// rebuild; flat here means the hypothesis is wrong and extraction is hiding it somewhere else.
+///
+///   cargo test --features alloc-probe --lib does_the_per_ingest_reconstruct_explain_the_growth -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_the_per_ingest_reconstruct_explain_the_growth() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  corpus   reconstruct allocs   reconstruct bytes   vs first rung
+"
+    );
+    let mut first: Option<u64> = None;
+    for rung in [40_usize, 120, 320] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 7801,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 7801,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("RECON-{index:06}"),
+                        title: format!("recon {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        // The reconstruct on its own, on a store of this size. Warm first: the call is idempotent,
+        // so a second one measures steady state rather than whatever the last ingest left dirty.
+        engine.reconstruct_bucket_index_now(1);
+        let probe = crate::alloc_probe::Probe::start();
+        engine.reconstruct_bucket_index_now(1);
+        let counts = probe.stop();
+
+        let ratio = match first {
+            Some(base) if base > 0 => counts.allocs as f64 / base as f64,
+            _ => {
+                first = Some(counts.allocs);
+                1.0
+            }
+        };
+        println!(
+            "  {rung:>6}   {:>18}   {:>17}   {ratio:>13.2}x",
+            counts.allocs, counts.alloc_bytes,
+        );
+    }
+    println!(
+        "
+  Compare against the add itself: 5,293 / 13,099 / 32,629 allocations, 6.16x across these rungs.
+  A reconstruct that tracks those numbers is the cost; one that is flat clears it.
+"
+    );
+}
+
+/// Is add's corpus-proportional allocation in the engine write, or in the extraction above it?
+///
+/// One add allocates 5,293 / 13,099 / 32,629 times at 40 / 120 / 320 memories -- 6.16x for an 8x
+/// corpus. The bucket-index rebuild is not the cause (that is 3 visits per add now), so something
+/// else is proportional to the store.
+///
+/// This measures a BARE `ContextUpsertNode` against stores grown to the same sizes. A bare write
+/// that stays flat puts the growth above the engine, in the extraction pipeline; one that rises
+/// puts it in the write path itself. The two need different fixes, which is why it is worth
+/// separating before looking anywhere.
+///
+///   cargo test --features alloc-probe --lib where_does_an_adds_corpus_proportional_cost_live -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn where_does_an_adds_corpus_proportional_cost_live() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  corpus   bare write allocs   bare write bytes   vs first rung
+"
+    );
+    let mut first: Option<u64> = None;
+    for rung in [40_usize, 120, 320] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Grow the store with REAL adds, so the bare write below sees a realistic store rather
+        // than one containing only nodes.
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 7701,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 7701,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("BISECT-{index:06}"),
+                        title: format!("bisect {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        let node = crate::types::ContextNode {
+            node_hash: 9_000_000 + rung as u64,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: format!("session/bare-{rung}"),
+            l0: "a bare write, carrying no extraction".to_string(),
+            status: 0,
+            last_event_time_ms: 1_781_700_000_000,
+            l1_ref: String::new(),
+            raw_metadata_ref: String::new(),
+            vector: vec![0.25_f32; 16],
+            embedding_model_hash: 7,
+            embedding_updated_at_ms: 1,
+            summary_vector: vec![0.5_f32; 16],
+            summary_vector_valid_from_ms: 1_781_700_000_000,
+            summary_vector_model_hash: 7,
+        };
+        // Warm: the first write of a session touches one-off structures.
+        let warm = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode { tenant_hash: 7701, node: node.clone() },
+        });
+        assert!(warm.status.ok, "{:?}", warm.status);
+
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode { tenant_hash: 7701, node },
+        });
+        assert!(out.status.ok, "{:?}", out.status);
+        let counts = probe.stop();
+
+        let ratio = match first {
+            Some(base) if base > 0 => counts.allocs as f64 / base as f64,
+            _ => {
+                first = Some(counts.allocs);
+                1.0
+            }
+        };
+        println!(
+            "  {rung:>6}   {:>17}   {:>16}   {ratio:>13.2}x",
+            counts.allocs, counts.alloc_bytes,
+        );
+    }
+    println!(
+        "
+  bare write FLAT   => the growth is above the engine, in the extraction pipeline.
+  bare write RISING => the engine write path itself does work proportional to the store.
+"
+    );
+}
+
+/// What does one add allocate, and does it grow with the corpus?
+///
+/// `add` is the largest single cost in the API matrix, and the only thing measured about it so far
+/// is bucket-index visits. Allocation is a separate question: a constant-allocation add is
+/// acceptable however slow, while one that allocates in proportion to the store is the quadratic
+/// shape the index work removed, resurfacing somewhere else.
+///
+/// Measures the LAST add at each rung, so the figure is what an add costs on a store of that size
+/// rather than an average smeared across the growth.
+///
+///   cargo test --features alloc-probe --lib what_one_add_allocates_as_the_corpus_grows -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_one_add_allocates_as_the_corpus_grows() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    fn one_add(engine: &TemporalEngine, index: usize) {
+        let report = ingest_extract_context(
+            engine,
+            ContextIngestExtractRequest {
+                shard_id: 1,
+                tenant_hash: 7601,
+                sources: vec![ContextExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 7601,
+                    source_kind: ContextSourceKind::Incident,
+                    source_id: format!("ALLOCADD-{index:06}"),
+                    title: format!("add {index}"),
+                    body: format!(
+                        "{}{}",
+                        format!("entry {index} covering the depot rota "),
+                        "context payload sentence. ".repeat(40)
+                    ),
+                    timestamp_ms: 1_000 + index as u64,
+                    provider: ContextModelProviderConfig::default(),
+                }],
+                provider: ContextModelProviderConfig::default(),
+                start_time_ms: 0,
+                end_time_ms: 0,
+                max_events: 0,
+                query: String::new(),
+            },
+        );
+        assert!(report.status.ok, "add {index} failed: {:?}", report.status);
+    }
+
+    println!(
+        "
+  corpus   allocs for one add   bytes for one add   allocs vs first rung
+"
+    );
+    let mut first: Option<u64> = None;
+    for rung in [40_usize, 120, 320] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        // Grow to one short of the rung, then measure the add that lands ON it.
+        for index in 0..rung.saturating_sub(1) {
+            one_add(&engine, index);
+        }
+        let probe = crate::alloc_probe::Probe::start();
+        one_add(&engine, rung - 1);
+        let counts = probe.stop();
+        let ratio = match first {
+            Some(base) if base > 0 => counts.allocs as f64 / base as f64,
+            _ => {
+                first = Some(counts.allocs);
+                1.0
+            }
+        };
+        println!(
+            "  {rung:>6}   {:>18}   {:>17}   {ratio:>20.2}x",
+            counts.allocs, counts.alloc_bytes,
+        );
+    }
+    println!(
+        "
+  ratio flat across rungs => an add costs the same on a big store as a small one.
+  ratio rising with corpus => the add path still does work proportional to the store.
+"
+    );
+}
+
 /// How many allocations does one retrieve make, and how does that scale with the corpus?
 ///
 /// Bytes decoded are not the interesting quantity on their own: with a production-width vector the
@@ -4668,5 +5117,166 @@ fn a_copy_from_a_replaced_encoder_is_declined_and_counted() {
         0, retrieve.fanout_plan.summary_lookup_nodes,
         "the copy already answered; reading the summary again would reach the same verdict and \
          count it twice"
+    );
+}
+
+
+/// Does a summary write fall through to a full bucket-index rebuild?
+///
+/// Every piece of the summary arm measures flat: the series append is 35 allocations at both 40 and
+/// 320 memories, the plain value append 8, and disabling the node-copy path gives byte-identical
+/// counts. Yet `ContextUpsertSummary` costs 1,553 allocations at 40 and 10,667 at 320 while
+/// `ContextUpsertNode` stays at ~190. The cost is therefore not the write but what the post-write
+/// path does after it: maintain the bucket index for the touched keys, or -- when maintenance does
+/// not cover them -- rebuild it, walking every live page in the shard.
+///
+/// `live_page_scan_entries` counts exactly the entries that walk materializes, so it separates the
+/// two outcomes by measurement rather than by reading:
+///
+///   live entries ~0           => maintenance covered the write
+///   live entries ~ store size => it did not, and every write of that shape is O(store)
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib does_a_summary_write_rebuild_the_whole_index -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_a_summary_write_rebuild_the_whole_index() {
+    const TENANT: u64 = 7907;
+
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    let node = |hash: u64| Command::ContextUpsertNode {
+        tenant_hash: TENANT,
+        node: crate::types::ContextNode {
+            node_hash: hash,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: format!("session/rebuild-{hash}"),
+            l0: "probe node".to_string(),
+            status: 0,
+            last_event_time_ms: 1_781_700_000_000,
+            l1_ref: String::new(),
+            raw_metadata_ref: String::new(),
+            vector: vec![0.25_f32; 16],
+            embedding_model_hash: 7,
+            embedding_updated_at_ms: 1,
+            summary_vector: vec![0.5_f32; 16],
+            summary_vector_valid_from_ms: 1_781_700_000_000,
+            summary_vector_model_hash: 7,
+        },
+    };
+    let summary = |hash: u64| Command::ContextUpsertSummary {
+        tenant_hash: TENANT,
+        summary: crate::types::ContextSummary {
+            node_hash: hash,
+            level: 2,
+            text: "a probe summary of ordinary length for one turn".to_string(),
+            valid_from_ms: 1_781_700_000_000,
+            vector: vec![0.5_f32; 16],
+            embedding_model_hash: 7,
+        },
+    };
+
+    // Warm with one key, measure a different one: the first write of a shape touches one-off
+    // structures that are not part of a steady-state write.
+    fn measure(
+        engine: &TemporalEngine,
+        tag: u64,
+        command: impl Fn(u64) -> Command,
+    ) -> (u64, u64, u64, u64, u64, u64) {
+        let warm = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: command(tag),
+        });
+        assert!(warm.status.ok, "warm: {:?}", warm.status);
+        crate::engine::reset_live_page_scan_entries();
+        crate::engine::bucket_visit_sites::reset();
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: command(tag + 1),
+        });
+        let allocs = probe.stop().allocs;
+        assert!(out.status.ok, "measured: {:?}", out.status);
+        let (layout, clear_dirty, refresh, remove_all) = crate::engine::bucket_visit_sites::snapshot();
+        (
+            allocs,
+            crate::engine::live_page_scan_entries(),
+            layout,
+            clear_dirty,
+            refresh,
+            remove_all,
+        )
+    }
+
+    println!(
+        "
+  corpus   command                  allocs   live   layout   clear_dirty   refresh   remove_all
+"
+    );
+
+    for rung in [40_usize, 320] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: TENANT,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: TENANT,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("REBUILD-{index:06}"),
+                        title: format!("rebuild {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        let node_row = measure(&engine, 9_500_000 + rung as u64 * 10, node);
+        let summary_row = measure(&engine, 9_700_000 + rung as u64 * 10, summary);
+        for (label, row) in [
+            ("ContextUpsertNode   ", node_row),
+            ("ContextUpsertSummary", summary_row),
+        ] {
+            let (allocs, live, layout, clear_dirty, refresh, remove_all) = row;
+            println!(
+                "  {rung:>6}   {label}  {allocs:>9}   {live:>4}   {layout:>6}   {clear_dirty:>11}   {refresh:>7}   {remove_all:>10}"
+            );
+        }
+    }
+
+    println!(
+        "
+  live is 0 everywhere: no rebuild fires. Whichever of the remaining columns rises with the corpus
+  is the walk that makes a summary write cost 54x a node write; if none rises, the cost is not a
+  bucket walk at all and the next cut is inside the maintenance call itself.
+"
     );
 }

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -682,7 +682,7 @@ impl CoreIndex {
                     .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                     .map(|page| {
                         !page.deleted
-                            && page.model_id == Arc::from(model_id)
+                            && &*page.model_id == model_id
                             && page.object_key == object_key
                             && page.component.as_deref() == component
                             && same_page_address(&page.address, address)
@@ -698,7 +698,7 @@ impl CoreIndex {
         self.bucket_map.values().any(|bucket| {
             bucket.page_index.values().any(|page| {
                 !page.deleted
-                    && page.model_id == Arc::from(model_id)
+                    && &*page.model_id == model_id
                     && page.object_key == object_key
                     && page.component.as_deref() == component
                     && same_page_address(&page.address, address)

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -972,7 +972,7 @@ pub(super) fn rebuild_unserialized_model_maps_from_bucket_index(shard: &mut Shar
     }
     let mut hashes = HashMap::<String, HashMap<String, BlockAddress>>::new();
     for entry in collect_bucket_index_live_page_entries(shard) {
-        if entry.deleted || entry.kind != Arc::from("hash") {
+        if entry.deleted || &*entry.kind != "hash" {
             continue;
         }
         hashes
@@ -1485,7 +1485,20 @@ pub(super) fn sync_bucket_index_object_pages(
 ) {
     let mut touched_buckets = BTreeSet::new();
     let mut removed_any = false;
-    let target_buckets = if shard.bucket_index.object_page_lookup.is_empty() {
+    // An empty lookup means "not established yet", which callers read as a signal to fall back to
+    // scanning. Establishing it still walks the buckets; maintaining an established one must not.
+    //
+    // The ref total counts as part of being established. Only a rebuild can set it -- a count that
+    // starts at "unknown" cannot be incremented into a right answer -- and the load path fills the
+    // lookup without it, so a shard can come up with entries and no total. The wholesale rebuild
+    // this replaces re-established the total on every series write, which hid that. Tie the two
+    // together instead: either both are established or the next write establishes both.
+    let lookup_needs_establishing = shard.bucket_index.object_page_lookup.is_empty()
+        || shard.bucket_index.object_component_page_refs.is_none();
+    // Components whose pages this call drops, so the lookup can be corrected for exactly those
+    // instead of being rebuilt from every page in the shard.
+    let mut removed_components: BTreeSet<Option<Arc<str>>> = BTreeSet::new();
+    let target_buckets = if lookup_needs_establishing {
         shard
             .bucket_index
             .bucket_map
@@ -1509,8 +1522,13 @@ pub(super) fn sync_bucket_index_object_pages(
             continue;
         };
         let before = bucket.page_index.len();
-        bucket.page_index
-            .retain(|_, page| !(page.model_id == Arc::from(kind) && page.object_key == object_key));
+        bucket.page_index.retain(|_, page| {
+            let matches_object = &*page.model_id == kind && page.object_key == object_key;
+            if matches_object {
+                removed_components.insert(page.component.clone());
+            }
+            !matches_object
+        });
         if bucket.page_index.len() != before {
             removed_any = true;
             touched_buckets.insert(routing_bucket);
@@ -1521,6 +1539,17 @@ pub(super) fn sync_bucket_index_object_pages(
             }
             bucket.in_memory = !bucket.page_index.is_empty();
             update_bucket_layout(bucket);
+        }
+    }
+
+    if !lookup_needs_establishing {
+        // Only this object's own entries were dropped above, so only they need correcting.
+        for component in &removed_components {
+            shard.bucket_index.remove_object_page_lookup_entry(
+                kind,
+                object_key,
+                component.as_deref(),
+            );
         }
     }
 
@@ -1576,20 +1605,25 @@ pub(super) fn sync_bucket_index_object_pages(
         bucket.in_memory = true;
         bucket.object_index.insert(object_id);
         bucket.deleted_object_index.remove(&object_id);
-        bucket.page_index.insert(
-            page_index_ref_key(&entry),
-            PageIndex {
-                object_key: entry.object_key,
-                model_id: entry.kind,
-                component: entry.component.clone(),
-                object_id,
-                address: entry.address,
-                dirty: entry.dirty,
-                deleted: entry.deleted,
-                log_backed: entry.log_backed,
-            },
-        );
+        let page_ref_key = page_index_ref_key(&entry);
+        let page = PageIndex {
+            object_key: entry.object_key,
+            model_id: entry.kind,
+            component: entry.component.clone(),
+            object_id,
+            address: entry.address,
+            dirty: entry.dirty,
+            deleted: entry.deleted,
+            log_backed: entry.log_backed,
+        };
+        bucket.page_index.insert(Arc::clone(&page_ref_key), page.clone());
         update_bucket_layout(bucket);
+        // The bucket borrow has to end before the lookup, which borrows the index itself.
+        if !lookup_needs_establishing {
+            shard
+                .bucket_index
+                .insert_object_page_lookup(routing_bucket, page_ref_key, &page);
+        }
     }
 
     if removed_any || dirty {
@@ -1598,7 +1632,9 @@ pub(super) fn sync_bucket_index_object_pages(
             .bucket_map
             .retain(|_, bucket| !bucket.page_index.is_empty() || !bucket.object_index.is_empty());
     }
-    shard.bucket_index.rebuild_object_page_lookup();
+    if lookup_needs_establishing {
+        shard.bucket_index.rebuild_object_page_lookup();
+    }
 }
 
 pub(super) fn classify_bucket_layout(object_count: usize, page_ref_count: usize) -> BucketLayoutState {

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -975,7 +975,7 @@ pub(super) fn storage_feature_page_layout_report(
         });
         report.unique_timestamped_page_refs = report.unique_timestamped_page_refs.saturating_add(1);
         family.unique_page_refs = family.unique_page_refs.saturating_add(1);
-        if entry.kind == Arc::from("feature") {
+        if &*entry.kind == "feature" {
             report.unique_feature_page_refs = report.unique_feature_page_refs.saturating_add(1);
         }
         match page_store.read(&entry.address) {
@@ -984,7 +984,7 @@ pub(super) fn storage_feature_page_layout_report(
                     report.packed_timestamped_pages =
                         report.packed_timestamped_pages.saturating_add(1);
                     family.packed_pages = family.packed_pages.saturating_add(1);
-                    if entry.kind == Arc::from("feature") {
+                    if &*entry.kind == "feature" {
                         report.packed_feature_pages = report.packed_feature_pages.saturating_add(1);
                     }
                     for point in points {
@@ -1012,7 +1012,7 @@ pub(super) fn storage_feature_page_layout_report(
                     report.legacy_timestamped_value_pages =
                         report.legacy_timestamped_value_pages.saturating_add(1);
                     family.legacy_value_pages = family.legacy_value_pages.saturating_add(1);
-                    if entry.kind == Arc::from("feature") {
+                    if &*entry.kind == "feature" {
                         report.legacy_feature_value_pages =
                             report.legacy_feature_value_pages.saturating_add(1);
                     }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3682,3 +3682,701 @@ fn how_scattered_are_node_extents_after_a_real_ingest() {
 "
     );
 }
+
+
+/// Does the per-ingest bucket-index reconstruct change anything, or recompute what is already right?
+///
+/// It costs 94% of an add's allocations at 320 memories and grows with the store. Since a context
+/// write now maintains the index rather than asking for a rebuild, the rebuild at the end of each
+/// ingest may be pure overhead -- and if it is, skipping it removes almost all of an add's
+/// allocation.
+///
+/// Snapshots every bucket before and after, and reports the buckets that differ. A difference is
+/// not a failure of this test: it names precisely what a write still fails to maintain, which is
+/// the next thing to fix.
+///
+///   cargo test -p temporalstore-rust --lib does_the_per_ingest_reconstruct_change_anything -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_the_per_ingest_reconstruct_change_anything() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+
+    /// (routing bucket, pages, live object ids, tombstoned ids, layout, deleted, in_memory)
+    type Shape = (u32, usize, usize, usize, String, bool, bool);
+
+    fn snapshot(engine: &TemporalEngine) -> Vec<Shape> {
+        let shards = engine.shards.read().expect("engine lock poisoned");
+        let shard = shards.get(&1).expect("loaded shard");
+        let mut out: Vec<Shape> = shard
+            .bucket_index
+            .bucket_map
+            .iter()
+            .map(|(routing_bucket, bucket)| {
+                (
+                    *routing_bucket,
+                    bucket.page_index.len(),
+                    bucket.object_index.len(),
+                    bucket.deleted_object_index.len(),
+                    format!("{:?}", bucket.layout),
+                    bucket.deleted,
+                    bucket.in_memory,
+                )
+            })
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    for rung in [40_usize, 160] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 7901,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 7901,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("REDUN-{index:06}"),
+                        title: format!("redundancy {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        // The ingest already ran a reconstruct at its end. Snapshot, run another, compare: a
+        // reconstruct that changes nothing on an already-reconstructed store is idempotent, which
+        // is necessary but not sufficient. The interesting case is the one below it.
+        let before_idempotent = snapshot(&engine);
+        engine.reconstruct_bucket_index_now(1);
+        let after_idempotent = snapshot(&engine);
+
+        // The real question: does a reconstruct change anything after ONE MORE plain write, which
+        // is what the ingest's own final reconstruct is there to absorb?
+        let node = crate::types::ContextNode {
+            node_hash: 8_500_000 + rung as u64,
+            parent_hash: 0,
+            kind: 1,
+            canonical_name: format!("session/redun-{rung}"),
+            l0: "one more write, then reconstruct".to_string(),
+            status: 0,
+            last_event_time_ms: 1_781_700_000_000,
+            l1_ref: String::new(),
+            raw_metadata_ref: String::new(),
+            vector: vec![0.25_f32; 16],
+            embedding_model_hash: 7,
+            embedding_updated_at_ms: 1,
+            summary_vector: vec![0.5_f32; 16],
+            summary_vector_valid_from_ms: 1_781_700_000_000,
+            summary_vector_model_hash: 7,
+        };
+        let wrote = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode { tenant_hash: 7901, node },
+        });
+        assert!(wrote.status.ok, "{:?}", wrote.status);
+        let before_write = snapshot(&engine);
+        engine.reconstruct_bucket_index_now(1);
+        let after_write = snapshot(&engine);
+
+        let idempotent_differs = before_idempotent
+            .iter()
+            .zip(after_idempotent.iter())
+            .filter(|(a, b)| a != b)
+            .count()
+            + before_idempotent.len().abs_diff(after_idempotent.len());
+        let write_differs = before_write
+            .iter()
+            .zip(after_write.iter())
+            .filter(|(a, b)| a != b)
+            .count()
+            + before_write.len().abs_diff(after_write.len());
+
+        println!(
+            "  corpus {rung:>4}: buckets {:>4}   reconstruct-after-reconstruct differs in {idempotent_differs}   reconstruct-after-one-write differs in {write_differs}",
+            before_idempotent.len(),
+        );
+        if write_differs > 0 {
+            for (a, b) in before_write.iter().zip(after_write.iter()).filter(|(a, b)| a != b).take(3)
+            {
+                println!("      before {a:?}");
+                println!("      after  {b:?}");
+            }
+        }
+    }
+    println!(
+        "
+  both columns 0 => the reconstruct recomputes an index the writes already maintain, and the
+                    ingest's final call is removable (94% of an add's allocations at 320 memories).
+  non-zero      => that difference is what a write still fails to maintain; fix that first.
+"
+    );
+}
+
+
+/// Full-contents version of the reconstruct-redundancy question.
+///
+/// The shape comparison said a reconstruct changes nothing, but it compared counts after a bare
+/// node write. Removing a call that keeps a durable index correct deserves the strong form: every
+/// page entry's identity, address and flags, captured after a COMPLETE ingest rather than one
+/// write.
+///
+///   cargo test -p temporalstore-rust --lib deep_compare_the_index_a_reconstruct_produces -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn deep_compare_the_index_a_reconstruct_produces() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+
+    /// Every field of every page entry, ordered, so two indexes compare exactly.
+    fn deep(engine: &TemporalEngine) -> Vec<String> {
+        let shards = engine.shards.read().expect("engine lock poisoned");
+        let shard = shards.get(&1).expect("loaded shard");
+        let mut rows: Vec<String> = Vec::new();
+        for (routing_bucket, bucket) in shard.bucket_index.bucket_map.iter() {
+            for (field_key, page) in bucket.page_index.iter() {
+                rows.push(format!(
+                    "{routing_bucket}|{field_key}|{}|{}|{:?}|{}|{}|{}|{}|{}|{}|{}|{}",
+                    page.object_key,
+                    page.model_id,
+                    page.component,
+                    page.object_id,
+                    page.address.page_slab_id,
+                    page.address.offset,
+                    page.address.length,
+                    page.dirty,
+                    page.deleted,
+                    page.log_backed,
+                    bucket.layout as u8 as u32,
+                ));
+            }
+            for object_id in bucket.object_index.iter() {
+                rows.push(format!("{routing_bucket}|obj|{object_id}"));
+            }
+            for object_id in bucket.deleted_object_index.iter() {
+                rows.push(format!("{routing_bucket}|tomb|{object_id}"));
+            }
+        }
+        rows.sort_unstable();
+        rows
+    }
+
+    for rung in [30_usize, 120] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        let mut ingest = |index: usize| {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 8101,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 8101,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("DEEP-{index:06}"),
+                        title: format!("deep {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "ingest {index}: {:?}", report.status);
+        };
+
+        for index in 0..rung {
+            ingest(index);
+        }
+
+        // A COMPLETE ingest, then compare the index before and after a reconstruct. The ingest ran
+        // its own reconstruct at the end, so this asks whether a further one would find anything to
+        // change -- which is exactly what removing the call would rely on.
+        ingest(rung);
+        let before = deep(&engine);
+        engine.reconstruct_bucket_index_now(1);
+        let after = deep(&engine);
+
+        let only_before = before.iter().filter(|row| !after.contains(row)).count();
+        let only_after = after.iter().filter(|row| !before.contains(row)).count();
+        println!(
+            "  corpus {rung:>4}: {} page/index rows   only-before {only_before}   only-after {only_after}",
+            before.len(),
+        );
+        for row in before.iter().filter(|row| !after.contains(row)).take(2) {
+            println!("      lost by reconstruct: {row}");
+        }
+        for row in after.iter().filter(|row| !before.contains(row)).take(2) {
+            println!("      added by reconstruct: {row}");
+        }
+    }
+    println!(
+        "
+  both 0 => the reconstruct reproduces the index the writes already built, entry for entry, and
+            the ingest's final call can go (94% of an add's allocations at 320 memories).
+  non-0  => those rows are what a write fails to maintain, and are the thing to fix instead.
+"
+    );
+}
+
+
+/// Series append or block-store append: which one grows with the store?
+///
+/// `ContextUpsertSummary` costs 1,553 allocations at 40 memories and 10,667 at 320, while
+/// `ContextUpsertNode` is flat at ~194. They differ in their write primitive, so measure the
+/// primitives directly on grown stores with FRESH keys -- nothing merges into an existing series,
+/// so anything that grows is responding to the store rather than to the key.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib which_write_primitive_grows_with_the_store -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn which_write_primitive_grows_with_the_store() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+    use crate::types::FeaturePoint;
+
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  primitive                        corpus 40   corpus 320   growth
+"
+    );
+
+    let mut series_small = 0_u64;
+    let mut series_large = 0_u64;
+    let mut value_small = 0_u64;
+    let mut value_large = 0_u64;
+
+    for (rung, series_out, value_out) in [
+        (40_usize, &mut series_small, &mut value_small),
+        (320_usize, &mut series_large, &mut value_large),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: 8301,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: 8301,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("PRIM-{index:06}"),
+                        title: format!("prim {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        let payload = vec![7_u8; 512];
+        let shards = engine.shards.read().expect("engine lock poisoned");
+        let _ = shards.get(&1).expect("loaded shard");
+        drop(shards);
+
+        // The series primitive, on a fresh key.
+        let warm_key = format!("probe:series:warm:{rung}");
+        let _ = super::packed_pages::append_timestamped_kv_pages(
+            &engine.cache,
+            &engine.page_store,
+            1,
+            "context_summary",
+            &warm_key,
+            vec![FeaturePoint { timestamp_ms: 1, value: payload.clone() }],
+            0,
+            false,
+        );
+        let key = format!("probe:series:{rung}");
+        let probe = crate::alloc_probe::Probe::start();
+        let _ = super::packed_pages::append_timestamped_kv_pages(
+            &engine.cache,
+            &engine.page_store,
+            1,
+            "context_summary",
+            &key,
+            vec![FeaturePoint { timestamp_ms: 1, value: payload.clone() }],
+            0,
+            false,
+        );
+        *series_out = probe.stop().allocs;
+
+        // The plain value append, for contrast.
+        let _ = super::append_value(
+            &engine.cache,
+            &engine.page_store,
+            1,
+            &payload,
+            Some(9_900_000 + rung as u64),
+            Some(0),
+            false,
+        );
+        let probe = crate::alloc_probe::Probe::start();
+        let _ = super::append_value(
+            &engine.cache,
+            &engine.page_store,
+            1,
+            &payload,
+            Some(9_950_000 + rung as u64),
+            Some(0),
+            false,
+        );
+        *value_out = probe.stop().allocs;
+    }
+
+    println!(
+        "  append_timestamped_kv_pages    {series_small:>9}   {series_large:>10}   {:>6.2}x",
+        series_large as f64 / series_small.max(1) as f64,
+    );
+    println!(
+        "  append_value                   {value_small:>9}   {value_large:>10}   {:>6.2}x",
+        value_large as f64 / value_small.max(1) as f64,
+    );
+    println!(
+        "
+  series grows, value flat => the series primitive is the cost.
+  both grow                => the block-store append beneath them is.
+  neither grows            => the cost is elsewhere in the command arm.
+"
+    );
+}
+
+
+/// What does post-write index maintenance cost, per key kind?
+///
+/// A summary write costs 1,554 allocations at 40 memories and 10,671 at 320; a node write is flat
+/// at ~197. The append primitives underneath both are flat, no rebuild fires, and every counted
+/// bucket walk is flat -- so the cost is in the maintenance that succeeds, not in the write and not
+/// in a fallback. The two arms differ in which branch of `sync_context_pages_for_object` they take:
+/// a node's page is filed under `shard.hashes` and goes through `upsert_bucket_index_page_with`, a
+/// summary is a timestamped series and goes through `sync_bucket_index_object_pages`.
+///
+/// Calling maintenance directly, on the same grown stores, one key of each kind, decides it.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_post_write_maintenance_costs_per_key_kind -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_post_write_maintenance_costs_per_key_kind() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+
+    const TENANT: u64 = 8807;
+
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  corpus   maintained key kind      allocs   covered
+"
+    );
+
+    for rung in [40_usize, 320] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for index in 0..rung {
+            let report = ingest_extract_context(
+                &engine,
+                ContextIngestExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: TENANT,
+                    sources: vec![ContextExtractRequest {
+                        shard_id: 1,
+                        tenant_hash: TENANT,
+                        source_kind: ContextSourceKind::Incident,
+                        source_id: format!("MAINT-{index:06}"),
+                        title: format!("maint {index}"),
+                        body: format!(
+                            "{}{}",
+                            format!("entry {index} covering the depot rota "),
+                            "context payload sentence. ".repeat(40)
+                        ),
+                        timestamp_ms: 1_000 + index as u64,
+                        provider: ContextModelProviderConfig::default(),
+                    }],
+                    provider: ContextModelProviderConfig::default(),
+                    start_time_ms: 0,
+                    end_time_ms: 0,
+                    max_events: 0,
+                    query: String::new(),
+                },
+            );
+            assert!(report.status.ok, "grow {index}: {:?}", report.status);
+        }
+
+        // Real keys, written through the real arms, so maintenance sees exactly what it sees in
+        // production rather than a key that happens to be absent.
+        let node_hash = 9_800_000 + rung as u64;
+        let node_write = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertNode {
+                tenant_hash: TENANT,
+                node: crate::types::ContextNode {
+                    node_hash,
+                    parent_hash: 0,
+                    kind: 1,
+                    canonical_name: format!("session/maint-{node_hash}"),
+                    l0: "probe node".to_string(),
+                    status: 0,
+                    last_event_time_ms: 1_781_700_000_000,
+                    l1_ref: String::new(),
+                    raw_metadata_ref: String::new(),
+                    vector: vec![0.25_f32; 16],
+                    embedding_model_hash: 7,
+                    embedding_updated_at_ms: 1,
+                    summary_vector: vec![0.5_f32; 16],
+                    summary_vector_valid_from_ms: 1_781_700_000_000,
+                    summary_vector_model_hash: 7,
+                },
+            },
+        });
+        assert!(node_write.status.ok, "{:?}", node_write.status);
+        let summary_write = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: crate::types::ContextSummary {
+                    node_hash,
+                    level: 2,
+                    text: "a probe summary of ordinary length for one turn".to_string(),
+                    valid_from_ms: 1_781_700_000_000,
+                    vector: vec![0.5_f32; 16],
+                    embedding_model_hash: 7,
+                },
+            },
+        });
+        assert!(summary_write.status.ok, "{:?}", summary_write.status);
+
+        let node_key = super::context::context_node_key(TENANT, node_hash);
+        let summary_key = super::context::context_summary_key(TENANT, node_hash, 2);
+
+        let mut shards = engine.shards.write().expect("engine lock poisoned");
+        let shard = shards.get_mut(&1).expect("loaded shard");
+        for (label, key) in [("context node   ", &node_key), ("context summary", &summary_key)] {
+            // Warm once: the first maintenance of a key does one-off work.
+            let _ = super::storage_bucket_internals::sync_context_pages_for_object(
+                shard, 1, key,
+            );
+            let probe = crate::alloc_probe::Probe::start();
+            let covered = super::storage_bucket_internals::sync_context_pages_for_object(
+                shard, 1, key,
+            );
+            let allocs = probe.stop().allocs;
+            println!("  {rung:>6}   {label}      {allocs:>9}   {covered}");
+        }
+    }
+
+    println!(
+        "
+  summary rising while node stays flat => maintenance is the cost, and the fix belongs in the
+  series branch of it. Both flat => maintenance is not the cost either, and what remains is the
+  wrapper around the arm.
+"
+    );
+}
+
+
+/// The incrementally maintained object->page lookup must equal a rebuilt one.
+///
+/// `sync_bucket_index_object_pages` used to end by rebuilding the shard's entire object->page
+/// lookup, which made every timestamped-series write O(pages in the shard) -- 10,457 allocations for
+/// one summary write at 320 memories against 27 for a node write, which never reaches that path.
+/// The rebuild is now confined to establishing an empty lookup, and the steady state applies only
+/// the pages a write touched.
+///
+/// A rebuild is self-correcting: it cleared the lookup and refilled it from the buckets, so it
+/// repaired any drift for free. Incremental maintenance does not, so the equivalence has to be
+/// asserted rather than assumed. Rewrites matter as much as first writes: a rewrite drops this
+/// object's entries and inserts new ones, and applying those two in the wrong order deletes what the
+/// same call just wrote.
+#[test]
+fn the_maintained_page_lookup_matches_a_rebuilt_one() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+
+    const TENANT: u64 = 6203;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        64 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    for index in 0..24_usize {
+        let report = ingest_extract_context(
+            &engine,
+            ContextIngestExtractRequest {
+                shard_id: 1,
+                tenant_hash: TENANT,
+                sources: vec![ContextExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: TENANT,
+                    source_kind: ContextSourceKind::Incident,
+                    source_id: format!("LOOKUP-{index:06}"),
+                    title: format!("lookup {index}"),
+                    body: format!(
+                        "{}{}",
+                        format!("entry {index} covering the depot rota "),
+                        "context payload sentence. ".repeat(12)
+                    ),
+                    timestamp_ms: 1_000 + index as u64,
+                    provider: ContextModelProviderConfig::default(),
+                }],
+                provider: ContextModelProviderConfig::default(),
+                start_time_ms: 0,
+                end_time_ms: 0,
+                max_events: 0,
+                query: String::new(),
+            },
+        );
+        assert!(report.status.ok, "ingest {index}: {:?}", report.status);
+    }
+
+    // Write the same summary key twice at different times, then a second key once: the first pair
+    // exercises the drop-then-insert path, the single write the plain insert.
+    for (node_hash, valid_from_ms) in [
+        (7_100_001_u64, 1_781_700_000_000_u64),
+        (7_100_001, 1_781_700_000_001),
+        (7_100_002, 1_781_700_000_000),
+    ] {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ContextUpsertSummary {
+                tenant_hash: TENANT,
+                summary: crate::types::ContextSummary {
+                    node_hash,
+                    level: 2,
+                    text: "a summary written to exercise lookup maintenance".to_string(),
+                    valid_from_ms,
+                    vector: vec![0.5_f32; 16],
+                    embedding_model_hash: 7,
+                },
+            },
+        });
+        assert!(out.status.ok, "summary {node_hash}: {:?}", out.status);
+    }
+
+    let mut shards = engine.shards.write().expect("engine lock poisoned");
+    let shard = shards.get_mut(&1).expect("loaded shard");
+
+    let maintained = shard.bucket_index.object_page_lookup.clone();
+    let maintained_total = shard.bucket_index.object_component_page_refs;
+    assert!(
+        !maintained.is_empty(),
+        "the lookup is empty, so this test would pass without maintaining anything"
+    );
+
+    shard.bucket_index.rebuild_object_page_lookup();
+    let rebuilt = &shard.bucket_index.object_page_lookup;
+
+    let missing: Vec<&String> = rebuilt.keys().filter(|key| !maintained.contains_key(*key)).collect();
+    let extra: Vec<&String> = maintained.keys().filter(|key| !rebuilt.contains_key(*key)).collect();
+    let differing: Vec<&String> = rebuilt
+        .iter()
+        .filter(|(key, refs)| maintained.get(*key).map(|held| held != *refs).unwrap_or(false))
+        .map(|(key, _)| key)
+        .collect();
+    assert!(
+        missing.is_empty() && extra.is_empty() && differing.is_empty(),
+        "maintained lookup differs from a rebuilt one: {} missing {:?}, {} extra {:?}, {} differing {:?}",
+        missing.len(),
+        missing.iter().take(4).collect::<Vec<_>>(),
+        extra.len(),
+        extra.iter().take(4).collect::<Vec<_>>(),
+        differing.len(),
+        differing.iter().take(4).collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        maintained_total, shard.bucket_index.object_component_page_refs,
+        "the page-ref total drifted; the stats path reads it instead of walking the shard"
+    );
+}


### PR DESCRIPTION
An add allocated **5,293 / 13,099 / 32,629** at 40 / 120 / 320 memories — 6.16x more work on an 8x
larger store, so ingestion did work proportional to the corpus it was ingesting into. It now costs
**1,414 / 1,414 / 1,410**: flat, and 23.1x cheaper at 320 memories. Bytes per add fall from 2.94 MB
to 304 KB.

## Where the cost was

The last line of `sync_bucket_index_object_pages` rebuilt the shard's entire object-to-page lookup:
clear it, then reinsert an entry for every page in every bucket, cloning each one. That ran on every
write of a timestamped series — summary, event, index, audit, child, compression — which is most of
the writes an ingest issues.

Calling post-write maintenance directly, on stores grown by real ingests:

| maintained key kind | corpus 40 | corpus 320 | |
|---|---:|---:|---|
| context node | 26 | 27 | never reaches this path |
| context summary | 1,352 | 10,457 | 7.7x, rising with the store |
| **context summary, after** | **43** | **43** | flat |

That was 10,457 of a summary write's 10,671 allocations — 98%. The whole write is now 225.

A node write looked innocent throughout, flat at ~197 at every corpus size. Not because it is
cheaper, but because a node's page lives in `shard.hashes` and takes the hash-upsert path, which
never reaches this function. Comparing the two arms against each other is what localised it.

## What changed

The lookup already had incremental primitives that maintain the same page-ref total the rebuild
establishes, so a write now applies only the pages it actually touched.

Establishing an empty lookup still rebuilds. An empty lookup means "not established yet", which
callers read as a signal to fall back to scanning, so the first call on a shard must still build it
from the buckets.

Two things this had to get right, both caught by measurement rather than by reading:

- **Order.** Removing a component drops all of its refs for the object, so the removals the `retain`
  records have to be applied *before* the new pages go in. Applied after, they delete what the same
  call just wrote.
- **The page-ref total is only settable by a rebuild** — a count that starts at "unknown" cannot be
  incremented into a right answer — and the load path fills the lookup without it, so a shard can
  come up holding entries and no total. The rebuild this replaces reset the total on every series
  write, which hid that. Being established now means both, or neither.

## How it is kept honest

A rebuild is self-correcting: it refilled the lookup from the buckets, repairing any drift another
path introduced, for free. Incremental maintenance does not — that is the point, and the risk. So
the equivalence is asserted rather than assumed: `the_maintained_page_lookup_matches_a_rebuilt_one`
ingests, rewrites one summary key twice (the drop-then-insert path) and writes a second key once,
then compares the maintained lookup against a freshly rebuilt one entry for entry, plus the total.
It caught the total on the first attempt.

## Also here

Seven comparisons that built an `Arc` purely to compare against one, each inside a loop over page
entries. Removing them changed the measured counts **not at all**, byte for byte — they are gone
because allocating in order to compare is waste, not because they were the cost.

The harnesses that found this ship with it — what a summary write costs, what maintenance costs per
key kind, and which write primitive grows with the store — so the property stays measurable rather
than becoming a number in a commit message.

## Testing

`cargo test --lib`: 1,520 passed, 16 failed. All 16 pass when re-run serially except
`a_node_and_its_level_two_summary_share_one_embedding`, which fails byte-identically on a clean
worktree at this base with none of these changes applied — it is pre-existing on `main`, comparing a
stored-form vector against a raw one. The other 15 are the suite's `set_var` races under
parallelism.
