### PR TITLE
Build context object keys in one allocation

### DIFF
--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -16,12 +16,37 @@ use matrixcache::MultiLayerCache;
 
 use super::packed_pages::{read_feature_point, read_feature_point_cached, read_feature_point_cold};
 use super::{read_page_bytes, stable_object_hash, ShardState};
+/// `prefix` then two decimal parts, joined by colons, in one allocation.
+///
+/// `format!` would take two: the String it returns, plus one inside the formatting machinery.
+/// `write!` into a String that already has capacity takes none, so building the key directly halves
+/// its cost. These run on the hot path -- `context_node_key` once per retrieval candidate -- and the
+/// bytes are identical to the format strings they replace, which matters because these keys are
+/// stored in the shard's maps and the bucket index and compared against keys already written.
+fn context_key_2(prefix: &str, first: u64, second: u64) -> String {
+    use std::fmt::Write as _;
+    // Prefix, two u64 at 20 digits each, and the colon between them.
+    let mut key = String::with_capacity(prefix.len() + 41);
+    key.push_str(prefix);
+    let _ = write!(key, "{first}:{second}");
+    key
+}
+
+/// As [`context_key_2`], with a third part.
+fn context_key_3(prefix: &str, first: u64, second: u64, third: u64) -> String {
+    use std::fmt::Write as _;
+    let mut key = String::with_capacity(prefix.len() + 62);
+    key.push_str(prefix);
+    let _ = write!(key, "{first}:{second}:{third}");
+    key
+}
+
 pub(super) fn context_node_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:node:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:node:", tenant_hash, node_hash)
 }
 
 pub(super) fn context_event_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:event:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:event:", tenant_hash, node_hash)
 }
 
 pub(super) fn normalize_context_event_storage_keys(node_hash: u64, event: &mut ContextEvent) {
@@ -60,19 +85,19 @@ pub(super) fn context_event_kind_hash(event: &ContextEvent) -> u64 {
 }
 
 pub(super) fn context_audit_key(tenant_hash: u64, session_hash: u64) -> String {
-    format!("ctx:audit:{tenant_hash}:{session_hash}")
+    context_key_2("ctx:audit:", tenant_hash, session_hash)
 }
 
 pub(super) fn context_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:dirty:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:dirty:", tenant_hash, node_hash)
 }
 
 pub(super) fn context_embedding_dirty_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:embdirty:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:embdirty:", tenant_hash, node_hash)
 }
 
 pub(super) fn context_entity_key(tenant_hash: u64, node_hash: u64, entity_hash: u64) -> String {
-    format!("ctx:entity:{tenant_hash}:{node_hash}:{entity_hash}")
+    context_key_3("ctx:entity:", tenant_hash, node_hash, entity_hash)
 }
 
 /// Split a persisted per-entity key back into (collection key, entity hash).
@@ -97,19 +122,19 @@ pub(super) fn split_context_entity_key(object_key: &str) -> Option<(String, u64)
 }
 
 pub(super) fn context_entity_collection_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:entity:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:entity:", tenant_hash, node_hash)
 }
 
 pub(super) fn context_child_key(tenant_hash: u64, parent_hash: u64) -> String {
-    format!("ctx:child:{tenant_hash}:{parent_hash}")
+    context_key_2("ctx:child:", tenant_hash, parent_hash)
 }
 
 pub(super) fn context_summary_key(tenant_hash: u64, node_hash: u64, level: u32) -> String {
-    format!("ctx:summary:{tenant_hash}:{node_hash}:{level}")
+    context_key_3("ctx:summary:", tenant_hash, node_hash, u64::from(level))
 }
 
 pub(super) fn context_compression_key(tenant_hash: u64, node_hash: u64) -> String {
-    format!("ctx:compress:{tenant_hash}:{node_hash}")
+    context_key_2("ctx:compress:", tenant_hash, node_hash)
 }
 
 /// Configurable temporal-compression policy for a context node.

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -4513,3 +4513,46 @@ fn what_the_two_halves_of_a_node_fetch_cost() {
 "
     );
 }
