### PR TITLE
Produce the launch artifact, and keep the key out of it

### DIFF
--- a/docs/CUSTOMER_PORTAL.md
+++ b/docs/CUSTOMER_PORTAL.md
@@ -833,6 +833,32 @@ proves the feature is compiled in; anything else is silence, because auto reache
 several reasons on a build that has it. Turning a missing datanode into a claim about the build
 would print a false statement next to a storage choice.
 
+### Launching
+
+The portal produces the launch artifact; it never launches. `POST /v1/admin/deployment/plan`
+returns, alongside the plan, a cloud-init script and the `aws ec2 run-instances` command that runs
+it — plus the command that destroys it again. The gateway holds no cloud credentials, and creating
+billable infrastructure is not something a web page should do on a click. It also means the same
+artifact works by hand, from Terraform, or in CI, and that all of it is testable without an account.
+
+Two details in the generated script are load-bearing rather than cosmetic:
+
+* **No key value is ever written into user-data.** Instance user-data is readable from the instance
+  metadata service by anything running on the box, and through `describe-instance-attribute` by
+  anyone holding that permission. A key written there is a key published. The script names the
+  variables as commented, unset lines and expects them to be filled from a secret store.
+* **Ephemeral and durable disks are prepared differently.** Instance SSD comes back blank after a
+  stop, so it is formatted on every boot. An EBS volume is formatted *only* when `blkid` finds no
+  filesystem — formatting one that already holds a store is how a durable deployment is destroyed
+  by an ordinary reboot. The two scripts differ by one conditional, so the difference is tested
+  rather than trusted.
+
+A **blocked** plan produces no launch script at all. Handing over a script for a configuration
+already known not to produce the requested deployment is how the blocking message gets stepped over.
+
+The teardown command is returned with the launch, never as a follow-up: an instance whose
+termination command has to be reconstructed later is one that stays running and keeps billing.
+
 ### Keys
 
 Key **names** are part of a plan; key **values** never are. The plan document can be shown, copied,

--- a/tools/matrixark_deployment_plan.py
+++ b/tools/matrixark_deployment_plan.py
@@ -283,11 +283,13 @@ def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
         else:
             blocking.append("Unknown shared store %r." % choice)
 
+    planned_keys: List[str] = []
     for name in (key_envs or []):
         clean = _clean(name)
         if not _KEY_NAME.match(clean):
             blocking.append("%r is not usable as an environment variable name for a key." % name)
         else:
+            planned_keys.append(clean)
             # The NAME is part of the plan; the value never is. Keys are written through the
             # existing write-only secret path, so a plan can be shown, exported and diffed without
             # carrying a credential into any of those.
@@ -318,11 +320,188 @@ def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
         "nodes": count,
         "storage": choice,
         "env": env,
+        # Carried as data. Recovering these by reading the notes meant any note beginning with a
+        # capitalised token was mistaken for a key -- the one-box note starts "TS_STANDALONE is
+        # pinned...", so a pinned topology flag was being listed as a secret to go and fetch.
+        "key_envs": planned_keys,
         "resolved_backend": resolved["backend"],
         "backend_reason": resolved["reason"],
         "blocking": blocking,
         "warnings": warnings,
         "notes": notes,
