### PR TITLE
A write continues the snapshot's tail, or leaves it alone

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -116,15 +116,21 @@ LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
     1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "2000"))
 )
-# A floor between durable read-cache writes. The append-only fast path keeps the usual cost
-# proportional to what was appended, but when it cannot apply -- no epoch, a competing
-# adapter, or a compaction since the last write -- the fallback rewrites the WHOLE record
-# set as JSON, and with no floor that happened on every append.
+# No floor by default. One was added because the fallback rewrote the WHOLE record set as JSON
+# whenever the append-only path could not apply, which was almost every append -- so a delay
+# between writes was the only thing keeping it bounded.
 #
-# Measured: test_intern_record_metadata's codec round-trip does not finish in 45s at 0, and
-# passes with a 250ms floor. The cache is validated by signature on read, so a slightly
-# staler file costs nothing but a rebuild.
-LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "250")))
+# A write no longer takes that fallback at all: it continues the tail or leaves the snapshot alone.
+# Measured over 40 ingests, with the writes interleaved to cancel machine drift:
+#
+#   no structural fix, no floor      ingest 2.714 s   time inside the writer 5.869 s
+#   no structural fix, 250 ms floor  ingest ~2.0 s    time inside the writer ~2.9 s
+#   this, no floor                   ingest 0.768 s   time inside the writer 0.146 s
+#
+# So the delay is no longer buying anything, and it cost correctness: four tests assert that a
+# snapshot is refreshed promptly enough for a restart to use it, and a floor makes that false for
+# a quarter of a second. They pass again at 0.
+LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "0")))
 
 
 def _snapshot_prefix_fingerprint(record: "Json") -> str:
@@ -4190,6 +4196,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         *,
         force: bool = False,
         epoch: int | None = None,
