### PR TITLE
The scan names what it drops, instead of what it keeps

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -39,19 +39,30 @@ def _idle_drain_min_interval_ms() -> int:
 # Fields the retrieval scan actually reads, measured with a probe that recorded every key access
 # rather than chosen by inspection. `text`, `heading` and `source_locator` are absent because the
 # scan never asks for them -- they exist to RETURN a hit, not to find one.
-RETRIEVAL_SCAN_FIELDS = (
-    "record_type", "node_path", "access_scope", "metadata", "scope", "scope_key", "envelope",
-    "node_hash", "memory_scope", "session_continuity", "embedding_meta", "vector",
-    "event_id_hash", "entity_hash", "segment_hash", "summary_hash", "compression_id_hash",
-    "chunk_hash", "section_hash", "skill_hash", "ref_hash", "ref_hashes", "ref_type",
-    "index_name", "batch_id_hash", "batch_id_hashes", "node_hashes", "updated_at_ms",
-    "stale_or_superseded", "superseded_by_ref_hash", "superseded_by_entity_hash",
-    "profile_shadowed_by_ref_hash", "expires_at", "tombstone_kind", "posting_part",
-    # The pack is built from these same rows, so a row that reaches the answer must still carry
-    # what the answer prints. Dropping them shrank the scan and emptied the reply: retrieval came
-    # back with "text": "" for every hit. Narrowing the scan further needs the pack to re-read the
-    # chosen rows in a second pass, not a shorter row here.
-    "text", "summary_text", "heading", "source_locator",
+# The scan carries every field EXCEPT the ones proven unused, rather than only the ones on a list.
+#
+# An allowlist fails dangerously here: the pack is built from these same rows, so any field the
+# list forgets is a field the answer cannot print. That shipped once -- retrieval returned
+# "text": "" for every hit while every ranking number stayed green, because ranking does not read
+# the fields it dropped. Extending the list one failing test at a time fixed the case in hand and
+# left the next. A denylist inverts the failure: a field nobody thought of is kept.
+#
+# Two fields hold 38% of the scanned bytes, and neither is read while serving:
+#
+#   storage_route     80.5 KB   24.0%
+#   storage_options   47.4 KB   14.1%
+#
+# Both are routing metadata for the WRITE path. They are read from records by the indexing and
+# latest-state paths, which work from the full records, not from this projected copy.
+#
+# The evidence for dropping a field is deliberately two-sided, because each side alone was wrong:
+# a runtime probe over every ingest kind said `model` and `model_ref` were unread, when the encoder
+# guard reads them on a path the corpus never triggered; a source scan cannot tell record.get from
+# os.environ.get. A field is dropped only when the probe never saw it read AND the serving source
+# never names it.
+RETRIEVAL_SCAN_DROPPED_FIELDS = (
+    "storage_route",
+    "storage_options",
 )
 
 # OFF by default. A projected record cannot serve the resource and skill scans' lexical, keyword and
@@ -126,7 +137,8 @@ def project_scan_record(record, enabled=None):
         enabled = retrieval_scan_projection()
     if not enabled:
         return record
-    return {key: value for key, value in record.items() if key in RETRIEVAL_SCAN_FIELDS}
+    return {key: value for key, value in record.items()
+            if key not in RETRIEVAL_SCAN_DROPPED_FIELDS}
 
 
 class _LocalAdapterRetrievalMixin:

--- a/tools/test_matrixark_scan_holds_what_it_reads.py
+++ b/tools/test_matrixark_scan_holds_what_it_reads.py
@@ -43,6 +43,11 @@ def _record():
         "text": "the body of the section, which the scan never reads",
         "heading": "Step 1",
         "source_locator": "heading=doc/step-1",
+        # routing metadata for the WRITE path -- the two fields the scan drops, and 38% of its bytes
+        "storage_route": {"tier": "hot", "replicas": 3, "region": "eu-central"},
+        "storage_options": {"replicas": 3, "tier": "hot"},
+        # kept: named by the serving source, so it is not eligible to be dropped
+        "storage_record_kind": "node",
     }
 
 