+
+
+/// Every context object key, byte for byte.
+///
+/// These keys are stored in the shard's model maps and in the bucket index, and every read compares
+/// one against keys already written. Building them directly instead of through `format!` saves an
+/// allocation each -- `format!` costs two, the String it returns plus one inside the formatting
+/// machinery -- but only if the bytes do not move. A changed byte here does not fail anything on its
+/// own: it makes existing records unfindable, which reads as data loss.
+#[test]
+fn context_object_keys_keep_their_exact_bytes() {
+    use super::context::*;
+
+    assert_eq!(context_node_key(81, 4242), "ctx:node:81:4242");
+    assert_eq!(context_event_key(81, 4242), "ctx:event:81:4242");
+    assert_eq!(context_audit_key(81, 4242), "ctx:audit:81:4242");
+    assert_eq!(context_dirty_key(81, 4242), "ctx:dirty:81:4242");
+    assert_eq!(context_embedding_dirty_key(81, 4242), "ctx:embdirty:81:4242");
+    assert_eq!(context_entity_key(81, 4242, 7), "ctx:entity:81:4242:7");
+    assert_eq!(context_entity_collection_key(81, 4242), "ctx:entity:81:4242");
+    assert_eq!(context_child_key(81, 4242), "ctx:child:81:4242");
+    assert_eq!(context_summary_key(81, 4242, 2), "ctx:summary:81:4242:2");
+    assert_eq!(context_compression_key(81, 4242), "ctx:compress:81:4242");
+
+    // Zero and the largest u64 both round-trip: a key builder that sized its buffer for typical
+    // values would truncate here, and truncation is exactly the silent kind of wrong.
+    assert_eq!(context_node_key(0, 0), "ctx:node:0:0");
+    assert_eq!(
+        context_node_key(u64::MAX, u64::MAX),
+        "ctx:node:18446744073709551615:18446744073709551615"
+    );
+    assert_eq!(
+        context_summary_key(u64::MAX, u64::MAX, u32::MAX),
+        "ctx:summary:18446744073709551615:18446744073709551615:4294967295"
+    );
+
+    // An entity key and its collection key share a prefix; the third part is what separates them,
+    // so one must never be mistaken for the other.
+    assert_ne!(context_entity_key(81, 4242, 7), context_entity_collection_key(81, 4242));
+
+    // Distinct inputs stay distinct across the colon: (1, 23) and (12, 3) must not collide.
+    assert_ne!(context_node_key(1, 23), context_node_key(12, 3));
+}


### PR DESCRIPTION
`format!` costs **two** allocations, not one: the `String` it returns, plus one inside the formatting
machinery. Every context object key was built with it, and `context_node_key` runs once per retrieval
candidate.

| | before | after |
|---|---:|---:|
| retrieve, allocations per candidate | 14.4 | **13.4** |
| &nbsp;&nbsp;of which the node fetch | 13.0 | **12.0** |
| one add (already flat in the corpus) | 1,408 | **1,393** |

An add builds about fifteen of these keys, so it drops fifteen.

The same second allocation was just removed from the cache's page keys, which took a page read from
six allocations to four. This is the store's own half of it: ten builders, each now writing into a
`String` sized up front rather than going through `format!`.

## Why the bytes are the thing to assert

These keys are stored in the shard's model maps and in the bucket index, and every read compares one
against keys already written. A changed byte does not fail anything on its own — it makes existing
records unfindable, which reads as data loss.

So `context_object_keys_keep_their_exact_bytes` pins all ten, and covers the cases where a hand-built
key would plausibly go wrong:

- zero and `u64::MAX` both round-trip — a builder that sized its buffer for typical values would
  truncate there, and truncation is exactly the silent kind of wrong
- an entity key is never mistaken for its collection key, which shares its prefix
- `(1, 23)` and `(12, 3)` do not collide across the separator

## Testing

`cargo test --lib` on this tree; failures under parallelism are re-run serially, since the suite has
~180 `std::env::set_var` sites and a parallel failure is not evidence until reproduced.
