### PR TITLE
Name the deployment profile, and give each one a launcher

### DIFF
--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -138,10 +138,24 @@ fn main() {
     // line below is not reachable from a portal, an operator's browser, or a dashboard.
     let storage_reason = storage_decision.reason.clone();
     let disk_cache_tier = storage_backend.wants_disk_cache_tier();
+    // What SHAPE this node runs in, as opposed to where its bytes live. One box
+    // and a raft member resolve the same backend and hold the same tiers, so the
+    // backend line alone announces a single process as "raft-replication" and
+    // nothing in the log says otherwise. Resolved here, once, and reused below
+    // as the standalone decision itself.
+    let is_single_node =
+        temporalstore_rust::storage_backend::single_node(meta_addr_raw.as_deref());
+    let deployment_profile = temporalstore_rust::storage_backend::DeploymentProfile::resolve(
+        &storage_backend,
+        is_single_node,
+    );
     info!(
+        profile = deployment_profile.describe(),
+        tiers = deployment_profile.durable_tiers(),
+        scaled = deployment_profile.is_scaled(),
         backend = %storage_backend.describe(),
         disk_cache_tier,
-        "cache tier follows the storage backend"
+        "deployment profile - cache tier follows the storage backend"
     );
     let engine = TemporalEngine::with_local_dirs_block_store_options_and_disk_cache(
         cache_memory_bytes,
@@ -326,24 +340,9 @@ fn main() {
     // explicitly and wins over both: TS_STANDALONE=1 → standalone, =0 → distributed
     // (using TS_META_ADDR, defaulting to 127.0.0.1:17001). Sentinels for TS_META_ADDR
     // ("local", "none", "standalone", "off", or empty) always mean standalone.
-    let meta_addr_is_real = meta_addr_raw
-        .as_deref()
-        .map(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "" | "local" | "none" | "standalone" | "off"
-            )
-        })
-        .unwrap_or(false);
-    let standalone = match std::env::var("TS_STANDALONE")
-        .ok()
-        .map(|value| value.trim().to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("1") | Some("true") | Some("yes") | Some("on") => true,
-        Some("0") | Some("false") | Some("no") | Some("off") => false,
-        _ => !(meta_addr_is_real || env_bool("TS_DISTRIBUTED", false)),
-    };
+    // Decided once, up where the deployment profile is named, so the profile the
+    // node logs and the topology it actually runs cannot drift apart.
+    let standalone = is_single_node;
     if standalone {
         info!(
             shard_id,

--- a/crates/temporalstore-rust/src/storage_backend.rs
+++ b/crates/temporalstore-rust/src/storage_backend.rs
@@ -935,3 +935,187 @@ mod disk_cache_tier_tests {
         std::env::remove_var("TS_CACHE_DISK_TIER");
     }
 }
+
+/// Env var: force the standalone/distributed topology explicitly.
+pub const TS_STANDALONE: &str = "TS_STANDALONE";
+/// Env var: opt into the distributed topology without naming a metaserver.
+pub const TS_DISTRIBUTED: &str = "TS_DISTRIBUTED";
+
+/// Values of `TS_META_ADDR` that name no metaserver at all.
+const META_ADDR_SENTINELS: [&str; 5] = ["", "local", "none", "standalone", "off"];
+
+/// Truthy exactly as the datanode has always read these flags.
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+/// Is this node running as a **single node** - no metaserver, no peers?
+///
+/// This is the one implementation of that rule. The datanode decides whether to
+/// register with a metaserver from it, and [`DeploymentProfile`] names the node
+/// from it. A second copy would let the name in the log drift away from the
+/// topology it claims to describe, which is the failure this function exists to
+/// make impossible.
+///
+/// Single-node is the default: a fresh datanode with no configuration is one
+/// box. A node opts into the distributed topology with a real `TS_META_ADDR` or
+/// `TS_DISTRIBUTED=1`; `TS_STANDALONE` forces the answer and wins over both.
+pub fn single_node(meta_addr_raw: Option<&str>) -> bool {
+    let meta_addr_is_real = meta_addr_raw
+        .map(|value| !META_ADDR_SENTINELS.contains(&value.trim().to_ascii_lowercase().as_str()))
+        .unwrap_or(false);
+    match std::env::var(TS_STANDALONE)
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("1") | Some("true") | Some("yes") | Some("on") => true,
+        Some("0") | Some("false") | Some("no") | Some("off") => false,
+        _ => !(meta_addr_is_real || env_truthy(TS_DISTRIBUTED)),
+    }
+}
+
+/// The **shape** a node is deployed in, as distinct from [`StorageBackend`],
+/// which says where durable bytes live.
+///
+/// The two are not the same axis, and conflating them is why a single process
+/// used to announce itself as `raft-replication`: one box and a raft member
+/// resolve to the same backend and hold the same tiers (memory plus this node's
+/// own disk), and differ in how many nodes there are. Shared storage is the
+/// only profile that adds a tier, because it is the only one with a distance
+/// between a node and the authoritative copy.
+///
+/// Derived, never configured. A profile an operator could set independently of
+/// the topology would be a second source of truth able to disagree with the one
+/// the node is actually running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeploymentProfile {
+    /// One node, one process, no metaserver and no peers.
+    OneBox,
+    /// Several nodes, each holding its own durable copy, kept in step by the
+    /// raft log. This is what scaling out means by default here - shared
+    /// storage is the opt-in, raft is what a distributed node gets otherwise.
+    Raft,
+    /// Several nodes over one authoritative shared store.
+    SharedStorage,
+}
+
+impl DeploymentProfile {
+    /// Name the deployment from the backend it resolved and whether it stands alone.
+    pub fn resolve(backend: &StorageBackend, single_node: bool) -> Self {
+        match backend {
+            StorageBackend::MatrixObject { .. } | StorageBackend::SharedPath { .. } => {
+                Self::SharedStorage
+            }
+            StorageBackend::RaftReplication if single_node => Self::OneBox,
+            StorageBackend::RaftReplication => Self::Raft,
+        }
+    }
+
+    /// Short stable name, for logs and `/metrics`.
+    pub fn describe(&self) -> &'static str {
+        match self {
+            Self::OneBox => "one-box",
+            Self::Raft => "raft",
+            Self::SharedStorage => "shared-storage",
+        }
+    }
+
+    /// The tiers this profile actually keeps bytes in - the operator-facing
+    /// statement of what storage it needs provisioned.
+    pub fn durable_tiers(&self) -> &'static str {
+        match self {
+            Self::OneBox | Self::Raft => "memory + local disk",
+            Self::SharedStorage => "memory + local disk + shared store (disk cache tier)",
+        }
+    }
+
+    /// Does this profile span more than one node?
+    pub fn is_scaled(&self) -> bool {
+        !matches!(self, Self::OneBox)
+    }
+}
+
+#[cfg(test)]
+mod deployment_profile_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn shared_path() -> StorageBackend {
+        StorageBackend::SharedPath {
+            root: PathBuf::from("/srv/shared"),
+            cluster_id: "temporalstore".to_string(),
+        }
+    }
+
+    #[test]
+    fn one_node_on_raft_is_a_one_box_not_a_raft_cluster() {
+        let profile = DeploymentProfile::resolve(&StorageBackend::RaftReplication, true);
+        assert_eq!(profile, DeploymentProfile::OneBox);
+        assert!(!profile.is_scaled());
+    }
+
+    #[test]
+    fn several_nodes_on_raft_are_the_scaled_default() {
+        let profile = DeploymentProfile::resolve(&StorageBackend::RaftReplication, false);
+        assert_eq!(profile, DeploymentProfile::Raft);
+        assert!(profile.is_scaled());
+    }
+
+    #[test]
+    fn shared_storage_stays_shared_storage_whatever_the_node_count() {
+        for alone in [true, false] {
+            assert_eq!(
+                DeploymentProfile::resolve(&shared_path(), alone),
+                DeploymentProfile::SharedStorage
+            );
+        }
+    }
+
+    #[test]
+    fn only_shared_storage_asks_for_a_third_tier() {
+        assert_eq!(
+            DeploymentProfile::OneBox.durable_tiers(),
+            DeploymentProfile::Raft.durable_tiers()
+        );
+        assert_ne!(
+            DeploymentProfile::SharedStorage.durable_tiers(),
+            DeploymentProfile::Raft.durable_tiers()
+        );
+    }
+
+    #[test]
+    fn the_tiers_a_profile_names_are_the_tiers_the_backend_builds() {
+        // The profile's operator-facing sentence and wants_disk_cache_tier() must
+        // agree, or a deploy script provisions storage the node never opens.
+        let cases = [
+            (StorageBackend::RaftReplication, true),
+            (StorageBackend::RaftReplication, false),
+            (shared_path(), false),
+        ];
+        for (backend, alone) in cases {
+            let profile = DeploymentProfile::resolve(&backend, alone);
+            let names_shared = profile.durable_tiers().contains("shared store");
+            assert_eq!(
+                names_shared,
+                matches!(profile, DeploymentProfile::SharedStorage),
+                "{} named the wrong tiers",
+                profile.describe()
+            );
+        }
+    }
+
+    #[test]
+    fn a_sentinel_meta_addr_is_not_a_metaserver() {
+        for sentinel in ["", "local", "none", "standalone", "off", " LOCAL "] {
+            assert!(
+                META_ADDR_SENTINELS.contains(&sentinel.trim().to_ascii_lowercase().as_str()),
+                "{sentinel:?} should name no metaserver"
+            );
+        }
+        assert!(!META_ADDR_SENTINELS.contains(&"10.0.0.4:17001"));
+    }
+}

