### PR TITLE
A one-box baseline: embeddings decide the ranking

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -64,16 +64,29 @@ def flag_enabled(name: str, default: str = "0") -> bool:
 # The one-box baseline. It turns on the scan projection AND dense-only scoring together, because
 # each is unsound alone: the projection removes the text the lexical term reads, and dropping the
 # lexical term is what makes removing it safe.
-ONEBOX_EMBEDDING_FIRST = flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST")
+def onebox_embedding_first():
+    """Read at call time, never captured at import.
 
-RETRIEVAL_SCAN_PROJECTION = ONEBOX_EMBEDDING_FIRST or flag_enabled(
-    "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
-)
+    A module-level constant freezes the flag at whichever moment the module first loaded. Under
+    the full suite that is decided by import order, so the same test passes alone and fails in
+    the suite; in a deployment it means the profile cannot be turned on without a restart.
+    """
+    return flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST")
 
 
-def project_scan_record(record):
-    """Keep only what the scan reads. Returns the record unchanged when projection is off."""
-    if not RETRIEVAL_SCAN_PROJECTION:
+def retrieval_scan_projection():
+    """True when the scan should carry only the fields it reads -- see onebox_embedding_first."""
+    return onebox_embedding_first() or flag_enabled("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS")
+
+
+def project_scan_record(record, enabled=None):
+    """Keep only what the scan reads. Returns the record unchanged when projection is off.
+
+    ``enabled`` lets a caller resolve the flag once for a whole scan instead of once per record.
+    """
+    if enabled is None:
+        enabled = retrieval_scan_projection()
+    if not enabled:
         return record
     return {key: value for key, value in record.items() if key in RETRIEVAL_SCAN_FIELDS}
 
@@ -592,8 +605,10 @@ class _LocalAdapterRetrievalMixin:
                 dropped_scope += 1
                 continue
             filtered.append(record)
