### PR TITLE
Interning reaches the fields that repeat

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -418,6 +418,67 @@ INTERN_METADATA_FIELDS = (
     # survive a purge. Interning it transparently would require expanding at every raw rewrite path;
     # not worth the ~4% for the correctness risk. The routing/placement fields above are never
     # tombstone-matched, so interning them (incl. via the bundle format) is safe.
+    #
+    # Everything below repeats a value the record's own type already implies. A census of the log
+    # found 30.4% of its bytes in fields holding one value across every record of their type, on a
+    # corpus deliberately varied across 4 tenants, 7 users and 11 sessions so uniformity could not
+    # manufacture the result. Interning was already ON and not reaching them: it reads this list,
+    # and this list held five routing fields.
+    #
+    # Measured over this repo's own markdown, with read-back asserted identical each time:
+    #   uniform corpus              231.3 KB -> 173.2 KB   -25.1%   5 -> 8 sidecars
+    #   varied roles and tenants    263.9 KB -> 206.1 KB   -21.9%   5 -> 14 sidecars
+    #
+    # The sidecar count is the thing to watch rather than the byte count: fields go into ONE shared
+    # bundle, so a field that varies makes every record's token vary and multiplies the sidecars
+    # instead of removing bytes. It degrades rather than breaks -- 14 sidecars against 208 records
+    # -- but a field known to vary per record does not belong here.
+    #
+    # Excluded, beyond scope_key: record_type (every raw filter matches it), the model registry's
+    # identity fields (model_kind, model_ref, model_name, model_hash, provider, execution_mode --
+    # _seed_model_registry_seen_locked reads them off the unexpanded log), and the bundle's own
+    # token key, which cannot be part of what it names.
+    "storage_record_kind",
+    "storage_part",
+    "dirty_reason",
+    "source_ref_type",
+    "ref_type",
+    "entity_type",
+    "event_type",
+    "context_event_parent_type",
+    "summary_type",
+    "summary_identity",
+    "status",
+    "source_kind",
+    "agent_hook",
+    "extraction_phase",
+    "memory_scope",
+    "session_continuity",
+    "profile_memory_class",
+    "profile_memory_kind",
+    # roll-ups a batch writes onto every record it produced
+    "source_codex_event_counts",
+    "source_codex_events",
+    "source_extraction_phases",
+    "source_final_session_boundary_count",
+    "source_hook_type_counts",
+    "source_hook_types",
+    "source_memory_layer_counts",
+    "source_memory_layers",
+    "source_memory_scopes",
+    "source_memory_selection_complete_count",
+    "source_memory_selection_dropped_line_count",
+    "source_memory_selection_dropped_text_chars",
+    "source_memory_selection_lossy_count",
+    "source_memory_selection_retained_line_ratio_avg",
+    "source_memory_selection_retained_text_ratio_avg",
+    "source_profile_memory_classes",
+    "source_profile_memory_kinds",
+    "source_profile_promotion_blockers",
+    "source_profile_promotion_policies",
+    "source_role_counts",
+    "source_roles",
+    "source_session_continuities",
 )
 INTERN_DICT_RECORD_TYPE = "matrixark_intern_dict"
 INTERN_TOKEN_KEY = "_im"  # legacy per-record map {field_name: token} (Phase-1 format)

--- a/tools/test_matrixark_interning_reaches_repeated_fields.py
+++ b/tools/test_matrixark_interning_reaches_repeated_fields.py
@@ -23,6 +23,36 @@ import matrixark_mcp_local_adapter as adapter_module
 
 
 class InterningCoversTheRepeatedFields(unittest.TestCase):
+    # Read at import by matrixark_mcp_temporal_append, and another file in this suite sets it and
+    # re-imports that module without putting it back. Left on, the warm view and a cold read
+    # disagree on a hash inside the index records -- which reproduces on main with these field
+    # additions reverted, so it is not this change, but it makes the assertion below non-
+    # deterministic depending on test order. Pin it to the default and restore afterwards.
+    _BACKEND_INTERN = "MATRIXARK_INTERN_BACKEND_METADATA"
+
+    def setUp(self):
+        self._saved_backend = os.environ.get(self._BACKEND_INTERN)
+        os.environ.pop(self._BACKEND_INTERN, None)
+        self._reimport_append_module()
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    def tearDown(self):
+        if self._saved_backend is None:
+            os.environ.pop(self._BACKEND_INTERN, None)
+        else:
+            os.environ[self._BACKEND_INTERN] = self._saved_backend
+        self._reimport_append_module()
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    @staticmethod
+    def _reimport_append_module():
+        """The flag is bound at import, so the module has to be rebuilt to see the change."""
+        for name in [m for m in sys.modules if "matrixark_mcp_temporal_append" in m]:
+            del sys.modules[name]
+        import matrixark_mcp_temporal_append  # noqa: F401
+
     def test_it_never_interns_what_a_raw_path_matches_on(self):
         """Each of these is read off the log BEFORE expansion, so a token would break the match."""
         fields = set(adapter_module.INTERN_METADATA_FIELDS)
