### PR TITLE
Score a candidate without decoding the whole record

### DIFF
--- a/crates/temporalstore-rust/src/engine/context.rs
+++ b/crates/temporalstore-rust/src/engine/context.rs
@@ -810,6 +810,29 @@ pub(super) fn load_context_children(
         .unwrap_or_default()
 }
 
+/// The same lookup as `load_context_node`, decoding only the vector.
+///
+/// Used where a candidate is scored and discarded, which is most of them.
+pub(super) fn load_context_node_vector(
+    cache: &MultiLayerCache,
+    page_store: &LocalBlockStore,
+    shard_id: ShardId,
+    shard: &ShardState,
+    tenant_hash: u64,
+    node_hash: u64,
+) -> Option<Vec<f32>> {
+    let object_key = context_node_key(tenant_hash, node_hash);
+    shard
+        .hashes
+        .get(&object_key)
+        .and_then(|fields| fields.get(CONTEXT_NODE_FIELD))
+        .or_else(|| shard.context_nodes.get(&object_key))
+        .and_then(|address| {
+            super::read_page_shared(cache, page_store, shard_id, address)
+                .and_then(|bytes| crate::types::decode_context_node_vector(&bytes))
+        })
+}
+
 pub(super) fn load_context_node(
     cache: &MultiLayerCache,
     page_store: &LocalBlockStore,
@@ -1033,7 +1056,7 @@ pub(super) fn traverse_context_tree(
                 // the child hash already in hand; the retired separate records were not -- they
                 // were keyed by a one-way hash of (tenant, owner, level) that no reader could
                 // reconstruct without already holding the owner.
-                let vector = load_context_node(
+                let vector = load_context_node_vector(
                     cache,
                     page_store,
                     shard_id,
@@ -1041,8 +1064,7 @@ pub(super) fn traverse_context_tree(
                     tenant_hash,
                     child.child_hash,
                 )
-                .filter(|node| !node.vector.is_empty())
-                .map(|node| node.vector);
+                .filter(|vector| !vector.is_empty());
                 let Some(vector) = vector else {
                     continue;
                 };

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1970,6 +1970,35 @@ pub enum Command {
 /// them and is silently dropped on persist -- the struct is populated in memory and the value
 /// is gone by the time it reaches a page, with no error anywhere. 20 is clear of every field
 /// number the three messages already use.
+/// A node's vector, without decoding the node.
+///
+/// The traversal scores candidates on this one field. Decoding the whole record to read it
+/// allocates every string and the summary vector as well, for a candidate that usually loses.
+///
+/// Scanning continues past a match on purpose: the full decoder assigns to `vector` on each
+/// vector field it meets, so the last encoding present is the one that wins. Stopping at the
+/// first would disagree with it on any record carrying more than one.
+pub(crate) fn decode_context_node_vector(bytes: &[u8]) -> Option<Vec<f32>> {
+    let mut cursor = 0;
+    let mut found: Option<Vec<f32>> = None;
+    while cursor < bytes.len() {
+        let tag = decode_varint(bytes, &mut cursor)?;
+        match (tag >> 3, tag & 0x7) {
+            (CONTEXT_VECTOR_FIELD, 2) => {
+                found = Some(unpack_f32_vector(decode_bytes_ref(bytes, &mut cursor)?));
+            }
+            (CONTEXT_VECTOR_INT8_FIELD, 2) => {
+                found = Some(unpack_i8_vector(decode_bytes_ref(bytes, &mut cursor)?));
+            }
+            (CONTEXT_VECTOR_SCALED_FIELD, 2) => {
+                found = Some(unpack_scaled_vector(decode_bytes_ref(bytes, &mut cursor)?));
+            }
+            (_, wire_type) => skip_proto_field(bytes, &mut cursor, wire_type)?,
+        }
+    }
+    found
+}
+
 const CONTEXT_VECTOR_FIELD: u64 = 20;
 // Which model produced the inline vector, and when. Both travelled with the separate
 // embedding record; an owner carrying a vector without them cannot say whether the vector
@@ -2650,6 +2679,54 @@ mod tests {
                 None => std::env::remove_var("TS_VECTOR_INT8"),
             }
         }
+    }
+
+    /// Reading only the vector must give what reading everything gives.
+    ///
+    /// Checked across the encodings a record can actually carry, because the partial decoder
+    /// skips fields by wire type and a mistake there returns a plausible-looking vector rather
+    /// than an error. Compared against the full decoder on the same bytes -- the thing it is
+    /// standing in for -- rather than against the input vector, which would not catch a decoder
+    /// that agreed with itself.
+    #[test]
+    fn vector_only_decode_agrees_with_the_full_decode() {
+        let vector: Vec<f32> = (0..48).map(|i| (i as f32 / 48.0) - 0.5).collect();
+
+        for (label, var, value) in [
+            ("f32", "TS_VECTOR_SCALED", "0"),
+            ("scaled", "TS_VECTOR_SCALED", "1"),
+            ("int8", "TS_VECTOR_INT8", "1"),
+        ] {
+            // SAFETY: single-threaded test process.
+            unsafe { std::env::set_var(var, value) };
+            let node = int8_node(7, vector.clone());
+            let bytes = node.encode_context_proto_value();
+            unsafe { std::env::remove_var(var) };
+
+            let full = ContextNode::decode_context_proto_value(&bytes)
+                .unwrap_or_else(|| panic!("{label}: the full decode must succeed"));
+            let partial = decode_context_node_vector(&bytes)
+                .unwrap_or_else(|| panic!("{label}: the vector-only decode must find a vector"));
+
+            assert!(!full.vector.is_empty(), "{label}: the record must carry a vector");
+            assert_eq!(
+                partial, full.vector,
+                "{label}: reading only the vector disagreed with reading everything"
+            );
+        }
+    }
+
+    /// A record with no vector reports none, rather than an empty one that scores as a match.
+    #[test]
+    fn vector_only_decode_reports_absence() {
+        let node = int8_node(9, Vec::new());
+        let bytes = node.encode_context_proto_value();
+        let full = ContextNode::decode_context_proto_value(&bytes).expect("decodes");
+        assert!(full.vector.is_empty(), "the record carries no vector");
+        assert!(
+            decode_context_node_vector(&bytes).map_or(true, |v| v.is_empty()),
+            "a record with no vector must not yield one"
+        );
     }
 
     fn int8_node(node_hash: u64, vector: Vec<f32>) -> ContextNode {


### PR DESCRIPTION
The graph traversal decoded an entire record to read one field of it:

```rust
let vector = load_context_node(…)
    .filter(|node| !node.vector.is_empty())
    .map(|node| node.vector);
let score = cosine_similarity(query_vector, &vector);
```

Every string, both vectors and all the metadata of a `ContextNode` were allocated, then dropped, **per candidate** — and most candidates lose. This reads only the vector field and skips the rest by wire type, using the same skip helper the full decoder uses.

Nothing shrinks in memory here. What changes is how much gets *built* per scored candidate, on the path where this store's allocation pressure actually lives.

### Scanning continues past a match, deliberately

The full decoder **assigns** to `vector` on each vector field it meets, so when a record carries more than one encoding, the last one wins. Returning at the first match would silently disagree with the decoder this stands in for.

### The test compares against the decoder it replaces

Across all three encodings a record can carry — `f32`, uniform-scaled, and int8 — the vector-only decode is asserted equal to `ContextNode::decode(…).vector` **on the same bytes**.

Comparing against the vector that was *encoded* would have been weaker: a decoder that skipped a field wrongly still returns a plausible-looking vector rather than an error, and would agree with itself. A second test covers a record with no vector, which must report absence rather than an empty vector that scores as a match.

### Verification

Full lib suite, single-threaded: 1550 passed, with one intermittent timing assertion (`raft_replication_deadline_…`, a 300 ms bound) that fails independently of this change — A/B against this commit's own parent, four runs each side, 4/4 both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
