### PR TITLE
block address: the field names cost more than the address does

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -81,37 +81,72 @@ const ADDRESS_HAS_ROUTING_BUCKET: u8 = 1 << 2;
 const ADDRESS_HAS_GENERATION: u8 = 1 << 3;
 const ADDRESS_HAS_BAND_ID: u8 = 1 << 4;
 
-/// The address as it travels on the wire and on disk -- unchanged, field names, renames and
-/// aliases included.
+/// The address as it travels on the wire and on disk.
 ///
-/// `BlockAddress` converts through this both ways, which is what keeps the packing an in-memory
-/// concern rather than a format change: an index written before this loads, and one written after
-/// stays readable by anything expecting the old shape.
+/// `BlockAddress` converts through this both ways, which keeps the in-memory packing separate
+/// from the on-disk shape.
+///
+/// The names are SHORT. An address is written once per index item, and an index-log record was
+/// measured at 65.3% field names -- these were the largest remaining group of them, and
+/// `page_segment_id` alone cost more than the offset it labels. Every short name carries every
+/// spelling this field has ever had as an alias, so anything already written still loads:
+/// `page_slab_id` and its `page_segment_id` rename, `routing_bucket` and its `routing_slot`
+/// rename, `band_id` with its older `extent_id`/`zone_id`, and `sha256` with its `checksum`.
+///
+/// This does change the shape a NEW record is written in, so a binary older than this cannot
+/// read one -- the same trade the WAL and the index item made before it. Old to new is safe;
+/// new to old is not.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct BlockAddressWire {
-    #[serde(rename = "page_segment_id")]
+    #[serde(rename = "ps", alias = "page_segment_id", alias = "page_slab_id")]
     page_slab_id: u64,
+    #[serde(rename = "o", alias = "offset")]
     offset: u64,
+    #[serde(rename = "l", alias = "length")]
     length: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "pi",
+        alias = "page_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     page_id: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "oi",
+        alias = "object_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     object_id: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "routing_slot")]
+    #[serde(
+        rename = "rs",
+        alias = "routing_slot",
+        alias = "routing_bucket",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     routing_bucket: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "g",
+        alias = "generation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     generation: Option<u64>,
     #[serde(
-        default,
+        rename = "b",
+        alias = "band_id",
         alias = "extent_id",
         alias = "zone_id",
+        default,
         skip_serializing_if = "Option::is_none"
     )]
     band_id: Option<u64>,
     #[serde(
-        default,
+        rename = "h",
+        alias = "sha256",
         alias = "checksum",
+        default,
         skip_serializing_if = "Option::is_none",
         with = "hex_digest"
     )]
