### PR TITLE
The last tenant knob with no caller now has one

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -282,31 +282,13 @@ def _tenant_retrieval_limit(name: str, scope: Any, fallback: int) -> int:
     than ignoring a bad setting.
     """
     try:
-        from matrixark_tenant_policy import KNOBS as _KNOBS, tenant_policy as _tenant_policy
+        from matrixark_tenant_policy import explicit_int
     except Exception:  # pragma: no cover - policy module absent
         return fallback
-
-    def _positive_int(value: Any) -> Optional[int]:
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return None
-        return parsed if parsed > 0 else None
-
     try:
-        override = _positive_int((_tenant_policy(scope) or {}).get(name))
-    except Exception:
-        override = None
-    if override is not None:
-        return override
-
-    knob = _KNOBS.get(name)
-    env_name = getattr(knob, "env", "") if knob is not None else ""
-    if env_name:
-        from_env = _positive_int(os.environ.get(env_name))
-        if from_env is not None:
-            return from_env
-    return fallback
+        return explicit_int(name, scope, fallback)
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        return fallback
 
 
 class _LocalAdapterRetrieveMixin:

--- a/tools/matrixark_mcp_core_scoring.py
+++ b/tools/matrixark_mcp_core_scoring.py
@@ -242,6 +242,24 @@ def float_arg(data: Json, field: str, default: float, *, minimum: float = 0.0, m
     return result
 
 
+def _tenant_profile_max_candidates(args: Json, fallback: int) -> int:
+    """This tenant's cross-session PROFILE candidate ceiling, or the build's default.
+
+    Reads the shared explicit-only resolver rather than `resolve()`: the knob registry's default is
+    2000 and the value in use here is 48, so resolving would multiply the budget forty-fold for
+    every deployment that never configured one.
+    """
+    try:
+        from matrixark_tenant_policy import explicit_int
+    except Exception:  # pragma: no cover - policy module absent
+        return fallback
+    try:
+        return explicit_int("cross_session_profile_max_candidates",
+                            (args or {}).get("scope"), fallback)
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        return fallback
+
+
 def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str, session_scope: str, remote_budget_tokens: int, context_source_mode: str = "") -> Json:
     raw = args.get("cross_session", ranking.get("cross_session", {}))
     if isinstance(raw, bool):
@@ -365,7 +383,15 @@ def build_cross_session_policy(args: Json, ranking: Json, *, question_type: str,
         max_budget_tokens if max_budget_tokens > 0 else remote_budget_tokens,
     )
     max_sessions_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_SESSIONS if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_SESSIONS
-    max_candidates_default = DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES if profile_budget_query else DEFAULT_CROSS_SESSION_MAX_CANDIDATES
+    # The last of the tenant knobs that resolved correctly and was read by nobody. It applies
+    # only to the PROFILE budget, which is what it is named for; the non-profile default is
+    # untouched. Explicit-only precedence, so a deployment that configured nothing does not move --
+    # the registry default for this knob is 2000 against the 48 used here.
+    max_candidates_default = (
+        _tenant_profile_max_candidates(args, DEFAULT_CROSS_SESSION_PROFILE_MAX_CANDIDATES)
+        if profile_budget_query
+        else DEFAULT_CROSS_SESSION_MAX_CANDIDATES
+    )
     min_bridge_default = (
         DEFAULT_CROSS_SESSION_PROFILE_MIN_ENTITY_BRIDGE_REFS
         if profile_budget_query

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -829,6 +829,45 @@ def tenant_scope_from_node_path(node_path: Any) -> Json:
     return {}
 
 
+def explicit_int(name: str, scope: Any, fallback: int) -> int:
+    """An explicitly-set integer for `scope`: a tenant override, else an env var, else `fallback`.
+
+    Deliberately NOT `resolve()`. That returns the knob registry's default when nobody has set
+    anything, and several registry defaults are far larger than the value the consuming code
+    actually uses -- `cross_session_profile_max_candidates` is 2000 here and 48 there. Wiring a
+    consumer to `resolve()` therefore looks like "the knob works now" and silently multiplies the
+    budget for every deployment that configured nothing.
+
+    Both explicit levels are read per call, so a change at either applies with no restart. With
+    nothing set the caller's own default is returned unchanged, so no deployment moves.
+
+    Anything unexpected -- no such knob, a non-numeric value, a nonsensical zero -- falls back to
+    the caller's default: a budget that resolved to nothing would return nothing at all, which is a
+    worse failure than ignoring a bad setting.
+    """
+    def _positive(value: Any):
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+
+    try:
+        override = _positive((tenant_policy(scope) or {}).get(name))
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        override = None
+    if override is not None:
+        return override
+
+    knob = KNOBS.get(name)
+    env_name = getattr(knob, "env", "") if knob is not None else ""
+    if env_name:
+        from_env = _positive(os.environ.get(env_name))
+        if from_env is not None:
+            return from_env
+    return fallback
+
+
 def tenant_policy(scope: Any = None) -> Json:
     """The merged override set for `scope`'s tenant (file defaults < file tenant < store record)."""
     file_defaults, file_tenants = _load_file_policies()