@@ -96,13 +101,20 @@ class TheScanCanHoldOnlyWhatItReads(unittest.TestCase):
     def test_enabled_it_drops_what_the_scan_never_reads(self):
         with _projection(True) as reloaded:
             _ignored = None
-            projected = reloaded.project_scan_record(_record())
-            for absent in ("storage_record_kind", "storage_part"):
+            record = _record()
+            projected = reloaded.project_scan_record(record)
+            for absent in ("storage_route", "storage_options"):
+                self.assertIn(absent, record,
+                              "the fixture must carry %s, or the next assertion proves nothing "
+                              "-- assertNotIn passes for free on a field that was never there"
+                              % absent)
                 self.assertNotIn(absent, projected,
-                                 "%s is neither scored nor printed" % absent)
+                                 "%s is write-path routing; serving never reads it" % absent)
             for printed in ("text", "heading", "source_locator"):
                 self.assertIn(printed, projected,
                               "%s is printed by the answer, which is built from this row" % printed)
+            self.assertIn("storage_record_kind", projected,
+                          "only the named fields go; the serving source names this one")
 
     def test_enabled_it_keeps_everything_the_scan_reads(self):
         """The probe's field list, asserted rather than trusted."""

--- a/tools/test_matrixark_the_scan_drops_only_what_is_unused.py
+++ b/tools/test_matrixark_the_scan_drops_only_what_is_unused.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The scan drops the two routing fields it never reads, and nothing else.
+
+This replaces an allowlist. The pack is assembled from these same rows, so a field the list forgets
+is a field the answer cannot print -- which shipped once: retrieval returned "text": "" for every
+hit while every ranking number stayed green, because ranking does not read the dropped fields.
+
+A denylist inverts the failure. A field nobody thought of is kept, so the cost of an omission is a
+smaller saving rather than an empty answer. That matters more than it sounds: on this corpus a
+correct allowlist and this denylist save nearly the same, because the bytes are concentrated in two
+fields rather than spread across the ones a list would forget.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+import matrixark_local_adapter_retrieval as retrieval
+
+PROJECTION = "MATRIXARK_RETRIEVAL_PROJECT_SCAN_FIELDS"
+PROFILE = "MATRIXARK_ONEBOX_EMBEDDING_FIRST"
+
+FACTS = [
+    "I work on the ingestion pipeline and own the retrieval budget code.",
+    "My name is Dana and I lead the storage team in Berlin.",
+    "The deploy runbook lives in docs/INSTALL.md and needs the staging key.",
+]
+
+
+class TheScanDropsOnlyWhatIsUnused(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in (PROJECTION, PROFILE)}
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    @staticmethod
+    def _corpus(store):
+        adapter = adapter_module.MatrixArkLocalAdapter(Path(store) / "events.jsonl")
+        scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "s0"}
+        for i in range(12):
+            adapter.ingest({
+                "kind": "message",
+                "scope": dict(scope, session_id="s%d" % (i // 4)),
+                "messages": [{"role": ["user", "assistant", "tool"][i % 3],
+                              "content": "%s (turn %d)" % (FACTS[i % len(FACTS)], i)}],
+            })
+        return adapter, scope
+
+    def test_it_drops_the_routing_fields_and_keeps_everything_else(self):
+        record = {"record_type": "context_event", "node_hash": 1, "vector": [0.5, 0.5],
+                  "text": "the answer prints this", "heading": "H",
+                  "storage_route": {"tier": "hot"}, "storage_options": {"replicas": 3},
+                  "a_field_nobody_listed": "kept, because the list names what goes, not what stays"}
+        projected = retrieval.project_scan_record(record, True)
+        for gone in ("storage_route", "storage_options"):
+            self.assertNotIn(gone, projected)
+        for kept in ("record_type", "node_hash", "vector", "text", "heading",
+                     "a_field_nobody_listed"):
+            self.assertIn(kept, projected,
+                          "%s was dropped; only the named fields may go" % kept)
+
+    def test_an_unlisted_field_survives(self):
+        """The property an allowlist cannot have, stated on its own so it cannot be lost."""
+        projected = retrieval.project_scan_record({"invented_later": "x"}, True)
+        self.assertIn("invented_later", projected)
+
+    def test_the_answer_is_unchanged_with_the_projection_on(self):
+        """Asserted on the ANSWER, not on the ranking.
+
+        Ranking cannot see this: it does not read the dropped fields, so hit@1 stays flat whether
+        the reply carries its text or comes back empty.
+        """
+        os.environ[PROFILE] = "1"
+        with tempfile.TemporaryDirectory() as store:
+            adapter, scope = self._corpus(store)
+            queries = ["what do I work on", "who am I", "where is the deploy runbook"]
+
+            def answers(enabled):
+                os.environ[PROJECTION] = "1" if enabled else "0"
+                return [json.dumps(adapter.retrieve({"query": q, "scope": scope}),
+                                   sort_keys=True, default=str) for q in queries]
+
+            off, on = answers(False), answers(True)
+            self.assertEqual(off, on, "the projection changed what retrieval returned")
+            self.assertTrue(any(len(a) > 2 for a in off), "no query returned anything to compare")
+
+    def test_the_dropped_fields_are_the_ones_holding_the_bytes(self):
+        """Why these two and not others -- if they stop being the bulk, the list should be revisited."""
+        with tempfile.TemporaryDirectory() as store:
+            adapter, _scope = self._corpus(store)
+            records = adapter.read_all()
+            total = sum(len(json.dumps(r, separators=(",", ":"), default=str)) for r in records)
+            dropped = sum(
+                len(json.dumps(r.get(f), separators=(",", ":"), default=str))
+                for r in records for f in retrieval.RETRIEVAL_SCAN_DROPPED_FIELDS if f in r)
+            self.assertGreater(total, 0)
+            self.assertGreater(100.0 * dropped / total, 10.0,
+                               "the dropped fields hold only %.1f%% of the scan; this projection "
+                               "is no longer paying for itself" % (100.0 * dropped / total))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The scan names what it drops, instead of what it keeps

The projection was an allowlist, and an allowlist fails dangerously here: the pack is assembled
from the same rows the scan carries, so any field the list forgets is a field the answer cannot
print. That shipped -- retrieval returned "text": "" for every hit while every ranking number
stayed green, because ranking does not read the fields it dropped. Extending the list one failing
test at a time fixed the case in hand and left the next one.

It now names the two fields that go:

  storage_route     80.5 KB   24.0% of the scanned bytes
  storage_options   47.4 KB   14.1%

Both are routing metadata for the WRITE path. The indexing and latest-state paths do read them off
records, but from the full records, not from this projected copy.

Measured over 145 rows spanning 19 record types: 335.9 KB -> 208.0 KB, 38.1% smaller, with the
answers to six queries byte-identical either way.

How the two were chosen, since each kind of evidence was wrong on its own:

- A runtime probe wrapped every record the serving path sees and recorded each key anyone looked
  at, over a corpus carrying all the ingest kinds -- message, skill, resource, business_data,
  feedback. It found 41 fields the old list dropped that serving reads, `event_type` 840 times.
- That probe alone said `model` and `model_ref` were unread. They are read by the encoder guard,
  on a path the corpus never triggered. Dropping them would have degraded retrieval silently.
- A source scan alone is useless as a list: it cannot tell record.get from os.environ.get and
  returns 294 keys. As a SUBTRACTION it is exactly right -- noise costs saving, never correctness.

So a field is dropped only when the probe never saw it read AND the serving source never names it.
That left 61 candidates; the bytes are in two of them.

Also fixes an assertion that could not fail: the scan test named two fields its own fixture did not
carry, so assertNotIn passed for free. The fixture now carries them, and the test asserts that it
does before asserting they are gone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
