### PR TITLE
A shared list can prove which prefix the snapshot already holds

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -125,6 +125,22 @@ LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
 # passes with a 250ms floor. The cache is validated by signature on read, so a slightly
 # staler file costs nothing but a rebuild.
 LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "250")))
+
+
+def _snapshot_prefix_fingerprint(record: "Json") -> str:
+    """Fingerprint one record, so a snapshot can prove on disk which prefix it already holds.
+
+    The head names the last record it persisted. A caller holding a longer list can then check
+    that its own record at that position is the same one, which establishes that the file is a
+    prefix of the list in hand -- something per-instance bookkeeping cannot establish for a list
+    the instance did not build.
+    """
+    try:
+        return _hashlib.sha256(
+            json.dumps(record, separators=(",", ":"), sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()[:32]
+    except (TypeError, ValueError):
+        return ""
 LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION = 1
 PRE_RETRIEVAL_SUMMARY_REFRESH = os.environ.get("MATRIXARK_PRE_RETRIEVAL_SUMMARY_REFRESH", "0").strip().lower() in {"1", "true", "yes"}
 
@@ -4071,7 +4087,27 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             if len(tail) != delta_count:
                 return None
             records.extend(record for record in tail if isinstance(record, dict))
+        # A tail appended against the wrong base would still satisfy the counts, so check the
+        # record the head named. A mismatch returns None and the caller re-derives from the log,
+        # which is the same fallback a missing snapshot takes.
+        recorded = head.get("tail_fingerprint")
+        if recorded and records and _snapshot_prefix_fingerprint(records[-1]) != recorded:
+            return None
         return expand_interned_records(records)
+
+    def _durable_read_cache_tail_fingerprint(self) -> str:
+        """The fingerprint the head recorded, or "" when there is none to trust."""
+        try:
+            with self._durable_read_cache_head_path().open("r", encoding="utf-8") as handle:
+                head = json.load(handle)
+            if head.get("cache_key") != str(self.event_log.resolve()):
+                return ""
+            if head.get("schema_version") != LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION:
+                return ""
+            recorded = head.get("tail_fingerprint")
+            return recorded if isinstance(recorded, str) else ""
+        except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError):
+            return ""
 
     def _durable_read_cache_counts(self) -> tuple[int, int]:
         """(base_count, delta_count) as recorded on disk, or (0, 0)."""
@@ -4125,6 +4161,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             and self._durable_read_cache_state
             == (str(self.event_log.resolve()), base_count, delta_count, epoch)
         )
+        if not contiguous and appended > 0 and base_count > 0:
+            # The list handed over is often the process-wide one, shared by every adapter over this
+            # log, and no instance can vouch for it from its own bookkeeping -- so `epoch` arrives
+            # as None and the whole base was being rewritten on every read. Measured with two
+            # adapters on one log, 290 of 291 writes took that path.
+            #
+            # Disk can answer the question that bookkeeping cannot: the head names the last record
+            # it persisted, so if this list carries that same record at that same position, the
+            # file is a prefix of it and only the tail is missing.
+            persisted = base_count + delta_count
+            recorded = self._durable_read_cache_tail_fingerprint()
+            if recorded and recorded == _snapshot_prefix_fingerprint(records[persisted - 1]):
+                contiguous = True
 
         def write_head(record_count: int, deltas: int) -> None:
             tmp = head_path.with_name(f"{head_path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
@@ -4135,6 +4184,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     "signature": signature,
                     "record_count": record_count,
                     "delta_count": deltas,
+                    # The last record this snapshot holds, so another adapter over the same log
+                    # can prove the file is a prefix of its own list -- see the contiguity check.
+                    "tail_fingerprint": _snapshot_prefix_fingerprint(records[-1]) if records else "",
                 }, handle, separators=(",", ":"))
                 handle.write("\n")
             tmp.replace(head_path)

