### PR TITLE
Six tenant-policy knobs resolve correctly and change nothing

### DIFF
--- a/tools/test_matrixark_policy_gates_wired.py
+++ b/tools/test_matrixark_policy_gates_wired.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A tenant-policy gate that nothing calls is a knob that resolves correctly and changes nothing.
+
+This is the worst shape a configuration surface can take. The knob is in the registry, the portal
+offers it, `resolve()` returns exactly what the tenant set, the docstring explains what it does --
+and the write path never asks. Nothing errors, nothing logs, and the only way to notice is to ingest
+under two opposite policies and compare what was stored.
+
+Six of the fourteen gates are in that state today. They are listed rather than fixed-by-assertion so
+this file can land ahead of the wiring and hold the line meanwhile: a NEW unwired gate fails, and a
+listed gate that gets wired ALSO fails, telling you to strike it off. A list that is allowed to
+silently stay wrong is the same failure one level up.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+from typing import Dict, List, Set
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(TOOLS)
+GATES_MODULE = os.path.join(TOOLS, "matrixark_index_growth_bound.py")
+
+# Known unwired as of 2026-09-01, verified three ways: no call to the gate, no direct
+# resolve_tenant_policy() for the knob, and no read of the knob's env var in any .py or .rs.
+# Shrink this list as they are wired -- the test fails if you forget to.
+KNOWN_UNWIRED: Set[str] = {
+    "extract_segments_enabled",
+    "generate_embeddings_enabled",
+    "node_path_embeddings_enabled",
+    "return_all_candidates_enabled",
+    "store_event_summary_text_enabled",
+    "traverse_sibling_sessions_enabled",
+}
+
+# The census found 14. If a refactor moves gates elsewhere this number drops and every "no unwired
+# gate found" assertion below becomes vacuously true, so the count is asserted too -- a guard that
+# scans source has to assert its own extent or it silently degrades into checking nothing.
+EXPECTED_GATE_FLOOR = 14
+
+
+def _gates() -> List[str]:
+    with open(GATES_MODULE, encoding="utf-8") as handle:
+        return re.findall(r"^def ([a-z0-9_]+_enabled)\(", handle.read(), re.M)
+
+
+def _production_sources() -> List[str]:
+    listed = subprocess.run(["git", "ls-files", "*.py"], cwd=REPO,
+                            capture_output=True, text=True).stdout.split()
+    return [path for path in listed
+            if not os.path.basename(path).startswith("test_")]
+
+
+def _callers() -> Dict[str, List[str]]:
+    """Production call sites per gate. A definition, an import and a comment are not calls."""
+    gates = _gates()
+    found: Dict[str, List[str]] = {gate: [] for gate in gates}
+    for path in _production_sources():
+        try:
+            with open(os.path.join(REPO, path), encoding="utf-8") as handle:
+                lines = handle.read().splitlines()
+        except OSError:
+            continue
+        for number, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith(("import ", "from ", "#")):
+                continue
+            for gate in gates:
+                if gate not in line or stripped.startswith("def %s(" % gate):
+                    continue
+                found[gate].append("%s:%d" % (path, number))
+    return found
+
+
+class PolicyGatesAreWiredTest(unittest.TestCase):
+
+    def test_the_census_still_finds_the_gates(self) -> None:
+        # Asserted so the checks below cannot pass by finding nothing to check.
+        gates = _gates()
+        self.assertGreaterEqual(
+            len(gates), EXPECTED_GATE_FLOOR,
+            "found %d policy gates, expected at least %d -- if they moved, this file is no longer "
+            "looking where they live and every assertion under it is vacuous"
+            % (len(gates), EXPECTED_GATE_FLOOR))
+
+    def test_no_new_gate_is_left_unwired(self) -> None:
+        callers = _callers()
+        unwired = {gate for gate, sites in callers.items() if not sites}
+        new = sorted(unwired - KNOWN_UNWIRED)
+        self.assertEqual(
+            [], new,
+            "these tenant-policy gates have no production caller, so the knobs they guard resolve "
+            "correctly and change nothing: %s. A customer sets them, the portal shows them, and "
+            "the write path never asks." % new)
+
+    def test_a_gate_that_got_wired_is_struck_off_the_list(self) -> None:
+        callers = _callers()
+        wired = sorted(gate for gate in KNOWN_UNWIRED if callers.get(gate))
+        self.assertEqual(
+            [], wired,
+            "these are listed as known-unwired but now have callers: %s. Remove them from "
+            "KNOWN_UNWIRED -- a list of known problems that is allowed to go stale hides the fix "
+            "as effectively as it hid the defect." % wired)
+
+    def test_every_listed_gate_still_exists(self) -> None:
+        gates = set(_gates())
+        vanished = sorted(KNOWN_UNWIRED - gates)
+        self.assertEqual(
+            [], vanished,
+            "KNOWN_UNWIRED names gates that no longer exist: %s. A renamed gate leaves an entry "
+            "here that excuses nothing and silently shrinks what is checked." % vanished)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A census of the fourteen `*_enabled` gates in `matrixark_index_growth_bound.py` finds
**six with no production caller**: `extract_segments`, `generate_embeddings`,
`node_path_embeddings`, `return_all_candidates`, `store_event_summary_text` and
`traverse_sibling_sessions`. The other eight are wired, so an uncalled gate here is a gap
rather than a house style — which is why this is a census and not a spot check.

This is the worst shape a configuration surface can take. The knob is in the registry, the
portal offers it, `resolve()` returns exactly what the tenant set, the docstring explains
what it does — and the write path never asks. Nothing errors and nothing logs.

## Checked three ways

A gate with no caller is only a defect if the knob is unreachable by *every* route:

- no call to the gate anywhere outside its own definition;
- no direct `resolve_tenant_policy("<knob>", …)` for it;
- no read of its environment variable in any `.py` or `.rs`.

The one apparent hit — `MATRIXARK_EXTRACT_SEGMENTS` in the gates module — is the gate's own
**docstring**, telling operators to set a variable nothing reads.

Confirmed behaviourally too: ingesting identical text for two tenants with *opposite*
policies produces near-identical record profiles — `context_segment: 1` and
`context_entity: 2` for both. `test_tenant_policy` already fails on this on `main`; it
fails at its first assertion, which masks a second real failure on the line asserting the
opted-out tenant stores no segments.

Two of the six are read-path knobs offered per user, so that surface currently offers
settings that do nothing.

## Why the guard lands before the wiring

So the gap stops growing while the sites are fixed. A **new** unwired gate fails the build;
a listed gate that **gets wired** also fails, so the list cannot quietly go stale. The
census count is asserted as well — a guard that scans source has to assert its own extent,
or a rename degrades it into checking nothing while still passing. All four assertions are
mutation-checked.

## The wiring is the follow-up, and it is not small

Segments have 2 ingest write sites; vectors have about 10 attach sites across 6 modules
(events, entities, profile entities, segments, summaries, nodes, resources, hook). Gating
9 of 10 would leave a tenant who opted out still receiving vectors on some record types —
worse than gating none, because it looks like it works.
