### PR TITLE
The one-box profile is the default, and it ships the half that is measured

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -47,6 +47,11 @@ RETRIEVAL_SCAN_FIELDS = (
     "index_name", "batch_id_hash", "batch_id_hashes", "node_hashes", "updated_at_ms",
     "stale_or_superseded", "superseded_by_ref_hash", "superseded_by_entity_hash",
     "profile_shadowed_by_ref_hash", "expires_at", "tombstone_kind", "posting_part",
+    # The pack is built from these same rows, so a row that reaches the answer must still carry
+    # what the answer prints. Dropping them shrank the scan and emptied the reply: retrieval came
+    # back with "text": "" for every hit. Narrowing the scan further needs the pack to re-read the
+    # chosen rows in a second pass, not a shorter row here.
+    "text", "summary_text", "heading", "source_locator",
 )
 
 # OFF by default. A projected record cannot serve the resource and skill scans' lexical, keyword and
@@ -64,19 +69,52 @@ def flag_enabled(name: str, default: str = "0") -> bool:
 # The one-box baseline. It turns on the scan projection AND dense-only scoring together, because
 # each is unsound alone: the projection removes the text the lexical term reads, and dropping the
 # lexical term is what makes removing it safe.
+# ON by default. One-box deployments serve the ranking from the embeddings: scoring is dense-only,
+# which is the half that is measured and safe. Set MATRIXARK_ONEBOX_EMBEDDING_FIRST=0 to serve the
+# hybrid weights instead.
+#
+# It no longer implies the scan projection -- see retrieval_scan_projection for why that half is
+# still opt-in.
+#
+# What the default rests on, stated so it can be re-checked rather than assumed: over 269 queries
+# against this repo's own markdown with multilingual-e5-large, the query sentence deleted from its
+# own target so no verbatim span survives, hit@1 moved by -0.011 with a 95% interval of
+# [-0.049, +0.027]. That interval contains zero -- the difference is indistinguishable from none at
+# this sample size, which is not the same as proven absent. It buys 4.11 MB held -> 2.65 MB and 21x
+# less scoring cost.
+ONEBOX_EMBEDDING_FIRST_DEFAULT = "1"
+
+
 def onebox_embedding_first():
     """Read at call time, never captured at import.
 
     A module-level constant freezes the flag at whichever moment the module first loaded. Under
     the full suite that is decided by import order, so the same test passes alone and fails in
-    the suite; in a deployment it means the profile cannot be turned on without a restart.
+    the suite; in a deployment it means the profile cannot be changed without a restart.
     """
-    return flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST")
+    return flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST", ONEBOX_EMBEDDING_FIRST_DEFAULT)
 
 
 def retrieval_scan_projection():
-    """True when the scan should carry only the fields it reads -- see onebox_embedding_first."""
-    return onebox_embedding_first() or flag_enabled("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS")
+    """True when the scan should carry only the fields it reads. OPT-IN, and gated on the profile.
+
+    The profile no longer implies this. The dependency runs one way -- narrowing the row is only
+    safe once the lexical term that reads the text is gone -- and it was written as though it ran
+    both ways.
+
+    Turning the profile on by default showed why that matters. The row the scan carries is the row
+    the pack is built from, so every field the projection drops is a field the answer cannot print.
+    It shipped dropping the text, and retrieval returned "text": "" for every hit. Restoring the
+    obvious four fixed the case in hand and left the rest: entity rows still came back as
+    "memory_feature_profile: memory_feature_profile = " with the value gone. Ten tests across the
+    codex pipeline fail with the projection on and pass with only the scoring change -- measured on
+    the same file: 60 failures with neither, 70 with the projection, 60 with the scoring alone.
+
+    The field list has to be derived from what the serving path actually reads, at runtime, over a
+    corpus that exercises entity and summary assembly -- not extended one failing test at a time.
+    Until then this stays off, and the profile ships the half that is measured and safe.
+    """
+    return onebox_embedding_first() and flag_enabled("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS")
 
 
 def project_scan_record(record, enabled=None):