--- a/tools/test_matrixark_retrieval_budgets_follow_the_tenant.py
+++ b/tools/test_matrixark_retrieval_budgets_follow_the_tenant.py
@@ -150,5 +150,57 @@ class NonsenseFallsBackTest(unittest.TestCase):
                     os.environ.pop(env, None)
 
 
+class TheProfileCandidateCeilingFollowsTheTenantTest(unittest.TestCase):
+    """The fifth budget, and the last tenant knob that had no caller at all.
+
+    It could not be wired until there was one `build_cross_session_policy` to wire: the function
+    existed twice, bound by different callers, so gating one would have left the other untouched --
+    the guard-one-route-of-two mistake, which looks like it works.
+
+    Asserted through the policy the builder returns rather than through the helper, because the
+    helper returning the right number proves nothing about whether the builder consults it.
+    """
+
+    def _max_candidates(self, tenant, budget=8192):
+        import matrixark_mcp_core_scoring as scoring
+        args = {"scope": {"tenant_id": tenant},
+                "query": "what is my standing rule about deploys"}
+        policy_out = scoring.build_cross_session_policy(
+            args, {}, question_type="profile_memory", session_scope="prefer",
+            remote_budget_tokens=budget)
+        return policy_out.get("max_candidates")
+
+    def test_a_tenant_ceiling_is_applied(self) -> None:
+        _set_policy("profile_ceiling", {"cross_session_profile_max_candidates": 6})
+        self.assertEqual(6, self._max_candidates("profile_ceiling"))
+
+    def test_an_unconfigured_tenant_does_not_move(self) -> None:
+        # The registry default for this knob is 2000 and the value in use is 48. Wiring through
+        # resolve() would have multiplied it forty-fold for everyone who set nothing.
+        os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_unconfigured"))
+
+    def test_an_explicit_env_var_applies_without_a_restart(self) -> None:
+        os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_env"))
+        try:
+            os.environ["MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES"] = "11"
+            self.assertEqual(11, self._max_candidates("profile_env"))
+        finally:
+            os.environ.pop("MATRIXARK_CROSS_SESSION_PROFILE_MAX_CANDIDATES", None)
+        self.assertEqual(48, self._max_candidates("profile_env"))
+
+    def test_it_does_not_touch_the_non_profile_budget(self) -> None:
+        # The knob names the PROFILE ceiling. A non-profile query must keep its own default, or
+        # this would be a much larger change than the name promises.
+        import matrixark_mcp_core_scoring as scoring
+        _set_policy("profile_only", {"cross_session_profile_max_candidates": 6})
+        args = {"scope": {"tenant_id": "profile_only"}, "query": "what did we ship last week"}
+        out = scoring.build_cross_session_policy(
+            args, {}, question_type="latest", session_scope="prefer", remote_budget_tokens=8192)
+        self.assertNotEqual(6, out.get("max_candidates"),
+                            "the profile ceiling was applied to a non-profile query")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> Stacked on #612. That change made this one possible.

`cross_session_profile_max_candidates` is the **final** tenant knob that resolved correctly,
appeared on the portal, and was read by nobody.

It could not be wired before #612: `build_cross_session_policy` existed twice, bound by
different callers, so gating one would have left the other untouched — which *looks* like it
works, and is the exact failure this whole line of work has been about.

## Explicit-only precedence, and why

An explicit tenant override → an explicit environment variable → the build's default.

The registry default for this knob is **2000**; the value actually in use is **48**. Wiring
through `resolve()` would have multiplied the profile candidate budget **forty-fold** for
every deployment that configured nothing — while reading, in a diff, exactly like "the knob
works now". There is a test that fails if anyone reaches for `resolve()` again, and the
mutation confirming it turns red.

Both explicit levels are read per call, so a change at either applies with no restart, and a
deployment that set nothing does not move.

## Scoped to what its name promises

It applies to the **profile** budget only; a non-profile query keeps its own default. Asserted
explicitly, because a knob that quietly widened its own scope would be a far larger change
than its name suggests.

## One implementation of the precedence, not two

The precedence moves to `matrixark_tenant_policy.explicit_int`, and the retrieval helper now
calls it. Copying it into `core_scoring` was the obvious move and the wrong one — #612 removed
a duplicated function whose two copies had drifted, and adding a fresh duplicate in the same
breath would have been remarkable.

## Verification

260 of 261 tests green across ten suites. The single failure
(`test_two_tenants_one_store_get_different_storage`, which asserts separate
`context_embedding` records for a store that now folds vectors onto their owners) fails
identically on clean `main` — re-verified in a throwaway worktree rather than assumed from
earlier in the day.
