### PR TITLE
Bring the cache pin forward onto the borrowed namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "matrixcache"
 version = "0.1.0"
-source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b#7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b"
+source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=00e886e852df6919693b5f178c0770fc302c790c#00e886e852df6919693b5f178c0770fc302c790c"
 dependencies = [
  "rocksdb",
  "serde",

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"
 matrixraft = { package = "matrixraft", git = "https://github.com/matrixarkai/MatrixRaft.git", rev = "a4334b37ba6592e7c7192f3eaa2afe087746ccc9" }
-matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "7f2a2a9f65cd3d35a16d189792d8f5e38fa5657b", features = ["rocksdb-ssd"] }
+matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "00e886e852df6919693b5f178c0770fc302c790c", features = ["rocksdb-ssd"] }
 temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
matrixarkai/MatrixCache#19 stopped copying a constant onto the heap for every cache key. **Nothing
consumed it until this pin moved.**

One allocation off every key is one off every cache get and every cache put. Measured across every
api on the same store, at two corpus sizes:

| api | before | after |
|---|---:|---:|
| **retrieve, per candidate** | 9.4 | **8.4** |
| &nbsp;&nbsp;of which the node fetch | 8.0 | **7.0** |
| `get` (one node) | 9 | **8** |
| `history` (summaries) | 17 | **16** |
| `update` (rewrite node) | 192 | **188** |
| `query embeddings` (32 nodes) | 301 | **269** |
| `get_all` at 320 nodes | 2,579 | **2,259** |
| one add (flat in the corpus) | 1,368 | **1,342** |

The two batch reads falling by **exactly one per node** — 32 and 320 — is what says the change did
what it claimed and nothing else.

## Every api is flat

`get_all` is the only one that grows, and it grows with **what it returns**, not with the store:
8.3 allocations per node at 40, **8.1** at 320, matching the node-fetch cost. That is the shape it
should have, not a defect.

## On the pin itself

The revision is matched on the `matrixcache` line rather than on the first revision in the file. The
`matrixraft` pin sits directly above it, and taking "the first forty hex characters" pointed a raft
dependency at a cache commit. Cargo caught that because the revision does not exist in that repo —
which is luck, not a gate. This change asserts both that the cache pin moved **and** that the raft
pin did not.

## Testing

`cargo test --lib`, with any parallel failures re-run serially — this suite has ~180
`std::env::set_var` sites, so a parallel failure is not evidence until it reproduces.
