### PR TITLE
One cross-session policy builder, not two that disagreed

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -282,31 +282,13 @@ def _tenant_retrieval_limit(name: str, scope: Any, fallback: int) -> int:
     than ignoring a bad setting.
     """
     try:
-        from matrixark_tenant_policy import KNOBS as _KNOBS, tenant_policy as _tenant_policy
+        from matrixark_tenant_policy import explicit_int
     except Exception:  # pragma: no cover - policy module absent
         return fallback
-
-    def _positive_int(value: Any) -> Optional[int]:
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return None
-        return parsed if parsed > 0 else None
-
     try:
-        override = _positive_int((_tenant_policy(scope) or {}).get(name))
-    except Exception:
-        override = None
-    if override is not None:
-        return override
-
-    knob = _KNOBS.get(name)
-    env_name = getattr(knob, "env", "") if knob is not None else ""
-    if env_name:
-        from_env = _positive_int(os.environ.get(env_name))
-        if from_env is not None:
-            return from_env
-    return fallback
+        return explicit_int(name, scope, fallback)
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        return fallback
 
 
 class _LocalAdapterRetrieveMixin:

--- a/tools/matrixark_mcp_budget_policies.py
+++ b/tools/matrixark_mcp_budget_policies.py
@@ -141,6 +141,10 @@ def build_cross_session_policy(
         session_scope=session_scope,
         remote_budget_tokens=remote_budget_tokens,
         context_source_mode=context_source_mode,
+        # THIS module's binding, looked up now rather than captured at import, so a rebound
+        # attribute is seen. Without it the delegation would read the other module's copy and a
+        # toggle here would silently stop working -- which it did, changing two budget ratios.
+        mode_dependent_quota=MODE_DEPENDENT_QUOTA_ENABLED,
     )
 
 

--- a/tools/matrixark_mcp_budget_policies.py
+++ b/tools/matrixark_mcp_budget_policies.py
@@ -112,158 +112,36 @@ def build_cross_session_policy(
     remote_budget_tokens: int,
     context_source_mode: str = "",
 ) -> Json:
-    raw = args.get("cross_session", ranking.get("cross_session", {}))
-    if isinstance(raw, bool):
-        config: Json = {"enabled": raw}
-    elif raw is None:
-        config = {}
-    elif isinstance(raw, dict):
-        config = raw
-    else:
-        raise MatrixArkError("cross_session must be an object or boolean")
+    """Delegates to the one implementation, in matrixark_mcp_core_scoring.
 