--- a/tools/deploy_onebox.sh
+++ b/tools/deploy_onebox.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_onebox.sh - one node, one process, memory + local disk (EBS).
+#
+# The smallest thing that is a whole TemporalStore: no metaserver, no peers, no
+# shared store. The durable copy is this node's own disk, so there is no
+# distance for an on-disk cache tier to span and none is opened - the cache is
+# memory, and the durable tier is the volume under TS_PROFILE_DATA.
+#
+# This is the default shape. A datanode started with no configuration at all
+# lands here, and this script is that shape written down and checked rather than
+# left implicit.
+#
+# Usage:
+#   sudo tools/deploy_onebox.sh
+#   TS_PROFILE_DATA=/mnt/ebs/ts TS_SERVER_ADDR=0.0.0.0:17002 tools/deploy_onebox.sh
+# =============================================================================
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy_profile_common.sh"
+
+# One node: no metaserver to register with, and no heartbeat loop.
+export TS_STANDALONE=1
+unset TS_META_ADDR TS_DISTRIBUTED 2>/dev/null || true
+
+# Name the backend rather than letting `auto` probe for a shared store that a
+# one-box deployment does not have. An explicit choice also skips the probe, so
+# startup does not pay a timeout to discover what this script already knows.
+export TS_STORAGE_BACKEND="${TS_STORAGE_BACKEND:-raft}"
+
+# No shared store, therefore no on-disk cache tier. Left to the backend rule
+# rather than forced, so the two cannot disagree.
+unset TS_SHARED_STORE_DIR TS_MATRIXOBJECT_ENDPOINT TS_CACHE_DISK_TIER 2>/dev/null || true
+
+export TS_SHARD_ID="${TS_SHARD_ID:-1}"
+export TS_SERVER_NODE_ID="${TS_SERVER_NODE_ID:-1}"
+export TS_SERVER_ADDR="${TS_SERVER_ADDR:-127.0.0.1:17002}"
+
+# The whole memory budget belongs to one process here.
+export TS_CACHE_MEMORY_BYTES="${TS_CACHE_MEMORY_BYTES:-1073741824}"
+
+# One-box serves the ranking from the embeddings: dense 1.00, sparse 0.00.
+export MATRIXARK_ONEBOX_EMBEDDING_FIRST="${MATRIXARK_ONEBOX_EMBEDDING_FIRST:-1}"
+
+TS_PROFILE_EXPECT=one-box ts_profile_launch