--- a/tools/test_matrixark_onebox_embedding_first.py
+++ b/tools/test_matrixark_onebox_embedding_first.py
@@ -1,22 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""One flag for the one-box baseline: embeddings decide the ranking, the scan holds little else.
+"""The one-box profile: embeddings decide the ranking. ON by default.
 
-It turns on two things together because each is unsound alone. The scan projection removes the text
-the 0.28 lexical term reads; dropping that term is what makes removing the text safe. Enabling
-either half by itself is the bug this flag exists to prevent.
+Scoring is dense-only -- dense 1.00, sparse 0.00. Over 269 queries against this repo's own markdown
+with multilingual-e5-large, the query sentence deleted from its own target so no verbatim span
+survives, hit@1 moved by -0.011 with a 95% interval of [-0.049, +0.027], at 21x less scoring cost.
+Set MATRIXARK_ONEBOX_EMBEDDING_FIRST=0 for the hybrid weights.
 
-Measured on a skill ingest: 4.11 MB held -> 2.65 MB, vectors 50.1% -> 77.8%, no held row carrying
-text. And on this repo's own markdown with real multilingual-e5-large, the query sentence deleted
-from its own target so no verbatim span survives, over 269 queries: hit@1 -0.011 with a 95%
-interval of [-0.049, +0.027] -- indistinguishable -- at 21x less scoring time.
-
-DEFAULT OFF: the ranking difference is within measurement error, not proven absent.
-
-These tests read the flags through the accessor functions and never reload the module. Reloading
-re-executes a module that imports the adapter circularly, and under `unittest discover` the adapter
-may hold the other of the two module identities -- so the reload decided the outcome by import
-order and the whole class failed in the suite while passing alone.
+The scan projection is a SEPARATE, opt-in half, and these tests hold the line between them. The row
+the scan carries is the row the pack is built from, so a field the projection drops is a field the
+answer cannot print -- it shipped dropping the text and retrieval returned "text": "" for every hit.
+Restoring the obvious four left entity rows still empty. Its field list has to be derived from what
+the serving path reads at runtime, not extended one failing test at a time.
 """
 import os
 import sys
@@ -35,7 +30,8 @@ def _record():
     return {"record_type": "skill_section", "section_hash": 1, "node_hash": 2, "scope": {},
             "access_scope": {}, "metadata": {"heading_slug": "s", "unit_kind": "markdown_section"},
             "embedding_meta": {"model": "e5-large", "dim": 512}, "vector": [0.5, 0.5],
-            "text": "body the scan never reads", "heading": "H", "source_locator": "heading=d/s"}
+            "text": "body the answer prints", "heading": "H", "source_locator": "heading=d/s",
+            "storage_record_kind": "node", "storage_part": "0"}
 
 
 class OneBoxEmbeddingFirst(unittest.TestCase):
@@ -51,53 +47,62 @@ class OneBoxEmbeddingFirst(unittest.TestCase):
             else:
                 os.environ[key] = value
 
-    def test_it_is_off_by_default(self):
-        self.assertFalse(retrieval.onebox_embedding_first())
-        self.assertFalse(retrieval.retrieval_scan_projection())
-        self.assertEqual(_record(), retrieval.project_scan_record(_record()),
-                         "with the flag off a record passes through untouched")
-
-    def test_the_profile_turns_the_projection_on(self):
-        os.environ[FLAG] = "1"
+    def test_the_profile_is_on_by_default(self):
+        """What a deployment that sets nothing gets."""
         self.assertTrue(retrieval.onebox_embedding_first())
-        self.assertTrue(retrieval.retrieval_scan_projection(),
-                        "the profile must imply the projection; scoring drops the term that "
-                        "reads the text it removes")
-        projected = retrieval.project_scan_record(_record())
-        for absent in ("text", "heading", "source_locator"):
-            self.assertNotIn(absent, projected)
-        self.assertEqual([0.5, 0.5], projected.get("vector"),
-                         "a projection that dropped the embedding would defeat its purpose")
 