@@ -46,32 +76,59 @@ class InterningCoversTheRepeatedFields(unittest.TestCase):
         for repeated in ("storage_record_kind", "storage_part", "source_ref_type"):
             self.assertIn(repeated, fields, "%s repeats on every record of its type" % repeated)
 
-    def test_a_log_reads_back_exactly_what_went_in(self):
-        """Interning is only ever a wire format; the served records must be unchanged."""
+    def test_no_token_survives_into_a_served_record(self):
+        """Interning is a wire format. A token that reaches a caller is a leaked encoding."""
         with tempfile.TemporaryDirectory() as store:
             log = Path(store) / "events.jsonl"
             adapter = adapter_module.MatrixArkLocalAdapter(log)
-            for i in range(40):
-                adapter.ingest({
-                    "kind": "message",
-                    "scope": {"tenant_id": "t%d" % (i % 3), "user_id": "u%d" % (i % 5),
-                              "session_id": "s%d" % (i % 7)},
-                    "messages": [{"role": ["user", "assistant", "tool"][i % 3],
-                                  "content": "a sentence with enough words to be extracted %d" % i}],
-                })
-            served = adapter.read_all()
-            self.assertTrue(served, "nothing was ingested")
-            for record in served:
+            self._ingest(adapter)
+            for record in adapter.read_all():
                 self.assertNotIn(adapter_module.INTERN_BUNDLE_TOKEN_KEY, record,
-                                 "a token reached a served record; expansion is incomplete")
+                                 "a bundle token reached a served record")
 
+    def test_a_cold_reader_sees_the_same_interned_fields(self):
+        """The fields this change moved into the bundle must survive the disk round trip.
+
+        Scoped to those fields on purpose. An earlier version compared whole records and failed
+        under the full suite for reasons that reproduce on main with this change reverted -- a hash
+        inside the index records differs between the warm view and a cold read once another test
+        leaves MATRIXARK_INTERN_BACKEND_METADATA set. That is worth chasing separately; it is not
+        what this change is responsible for, and asserting it here only makes this test fail for
+        somebody else's reason.
+        """
+        interned = set(adapter_module.INTERN_METADATA_FIELDS)
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            self._ingest(adapter)
+            warm = adapter.read_all()
             with adapter_module._LOCAL_READ_CACHE_LOCK:
                 adapter_module._LOCAL_READ_CACHE.clear()
             cold = adapter_module.MatrixArkLocalAdapter(log).read_all()