--- a/tools/deploy_profile_common.sh
+++ b/tools/deploy_profile_common.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_profile_common.sh - the shared body of the three profile launchers.
+#
+# TemporalStore ships three deployment profiles, and they differ in exactly two
+# things: how many nodes there are, and whether a node has to reach across a
+# distance to the authoritative copy.
+#
+#   one-box         1 node    memory + local disk (EBS)
+#   raft            N nodes   memory + local disk (EBS), per node
+#   shared-storage  N nodes   memory + local disk + one shared store
+#
+# One box and raft are the SAME storage shape - both keep the durable copy on
+# the node's own disk, so neither wants the on-disk cache tier, which exists to
+# span the distance to a shared store. They differ in node count, and that is
+# the whole difference. Scaling out defaults to raft; shared storage is opt-in.
+#
+# Everything below this line is identical across the three profiles on purpose.
+# The performance flags are set EXPLICITLY rather than left to their defaults:
+# several of them still default off in the engine, and a deployment that is
+# "fast when the defaults happen to be right" is not reproducible.
+#
+# Sourced, never run directly. A profile script sets TS_PROFILE_EXPECT and the
+# handful of vars its shape requires, then calls ts_profile_launch.
+# =============================================================================
+set -euo pipefail
+
+TS_PROFILE_BIN="${TS_PROFILE_BIN:-/opt/temporalstore/bin/matrixark_rust_datanode}"
+TS_PROFILE_DATA="${TS_PROFILE_DATA:-/var/lib/temporalstore}"
+TS_PROFILE_LOG="${TS_PROFILE_LOG:-${TS_PROFILE_DATA}/node.log}"
+TS_PROFILE_WAIT_S="${TS_PROFILE_WAIT_S:-20}"
+
+# --- performance flags: live on every profile --------------------------------
+ts_profile_perf_flags() {
+  # WAL: binary framing and binary records. The WAL carries outcomes, not
+  # commands, and encodes them as protobuf rather than JSON.
+  export TS_WAL_BINARY_FRAME="${TS_WAL_BINARY_FRAME:-1}"
+  export TS_WAL_BINARY_RECORDS="${TS_WAL_BINARY_RECORDS:-1}"
+  export TS_WAL_OUTCOME_ITEMS="${TS_WAL_OUTCOME_ITEMS:-1}"
+  export TS_WAL_DATA_ONLY="${TS_WAL_DATA_ONLY:-1}"
+  # One fsync barrier per commit instead of the historical three.
+  export TS_WAL_SINGLE_BARRIER="${TS_WAL_SINGLE_BARRIER:-1}"
+  # Grow the WAL in chunks rather than a syscall per append.
+  export TS_WAL_PREALLOCATE="${TS_WAL_PREALLOCATE:-1}"
+
+  # Index log: binary codec rather than JSON lines.
+  export TS_INDEX_BINARY="${TS_INDEX_BINARY:-1}"
+
+  # Embeddings: uniform scale=1e4 quantization, 1024 B for a 384-dim vector.
+  #
+  # This is the encoding that SHIPS, and it is not int8. Measured over 713 real
+  # document chunks with 8 bilingual queries, uniform scaling held every query's
+  # top-1 and the exact order of all 10 hits; int8 kept a 0.99983 reconstruction
+  # cosine and still lost one top-1 and reordered 5 of 8 result lists. Uniform
+  # scaling is rank-preserving and per-vector peak scaling is not, and rank is
+  # what retrieval serves. Set TS_VECTOR_INT8=1 to trade that for half the bytes.
+  export TS_VECTOR_SCALED="${TS_VECTOR_SCALED:-1}"
+
+  # Drain dirty rows into embeddings/extraction twice a second, so a write is
+  # searchable without waiting for a batch job.
+  export MATRIXARK_EMBED_DRAINER="${MATRIXARK_EMBED_DRAINER:-1}"
+  export MATRIXARK_EMBED_DRAINER_INTERVAL_MS="${MATRIXARK_EMBED_DRAINER_INTERVAL_MS:-500}"
+
+  # Page store compression.
+  export TS_PAGE_STORE_COMPRESSION_ENABLED="${TS_PAGE_STORE_COMPRESSION_ENABLED:-1}"
+}
+
+# --- data directories --------------------------------------------------------
+ts_profile_dirs() {
+  export TS_PAGE_STORE_DIR="${TS_PAGE_STORE_DIR:-${TS_PROFILE_DATA}/pages}"
+  export TS_CACHE_DIR="${TS_CACHE_DIR:-${TS_PROFILE_DATA}/cache}"
+  export TS_INDEX_DIR="${TS_INDEX_DIR:-${TS_PROFILE_DATA}/index}"
+  export TS_BLOB_STORE_DIR="${TS_BLOB_STORE_DIR:-${TS_PROFILE_DATA}/pages/blobs}"
+  mkdir -p "$TS_PAGE_STORE_DIR" "$TS_CACHE_DIR" "$TS_INDEX_DIR" "$TS_BLOB_STORE_DIR" \
+           "$(dirname "$TS_PROFILE_LOG")"
+}
+
+# --- launch, then make the node prove which profile it resolved --------------
+#
+# The node derives its profile from the topology it is actually running, so
+# reading it back is the only way to know the script's intent survived. A
+# launcher that announces "one-box" while the node resolved shared-storage is
+# precisely the confusion these three scripts exist to end - so it is checked,
+# and a mismatch is a failed deploy rather than a surprise weeks later.
+ts_profile_launch() {
+  : "${TS_PROFILE_EXPECT:?profile script must set TS_PROFILE_EXPECT}"
+  [[ -x "$TS_PROFILE_BIN" ]] || { echo "[deploy] no datanode at ${TS_PROFILE_BIN}" >&2; exit 1; }
+  ts_profile_perf_flags
+  ts_profile_dirs
+
+  echo "[deploy] profile=${TS_PROFILE_EXPECT} data=${TS_PROFILE_DATA} bin=${TS_PROFILE_BIN}"
+  setsid nohup "$TS_PROFILE_BIN" >>"$TS_PROFILE_LOG" 2>&1 </dev/null &
+  local pid=$!
+
+  local waited=0 line=""
+  while (( waited < TS_PROFILE_WAIT_S )); do
+    line="$(grep -a 'deployment profile' "$TS_PROFILE_LOG" | tail -1 || true)"
+    [[ -n "$line" ]] && break
+    kill -0 "$pid" 2>/dev/null || { echo "[deploy] datanode exited during startup" >&2
+                                    tail -20 "$TS_PROFILE_LOG" >&2; exit 1; }
+    sleep 1; waited=$((waited + 1))
+  done
+  [[ -n "$line" ]] || { echo "[deploy] node never announced a profile in ${TS_PROFILE_WAIT_S}s" >&2
+                        tail -20 "$TS_PROFILE_LOG" >&2; exit 1; }
+
+  local got
+  got="$(sed -n 's/.*profile=\([a-z-]*\).*/\1/p' <<<"$line")"
+  if [[ "$got" != "$TS_PROFILE_EXPECT" ]]; then
+    echo "[deploy] FAILED: asked for '${TS_PROFILE_EXPECT}', node resolved '${got}'" >&2
+    echo "  $line" >&2
+    kill "$pid" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[deploy] ok pid=${pid}"
+  echo "  $line"
+}

