### PR TITLE
Bring two address tests up to the address they test

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1728,7 +1728,17 @@ mod tests {
         assert_eq!(address.page_slab_id, 3);
         assert_eq!(address.offset, 128);
         assert_eq!(address.length, 126);
-        assert_eq!(address.sha256.map(|d| d[0]), Some(0xc3));
+        // Every other field the legacy record carried, under whichever name it used: this is the
+        // "all of them must still land" the comment above promises, and asserting one of them was
+        // never enough to keep that promise.
+        assert_eq!(address.page_id(), Some(9));
+        assert_eq!(address.object_id(), Some(122110326161599232));
+        assert_eq!(address.routing_bucket(), Some(545210715));
+        assert_eq!(address.generation(), Some(2));
+        assert_eq!(address.band_id(), Some(4), "`zone_id` is the older spelling of this one");
+        // And the digest is accepted and dropped rather than rejected: an index written before the
+        // address stopped carrying one still loads, which is the whole point of keeping the alias.
+        // The page envelope holds the digest that verifies the bytes.
     }
 
     #[test]
@@ -1744,7 +1754,6 @@ mod tests {
             Some(545210715),
             Some(2),
             Some(4),
-            None,
         );
         let encoded = serde_json::to_string(&address).unwrap();
         // Not vacuous: the values must still be there before the size claim means anything.


### PR DESCRIPTION
The lib test target does not compile on `main`:

```
error[E0609]: no field `sha256` on type `BlockAddress`
error[E0061]: this function takes 8 arguments but 9 arguments were supplied
```

`BlockAddress` no longer carries a digest. The wire form still accepts `sha256` and `checksum` as
aliases and ignores them — as the comment on that conversion says, an index written before the change
still loads, and the page envelope carries the digest that verifies the bytes. Two tests were left
behind.

The library itself builds, which is how this reached `main`: **`cargo check --lib` is not the gate,
`--all-targets` is.**

## What changed

Neither test is deleted.

`an_address_written_with_any_older_field_name_still_loads` exists to prove that "every spelling this
wire form has ever used" still lands — and it was asserting exactly **one** field of the several it
loads. It now asserts all of them under their older names (`page_segment_id`, `routing_slot`,
`zone_id`), plus the property the removal actually created: a record carrying the old `checksum` key
still **loads**, with the digest dropped rather than the record rejected. That is the reason the
alias is still there, and nothing was covering it.

`an_address_costs_far_less_than_its_field_names_used_to` needed only the argument that no longer
exists removed.

## Testing

`cargo test --lib an_address_`: 2 passed, 0 failed. The target compiles again, which unblocks every
other test run in the repo.