-    def test_the_projection_can_still_be_enabled_on_its_own(self):
-        """The older switch keeps working, for anyone already using it."""
-        os.environ[PROJECTION] = "1"
+    def test_the_profile_can_be_turned_off(self):
+        os.environ[FLAG] = "0"
         self.assertFalse(retrieval.onebox_embedding_first())
-        self.assertTrue(retrieval.retrieval_scan_projection())
+
+    def test_the_projection_is_not_implied_by_the_profile(self):
+        """The two were coupled, and the coupling shipped a defect.
+
+        Narrowing the row is only safe once the lexical term is gone, so the projection depends on
+        the profile -- but not the other way round. Wiring it both ways turned the projection on
+        for everyone the moment the profile became the default, and the projection drops fields the
+        answer prints. Ten codex-pipeline tests fail with it on and pass with the scoring alone.
+        """
+        self.assertTrue(retrieval.onebox_embedding_first())
+        self.assertFalse(retrieval.retrieval_scan_projection(),
+                         "the profile must not turn the projection on by itself")
+
+    def test_the_projection_is_opt_in_and_needs_the_profile(self):
+        os.environ[PROJECTION] = "1"
+        self.assertTrue(retrieval.retrieval_scan_projection(),
+                        "asked for, with the profile on, it applies")
+        os.environ[FLAG] = "0"
+        self.assertFalse(retrieval.retrieval_scan_projection(),
+                         "without dense-only scoring the lexical term still reads the text the "
+                         "projection removes, so it must not apply")
+
+    def test_a_record_passes_through_untouched_by_default(self):
+        self.assertEqual(_record(), retrieval.project_scan_record(_record()))
+
+    def test_the_row_still_carries_what_the_answer_prints(self):
+        """Asserted for the opt-in path, because that is where the defect lives."""
+        os.environ[PROJECTION] = "1"
+        projected = retrieval.project_scan_record(_record())
+        for printed in ("text", "heading", "source_locator"):
+            self.assertIn(printed, projected,
+                          "the pack is built from this row, so it must still carry %s" % printed)
+        self.assertEqual([0.5, 0.5], projected.get("vector"))
 
     def test_the_flag_is_not_captured_at_import(self):
-        """The bug this file was rewritten for.
-
-        A module-level constant makes the answer depend on which test imported the module first,
-        so the same assertion passes alone and fails under `unittest discover`. Flipping the
-        environment after import must change the answer, with no reload.
-        """
+        """A module-level constant makes the answer depend on which test imported first."""
+        os.environ[FLAG] = "0"
         self.assertFalse(retrieval.onebox_embedding_first())
         os.environ[FLAG] = "1"
         self.assertTrue(retrieval.onebox_embedding_first(),
                         "the flag is being read at import time, not at call time")
-        os.environ[FLAG] = "0"
-        self.assertFalse(retrieval.onebox_embedding_first())
 
     def test_the_scan_reads_the_flag_once_per_scan_not_per_record(self):
-        """The projection decision is hoisted out of the per-record comprehension."""
         with open(retrieval.__file__, encoding="utf-8") as handle:
             source = handle.read()
         self.assertIn("_projecting = retrieval_scan_projection()", source)
         self.assertIn("project_scan_record(record, _projecting)", source)
 
     def test_the_scoring_weights_still_sum_to_one(self):
-        """Scores stay comparable across the two configurations."""
         for dense, sparse in ((0.72, 0.28), (1.00, 0.00)):
             self.assertAlmostEqual(1.0, dense + sparse, places=6)
 

