### PR TITLE
main does not build: two tests still describe the address that was replaced

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -1728,7 +1728,11 @@ mod tests {
         assert_eq!(address.page_slab_id, 3);
         assert_eq!(address.offset, 128);
         assert_eq!(address.length, 126);
-        assert_eq!(address.sha256.map(|d| d[0]), Some(0xc3));
+        // The `checksum` above is a legacy key and is ignored rather than stored: the index holds
+        // no digest, and the page envelope carries the one a read verifies against. What matters
+        // here is that its presence does not stop the rest of the address from loading.
+        assert_eq!(address.page_id(), Some(9));
+        assert_eq!(address.band_id(), Some(4));
     }
 
     #[test]
@@ -1744,7 +1748,6 @@ mod tests {
             Some(545210715),
             Some(2),
             Some(4),
-            None,
         );
         let encoded = serde_json::to_string(&address).unwrap();
         // Not vacuous: the values must still be there before the size claim means anything.


### PR DESCRIPTION
`main` does not compile.

`BlockAddress` no longer carries a digest and `from_parts` takes eight arguments. Both are
deliberate — the constructor's own doc says a discarded digest parameter *"would invite a caller to
pass a freshly computed digest believing it was kept"*. But two call sites **inside
`block_store.rs`'s own tests** were not updated:

```
error[E0609] no field `sha256` on type `block_store::BlockAddress`   block_store.rs:1731
error[E0061] this function takes 8 arguments but 9 were supplied     block_store.rs:1738
```

The ninth argument was the removed digest.

## The legacy test keeps its point

Its purpose is that every older field **spelling** still loads, or an index already on disk stops
resolving and the blocks it points at become unreachable. A legacy `checksum` key is now *ignored*
rather than stored, so the assertion becomes that its presence does not stop the rest of the address
loading — checked through the `page_id()` / `band_id()` accessors the rest of the file already uses.

`cargo check --all-targets` is clean.

## Second break of this shape today

After the `registered_at_ms` initializers this morning. Both are **semantic conflicts between
merges**: each branch is correct on its own and only the combination fails, which per-PR CI cannot
see because nothing builds that combination until it has already landed.

Three PRs are currently blocked behind this — their cargo failures are inherited from `main`, not
their own.
