### PR TITLE
A tenant can decline the write that retrieval performs

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -265,6 +265,23 @@ def _sibling_sessions_enabled(scope) -> bool:
     return bool(traverse_sibling_sessions_enabled(scope))
 
 
+def _tenant_allows_recall_reinforcement(scope: Any) -> bool:
+    """Whether this tenant permits retrieval to write recall-protection markers (default ON).
+
+    Fails OPEN: a deployment without the policy module keeps writing them, which is today's
+    behaviour. Silently dropping the markers would let recalled memory be pruned, which is a
+    data-shaped failure rather than a cost one.
+    """
+    try:
+        from matrixark_tenant_policy import explicit_bool
+    except Exception:  # pragma: no cover - policy module absent
+        return True
+    try:
+        return explicit_bool("recall_reinforcement", scope, True)
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        return True
+
+
 def _tenant_retrieval_limit(name: str, scope: Any, fallback: int) -> int:
     """A retrieval budget: an explicit tenant override, else an explicit env var, else this build.
 
@@ -3412,7 +3429,18 @@ class _LocalAdapterRetrieveMixin:
             quality_warnings.append(f"session_identity_fallback:{session_id_source}")
         context_pack_id = stable_hash(f"{query}:{selected}:{now_ms()}")
         context_pack_id_text = str(context_pack_id)
-        recall_reinforcement_enabled = bool(ranking.get("recall_reinforcement", True))
+        # A CEILING, not a default. This knob decides whether RETRIEVAL WRITES -- a protection
+        # marker per selected ref -- so a tenant that declined it must not have it switched back on
+        # by a per-request argument. Both have to allow it; with neither set both are True and this
+        # is exactly today's behaviour.
+        #
+        # The local name below is deliberate and was previously the whole story: reading
+        # `ranking` and never the tenant knob is what made a name-matching census report this gate
+        # as wired when nothing consulted it.
+        recall_reinforcement_enabled = (
+            bool(ranking.get("recall_reinforcement", True))
+            and _tenant_allows_recall_reinforcement(scope)
+        )
         if recall_reinforcement_enabled:
             reinforcement = self.append_recall_reinforcement_markers(
                 context_pack_id=context_pack_id_text,

--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -868,6 +868,44 @@ def explicit_int(name: str, scope: Any, fallback: int) -> int:
     return fallback
 
 
+def explicit_bool(name: str, scope: Any, fallback: bool) -> bool:
+    """An explicitly-set boolean for `scope`: a tenant override, else an env var, else `fallback`.
+
+    The bool sibling of `explicit_int`, and explicit-only for the same reason: `resolve()` returns
+    the registry default when nobody has set anything, which silently substitutes the registry's
+    opinion for the caller's. With nothing set the caller's own default is returned unchanged.
+    """
+    truthy = {"1", "true", "yes", "on"}
+    falsy = {"0", "false", "no", "off"}
+
+    def _as_bool(value: Any):
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        if text in truthy:
+            return True
+        if text in falsy:
+            return False
+        return None
+
+    try:
+        override = _as_bool((tenant_policy(scope) or {}).get(name))
+    except Exception:  # pragma: no cover - a malformed policy must not break retrieval
+        override = None
+    if override is not None:
+        return override
+
+    knob = KNOBS.get(name)
+    env_name = getattr(knob, "env", "") if knob is not None else ""
+    if env_name:
+        from_env = _as_bool(os.environ.get(env_name))
+        if from_env is not None:
+            return from_env
+    return fallback
+
+
 def tenant_policy(scope: Any = None) -> Json:
     """The merged override set for `scope`'s tenant (file defaults < file tenant < store record)."""
     file_defaults, file_tenants = _load_file_policies()