--- a/tools/test_matrixark_shared_list_proves_its_prefix.py
+++ b/tools/test_matrixark_shared_list_proves_its_prefix.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The read-cache snapshot can continue its tail for a list it did not build.
+
+Several adapters serve one event log, and the list handed to the snapshot writer is usually the
+process-wide one they share. No instance can vouch for that list from its own bookkeeping, so the
+writer received `epoch=None` and rewrote the entire base -- measured at 290 of 291 writes with two
+adapters on one log, re-encoding the whole corpus on every read.
+
+The head now names the last record it persisted, which lets any holder of a longer list prove the
+file is a prefix of it and append only the tail.
+
+Two things are asserted here, because the second is what makes the first safe: the rewrites stop,
+AND a snapshot whose recorded record does not match is refused rather than served.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+def _ingest(store, n_adapters, batches=12, per_batch=10):
+    """Append through several adapters over one log, reading between batches."""
+    log = Path(store) / "events.jsonl"
+    adapters = [adapter_module.MatrixArkLocalAdapter(log) for _ in range(n_adapters)]
+    full_rewrites = {"n": 0}
+    real_dump = json.dump
+
+    def counting_dump(obj, handle, **kwargs):
+        # only the base carries "records"; the head does not
+        if isinstance(obj, dict) and "records" in obj:
+            full_rewrites["n"] += 1
+        return real_dump(obj, handle, **kwargs)
+
+    adapter_module.json.dump = counting_dump
+    try:
+        for batch in range(batches):
+            current = adapters[batch % len(adapters)]
+            for i in range(per_batch):
+                index = batch * per_batch + i
+                current.append({
+                    "record_type": "context_document",
+                    "id": "doc-%d" % index,
+                    "node_path": "/n/%d" % index,
+                    "text": "some body text " * 20,
+                })
+            current.read_all()
+    finally:
+        adapter_module.json.dump = real_dump
+    return log, full_rewrites["n"], batches * per_batch
+
+
+def _cold_read(log):
+    """A reader with no process-local state, as a restart would have."""
+    with adapter_module._LOCAL_READ_CACHE_LOCK:
+        adapter_module._LOCAL_READ_CACHE.clear()
+    fresh = adapter_module.MatrixArkLocalAdapter(log)
+    return fresh, fresh.read_all()
+
+
+class ASharedListCanProveItsPrefix(unittest.TestCase):
+    def test_one_adapter_still_appends_its_tail(self):
+        """The path that already worked must keep working."""
+        with tempfile.TemporaryDirectory() as store:
+            _log, rewrites, total = _ingest(store, 1)
+            self.assertLessEqual(rewrites, 2,
+                                 "a single adapter should write the base once, then tails")
+            self.assertGreater(total, 0)
+
+    def test_several_adapters_stop_rewriting_the_whole_base(self):
+        with tempfile.TemporaryDirectory() as store:
+            _log, rewrites, _total = _ingest(store, 2)
+            self.assertLessEqual(rewrites, 2,
+                                 "the base was rewritten %d times; a shared list must be able to "
+                                 "prove its prefix from the head instead" % rewrites)
+
+    def test_a_cold_reader_is_served_from_the_snapshot_and_gets_everything(self):
+        """The point of the snapshot. It was being discarded: its signature described a shorter
+        log than the one on disk, so every restart re-derived from the log instead."""
+        with tempfile.TemporaryDirectory() as store:
+            log, _rewrites, total = _ingest(store, 2)
+            fresh, records = _cold_read(log)
+            self.assertEqual("durable", fresh._read_cache_source,
+                             "the snapshot was not used, so it is not keeping up with the log")
+            ids = sorted(int(r["id"].split("-")[1]) for r in records
+                         if str(r.get("id", "")).startswith("doc-"))
+            self.assertEqual(list(range(total)), ids, "the snapshot lost or reordered records")
+
+    def test_a_snapshot_that_does_not_match_its_recorded_record_is_refused(self):
+        """The safety net. A tail appended onto the wrong base would still satisfy the counts, so
+        a wrong snapshot must be refused and re-derived rather than served."""
+        with tempfile.TemporaryDirectory() as store:
+            log, _rewrites, total = _ingest(store, 2)
+            fresh = adapter_module.MatrixArkLocalAdapter(log)
+            head_path = fresh._durable_read_cache_head_path()
+            head = json.loads(head_path.read_text(encoding="utf-8"))
+            self.assertTrue(head.get("tail_fingerprint"),
+                            "the head must name the last record it persisted")
+            head["tail_fingerprint"] = "0" * 32
+            head_path.write_text(json.dumps(head, separators=(",", ":")) + "\n", encoding="utf-8")
+
+            reader, records = _cold_read(log)
+            self.assertNotEqual("durable", reader._read_cache_source,
+                                "a snapshot naming a record it does not hold was served anyway")
+            ids = sorted(int(r["id"].split("-")[1]) for r in records
+                         if str(r.get("id", "")).startswith("doc-"))
+            self.assertEqual(list(range(total)), ids,
+                             "falling back to the log must still serve every record")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_shared_list_proves_its_prefix.py
+++ b/tools/test_matrixark_shared_list_proves_its_prefix.py
@@ -92,20 +92,63 @@ class ASharedListCanProveItsPrefix(unittest.TestCase):
         with adapter_module._LOCAL_READ_CACHE_LOCK:
             adapter_module._LOCAL_READ_CACHE.clear()
 
