### PR TITLE
Return the heap a GC just freed to the operating system

### DIFF
--- a/crates/temporalstore-rust/src/data_node/task_execution.rs
+++ b/crates/temporalstore-rust/src/data_node/task_execution.rs
@@ -237,6 +237,10 @@ pub(super) fn run_gc_inner(inner: &DataNodeRuntimeInner, request: GcRequest) -> 
         .lock()
         .expect("runtime stats lock poisoned")
         .gc_runs += 1;
+    // Hand back what this just released. `free` returns memory to the allocator, not to the kernel:
+    // measured here, dropping 46 MB returned 2.3% of it, and one trim returned 95% of the rest. GC
+    // is where a lot is released at once and nothing is waiting on the result.
+    let _ = crate::memory_trim::release_free_heap_to_os();
     GcResponse {
         status,
         shard_id: request.shard_id,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -4556,3 +4556,100 @@ fn context_object_keys_keep_their_exact_bytes() {
     // Distinct inputs stay distinct across the colon: (1, 23) and (12, 3) must not collide.
     assert_ne!(context_node_key(1, 23), context_node_key(12, 3));
 }
+
+
+/// How much resident memory is the allocator holding rather than the store?
+///
+/// A proxy measured 444.9 MB resident against 128.6 MB of live data. The only `#[global_allocator]`
+/// in this tree is the test-only counting probe, so production runs on glibc malloc with no tuning:
+/// freed chunks sit in per-thread arenas and go back to the OS only when the heap top is free or
+/// `malloc_trim` is called. Nothing here calls it and nothing caps arenas.
+///
+/// This churns allocations in the shape the decode path produces, drops them, and reads RSS three
+/// times:
+///
+///   after the churn            -> what the work cost
+///   after dropping everything  -> what the allocator kept
+///   after `malloc_trim(0)`     -> what it returns when asked
+///
+/// RSS flat on the drop and falling on the trim means the retention is the allocator's, and a trim
+/// on an existing maintenance path recovers it. RSS falling on the drop means there is nothing to
+/// fix here.
+///
+///   cargo test -p temporalstore-rust --lib how_much_resident_memory_is_the_allocator_holding -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn how_much_resident_memory_is_the_allocator_holding() {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    extern "C" {
+        /// glibc: release free heap above `pad` back to the OS. Returns non-zero if it freed any.
+        fn malloc_trim(pad: usize) -> i32;
+    }
+
+    fn resident_kb() -> u64 {
+        // The same source `wal.rs` reads. Zero means unreadable, which the assertions below catch
+        // rather than quietly reporting a 0 KB result as an improvement.
+        std::fs::read_to_string("/proc/self/status")
+            .ok()
+            .and_then(|status| {
+                status.lines().find_map(|line| {
+                    line.strip_prefix("VmRSS:")
+                        .and_then(|rest| rest.split_whitespace().next().map(str::to_string))
+                })
+            })
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0)
+    }
+
+    let baseline = resident_kb();
+    assert!(baseline > 0, "could not read VmRSS, so every number below would be fiction");
+
+    // The shapes a decode produces, at a size worth measuring: byte buffers off pages, the strings
+    // a record carries, and the float vectors. Held all at once, then dropped all at once.
+    {
+        let mut held: Vec<(Vec<u8>, String, Vec<f32>)> = Vec::with_capacity(20_000);
+        for index in 0..20_000_u32 {
+            held.push((
+                vec![(index % 251) as u8; 512],
+                format!("ctx:node:{index}:{index} a canonical name and some discarded text"),
+                vec![index as f32 / 1024.0; 384],
+            ));
+        }
+        let churned = resident_kb();
+        println!(
+            "
+  resident memory, KB
+    baseline                    {baseline:>9}
+    holding 20,000 records      {churned:>9}   (+{} KB)",
+            churned.saturating_sub(baseline),
+        );
+        assert!(
+            churned > baseline,
+            "holding 20,000 records did not raise RSS, so this probe is not measuring anything"
+        );
+    }
+
+    let dropped = resident_kb();
+    println!("    after dropping them all     {dropped:>9}   (+{} KB over baseline)",
+        dropped.saturating_sub(baseline));
+
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        let returned = unsafe { malloc_trim(0) };
+        let trimmed = resident_kb();
+        println!(
+            "    after malloc_trim(0)        {trimmed:>9}   (+{} KB over baseline, trim returned {returned})
+",
+            trimmed.saturating_sub(baseline),
+        );
+        let kept_after_drop = dropped.saturating_sub(baseline);
+        let kept_after_trim = trimmed.saturating_sub(baseline);
+        println!(
+            "  the allocator kept {kept_after_drop} KB after the drop and {kept_after_trim} KB after the trim:
+  a large fall here is memory a proxy could return on any maintenance tick, for one call.
+"
+        );
+    }
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+    println!("    malloc_trim: not glibc on this target, so this half did not run\n");
+}

--- a/crates/temporalstore-rust/src/lib.rs
+++ b/crates/temporalstore-rust/src/lib.rs
@@ -30,6 +30,7 @@ pub mod data_node;
 pub mod e2e;
 pub mod durability_metrics;
 pub mod flush_gate;
+pub mod memory_trim;
 pub mod engine;
 pub mod http;
 pub mod index_log;