--- a/tools/test_matrixark_policy_gates_wired.py
+++ b/tools/test_matrixark_policy_gates_wired.py
@@ -41,7 +41,6 @@ KNOWN_UNWIRED: Set[str] = {
     "embed_node_path_prefix_enabled",
     "generate_l1_summaries_enabled",
     "index_compact_on_summary_enabled",
-    "recall_reinforcement_enabled",
     # `return_all_candidates` is NOT a wiring job, and calling it one would mislead whoever picks
     # it up. It means "return every candidate, no prefilter and no scoring", and no such bypass
     # exists in `retrieve()` -- nor does anything read its companion knob
@@ -96,13 +95,28 @@ def _callers() -> Dict[str, List[str]]:
             if stripped.startswith(("import ", "from ", "#")):
                 continue
             for gate in gates:
-                if gate not in line or stripped.startswith("def %s(" % gate):
+                knob_name = gate[: -len("_enabled")]
+                # The cheap pre-filter has to admit BOTH spellings. A knob wired through the
+                # shared explicit-only resolver names the KNOB, not the gate, so filtering on the
+                # gate name alone skipped the line before the real check below ever saw it -- and
+                # reported a wired knob as unwired.
+                if (gate not in line and knob_name not in line) or                         stripped.startswith("def %s(" % gate):
                     continue
                 # A CALL, not a mention. Matching the bare name counted
                 #     recall_reinforcement_enabled = bool(ranking.get(...))
                 # -- a local variable sharing the name and reading a different source entirely --
                 # as wiring, and reported 8 of 14 gates wired when the real number was 2.
-                if not re.search(r"(?<![\w.])%s\s*\(" % re.escape(gate), line):
+                knob = gate[: -len("_enabled")]
+                # Two ways a knob is genuinely read: calling its accessor, or naming it to the
+                # shared explicit-only resolvers. The second is how the knobs whose consumers must
+                # NOT adopt the registry default are wired -- several registry defaults are far
+                # larger than the value in use, so resolving would change behaviour rather than
+                # honour a setting. Counting only the accessor would report those as unwired.
+                reads_knob = (
+                    re.search(r"(?<![\w.])%s\s*\(" % re.escape(gate), line)
+                    or re.search(r"explicit_(?:bool|int)\(\s*[\"']%s[\"']" % re.escape(knob), line)
+                )
+                if not reads_knob:
                     continue
                 # ...and not the assignment form, which contains a call on its right-hand side but
                 # is defining a look-alike rather than consulting the gate.

--- a/tools/test_matrixark_recall_reinforcement_follows_the_tenant.py
+++ b/tools/test_matrixark_recall_reinforcement_follows_the_tenant.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A tenant can decline the write that retrieval performs.
+
+`recall_reinforcement` writes a protection marker for every ref a retrieval selected, so recently
+recalled memory survives raw-event pruning. It is genuinely useful, and it makes **retrieval a
+writer** — the knob's own description carries the measurement. A tenant paying for that had no way
+to decline it: the code read `ranking.get("recall_reinforcement", True)`, a per-REQUEST dict, and
+never the tenant knob.
+
+That line is also why an earlier census reported this gate as wired. A local variable named after
+the gate, reading a different source entirely — see the name-matching failure recorded in
+`test_matrixark_policy_gates_wired`.
+
+It is applied as a **ceiling**, not a default. For a knob whose effect is "retrieval writes
+records", a tenant's *off* must not be re-enabled by a per-request argument.
+
+These assert what is STORED. A test that the gate function returns False would have passed
+throughout the entire period nothing consulted it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_tenant_policy as policy  # noqa: E402
+
+MARKER = "context_recall_reinforcement"
+
+
+def _set_policy(tenant, knobs):
+    """Set on every loaded copy of the policy module.
+
+    Under `unittest discover` it is imported under two names, each keeping its own records, so
+    setting only the copy this file imported leaves the reader consulting the other one.
+    """
+    for module in list(sys.modules.values()):
+        if getattr(module, "__name__", "").endswith("matrixark_tenant_policy") and \
+                hasattr(module, "set_tenant_policy"):
+            module.set_tenant_policy(tenant, knobs)
+
+
+def _markers_after_searching(tenant, knobs, ranking=None):
+    import matrixark_mcp_server as mcp
+
+    _set_policy(tenant, knobs)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        adapter = mcp.MatrixArkLocalAdapter(Path(tmp) / "memory.jsonl")
+        server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
+        scope = {"tenant_id": tenant, "user_id": "u1", "session_id": "s1"}
+        for message in ("I am allergic to peanuts and I live in Kyoto.",
+                        "My favourite drink is matcha and I bike to work."):
+            server.call_tool("matrixark_ingest", {
+                "scope": scope, "finalize": True,
+                "messages": [{"role": "user", "content": message}]})
+        server.call_tool("matrixark_session_commit", {"scope": scope})
+        for query in ("what am I allergic to?", "where do I live?", "what do I drink?"):
+            request = {"scope": scope, "query": query}
+            if ranking is not None:
+                request["ranking"] = ranking
+            server.call_tool("matrixark_retrieve", request)
+        records = adapter.read_all()
+    return (sum(1 for r in records if str(r.get("record_type")) == MARKER), len(records))
+
+
+class ATenantCanDeclineTheWriteTest(unittest.TestCase):
+
+    def test_declining_stops_the_markers(self) -> None:
+        off, off_total = _markers_after_searching("rr_declined", {"recall_reinforcement": False})
+        self.assertEqual(0, off, "a tenant that declined recall reinforcement still got markers")
+        self.assertGreater(off_total, 0,
+                           "nothing was stored at all, so the zero above proves nothing")
+
+    def test_the_default_still_writes_them(self) -> None:
+        # Without this the assertion above would hold on a deployment that never wrote markers.
+        os.environ.pop("MATRIXARK_RECALL_REINFORCEMENT", None)
+        on, _total = _markers_after_searching("rr_default", {})
+        self.assertGreater(on, 0,
+                           "no markers even with the knob at its default, so the comparison is "
+                           "vacuous and recall protection may be broken outright")
+
+    def test_a_request_cannot_re_enable_what_the_tenant_declined(self) -> None:
+        # The ceiling. This knob decides whether retrieval WRITES, so a per-request argument must
+        # not overrule a tenant that turned it off.
+        count, _total = _markers_after_searching(
+            "rr_ceiling", {"recall_reinforcement": False},
+            ranking={"recall_reinforcement": True})
+        self.assertEqual(0, count,
+                         "a per-request argument switched the tenant's decision back on")
+
+    def test_a_request_can_still_decline_for_a_tenant_that_allows_it(self) -> None:
+        count, total = _markers_after_searching(
+            "rr_request_off", {}, ranking={"recall_reinforcement": False})
+        self.assertEqual(0, count, "the existing per-request opt-out stopped working")
+        self.assertGreater(total, 0)
+
+
+class TheResolverIsExplicitOnlyTest(unittest.TestCase):
+
+    def test_nothing_set_returns_the_callers_default(self) -> None:
+        os.environ.pop("MATRIXARK_RECALL_REINFORCEMENT", None)
+        self.assertTrue(policy.explicit_bool("recall_reinforcement",
+                                             {"tenant_id": "rr_untouched"}, True))
+        self.assertFalse(policy.explicit_bool("recall_reinforcement",
+                                              {"tenant_id": "rr_untouched"}, False))
+
+    def test_an_env_var_applies_without_a_restart(self) -> None:
+        scope = {"tenant_id": "rr_env"}
+        os.environ.pop("MATRIXARK_RECALL_REINFORCEMENT", None)
+        self.assertTrue(policy.explicit_bool("recall_reinforcement", scope, True))
+        try:
+            os.environ["MATRIXARK_RECALL_REINFORCEMENT"] = "0"
+            self.assertFalse(policy.explicit_bool("recall_reinforcement", scope, True))
+        finally:
+            os.environ.pop("MATRIXARK_RECALL_REINFORCEMENT", None)
+        self.assertTrue(policy.explicit_bool("recall_reinforcement", scope, True))
+
+    def test_junk_is_ignored_rather_than_treated_as_false(self) -> None:
+        # "maybe" is not off. Coercing an unparseable value to False would silently disable a
+        # protection the tenant never asked to disable.
+        scope = {"tenant_id": "rr_junk"}
+        try:
+            os.environ["MATRIXARK_RECALL_REINFORCEMENT"] = "maybe"
+            self.assertTrue(policy.explicit_bool("recall_reinforcement", scope, True))
+        finally:
+            os.environ.pop("MATRIXARK_RECALL_REINFORCEMENT", None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`recall_reinforcement` writes a protection marker for every ref a retrieval selected, so
recently recalled memory survives raw-event pruning. It's genuinely useful — and it makes
**retrieval a writer**. The knob's own description carries the measurement.

A tenant paying for that had no way to decline it. The code read
`ranking.get("recall_reinforcement", True)` — a per-**request** dict — and never the tenant
knob.

That line is also why an earlier census reported this gate as *wired*: a local variable named
after the gate, reading a different source entirely.

## A ceiling, not a default

For a knob whose effect is "retrieval writes records", a tenant's **off** must not be
re-enabled by a per-request argument — so both have to allow it. With neither set, both are
`True` and the behaviour is exactly today's.

Measured: three searches over a two-message store write **9 markers** by default and **0** for
a tenant that declined.

## Two supporting changes

**`explicit_bool`** joins `explicit_int` in the policy module — explicit-only for the same
reason, that `resolve()` substitutes the registry's opinion when nobody has set anything. Junk
is *ignored* rather than coerced to `False`: `"maybe"` is not off, and treating it as off would
disable a protection nobody asked to disable.

**The wiring guard** now counts a knob named to `explicit_bool`/`explicit_int` as a read, not
only a call to its accessor. Its cheap pre-filter tested for the *gate* name, so a line naming
the *knob* was skipped before the real check ran — it reported this knob as unwired while the
wiring sat three lines above. Same class of miss as the name-matching it replaced, which is
worth noting: the fix to a matching bug had a matching bug in it.

## Verification

278 tests green across eleven suites. Four mutations, all biting: ignoring the tenant, dropping
the ceiling so a request overrules it, coercing junk to `False`, and wiring the resolver to
`resolve()`.