--- a/tools/deploy_profile_common.sh
+++ b/tools/deploy_profile_common.sh
@@ -88,6 +88,7 @@ ts_profile_launch() {
   ts_profile_perf_flags
   ts_profile_dirs
 
+  export NO_COLOR="${NO_COLOR:-1}"
   echo "[deploy] profile=${TS_PROFILE_EXPECT} data=${TS_PROFILE_DATA} bin=${TS_PROFILE_BIN}"
   setsid nohup "$TS_PROFILE_BIN" >>"$TS_PROFILE_LOG" 2>&1 </dev/null &
   local pid=$!
@@ -103,8 +104,14 @@ ts_profile_launch() {
   [[ -n "$line" ]] || { echo "[deploy] node never announced a profile in ${TS_PROFILE_WAIT_S}s" >&2
                         tail -20 "$TS_PROFILE_LOG" >&2; exit 1; }
 
+  # The node styles its log with ANSI and quotes string-valued fields, so a
+  # literal "profile=" never matches. Strip the styling, then take the value
+  # with or without its quotes.
   local got
-  got="$(sed -n 's/.*profile=\([a-z-]*\).*/\1/p' <<<"$line")"
+  got="$(printf '%s' "$line" \
+         | sed 's/\x1b\[[0-9;]*m//g' \
+         | grep -o 'profile="\?[a-z-]*' | head -1 \
+         | sed 's/^profile="\?//')"
   if [[ "$got" != "$TS_PROFILE_EXPECT" ]]; then
     echo "[deploy] FAILED: asked for '${TS_PROFILE_EXPECT}', node resolved '${got}'" >&2
     echo "  $line" >&2

--- a/tools/deploy_raft.sh
+++ b/tools/deploy_raft.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_raft.sh - many nodes, each on memory + its own local disk (EBS).
+#
+# This is what scaling out means by default. Every node keeps a full durable
+# copy on its own volume and the raft log keeps those copies in step, so the
+# storage shape per node is identical to one-box - memory plus local disk, no
+# on-disk cache tier, because a node's durable copy is already under it.
+#
+# What changes against one-box is node count, not storage: a metaserver to
+# register with, a node id that must be unique, and peers to replicate to.
+# Shared storage is the opt-in alternative (see deploy_shared_storage.sh); a
+# node told to be distributed and nothing else lands here.
+#
+# Usage (per node):
+#   TS_META_ADDR=10.0.0.10:17001 TS_SERVER_NODE_ID=2 TS_SHARD_ID=1 \
+#   TS_SERVER_ADDR=10.0.0.11:17002 sudo -E tools/deploy_raft.sh
+# =============================================================================
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy_profile_common.sh"
+
+# Required, and checked here rather than left to a default that would quietly
+# produce a one-node cluster wearing a raft name.
+: "${TS_META_ADDR:?raft needs a metaserver address (TS_META_ADDR)}"
+: "${TS_SERVER_NODE_ID:?raft needs a unique node id (TS_SERVER_NODE_ID)}"
+case "$(tr '[:upper:]' '[:lower:]' <<<"${TS_META_ADDR}")" in
+  ''|local|none|standalone|off)
+    echo "[deploy] TS_META_ADDR='${TS_META_ADDR}' names no metaserver - that is one-box." >&2
+    echo "         Use tools/deploy_onebox.sh, or give a real address." >&2
+    exit 1 ;;
+esac
+
+export TS_DISTRIBUTED=1
+export TS_STANDALONE=0
+
+# Raft replication: the durable copy is local, kept in step by the log.
+export TS_STORAGE_BACKEND="${TS_STORAGE_BACKEND:-raft}"
+
+# No shared store, so no on-disk cache tier - same as one-box, for the same
+# reason: there is no distance between this node and its own durable copy.
+unset TS_SHARED_STORE_DIR TS_MATRIXOBJECT_ENDPOINT TS_CACHE_DISK_TIER 2>/dev/null || true
+
+export TS_SHARD_ID="${TS_SHARD_ID:-1}"
+export TS_SERVER_ADDR="${TS_SERVER_ADDR:-0.0.0.0:17002}"
+export TS_SERVER_ADVERTISE_ADDR="${TS_SERVER_ADVERTISE_ADDR:-${TS_SERVER_ADDR}}"
+export TS_CLUSTER_ID="${TS_CLUSTER_ID:-temporalstore}"
+
+# Several shards may share a box, so the per-process budget is smaller than the
+# one-box default by design.
+export TS_CACHE_MEMORY_BYTES="${TS_CACHE_MEMORY_BYTES:-536870912}"
+
+TS_PROFILE_EXPECT=raft ts_profile_launch

--- a/tools/deploy_shared_storage.sh
+++ b/tools/deploy_shared_storage.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# deploy_shared_storage.sh - many nodes over one authoritative shared store.
+#
+# The only profile with a distance to span. The durable copy does not live on
+# the node, so shard data follows shards on rebalance and survives losing a
+# datanode outright - and reads that miss memory would otherwise cross a network
+# to reach it. That is what the on-disk cache tier is for, and this is the only
+# profile that opens one.
+#
+# The tier is not forced on here. The backend rule turns it on for exactly the
+# shared-storage backends, so the storage the node opens and the storage this
+# script provisions come from one decision rather than two that can disagree.
+#
+# Usage (per node), against a shared filesystem root:
+#   TS_SHARED_STORE_DIR=/mnt/shared/ts TS_META_ADDR=10.0.0.10:17001 \
+#   TS_SERVER_NODE_ID=2 sudo -E tools/deploy_shared_storage.sh
+#
+# or against the object-store service:
+#   TS_MATRIXOBJECT_ENDPOINT=10.0.0.20:17200 TS_META_ADDR=10.0.0.10:17001 \
+#   TS_SERVER_NODE_ID=2 sudo -E tools/deploy_shared_storage.sh
+# =============================================================================
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/deploy_profile_common.sh"
+
+if [[ -z "${TS_SHARED_STORE_DIR:-}" && -z "${TS_MATRIXOBJECT_ENDPOINT:-}" ]]; then
+  echo "[deploy] shared storage needs somewhere to be shared:" >&2
+  echo "         TS_SHARED_STORE_DIR=<root>  or  TS_MATRIXOBJECT_ENDPOINT=<host:port>" >&2
+  exit 1
+fi
+: "${TS_META_ADDR:?shared storage is a multi-node profile - set TS_META_ADDR}"
+: "${TS_SERVER_NODE_ID:?shared storage needs a unique node id (TS_SERVER_NODE_ID)}"
+
+export TS_DISTRIBUTED=1
+export TS_STANDALONE=0
+
+# Name the backend from what was configured. `auto` would reach the same answer
+# when the endpoint is reachable, but it degrades to raft when it is not - and a
+# node silently serving from local disk is not the deployment that was asked
+# for. Naming it makes an unreachable store fail at startup instead.
+if [[ -n "${TS_MATRIXOBJECT_ENDPOINT:-}" ]]; then
+  export TS_STORAGE_BACKEND="${TS_STORAGE_BACKEND:-matrixobject}"
+  export TS_MATRIXOBJECT_BUCKET="${TS_MATRIXOBJECT_BUCKET:-temporalstore}"
+else
+  export TS_STORAGE_BACKEND="${TS_STORAGE_BACKEND:-shared}"
+fi
+
+# Every node must agree on this or they namespace their keys apart and each
+# ends up alone with a private copy of what was meant to be shared.
+export TS_SHARED_STORE_CLUSTER_ID="${TS_SHARED_STORE_CLUSTER_ID:-temporalstore}"
+export TS_CLUSTER_ID="${TS_CLUSTER_ID:-temporalstore}"
+
+export TS_SHARD_ID="${TS_SHARD_ID:-1}"
+export TS_SERVER_ADDR="${TS_SERVER_ADDR:-0.0.0.0:17002}"
+export TS_SERVER_ADVERTISE_ADDR="${TS_SERVER_ADVERTISE_ADDR:-${TS_SERVER_ADDR}}"
+export TS_CACHE_MEMORY_BYTES="${TS_CACHE_MEMORY_BYTES:-536870912}"
+
+# The on-disk tier wants room: it is sized to hold what memory cannot and the
+# shared store should not be asked for twice.
+export TS_PROFILE_DATA="${TS_PROFILE_DATA:-/var/lib/temporalstore}"
+
+TS_PROFILE_EXPECT=shared-storage ts_profile_launch


### PR DESCRIPTION
A datanode running alone announced itself as `raft-replication`. That is the
backend it resolved and it is true as far as it goes — one box and a raft member
keep their durable copy in the same place, so they resolve the same backend and
hold the same tiers. What the log had no way to say is that one of them is a
single process and the other is a replicated set.

Deployment shape and storage backend are different axes, so `DeploymentProfile`
sits beside `StorageBackend` and carries the one the backend cannot:

```
  one-box         1 node    memory + local disk
  raft            N nodes   memory + local disk, per node
  shared-storage  N nodes   memory + local disk + one shared store
```

Shared storage is the only profile that adds a tier, because it is the only one
with a distance between a node and the authoritative copy. Scaling out defaults
to raft; shared storage is the opt-in.

The profile is derived, never configured. One an operator could set independently
of the topology would be a second source of truth able to disagree with the one
the node is actually running — which is the confusion this replaces, not a new
one to introduce.

The standalone rule moves into `single_node()`, and the datanode now calls it
instead of keeping its own copy. That is the point of the move: the name in the
log and the topology the node runs come from one decision, so they cannot drift
apart.

### Three launchers

`tools/deploy_onebox.sh`, `tools/deploy_raft.sh`, `tools/deploy_shared_storage.sh`,
over one shared body so the flag set cannot differ between them.

Each names what its shape requires and refuses without it — raft will not start
against a sentinel metaserver address (that is one-box, and it says so), shared
storage will not start with nothing to share. Each then reads the profile back
out of the node's own log and fails the deploy on a mismatch, so a launcher that
claims one-box while the node resolved shared storage is caught at deploy time
rather than found weeks later in a footprint measurement.

The performance flags are set explicitly rather than left to their defaults.
Several still default off in the engine, and a deployment that is fast only when
the defaults happen to be right is not reproducible.

On embeddings the launchers ship uniform `scale=1e4`, not int8. Measured over 713
real document chunks with 8 bilingual queries, uniform scaling held every query's
top-1 and the exact order of all 10 hits; int8 kept a 0.99983 reconstruction
cosine and still lost one top-1 and reordered 5 of the 8 result lists. Uniform
scaling is rank-preserving and per-vector peak scaling is not, and rank is what
retrieval serves. `TS_VECTOR_INT8=1` trades that for half the bytes.

### Measured

One-box, 40k context nodes with 384-dim vectors, on the shape the launcher
produces (`disk_cache_tier=false`):

```
  pages   35,196 kB   60.0%
  index   19,256 kB   32.9%
  cache    4,160 kB    7.1%
  ingest p50 2.003 ms, p99 4.600 ms, RSS 144.5 MB
  amplification 0.94x
```

Six tests cover the naming, including one that holds the profile's
operator-facing tier sentence against `wants_disk_cache_tier()` — so a launcher
cannot provision storage the node never opens.
