### PR TITLE
Say whether a readiness row measured something or read a setting

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2194,6 +2194,37 @@ def _import_progress() -> Json:
     return result
 
 
+# What each readiness answer is derived from. The labels are what the page prints, because "ok"
+# means something different in each case: a configured encoder can still be serving hash vectors,
+# while a counted record is a record.
+_CHECK_SOURCE_LABELS: Json = {
+    "configuration": "what you configured",
+    "measured": "measured in this deployment",
+    "engine": "reported by the engine",
+}
+
+# Declared per check rather than defaulted, so a check added later has to say which kind of claim it
+# is making instead of inheriting the one that looks authoritative.
+_CHECK_SOURCES: Json = {
+    "extraction": "configuration",
+    "extraction_key": "configuration",
+    "embedding": "configuration",
+    "fail_closed": "configuration",
+    "config_warnings": "configuration",
+    "ingestion_root": "configuration",
+    "content": "measured",
+    # Counts of what is actually there, and traffic actually observed -- these survive a
+    # deployment being misconfigured, which is the whole reason the distinction is printed.
+    "memory": "measured",
+    "metrics": "measured",
+    "import_retries": "measured",
+    # Settings. "ok" here means the setting is set, not that the thing it configures works.
+    "auth": "configuration",
+    "single_writer": "configuration",
+    "storage_backend": "engine",
+}
+
+
 def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
                       request_total: float = 0.0,
                       imports: Optional[Json] = None) -> List[Json]:
@@ -2220,8 +2251,16 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
             href: str = "", action: str = "", how: Optional[List[str]] = None) -> None:
         # `how` is the steps, in order, for the state the check is IN -- an item that is already ok
         # carries none, because the useful thing there is that there is nothing to do.
+        source = _CHECK_SOURCES.get(check_id)
+        if source is None:
+            raise ValueError(
+                "readiness check %r has no entry in _CHECK_SOURCES. Every check has to say whether "
+                "it measured something or read a setting: a row that read the configuration and a "
+                "row that counted records both print as 'ok', and only one of them survives a "
+                "deployment that is misconfigured in a way that still answers 200." % check_id)
         checks.append({"id": check_id, "title": title, "status": status, "detail": detail,
                        "href": href, "action": action,
+                       "source": source, "source_label": _CHECK_SOURCE_LABELS[source],
                        "how": list(how or []) if status != "ok" else []})
 
     model_on = str(extraction.get("provider", "")).lower() not in deterministic
@@ -2288,6 +2327,24 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
                 "The trade is real: an encoder outage becomes failed requests instead of silently "
                 "worse retrieval. Failed requests are the ones you find out about.",
             ])
+
+    # The one thing here that is neither a setting nor a count: what the datanode says it actually
+    # resolved. Worth its own row because the configured backend and the running one differ silently
+    # -- a shared backend with no directory, or MatrixObject on a build without it, both fall
+    # through to auto-detection without erroring.
+    live_backend = config_snapshot.get("live_storage_backend")
+    if live_backend:
+        add("storage_backend", "Storage backend", "ok",
+            "The datanode resolved the " + str(live_backend) + " backend. This is what it is "
+            "running, not what was requested; the engine records why only in a startup log line.")
+    else:
+        add("storage_backend", "Storage backend", "warn",
+            "Could not read the datanode's backend, so what this deployment is storing to is "
+            "unknown from here. An unreachable datanode and a gateway pointed at the wrong "
+            "address look identical at this distance.",
+            "/v1/admin/setup", "Check the datanode URL",
+            how=["Confirm MATRIXARK_DATANODE_URL points at a datanode that is up.",
+                 "That process publishes temporalstore_storage_backend on its own /metrics."])
 
     warnings = config_snapshot.get("warnings") or []
     add("config_warnings", "Configuration warnings", "ok" if not warnings else "warn",
@@ -3451,6 +3508,12 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             except Exception:
                 traffic = {"total_requests": 0}
             imports = _import_progress()
+            # Asked once per overview. Best-effort: an unreachable datanode leaves the row
+            # saying so rather than failing the page that exists to report on the deployment.
+            live = _probe_storage_backend(cfg)
+            if live:
+                config_snapshot = dict(config_snapshot)
+                config_snapshot["live_storage_backend"] = live.get("backend")
             checks = _readiness_checks(config_snapshot, counts, cfg,
                                        float(traffic.get("total_requests") or 0), imports)
             done = sum(1 for c in checks if c["status"] == "ok")

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2697,9 +2697,15 @@ function liveStream(options) {
           c.how.map(function (step) { return "<li>" + esc(step) + "</li>"; }).join("") +
           "</ol></details>";
       }
+      /* Where the answer came from, next to the answer. "ok" on a configured encoder and "ok" on
+         a counted record are different claims: the first survives the encoder being unreachable,
+         and that is precisely the failure this page exists to surface. */
+      var src = c.source_label
+        ? "<span class='hint' style='margin:2px 0 0'>" + esc(c.source_label) + "</span>"
+        : "";
       return '<div class="checkrow"><span class="mark ' + esc(c.status) + '">' +
         (MARK[c.status] || "") + '</span><span class="body"><b>' + esc(c.title) +
-        "</b><span>" + esc(c.detail) + "</span>" + how + "</span>" + go + "</div>";
+        "</b><span>" + esc(c.detail) + "</span>" + src + how + "</span>" + go + "</div>";
     }).join("") || '<div class="empty">Nothing to check.</div>';
 
     var pct = d.total ? Math.round((d.done / d.total) * 100) : 0;

