### PR TITLE
Drain the server a governance test starts before its directory is removed

### DIFF
--- a/tools/test_matrixark_access_governance.py
+++ b/tools/test_matrixark_access_governance.py
@@ -31,7 +31,12 @@ class MatrixArkAccessGovernanceTest(unittest.TestCase):
             else:
                 os.environ["MATRIXARK_AUDIT_MODE"] = previous
         self.addCleanup(restore)
-        return MatrixArkMcpServer(MatrixArkLocalAdapter(Path(tmp.name) / "events.jsonl"), line_json=True, access_mode="dev")
+        server = MatrixArkMcpServer(MatrixArkLocalAdapter(Path(tmp.name) / "events.jsonl"), line_json=True, access_mode="dev")
+        # Registered after tmp.cleanup so it runs BEFORE it: cleanups are LIFO, and the server's
+        # background workers keep writing into tmp until they are drained. Removing the directory
+        # first lets a worker re-create the event log inside it, and cleanup fails with ENOTEMPTY.
+        self.addCleanup(server.close, timeout_s=10.0)
+        return server
 
     def test_api_key_hash_only_and_role_limited_viewer(self) -> None:
         server = self.make_server()


### PR DESCRIPTION
Drain the server a governance test starts before its directory is removed

test_http_json_portal_facade_calls_live_mcp_admin_routes has been the ratchet's most persistent
flake: 1 failure in 40 runs in isolation, and unlike a rare one it survives the runner's
confirm-on-a-second-run pass, so it reaches the "NEW failures" list rather than being absorbed.

Every failure is the same, and none is an assertion:

    OSError: [Errno 39] Directory not empty: '/tmp/tmpd6ufk_s8'

The shared fixture builds a temporary directory and a server inside it, and registers a cleanup
for the directory only:

    tmp = tempfile.TemporaryDirectory()
    self.addCleanup(tmp.cleanup)
    ...
    return MatrixArkMcpServer(MatrixArkLocalAdapter(Path(tmp.name) / "events.jsonl"), ...)

Nothing ever closes that server, so its background workers are still writing into the directory
while it is being removed: rmtree unlinks the event log, the next append re-creates it, and the
rmdir that follows fails. This is the same defect already fixed once in the codex pipeline test,
in the same shape.

The fixture now registers the close. Cleanups run last-in-first-out, so registering it AFTER
tmp.cleanup is what makes it run BEFORE it, which is the order that matters here.

Isolated runs on a box at load 52: 39 of 40 to 100 of 100.

Note for a follow-up, not fixed here: MatrixArkMcpServer.close() joins the summary thread, the
stream materialize thread and the adapter, each bounded by timeout_s, and then calls
self._audit_executor.shutdown(wait=False, cancel_futures=False). That neither cancels queued
audit writes nor waits for in-flight ones, so a closed server can still be appending audit
records. This fixture is the one place that turns auditing on, which is why it surfaces
here. Draining it changes production shutdown behaviour, so it deserves its own change.