+        tail_only: bool = False,
     ) -> None:
         """Persist the read snapshot.
 
@@ -4276,6 +4283,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             except (OSError, TypeError, ValueError):
                 pass   # fall through to a full rewrite, which also clears the partial tail
 
+        if tail_only:
+            # The caller is a write. A full rewrite here is O(corpus) per append; leave the snapshot
+            # as it stands and let the next read refresh it.
+            return
         tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         payload = {
             "schema_version": LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
@@ -4505,7 +4516,19 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     compact_and_apply_tombstones(list(self._read_cache_records)),
                 )
         if durable_records is not None:
-            self._write_durable_read_cache(durable_records, signature, epoch=durable_epoch)
+            # Only continue the tail here; never rewrite the whole base from a write.
+            #
+            # Ingest does not just append: compaction rewrites earlier records, so the list is
+            # usually not an extension of what is persisted and the tail cannot apply. Measured over
+            # 40 ingests, 173 snapshot writes, 146 of them full rewrites of the entire record set,
+            # which came to two thirds of the time an ingest took.
+            #
+            # The snapshot is derived state -- _load_durable_read_cache checks it against the log's
+            # signature and returns None on any mismatch, and the caller re-derives. Skipping a
+            # rewrite here costs a slower cold start until the next read, and the read path installs
+            # the records and writes the snapshot anyway.
+            self._write_durable_read_cache(
+                durable_records, signature, epoch=durable_epoch, tail_only=True)
         if any(str(record.get("record_type") or "") in RETRIEVAL_HOT_RECORD_TYPES for record in records):
             with self._retrieval_records_cache_lock:
                 self._retrieval_records_cache_generation += 1

--- a/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
+++ b/tools/test_matrixark_a_write_does_not_rewrite_the_snapshot.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A write continues the snapshot's tail or leaves it alone. It never rewrites the whole base.
+
+Ingest does not only append. Compaction rewrites earlier records, so the list handed to the
+snapshot writer is usually not an extension of what is persisted and the tail cannot apply.
+Measured over 40 ingests: 173 snapshot writes, 146 of them rewriting the entire record set.
+
+The snapshot is derived state -- _load_durable_read_cache checks it against the log's signature and
+returns None on any mismatch, and the caller re-derives from the log. So a write can decline to
+refresh it; the read path installs the records and writes it anyway.
+
+Measured with the writes interleaved to cancel machine drift, eight paired runs: the time inside
+the snapshot writer fell from 2.864 s to 0.621 s across the set, and ingest was faster in six of
+the eight pairs, median 0.26 s.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+class AWriteDoesNotRewriteTheSnapshot(unittest.TestCase):
+    def setUp(self):
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    tearDown = setUp
+
+    @staticmethod
+    def _seeded(store):
+        log = Path(store) / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        for i in range(10):
+            adapter.append({"record_type": "context_document", "id": "doc-%d" % i,
+                            "node_path": "/n/%d" % i, "text": "body " * 20})
+        records = adapter.read_all()          # the read installs the base
+        # That read just stamped the write clock, and there is a floor between snapshot writes.
+        # Clear it, or the write under test is skipped for a reason unrelated to what is asserted.
+        adapter._durable_read_cache_last_write_ms = 0
+        return adapter, records
+
+    def test_a_write_will_not_rewrite_the_base(self):
+        """A list that is not a continuation used to cost a full rewrite on every append."""
+        with tempfile.TemporaryDirectory() as store:
+            adapter, records = self._seeded(store)
+            base = adapter._durable_read_cache_path()
+            before = base.read_bytes()
+
+            diverged = [dict(r) for r in records]
+            diverged[-1] = {"record_type": "context_document", "id": "changed",
+                            "node_path": "/n/changed", "text": "compaction rewrote this"}
+            diverged.append({"record_type": "context_document", "id": "new",
+                             "node_path": "/n/new", "text": "appended"})
+            adapter._durable_read_cache_state = None
+            adapter._durable_read_cache_last_write_ms = 0
+            adapter._write_durable_read_cache(
+                diverged, adapter._jsonl_cache_signature_detail(), epoch=None, tail_only=True)
+
+            self.assertEqual(before, base.read_bytes(),
+                             "a write rewrote the whole base; that is O(corpus) per append")
+
+    def test_a_write_still_appends_a_tail_it_can_prove(self):
+        """Declining the full rewrite must not disable the cheap path."""
+        with tempfile.TemporaryDirectory() as store:
+            adapter, records = self._seeded(store)
+            delta = adapter._durable_read_cache_delta_path()
+            before = delta.stat().st_size if delta.exists() else 0
+
+            longer = list(records) + [{"record_type": "context_document", "id": "tail",
+                                       "node_path": "/n/tail", "text": "appended after the base"}]
+            adapter._durable_read_cache_last_write_ms = 0
+            adapter._write_durable_read_cache(
+                longer, adapter._jsonl_cache_signature_detail(), epoch=None, tail_only=True)
+
+            self.assertGreater(delta.stat().st_size if delta.exists() else 0, before,
+                               "the tail was not appended, so nothing keeps the snapshot current")
+
+    def test_a_cold_reader_always_gets_every_record(self):
+        """Correctness does not depend on the snapshot at all.
+
+        This is the guarantee that makes declining a rewrite safe: _load_durable_read_cache checks
+        the snapshot against the log's signature and returns None on any mismatch, so a snapshot
+        that has fallen behind is not served -- the caller re-derives from the log.
+        """
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            for i in range(24):
+                adapter.ingest({
+                    "kind": "message",
+                    "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 8)},
+                    "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
+                })
+            expected = len(adapter.read_all())
+            self.assertGreater(expected, 0)
+
+            with adapter_module._LOCAL_READ_CACHE_LOCK:
+                adapter_module._LOCAL_READ_CACHE.clear()
+            cold = adapter_module.MatrixArkLocalAdapter(log)
+            self.assertEqual(expected, len(cold.read_all()),
+                             "a reader with no process state lost records")
+
+    def test_a_re_deriving_read_leaves_a_snapshot_the_next_start_can_use(self):
+        """What keeps the snapshot current once writes no longer refresh it.
+
+        Asserted through a read that actually re-derives -- a read served from the process cache
+        writes nothing, which is exactly the case that leaves the snapshot behind.
+        """
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            for i in range(24):
+                adapter.ingest({
+                    "kind": "message",
+                    "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 8)},
+                    "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
+                })
+            with adapter_module._LOCAL_READ_CACHE_LOCK:
+                adapter_module._LOCAL_READ_CACHE.clear()
+            refresher = adapter_module.MatrixArkLocalAdapter(log)
+            expected = len(refresher.read_all())      # re-derives, and writes the snapshot
+
+            with adapter_module._LOCAL_READ_CACHE_LOCK:
+                adapter_module._LOCAL_READ_CACHE.clear()
+            cold = adapter_module.MatrixArkLocalAdapter(log)
+            served = cold.read_all()
+            self.assertEqual(expected, len(served))
+            self.assertEqual("durable", cold._read_cache_source,
+                             "a read that re-derived did not leave a usable snapshot, so every "
+                             "restart would re-read the whole log")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A write continues the snapshot's tail, or leaves it alone

Ingest does not only append. Compaction rewrites earlier records, so the list handed to the
read-cache snapshot writer is usually not an extension of what is persisted, the tail cannot apply,
and the fallback rewrote the entire record set as JSON. Measured over 40 ingests: 173 snapshot
writes, 146 of them full rewrites.

A write now continues the tail or does nothing. The snapshot is derived state --
_load_durable_read_cache checks it against the log's signature and returns None on any mismatch,
and the caller re-derives -- so declining costs a slower cold start until the next re-deriving
read, which installs the records and writes it.

This also removes the floor between writes, restoring the default to 0.

The floor was added because that fallback ran on almost every append, so a delay was the only thing
bounding it. With the fallback gone it buys nothing, and it cost correctness: four tests assert a
snapshot is refreshed promptly enough for a restart to use, which a quarter-second delay makes
false. They have been failing on main since the floor landed and pass again at 0.

Measured over 40 ingests, interleaved to cancel machine drift:

  no structural fix, no floor      ingest 2.714 s   time inside the writer 5.869 s
  no structural fix, 250 ms floor  ingest ~2.0 s    time inside the writer ~2.9 s
  this, no floor                   ingest 0.768 s   time inside the writer 0.146 s

The test the floor was introduced for -- the codec round trip, said not to finish in 45 s at 0 --
now takes 3.2 s here, against 4.1 s on main with the floor and 7.1 s on main without it.

The tests assert the shape rather than the timing: a write must not rewrite the base, a write must
still append a tail it can prove, a cold reader must get every record whatever the snapshot's
state, and a read that re-derives must leave a snapshot the next start can use.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
