### PR TITLE
The durable read-cache rewrite had no floor between writes

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -116,7 +116,15 @@ LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "2000"))
 )
-LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "0")))
+# A floor between durable read-cache writes. The append-only fast path keeps the usual cost
+# proportional to what was appended, but when it cannot apply -- no epoch, a competing
+# adapter, or a compaction since the last write -- the fallback rewrites the WHOLE record
+# set as JSON, and with no floor that happened on every append.
+#
+# Measured: test_intern_record_metadata's codec round-trip does not finish in 45s at 0, and
+# passes with a 250ms floor. The cache is validated by signature on read, so a slightly
+# staler file costs nothing but a rebuild.
+LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "250")))
 LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION = 1
 PRE_RETRIEVAL_SUMMARY_REFRESH = os.environ.get("MATRIXARK_PRE_RETRIEVAL_SUMMARY_REFRESH", "0").strip().lower() in {"1", "true", "yes"}
 


### PR DESCRIPTION
`_write_durable_read_cache` has an append-only fast path that keeps the usual cost proportional to
what was appended. When it **cannot** apply — no epoch from the caller, a competing adapter, or a
compaction since the last write — the fallback rewrites the **whole record set** as JSON. The floor
bounding how often that happens defaulted to `0`, so it could run on every append, at O(corpus) each
time.

The comment above the fast path already names the hazard:

> rewriting it costs O(corpus) JSON on every append — and retrieval appends recall-reinforcement
> markers, so every query paid it

The knob to bound it existed and was off.

## Measured

`test_intern_record_metadata` reaches this through ordinary ingest:

| floor | result |
|---|---|
| `0` (today) | codec round-trip **does not finish in 45s** |
| `250ms` | **passes** |
| cache disabled | passes |

The stack, for the record:

```
_write_durable_read_cache        matrixark_mcp_local_adapter.py:4030
_update_read_cache_after_append  :4241
append                           :4474
ensure_context_node_path → _ingest_impl → ingest
```

That is the path of **every append**, not something peculiar to that test.

## Safety

The cache is validated by signature on read, so a slightly staler file costs a rebuild and nothing
else. `MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS=0` restores today's behaviour exactly.

## What this does not do

It does not make that test file fast — it still exceeds 240s, so something else in it is also slow.
This removes one quadratic that every append on every deployment was paying.