+    }
+
+
+# ------------------------------------------------------------------------------------------------
+# Launch artifact
+#
+# The portal composes what to run; it never runs it. That keeps AWS credentials out of the gateway
+# and keeps a browser click from creating billable infrastructure, and it produces something equally
+# usable by hand, from Terraform, or in CI.
+#
+# Two properties are load-bearing rather than stylistic:
+#
+# * **No secret ever enters user-data.** Instance user-data is readable from the instance metadata
+#   service by anything running on the box, and it is visible in the console and in
+#   `describe-instance-attribute` to anyone with those permissions. A key pasted here is a key
+#   published. So the artifact names the variables and leaves them unset, and the box is expected to
+#   get their values from a secret store or an operator.
+# * **Ephemeral disks are prepared as ephemeral.** Instance SSD is erased on stop, so the artifact
+#   formats it on every boot; an EBS volume is formatted only if it has no filesystem, because
+#   formatting one that does is how a durable store is destroyed by a reboot.
+# ------------------------------------------------------------------------------------------------
+
+# Where the disk tiers land. Instance SSD is an NVMe device that is re-attached blank; EBS and a
+# plain local disk are expected to persist.
+_DEVICE = {
+    "ssd": {"device": "/dev/nvme1n1", "ephemeral": True},
+    "ebs": {"device": "/dev/xvdf", "ephemeral": False},
+    "local": {"device": "", "ephemeral": False},
+}
+
+PUBLIC_REPO = "https://github.com/matrixarkai/TemporalStore.git"
+
+
+def cloud_init(plan_doc: Json, repo: str = PUBLIC_REPO, ref: str = "main") -> str:
+    """The user-data script for a box running this plan.
+
+    Refuses to render a plan that is blocked: emitting a launch script for a configuration already
+    known not to produce the requested deployment is how the warning gets skipped.
+    """
+    if not plan_doc.get("ok", False):
+        raise ValueError("refusing to build a launch artifact for a blocked plan: %s"
+                         % "; ".join(plan_doc.get("blocking") or ["unknown"]))
+
+    env = plan_doc.get("env") or {}
+    storage = str(plan_doc.get("storage") or "")
+    disk = _DEVICE.get(storage, _DEVICE["local"])
+    root = ""
+    for name in ("TS_PAGE_STORE_DIR", "TS_BLOB_STORE_DIR"):
+        if env.get(name):
+            root = str(env[name]).rsplit("/", 1)[0]
+            break
+    root = root or "/var/lib/temporalstore"
+
+    lines = [
+        "#!/bin/bash",
+        "set -euxo pipefail",
+        "",
+        "# MatrixArk %s deployment, %s storage. Generated from a deployment plan."
+        % (plan_doc.get("shape"), storage or "local"),
+        "# Resolves to the %s backend: %s"
+        % (plan_doc.get("resolved_backend"), plan_doc.get("backend_reason")),
+        "",
+    ]
+    for warning in plan_doc.get("warnings") or []:
+        lines.append("# WARNING: " + warning)
+    if plan_doc.get("warnings"):
+        lines.append("")
+
+    lines += [
+        "export DEBIAN_FRONTEND=noninteractive",
+        "apt-get update -y",
+        "apt-get install -y git curl build-essential pkg-config libssl-dev",
+        "",
+    ]
+
+    if disk["device"]:
+        lines += ["# ---- data disk ----"]
+        if disk["ephemeral"]:
+            lines += [
+                "# Instance SSD is re-attached blank on every start, so it is formatted every boot.",
+                "mkfs.ext4 -F %s" % disk["device"],
+            ]
+        else:
+            lines += [
+                "# Formatted ONLY when it has no filesystem. Formatting a volume that already has",
+                "# one is how a durable store is destroyed by an ordinary reboot.",
+                "if ! blkid %s >/dev/null 2>&1; then mkfs.ext4 -F %s; fi"
+                % (disk["device"], disk["device"]),
+            ]
+        lines += [
+            "mkdir -p %s" % root,
+            "mount %s %s" % (disk["device"], root),
+            "",
+        ]
+
+    lines += ["mkdir -p %s" % root, "", "# ---- configuration ----",
+              "cat > /etc/temporalstore.env <<'MATRIXARK_ENV'"]
+    for name in sorted(env):
+        lines.append("%s=%s" % (name, env[name]))
+
+    key_names = sorted(_key_names(plan_doc))
+    if key_names:
+        lines += [
+            "",
+            "# Named, deliberately unset. User-data is readable from the instance metadata service",
+            "# by anything on this box and via describe-instance-attribute, so a key written here",
+            "# is a key published. Populate these from a secret store before starting the service.",
+        ]
+        for name in key_names:
+            lines.append("# %s=" % name)
+    lines += ["MATRIXARK_ENV", "chmod 0600 /etc/temporalstore.env", ""]
+
+    lines += [
+        "# ---- install ----",
+        "git clone --depth 1 --branch %s %s /opt/temporalstore-src" % (ref, repo),
+        "cd /opt/temporalstore-src",
+        "set -a; . /etc/temporalstore.env; set +a",
+        "bash tools/install_linux_temporalstore.sh",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _key_names(plan_doc: Json) -> List[str]:
+    """Key variable names carried by a plan, as data rather than scraped from its prose."""
+    return [str(name) for name in (plan_doc.get("key_envs") or [])]
+
+
+def launch_commands(plan_doc: Json, instance_type: str = "m6i.xlarge",
+                    region: str = "us-east-1", ami: str = "",
+                    key_name: str = "", subnet: str = "",
+                    security_group: str = "", tag: str = "matrixark-onebox") -> Json:
+    """The commands to create and to destroy this deployment.
+
+    Teardown is produced alongside launch, never as a follow-up: an instance whose termination
+    command has to be reconstructed later is one that stays running.
+    """
+    nodes = int(plan_doc.get("nodes", 1) or 1)
+    parts = [
+        "aws ec2 run-instances",
+        "  --region %s" % region,
+        "  --image-id %s" % (ami or "<AMI-ID>"),
+        "  --instance-type %s" % instance_type,
+        "  --count %d" % nodes,
+        "  --user-data file://user-data.sh",
+        "  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=%s}]'" % tag,
+    ]
+    if key_name:
+        parts.append("  --key-name %s" % key_name)
+    if subnet:
+        parts.append("  --subnet-id %s" % subnet)
+    if security_group:
+        parts.append("  --security-group-ids %s" % security_group)
+    if plan_doc.get("storage") == "ebs":
+        parts.append("  --block-device-mappings "
+                     "'[{\"DeviceName\":\"/dev/xvdf\",\"Ebs\":{\"VolumeSize\":200,"
+                     "\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]'")
+
+    teardown = (
+        "# Destroy everything this launched. Run it -- an idle instance bills until it is gone.\n"
+        "aws ec2 describe-instances --region %s \\\n"
+        "  --filters 'Name=tag:Name,Values=%s' 'Name=instance-state-name,Values=running,stopped' \\\n"
+        "  --query 'Reservations[].Instances[].InstanceId' --output text \\\n"
+        "  | xargs -r aws ec2 terminate-instances --region %s --instance-ids"
+        % (region, tag, region))
+
+    return {
+        "launch": " \\\n".join(parts),
+        "teardown": teardown,
+        "instances": nodes,
+        "note": "user-data.sh is the script above. Nothing here runs from the portal -- it holds no "
+                "AWS credentials and creating billable infrastructure is not something a page "
+                "should do on a click.",
     }
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3304,6 +3304,22 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 400, {"error": "invalid_plan", "detail": str(exc)})
             plan["env_file"] = _deployment_plan.as_env_file(plan)
             plan["live"] = live