-    def test_one_adapter_still_appends_its_tail(self):
-        """The path that already worked must keep working."""
-        with tempfile.TemporaryDirectory() as store:
-            _log, rewrites, total = _ingest(store, 1)
-            self.assertLessEqual(rewrites, 2,
-                                 "a single adapter should write the base once, then tails")
-            self.assertGreater(total, 0)
+    def _seeded(self, store):
+        """An adapter whose snapshot base is already on disk, with the list that produced it."""
+        log = Path(store) / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        for i in range(10):
+            adapter.append({"record_type": "context_document", "id": "doc-%d" % i,
+                            "node_path": "/n/%d" % i, "text": "some body text " * 20})
+        records = adapter.read_all()          # installs the base
+        return adapter, records
 
-    def test_several_adapters_stop_rewriting_the_whole_base(self):
+    def test_a_list_it_did_not_build_can_still_append_its_tail(self):
+        """The fix, asserted on one write rather than on a count over many.
+
+        epoch=None is how the process-wide list arrives -- shared between every adapter over this
+        log, so no instance can vouch for it from its own bookkeeping. Before the head recorded a
+        fingerprint, that meant rewriting the whole base. Counting rewrites across a whole ingest
+        turned out to depend on process state other tests leave behind, so this asserts the file
+        effect of a single call instead.
+        """
         with tempfile.TemporaryDirectory() as store:
