### PR TITLE
Restore the environment the guard borrows

### DIFF
--- a/tools/test_matrixark_accessor_defaults_match_the_registry.py
+++ b/tools/test_matrixark_accessor_defaults_match_the_registry.py
@@ -52,9 +52,20 @@ def _bool_accessors():
 class AccessorsAgreeWithTheRegistryTest(unittest.TestCase):
 
     def setUp(self) -> None:
+        # Restore the ENTIRE environment afterwards. These tests ask what an accessor returns for an
+        # UNCONFIGURED tenant, which means unsetting each knob's env var -- and `unittest discover`
+        # runs the whole suite in ONE process, so unsetting without restoring silently reconfigures
+        # every test that comes after. It did: 35 unrelated tests failed, none of them near this
+        # file. Same defect as the ~180 set_var sites that make the Rust suite look flaky.
+        self._saved_environ = dict(os.environ)
+        self.addCleanup(self._restore_environ)
         self.accessors = _bool_accessors()
         self.assertGreater(len(self.accessors), 5,
                            "found almost no bool accessors, so these comparisons prove nothing")
+
+    def _restore_environ(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._saved_environ)
 
     def test_the_resolved_default_matches_the_registry_default(self) -> None:
         for knob_name, func in self.accessors:


### PR DESCRIPTION
Follow-up to #618, on a fresh branch — #618 auto-merged before this landed on it.

The new accessor guard asks what each accessor returns for an **unconfigured** tenant, which means unsetting that knob's env var. `unittest discover` runs the whole suite in one process, so unsetting without restoring reconfigures every test that runs after it.

Nothing has been observed failing from it. I initially suspected it caused the 35 red tests on that run and checked rather than assumed: main's own ratchet reports the identical `failing now: 156 baseline: 121`, the two NEW-failure name sets differ by zero in both directions, and stripping these vars by hand does not reproduce the failures. So this is a hazard being removed, not a regression being fixed.

It is worth removing anyway: a test that takes process environment and does not put it back is the Python form of the defect behind the "flaky" Rust suite, and it has no business being introduced by a test whose entire purpose is catching quiet disagreements.

Verified: with the cleanup in place, the process environment before and after the guard runs differs by no keys.

**Separately, and more important than this PR:** the ratchet baseline is stale. main is at 156 failing against a recorded baseline of 121, so the gate is currently red on every branch and gates nothing. Worth re-recording from a main run.