--- a/crates/temporalstore-rust/src/memory_trim.rs
+++ b/crates/temporalstore-rust/src/memory_trim.rs
@@ -1,0 +1,89 @@
+//! Returning freed heap to the operating system.
+//!
+//! Rust's `free` hands memory back to the allocator, not to the kernel. On glibc -- what this runs
+//! on, since the only `#[global_allocator]` here is a test-only probe -- freed chunks stay in
+//! per-thread arenas, and the process keeps its resident pages until the heap top happens to be
+//! free or something calls `malloc_trim`.
+//!
+//! Measured in process: dropping 46 MB of live data returned 2.3% of it; one `malloc_trim(0)`
+//! returned 95% of what was retained. A proxy holding 128.6 MB of live data measured 444.9 MB
+//! resident, which is the same effect at deployment scale.
+
+/// Ask the allocator to return free heap to the operating system.
+///
+/// Returns whether anything was released. `false` covers three different things and deliberately
+/// does not distinguish them at the call site: the allocator had nothing to give back, the trim is
+/// switched off, or this is not a glibc target.
+///
+/// Not on the serving path. A trim walks the free lists, so it belongs where a lot has just been
+/// released at once and the next request is not waiting on it.
+pub fn release_free_heap_to_os() -> bool {
+    if !trim_enabled() {
+        return false;
+    }
+    trim()
+}
+
+/// `TS_MALLOC_TRIM=0` (or `false`/`no`/`off`) switches the trim off.
+///
+/// On by default: the measurement is one-sided, in that what is returned is memory the process is
+/// not using. The escape hatch exists because a trim costs a walk of the free lists, and an
+/// operator who measures that as expensive on their heap should not need a build to stop it.
+fn trim_enabled() -> bool {
+    !matches!(
+        std::env::var("TS_MALLOC_TRIM")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn trim() -> bool {
+    extern "C" {
+        /// glibc: release free heap above `pad` back to the OS. Non-zero if it freed any.
+        fn malloc_trim(pad: usize) -> i32;
+    }
+    // Safe: no arguments derived from Rust memory, no pointers handed over, and the allocator's own
+    // bookkeeping is what it walks. It cannot invalidate a live allocation -- only unused pages go
+    // back.
+    unsafe { malloc_trim(0) != 0 }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+fn trim() -> bool {
+    // No portable equivalent. Reporting "nothing released" is the honest answer rather than
+    // pretending the platform did something.
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The switch has to be read at the call, not cached, or an operator turning it off mid-run
+    /// finds it still trimming.
+    #[test]
+    fn the_trim_switch_is_read_every_time() {
+        std::env::set_var("TS_MALLOC_TRIM", "0");
+        assert!(!trim_enabled(), "0 must switch the trim off");
+        for off in ["false", "NO", "Off", " 0 "] {
+            std::env::set_var("TS_MALLOC_TRIM", off);
+            assert!(!trim_enabled(), "{off:?} must switch the trim off");
+        }
+        std::env::set_var("TS_MALLOC_TRIM", "1");
+        assert!(trim_enabled(), "1 must leave it on");
+        std::env::remove_var("TS_MALLOC_TRIM");
+        assert!(trim_enabled(), "unset must leave it on, which is the default");
+    }
+
+    /// Off means off: the call must do nothing and say so.
+    #[test]
+    fn a_disabled_trim_releases_nothing() {
+        std::env::set_var("TS_MALLOC_TRIM", "0");
+        assert!(!release_free_heap_to_os(), "a disabled trim must not report a release");
+        std::env::remove_var("TS_MALLOC_TRIM");
+    }
+}


### PR DESCRIPTION
`free` hands memory back to the allocator, not to the kernel. The only `#[global_allocator]` in this
tree is a test-only counting probe, so this runs on **glibc malloc**: freed chunks stay in per-thread
arenas and the process keeps its resident pages until the heap top happens to be free or something
calls `malloc_trim`. Nothing called it.

## Measured in process

Allocating in the shapes a decode produces — byte buffers, strings, float vectors — then dropping all
of it:

| | resident KB |
|---|---:|
| baseline | 17,060 |
| holding 20,000 records | 63,268 (+46,208) |
| **after dropping every one** | 62,184 (**+45,124**) — `free` returned 2.3% |
| **after `malloc_trim(0)`** | 19,452 (**+2,392**) — **42.7 MB returned, 94.7%** |

Reproduced on two independent runs (45,060 KB / 45,124 KB retained; 2,328 KB / 2,392 KB after the
trim).

That is the shape a proxy showed at deployment scale: **444.9 MB resident against 128.6 MB of live
data**, 71% of it not held by the store at all. The memory was never lost or fragmented beyond
recovery — glibc simply does not return it unless asked.

## Where it is called

GC, and nowhere else. It is the point where the process has just released a lot at once, it is
infrequent, it is already an explicit operator-driven maintenance action, and nothing is waiting on
its result. **The serving path is untouched.**

## The switch

`TS_MALLOC_TRIM=0` (or `false`/`no`/`off`) turns it off. On by default because what comes back is
memory the process is not using and nothing else changes; the switch exists because a trim walks the
free lists, and an operator who measures that as expensive on their own heap should not need a build
to stop it.

The switch is read **at the call** rather than cached, so turning it off mid-run actually works —
`the_trim_switch_is_read_every_time` holds that, and `a_disabled_trim_releases_nothing` holds that off
means off.

Non-glibc targets get a no-op that reports "nothing released" rather than pretending the platform did
something. No new dependency: `malloc_trim` is declared `extern "C"` under
`cfg(target_os = "linux", target_env = "gnu")`.

## What this does not do

It moves **no allocation count** — every allocation harness in this repo scores it zero. It moves
RSS, which is the number a deployment is sized from.
`how_much_resident_memory_is_the_allocator_holding` ships with it so the property stays measurable
rather than becoming a number in a commit message.

## Testing

`cargo test --lib`: 1,532 passed, 13 failed under parallelism, **all 13 pass when re-run serially** —
including `appending_does_not_get_slower_as_the_log_grows`, the timing assertion most plausibly
affected by adding a free-list walk. This suite has ~180 `std::env::set_var` sites, so a parallel
failure is not evidence until it reproduces.
