### PR TITLE
Read a page without taking a copy of it, on the paths that read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "matrixcache"
 version = "0.1.0"
-source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=be08e8db69fee071390917eafeca10f5fef3099f#be08e8db69fee071390917eafeca10f5fef3099f"
+source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b#7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b"
 dependencies = [
  "rocksdb",
  "serde",

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"
 matrixraft = { package = "matrixraft", git = "https://github.com/matrixarkai/MatrixRaft.git", rev = "a4334b37ba6592e7c7192f3eaa2afe087746ccc9" }
-matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "be08e8db69fee071390917eafeca10f5fef3099f", features = ["rocksdb-ssd"] }
+matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b", features = ["rocksdb-ssd"] }
 temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }

--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3461,6 +3461,36 @@ fn read_page_bytes(
     Some(bytes)
 }
 
+/// The page's bytes, shared rather than copied.
+///
+/// `read_page_bytes` hands back a `Vec<u8>` the cache built by copying the `Arc<[u8]>` it already
+/// holds. A caller that parses the bytes and drops them pays that memcpy and that allocation for
+/// nothing -- once per retrieval candidate on the node fetch.
+///
+/// Identical to `read_page_bytes` in every other way: same key, same lookup, same spill and log
+/// fallbacks, same promotion. It differs only in not owning the result. Callers that keep or mutate
+/// the bytes should keep using `read_page_bytes`.
+fn read_page_shared(
+    cache: &MultiLayerCache,
+    page_store: &LocalBlockStore,
+    shard_id: ShardId,
+    address: &BlockAddress,
+) -> Option<std::sync::Arc<[u8]>> {
+    let cache_key = CacheKey::page_with_slot(
+        shard_id,
+        address.page_slab_id,
+        address.offset,
+        address.length,
+        address.routing_bucket());
+    if let Ok(Some(bytes)) = cache.get_shared(&cache_key) {
+        return Some(bytes);
+    }
+    // Every path below writes to the cache and hands back what it wrote, so going through
+    // `read_page_bytes` keeps the spill redirect, the in-log read and the block-store read in one
+    // place rather than duplicating three fallbacks that must not drift apart.
+    read_page_bytes(cache, page_store, shard_id, address).map(std::sync::Arc::from)
+}
+
 fn read_page_bytes_cold(page_store: &LocalBlockStore, address: &BlockAddress) -> Option<Vec<u8>> {
     page_store.read(address).ok()
 }

--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -828,7 +828,9 @@ pub(super) fn load_context_node(
         .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
         .or_else(|| shard.context_nodes.get(&object_key))
         .and_then(|address| {
-            read_page_bytes(cache, page_store, shard_id, address)
+            // Shared, not copied: the bytes are parsed here and dropped, so owning them costs a
+            // page-sized memcpy and an allocation for nothing.
+            super::read_page_shared(cache, page_store, shard_id, address)
                 .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
         })
 }

--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -83,6 +83,10 @@ fn load_context_node(
         .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
         .or_else(|| shard.context_nodes.get(object_key))
         .and_then(|address| {
+            // Owning, not shared: the summary upsert calls this while writing, where the page
+            // is as likely to be a miss as a hit -- and on a miss the shared read wraps an owned
+            // buffer in a fresh Arc, which copies a second time. The query commands, which are
+            // hit-heavy, do share.
             read_page_bytes(cache, page_store, shard_id, address)
                 .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
         })
@@ -2399,7 +2403,7 @@ pub(crate) fn execute_on_shard(
                         .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
                         .or_else(|| shard.context_nodes.get(&object_key))
                         .and_then(|address| {
-                            read_page_bytes(cache, page_store, shard_id, address)
+                            read_page_shared(cache, page_store, shard_id, address)
                                 .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
                         })?;
                     if node.vector.is_empty() {
@@ -2478,7 +2482,7 @@ pub(crate) fn execute_on_shard(
                 .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
                 .or_else(|| shard.context_nodes.get(&object_key))
                 .and_then(|address| {
-                    read_page_bytes(cache, page_store, shard_id, address)
+                    read_page_shared(cache, page_store, shard_id, address)
                         .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
                 });
             CommandResponse::ContextNode { object_key, node }
@@ -2497,7 +2501,7 @@ pub(crate) fn execute_on_shard(
                         .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
                         .or_else(|| shard.context_nodes.get(&object_key))
                         .and_then(|address| {
-                            read_page_bytes(cache, page_store, shard_id, address)
+                            read_page_shared(cache, page_store, shard_id, address)
                                 .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
                         })
                 })
@@ -3629,7 +3633,7 @@ pub(crate) fn execute_on_shard(
                 .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
                 .or_else(|| shard.context_nodes.get(&node_key))
                 .and_then(|address| {
-                    read_page_bytes(cache, page_store, shard_id, address)
+                    read_page_shared(cache, page_store, shard_id, address)
                         .and_then(|bytes| context_from_bytes::<ContextNode>(&bytes))
                 });
             let level = summary_level.unwrap_or(1).max(1);


### PR DESCRIPTION
`read_page_bytes` asks the cache for a `Vec<u8>`, which the cache builds by copying the `Arc<[u8]>`
it already holds. The bytes are then parsed and dropped — a page-sized memcpy and an allocation per
call, and a node fetch happens **once per retrieval candidate**.

matrixarkai/MatrixCache#17 and #18 added `get_shared`, which hands out the Arc. `read_page_shared`
uses it: same key, same lookup, same spill and in-log fallbacks, same promotion — one allocation
fewer and no copy.

| | before | after |
|---|---:|---:|
| retrieve, allocations per candidate | 12.4 | **11.4** |
| &nbsp;&nbsp;of which the node fetch | 11.0 | **10.0** |
| retrieve, bytes at 160 candidates | 222,894 | **196,219** (−12%) |
| one add (flat in the corpus) | 1,374 | 1,372 |

## Why only four of the five sites

The shared read skips a copy on a cache **hit** and adds one on a **miss** — the fallback wraps an
owned buffer in a fresh `Arc`, which copies a second time.

Sharing everywhere measured exactly that, in one run: retrieve fell to 11.4 **and** an add rose from
1,374 to 1,395. So the four query commands share — `ContextQueryNodeEmbeddings`, `ContextGetNode`,
`ContextGetNodes`, `ContextQueryNodeContext` — and the shard-local `load_context_node` keeps the
owning read, because the summary upsert calls it while writing, where a page is as likely to be a
miss as a hit. Scoping it that way keeps the retrieve win in full and returns the add to 1,372.

`read_page_bytes` is unchanged and still used wherever the bytes are kept rather than parsed and
dropped.

## Testing

`cargo test --lib`: 1,532 passed, 13 failed under parallelism, **all 13 pass when re-run serially**.
The two that had reproduced serially were genuine and are fixed separately in #594; nothing
deterministic fails here.