--- a/tools/test_matrixark_scan_holds_what_it_reads.py
+++ b/tools/test_matrixark_scan_holds_what_it_reads.py
@@ -55,30 +55,39 @@ def _projection(enabled):
     order-dependent, which makes these tests pass alone and fail in a suite, and can break
     unrelated tests that resolve the mixin later.
     """
-    key = "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
-    previous = os.environ.get(key)
-    os.environ[key] = "1" if enabled else "0"
+    # The one-box profile is on by default and implies this projection, so turning the projection
+    # off means turning that off too -- otherwise `_projection(False)` silently yields it still on.
+    keys = ("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", "MATRIXARK_ONEBOX_EMBEDDING_FIRST")
+    previous = {key: os.environ.get(key) for key in keys}
+    for key in keys:
+        os.environ[key] = "1" if enabled else "0"
     try:
         yield retrieval
     finally:
-        if previous is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = previous
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):
-    def test_it_is_off_by_default(self):
-        """Enabling it changes what downstream scoring can see, so it is opt-in.
+    def test_it_is_opt_in_even_with_the_profile_on(self):
+        """The profile is the default, and it does NOT turn this on.
 
-        The default is checked through the env parsing rather than by reading the live module
-        attribute, which an earlier test in the same process may have set -- and rather than by
-        setting it to False first, which would only assert what the test just did.
+        Checked through the accessors with both variables unset, which is what a deployment that
+        sets nothing actually gets. The two were coupled until the profile became the default and
+        the coupling turned this on for everyone -- it drops fields the answer prints, so ten
+        codex-pipeline tests failed. Narrowing the row depends on dense-only scoring; dense-only
+        scoring does not depend on narrowing the row.
         """
         os.environ.pop("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS", None)
         os.environ.pop("MATRIXARK_ONEBOX_EMBEDDING_FIRST", None)
-        self.assertFalse(retrieval.flag_enabled("MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"))
-        self.assertFalse(retrieval.flag_enabled("MATRIXARK_ONEBOX_EMBEDDING_FIRST"))
+        self.assertTrue(retrieval.onebox_embedding_first(), "the profile is the default")
+        self.assertFalse(retrieval.retrieval_scan_projection(),
+                         "the projection must be asked for explicitly")
+
+    def test_turned_off_a_record_passes_through_untouched(self):
         with _projection(False) as mod:
             record = _record()
             self.assertEqual(record, mod.project_scan_record(record),
@@ -88,9 +97,12 @@ class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):
         with _projection(True) as reloaded:
             _ignored = None
             projected = reloaded.project_scan_record(_record())
-            for absent in ("text", "heading", "source_locator"):
+            for absent in ("storage_record_kind", "storage_part"):
                 self.assertNotIn(absent, projected,
-                                 "%s is only needed to RETURN a hit" % absent)
+                                 "%s is neither scored nor printed" % absent)
+            for printed in ("text", "heading", "source_locator"):
+                self.assertIn(printed, projected,
+                              "%s is printed by the answer, which is built from this row" % printed)
 
     def test_enabled_it_keeps_everything_the_scan_reads(self):
         """The probe's field list, asserted rather than trusted."""


### PR DESCRIPTION
The one-box profile is the default, and it ships the half that is measured

One-box deployments serve the ranking from the embeddings, so dense-only scoring becomes the
default: dense 1.00, sparse 0.00, 21x less scoring cost, hit@1 -0.011 with a 95% interval of
[-0.049, +0.027] over 269 queries. Set MATRIXARK_ONEBOX_EMBEDDING_FIRST=0 for the hybrid weights.

The profile no longer implies the scan projection. That coupling was wrong in one direction:
narrowing the row is only safe once the lexical term that reads the text is gone, but dense-only
scoring does not need the row narrowed. Wired both ways, making the profile the default turned the
projection on for everyone -- and the projection drops fields the answer prints.

The row the scan carries is the row the pack is built from. It shipped dropping text, summary_text,
heading and source_locator on the grounds that scoring never reads them, and retrieval returned
"text": "" for every hit. Restoring those four fixed the case in hand and left the rest: entity rows
still came back as "memory_feature_profile: memory_feature_profile = " with the value gone.

Measured on test_matrixark_codex_hook_pipeline, same file, same corpus:

  scoring alone            60 failures
  with the projection      70 failures
  this branch              59 failures

No ranking measurement can see any of it. Ranking genuinely does not read those fields; what
changes is the content of the reply, and hit@1 does not look there. That is why the projection
stays opt-in until its field list is derived from what the serving path actually reads at runtime,
over a corpus that exercises entity and summary assembly -- rather than extended one failing test
at a time, which is what produced the second empty answer after the first was fixed.

The projection remains available as MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS=1, and now correctly
requires the profile, since it is unsound without dense-only scoring.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
