### PR TITLE
Make an accessor unable to disagree with its registry default

### DIFF
--- a/tools/matrixark_index_growth_bound.py
+++ b/tools/matrixark_index_growth_bound.py
@@ -208,7 +208,22 @@ def return_all_candidate_threshold(scope: Any = None) -> int:
 
 
 def node_path_embeddings_enabled(scope: Any = None) -> bool:
-    """Whether to store a `context_node` embedding of the node path (default OFF)."""
+    """Whether to store a `context_node` embedding of the node path (default ON).
+
+    Said as ON, and worth saying loudly: turning this off is a CORRECTNESS risk, not a memory
+    trade. A path is not content, so embedding it looks like pure waste -- but it is the only
+    embedding a node is guaranteed to have AT CREATION TIME. The node's other embedding comes from
+    its summary, written later by refresh_summaries, so switching this off leaves a window where a
+    node cannot be scored at all: retrieval selects no node, traversal has nothing to descend, and
+    the pack falls back to profile entities alone.
+
+    Measured with it off: a 40-event store returned 1 pack item instead of 38, in 8 of 10 retrieves
+    on a loaded machine. One retrieve per fresh process is what exposes it -- 25 inside one process
+    all succeed, because the first warms the state the rest rely on.
+
+    This docstring previously said "(default OFF)", which is both wrong and the opposite of a
+    measured warning.
+    """
     return bool(resolve_tenant_policy("node_path_embeddings", scope))
 
 
@@ -315,14 +330,24 @@ def audit_payload_retain_per_scope(scope: Any = None) -> int:
 
 
 def summarize_aggregation_only_nodes_enabled(scope: Any = None) -> bool:
-    """Whether nodes with no direct events still get summaries (default OFF)."""
+    """Whether nodes with no direct events still get summaries (default ON).
+
+    Said as ON deliberately: this used to default to OFF, on the argument that traversal visits the
+    spine nodes unconditionally so a summary there cannot help it prune. That was true and beside
+    the point -- retrieval also INJECTS summaries as their own memory layer, the profile node's
+    summary is what carries cross-session memory into a fresh session, and `node_l1` is only
+    generated where child summaries exist, which is exactly these nodes. Skipping them removed
+    every L1 in the store. The skip is now opt-in per tenant.
+    """
     return bool(resolve_tenant_policy("summarize_aggregation_only_nodes", scope))
 
 
 def node_summary_plan(scope: Any = None, *, conditional_l1: bool, has_direct_events: bool = True) -> tuple[bool, bool]:
     """Return ``(generate_l0, generate_l1)`` for `scope`'s tenant given the content rule's verdict.
 
-    A node with NO direct events (tenant / user / profile -- the spine) is skipped by default. Two
+    A node with NO direct events (tenant / user / profile -- the spine) is SUMMARIZED by default;
+    the skip is opt-in per tenant. (It was the other way round once, which removed every L1 in the
+    store -- see summarize_aggregation_only_nodes_enabled.) Two
     facts make that safe: the traversal reaches those nodes unconditionally, so a summary cannot
     change which subtree is chosen; and index compaction tombstones are built from a node's OWN
     ``source_event_ids``, which is empty for them, so no posting cleanup depends on their summary.

--- a/tools/test_matrixark_accessor_defaults_match_the_registry.py
+++ b/tools/test_matrixark_accessor_defaults_match_the_registry.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every policy accessor must agree with the registry it reads.
+
+An accessor and its knob can disagree in two ways, and both were live:
+
+* **In behaviour** — the accessor reads somewhere other than the registry, so a tenant sets a value
+  and the accessor returns something else.
+* **In description** — the accessor's docstring states a default the registry contradicts.
+  `summarize_aggregation_only_nodes_enabled` said "(default OFF)" while the registry said `True`,
+  because the default was deliberately reversed and the docstring was not. That reversal exists for
+  a measured reason: skipping the spine nodes removed *every* L1 in the store, since `node_l1` is
+  only generated where child summaries exist.
+
+The second is not cosmetic. A confident wrong comment is what stops the next person checking — the
+`matrixark_gateway_config` comment asserting that a per-tenant policy record "still applies
+immediately" is why nobody noticed for however long that retrieval read none of those knobs.
+
+This checks behaviour for every bool accessor, and checks the stated default for the ones whose
+docstrings name one.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_index_growth_bound as gates  # noqa: E402
+import matrixark_tenant_policy as policy  # noqa: E402
+
+DEFAULT_PHRASE = re.compile(r"\(default\s+(ON|OFF|True|False)\)", re.I)
+
+
+def _bool_accessors():
+    """(knob name, function) for every `<knob>_enabled` accessor with a bool knob."""
+    out = []
+    for name, func in vars(gates).items():
+        if not name.endswith("_enabled") or not callable(func):
+            continue
+        knob_name = name[: -len("_enabled")]
+        knob = policy.KNOBS.get(knob_name)
+        if knob is None or getattr(knob, "kind", "") != "bool":
+            continue
+        out.append((knob_name, func))
+    return sorted(out)
+
+
+class AccessorsAgreeWithTheRegistryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.accessors = _bool_accessors()
+        self.assertGreater(len(self.accessors), 5,
+                           "found almost no bool accessors, so these comparisons prove nothing")
+
+    def test_the_resolved_default_matches_the_registry_default(self) -> None:
+        for knob_name, func in self.accessors:
+            with self.subTest(knob=knob_name):
+                knob = policy.KNOBS[knob_name]
+                os.environ.pop(getattr(knob, "env", "") or "_none_", None)
+                try:
+                    got = func({"tenant_id": "registry_check_%s" % knob_name})
+                except TypeError:
+                    got = func()          # a few take no scope: a deployment-wide flag
+                self.assertEqual(
+                    bool(knob.default), bool(got),
+                    "%s resolves to %r for an unconfigured tenant while the registry default is "
+                    "%r. One of them is lying to the portal." % (knob_name, got, knob.default))
+
+    def test_a_stated_default_matches_the_registry(self) -> None:
+        # Only accessors whose docstring actually names a default are checked; the rest are free
+        # to say nothing.
+        checked = 0
+        for knob_name, func in self.accessors:
+            doc = inspect.getdoc(func) or ""
+            match = DEFAULT_PHRASE.search(doc)
+            if not match:
+                continue
+            checked += 1
+            stated = match.group(1).upper() in {"ON", "TRUE"}
+            with self.subTest(knob=knob_name):
+                self.assertEqual(
+                    bool(policy.KNOBS[knob_name].default), stated,
+                    "%s's docstring says (default %s) and the registry says %r. The docstring is "
+                    "what the next person reads before deciding not to check."
+                    % (knob_name, match.group(1), policy.KNOBS[knob_name].default))
+        self.assertGreater(checked, 0,
+                           "no accessor docstring names a default, so this test checked nothing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two policy accessors stated a default the registry contradicts.

| accessor | docstring said | registry says |
|---|---|---|
| `summarize_aggregation_only_nodes_enabled` | default OFF | `True` |
| `node_path_embeddings_enabled` | default OFF | `True` |

Behaviour is correct in both cases; only the prose is stale. That is the half that matters least and reads worst — a confident wrong comment is what stops the next person checking.

The second one is not a nit. The registry records that turning `node_path_embeddings` off is a **correctness risk, not a memory trade**: the path embedding is the only embedding a node is guaranteed to have at creation time, since the other comes from a summary written later. With it off, a 40-event store returned **1 pack item instead of 38, in 8 of 10 retrieves**. The accessor said the opposite of a measured warning. Its docstring now carries the measurement, and the portal already surfaces the same wording on the toggle.

**The guard is the point.** `test_matrixark_accessor_defaults_match_the_registry` checks, for every bool accessor:

- it resolves to the registry default for an unconfigured tenant (behaviour), and
- where its docstring names a default, that default matches the registry (prose).

It found the `node_path_embeddings` docstring on its first run — I was not looking for it.

Both tests self-guard: one asserts it found accessors at all, the other that at least one docstring named a default, so neither can pass by checking nothing.

Suites: 249 tests, one red — `test_index_growth_bound.test_rollup_prunes_event_postings_without_losing_recall`, which fails identically on main's copy of the file in an isolated tree. Not from this change; it is the dead index-compaction subsystem, and the assertion that fires is the test refusing to claim success with nothing to compact.