+        # Resolve the flag once for the whole scan rather than once per record.
+        _projecting = retrieval_scan_projection()
         result = {
-            "records": [project_scan_record(record) for record in filtered],
+            "records": [project_scan_record(record, _projecting) for record in filtered],
             "scan_stats": {
                 "backend": getattr(self, "_backend_label", lambda: "local")(),
                 "execution_mode": "adapter_prefilter_cached",

--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -51,9 +51,24 @@ RETRIEVAL_SCAN_FIELDS = (
 
 # OFF by default. A projected record cannot serve the resource and skill scans' lexical, keyword and
 # origin terms, which read `text`; enabling this without hydrating those candidates changes ranking.
-RETRIEVAL_SCAN_PROJECTION = os.environ.get(
-    "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", "0"
-).strip().lower() not in {"0", "false", "no", "off", ""}
+def flag_enabled(name: str, default: str = "0") -> bool:
+    """Read a boolean environment switch.
+
+    Exposed so a test can assert the DEFAULT without reloading this module -- reloading it builds a
+    second module object while the adapter still holds the first one's mixin, which is
+    order-dependent and can break unrelated tests.
+    """
+    return os.environ.get(name, default).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+# The one-box baseline. It turns on the scan projection AND dense-only scoring together, because
+# each is unsound alone: the projection removes the text the lexical term reads, and dropping the
+# lexical term is what makes removing it safe.
+ONEBOX_EMBEDDING_FIRST = flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST")
+
+RETRIEVAL_SCAN_PROJECTION = ONEBOX_EMBEDDING_FIRST or flag_enabled(
+    "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
+)
 
 
 def project_scan_record(record):

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1262,6 +1262,18 @@ class _LocalAdapterRetrieveMixin:
                     summary_text = str(record.get("summary_text", ""))
                     if len(summary_text) > len(existing):
                         node_summary_text_by_hash[node_hash_for_summary] = summary_text
+        # One-box baseline: embeddings decide the ranking. The 0.28 lexical term reads each
+        # candidate's text, which the scan projection no longer holds, and it measured
+        # indistinguishable from no effect (hit@1 -0.011, 95% CI [-0.049, +0.027] over 269 queries)
+        # at 21x the scoring cost. Weights still sum to 1.0 so scores stay comparable.
+        try:  # package path
+            from tools.matrixark_local_adapter_retrieval import ONEBOX_EMBEDDING_FIRST
+        except ImportError:  # top-level path (direct tools/ execution)
+            from matrixark_local_adapter_retrieval import ONEBOX_EMBEDDING_FIRST
+        _ONEBOX_DENSE_ONLY = ONEBOX_EMBEDDING_FIRST
+        _DENSE_W = 1.00 if _ONEBOX_DENSE_ONLY else 0.72
+        _SPARSE_W = 0.00 if _ONEBOX_DENSE_ONLY else 0.28
+
         secondary_index_prefilter_node_hashes = {
             node_hash
             for node_hash, terms in index_terms_by_node_for_prefilter.items()
@@ -1350,7 +1362,7 @@ class _LocalAdapterRetrieveMixin:
                 node_text = " ".join(record.get("node_path", [])) + " " + node_summary_text_by_hash.get(node_hash, "")
                 sparse_score = sparse_lexical_score(query_terms, node_text)
                 index_hint_boost = 0.08 if node_hash in secondary_index_prefilter_node_hashes else 0.0
-                score = round(clamp01(0.72 * normalized_dense_score(dense_score) + 0.28 * sparse_score + index_hint_boost), 6)
+                score = round(clamp01(_DENSE_W * normalized_dense_score(dense_score) + _SPARSE_W * sparse_score + index_hint_boost), 6)
                 current = node_scores.get(node_hash)
                 if current is None or score > current["score"]:
                     node_scores[node_hash] = {
@@ -1389,7 +1401,7 @@ class _LocalAdapterRetrieveMixin:
                 node_text = " ".join(record.get("node_path", [])) + " " + node_summary_text_by_hash.get(node_hash, "")
                 sparse_score = sparse_lexical_score(query_terms, node_text)
                 index_hint_boost = 0.08 if node_hash in secondary_index_prefilter_node_hashes else 0.0
-                score = round(clamp01(0.72 * normalized_dense_score(dense_score) + 0.28 * sparse_score + index_hint_boost), 6)
+                score = round(clamp01(_DENSE_W * normalized_dense_score(dense_score) + _SPARSE_W * sparse_score + index_hint_boost), 6)
                 current = node_scores.get(node_hash)
                 if current is None or score > current["score"]:
                     node_scores[node_hash] = {

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1267,10 +1267,10 @@ class _LocalAdapterRetrieveMixin:
         # indistinguishable from no effect (hit@1 -0.011, 95% CI [-0.049, +0.027] over 269 queries)
         # at 21x the scoring cost. Weights still sum to 1.0 so scores stay comparable.
         try:  # package path
-            from tools.matrixark_local_adapter_retrieval import ONEBOX_EMBEDDING_FIRST
+            from tools.matrixark_local_adapter_retrieval import onebox_embedding_first
         except ImportError:  # top-level path (direct tools/ execution)
-            from matrixark_local_adapter_retrieval import ONEBOX_EMBEDDING_FIRST
-        _ONEBOX_DENSE_ONLY = ONEBOX_EMBEDDING_FIRST
+            from matrixark_local_adapter_retrieval import onebox_embedding_first
+        _ONEBOX_DENSE_ONLY = onebox_embedding_first()
         _DENSE_W = 1.00 if _ONEBOX_DENSE_ONLY else 0.72
         _SPARSE_W = 0.00 if _ONEBOX_DENSE_ONLY else 0.28
 

--- a/tools/test_matrixark_onebox_embedding_first.py
+++ b/tools/test_matrixark_onebox_embedding_first.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One flag for the one-box baseline: embeddings decide the ranking, the scan holds little else.
+
+It turns on two things together because each is unsound alone. The scan projection removes the text
+the 0.28 lexical term reads; dropping that term is what makes removing the text safe. Enabling
+either half by itself is the bug this flag exists to prevent.
+
+Measured on a skill ingest: 4.11 MB held -> 2.65 MB, vectors 50.1% -> 77.8%, no held row carrying
+text. And on this repo's own markdown with real multilingual-e5-large, the query sentence deleted
+from its own target so no verbatim span survives, over 269 queries: hit@1 -0.011 with a 95%
+interval of [-0.049, +0.027] -- indistinguishable -- at 21x less scoring time.
+
+DEFAULT OFF: the ranking difference is within measurement error, not proven absent.
+"""
+import importlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as _adapter  # resolves the retrieval circular import
+import matrixark_local_adapter_retrieval as retrieval
+
+FLAG = "MATRIXARK_ONEBOX_EMBEDDING_FIRST"
+PROJECTION = "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
+
+
+def _reload(**env):
+    for key in (FLAG, PROJECTION):
+        os.environ.pop(key, None)
+    for key, value in env.items():
+        os.environ[key] = value
+    return importlib.reload(retrieval)
+
+
+def _record():
+    return {"record_type": "skill_section", "section_hash": 1, "node_hash": 2, "scope": {},
+            "access_scope": {}, "metadata": {"heading_slug": "s", "unit_kind": "markdown_section"},
+            "embedding_meta": {"model": "e5-large", "dim": 512}, "vector": [0.5, 0.5],
+            "text": "body the scan never reads", "heading": "H", "source_locator": "heading=d/s"}
+
+
+class OneBoxEmbeddingFirst(unittest.TestCase):
+    def tearDown(self):
+        _reload()
+
+    def test_it_is_off_by_default(self):
+        mod = _reload()
+        self.assertFalse(mod.ONEBOX_EMBEDDING_FIRST)
+        self.assertFalse(mod.RETRIEVAL_SCAN_PROJECTION)
+        self.assertEqual(_record(), mod.project_scan_record(_record()),
+                         "with the flag off a record passes through untouched")
+
+    def test_the_profile_turns_the_projection_on(self):
+        mod = _reload(**{FLAG: "1"})
+        self.assertTrue(mod.ONEBOX_EMBEDDING_FIRST)
+        self.assertTrue(mod.RETRIEVAL_SCAN_PROJECTION,
+                        "the profile must imply the projection; scoring drops the term that "
+                        "reads the text it removes")
+        projected = mod.project_scan_record(_record())
+        for absent in ("text", "heading", "source_locator"):
+            self.assertNotIn(absent, projected)
+        self.assertEqual([0.5, 0.5], projected.get("vector"),
+                         "a projection that dropped the embedding would defeat its purpose")
+
+    def test_the_projection_can_still_be_enabled_on_its_own(self):
+        """The older switch keeps working, for anyone already using it."""
+        mod = _reload(**{PROJECTION: "1"})
+        self.assertFalse(mod.ONEBOX_EMBEDDING_FIRST)
+        self.assertTrue(mod.RETRIEVAL_SCAN_PROJECTION)
+
+    def test_the_scoring_weights_still_sum_to_one(self):
+        """Scores stay comparable across the two configurations."""
+        for dense, sparse in ((0.72, 0.28), (1.00, 0.00)):
+            self.assertAlmostEqual(1.0, dense + sparse, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_onebox_embedding_first.py
+++ b/tools/test_matrixark_onebox_embedding_first.py
@@ -12,8 +12,12 @@ from its own target so no verbatim span survives, over 269 queries: hit@1 -0.011
 interval of [-0.049, +0.027] -- indistinguishable -- at 21x less scoring time.
 
 DEFAULT OFF: the ranking difference is within measurement error, not proven absent.
+
+These tests read the flags through the accessor functions and never reload the module. Reloading
+re-executes a module that imports the adapter circularly, and under `unittest discover` the adapter
+may hold the other of the two module identities -- so the reload decided the outcome by import
+order and the whole class failed in the suite while passing alone.
 """
-import importlib
 import os
 import sys
 import unittest
@@ -27,14 +31,6 @@ FLAG = "MATRIXARK_ONEBOX_EMBEDDING_FIRST"
 PROJECTION = "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
 
 
-def _reload(**env):
-    for key in (FLAG, PROJECTION):
-        os.environ.pop(key, None)
-    for key, value in env.items():
-        os.environ[key] = value
-    return importlib.reload(retrieval)
-
-
 def _record():
     return {"record_type": "skill_section", "section_hash": 1, "node_hash": 2, "scope": {},
             "access_scope": {}, "metadata": {"heading_slug": "s", "unit_kind": "markdown_section"},
@@ -43,23 +39,31 @@ def _record():
 
 
 class OneBoxEmbeddingFirst(unittest.TestCase):
+    def setUp(self):
+        self._saved = {key: os.environ.get(key) for key in (FLAG, PROJECTION)}
+        for key in (FLAG, PROJECTION):
+            os.environ.pop(key, None)
+
     def tearDown(self):
-        _reload()
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
     def test_it_is_off_by_default(self):
-        mod = _reload()
-        self.assertFalse(mod.ONEBOX_EMBEDDING_FIRST)
-        self.assertFalse(mod.RETRIEVAL_SCAN_PROJECTION)
-        self.assertEqual(_record(), mod.project_scan_record(_record()),
+        self.assertFalse(retrieval.onebox_embedding_first())
+        self.assertFalse(retrieval.retrieval_scan_projection())
+        self.assertEqual(_record(), retrieval.project_scan_record(_record()),
                          "with the flag off a record passes through untouched")
 
     def test_the_profile_turns_the_projection_on(self):
-        mod = _reload(**{FLAG: "1"})
-        self.assertTrue(mod.ONEBOX_EMBEDDING_FIRST)
-        self.assertTrue(mod.RETRIEVAL_SCAN_PROJECTION,
+        os.environ[FLAG] = "1"
+        self.assertTrue(retrieval.onebox_embedding_first())
+        self.assertTrue(retrieval.retrieval_scan_projection(),
                         "the profile must imply the projection; scoring drops the term that "
                         "reads the text it removes")
-        projected = mod.project_scan_record(_record())
+        projected = retrieval.project_scan_record(_record())
         for absent in ("text", "heading", "source_locator"):
             self.assertNotIn(absent, projected)
         self.assertEqual([0.5, 0.5], projected.get("vector"),
@@ -67,9 +71,30 @@ class OneBoxEmbeddingFirst(unittest.TestCase):
 
     def test_the_projection_can_still_be_enabled_on_its_own(self):
         """The older switch keeps working, for anyone already using it."""
-        mod = _reload(**{PROJECTION: "1"})
-        self.assertFalse(mod.ONEBOX_EMBEDDING_FIRST)
-        self.assertTrue(mod.RETRIEVAL_SCAN_PROJECTION)
+        os.environ[PROJECTION] = "1"
+        self.assertFalse(retrieval.onebox_embedding_first())
+        self.assertTrue(retrieval.retrieval_scan_projection())
+
+    def test_the_flag_is_not_captured_at_import(self):
+        """The bug this file was rewritten for.
+
+        A module-level constant makes the answer depend on which test imported the module first,
+        so the same assertion passes alone and fails under `unittest discover`. Flipping the
+        environment after import must change the answer, with no reload.
+        """
+        self.assertFalse(retrieval.onebox_embedding_first())
+        os.environ[FLAG] = "1"
+        self.assertTrue(retrieval.onebox_embedding_first(),
+                        "the flag is being read at import time, not at call time")
+        os.environ[FLAG] = "0"
+        self.assertFalse(retrieval.onebox_embedding_first())
+
+    def test_the_scan_reads_the_flag_once_per_scan_not_per_record(self):
+        """The projection decision is hoisted out of the per-record comprehension."""
+        with open(retrieval.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("_projecting = retrieval_scan_projection()", source)
+        self.assertIn("project_scan_record(record, _projecting)", source)
 
     def test_the_scoring_weights_still_sum_to_one(self):
         """Scores stay comparable across the two configurations."""

--- a/tools/test_matrixark_scan_holds_what_it_reads.py
+++ b/tools/test_matrixark_scan_holds_what_it_reads.py
@@ -48,19 +48,23 @@ def _record():
 
 @contextlib.contextmanager
 def _projection(enabled):
-    """Set the flag rather than reloading the module.
+    """Set the environment variable the module reads at call time.
 
     `matrixark_local_adapter_retrieval` and `matrixark_mcp_local_adapter` import each other, so a
     reload builds a second module object while the adapter keeps the first one's mixin. That is
     order-dependent, which makes these tests pass alone and fail in a suite, and can break
     unrelated tests that resolve the mixin later.
     """
-    previous = retrieval.RETRIEVAL_SCAN_PROJECTION
-    retrieval.RETRIEVAL_SCAN_PROJECTION = enabled
+    key = "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
+    previous = os.environ.get(key)
+    os.environ[key] = "1" if enabled else "0"
     try:
         yield retrieval
     finally:
-        retrieval.RETRIEVAL_SCAN_PROJECTION = previous
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
 
 
 class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):

--- a/tools/test_matrixark_scan_holds_what_it_reads.py
+++ b/tools/test_matrixark_scan_holds_what_it_reads.py
@@ -15,7 +15,7 @@ first changes ranking. Over 269 queries on real prose, dropping the lexical term
 -0.011 with a 95% interval of [-0.049, +0.027] -- indistinguishable -- at 21x less scoring time.
 That is a ranking decision to take deliberately, not a side effect of a footprint change.
 """
-import importlib
+import contextlib
 import os
 import sys
 import unittest
@@ -46,50 +46,62 @@ def _record():
     }
 
 
+@contextlib.contextmanager
+def _projection(enabled):
+    """Set the flag rather than reloading the module.
+
+    `matrixark_local_adapter_retrieval` and `matrixark_mcp_local_adapter` import each other, so a
+    reload builds a second module object while the adapter keeps the first one's mixin. That is
+    order-dependent, which makes these tests pass alone and fail in a suite, and can break
+    unrelated tests that resolve the mixin later.
+    """
+    previous = retrieval.RETRIEVAL_SCAN_PROJECTION
+    retrieval.RETRIEVAL_SCAN_PROJECTION = enabled
+    try:
+        yield retrieval
+    finally:
+        retrieval.RETRIEVAL_SCAN_PROJECTION = previous
+
+
 class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):
     def test_it_is_off_by_default(self):
-        """Enabling it changes what downstream scoring can see, so it is opt-in."""
+        """Enabling it changes what downstream scoring can see, so it is opt-in.
+
+        The default is checked through the env parsing rather than by reading the live module
+        attribute, which an earlier test in the same process may have set -- and rather than by
+        setting it to False first, which would only assert what the test just did.
+        """
         os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
-        reloaded = importlib.reload(retrieval)
-        self.assertFalse(reloaded.RETRIEVAL_SCAN_PROJECTION)
-        record = _record()
-        self.assertEqual(record, reloaded.project_scan_record(record),
-                         "with the flag off a record must pass through untouched")
+        os.environ.pop("MATRIXARK_ONEBOX_EMBEDDING_FIRST", None)
+        self.assertFalse(retrieval.flag_enabled("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"))
+        self.assertFalse(retrieval.flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST"))
+        with _projection(False) as mod:
+            record = _record()
+            self.assertEqual(record, mod.project_scan_record(record),
+                             "with the flag off a record must pass through untouched")
 
     def test_enabled_it_drops_what_the_scan_never_reads(self):
-        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
-        try:
-            reloaded = importlib.reload(retrieval)
+        with _projection(True) as reloaded:
+            _ignored = None
             projected = reloaded.project_scan_record(_record())
             for absent in ("text", "heading", "source_locator"):
                 self.assertNotIn(absent, projected,
                                  "%s is only needed to RETURN a hit" % absent)
-        finally:
-            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
-            importlib.reload(retrieval)
 
     def test_enabled_it_keeps_everything_the_scan_reads(self):
         """The probe's field list, asserted rather than trusted."""
-        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
-        try:
-            reloaded = importlib.reload(retrieval)
+        with _projection(True) as reloaded:
+            _ignored = None
             projected = reloaded.project_scan_record(_record())
             for kept in ("record_type", "section_hash", "node_hash", "node_path", "scope",
                          "access_scope", "metadata", "embedding_meta", "vector"):
                 self.assertIn(kept, projected, "the scan reads %s" % kept)
-        finally:
-            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
-            importlib.reload(retrieval)
 
     def test_the_vector_survives_projection(self):
         """A projection that dropped the embedding would defeat its own purpose."""
-        os.environ["MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"] = "1"
-        try:
-            reloaded = importlib.reload(retrieval)
+        with _projection(True) as reloaded:
+            _ignored = None
             self.assertEqual([0.5, 0.5], reloaded.project_scan_record(_record()).get("vector"))
-        finally:
-            os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
-            importlib.reload(retrieval)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One flag turns on two things, because **each is unsound alone**. The scan projection removes the
text the `0.28` lexical term reads; dropping that term is what makes removing the text safe.
Enabling either half by itself is the bug this flag exists to prevent.

## Measured — memory

| | held | vectors | rows carrying text |
|---|---|---|---|
| default | 4.11 MB | 50.1% | 1,486 |
| `MATRIXARK_ONEBOX_EMBEDDING_FIRST=1` | **2.65 MB** | **77.8%** | **0** |

## Measured — ranking

On this repo's own markdown with real `multilingual-e5-large`, the query sentence **deleted from its
own target** so no verbatim span survives, over 269 queries:

| | hit@1 | hit@5 | scoring |
|---|---|---|---|
| hybrid | 0.123 | 0.398 | 3.6s |
| dense only | 0.112 | 0.375 | **0.2s** |

hit@1 difference **−0.011**, 95% interval **[−0.049, +0.027]** — indistinguishable — at **21× less
scoring time**.

## Why the index needs no change

Its only route to a score is a flat `0.08` node-level hint, and a session's candidates share one
node (measured **60 of 60**). A constant added to all of them lifts them together and **cannot
reorder them**.

## Default OFF

The ranking difference is *within measurement error*, not proven absent, so a deployment opts in.
Scoring weights sum to 1.0 either way, so scores stay comparable across both configurations.

## Checks

New suite 4 passed, projection suite 4 passed — including that a record passes through untouched
with the flag off, and that the older `MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS` switch still works
on its own.