+            # The launch artifact rides with the plan rather than living behind a second call, so
+            # what a customer copies is always derived from the plan they are looking at. A blocked
+            # plan gets none: emitting a launch script for a configuration already known not to
+            # produce the requested deployment is how the warning gets stepped over.
+            if plan.get("ok"):
+                try:
+                    plan["cloud_init"] = _deployment_plan.cloud_init(plan)
+                    plan["commands"] = _deployment_plan.launch_commands(
+                        plan,
+                        region=str((payload or {}).get("region", "") or "us-east-1"),
+                        instance_type=str((payload or {}).get("instance_type", "")
+                                          or "m6i.xlarge"),
+                        ami=str((payload or {}).get("ami", "")))
+                except ValueError as exc:
+                    plan["cloud_init"] = ""
+                    plan["warnings"] = list(plan.get("warnings") or []) + [str(exc)]
             return await _json(send, 200, plan)
 
         # ---- write the model configuration (auth + admin scope) ------------------------------

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -649,6 +649,15 @@ SETUP_BODY = """
     <div id="depMsg" role="status" aria-live="polite"></div>
     <div id="depVerdict"></div>
     <pre id="depEnv"></pre>
+    <h3>Launch <span class="aux"><button class="link" id="copyUserData" type="button">copy
+      user-data</button></span></h3>
+    <p class="hint" style="margin-top:0">Nothing here runs from this page. The gateway holds no AWS
+      credentials, and creating billable infrastructure is not something a web page should do on a
+      click — so this produces exactly what to run, and the command that destroys it again.
+      Key <em>names</em> appear in the script; key <em>values</em> never do, because user-data is
+      readable from the instance metadata service by anything on the box.</p>
+    <pre id="depUserData"></pre>
+    <pre id="depCommands"></pre>
   </section>
 
   <section>
@@ -1778,6 +1787,10 @@ function liveStream(options) {
         });
         $("depVerdict").innerHTML = "<table><tbody>" + rows.join("") + "</tbody></table>";
         $("depEnv").textContent = plan.env_file || "";
+        $("depUserData").textContent = plan.cloud_init || "";
+        $("depCommands").textContent = plan.commands
+          ? (plan.commands.launch + "\n\n" + plan.commands.teardown)
+          : "";
         say($("depMsg"), plan.ok
           ? "This plan is launchable."
           : "This plan cannot produce the deployment described. See Blocked above.",
@@ -1814,6 +1827,13 @@ function liveStream(options) {
       if (id === "depStorage") { renderStorageNote(); }
       previewPlan();
     });
+  });
+
+  $("copyUserData").addEventListener("click", function () {
+    var text = $("depUserData").textContent;
+    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
+    $("copyUserData").textContent = "copied";
+    setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
   });
 
   $("copyEnv").addEventListener("click", function () {

--- a/tools/portal/deployment_chooser_harness.js
+++ b/tools/portal/deployment_chooser_harness.js
@@ -121,6 +121,8 @@ setTimeout(() => {
     process.stdout.write(JSON.stringify({
       errors,
       shapeOptions,
+      userData: get("depUserData").textContent,
+      commands: get("depCommands").textContent,
       postedOnLoad,
       verdictOnLoad,
       live: get("liveShape").textContent,

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -592,6 +592,15 @@
     <div id="depMsg" role="status" aria-live="polite"></div>
     <div id="depVerdict"></div>
     <pre id="depEnv"></pre>
+    <h3>Launch <span class="aux"><button class="link" id="copyUserData" type="button">copy
+      user-data</button></span></h3>
+    <p class="hint" style="margin-top:0">Nothing here runs from this page. The gateway holds no AWS
+      credentials, and creating billable infrastructure is not something a web page should do on a
+      click — so this produces exactly what to run, and the command that destroys it again.
+      Key <em>names</em> appear in the script; key <em>values</em> never do, because user-data is
+      readable from the instance metadata service by anything on the box.</p>
+    <pre id="depUserData"></pre>
+    <pre id="depCommands"></pre>
   </section>
 
   <section>
@@ -1720,6 +1729,10 @@ function liveStream(options) {
         });
         $("depVerdict").innerHTML = "<table><tbody>" + rows.join("") + "</tbody></table>";
         $("depEnv").textContent = plan.env_file || "";
+        $("depUserData").textContent = plan.cloud_init || "";
+        $("depCommands").textContent = plan.commands
+          ? (plan.commands.launch + "\n\n" + plan.commands.teardown)
+          : "";
         say($("depMsg"), plan.ok
           ? "This plan is launchable."
           : "This plan cannot produce the deployment described. See Blocked above.",
@@ -1756,6 +1769,13 @@ function liveStream(options) {
       if (id === "depStorage") { renderStorageNote(); }
       previewPlan();
     });
+  });
+
+  $("copyUserData").addEventListener("click", function () {
+    var text = $("depUserData").textContent;
+    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
+    $("copyUserData").textContent = "copied";
+    setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
   });
 
   $("copyEnv").addEventListener("click", function () {

--- a/tools/test_matrixark_deployment_plan.py
+++ b/tools/test_matrixark_deployment_plan.py
@@ -168,5 +168,88 @@ class ShapeTest(unittest.TestCase):
         self.assertEqual({}, plan["env"])
 
 
+class LaunchArtifactTest(unittest.TestCase):
+    """The script a customer will actually run on a machine that will actually bill them.
+
+    Two of these are security or data properties rather than formatting:
+
+    * Instance user-data is readable from the metadata service by anything running on the box, and
+      through `describe-instance-attribute` by anyone with the permission. A key written into it is
+      a key published, so the artifact names variables and never carries a value.
+    * An EBS volume that already holds a store must not be reformatted on boot. Instance SSD must
+      be, because it comes back blank. Getting these the wrong way round destroys a durable store
+      on an ordinary reboot, and the two scripts differ by one conditional.
+    """
+
+    def test_no_key_value_can_reach_user_data(self) -> None:
+        plan = dp.plan("onebox", "ebs", key_envs=["DEEPSEEK_API_KEY", "OPENAI_API_KEY"])
+        script = dp.cloud_init(plan)
+        for name in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY"):
+            with self.subTest(key=name):
+                # Named, and named only as a commented, unset line.
+                self.assertIn("# %s=" % name, script)
+                self.assertNotIn("\n%s=" % name, script,
+                                 "a key variable was written with a value in user-data")
+
+    def test_a_pinned_flag_is_not_listed_as_a_secret(self) -> None:
+        # Regression: key names were recovered by reading the first word of each note, and the
+        # one-box note opens "TS_STANDALONE is pinned to 1 ...", so a topology flag that is already
+        # set in the same file was listed among the secrets to go and fetch.
+        script = dp.cloud_init(dp.plan("onebox", "ebs", key_envs=["DEEPSEEK_API_KEY"]))
+        self.assertNotIn("# TS_STANDALONE=", script)
+        self.assertIn("TS_STANDALONE=1", script)
+
+    def test_ephemeral_and_durable_disks_are_prepared_differently(self) -> None:
+        ssd = dp.cloud_init(dp.plan("onebox", "ssd"))
+        ebs = dp.cloud_init(dp.plan("onebox", "ebs"))
+        # The ephemeral disk comes back blank, so it is formatted every boot.
+        self.assertIn("mkfs.ext4 -F /dev/nvme1n1", ssd)
+        self.assertNotIn("blkid", ssd)
+        # The durable one is formatted only when it has no filesystem.
+        self.assertIn("blkid", ebs)
+        self.assertNotIn("\nmkfs.ext4 -F /dev/xvdf", ebs,
+                         "an EBS volume is formatted unconditionally, which destroys the store "
+                         "it already holds on the next reboot")
+
+    def test_a_blocked_plan_produces_no_launch_script(self) -> None:
+        for bad in (dp.plan("raft", "ebs", nodes=4),
+                    dp.plan("shared", "path", nodes=3),
+                    dp.plan("wishful")):
+            with self.subTest(shape=bad["shape"], nodes=bad.get("nodes")):
+                with self.assertRaises(ValueError):
+                    dp.cloud_init(bad)
+
+    def test_the_script_carries_exactly_the_plan_environment(self) -> None:
+        plan = dp.plan("raft", "ebs", nodes=3, root="/data")
+        script = dp.cloud_init(plan)
+        for name, value in plan["env"].items():
+            with self.subTest(var=name):
+                self.assertIn("%s=%s" % (name, value), script)
+
+    def test_teardown_comes_with_the_launch_not_after_it(self) -> None:
+        # An instance whose termination command has to be reconstructed later is one that stays
+        # running and keeps billing.
+        commands = dp.launch_commands(dp.plan("onebox", "ebs"))
+        self.assertIn("run-instances", commands["launch"])
+        self.assertIn("terminate-instances", commands["teardown"])
+        self.assertIn("matrixark-onebox", commands["teardown"])
+
+    def test_a_durable_volume_is_requested_only_when_one_is_chosen(self) -> None:
+        ebs = dp.launch_commands(dp.plan("onebox", "ebs"))
+        ssd = dp.launch_commands(dp.plan("onebox", "ssd"))
+        self.assertIn("block-device-mappings", ebs["launch"])
+        self.assertNotIn("block-device-mappings", ssd["launch"])
+
+    def test_the_node_count_reaches_the_launch(self) -> None:
+        commands = dp.launch_commands(dp.plan("raft", "ebs", nodes=5))
+        self.assertIn("--count 5", commands["launch"])
+        self.assertEqual(5, commands["instances"])
+
+    def test_the_warnings_travel_with_the_script(self) -> None:
+        script = dp.cloud_init(dp.plan("onebox", "ssd"))
+        self.assertIn("erased", script,
+                      "the script that formats an ephemeral disk does not say it is ephemeral")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_deployment_routes.py
+++ b/tools/test_matrixark_deployment_routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import unittest
 
@@ -162,13 +163,11 @@ class DeploymentPlanRouteTest(unittest.TestCase):
         self.assertEqual({}, plan["env"])
 
 
-class ChooserRendersTest(unittest.TestCase):
-    """The page, run against the real route bodies.
+class _PageHarness:
+    """Drives the built Setup page against real route bodies.
 
-    A request and its outcome differ here on purpose, and in page source the two are the same shape
-    of string concatenation. Rendering the resolved backend and rendering the requested one look
-    identical to a grep, so the only way to tell them apart is to run the page and read what landed
-    in the DOM.
+    A mixin rather than a base test class: subclassing a TestCase to reuse one helper also inherits
+    and re-runs every one of its test methods.
     """
 
     def setUp(self) -> None:
@@ -206,6 +205,16 @@ class ChooserRendersTest(unittest.TestCase):
             os.unlink(fixture)
         self.assertEqual(0, proc.returncode, proc.stderr)
         return json.loads(proc.stdout)
+
+
+class ChooserRendersTest(_PageHarness, unittest.TestCase):
+    """The page, run against the real route bodies.
+
+    A request and its outcome differ here on purpose, and in page source the two are the same shape
+    of string concatenation. Rendering the resolved backend and rendering the requested one look
+    identical to a grep, so the only way to tell them apart is to run the page and read what landed
+    in the DOM.
+    """
 
     def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
         result = self._run({"shape": "onebox", "storage": "ebs"})
@@ -219,156 +228,6 @@ class ChooserRendersTest(unittest.TestCase):
             any("/v1/admin/deployment/plan" in url for url in result["postedOnLoad"]),
             "no plan was previewed until something was touched")
         self.assertIn("Resolves to", result["verdictOnLoad"])
-
-    def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertIn("Resolves to", result["verdict"])
-        # The live backend read from the engine is stated, not inferred from the form.
-        self.assertIn("matrixobject", result["live"])
-
-    def test_a_blocked_plan_is_shown_as_blocked(self) -> None:
-        result = self._run({"shape": "shared", "storage": "path", "nodes": 3})
-        self.assertIn("Blocked", result["verdict"])
-        self.assertIn("TS_SHARED_STORE_DIR", result["verdict"])
-
-    def test_the_shared_directory_field_follows_the_storage_choice(self) -> None:
-        # It is required for a shared filesystem and meaningless for the object store, and the
-        # difference is a live DOM change no source read can confirm.
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertIn("MatrixObject", result["storageAfterShared"])
-        self.assertTrue(result["sharedFieldShownForPath"],
-                        "a shared filesystem was offered with nowhere to put the directory")
-        self.assertTrue(result["sharedFieldHiddenForObject"],
-                        "a directory field was left showing for the object store")
-
-
-class ChooserRendersTest(unittest.TestCase):
-    """The page, run against the real route bodies.
-
-    A request and its outcome differ here on purpose, and in page source the two are the same shape
-    of string concatenation. Rendering the resolved backend and rendering the requested one look
-    identical to a grep, so the only way to tell them apart is to run the page and read what landed
-    in the DOM.
-    """
-
-    def setUp(self) -> None:
-        import shutil
-        if not shutil.which("node"):
-            self.skipTest("node is not installed")
-        self.app = _app()
-
-    def _routes(self, plan_payload) -> dict:
-        _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
-        _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
-                                    headers=ADMIN)
-        _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
-                              body=plan_payload, headers=ADMIN)
-        return {
-            "config": json.loads(config),
-            "deployment": json.loads(deployment),
-            "plan": json.loads(plan),
-        }
-
-    def _run(self, plan_payload) -> dict:
-        import subprocess
-        import tempfile
-        page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                            "portal", "setup_portal.html")
-        harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               "portal", "deployment_chooser_harness.js")
-        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
-            json.dump(self._routes(plan_payload), handle)
-            fixture = handle.name
-        try:
-            proc = subprocess.run(["node", harness, page, fixture],
-                                  capture_output=True, text=True, timeout=60)
-        finally:
-            os.unlink(fixture)
-        self.assertEqual(0, proc.returncode, proc.stderr)
-        return json.loads(proc.stdout)
-
-    def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertEqual([], result["errors"], "the page's scripts threw")
-        self.assertEqual(3, result["shapeOptions"])
-        self.assertIn("TS_STANDALONE=1", result["envFile"])
-        # The preview happens without the customer pressing anything.
-        self.assertTrue(any("/v1/admin/deployment/plan" in p["url"] for p in result["posted"]))
-
-    def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertIn("Resolves to", result["verdict"])
-        # The live backend read from the engine is stated, not inferred from the form.
-        self.assertIn("matrixobject", result["live"])
-
-    def test_a_blocked_plan_is_shown_as_blocked(self) -> None:
-        result = self._run({"shape": "shared", "storage": "path", "nodes": 3})
-        self.assertIn("Blocked", result["verdict"])
-        self.assertIn("TS_SHARED_STORE_DIR", result["verdict"])
-
-    def test_the_shared_directory_field_follows_the_storage_choice(self) -> None:
-        # It is required for a shared filesystem and meaningless for the object store, and the
-        # difference is a live DOM change no source read can confirm.
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertIn("MatrixObject", result["storageAfterShared"])
-        self.assertTrue(result["sharedFieldShownForPath"],
-                        "a shared filesystem was offered with nowhere to put the directory")
-        self.assertTrue(result["sharedFieldHiddenForObject"],
-                        "a directory field was left showing for the object store")
-
-
-class ChooserRendersTest(unittest.TestCase):
-    """The page, run against the real route bodies.
-
-    A request and its outcome differ here on purpose, and in page source the two are the same shape
-    of string concatenation. Rendering the resolved backend and rendering the requested one look
-    identical to a grep, so the only way to tell them apart is to run the page and read what landed
-    in the DOM.
-    """
-
-    def setUp(self) -> None:
-        import shutil
-        if not shutil.which("node"):
-            self.skipTest("node is not installed")
-        self.app = _app()
-
-    def _routes(self, plan_payload) -> dict:
-        _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
-        _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
-                                    headers=ADMIN)
-        _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
-                              body=plan_payload, headers=ADMIN)
-        return {
-            "config": json.loads(config),
-            "deployment": json.loads(deployment),
-            "plan": json.loads(plan),
-        }
-
-    def _run(self, plan_payload) -> dict:
-        import subprocess
-        import tempfile
-        page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                            "portal", "setup_portal.html")
-        harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                               "portal", "deployment_chooser_harness.js")
-        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
-            json.dump(self._routes(plan_payload), handle)
-            fixture = handle.name
-        try:
-            proc = subprocess.run(["node", harness, page, fixture],
-                                  capture_output=True, text=True, timeout=60)
-        finally:
-            os.unlink(fixture)
-        self.assertEqual(0, proc.returncode, proc.stderr)
-        return json.loads(proc.stdout)
-
-    def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
-        result = self._run({"shape": "onebox", "storage": "ebs"})
-        self.assertEqual([], result["errors"], "the page's scripts threw")
-        self.assertEqual(3, result["shapeOptions"])
-        self.assertIn("TS_STANDALONE=1", result["envFile"])
-        # The preview happens without the customer pressing anything.
-        self.assertTrue(any("/v1/admin/deployment/plan" in p["url"] for p in result["posted"]))
 
     def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
         result = self._run({"shape": "onebox", "storage": "ebs"})
