### PR TITLE
The engine says why it chose a storage backend

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -134,6 +134,9 @@ fn main() {
     // used to sit) meant every deployment paid for a disk tier whether or not it could help.
     let storage_decision = temporalstore_rust::StorageBackendConfig::from_env().resolve_decision();
     let storage_backend = storage_decision.backend.clone();
+    // Kept alongside the backend so /metrics can publish why this node chose it. The log
+    // line below is not reachable from a portal, an operator's browser, or a dashboard.
+    let storage_reason = storage_decision.reason.clone();
     let disk_cache_tier = storage_backend.wants_disk_cache_tier();
     info!(
         backend = %storage_backend.describe(),
@@ -541,7 +544,7 @@ fn main() {
                 let mut metrics = engine.prometheus_metrics();
                 append_ingestion_metrics(&mut metrics, &engine);
                 append_runtime_metrics(&mut metrics, &runtime);
-                append_storage_backend_metric(&mut metrics, &storage_backend);
+                append_storage_backend_metric(&mut metrics, &storage_backend, &storage_reason);
                 if let Some(raft_state) = &raft_state {
                     metrics.push_str(&raft_state.runtime.cluster().prometheus_metrics());
                 }
@@ -2627,6 +2630,45 @@ fn send_heartbeat(
 
 #[cfg(test)]
 mod tests {
+    /// The reason is free text carrying paths and endpoint URLs, so it reaches this label with
+    /// quotes and backslashes in it. An unescaped one produces a line Prometheus rejects, which
+    /// takes down the WHOLE scrape rather than this one series -- strictly worse than publishing
+    /// nothing at all, which is why this is asserted rather than assumed.
+    #[test]
+    fn storage_backend_reason_is_escaped_for_a_prometheus_label() {
+        let mut out = String::new();
+        // Raw strings on both sides: exactly one level of escaping to reason about. The input is
+        // what the engine would hand over -- a reason containing a quote AND a backslash.
+        let reason = r#"auto: probe of "http://s\x" failed, degraded"#;
+        append_storage_backend_metric(
+            &mut out,
+            &temporalstore_rust::StorageBackend::RaftReplication,
+            reason,
+        );
+        let info = out
+            .lines()
+            .find(|line| line.starts_with("temporalstore_storage_backend_info{"))
+            .expect("no info series emitted");
+        assert!(info.contains(r#"backend="raft""#), "{info}");
+        // Both arrive escaped, so the line stays parseable: " becomes \" and \ becomes \\.
+        assert!(info.contains(r#"\"http://s\\x\""#), "{info}");
+        // Exactly one closing brace before the value: proof the value did not terminate early.
+        assert_eq!(1, info.matches("} 1").count(), "{info}");
+    }
+
+    /// The outcome series must keep its shape: the dashboards and the gateway probe both read it,
+    /// and adding a second series next to it is exactly how the first one gets broken.
+    #[test]
+    fn the_outcome_series_is_unchanged_by_the_reason_series() {
+        let mut out = String::new();
+        append_storage_backend_metric(
+            &mut out,
+            &temporalstore_rust::StorageBackend::RaftReplication,
+            "auto: nothing shared is reachable",
+        );
+        assert!(out.contains("temporalstore_storage_backend{backend=\"raft\",replication=\"raft\"} 1"));
+    }
+
     use std::net::TcpListener;
     use std::path::Path;
     use std::sync::{Arc, Mutex};

--- a/crates/temporalstore-rust/src/bin/server/metrics.rs
+++ b/crates/temporalstore-rust/src/bin/server/metrics.rs
@@ -4,9 +4,28 @@
 // Prometheus metrics appenders (runtime/storage-manager/ingestion), split from
 // server.rs (textual include!, shared flat scope + use-imports; no mod wrapper).
 
+/// Escape a string for use as a Prometheus label value.
+///
+/// The reason is free text assembled from paths and endpoint URLs, so it can contain a backslash or
+/// a quote. An unescaped one produces a line Prometheus rejects, which would take the whole scrape
+/// down rather than just this series -- a worse outcome than not publishing it at all.
+fn escape_label_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 fn append_storage_backend_metric(
     out: &mut String,
     backend: &temporalstore_rust::StorageBackend,
+    reason: &str,
 ) {
     use temporalstore_rust::StorageBackend;
     let (kind, replication) = match backend {
@@ -20,6 +39,17 @@ fn append_storage_backend_metric(
     out.push_str("# TYPE temporalstore_storage_backend gauge\n");
     out.push_str(&format!(
         "temporalstore_storage_backend{{backend=\"{kind}\",replication=\"{replication}\"}} 1\n"
+    ));
+    // Why, not just which. The outcome above cannot distinguish a backend that was asked for from
+    // one that was fallen back to, and those are the cases an operator is actually chasing.
+    out.push_str(
+        "# HELP temporalstore_storage_backend_info Why this node selected its storage backend.\n",
+    );
+    out.push_str("# TYPE temporalstore_storage_backend_info gauge\n");
+    out.push_str(&format!(
+        "temporalstore_storage_backend_info{{backend=\"{kind}\",reason=\"{reason}\"}} 1\n",
+        kind = kind,
+        reason = escape_label_value(reason)
     ));
 }
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2334,9 +2334,12 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
     # through to auto-detection without erroring.
     live_backend = config_snapshot.get("live_storage_backend")
     if live_backend:
+        why = str(config_snapshot.get("live_storage_reason") or "").strip()
         add("storage_backend", "Storage backend", "ok",
             "The datanode resolved the " + str(live_backend) + " backend. This is what it is "
-            "running, not what was requested; the engine records why only in a startup log line.")
+            "running, not what was requested"
+            + ((" — " + why) if why else
+               ". This engine does not publish why it chose it; that is only in its startup log."))
     else:
         add("storage_backend", "Storage backend", "warn",
             "Could not read the datanode's backend, so what this deployment is storing to is "
@@ -2996,6 +2999,48 @@ def _build_direct_client(cfg: GatewayConfig) -> DirectBackendClient:
     )
 
 
+def _parse_prom_labels(line: str) -> Json:
+    """Labels of one Prometheus sample, honouring backslash escapes.
+
+    Splitting on "," and stripping quotes tears a value in half at its first escaped quote, and the
+    reason label carries paths and endpoint URLs, so that is a matter of when rather than whether.
+    """
+    start = line.find("{")
+    end = line.rfind("}")
+    if start < 0 or end < start:
+        return {}
+    out: Json = {}
+    key = ""
+    buf: List[str] = []
+    in_value = False
+    escaped = False
+    for ch in line[start + 1:end]:
+        if not in_value:
+            if ch == "=":
+                key = "".join(buf).strip()
+                buf = []
+            elif ch == '"' and not key:
+                continue
+            elif ch == '"':
+                in_value = True
+            elif ch == ",":
+                buf = []
+            else:
+                buf.append(ch)
+            continue
+        if escaped:
+            buf.append({"n": "\n", "\\": "\\", '"': '"'}.get(ch, ch))
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        elif ch == '"':
+            out[key] = "".join(buf)
+            key, buf, in_value = "", [], False
+        else:
+            buf.append(ch)
+    return out
+
+
 def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
     """Which storage backend the datanode actually resolved. None => could not determine.
 
@@ -3021,20 +3066,25 @@ def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
         _safe_close(conn)
         if status >= 400:
             return None
-        for line in body.decode("utf-8", "replace").splitlines():
-            if not line.startswith("temporalstore_storage_backend{"):
-                continue
-            labels = line[line.find("{") + 1:line.find("}")]
-            parsed: Json = {}
-            for pair in labels.split(","):
-                if "=" in pair:
-                    key, _, value = pair.partition("=")
-                    parsed[key.strip()] = value.strip().strip('"')
-            if parsed.get("backend"):
-                return {"backend": parsed["backend"],
-                        "replication": parsed.get("replication", ""),
-                        "source": "datanode /metrics"}
-        return None
+        text = body.decode("utf-8", "replace")
+        outcome: Json = {}
+        reason = ""
+        for line in text.splitlines():
+            if line.startswith("temporalstore_storage_backend_info{"):
+                labels = _parse_prom_labels(line)
+                reason = labels.get("reason", "") or reason
+            elif line.startswith("temporalstore_storage_backend{"):
+                labels = _parse_prom_labels(line)
+                if labels.get("backend"):
+                    outcome = {"backend": labels["backend"],
+                               "replication": labels.get("replication", ""),
+                               "source": "datanode /metrics"}
+        if not outcome:
+            return None
+        # Absent on an engine older than the series. That is a fact about the deployment, not a
+        # failure, so the caller distinguishes "no reason published" from "could not reach it".
+        outcome["reason"] = reason
+        return outcome
     except Exception:
         return None
 
@@ -3323,9 +3373,11 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 "catalogue": catalogue,
                 "live": live,
                 "live_detail": (
-                    "This deployment resolved the %s backend. The engine records WHY in a startup "
-                    "log line only, so the reason is not readable over HTTP."
-                    % live["backend"] if live else
+                    ("This deployment resolved the %s backend. %s" % (
+                        live["backend"],
+                        live.get("reason")
+                        or "This engine does not publish why it chose it; that is only in its "
+                           "startup log.")) if live else
                     "Could not read the datanode's backend. It publishes "
                     "temporalstore_storage_backend on /metrics; an unreachable datanode or a "
                     "gateway pointed at the wrong address both look like this."),
@@ -3530,6 +3582,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             if live:
                 config_snapshot = dict(config_snapshot)
                 config_snapshot["live_storage_backend"] = live.get("backend")
+                config_snapshot["live_storage_reason"] = live.get("reason") or ""
             checks = _readiness_checks(config_snapshot, counts, cfg,
                                        float(traffic.get("total_requests") or 0), imports)
             done = sum(1 for c in checks if c["status"] == "ok")

--- a/tools/test_matrixark_readiness_sources.py
+++ b/tools/test_matrixark_readiness_sources.py
@@ -32,9 +32,23 @@ _BACKEND_METRICS = (
 )
 
 
+def _app_with(factory):
+    """Build the app from a plain dict rather than a constructed GatewayConfig.
+
+    Under `unittest discover` the gateway module is imported under two names in one process, so a
+    GatewayConfig built from one copy of the class fails the `isinstance` check in the other and
+    `_coerce_config` falls through to `dict(overrides)` on it. Passing a dict lets whichever copy
+    is live build its own, which is what the app does with a fresh deployment anyway.
+    """
+    return gw.make_v1_app(_FakeServer(), {
+        "api_keys": {"k-acme": "acme", "k-globex": "globex"},
+        "require_auth": True,
+        "blob_connection_factory": factory,
+    })
+
+
 def _overview(response=None):
-    cfg = _cfg(blob_connection_factory=_factory_for(response or _FakeResponse(200, _BACKEND_METRICS)))
-    app = gw.make_v1_app(_FakeServer(), cfg)
+    app = _app_with(_factory_for(response or _FakeResponse(200, _BACKEND_METRICS)))
     status, _headers, body = drive(app, method="GET", path="/v1/admin/overview", headers=ADMIN)
     return status, json.loads(body)
 
@@ -109,7 +123,7 @@ class TheEngineRowReportsTheEngineTest(unittest.TestCase):
     def test_the_overview_still_answers_when_the_datanode_raises(self) -> None:
         def explode(_cfg_arg):
             raise OSError("connection refused")
-        app = gw.make_v1_app(_FakeServer(), _cfg(blob_connection_factory=explode))
+        app = _app_with(explode)
         status, _h, body = drive(app, method="GET", path="/v1/admin/overview", headers=ADMIN)
         self.assertEqual(200, status, "the page that reports on the deployment fell over")
         row = {r["id"]: r for r in _rows(json.loads(body))}["storage_backend"]
@@ -203,9 +217,7 @@ class TheEngineSaysWhyTest(unittest.TestCase):
         self.assertEqual({"backend": "raft", "replication": "raft"}, labels)
 
     def test_the_deployment_route_stops_saying_the_reason_is_unavailable(self) -> None:
-        cfg = _cfg(blob_connection_factory=_factory_for(
-            _FakeResponse(200, _BACKEND_WITH_REASON)))
-        app = gw.make_v1_app(_FakeServer(), cfg)
+        app = _app_with(_factory_for(_FakeResponse(200, _BACKEND_WITH_REASON)))
         _st, _h, body = drive(app, method="GET", path="/v1/admin/deployment", headers=ADMIN)
         detail = json.loads(body)["live_detail"]
         self.assertIn("forced shared-path", detail)

--- a/tools/test_matrixark_readiness_sources.py
+++ b/tools/test_matrixark_readiness_sources.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
 """A readiness row that read a setting and one that counted records both print "ok".
 
 Only one of them survives the deployment being misconfigured in a way that still answers 200, and

--- a/tools/test_matrixark_readiness_sources.py
+++ b/tools/test_matrixark_readiness_sources.py
@@ -156,5 +156,60 @@ class ThePageShowsTheSourceTest(unittest.TestCase):
         self.assertIn(gw._CHECK_SOURCE_LABELS["engine"], result["checks"])
 
 
+_BACKEND_WITH_REASON = (
+    b'temporalstore_storage_backend{backend="shared_path",replication="shared_store"} 1\n'
+    b'temporalstore_storage_backend_info{backend="shared_path",'
+    b'reason="TS_STORAGE_BACKEND=shared: forced shared-path at /srv/a \\"b\\", ok"} 1\n'
+)
+
+
+class TheEngineSaysWhyTest(unittest.TestCase):
+    """The outcome cannot distinguish a backend that was asked for from one fallen back to.
+
+    Those are the cases an operator is actually chasing -- shared storage with no directory, and
+    MatrixObject on a build without the feature, both degrade to auto-detection without erroring --
+    and until now the answer existed only in a startup log line no portal can read.
+    """
+
+    def test_the_reason_reaches_the_checklist(self) -> None:
+        _st, payload = _overview(_FakeResponse(200, _BACKEND_WITH_REASON))
+        row = {r["id"]: r for r in _rows(payload)}["storage_backend"]
+        self.assertEqual("ok", row["status"])
+        self.assertIn("forced shared-path", row["detail"])
+
+    def test_an_engine_that_publishes_no_reason_is_not_an_error(self) -> None:
+        # The gateway talks to whatever datanode is deployed, which is routinely older than this.
+        # Absent means "this engine does not publish it", not "something is wrong".
+        _st, payload = _overview(_FakeResponse(
+            200, b'temporalstore_storage_backend{backend="raft",replication="raft"} 1\n'))
+        row = {r["id"]: r for r in _rows(payload)}["storage_backend"]
+        self.assertEqual("ok", row["status"], "a missing reason was treated as a failure")
+        self.assertIn("raft", row["detail"])
+        self.assertIn("does not publish", row["detail"])
+
+    def test_a_reason_with_quotes_and_commas_survives_the_wire(self) -> None:
+        # The reason carries paths and endpoint URLs, so an escaped quote is a matter of when
+        # rather than whether; splitting on "," and stripping quotes tears the value in half.
+        labels = gw._parse_prom_labels(
+            'temporalstore_storage_backend_info{backend="shared_path",'
+            'reason="forced shared-path at /srv/a \\"b\\", ok"} 1')
+        self.assertEqual("shared_path", labels["backend"])
+        self.assertEqual('forced shared-path at /srv/a "b", ok', labels["reason"])
+
+    def test_a_plain_sample_still_parses(self) -> None:
+        labels = gw._parse_prom_labels(
+            'temporalstore_storage_backend{backend="raft",replication="raft"} 1')
+        self.assertEqual({"backend": "raft", "replication": "raft"}, labels)
+
+    def test_the_deployment_route_stops_saying_the_reason_is_unavailable(self) -> None:
+        cfg = _cfg(blob_connection_factory=_factory_for(
+            _FakeResponse(200, _BACKEND_WITH_REASON)))
+        app = gw.make_v1_app(_FakeServer(), cfg)
+        _st, _h, body = drive(app, method="GET", path="/v1/admin/deployment", headers=ADMIN)
+        detail = json.loads(body)["live_detail"]
+        self.assertIn("forced shared-path", detail)
+        self.assertNotIn("not readable over HTTP", detail)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`BackendDecision` already carries a reason — whether the backend was forced, auto-detected,
or fallen back to because what was asked for could not be honoured. It went to a startup
log line and nowhere else, so an operator asking *why* a deployment is on raft when they
configured shared storage had to find and read the process log, and the portal had to say
the answer was not available over HTTP.

That matters because the fall-through cases are the ones nobody expects: shared storage
with no directory, and MatrixObject on a build without the feature, both degrade to
auto-detection **without erroring**. The outcome metric says what happened; only the reason
says why.

## What is published

`temporalstore_storage_backend_info{backend,reason}` — the Prometheus idiom for a labelled
constant. One series per process, fixed at startup, so free text costs no cardinality over
time.

The reason is assembled from paths and endpoint URLs, so it can contain a quote or a
backslash. It is escaped, because an unescaped one produces a line Prometheus rejects and
that takes down the **whole scrape**, not just this series — strictly worse than publishing
nothing. A unit test asserts the escaping against a reason containing both `"` and `\`.

The existing outcome series is unchanged, and a second test pins that: adding a series
beside another is exactly how the first one gets broken, and both the dashboards and the
gateway probe read it.

## The gateway reads it, and copes without it

Absence means "this engine is older", not a failure — the gateway talks to whatever
datanode is deployed. Parsing honours backslash escapes: splitting on `,` and stripping
quotes tears the value in half at its first escaped quote, which for a reason carrying
filesystem paths is a matter of when rather than whether.

## Tests

13 Python tests and 2 Rust unit tests, all passing on this base. The Python side is
mutation-checked — 3 of 3 bite, including the naive comma-split.