--- a/tools/portal/overview_checklist_harness.js
+++ b/tools/portal/overview_checklist_harness.js
@@ -1,0 +1,95 @@
+/* Run the Overview page against a real /v1/admin/overview body and report the rendered checklist.
+ *
+ * The presence check this replaces was satisfied by any surviving mention of `source_label` in the
+ * file -- a mutation that broke the actual render still passed, because the variable was still
+ * assigned somewhere above. Reading what the row HTML ends up containing is the only way to tell a
+ * label that renders from one that is merely referenced.
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const overview = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+const byId = new Map();
+
+function makeEl(id) {
+  const listeners = {};
+  const attrs = {};
+  return {
+    id: id || "",
+    hidden: false, innerHTML: "", textContent: "", value: "", checked: false, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(t, fn) { (listeners[t] = listeners[t] || []).push(fn); },
+    removeEventListener() {},
+    dispatch(t, ev) { (listeners[t] || []).forEach((fn) => fn(ev || {})); },
+    appendChild() {}, removeChild() {},
+    setAttribute(k, v) { attrs[k] = v; }, getAttribute(k) { return k in attrs ? attrs[k] : null; },
+    closest() { return null; }, querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+
+function get(id) {
+  if (!byId.has(id)) { byId.set(id, makeEl(id)); }
+  return byId.get(id);
+}
+
+function respond(body) {
+  return Promise.resolve({
+    ok: true, status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  });
+}
+
+const win = {
+  document: {
+    getElementById: get,
+    querySelector: () => makeEl(),
+    querySelectorAll: () => [],
+    createElement: () => makeEl(),
+    addEventListener() {},
+    body: makeEl("body"),
+    hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", host: "gw.example:8080", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0,
+  setInterval: () => 0,
+  clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {},
+  Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const key = String(url);
+    if (key.indexOf("/v1/admin/overview") === 0) { return respond(overview); }
+    return respond({});
+  },
+  __matrixarkOnFrame() {}
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+const errors = [];
+scripts.forEach((body) => {
+  try { new Function(...names, body)(...values); } catch (e) { errors.push(String(e)); }
+});
+
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    errors,
+    checks: get("checks").innerHTML,
+    rows: (get("checks").innerHTML.match(/class="checkrow"/g) || []).length
+  }));
+}, 0);

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -641,9 +641,15 @@ function liveStream(options) {
           c.how.map(function (step) { return "<li>" + esc(step) + "</li>"; }).join("") +
           "</ol></details>";
       }
+      /* Where the answer came from, next to the answer. "ok" on a configured encoder and "ok" on
+         a counted record are different claims: the first survives the encoder being unreachable,
+         and that is precisely the failure this page exists to surface. */
+      var src = c.source_label
+        ? "<span class='hint' style='margin:2px 0 0'>" + esc(c.source_label) + "</span>"
+        : "";
       return '<div class="checkrow"><span class="mark ' + esc(c.status) + '">' +
         (MARK[c.status] || "") + '</span><span class="body"><b>' + esc(c.title) +