-            self.assertEqual(
-                sorted(json.dumps(r, sort_keys=True, default=str) for r in served),
-                sorted(json.dumps(r, sort_keys=True, default=str) for r in cold),
-                "a reader with no process state saw different records")
+            self.assertEqual(len(warm), len(cold), "a cold reader saw a different record count")
+
+            def projection(records):
+                return sorted(
+                    json.dumps({k: v for k, v in r.items() if k in interned},
+                               sort_keys=True, default=str)
+                    for r in records)
+
+            self.assertEqual(projection(warm), projection(cold),
+                             "an interned field did not survive the disk round trip")
+            self.assertTrue(any(set(r) & interned for r in warm),
+                            "nothing in this corpus carried an interned field, so the assertion "
+                            "above proved nothing")
+
+    @staticmethod
+    def _ingest(adapter):
+        for i in range(40):
+            adapter.ingest({
+                "kind": "message",
+                "scope": {"tenant_id": "t%d" % (i % 3), "user_id": "u%d" % (i % 5),
+                          "session_id": "s%d" % (i % 7)},
+                "messages": [{"role": ["user", "assistant", "tool"][i % 3],
+                              "content": "a sentence with enough words to be extracted %d" % i}],
+            })
 
     def test_the_sidecar_count_stays_far_below_the_record_count(self):
         """The failure mode to watch. Fields share ONE bundle, so a field that varies per record

--- a/tools/test_matrixark_interning_reaches_repeated_fields.py
+++ b/tools/test_matrixark_interning_reaches_repeated_fields.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Interning covers the fields that repeat, and still refuses the ones raw-log paths match on.
+
+A census of the event log found 30.4% of its bytes in fields holding a single value across every
+record of their type -- on a corpus varied across tenants, users and sessions so uniformity could
+not manufacture the result. Interning was already enabled and not reaching them, because it reads
+INTERN_METADATA_FIELDS and that list held five routing fields.
+
+The exclusions matter more than the additions, so they are asserted by name here: a field matched
+on the UNEXPANDED log cannot be interned, because the token is what the matcher would see.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+class InterningCoversTheRepeatedFields(unittest.TestCase):
+    def test_it_never_interns_what_a_raw_path_matches_on(self):
+        """Each of these is read off the log BEFORE expansion, so a token would break the match."""
+        fields = set(adapter_module.INTERN_METADATA_FIELDS)
+        self.assertNotIn("scope_key", fields,
+                         "scope-level tombstones match scope_key on unexpanded records in "
+                         "purge_tombstones; interning it makes them miss and tombstoned records "
+                         "survive a purge")
+        self.assertNotIn("record_type", fields,
+                         "every raw filter, including the tombstone scan, matches record_type")
+        for identity in ("model_kind", "model_ref", "model_name", "model_hash",
+                         "provider", "execution_mode"):
+            self.assertNotIn(identity, fields,
+                             "_seed_model_registry_seen_locked reads %s off the unexpanded log"
+                             % identity)
+        self.assertNotIn(adapter_module.INTERN_BUNDLE_TOKEN_KEY, fields,
+                         "the bundle's own token cannot be part of what it names")
+
+    def test_the_list_reaches_past_routing(self):
+        """The defect: the list held only routing fields while the repetition was elsewhere."""
+        fields = set(adapter_module.INTERN_METADATA_FIELDS)
+        for repeated in ("storage_record_kind", "storage_part", "source_ref_type"):
+            self.assertIn(repeated, fields, "%s repeats on every record of its type" % repeated)
+
+    def test_a_log_reads_back_exactly_what_went_in(self):
+        """Interning is only ever a wire format; the served records must be unchanged."""
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            for i in range(40):
+                adapter.ingest({
+                    "kind": "message",
+                    "scope": {"tenant_id": "t%d" % (i % 3), "user_id": "u%d" % (i % 5),
+                              "session_id": "s%d" % (i % 7)},
+                    "messages": [{"role": ["user", "assistant", "tool"][i % 3],
+                                  "content": "a sentence with enough words to be extracted %d" % i}],
+                })
+            served = adapter.read_all()
+            self.assertTrue(served, "nothing was ingested")
+            for record in served:
+                self.assertNotIn(adapter_module.INTERN_BUNDLE_TOKEN_KEY, record,
+                                 "a token reached a served record; expansion is incomplete")
+
+            with adapter_module._LOCAL_READ_CACHE_LOCK:
+                adapter_module._LOCAL_READ_CACHE.clear()
+            cold = adapter_module.MatrixArkLocalAdapter(log).read_all()
+            self.assertEqual(
+                sorted(json.dumps(r, sort_keys=True, default=str) for r in served),
+                sorted(json.dumps(r, sort_keys=True, default=str) for r in cold),
+                "a reader with no process state saw different records")
+
+    def test_the_sidecar_count_stays_far_below_the_record_count(self):
+        """The failure mode to watch. Fields share ONE bundle, so a field that varies per record
+        multiplies sidecars instead of removing bytes -- that would make the log bigger."""
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            for i in range(40):
+                adapter.ingest({
+                    "kind": "message",
+                    "scope": {"tenant_id": "t%d" % (i % 3), "user_id": "u%d" % (i % 5),
+                              "session_id": "s%d" % (i % 7)},
+                    "messages": [{"role": ["user", "assistant", "tool"][i % 3],
+                                  "content": "a sentence with enough words to be extracted %d" % i}],
+                })
+            sidecars = data = 0
+            for line in log.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                record = json.loads(line)
+                if str(record.get("record_type") or "") == adapter_module.INTERN_DICT_RECORD_TYPE:
+                    sidecars += 1
+                else:
+                    data += 1
+            self.assertGreater(data, 0)
+            self.assertLess(sidecars, data / 4.0,
+                            "%d sidecars for %d records -- a field in the bundle is varying per "
+                            "record, which costs bytes instead of saving them" % (sidecars, data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Interning reaches the fields that repeat

A census of the event log found 30.4% of its bytes in fields holding one value across every record
of their type -- on a corpus varied across 4 tenants, 7 users and 11 sessions, so uniformity could
not manufacture the result. Interning was already enabled by default and was not reaching any of
them: it reads INTERN_METADATA_FIELDS, and that list held five routing fields.

Measured over this repo's own markdown, ingested through the real path:

  uniform corpus            231.3 KB -> 173.2 KB   -25.1%    5 -> 8 sidecars
  varied roles and tenants  263.9 KB -> 206.1 KB   -21.9%    5 -> 14 sidecars

Read-back is asserted identical, and a log written with the new fields expands byte-for-byte the
same under the previous code, so existing logs and older readers are unaffected.

The sidecar count is the number to watch, not the byte count. Fields share ONE bundle, so a field
that varies per record makes every token vary and multiplies sidecars instead of removing bytes --
it would make the log bigger. That is why the varied-corpus row is here beside the uniform one, and
why a test asserts sidecars stay well below the record count.

What is deliberately NOT interned, because each is matched on the UNEXPANDED log where the token is
what the matcher would see:

  scope_key                       scope-level tombstones match it in purge_tombstones
  record_type                     every raw filter, including the tombstone scan
  the model registry identity     _seed_model_registry_seen_locked reads it off the raw log
  the bundle's own token key      cannot be part of what it names

Those exclusions are asserted by name, so a later addition has to confront them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
