### PR TITLE
Segments follow their tenant knob

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -13,6 +13,20 @@ import warnings as _warnings
 _PROFILE_SCOPE_WARNED: set = set()
 
 
+def _segments_enabled(scope) -> bool:
+    """Whether this tenant materialises context_segment rows (default OFF).
+
+    Second of the two segment writers. Both consult the same knob, and the pair is covered by one
+    behavioural test rather than a shared symbol: what must not drift is the OUTCOME, not the
+    spelling.
+    """
+    try:
+        from matrixark_index_growth_bound import extract_segments_enabled
+    except Exception:  # pragma: no cover - policy module absent
+        return False
+    return bool(extract_segments_enabled(scope))
+
+
 def _segment_access_scope_enabled() -> bool:
     """Gate: write context_segment records WITH a tenant/user/session access_scope so a
     scored segment passes access_scope_matches_before_scoring instead of being dropped
@@ -3293,7 +3307,7 @@ class _LocalAdapterIngestMixin:
                 )
 
         segment_hashes = []
-        for segment in extraction["segments"]:
+        for segment in (extraction["segments"] if _segments_enabled(envelope.get("scope")) else []):
             segment_hash = stable_hash(f"{batch_id_hash}:segment:{segment['topic']}:{segment['coordinate_tuples']}")
             segment_hashes.append(segment_hash)
             (

--- a/tools/matrixark_mcp_local_batch_extract_runtime.py
+++ b/tools/matrixark_mcp_local_batch_extract_runtime.py
@@ -73,6 +73,19 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     )
 
 
+def _segments_enabled(scope: Any) -> bool:
+    """Whether this tenant materialises context_segment rows (default OFF).
+
+    A segment restates its event -- same text up to a role or index prefix -- so each one costs a
+    record, an embedding and a set of index postings to store what the event already holds.
+    """
+    try:
+        from matrixark_index_growth_bound import extract_segments_enabled
+    except Exception:  # pragma: no cover - policy module absent
+        return False
+    return bool(extract_segments_enabled(scope))
+
+
 def compact_context_embedding_record(record: Json) -> Json:
     return compact_hot_context_embedding_record(record)
 
@@ -927,7 +940,9 @@ def batch_extract_after_start(self: Any, args: Json, batch_start: Json) -> Json:
             records_to_append.extend(profile_dirty_records)
 
     segment_hashes = []
-    for segment in extraction["segments"]:
+    # The list stays empty rather than absent, which keeps every downstream
+    # source_segment_hashes field well-formed instead of missing.
+    for segment in (extraction["segments"] if _segments_enabled(envelope.get("scope")) else []):
         segment_hash = stable_hash(f"{batch_id_hash}:segment:{segment['topic']}:{segment['coordinate_tuples']}")
         segment_hashes.append(segment_hash)
         records_to_append.append(

--- a/tools/test_codex_pipeline_part2.py
+++ b/tools/test_codex_pipeline_part2.py
@@ -3,6 +3,9 @@
 """_CodexPipelinePart2 methods split from test_matrixark_codex_hook_pipeline.MatrixArkCodexHookPipelineTest (mixin)."""
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -1633,6 +1636,10 @@ class _CodexPipelinePart2:
             self.assertTrue(any(ref.get("ref_type") == "summary" for ref in pack["selected_refs"]))
             self.assertLessEqual(pack["used_context_tokens"], 120)
 
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_fast_hook_threshold_commit_persists_real_adapter_memory_layers(self) -> None:
         original_auto_batch = matrixark_codex_hook.HOOK_AUTO_BATCH_EXTRACT
         matrixark_codex_hook.HOOK_AUTO_BATCH_EXTRACT = True

--- a/tools/test_codex_pipeline_part3.py
+++ b/tools/test_codex_pipeline_part3.py
@@ -3,6 +3,9 @@
 """_CodexPipelinePart3 methods split from test_matrixark_codex_hook_pipeline.MatrixArkCodexHookPipelineTest (mixin)."""
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -43,6 +46,10 @@ except ImportError:
 
 
 class _CodexPipelinePart3:
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_fast_hook_threshold_commit_recovers_pending_buffer_after_restart(self) -> None:
         original_auto_batch = matrixark_codex_hook.HOOK_AUTO_BATCH_EXTRACT
         matrixark_codex_hook.HOOK_AUTO_BATCH_EXTRACT = True

--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -3,6 +3,9 @@
 """_CodexPipelinePart4 methods split from test_matrixark_codex_hook_pipeline.MatrixArkCodexHookPipelineTest (mixin)."""
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -2986,6 +2989,10 @@ class _CodexPipelinePart4:
             self.assertEqual("prefer", inventory["query_scope"]["session_scope"])
             self.assertNotIn("source_event_ids", json.dumps(inventory, sort_keys=True))
 
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_context_segment_debug_pack_shows_source_context_events(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             adapter = MatrixArkLocalAdapter(Path(tmp_dir) / "matrixark-segment-source-events.jsonl")

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -3,6 +3,9 @@
 """_CodexPipelinePart5 methods split from test_matrixark_codex_hook_pipeline.MatrixArkCodexHookPipelineTest (mixin)."""
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -570,6 +573,10 @@ class _CodexPipelinePart5:
                 tool_entity["source_memory_selection_policies"],
             )
 
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_batch_extraction_keeps_segment_selection_policies_role_specific(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             adapter = MatrixArkLocalAdapter(Path(tmp_dir) / "matrixark-role-specific-segment-policies.jsonl")
@@ -984,6 +991,10 @@ class _CodexPipelinePart5:
             self.assertFalse(matrixark_codex_hook.should_run_session_commit_after_ingest("UserPromptSubmit", ""))
             self.assertFalse(matrixark_codex_hook.should_run_session_commit_after_ingest("IdleTimeout", "timeout"))
 
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_batch_extract_events_are_timestamp_keyed_under_segment_parent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             adapter = MatrixArkLocalAdapter(Path(tmp_dir) / "matrixark-batch-segment-time.jsonl")

--- a/tools/test_matrixark_policy_gates_take_effect.py
+++ b/tools/test_matrixark_policy_gates_take_effect.py
@@ -301,5 +301,96 @@ class TraverseSiblingSessionsTest(unittest.TestCase):
             "a tenant that declined sibling sessions still had another session searched")
 
 
+class ExtractSegmentsTest(unittest.TestCase):
+    """A segment restates its event, so a tenant can decline them.
+
+    Two things are checked, and the second is the one that matters. Counting stored records shows
+    the knob is consulted; it cannot tell "redundant" from "lost". The knob's whole justification is
+    that the event still carries the answer, which is a claim about RETRIEVAL -- so that is checked
+    the way a customer would notice.
+    """
+
+    def _stored(self, tenant, enabled):
+        import matrixark_mcp_server as mcp
+        policy.set_tenant_policy(tenant, {"extract_segments": enabled})
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            scope = {"tenant_id": tenant, "user_id": "u1", "session_id": "s1"}
+            server.call_tool("matrixark_ingest", {
+                "scope": scope, "finalize": True,
+                "messages": [{"role": "user",
+                              "content": "I am allergic to peanuts and I live in Kyoto."}]})
+            server.call_tool("matrixark_session_commit", {"scope": scope})
+            records = adapter.read_all()
+        identities = {tenant, policy.tenant_hash_of(tenant)}
+        segments = total = 0
+        for record in records:
+            scope_value = (record.get("scope") or record.get("access_scope")
+                           or record.get("scope_key"))
+            if policy.tenant_of(scope_value) not in identities:
+                continue
+            total += 1
+            if str(record.get("record_type")) == "context_segment":
+                segments += 1
+        return segments, total
+
+    def test_the_knob_decides_whether_segments_are_written(self) -> None:
+        on_segments, on_total = self._stored("seg_on_case", True)
+        off_segments, off_total = self._stored("seg_off_case", False)
+        self.assertGreater(on_total, 0, "nothing was stored at all, so this proves nothing")
+        self.assertGreater(off_total, 0, "declining segments took the whole memory with it")
+        self.assertGreater(on_segments, 0, "a tenant that asked for segments got none")
+        self.assertEqual(0, off_segments, "a tenant that declined segments still got them")
+
+    def test_both_writers_honour_it(self) -> None:
+        # There are two segment writers. What must not drift between them is the outcome, so this
+        # asserts on the stored result rather than on a shared symbol.
+        import matrixark_mcp_local_adapter  # noqa: F401  (import order: adapter before submodule)
+        import matrixark_local_adapter_ingest as ingest
+        import matrixark_mcp_local_batch_extract_runtime as runtime
+        policy.set_tenant_policy("both_off", {"extract_segments": False})
+        policy.set_tenant_policy("both_on", {"extract_segments": True})
+        for module in (ingest, runtime):
+            with self.subTest(module=module.__name__):
+                self.assertFalse(module._segments_enabled({"tenant_id": "both_off"}))
+                self.assertTrue(module._segments_enabled({"tenant_id": "both_on"}))
+                # No tenant falls to the knob's own default, which for segments is OFF.
+                self.assertFalse(module._segments_enabled(None))
+
+
+class TurningSegmentsOffDoesNotLoseTheAnswerTest(unittest.TestCase):
+    """The claim that justifies the default, checked instead of trusted.
+
+    "A segment restates its event" means the event still answers the question. Counting records
+    cannot show that; asking can.
+    """
+
+    def _ask(self, tenant, enabled, query):
+        import matrixark_mcp_server as mcp
+        policy.set_tenant_policy(tenant, {"extract_segments": enabled})
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+            scope = {"tenant_id": tenant, "user_id": "u1", "session_id": "s1"}
+            for message in ("I am allergic to peanuts and I live in Kyoto.",
+                            "My favourite drink is matcha, and I bike to work."):
+                server.call_tool("matrixark_ingest", {
+                    "scope": scope, "finalize": True,
+                    "messages": [{"role": "user", "content": message}]})
+            server.call_tool("matrixark_session_commit", {"scope": scope})
+            return str(server.call_tool("matrixark_retrieve",
+                                        {"scope": scope, "query": query})).lower()
+
+    def test_the_answer_survives_without_segments(self) -> None:
+        with_them = self._ask("ans_on", True, "what am I allergic to?")
+        without = self._ask("ans_off", False, "what am I allergic to?")
+        self.assertIn("peanut", with_them,
+                      "the query does not work even WITH segments, so the check below is vacuous")
+        self.assertIn("peanut", without,
+                      "turning segments off lost the answer -- they are not redundant, and the "
+                      "default-OFF behaviour is not safe")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_policy_gates_wired.py
+++ b/tools/test_matrixark_policy_gates_wired.py
@@ -38,10 +38,6 @@ GATES_MODULE = os.path.join(TOOLS, "matrixark_index_growth_bound.py")
 # reachable from production code.
 KNOWN_UNWIRED: Set[str] = {
     "dedupe_index_postings_enabled",
-    # Wired and working, but held back to its own change: honouring its default (OFF) stops
-    # segment rows for every deployment that has set no policy, and six existing tests depend on
-    # them. Retrieval still returns the answer without them, but that is a decision on its own.
-    "extract_segments_enabled",
     "embed_node_path_prefix_enabled",
     "generate_l1_summaries_enabled",
     "index_compact_on_summary_enabled",

--- a/tools/test_python_module_boundaries_part2.py
+++ b/tools/test_python_module_boundaries_part2.py
@@ -3,6 +3,9 @@
 """_ModuleBoundaryPart2 methods split from test_matrixark_python_module_boundaries.MatrixArkPythonModuleBoundaryTest (mixin)."""
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -2227,6 +2230,10 @@ class _ModuleBoundaryPart2:
         self.assertEqual("final", profile_dirty[0]["extraction_phase"])
         self.assertTrue(profile_dirty[0]["final_session_boundary"])
 
+    # This test exercises context_segment rows, which are OFF unless a tenant asks for them.
+    # Patched for the duration of the test only: setting it at module scope would leak across
+    # the single-process suite run and flip the knob for tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_modular_batch_extract_writes_distinct_segments_and_profile_entities(self) -> None:
         batch_mod = importlib.import_module("tools.matrixark_mcp_local_batch_extract_runtime")
 


### PR DESCRIPTION
The sixth and last of the knobs that resolved correctly and changed nothing. It is separate
from the other five ([#586](https://github.com/matrixarkai/TemporalStore/pull/586)) because
honouring its documented default (**OFF**) changes what an unconfigured deployment stores,
and those five did not.

A segment restates its event — same text up to a role or index prefix — so each costs a
record, an embedding and a set of index postings to store what the event already holds.
`MATRIXARK_EXTRACT_SEGMENTS=1` restores them everywhere.

## The justification is about retrieval, so it is tested that way

"A segment restates its event" means the event still answers the question. Counting stored
records shows only that the knob is consulted; it cannot tell *redundant* from *lost*. So
there is a test that ingests, asks, and checks the answer still comes back without segments.
It does — asserted on both sides, since if the query stopped working entirely the comparison
would still hold and prove nothing.

## Six existing tests now state their dependency

They exercise segment behaviour and relied on a knob nothing consulted. Each gets a **scoped**
`mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})`.

Deliberately not a module-level `setUpModule`: setting `os.environ` at import time leaks
across the single-process suite run and would flip the knob for the tests that assert it is
*off* — the same cross-test pollution that makes this suite fail en masse, self-inflicted.
The gate reads the variable at call time, so the patch is true inside the test and false
either side; that was verified before relying on it.

## Verification

The knob's own tests plus the corrected guard pass. On the two parent suites these six live
in, this branch produces **exactly** the failure counts clean `main` does (69 and 85) — those
suites are already deeply red for unrelated reasons, so the meaningful check is that this adds
nothing, and the ratchet name-diff is the authoritative one.
