### PR TITLE
Two tests that decided by timing and by import order

### DIFF
--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -115,16 +115,32 @@ class InterningCase(_FlagGuard):
         C.PRUNE_INTERNAL_INDEX_DIMENSIONS = False  # isolate lever 1 on the full metadata-heavy corpus
         A.INTERN_RECORD_METADATA = True
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
-            adapter, server = self._server(tmp)
+            path = Path(tmp) / "events.jsonl"
+            adapter = mcp.MatrixArkLocalAdapter(path)
+            server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
             self._ingest_turns(server, 50)
+            # Snapshot a FROZEN log, as the reload tests already do. Reading while the background
+            # extraction workers are still appending measured a different corpus every run -- 762,
+            # 687 and 681 records across three runs of the same 50 fixed turns -- and the ratio
+            # moves with it, so a threshold a point or two above the line flips on corpus size
+            # rather than on anything about interning. This test failed in 4 of 8 CI runs.
+            server.close(timeout_s=10.0)
+            self._wait_log_frozen(path)
             records = adapter._read_raw_records()  # expanded, token-free logical history
         off_bytes = _serialized_bytes(records)
         on_bytes = _serialized_bytes(A.encode_interned_records(records, set()))
         reduction = 100.0 * (off_bytes - on_bytes) / off_bytes
         print(f"\n[lever1] on-disk OFF={off_bytes/1024:.1f}KB ON={on_bytes/1024:.1f}KB "
               f"reduction={reduction:.1f}% over {len(records)} records")
+        # The ratio depends on how much repeated metadata the corpus actually contains, so assert
+        # the corpus before asserting the ratio -- otherwise a short corpus reports itself as a
+        # regression in interning, which is what a 50% threshold with ~1 point of headroom does.
+        self.assertGreater(len(records), 600,
+                           f"only {len(records)} records: too small to measure interning against, "
+                           f"so the ratio below would be reporting corpus size")
         self.assertGreaterEqual(reduction, 50.0,
-                                f"interning reclaimed only {reduction:.1f}% (< 50%)")
+                                f"interning reclaimed only {reduction:.1f}% (< 50%) "
+                                f"over {len(records)} records")
 
     def test_codec_roundtrip_is_byte_identical(self):
         """encode -> expand returns the EXACT original records (no token ever escapes)."""


### PR DESCRIPTION
Two tests that decided by timing and by import order

Across eight consecutive ratchet runs on main, 29 tests failed in all of them and six varied. These
are the two that varied most; the other four appeared in one run each and have not recurred.

test_interning_reduces_bytes_by_at_least_half -- failed 4 of 8

It read the log while the background extraction workers were still appending. The same fifty fixed
input turns produced 762, 687 and 681 records across three runs, and the compression ratio moves
with the corpus, so a threshold about a point above the line flipped on corpus size rather than on
anything about interning. The file already had a _wait_log_frozen helper that two other tests use;
this one did not call it. It now closes the server and waits for the log to freeze, as they do:
759-770 records across five runs, 51.0-51.3%.

A short corpus now fails as itself, rather than as a compression regression.

test_mcp_entrypoint_reexports_split_modules -- failed 7 of 8

    AssertionError: <class 'tools.matrixark_mcp_local_adapter.MatrixArkLocalAdapter'>
                is not <class 'tools.matrixark_mcp_local_adapter.MatrixArkLocalAdapter'>

Two classes, one qualified name. Another file in the suite deletes a module from sys.modules and
re-imports it to pick up an environment change, which builds a second module object holding a
second class -- so whether these are the same object depends on what ran first. Reproduced
directly: assertIs fails, comparing qualname and defining module passes.

The test means to check that the entrypoint re-exports the split modules rather than defining its
own copies, and that holds however many times the module was loaded. A copy defined in the
entrypoint still fails it, because its defining module would be matrixark_mcp_server.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
