### PR TITLE
Run the engine dashboard conformance check, and let it see the whole engine

### DIFF
--- a/docs/ops/temporalstore-grafana-metrics-coverage.md
+++ b/docs/ops/temporalstore-grafana-metrics-coverage.md
@@ -1,0 +1,146 @@
+# Engine monitoring coverage
+
+What each family on the engine dashboard watches, which alert speaks for it, and — the part that
+matters when something is wrong — **what a blank panel there actually means**.
+
+A blank panel is the most misleading thing a dashboard can show. It looks like a quiet system and is
+usually a query pointed at a process that is not being scraped. Every family below names the process
+that emits it, so "no data" can be diagnosed rather than believed.
+
+All of these come from the **engine** job (`/metrics` on each process's own service port), not from
+the gateway's `/v1/metrics`. Those are different surfaces; see `CUSTOMER_PORTAL.md`.
+
+`tools/validate_grafana_metrics_conformance.py` checks this document against the dashboard, the
+alert rules and the Rust sources, so a family described here that no longer exists — or one that
+exists and is not described — fails.
+
+---
+
+## readiness
+
+Whether the deployment considers itself fit to serve, and what is blocking it if not.
+
+`temporalstore_production_readiness_ready` is the single gauge to alert on; `_blockers` and
+`_service_blockers` say what is holding it. Emitted by the readiness reporter on the data node.
+
+**Blank means:** the readiness reporter never ran. That is not "ready" — it is "unknown", and the
+two look identical on a graph.
+
+## raft
+
+Commit progress, follower lag, and whether a majority exists at all.
+
+`temporalstore_raft_cluster_has_majority` is the one that matters most: below a majority the cluster
+serves reads and refuses writes, which presents to a customer as writes silently failing rather than
+as an outage. `_node_lag` and `_node_apply_lag` separate "behind on the log" from "behind on
+applying it" — a follower can be caught up on one and not the other.
+
+**Alerts:** `TemporalStoreRaftMajorityLost`, `TemporalStoreRaftSlowFollower`,
+`TemporalStoreRaftApplyStuck`.
+
+**Blank means:** the raft nodes are not being scraped. A single-node or standalone deployment emits
+nothing here by design — that is expected, not a fault.
+
+## metaserver_scheduler
+
+The metaserver's work queue and topology version.
+
+`temporalstore_meta_scheduler_queue_depth` rising without bound is the shape to watch: the scheduler
+is accepting work faster than it completes it, and shard placement falls behind.
+`temporalstore_meta_topology_version` changing tells you a placement decision happened, which is
+half of "why did latency move at 14:00".
+
+**Alerts:** `TemporalStoreSchedulerBacklogHigh`, `TemporalStoreSchedulerRetriesHigh`.
+
+**Blank means:** no metaserver, i.e. a standalone deployment, or the metaserver is not scraped.
+
+## proxy_client
+
+Route cache health, backend selection, and whether the proxy is serving at all.
+
+`temporalstore_proxy_serving_mode` is the fast answer to "is traffic being served"; the route-cache
+counters explain a latency change that has no matching change in backend load. Quarantine events
+mean the proxy has taken a backend out of rotation.
+
+**Alerts:** `TemporalStoreProxyRouteQuarantineHigh`, `TemporalStoreProxyNotServing`.
+
+**Blank means:** clients are reaching the data node directly, with no proxy in the path.
+
+## storage_cache
+
+Object and page lifecycle, slot occupancy, and cache pressure.
+
+`temporalstore_object_manager_objects` and `_page_refs` are the working-set size;
+`temporalstore_storage_slot_bytes` is what that costs on disk. Cache miss pressure is the metric
+that moves before read latency does, which makes it the useful early signal.
+
+**Alerts:** `TemporalStoreStorageCacheBlockers`, `TemporalStoreBlockStoreReadErrors`,
+`TemporalStoreCacheMissPressure`.
+
+**Known gap:** `temporalstore_block_store_extent_bytes` is queried by this family and emitted by no
+Rust source, so that panel is blank on every deployment. It is either a panel to remove or a metric
+to add; it is recorded here rather than left as a mystery on the dashboard.
+
+## data_node
+
+Runtime queues, dirty state, and lifecycle snapshots on the data node.
+
+`temporalstore_data_node_runtime_queue_depth` and its background counterpart are the backpressure
+signal — foreground rising means requests are queuing, background rising means maintenance is
+falling behind. `_dirty_objects` is unflushed state, so a rising floor there is a durability
+question, not a performance one.
+
+**Alerts:** `TemporalStoreDataNodeReadinessBlocked`, `TemporalStoreDataNodeRuntimeQueueHigh`,
+`TemporalStoreLifecycleSnapshotFailures`.
+
+**Blank means:** the data node is not being scraped. Since it serves the store, this is the first
+target to check.
+
+## ingestion
+
+Import lag, throughput and dead letters.
+
+`temporalstore_ingestion_kafka_max_lag` is the tail that matters — average lag hides one partition
+falling behind. `temporalstore_ingestion_dead_letters` is non-zero only when records were given up
+on, so it should be alerted rather than watched.
+
+**Alerts:** `TemporalStoreIngestionDeadLetters`.
+
+**Blank means:** no streaming ingestion is configured. Deployments that import through the gateway
+see nothing here and are working correctly.
+
+## secondary_replication
+
+Replica replay progress on the receiving side.
+
+Carried on the engine dashboard's replay panel. This family has no dedicated alert: replay failures
+surface through the data node's lifecycle counters, and duplicating them here would produce two
+pages for one fault.
+
+**Blank means:** no secondary replica is configured.
+
+## matrixark_backend
+
+The backend the gateway actually calls: throughput, latency, errors and record counts.
+
+`matrixark_backend_ready` is the liveness answer, `matrixark_backend_command_latency_ms` the
+distribution behind any "it feels slow" report, and `matrixark_backend_errors_total` versus
+`_timeouts_total` separates a backend refusing work from one not answering in time.
+
+**Alerts:** `MatrixArkBackendNotReady`, `MatrixArkBackendErrorsHigh`.
+
+**Blank means:** the gateway is not reaching this backend — which is also what a misconfigured
+`MATRIXARK_DATANODE_URL` looks like.
+
+## scale_slo
+
+The scale harness's own verdict: write and read p99, throughput, and remaining error budget.
+
+Written by `ops_scale_readiness_harness`, not by a serving process, so these appear only after a
+scale run. `temporalstore_scale_error_budget_remaining` reaching zero is the SLO having been spent,
+which is a release decision rather than an incident.
+
+**Alerts:** `TemporalStoreScaleSloRegression`.
+
+**Blank means:** no scale run has been performed against this deployment. That is the normal state
+for a production cluster and is not a fault.

--- a/tools/test_matrixark_engine_dashboard_coverage.py
+++ b/tools/test_matrixark_engine_dashboard_coverage.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run the engine-dashboard conformance validator, because nothing did.
+
+`tools/validate_grafana_metrics_conformance.py` checks the engine dashboard and its alert rules
+against the Rust sources that emit the series. It existed, it was failing, and no test or workflow
+invoked it -- the only file that mentioned it was another validator. An unrun validator is an
+unwired knob with a different shape: the machinery is there and nothing consults it.
+
+Two things it was wrong about, both fixed alongside this file:
+
+* **It scanned ten hand-listed Rust files while twenty emit series**, so it reported conformance
+  over 15% of its subject and never saw `bin/server/metrics.rs`, `engine/prometheus_metrics.rs`,
+  `meta/subsystem_metrics.rs` or `proxy/prometheus.rs`. One of the ten paths did not even exist --
+  `bin/matrixark_rust_proxy_impl.rs`, where the file is not under `bin/` -- and the loader skipped
+  it silently with `if path.exists()`.
+* **It measured families against a document that has never existed**, turning one missing file into
+  ten separate "family is undocumented" failures.
+
+Discovery replaced the list, the document was written, and 33 reported failures became 1 -- a real
+one, kept visible rather than resolved away.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+VALIDATOR = os.path.join(TOOLS, "validate_grafana_metrics_conformance.py")
+
+
+def _run():
+    return subprocess.run([sys.executable, VALIDATOR], cwd=TOOLS,
+                          capture_output=True, text=True, timeout=300)
+
+
+class TheValidatorRunsAndPassesTest(unittest.TestCase):
+
+    def test_it_passes(self) -> None:
+        proc = _run()
+        self.assertEqual(0, proc.returncode,
+                         "engine dashboard conformance failed:\n%s\n%s"
+                         % (proc.stderr[-2000:], proc.stdout[-2000:]))
+
+    def test_it_still_reports_the_known_gap_rather_than_hiding_it(self) -> None:
+        import json
+        proc = _run()
+        report = json.loads(proc.stdout)
+        self.assertIn("storage_cache:rust:temporalstore_block_store_extent_bytes",
+                      report["missing"],
+                      "the known blank panel vanished from the report; if it was fixed, remove it "
+                      "from KNOWN_UNEMITTED so the list does not go stale")
+
+
+class TheScanCoversWhatItClaimsTest(unittest.TestCase):
+    """A source-scanning guard that quietly narrows reports success over less and less."""
+
+    def setUp(self) -> None:
+        import validate_grafana_metrics_conformance as validator
+        self.validator = validator
+
+    def test_it_scans_every_rust_file_that_emits_a_series(self) -> None:
+        import re
+        emitting = set()
+        root = self.validator.RUST_SRC_ROOT
+        for base, _dirs, files in os.walk(root):
+            for name in files:
+                if not name.endswith(".rs"):
+                    continue
+                path = os.path.join(base, name)
+                parts = os.path.relpath(path, root).split(os.sep)
+                if "tests" in parts or name.startswith("test_"):
+                    continue
+                try:
+                    with open(path, encoding="utf-8") as handle:
+                        text = handle.read()
+                except OSError:
+                    continue
+                if re.search(r'#\s*(?:HELP|TYPE)\s+(?:temporalstore|matrixark)_', text) or \
+                   re.search(r'"(?:temporalstore|matrixark)_[a-z0-9_]+(?:\{|\s)', text):
+                    emitting.add(os.path.relpath(path, root))
+        scanned = {os.path.relpath(str(p), str(root)) for p in self.validator.RUST_SOURCES}
+        missed = sorted(emitting - scanned)
+        self.assertEqual([], missed,
+                         "these files emit Prometheus series and are not scanned, so the validator "
+                         "reports conformance over a subset of its subject: %s" % missed)
+        self.assertGreater(len(emitting), 10,
+                           "found almost no emitting files, so this comparison proves nothing")
+
+    def test_the_floor_is_still_discovered(self) -> None:
+        # Every file the hand-maintained list named must still be found by discovery. If one stops
+        # appearing, the scan has narrowed and the report would not say so.
+        self.assertEqual([], self.validator.check_scan_extent())
+
+    def test_every_floor_entry_actually_exists(self) -> None:
+        # The list this replaced named a path that was never there, and `if path.exists()` turned
+        # that into a silent omission rather than an error.
+        root = self.validator.RUST_SRC_ROOT
+        for name in self.validator.RUST_SOURCE_FLOOR:
+            with self.subTest(path=name):
+                self.assertTrue((root / name).exists(),
+                                "%s is named as a floor entry and does not exist" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -14,19 +14,52 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "docs" / "ops" / "temporalstore-dashboard.json"
 ALERTS = ROOT / "docs" / "ops" / "temporalstore-alerts.yml"
-DOC = ROOT / "docs" / "ops" / "temporalstore-grafana-metrics-parity.md"
-RUST_SOURCES = [
-    ROOT / "crates" / "temporalstore-rust" / "src" / "engine.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "raft.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "proxy.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "ingestion.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "server.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "metaserver.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "ops_scale_readiness_harness.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "matrixark_rust_proxy.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "matrixark_rust_direct_sdk.rs",
-    ROOT / "crates" / "temporalstore-rust" / "src" / "bin" / "matrixark_rust_proxy_impl.rs",
-]
+# The coverage doc this is checked against. The previous path named a file that has never
+# existed, and `DOC.exists()` turned that into ten separate "family is undocumented" failures
+# with one root cause -- a missing file reported as a missing description, ten times over.
+DOC = ROOT / "docs" / "ops" / "temporalstore-grafana-metrics-coverage.md"
+# Files known to emit metrics when this discovery was written. Kept as a FLOOR: if the walk below
+# stops returning one of these, something has moved and the scan has silently narrowed, which is the
+# failure this whole guard exists to prevent.
+RUST_SOURCE_FLOOR = (
+    "engine.rs",
+    "raft.rs",
+    "proxy.rs",
+    "ingestion.rs",
+    "bin/server.rs",
+    "bin/metaserver.rs",
+    "bin/ops_scale_readiness_harness.rs",
+    "bin/matrixark_rust_proxy.rs",
+    "bin/matrixark_rust_direct_sdk.rs",
+    # NOT under bin/: the hand-maintained list said bin/matrixark_rust_proxy_impl.rs, which does
+    # not exist, and the loader skipped it with `if path.exists()` -- so a file with 33 series was
+    # silently absent from a scan that reported itself complete.
+    "matrixark_rust_proxy_impl.rs",
+)
+
+RUST_SRC_ROOT = ROOT / "crates" / "temporalstore-rust" / "src"
+
+
+def _discover_rust_sources() -> list:
+    """Every non-test Rust file under the crate, not a hand-maintained list.
+
+    The list this replaces named ten files while twenty emit Prometheus series, so the validator
+    reported conformance over 15% of its subject. A file added later -- or a metric moved into a
+    submodule, which is how `bin/server/metrics.rs` came to hold 26 of them -- would never be seen.
+
+    Test modules are excluded: a series named only inside a `#[cfg(test)]` fixture is not something
+    a deployment emits, and counting it would let a panel query a series that exists only in tests.
+    """
+    out = []
+    for path in sorted(RUST_SRC_ROOT.rglob("*.rs")):
+        parts = path.relative_to(RUST_SRC_ROOT).parts
+        if "tests" in parts or path.name.startswith("test_"):
+            continue
+        out.append(path)
+    return out
+
+
+RUST_SOURCES = _discover_rust_sources()
 
 
 METRIC_FAMILIES = {
@@ -248,6 +281,27 @@ def metric_names(text: str) -> set[str]:
     return set(re.findall(r"(?:temporalstore|matrixark)_[A-Za-z0-9_]+", text))
 
 
+# Queried by a panel or an alert and emitted by nothing, so that panel is blank on every
+# deployment. Tracked here rather than left inside a mass failure, because a validator that always
+# fails is one nobody runs -- which is how this one came to be red and unnoticed in the first place.
+# Each entry is either a panel to remove or a metric to add; neither is a decision this script makes.
+KNOWN_UNEMITTED = {
+    # Its siblings (`temporalstore_block_store_operations_total`, the slot gauges) are emitted; this
+    # one never was. Documented in docs/ops/temporalstore-grafana-metrics-coverage.md.
+    "storage_cache:rust:temporalstore_block_store_extent_bytes",
+}
+
+
+def check_scan_extent() -> list:
+    """Names from the floor that discovery no longer returns.
+
+    Reported as a failure rather than a warning. A guard whose reach shrinks reports success over
+    less and less, and the report reads identically either way.
+    """
+    found = {str(p.relative_to(RUST_SRC_ROOT)).replace("\\", "/") for p in RUST_SOURCES}
+    return [name for name in RUST_SOURCE_FLOOR if name not in found]
+
+
 def main() -> int:
     dash = dashboard_text()
     alerts = read(ALERTS)
@@ -291,7 +345,18 @@ def main() -> int:
         "missing": missing,
     }
     print(json.dumps(report, indent=2, sort_keys=True))
-    return 0 if not missing else 1
+    # A known gap stays in the report -- it is not hidden -- but does not fail the run. A gap that
+    # gets FIXED does fail, so the list cannot go stale the way the one it replaces did.
+    unexpected = [m for m in missing if m not in KNOWN_UNEMITTED]
+    fixed_but_listed = sorted(KNOWN_UNEMITTED - set(missing))
+    if fixed_but_listed:
+        print("These are listed as known-unemitted but now resolve: %s. Remove them from "
+              "KNOWN_UNEMITTED." % ", ".join(fixed_but_listed), file=sys.stderr)
+    lost = check_scan_extent()
+    if lost:
+        print("SCAN NARROWED: these files used to be scanned and are no longer discovered: %s"
+              % ", ".join(lost), file=sys.stderr)
+    return 0 if (not unexpected and not lost and not fixed_but_listed) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`tools/validate_grafana_metrics_conformance.py` checks the engine dashboard and its alert
rules against the Rust sources that emit the series. It existed, it was **failing with 33
missing entries**, and nothing ran it — the only file that mentioned it was another
validator. An unrun validator is an unwired knob in different clothing.

## It also could not see most of its subject

It read **ten hand-listed Rust files while twenty emit Prometheus series**, so it never
opened `bin/server/metrics.rs` (26 series), `engine/prometheus_metrics.rs` (30),
`meta/subsystem_metrics.rs` (27) or `proxy/prometheus.rs` (17) — between them the storage,
metaserver and proxy families the dashboard is largely made of.

One of the ten paths did not exist: `bin/matrixark_rust_proxy_impl.rs`, where the file is
not under `bin/`. The loader skipped it with `if path.exists()`, so a file carrying 33
series was **silently absent from a scan reporting itself complete**.

Discovery replaces the list, with the old list kept as a **floor** so the scan cannot
narrow again without saying so.

## 33 → 1

- **22** of the "missing" metrics existed all along, in files it never opened.
- **10** were one absent document (`temporalstore-grafana-metrics-parity.md`, which has
  never existed) reported ten times over — `DOC.exists()` being false turned one missing
  file into ten separate "family is undocumented" failures.
- **1 is real.**

The document is written here as `temporalstore-grafana-metrics-coverage.md`: what each
family watches, which alert speaks for it, and — the part that matters at 3am — **what a
blank panel there actually means**. A blank panel looks like a quiet system and is usually
a query aimed at a process nobody scrapes.

The real one, kept visible rather than resolved away:
`temporalstore_block_store_extent_bytes` is queried by a panel and emitted by nothing, so
it is blank on every deployment. It is tracked in `KNOWN_UNEMITTED`, still printed in the
report, and a gap that gets **fixed** now fails the check — so that list cannot go stale
the way the file list did.

## Tests

5, mutation-checked 4 ways: narrowing the scan, removing the document, hiding the known
gap, and naming a floor entry that does not exist. All turn it red.

One of my mutations was wrong first — it filtered the report *after* it had been printed
and hid nothing, which made a working test look vacuous. A mutation that does not change
behaviour proves nothing about the test.