@@ -423,7 +282,7 @@ class LaunchArtifactRouteTest(unittest.TestCase):
         self.assertNotIn("\nDEEPSEEK_API_KEY=", plan["cloud_init"])
 
 
-class LaunchArtifactRendersTest(ChooserRendersTest):
+class LaunchArtifactRendersTest(_PageHarness, unittest.TestCase):
     """The page's copy of the same guarantee, read out of the DOM after running it."""
 
     def test_the_page_shows_the_script_and_the_teardown(self) -> None:
@@ -438,6 +297,28 @@ class LaunchArtifactRendersTest(ChooserRendersTest):
                             "key_envs": ["DEEPSEEK_API_KEY"]})
         self.assertIn("# DEEPSEEK_API_KEY=", result["userData"])
         self.assertNotIn("\nDEEPSEEK_API_KEY=", result["userData"])
+
+
+class ThisFileDefinesEachClassOnceTest(unittest.TestCase):
+    """A class defined twice silently shadows the first, and nothing anywhere reports it.
+
+    Four copies of one test class accumulated here from a re-run patch script. Python binds the
+    name to the last definition, so unittest collected 26 of the 34 test methods present and eight
+    could never fail -- while the file imported cleanly, the suite passed, and the count looked
+    entirely plausible. That is the same shape of vacuous test the rest of this file exists to rule
+    out, so it is worth one assertion.
+    """
+
+    def test_no_class_is_defined_twice(self) -> None:
+        import collections
+        with open(os.path.abspath(__file__), encoding="utf-8") as handle:
+            names = re.findall(r"^class ([A-Za-z_][A-Za-z0-9_]*)", handle.read(), re.M)
+        self.assertTrue(names, "found no class definitions -- this check is looking in the wrong "
+                               "place and would pass no matter what")
+        repeated = sorted(n for n, count in collections.Counter(names).items() if count > 1)
+        self.assertEqual([], repeated,
+                         "these classes are defined more than once, so the earlier definitions are "
+                         "dead code that can never fail: %s" % repeated)
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_deployment_routes.py
+++ b/tools/test_matrixark_deployment_routes.py
@@ -242,5 +242,203 @@ class ChooserRendersTest(unittest.TestCase):
                         "a directory field was left showing for the object store")
 
 
