### PR TITLE
Bring the cache pin forward

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -702,11 +702,11 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "matrixcache"
 version = "0.1.0"
-source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a#7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a"
+source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=be08e8db69fee071390917eafeca10f5fef3099f#be08e8db69fee071390917eafeca10f5fef3099f"
 dependencies = [
  "rocksdb",
  "serde",
- "thiserror",
+ "thiserror 2.0.20",
  "zstd",
 ]
 
@@ -717,7 +717,7 @@ source = "git+https://github.com/matrixarkai/MatrixRaft.git?rev=a4334b37ba6592e7
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -845,7 +845,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -908,7 +908,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -937,7 +937,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -951,7 +951,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1203,7 +1203,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1295,6 +1295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,7 +1341,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "temporalstore-snapshot",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1353,7 +1364,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "uuid",
 ]
@@ -1364,7 +1375,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1375,7 +1395,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1410,7 +1441,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1478,7 +1509,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1546,7 +1577,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1690,7 +1721,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1724,7 +1755,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1735,7 +1766,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1876,7 +1907,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"
 matrixraft = { package = "matrixraft", git = "https://github.com/matrixarkai/MatrixRaft.git", rev = "a4334b37ba6592e7c7192f3eaa2afe087746ccc9" }
-matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "7104e0c653e3a5496ae0bff6e83f65ca5e63fe9a", features = ["rocksdb-ssd"] }
+matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "be08e8db69fee071390917eafeca10f5fef3099f", features = ["rocksdb-ssd"] }
 temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -4380,3 +4380,136 @@ fn the_maintained_page_lookup_matches_a_rebuilt_one() {
         "the page-ref total drifted; the stats path reads it instead of walking the shard"
     );
 }
+
+
+/// Reading the page, or decoding it: which half of a node fetch costs the 15 allocations?
+///
+/// Retrieve is 16.4 allocations per candidate and the node fetch is 15.0 of them -- the largest
+/// remaining cost on any indicator once ingest went flat. `load_context_node` is a map lookup, then
+/// `read_page_bytes`, then `context_from_bytes`. The lookup cannot be 15, so it is one of the other
+/// two, and each implies a different fix: a read that dominates asks for buffer reuse, a decode that
+/// dominates asks about the record's shape -- four Strings and two vectors per node, built whether
+/// or not the scoring pass reads them.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_the_two_halves_of_a_node_fetch_cost -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_the_two_halves_of_a_node_fetch_cost() {
+    use crate::context_workflow::{
+        ingest_extract_context, ContextExtractRequest, ContextIngestExtractRequest,
+        ContextModelProviderConfig, ContextSourceKind,
+    };
+
+    const TENANT: u64 = 5501;
+
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        64 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for index in 0..80_usize {
+        let report = ingest_extract_context(
+            &engine,
+            ContextIngestExtractRequest {
+                shard_id: 1,
+                tenant_hash: TENANT,
+                sources: vec![ContextExtractRequest {
+                    shard_id: 1,
+                    tenant_hash: TENANT,
+                    source_kind: ContextSourceKind::Incident,
+                    source_id: format!("FETCH-{index:06}"),
+                    title: format!("fetch {index}"),
+                    body: format!(
+                        "{}{}",
+                        format!("entry {index} covering the depot rota "),
+                        "context payload sentence. ".repeat(40)
+                    ),
+                    timestamp_ms: 1_000 + index as u64,
+                    provider: ContextModelProviderConfig::default(),
+                }],
+                provider: ContextModelProviderConfig::default(),
+                start_time_ms: 0,
+                end_time_ms: 0,
+                max_events: 0,
+                query: String::new(),
+            },
+        );
+        assert!(report.status.ok, "grow {index}: {:?}", report.status);
+    }
+
+    // A node that exists, found the way retrieval finds one.
+    let shards = engine.shards.read().expect("engine lock poisoned");
+    let shard = shards.get(&1).expect("loaded shard");
+    let (object_key, address) = shard
+        .hashes
+        .iter()
+        .find_map(|(key, fields)| {
+            fields
+                .get(super::constants::CONTEXT_NODE_FIELD)
+                .map(|address| (key.clone(), address.clone()))
+        })
+        .expect("the ingest wrote at least one context node page");
+
+    let cache = &engine.cache;
+    let page_store = &engine.page_store;
+
+    // Warm: the first read of a page touches one-off structures.
+    let warm = super::read_page_bytes(cache, page_store, 1, &address)
+        .expect("the page reads back");
+    assert!(!warm.is_empty(), "an empty page would make every number below meaningless");
+
+    let probe = crate::alloc_probe::Probe::start();
+    let bytes = super::read_page_bytes(cache, page_store, 1, &address)
+        .expect("the page reads back");
+    let read_allocs = probe.stop().allocs;
+
+    let probe = crate::alloc_probe::Probe::start();
+    let node = super::context::context_from_bytes::<crate::types::ContextNode>(&bytes)
+        .expect("the page decodes to a node");
+    let decode_allocs = probe.stop().allocs;
+
+    println!(
+        "
+  half                         allocs
+  read_page_bytes           {read_allocs:>9}
+  context_from_bytes        {decode_allocs:>9}
+  ------------------------------------
+  together                  {:>9}   (a whole fetch measures ~15 per candidate)
+",
+        read_allocs + decode_allocs,
+    );
+
+    println!(
+        "  what the decode built, and what scoring actually reads:
+    canonical_name    {:>5} bytes
+    l0                {:>5} bytes   <- the discarded text
+    l1_ref            {:>5} bytes
+    raw_metadata_ref  {:>5} bytes
+    vector            {:>5} floats
+    summary_vector    {:>5} floats  <- the one scoring reads
+",
+        node.canonical_name.len(),
+        node.l0.len(),
+        node.l1_ref.len(),
+        node.raw_metadata_ref.len(),
+        node.vector.len(),
+        node.summary_vector.len(),
+    );
+    println!(
+        "  read >> decode => reuse the read buffer.
+  decode >> read => the record's shape is the cost, and a projection that skips fields scoring
+                    never reads is worth its complexity.
+"
+    );
+}


