### PR TITLE
The dashboard asks for metric names the engine stopped using

### DIFF
--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -125,10 +125,10 @@
           "expr": "sum by (kind) (temporalstore_block_store_operations_total)"
         },
         {
-          "expr": "temporalstore_block_store_extent_bytes"
+          "expr": "temporalstore_block_store_band_bytes"
         },
         {
-          "expr": "temporalstore_block_store_extent_oldest_age_ms"
+          "expr": "temporalstore_block_store_band_oldest_age_ms"
         }
       ]
     },

--- a/docs/ops/temporalstore-grafana-metrics-coverage.md
+++ b/docs/ops/temporalstore-grafana-metrics-coverage.md
@@ -77,9 +77,11 @@ that moves before read latency does, which makes it the useful early signal.
 **Alerts:** `TemporalStoreStorageCacheBlockers`, `TemporalStoreBlockStoreReadErrors`,
 `TemporalStoreCacheMissPressure`.
 
-**Known gap:** `temporalstore_block_store_extent_bytes` is queried by this family and emitted by no
-Rust source, so that panel is blank on every deployment. It is either a panel to remove or a metric
-to add; it is recorded here rather than left as a mystery on the dashboard.
+**A rename that left two panels blank:** the dashboard queried
+`temporalstore_block_store_extent_bytes` and `_extent_oldest_age_ms` while the engine emits
+`_band_bytes` and `_band_oldest_age_ms`. "Extent" became "band" and the dashboard was not updated,
+so both panels read empty on every deployment — which looks like a store with nothing in it. The
+dashboard now uses the current names.
 
 ## data_node
 

--- a/tools/test_matrixark_engine_dashboard_coverage.py
+++ b/tools/test_matrixark_engine_dashboard_coverage.py
@@ -46,14 +46,22 @@ class TheValidatorRunsAndPassesTest(unittest.TestCase):
                          "engine dashboard conformance failed:\n%s\n%s"
                          % (proc.stderr[-2000:], proc.stdout[-2000:]))
 
-    def test_it_still_reports_the_known_gap_rather_than_hiding_it(self) -> None:
+    def test_nothing_is_excused(self) -> None:
+        """KNOWN_UNEMITTED is empty, and the report has nothing missing.
+
+        It briefly held one entry: the dashboard queried
+        `temporalstore_block_store_extent_bytes` while the engine emits `_band_bytes`. "Extent" had
+        been renamed to "band" and the dashboard was not updated, so that panel read empty on every
+        deployment. Renaming it in the dashboard closed the gap, which FAILED the test that pinned
+        the gap -- which is what that test was for. The list cannot quietly outlive the problem.
+        """
         import json
-        proc = _run()
-        report = json.loads(proc.stdout)
-        self.assertIn("storage_cache:rust:temporalstore_block_store_extent_bytes",
-                      report["missing"],
-                      "the known blank panel vanished from the report; if it was fixed, remove it "
-                      "from KNOWN_UNEMITTED so the list does not go stale")
+        import validate_grafana_metrics_conformance as validator
+        self.assertEqual(set(), set(validator.KNOWN_UNEMITTED),
+                         "something is being excused; if it is a real gap, say so in "
+                         "docs/ops/temporalstore-grafana-metrics-coverage.md as well")
+        report = json.loads(_run().stdout)
+        self.assertEqual([], report["missing"])
 
 
 class TheScanCoversWhatItClaimsTest(unittest.TestCase):

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -153,7 +153,7 @@ METRIC_FAMILIES = {
             "temporalstore_storage_slot_bytes",
             "temporalstore_cache_operations_total",
             "temporalstore_block_store_operations_total",
-            "temporalstore_block_store_extent_bytes",
+            "temporalstore_block_store_band_bytes",
         ],
         "alerts": [
             "TemporalStoreStorageCacheBlockers",
@@ -169,7 +169,7 @@ METRIC_FAMILIES = {
             "temporalstore_cache_operations_total",
             "temporalstore_cache_bytes",
             "temporalstore_block_store_operations_total",
-            "temporalstore_block_store_extent_bytes",
+            "temporalstore_block_store_band_bytes",
         ],
     },
     "data_node": {
@@ -285,11 +285,7 @@ def metric_names(text: str) -> set[str]:
 # deployment. Tracked here rather than left inside a mass failure, because a validator that always
 # fails is one nobody runs -- which is how this one came to be red and unnoticed in the first place.
 # Each entry is either a panel to remove or a metric to add; neither is a decision this script makes.
-KNOWN_UNEMITTED = {
-    # Its siblings (`temporalstore_block_store_operations_total`, the slot gauges) are emitted; this
-    # one never was. Documented in docs/ops/temporalstore-grafana-metrics-coverage.md.
-    "storage_cache:rust:temporalstore_block_store_extent_bytes",
-}
+KNOWN_UNEMITTED: set = set()
 
 
 def check_scan_extent() -> list:


### PR DESCRIPTION
Two storage panels have been **blank on every deployment**.

The dashboard queries `temporalstore_block_store_extent_bytes` and `_extent_oldest_age_ms`;
the engine emits `_band_bytes` and `_band_oldest_age_ms`. **"Extent" was renamed to "band"**
and the dashboard was not updated with it.

A blank panel is the most misleading thing a dashboard can show — it reads as a store with
nothing in it, rather than as a query using a name nobody answers to. These have been empty
since the rename and nothing said so, because until #611 made the conformance check actually
run *and* see the whole crate, nothing compared the two lists.

This is that check paying for itself on its first outing. It was the single entry it had
left after 33 → 1, and it turned out to be a **stale name, not a missing metric** — so the
fix is two words in the dashboard rather than a new Rust metric.

## The guard did its job in both directions

`KNOWN_UNEMITTED` is now empty. The test that *pinned* the known gap **failed when the gap
closed** — which is exactly what it was written for — and is replaced by one asserting that
nothing is excused at all. A list of known problems that is allowed to go stale hides the fix
as effectively as it hid the defect.

Validator exits 0 with `missing: []`. 5 tests green; the mutation putting a fake entry back
into `KNOWN_UNEMITTED` turns them red.