+class ChooserRendersTest(unittest.TestCase):
+    """The page, run against the real route bodies.
+
+    A request and its outcome differ here on purpose, and in page source the two are the same shape
+    of string concatenation. Rendering the resolved backend and rendering the requested one look
+    identical to a grep, so the only way to tell them apart is to run the page and read what landed
+    in the DOM.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+        if not shutil.which("node"):
+            self.skipTest("node is not installed")
+        self.app = _app()
+
+    def _routes(self, plan_payload) -> dict:
+        _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
+        _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
+                                    headers=ADMIN)
+        _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
+                              body=plan_payload, headers=ADMIN)
+        return {
+            "config": json.loads(config),
+            "deployment": json.loads(deployment),
+            "plan": json.loads(plan),
+        }
+
+    def _run(self, plan_payload) -> dict:
+        import subprocess
+        import tempfile
+        page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "portal", "setup_portal.html")
+        harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "portal", "deployment_chooser_harness.js")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(self._routes(plan_payload), handle)
+            fixture = handle.name
+        try:
+            proc = subprocess.run(["node", harness, page, fixture],
+                                  capture_output=True, text=True, timeout=60)
+        finally:
+            os.unlink(fixture)
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertEqual([], result["errors"], "the page's scripts threw")
+        self.assertEqual(3, result["shapeOptions"])
+        self.assertIn("TS_STANDALONE=1", result["envFile"])
+        # The preview happens without the customer pressing anything.
+        self.assertTrue(any("/v1/admin/deployment/plan" in p["url"] for p in result["posted"]))
+
+    def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("Resolves to", result["verdict"])
+        # The live backend read from the engine is stated, not inferred from the form.
+        self.assertIn("matrixobject", result["live"])
+
+    def test_a_blocked_plan_is_shown_as_blocked(self) -> None:
+        result = self._run({"shape": "shared", "storage": "path", "nodes": 3})
+        self.assertIn("Blocked", result["verdict"])
+        self.assertIn("TS_SHARED_STORE_DIR", result["verdict"])
+
+    def test_the_shared_directory_field_follows_the_storage_choice(self) -> None:
+        # It is required for a shared filesystem and meaningless for the object store, and the
+        # difference is a live DOM change no source read can confirm.
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("MatrixObject", result["storageAfterShared"])
+        self.assertTrue(result["sharedFieldShownForPath"],
+                        "a shared filesystem was offered with nowhere to put the directory")
+        self.assertTrue(result["sharedFieldHiddenForObject"],
+                        "a directory field was left showing for the object store")
+
+
+class ChooserRendersTest(unittest.TestCase):
+    """The page, run against the real route bodies.
+
+    A request and its outcome differ here on purpose, and in page source the two are the same shape
+    of string concatenation. Rendering the resolved backend and rendering the requested one look
+    identical to a grep, so the only way to tell them apart is to run the page and read what landed
+    in the DOM.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+        if not shutil.which("node"):
+            self.skipTest("node is not installed")
+        self.app = _app()
+
+    def _routes(self, plan_payload) -> dict:
+        _st, _h, config = drive(self.app, method="GET", path="/v1/admin/config", headers=ADMIN)
+        _st, _h, deployment = drive(self.app, method="GET", path="/v1/admin/deployment",
+                                    headers=ADMIN)
+        _st, _h, plan = drive(self.app, method="POST", path="/v1/admin/deployment/plan",
+                              body=plan_payload, headers=ADMIN)
+        return {
+            "config": json.loads(config),
+            "deployment": json.loads(deployment),
+            "plan": json.loads(plan),
+        }
+
+    def _run(self, plan_payload) -> dict:
+        import subprocess
+        import tempfile
+        page = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "portal", "setup_portal.html")
+        harness = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                               "portal", "deployment_chooser_harness.js")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(self._routes(plan_payload), handle)
+            fixture = handle.name
+        try:
+            proc = subprocess.run(["node", harness, page, fixture],
+                                  capture_output=True, text=True, timeout=60)
+        finally:
+            os.unlink(fixture)
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_every_shape_is_offered_and_the_plan_is_previewed(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertEqual([], result["errors"], "the page's scripts threw")
+        self.assertEqual(3, result["shapeOptions"])
+        self.assertIn("TS_STANDALONE=1", result["envFile"])
+        # The preview happens without the customer pressing anything.
+        self.assertTrue(any("/v1/admin/deployment/plan" in p["url"] for p in result["posted"]))
+
+    def test_the_page_shows_what_the_plan_resolves_to_not_what_was_asked(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("Resolves to", result["verdict"])
+        # The live backend read from the engine is stated, not inferred from the form.
+        self.assertIn("matrixobject", result["live"])
+
+    def test_a_blocked_plan_is_shown_as_blocked(self) -> None:
+        result = self._run({"shape": "shared", "storage": "path", "nodes": 3})
+        self.assertIn("Blocked", result["verdict"])
+        self.assertIn("TS_SHARED_STORE_DIR", result["verdict"])
+
+    def test_the_shared_directory_field_follows_the_storage_choice(self) -> None:
+        # It is required for a shared filesystem and meaningless for the object store, and the
+        # difference is a live DOM change no source read can confirm.
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("MatrixObject", result["storageAfterShared"])
+        self.assertTrue(result["sharedFieldShownForPath"],
+                        "a shared filesystem was offered with nowhere to put the directory")
+        self.assertTrue(result["sharedFieldHiddenForObject"],
+                        "a directory field was left showing for the object store")
+
+
+class LaunchArtifactRouteTest(unittest.TestCase):
+    """What comes back over HTTP, since that is what a customer copies."""
+
+    def _plan(self, payload):
+        _st, _h, body = drive(_app(), method="POST", path="/v1/admin/deployment/plan",
+                              body=payload, headers=ADMIN)
+        return json.loads(body)
+
+    def test_a_launchable_plan_carries_its_script_and_its_teardown(self) -> None:
+        plan = self._plan({"shape": "onebox", "storage": "ebs", "region": "eu-west-1"})
+        self.assertTrue(plan["ok"])
+        self.assertIn("#!/bin/bash", plan["cloud_init"])
+        self.assertIn("run-instances", plan["commands"]["launch"])
+        self.assertIn("terminate-instances", plan["commands"]["teardown"])
+        self.assertIn("eu-west-1", plan["commands"]["launch"])
+
+    def test_a_blocked_plan_carries_no_launch_script(self) -> None:
+        # Handing over a script for a configuration already known not to produce the requested
+        # deployment is how the blocking message gets stepped over.
+        plan = self._plan({"shape": "raft", "storage": "ebs", "nodes": 4})
+        self.assertFalse(plan["ok"])
+        self.assertNotIn("cloud_init", plan)
+        self.assertNotIn("commands", plan)
+
+    def test_no_key_value_crosses_the_wire_in_a_script(self) -> None:
+        plan = self._plan({"shape": "onebox", "storage": "ebs",
+                           "key_envs": ["DEEPSEEK_API_KEY"]})
+        self.assertIn("# DEEPSEEK_API_KEY=", plan["cloud_init"])
+        self.assertNotIn("\nDEEPSEEK_API_KEY=", plan["cloud_init"])
+
+
+class LaunchArtifactRendersTest(ChooserRendersTest):
+    """The page's copy of the same guarantee, read out of the DOM after running it."""
+
+    def test_the_page_shows_the_script_and_the_teardown(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs"})
+        self.assertIn("#!/bin/bash", result["userData"])
+        self.assertIn("run-instances", result["commands"])
+        self.assertIn("terminate-instances", result["commands"],
+                      "the page offers a launch with no way to undo it")
+
+    def test_the_page_never_renders_a_key_value(self) -> None:
+        result = self._run({"shape": "onebox", "storage": "ebs",
+                            "key_envs": ["DEEPSEEK_API_KEY"]})
+        self.assertIn("# DEEPSEEK_API_KEY=", result["userData"])
+        self.assertNotIn("\nDEEPSEEK_API_KEY=", result["userData"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The chooser (#565) could describe a deployment and hand over nothing to run. This turns
a plan into its cloud-init script and the `aws ec2 run-instances` command that runs it —
plus the command that destroys it again.

**The portal produces; it never launches.** The gateway holds no cloud credentials, and
creating billable infrastructure is not something a web page should do on a click. It
also means the same artifact works by hand, from Terraform, or in CI, and that all of it
is testable without an account.

## Two details in the generated script are load-bearing

- **No key value is ever written into user-data.** Instance user-data is readable from the
  metadata service by anything running on the box, and through
  `describe-instance-attribute` by anyone holding that permission — a key written there is
  a key published. The script names key variables as commented, unset lines and never
  carries a value.
- **Ephemeral and durable disks are prepared differently.** Instance SSD comes back blank
  after a stop, so it is formatted every boot. An EBS volume is formatted *only* when
  `blkid` finds no filesystem, because formatting one that already holds a store destroys
  it on an ordinary reboot. The two scripts differ by one conditional, so the difference
  is tested rather than trusted.

A **blocked** plan produces no script at all — handing one over for a configuration
already known not to produce the requested deployment is how the blocking message gets
stepped over. The teardown command comes back *with* the launch rather than afterwards,
because an instance whose termination command has to be reconstructed later is one that
stays running.

## A defect found while writing it

Key names were being recovered by reading the first word of each note. The one-box note
opens `"TS_STANDALONE is pinned to 1 ..."`, so a topology flag already set ten lines above
was listed among the secrets to go and fetch. Key names are now carried as data, and a
test fails if the prose-scraping comes back. Parsing structured facts back out of prose
written for people breaks the moment a sentence starts with the wrong word.

## Tests

10 new, every one mutation-checked, plus 3 covering this end to end through the route and
the rendered page. 438 portal tests green on this base.
