### PR TITLE
memory_trim.rs carries the licence header the check requires

### DIFF
--- a/crates/temporalstore-rust/src/memory_trim.rs
+++ b/crates/temporalstore-rust/src/memory_trim.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 MatrixArkAI
+
 //! Returning freed heap to the operating system.
 //!
 //! Rust's `free` hands memory back to the allocator, not to the kernel. On glibc -- what this runs


### PR DESCRIPTION
`crates/temporalstore-rust/src/memory_trim.rs` landed in #591 without the SPDX header.

The Governance job scans **every** `crates/**/*.rs`, not just the files a pull request
touches, so `license headers (SPDX)` has been failing on every open PR since — none of
which go near this file. I hit it on two of my own and traced it here.

Two lines, matching every neighbouring source. Verified with the job's own command:

```
files=$(git ls-files 'crates/**/*.rs' 'sdk/**/*.rs')
grep -L 'SPDX-License-Identifier: Apache-2.0' $files
```

→ `OK: all 361 Rust sources carry the SPDX Apache-2.0 header.`