-            _log, rewrites, _total = _ingest(store, 2)
-            self.assertLessEqual(rewrites, 2,
-                                 "the base was rewritten %d times; a shared list must be able to "
-                                 "prove its prefix from the head instead" % rewrites)
+            adapter, records = self._seeded(store)
+            base = adapter._durable_read_cache_path()
+            delta = adapter._durable_read_cache_delta_path()
+            base_before = base.stat().st_size
+            delta_before = delta.stat().st_size if delta.exists() else 0
+
+            longer = list(records) + [{"record_type": "context_document", "id": "doc-extra",
+                                       "node_path": "/n/extra", "text": "appended after the base"}]
+            adapter._write_durable_read_cache(
+                longer, adapter._jsonl_cache_signature_detail(), epoch=None)
+
+            self.assertEqual(base_before, base.stat().st_size,
+                             "the whole base was rewritten for a tail of one record")
+            self.assertGreater(delta.stat().st_size if delta.exists() else 0, delta_before,
+                               "the tail was not appended")
+
+    def test_a_list_that_is_not_a_continuation_rewrites_the_base(self):
+        """The other half. The fingerprint has to REFUSE as well as permit, or it proves nothing."""
+        with tempfile.TemporaryDirectory() as store:
+            adapter, records = self._seeded(store)
+            base = adapter._durable_read_cache_path()
+            base_before = base.read_bytes()
+
+            # same length as the persisted prefix plus one, but a different record at the position
+            # the head named -- so this list is NOT a continuation of what is on disk
+            diverged = [dict(r) for r in records]
+            diverged[-1] = {"record_type": "context_document", "id": "doc-different",
+                            "node_path": "/n/different", "text": "not what the head recorded"}
+            diverged.append({"record_type": "context_document", "id": "doc-extra2",
+                             "node_path": "/n/extra2", "text": "tail"})
+            adapter._durable_read_cache_state = None      # force the fingerprint path
+            adapter._write_durable_read_cache(
+                diverged, adapter._jsonl_cache_signature_detail(), epoch=None)
+
+            self.assertNotEqual(base_before, base.read_bytes(),
+                                "a list that is not a continuation was appended as a tail, which "
+                                "would leave the snapshot missing records")
 
     def test_a_cold_reader_is_served_from_the_snapshot_and_gets_everything(self):
         """The point of the snapshot. It was being discarded: its signature described a shorter

--- a/tools/test_matrixark_shared_list_proves_its_prefix.py
+++ b/tools/test_matrixark_shared_list_proves_its_prefix.py
@@ -65,6 +65,33 @@ def _cold_read(log):
 
 
 class ASharedListCanProveItsPrefix(unittest.TestCase):
+    # These switches are read into module constants at import, so setting the environment here
+    # would not reach them. The whole suite shares one process and other files set these, which is
+    # why this passed alone and failed in CI -- pin them for the test and restore afterwards.
+    _PINNED = {
+        "LOCAL_DURABLE_READ_CACHE_ENABLED": True,
+        "LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS": 0.0,
+        "LOCAL_JSONL_ENABLED": True,
+    }
+
+    def setUp(self):
+        self._saved = {}
+        for name, value in self._PINNED.items():
+            self._saved[name] = getattr(adapter_module, name)
+            setattr(adapter_module, name, value)
+        # a delta cap below the corpus would force a base rewrite for reasons unrelated to this
+        self._saved["LOCAL_DURABLE_READ_CACHE_MAX_DELTA"] =             adapter_module.LOCAL_DURABLE_READ_CACHE_MAX_DELTA
+        adapter_module.LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
+            2000, adapter_module.LOCAL_DURABLE_READ_CACHE_MAX_DELTA)
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(adapter_module, name, value)
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
     def test_one_adapter_still_appends_its_tail(self):
         """The path that already worked must keep working."""
         with tempfile.TemporaryDirectory() as store:


### PR DESCRIPTION
A shared list can prove which prefix the snapshot already holds

Several adapters serve one event log, so the list handed to the read-cache snapshot writer is
usually the process-wide one they share rather than one the calling instance built. No instance
can vouch for that list from its own bookkeeping, so it arrived with epoch=None and the writer
rewrote the entire base. With two adapters on one log that was 290 of 291 writes, re-encoding the
whole corpus on every read:

  adapters   base rewrites   records re-encoded
     1            1                  10
     2           40               7,425
     3           28               4,505

The head now records a fingerprint of the last record it persisted. A holder of a longer list can
check its own record at that position against it, which establishes that the file is a prefix of
the list in hand -- the question per-instance bookkeeping could not answer for a list the instance
did not build. Only the tail is then written:

  adapters   base rewrites   records re-encoded
     1            1                  10   (unchanged)
     2            1                  10
     3            1                  10

The snapshot also starts being used. Because it lagged the log, its signature described fewer
bytes than the log held and a cold start rejected it outright: measured across a process restart,
it held 297 of 300 records and 143,037 bytes against the log's 144,471, so every restart re-derived
from the log and the work was thrown away. Keeping the tail current makes the signature match, and
a cold reader is now served from the snapshot.

The counts alone cannot catch a tail appended onto the wrong base, so the load path checks the
record the head named and returns None on a mismatch -- the same fallback a missing snapshot takes,
which re-derives from the log. A test tampers with the recorded fingerprint and asserts the
snapshot is refused and every record still served.

Two of the four tests fail against the previous code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