### PR DESCRIPTION
The pin sat three commits behind the cache, so three fixes were merged there and none were in the
product:

- page cache keys built directly rather than through `format!` (matrixarkai/MatrixCache#14)
- a cache preallocated 74 MB of write-ahead log to hold 0.3 MB
- the RocksDB write buffer is configurable rather than fixed

## Measured, before and after, on this tree

| | before | after |
|---|---:|---:|
| retrieve, allocations per candidate | 16.4 | **14.4** |
| &nbsp;&nbsp;of which the node fetch | 15.0 | **13.0** |
| `read_page_bytes`, one page, cache hit | 6 | **4** |
| one add (already flat in the corpus) | 1,410 | 1,408 |

The read is where it shows. Fetching one record was six allocations on a cache hit and **five of them
were the key**: three `String`s, plus two more that `format!` adds while building them. The key is
hashed and dropped immediately, so a read spent a third of its allocations on something it never
kept. Two are now gone — on every cache get and every put, so this is not only a retrieve cost.

Three Strings remain the floor while the key keeps its shape: it is `Serialize`, `Ord` and `Hash`
with eighteen constructors, so those fields are a persisted format rather than an implementation
detail. The cache-side change pins their exact bytes in a test, because a changed byte there is a
silent miss rather than a failure.

## What ships alongside

`what_the_two_halves_of_a_node_fetch_cost` splits a fetch into reading the page and decoding it —
the measurement that showed the key was almost the whole read half. With the read now at 4 and the
decode at 7, the record's own shape is the larger half, and that is where the next cut has to come
from.

## Testing

`cargo test --lib`: 1,524 passed, 13 failed under parallelism, **all 13 pass when re-run serially**
(this suite has ~180 `std::env::set_var` sites, so parallel failures are not evidence until
reproduced). Nothing reproduces serially.