-    normalized_question_type = str(question_type or "fact").strip().lower()
-    query_text = str(args.get("query") or ranking.get("query") or "")
-    query_lower = query_text.lower()
-    profile_memory_query = normalized_question_type == "profile_memory" or bool(
-        query_lower and PROFILE_MEMORY_QUERY_RE.search(query_lower)
-    )
-    feature_memory_query = bool(query_lower and FEATURE_MEMORY_QUERY_RE.search(query_lower))
-    cross_session_query = normalized_question_type in {
-        "current_state",
-        "latest",
-        "multi_hop",
-        "date",
-        "broad_exploration",
-        "evidence",
-        "benchmark_quality",
-    }
-    cross_session_allowed = session_scope == "prefer" or profile_memory_query or feature_memory_query or cross_session_query
-    default_enabled = cross_session_allowed and remote_budget_tokens > 0
-    enabled = bool(config.get("enabled", default_enabled)) and cross_session_allowed and remote_budget_tokens > 0
-    profile_budget_query = profile_memory_query or feature_memory_query
-    if normalized_question_type in {"current_state", "latest", "profile_memory"} or profile_budget_query:
-        default_ratio = DEFAULT_CROSS_SESSION_PROFILE_BUDGET_RATIO if profile_budget_query else DEFAULT_CROSS_SESSION_CURRENT_STATE_BUDGET_RATIO
-        if profile_budget_query:
-            question_budget_reason = "profile_memory_queries_need_long_term profile and cross-session state"
-        else:
-            question_budget_reason = "current_state_or_latest_queries_need_prior entity state and stale blockers"
-    elif normalized_question_type in {"multi_hop", "date"}:
-        default_ratio = DEFAULT_CROSS_SESSION_MULTI_HOP_BUDGET_RATIO
-        question_budget_reason = (
-            "multi_hop_or_date_queries_need cross-session memory for comparisons, timelines, "
-            "and facts that may live outside the active session"
+    This module used to carry its own copy. The two had drifted: this one matched a single
+    profile-memory pattern where the other matches three, and it had no handling for an explicitly
+    requested cross-session bridge. Callers reaching this module -- matrixark_mcp_budget_pack --
+    therefore behaved differently from callers reaching the other, for no reason anyone chose.
+
+    Comparing them by identifier and then line by line showed this copy held nothing the other
+    lacked: every line unique to it was a narrower form of a line over there. So it delegates, and
+    the difference disappears rather than being maintained in two places.
+
+    Imported here rather than at module scope: neither module imports the other, and keeping it
+    that way avoids a new edge between two modules that both sit low in the import graph.
+    """
+    try:  # package path
+        from tools.matrixark_mcp_core_scoring import (  # type: ignore
+            build_cross_session_policy as _build,
         )
-    elif normalized_question_type in {"broad_exploration", "evidence"}:
-        default_ratio = DEFAULT_CROSS_SESSION_BROAD_BUDGET_RATIO
-        question_budget_reason = "broad_or_evidence_queries_get_extra cross-session exploration"
-    else:
-        default_ratio = DEFAULT_CROSS_SESSION_BUDGET_RATIO
-        question_budget_reason = "normal_queries_keep_cross_session_small so current session/resources/skills dominate"
-    # Mode-dependent quota (opt-in). Augment: local carries the current session, so route the
-    # memory budget to cross-session + long-term profile. Remote-only: remote reconstructs the
-    # working context too, so cross-session takes the minority. OFF by default (legacy ratios).
-    _mode = str(context_source_mode or "").strip().lower()
-    if MODE_DEPENDENT_QUOTA_ENABLED and _mode == "local_and_remote":
-        default_ratio = max(default_ratio, DEFAULT_AUGMENT_CROSS_SESSION_BUDGET_RATIO)
-        question_budget_reason = "augment_mode_routes_memory_budget_to_cross_session_and_profile_local_carries_current_session"
-    elif MODE_DEPENDENT_QUOTA_ENABLED and _mode == "remote_only":
-        default_ratio = DEFAULT_REMOTE_ONLY_CROSS_SESSION_BUDGET_RATIO
-        question_budget_reason = "remote_only_reserves_majority_of_budget_for_current_session_reconstruction"
-    default_max_budget_ratio = DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_RATIO if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_BUDGET_RATIO
-    if MODE_DEPENDENT_QUOTA_ENABLED and _mode in {"local_and_remote", "remote_only"}:
-        # do not let the profile/default max-ratio cap the mode-dependent cross-session allocation
-        default_max_budget_ratio = max(default_max_budget_ratio, default_ratio)
-    max_budget_ratio = max(0.0, min(1.0, float(config.get("max_budget_ratio", default_max_budget_ratio))))
-    budget_ratio = float_arg(config, "budget_ratio", min(default_ratio, max_budget_ratio), minimum=0.0, maximum=max_budget_ratio)
-    max_budget_default = (
-        DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_TOKENS
-        if profile_budget_query
-        else DEFAULT_CROSS_SESSION_MAX_BUDGET_TOKENS
-    )
-    max_budget_tokens = integer_arg(config, "max_budget_tokens", max_budget_default, minimum=0)
-    ratio_budget_cap = int(remote_budget_tokens * max_budget_ratio) if max_budget_ratio > 0 else 0
-    max_budget_cap = max_budget_tokens if max_budget_tokens > 0 else remote_budget_tokens
-    computed_budget_before_floor = int(remote_budget_tokens * budget_ratio)
-    computed_budget = computed_budget_before_floor
-    budget_floor_tokens = DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS
-    budget_floor_applied = False
-    budget_floor_eligible = (
-        remote_budget_tokens >= 1200
-        and computed_budget > 0
-        and (ratio_budget_cap == 0 or ratio_budget_cap >= budget_floor_tokens)
-        and max_budget_cap >= budget_floor_tokens
-    )
-    if budget_floor_eligible:
-        computed_budget = max(DEFAULT_CROSS_SESSION_MIN_BUDGET_TOKENS, computed_budget)
-        budget_floor_applied = computed_budget != computed_budget_before_floor
-    budget_floor_status = (
-        "floor_applied"
-        if budget_floor_applied
-        else (
-            "remote_budget_too_small_for_profile_floor"
-            if enabled
-            and remote_budget_tokens > 0
-            and computed_budget_before_floor < budget_floor_tokens
-            and not budget_floor_eligible
-            else "not_needed"
+    except ImportError:
+        from matrixark_mcp_core_scoring import (  # type: ignore
+            build_cross_session_policy as _build,
         )
+    return _build(
+        args,
+        ranking,
+        question_type=question_type,
+        session_scope=session_scope,
+        remote_budget_tokens=remote_budget_tokens,
+        context_source_mode=context_source_mode,
     )
-    budget_tokens = integer_arg(config, "budget_tokens", computed_budget, minimum=0) if "budget_tokens" in config else computed_budget
-    budget_tokens = min(
-        remote_budget_tokens,
-        budget_tokens,
-        ratio_budget_cap if ratio_budget_cap > 0 else remote_budget_tokens,
-        max_budget_tokens if max_budget_tokens > 0 else remote_budget_tokens,
-    )
-    max_sessions_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_SESSIONS
-    max_candidates_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_CANDIDATES
-    min_bridge_default = DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS if profile_budget_query else DEFAULT_CROSS_SESSION_MIN_ENTITY_BRIDGE_REFS
-    max_sessions = integer_arg(config, "max_sessions", max_sessions_default, minimum=0)
-    max_candidates = integer_arg(config, "max_candidates", max_candidates_default, minimum=0)
-    min_entity_bridge_refs = integer_arg(config, "min_entity_bridge_refs", min_bridge_default, minimum=0)
-    parallelism = integer_arg(config, "parallelism", DEFAULT_CROSS_SESSION_PARALLELISM, minimum=1)
-    min_score = float_arg(config, "min_score", DEFAULT_CROSS_SESSION_MIN_SCORE, minimum=0.0, maximum=1.0)
-    raw_evidence_min_score = float_arg(config, "raw_evidence_min_score", DEFAULT_CROSS_SESSION_RAW_EVIDENCE_MIN_SCORE, minimum=0.0, maximum=1.0)
-    preferred_ref_types = config.get("preferred_ref_types", list(DEFAULT_CROSS_SESSION_PREFERRED_REF_TYPES))
-    if not isinstance(preferred_ref_types, list):
-        raise MatrixArkError("cross_session.preferred_ref_types must be an array")
-    preferred_ref_types = [str(item).strip() for item in preferred_ref_types if str(item).strip()]
-    return {
-        "enabled": enabled,
-        "mode": "prefer" if enabled else "disabled",
-        "decision": (
-            "always_consider_same_user_cross_session_for_profile_memory"
-            if enabled and profile_memory_query and session_scope != "prefer"
-            else "always_consider_same_user_cross_session_for_feature_memory"
-            if enabled and feature_memory_query and session_scope != "prefer"
-            else "always_consider_same_user_cross_session_for_query_type"
-            if enabled and cross_session_query and session_scope != "prefer"
-            else "always_consider_same_user_cross_session_when_session_scope_prefer"
-            if enabled
-            else "disabled_by_session_scope_or_budget"
-        ),
-        "question_type": normalized_question_type,
-        "question_budget_reason": question_budget_reason,
-        "budget_ratio": round(budget_ratio, 6),
-        "max_budget_ratio": round(max_budget_ratio, 6),
-        "budget_tokens": budget_tokens if enabled else 0,
-        "remote_budget_tokens": remote_budget_tokens,
-        "computed_budget_tokens": computed_budget_before_floor,
-        "budget_floor_tokens": budget_floor_tokens,
-        "budget_floor_applied": budget_floor_applied if enabled else False,
-        "budget_floor_status": budget_floor_status if enabled else "disabled",
-        "max_budget_tokens": max_budget_tokens,
-        "max_sessions": max_sessions if enabled else 0,
-        "max_candidates": max_candidates if enabled else 0,
-        "min_score": min_score if enabled else 0.0,
-        "raw_evidence_min_score": raw_evidence_min_score if enabled else 0.0,
-        "preferred_ref_types": preferred_ref_types if enabled else [],
-        "min_entity_bridge_refs": min_entity_bridge_refs if enabled else 0,
-        "parallelism": parallelism if enabled else 0,
-        "strategy": "same_session_first_entity_bridge_then_bounded_cross_session",
-        "budget_guidance": "cross-session budget is a maximum cap, not a quota: keep normal queries small, raise profile-memory queries for long-term profile state, spend it only on high-quality refs, prefer entities/summaries/compressions, and require high-confidence raw events",
-    }
 
 
 def build_shared_context_policy(args: Json, ranking: Json, *, remote_budget_tokens: int) -> Json:

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -260,7 +260,12 @@ def _tenant_profile_max_candidates(args: Json, fallback: int) -> int:
         return fallback
 
 
-def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str, session_scope: str, remote_budget_tokens: int, context_source_mode: str = "") -> Json:
+def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str, session_scope: str, remote_budget_tokens: int, context_source_mode: str = "", mode_dependent_quota: bool | None = None) -> Json:
+    # `mode_dependent_quota` exists so a delegating caller can supply ITS module's flag. The flag is
+    # defined once in matrixark_mcp_runtime_config, but every importer binds its own name, so
+    # rebinding one module's attribute -- which is how this behaviour is toggled in tests -- does
+    # not reach a reader in another module. Passing it keeps one implementation of the logic while
+    # leaving each caller's flag in charge of its own path. None means "use mine".
     raw = args.get("cross_session", ranking.get("cross_session", {}))
     if isinstance(raw, bool):
         config: Json = {"enabled": raw}
@@ -330,14 +335,16 @@ def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str,
     # memory budget to cross-session + long-term profile. Remote-only: remote reconstructs the
     # working context too, so cross-session takes the minority. OFF by default (legacy ratios).
     _mode = str(context_source_mode or "").strip().lower()
-    if MODE_DEPENDENT_QUOTA_ENABLED and _mode == "local_and_remote":
+    _mode_quota = (MODE_DEPENDENT_QUOTA_ENABLED if mode_dependent_quota is None
+                   else bool(mode_dependent_quota))
+    if _mode_quota and _mode == "local_and_remote":
         default_ratio = max(default_ratio, DEFAULT_AUGMENT_CROSS_SESSION_BUDGET_RATIO)
         question_budget_reason = "augment_mode_routes_memory_budget_to_cross_session_and_profile_local_carries_current_session"
-    elif MODE_DEPENDENT_QUOTA_ENABLED and _mode == "remote_only":
+    elif _mode_quota and _mode == "remote_only":
         default_ratio = DEFAULT_REMOTE_ONLY_CROSS_SESSION_BUDGET_RATIO
         question_budget_reason = "remote_only_reserves_majority_of_budget_for_current_session_reconstruction"
     default_max_budget_ratio = DEFAULT_CROSS_SESSION_PROFILE_MAX_BUDGET_RATIO if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_BUDGET_RATIO
-    if MODE_DEPENDENT_QUOTA_ENABLED and _mode in {"local_and_remote", "remote_only"}:
+    if _mode_quota and _mode in {"local_and_remote", "remote_only"}:
         # do not let the profile/default max-ratio cap the mode-dependent cross-session allocation
         default_max_budget_ratio = max(default_max_budget_ratio, default_ratio)
     max_budget_ratio = max(0.0, min(1.0, float(config.get("max_budget_ratio", default_max_budget_ratio))))

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -242,6 +242,24 @@ def float_arg(data: Json, field: str, default: float, *, minimum: float = 0.0, m
     return result
 
 
+def _tenant_profile_max_candidates(args: Json, fallback: int) -> int:
+    """This tenant's cross-session PROFILE candidate ceiling, or the build's default.
+
+    Reads the shared explicit-only resolver rather than `resolve()`: the knob registry's default is
+    2000 and the value in use here is 48, so resolving would multiply the budget forty-fold for
+    every deployment that never configured one.
+    """
+    try:
+        from matrixark_tenant_policy import explicit_int
+    except Exception:  # pragma: no cover - policy module absent
+        return fallback
+    try:
+        return explicit_int("cross_session_profile_max_candidates",
+                            (args or {}).get("scope"), fallback)
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        return fallback
+
+
 def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str, session_scope: str, remote_budget_tokens: int, context_source_mode: str = "") -> Json:
     raw = args.get("cross_session", ranking.get("cross_session", {}))
     if isinstance(raw, bool):
@@ -365,7 +383,15 @@ def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str,
         max_budget_tokens if max_budget_tokens > 0 else remote_budget_tokens,
     )
     max_sessions_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_SESSIONS
-    max_candidates_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_CANDIDATES
+    # The last of the tenant knobs that resolved correctly and was read by nobody. It applies
+    # only to the PROFILE budget, which is what it is named for; the non-profile default is
+    # untouched. Explicit-only precedence, so a deployment that configured nothing does not move --
+    # the registry default for this knob is 2000 against the 48 used here.
+    max_candidates_default = (
+        _tenant_profile_max_candidates(args, DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES)
+        if profile_budget_query
+        else DEFAULT_CROSS_SESSION_MAX_CANDIDATES
+    )
     min_bridge_default = (
         DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS
         if profile_budget_query

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -829,6 +829,45 @@ def tenant_scope_from_node_path(node_path: Any) -> Json:
     return {}
 
 
+def explicit_int(name: str, scope: Any, fallback: int) -> int:
+    """An explicitly-set integer for `scope`: a tenant override, else an env var, else `fallback`.
+
+    Deliberately NOT `resolve()`. That returns the knob registry's default when nobody has set
+    anything, and several registry defaults are far larger than the value the consuming code
+    actually uses -- `cross_session_profile_max_candidates` is 2000 here and 48 there. Wiring a
+    consumer to `resolve()` therefore looks like "the knob works now" and silently multiplies the
+    budget for every deployment that configured nothing.
+
+    Both explicit levels are read per call, so a change at either applies with no restart. With
+    nothing set the caller's own default is returned unchanged, so no deployment moves.
+
+    Anything unexpected -- no such knob, a non-numeric value, a nonsensical zero -- falls back to
+    the caller's default: a budget that resolved to nothing would return nothing at all, which is a
+    worse failure than ignoring a bad setting.
+    """
+    def _positive(value: Any):
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    try:
+        override = _positive((tenant_policy(scope) or {}).get(name))
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        override = None
+    if override is not None:
+        return override
+
+    knob = KNOBS.get(name)
+    env_name = getattr(knob, "env", "") if knob is not None else ""
+    if env_name:
+        from_env = _positive(os.environ.get(env_name))
+        if from_env is not None:
+            return from_env
+    return fallback
+
+
 def tenant_policy(scope: Any = None) -> Json:
     """The merged override set for `scope`'s tenant (file defaults < file tenant < store record)."""
     file_defaults, file_tenants = _load_file_policies()

--- a/tools/test_matrixark_one_cross_session_policy.py
+++ b/tools/test_matrixark_one_cross_session_policy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""There is one cross-session policy builder, and both paths reach it.
+
+`build_cross_session_policy` existed twice. `matrixark_local_adapter_retrieve` and
+`matrixark_mcp_retrieve_planning` bound the `matrixark_mcp_core_scoring` copy;
+`matrixark_mcp_budget_pack` bound the `matrixark_mcp_budget_policies` one. Both were live, reached
+by different callers, and they had drifted -- so which cross-session behaviour a request got
+depended on which module the caller happened to import.
+
+The drift was one-directional. `budget_policies` matched a single profile-memory pattern where
+`core_scoring` matches three, and had no handling for an explicitly requested bridge. Every line
+unique to it was a narrower form of a line in the other; it held nothing the other lacked.
+
+These tests assert the OUTCOME rather than the wiring: identical arguments through either module
+must produce an identical policy. Asserting that both names point at one function would pass just as
+well if the shared function were the narrower one, which is the failure this replaced.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter  # noqa: E402,F401  (establishes the package first)
+import matrixark_mcp_budget_policies as budget_policies  # noqa: E402
+import matrixark_mcp_core_scoring as core_scoring  # noqa: E402
+
+# A standing-rule phrasing. The retired copy matched only PROFILE_MEMORY_QUERY_RE, so it did not
+# recognise this as profile memory; the surviving one also checks
+# PROFILE_MEMORY_STANDING_RULE_QUERY_RE and ACTIVE_MEMORY_GOAL_QUERY_RE.
+STANDING_RULE = {"query": "what is my standing rule about deploys"}
+PLAIN = {"query": "what did we ship last week"}
+
+CASES = (
+    ("standing rule, prefer", STANDING_RULE, "profile_memory", "prefer"),
+    ("standing rule, session only", STANDING_RULE, "profile_memory", "only"),
+    ("plain query, prefer", PLAIN, "latest", "prefer"),
+    ("explicit bridge requested", STANDING_RULE, "current_state", "only"),
+)
+
+
+def _both(args, ranking, question_type, session_scope, budget=4096):
+    kwargs = dict(question_type=question_type, session_scope=session_scope,
+                  remote_budget_tokens=budget)
+    return (budget_policies.build_cross_session_policy(args, ranking, **kwargs),
+            core_scoring.build_cross_session_policy(args, ranking, **kwargs))
+
+
+class BothModulesGiveTheSamePolicyTest(unittest.TestCase):
+
+    def test_identical_for_every_case(self) -> None:
+        for label, args, question_type, session_scope in CASES:
+            with self.subTest(case=label):
+                through_pack, through_retrieve = _both(args, {}, question_type, session_scope)
+                self.assertEqual(
+                    through_retrieve, through_pack,
+                    "the two modules still disagree for %r: a request gets different "
+                    "cross-session behaviour depending on which one its caller imported" % label)
+
+    def test_an_explicitly_requested_bridge_is_honoured_through_both(self) -> None:
+        # `explicit_cross_session_enabled` / `explicit_profile_bridge_requested` existed only in the
+        # surviving copy, so this is one of the behaviours the pack path did without.
+        ranking = {"cross_session": {"enabled": True, "min_entity_bridge_refs": 2}}
+        through_pack, through_retrieve = _both(STANDING_RULE, ranking, "profile_memory", "only")
+        self.assertEqual(through_retrieve, through_pack)
+        self.assertTrue(through_pack.get("enabled"),
+                        "an explicitly enabled cross-session bridge was not honoured")
+
+    def test_the_result_is_not_trivially_empty(self) -> None:
+        # Two empty dicts compare equal. Without this, every assertion above would hold on a
+        # builder that returned nothing at all.
+        policy, _ = _both(STANDING_RULE, {}, "profile_memory", "prefer")
+        self.assertGreater(len(policy), 5, "the policy came back nearly empty: %r" % policy)
+        for key in ("enabled", "budget_tokens", "max_candidates"):
+            self.assertIn(key, policy)
+
+
+class ThereIsOnlyOneImplementationTest(unittest.TestCase):
+    """The duplicate must not come back."""
+
+    def test_budget_policies_does_not_define_its_own_body(self) -> None:
+        import ast
+        import io
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "matrixark_mcp_budget_policies.py")
+        with io.open(path, encoding="utf-8") as handle:
+            tree = ast.parse(handle.read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "build_cross_session_policy":
+                body = node.end_lineno - node.lineno
+                self.assertLess(
+                    body, 45,
+                    "build_cross_session_policy in matrixark_mcp_budget_policies is %d lines. It "
+                    "should delegate. A second implementation here drifted once already and the "
+                    "two disagreed for months." % body)
+                return
+        self.fail("build_cross_session_policy is not defined in matrixark_mcp_budget_policies")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_one_cross_session_policy.py
+++ b/tools/test_matrixark_one_cross_session_policy.py
@@ -100,5 +100,53 @@ class ThereIsOnlyOneImplementationTest(unittest.TestCase):
         self.fail("build_cross_session_policy is not defined in matrixark_mcp_budget_policies")
 
 
+class EachModulesFlagGovernsItsOwnPathTest(unittest.TestCase):
+    """Delegation must not move which copy of a module-level flag is read.
+
+    `MODE_DEPENDENT_QUOTA_ENABLED` is defined once, in matrixark_mcp_runtime_config, and imported by
+    both modules -- one definition, but each importer binds its own name. Rebinding one module's
+    attribute is how this behaviour is toggled, and a naive delegation made the call read the OTHER
+    module's binding: the toggle stopped reaching the code it controls and two budget ratios changed
+    silently, 0.6 to 0.12 and 0.30 to 0.12.
+
+    Nothing in a body-to-body comparison of the two functions could have shown that, because the
+    difference was not in either body. Only calling it both ways does.
+    """
+
+    def _ratio(self, module, mode):
+        args = {"query": "what did we ship", "cross_session": {}}
+        out = module.build_cross_session_policy(
+            args, {}, question_type="latest", session_scope="prefer",
+            remote_budget_tokens=8192, context_source_mode=mode)
+        return out.get("budget_ratio")
+
+    def test_toggling_one_module_does_not_reach_through_the_other(self) -> None:
+        original = budget_policies.MODE_DEPENDENT_QUOTA_ENABLED
+        try:
+            budget_policies.MODE_DEPENDENT_QUOTA_ENABLED = False
+            off = self._ratio(budget_policies, "local_and_remote")
+            budget_policies.MODE_DEPENDENT_QUOTA_ENABLED = True
+            on = self._ratio(budget_policies, "local_and_remote")
+        finally:
+            budget_policies.MODE_DEPENDENT_QUOTA_ENABLED = original
+        self.assertNotEqual(
+            off, on,
+            "toggling matrixark_mcp_budget_policies.MODE_DEPENDENT_QUOTA_ENABLED changed nothing. "
+            "The delegation is reading the other module's binding of the flag, so this path is "
+            "governed by a switch nobody here can see.")
+
+    def test_the_retrieval_path_keeps_its_own_flag(self) -> None:
+        original = core_scoring.MODE_DEPENDENT_QUOTA_ENABLED
+        try:
+            core_scoring.MODE_DEPENDENT_QUOTA_ENABLED = False
+            off = self._ratio(core_scoring, "local_and_remote")
+            core_scoring.MODE_DEPENDENT_QUOTA_ENABLED = True
+            on = self._ratio(core_scoring, "local_and_remote")
+        finally:
+            core_scoring.MODE_DEPENDENT_QUOTA_ENABLED = original
+        self.assertNotEqual(off, on,
+                            "the retrieval path no longer responds to its own flag")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_retrieval_budgets_follow_the_tenant.py
+++ b/tools/test_matrixark_retrieval_budgets_follow_the_tenant.py
@@ -150,5 +150,57 @@ class NonsenseFallsBackTest(unittest.TestCase):
                     os.environ.pop(env, None)
 
 
+class TheProfileCandidateCeilingFollowsTheTenantTest(unittest.TestCase):
+    """The fifth budget, and the last tenant knob that had no caller at all.
+
+    It could not be wired until there was one `build_cross_session_policy` to wire: the function
+    existed twice, bound by different callers, so gating one would have left the other untouched --
+    the guard-one-route-of-two mistake, which looks like it works.
+
+    Asserted through the policy the builder returns rather than through the helper, because the
+    helper returning the right number proves nothing about whether the builder consults it.
+    """
+
+    def _max_candidates(self, tenant, budget=8192):
+        import matrixark_mcp_core_scoring as scoring
+        args = {"scope": {"tenant_id": tenant},
+                "query": "what is my standing rule about deploys"}
+        policy_out = scoring.build_cross_session_policy(
+            args, {}, question_type="profile_memory", session_scope="prefer",
+            remote_budget_tokens=budget)
+        return policy_out.get("max_candidates")
+
+    def test_a_tenant_ceiling_is_applied(self) -> None:
+        _set_policy("profile_ceiling", {"cross_session_profile_max_candidates": 6})
+        self.assertEqual(6, self._max_candidates("profile_ceiling"))
+
+    def test_an_unconfigured_tenant_does_not_move(self) -> None:
+        # The registry default for this knob is 2000 and the value in use is 48. Wiring through
+        # resolve() would have multiplied it forty-fold for everyone who set nothing.
+        os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_unconfigured"))
+
+    def test_an_explicit_env_var_applies_without_a_restart(self) -> None:
+        os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_env"))
+        try:
+            os.environ["MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES"] = "11"
+            self.assertEqual(11, self._max_candidates("profile_env"))
+        finally:
+            os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_env"))
+
+    def test_it_does_not_touch_the_non_profile_budget(self) -> None:
+        # The knob names the PROFILE ceiling. A non-profile query must keep its own default, or
+        # this would be a much larger change than the name promises.
+        import matrixark_mcp_core_scoring as scoring
+        _set_policy("profile_only", {"cross_session_profile_max_candidates": 6})
+        args = {"scope": {"tenant_id": "profile_only"}, "query": "what did we ship last week"}
+        out = scoring.build_cross_session_policy(
+            args, {}, question_type="latest", session_scope="prefer", remote_budget_tokens=8192)
+        self.assertNotEqual(6, out.get("max_candidates"),
+                            "the profile ceiling was applied to a non-profile query")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`build_cross_session_policy` existed **twice**, and both copies were live:

| caller | bound copy |
|---|---|
| `matrixark_local_adapter_retrieve` | `matrixark_mcp_core_scoring` |
| `matrixark_mcp_retrieve_planning` | `matrixark_mcp_core_scoring` |
| `matrixark_mcp_budget_pack` | `matrixark_mcp_budget_policies` |

So which cross-session behaviour a request got depended on which module its caller happened
to import.

## The drift was one-directional

Compared **by identifier** — the raw diff is dominated by a reflowed signature and hides the
substance — `budget_policies` had *no* name `core_scoring` lacked, while `core_scoring` had
eight it did not. Compared line by line, every line unique to `budget_policies` was a
**narrower** form of a line in the other: one profile-memory pattern where the other matches
three, a one-line condition where the other spells the same thing out.

It held nothing the other lacked. That is what makes this a delegation rather than a merge
of two designs.

## Behaviour change, stated plainly

Callers of `matrixark_mcp_budget_pack` **gain** what the retired copy did without:

- standing-rule and active-goal query detection (`PROFILE_MEMORY_STANDING_RULE_QUERY_RE`,
  `ACTIVE_MEMORY_GOAL_QUERY_RE`)
- an explicitly requested cross-session bridge being honoured
- `allow_durable_profile_bridge_inside_session_only_scope`
- the `try`/`except` around the bridge-refs parse

That is the point of the change, not a side effect.

## Tests assert the outcome, not the wiring

Identical arguments through **either** module must produce an identical policy. Asserting
that both names point at one function would pass just as well if the shared function were
the narrower one — which is the failure this replaces.

One test checks the result is not nearly empty, because two empty dicts compare equal and
every other assertion would hold on a builder that returned nothing. Mutation-checked: making
the wrapper diverge again, and returning an empty policy, both turn it red.

297 tests green across the ten suites that exercise these paths.

## It unblocks the last knob

`cross_session_profile_max_candidates` is the one remaining tenant knob with no caller. Wiring
it meant wiring two implementations; now there is one.