-        "</b><span>" + esc(c.detail) + "</span>" + how + "</span>" + go + "</div>";
+        "</b><span>" + esc(c.detail) + "</span>" + src + how + "</span>" + go + "</div>";
     }).join("") || '<div class="empty">Nothing to check.</div>';
 
     var pct = d.total ? Math.round((d.done / d.total) * 100) : 0;

--- a/tools/test_matrixark_readiness_sources.py
+++ b/tools/test_matrixark_readiness_sources.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A readiness row that read a setting and one that counted records both print "ok".
+
+Only one of them survives the deployment being misconfigured in a way that still answers 200, and
+that is the case this checklist exists for. A configured encoder that is unreachable, misnamed, or
+pointed at a base URL without `/v1` falls back to hash vectors while "Embedding model: ok" keeps
+saying ok -- so the row has to say which kind of claim it is making.
+
+The engine is the third kind. It publishes nothing about embeddings or models, but it does publish
+the storage backend it actually resolved, which no amount of reading configuration can produce.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import (  # noqa: E402
+    _FakeResponse, _FakeServer, _cfg, _factory_for, drive,
+)
+
+ADMIN = {"Authorization": "Bearer k-acme"}
+
+_BACKEND_METRICS = (
+    b'temporalstore_storage_backend{backend="shared_path",replication="shared_store"} 1\n'
+)
+
+
+def _overview(response=None):
+    cfg = _cfg(blob_connection_factory=_factory_for(response or _FakeResponse(200, _BACKEND_METRICS)))
+    app = gw.make_v1_app(_FakeServer(), cfg)
+    status, _headers, body = drive(app, method="GET", path="/v1/admin/overview", headers=ADMIN)
+    return status, json.loads(body)
+
+
+def _rows(payload):
+    return payload.get("readiness") or payload.get("checks") or []
+
+
+class EveryCheckSaysWhereItsAnswerCameFromTest(unittest.TestCase):
+
+    def test_every_row_carries_a_known_source(self) -> None:
+        status, payload = _overview()
+        self.assertEqual(200, status)
+        rows = _rows(payload)
+        self.assertTrue(rows, "no readiness rows at all -- this test would pass on an empty list")
+        for row in rows:
+            with self.subTest(check=row["id"]):
+                self.assertIn(row.get("source"), gw._CHECK_SOURCE_LABELS)
+                self.assertTrue(row.get("source_label"))
+
+    def test_a_check_with_no_declared_source_is_refused(self) -> None:
+        # The point of declaring per id rather than defaulting: a check added later cannot inherit
+        # the authoritative-looking answer by saying nothing.
+        self.assertNotIn("invented_check", gw._CHECK_SOURCES)
+        original = dict(gw._CHECK_SOURCES)
+        try:
+            gw._CHECK_SOURCES.pop("memory")
+            with self.assertRaises(ValueError):
+                _overview()
+        finally:
+            gw._CHECK_SOURCES.clear()
+            gw._CHECK_SOURCES.update(original)
+
+    def test_a_configured_encoder_is_not_reported_as_a_working_one(self) -> None:
+        # The claim that matters. "Embedding model: ok" is a statement about configuration; it is
+        # not evidence that a single model vector was ever produced.
+        _st, payload = _overview()
+        by_id = {row["id"]: row for row in _rows(payload)}
+        self.assertEqual("configuration", by_id["embedding"]["source"])
+        self.assertEqual("configuration", by_id["extraction"]["source"])
+        # ...while counts of what is actually stored are measurements.
+        self.assertEqual("measured", by_id["memory"]["source"])
+        self.assertEqual("measured", by_id["content"]["source"])
+
+    def test_the_two_kinds_are_labelled_differently(self) -> None:
+        # If both labels rendered the same string the distinction would be invisible on the page,
+        # which is the only place it does any good.
+        self.assertNotEqual(gw._CHECK_SOURCE_LABELS["configuration"],
+                            gw._CHECK_SOURCE_LABELS["measured"])
+        self.assertNotEqual(gw._CHECK_SOURCE_LABELS["engine"],
+                            gw._CHECK_SOURCE_LABELS["configuration"])
+
+
+class TheEngineRowReportsTheEngineTest(unittest.TestCase):
+
+    def test_it_reports_the_backend_the_datanode_resolved(self) -> None:
+        _st, payload = _overview()
+        row = {r["id"]: r for r in _rows(payload)}["storage_backend"]
+        self.assertEqual("engine", row["source"])
+        self.assertEqual("ok", row["status"])
+        self.assertIn("shared_path", row["detail"])
+
+    def test_an_unreachable_datanode_says_unknown_rather_than_ok(self) -> None:
+        # Reporting "ok" from silence would be the same defect one level up: a row that cannot see
+        # the engine claiming to describe it.
+        _st, payload = _overview(_FakeResponse(503, b""))
+        row = {r["id"]: r for r in _rows(payload)}["storage_backend"]
+        self.assertEqual("engine", row["source"])
+        self.assertNotEqual("ok", row["status"])
+        self.assertTrue(row["how"], "no steps offered for a state that needs action")
+
+    def test_the_overview_still_answers_when_the_datanode_raises(self) -> None:
+        def explode(_cfg_arg):
+            raise OSError("connection refused")
+        app = gw.make_v1_app(_FakeServer(), _cfg(blob_connection_factory=explode))
+        status, _h, body = drive(app, method="GET", path="/v1/admin/overview", headers=ADMIN)
+        self.assertEqual(200, status, "the page that reports on the deployment fell over")
+        row = {r["id"]: r for r in _rows(json.loads(body))}["storage_backend"]
+        self.assertNotEqual("ok", row["status"])
+
+
+class ThePageShowsTheSourceTest(unittest.TestCase):
+    """Read out of the rendered DOM, not grepped out of the file.
+
+    The presence check this replaces passed a mutation that broke the actual render, because the
+    variable was still mentioned elsewhere in the file. Only running the page distinguishes a label
+    that reaches a row from one that is merely referenced.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+        if not shutil.which("node"):
+            self.skipTest("node is not installed")
+
+    def _render(self):
+        import subprocess
+        import tempfile
+        _st, payload = _overview()
+        here = os.path.dirname(os.path.abspath(__file__))
+        page = os.path.join(here, "portal", "overview_portal.html")
+        harness = os.path.join(here, "portal", "overview_checklist_harness.js")
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+            json.dump(payload, handle)
+            fixture = handle.name
+        try:
+            proc = subprocess.run(["node", harness, page, fixture],
+                                  capture_output=True, text=True, timeout=60)
+        finally:
+            os.unlink(fixture)
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_each_rendered_row_says_where_its_answer_came_from(self) -> None:
+        result = self._render()
+        self.assertEqual([], result["errors"], "the page's scripts threw")
+        self.assertGreater(result["rows"], 1, "no checklist rows rendered")
+        # Both kinds reach the page, and they read differently there.
+        self.assertIn(gw._CHECK_SOURCE_LABELS["configuration"], result["checks"])
+        self.assertIn(gw._CHECK_SOURCE_LABELS["measured"], result["checks"])
+        self.assertIn(gw._CHECK_SOURCE_LABELS["engine"], result["checks"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The readiness checklist makes two very different claims in one voice.

- **"Skills and resources: ok"** counts what is actually stored.
- **"Embedding model: ok"** reads `embedding.provider` out of the configuration and says
  nothing whatever about whether a single vector was ever produced.

The difference matters most exactly where this deployment fails quietly. A configured
encoder that is unreachable, misnamed, or pointed at a base URL without `/v1` falls back
to hash vectors — and that row keeps saying `ok`, because nothing about it was ever an
observation.

## Every row now says where its answer came from

`what you configured` · `measured in this deployment` · `reported by the engine`

Declared per check id rather than defaulted, and `add()` raises for an id with no entry —
so a check added later has to state which kind of claim it is making instead of inheriting
the authoritative-looking one. That guard immediately caught **five** checks this change
had missed, which is the argument for writing it that way.

## The engine gets its own row

It publishes nothing about embeddings or models — its metrics cover storage, raft,
ingestion and the data node — but it does publish the **storage backend it actually
resolved**, which no amount of reading configuration can produce and which differs
silently from what was requested. An unreachable datanode reports *unknown* rather than
`ok`: a row that cannot see the engine must not claim to describe it.

## The page test was wrong first

It was a presence grep, and a mutation that broke the render **passed** it — the variable
was still mentioned elsewhere in the file. It now runs the built page in a DOM harness and
reads the rendered rows, which is the only way to tell a label that reaches a row from one
that is merely referenced.

8 tests, every one mutation-checked. 420 portal tests green on this base.