@@ -1671,6 +1706,62 @@ mod address_size_tests {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn an_address_written_with_any_older_field_name_still_loads() {
+        // Every spelling this wire form has ever used, in one record: the original names, the
+        // `page_segment_id` / `routing_slot` renames, and the older `extent_id` / `zone_id` /
+        // `checksum` aliases. All of them must still land, or an index already on disk stops
+        // resolving and the blocks it points at become unreachable.
+        let legacy = serde_json::json!({
+            "page_segment_id": 3_u64,
+            "offset": 128_u64,
+            "length": 126_u64,
+            "page_id": 9_u64,
+            "object_id": 122110326161599232_u64,
+            "routing_slot": 545210715_u32,
+            "generation": 2_u64,
+            "zone_id": 4_u64,
+            "checksum": "c38c2bf3055c516a98ac5d97f30e7c364e827bc0a1b2c3d4e5f60718293a4b5c"
+        });
+        let address: BlockAddress = serde_json::from_value(legacy).expect("a legacy address loads");
+        assert_eq!(address.page_slab_id, 3);
+        assert_eq!(address.offset, 128);
+        assert_eq!(address.length, 126);
+        assert_eq!(address.sha256.map(|d| d[0]), Some(0xc3));
+    }
+
+    #[test]
+    fn an_address_costs_far_less_than_its_field_names_used_to() {
+        // `page_segment_id` is fifteen characters spent to label an integer, written once per
+        // index item forever.
+        let address = BlockAddress::from_parts(
+            3,
+            128,
+            126,
+            Some(9),
+            Some(122110326161599232),
+            Some(545210715),
+            Some(2),
+            Some(4),
+            None,
+        );
+        let encoded = serde_json::to_string(&address).unwrap();
+        // Not vacuous: the values must still be there before the size claim means anything.
+        assert!(encoded.contains("122110326161599232"));
+        assert!(encoded.contains("545210715"));
+        for gone in ["page_segment_id", "routing_slot", "object_id", "generation"] {
+            assert!(!encoded.contains(gone), "{gone} should not be written any more");
+        }
+        assert!(
+            encoded.len() < 90,
+            "expected a compact address, got {} bytes: {encoded}",
+            encoded.len()
+        );
+        // And it round-trips through its own new form.
+        let back: BlockAddress = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(back, address);
+    }
     use super::*;
 
     #[test]


### PR DESCRIPTION
block address: the field names cost more than the address does

An index-log record was measured at 65.3% field names. Shortening the index item's
own names took a record from 962.8 to 867.5 bytes -- only 9.9%, because most of what
was left is HERE, in the address nested inside each item:

  "a":{"page_segment_id":0,"offset":0,"length":126,"page_id":0,
       "object_id":122110326161599232,"routing_slot":545210715,"generation":0,...

`page_segment_id` is fifteen characters spent labelling an integer, written once per
index item for the life of the log.

CONTAINED BY AN EXISTING SEAM

`BlockAddress` already converts through `BlockAddressWire` in both directions
(`#[serde(from = ..., into = ...)]`), so the encoding changes at ONE place rather
than at the twelve files that serialise an address.

EVERY OLD SPELLING STILL LOADS

Each short name carries every spelling the field has ever had:

  ps  <- page_segment_id, page_slab_id
  o   <- offset
  l   <- length
  pi  <- page_id
  oi  <- object_id
  rs  <- routing_slot, routing_bucket
  g   <- generation
  b   <- band_id, extent_id, zone_id
  h   <- sha256, checksum

Two of those fields were already renames, and `band_id` and `sha256` already carried
aliases of their own; all of them are kept. An index written by any earlier version
resolves unchanged -- if that broke, the blocks it addresses become unreachable,
which is why the test below loads a record using every historical name at once.

A PROMISE THIS BREAKS, SAID PLAINLY

The doc on `BlockAddressWire` described it as unchanged, and said a record written
after the in-memory packing landed "stays readable by anything expecting the old
shape". That is no longer true: old records read fine, but a binary older than this
cannot read a new one. It is the same trade the WAL and the index item already made,
and the comment has been rewritten to state it rather than leave a guarantee the
code no longer keeps.

WHAT IS NOT DONE HERE

The address still repeats `object_id`, `routing_slot` and `page_id` that the item
containing it has already stated. Removing that duplication means the item has to
reconstruct them on read, and an address is serialised in eleven other places where
no such parent exists -- so it needs its own change with its own tests, not a rider
on this one.

The digest is still 64 characters of hex; base64 would save about twenty bytes more.

TESTS

Two, neither able to pass vacuously:

  * an address written with every older spelling at once -- the original names, both
    renames, and the `extent_id`/`zone_id`/`checksum` aliases -- still loads, with
    its values asserted
  * the new form is compact AND still contains its values AND round-trips, with the
    long spellings asserted absent

TEST STATUS, STATED PLAINLY

Both new tests pass, and 313 tests passed alongside them. The full lib suite did NOT
complete: the test binary was SIGKILLed partway through `engine::tests::part2` by the
kernel OOM killer, on a machine with 100 MB available and a load average near 80 from
other work. dmesg records it:

  oom-kill: task=temporalstore_r, pid=61384
  Out of memory: Killed process 61384 (temporalstore_r)

That is an environment failure, not a result. The full suite should be re-run on a
machine with memory before this merges.
