### PR TITLE
Key the page index by a handle instead of a rendered string

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2389,10 +2389,9 @@ fn fold_delta_page_items(
                 ..BucketNode::default()
             });
         bucket.object_index.insert(item.object_id);
+        // The record's key is not carried into memory: the map assigns a handle, and the
+        // record's spelling is only rebuilt when the index is written back out.
         bucket.page_index.insert(
-            // The record carries an owned String; the in-memory structures share one allocation,
-            // so it is converted once here as the page is installed.
-            std::sync::Arc::from(item.page_ref_key.as_str()),
             PageIndex {
                 object_key: Arc::from(item.object_key.clone()),
                 model_id: Arc::from(item.model_id.clone()),

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -320,7 +320,154 @@ pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
 pub(super) type ObjectIndex = BTreeSet<u64>;
 /// Keyed by a SHARED page-ref key: the same allocation is held by the lookups that point at this
 /// page, instead of each of the three keeping its own copy of the same ~117-byte string.
-pub(super) type PageIndexMap = BTreeMap<Arc<str>, PageIndex>;
+/// Pages of one bucket, keyed by an id assigned when the page is filed.
+///
+/// The key used to be a rendered string of the page's identity and address -- 45.6 B a page, and
+/// three quarters of what a page cost on the heap. It was never read as a name: every lookup goes
+/// through a ref this map handed out, and a rewrite produces a different key while leaving one
+/// entry, so identity comes from the lookup rather than from key equality.
+///
+/// Serializes as the string map it always was. The key is rebuilt from the value, which carries
+/// every part of it, and the handle is recomputed from the page on load.
+///
+/// The handle is NOT free to choose: the lookup's refs hold handles and the lookup is written to
+/// disk, so a handle has to mean the same page in every process that reads the file. Assigning
+/// them from a counter compiled, round-tripped, and lost an object on the first reload.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(from = "BTreeMap<String, PageIndex>", into = "BTreeMap<String, PageIndex>")]
+pub(super) struct PageIndexMap {
+    by_key: BTreeMap<u64, PageIndex>,
+}
+
+impl PageIndexMap {
+    pub(super) fn get(&self, key: &u64) -> Option<&PageIndex> {
+        self.by_key.get(key)
+    }
+
+    pub(super) fn get_mut(&mut self, key: &u64) -> Option<&mut PageIndex> {
+        self.by_key.get_mut(key)
+    }
+
+    pub(super) fn remove(&mut self, key: &u64) -> Option<PageIndex> {
+        self.by_key.remove(key)
+    }
+
+    /// File a page and return the handle it is filed under.
+    /// Install a page and return its handle.
+    ///
+    /// A page with the same identity replaces the one already there rather than adding beside it,
+    /// which is what the rendered string key used to do by being the key.
+    pub(super) fn insert(&mut self, page: PageIndex) -> u64 {
+        let handle = page_index_handle(&page);
+        self.by_key.insert(handle, page);
+        handle
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.by_key.len()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.by_key.is_empty()
+    }
+
+    pub(super) fn iter(&self) -> std::collections::btree_map::Iter<'_, u64, PageIndex> {
+        self.by_key.iter()
+    }
+
+    pub(super) fn values(&self) -> std::collections::btree_map::Values<'_, u64, PageIndex> {
+        self.by_key.values()
+    }
+
+    pub(super) fn values_mut(&mut self) -> std::collections::btree_map::ValuesMut<'_, u64, PageIndex> {
+        self.by_key.values_mut()
+    }
+
+    pub(super) fn retain(&mut self, mut keep: impl FnMut(&u64, &mut PageIndex) -> bool) {
+        self.by_key.retain(|key, page| keep(key, page));
+    }
+}
+
+impl<'a> IntoIterator for &'a PageIndexMap {
+    type Item = (&'a u64, &'a PageIndex);
+    type IntoIter = std::collections::btree_map::Iter<'a, u64, PageIndex>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.by_key.iter()
+    }
+}
+
+/// Collecting pages assigns handles, the same as inserting them one at a time.
+impl FromIterator<PageIndex> for PageIndexMap {
+    fn from_iter<I: IntoIterator<Item = PageIndex>>(pages: I) -> Self {
+        let mut map = Self::default();
+        for page in pages {
+            map.insert(page);
+        }
+        map
+    }
+}
+
+impl From<BTreeMap<String, PageIndex>> for PageIndexMap {
+    fn from(flat: BTreeMap<String, PageIndex>) -> Self {
+        // The handle is recomputed from the page, not read from the file and not assigned by a
+        // counter. A counter would hand out different handles than the ones the lookup refs were
+        // written with, and those refs are on disk too.
+        let mut by_key = BTreeMap::new();
+        for (_written_key, page) in flat {
+            by_key.insert(page_index_handle(&page), page);
+        }
+        Self { by_key }
+    }
+}
+
+impl From<PageIndexMap> for BTreeMap<String, PageIndex> {
+    fn from(map: PageIndexMap) -> Self {
+        map.by_key
+            .into_values()
+            .map(|page| (page_index_written_key(&page), page))
+            .collect()
+    }
+}
+
+/// The key this map writes, rebuilt from the page it is stored against.
+///
+/// The same spelling the map used to hold, so a dump written now reads the same as one written
+/// before. Shared with the replay log so the two cannot drift.
+/// The in-memory handle for a page: its identity, hashed.
+///
+/// Derived rather than assigned, because handles are written to disk inside the lookup's refs.
+/// Two processes holding the same page must compute the same handle or those refs point at
+/// nothing -- which is what a counter did, silently, until a reload lost an object.
+///
+/// Hashes exactly the fields [`page_index_written_key`] renders, so the handle and the written
+/// key always name the same page. Equal identity therefore lands on one slot, which is also how
+/// this map keeps a rewrite from accumulating a second entry for the same page.
+pub(super) fn page_index_handle(page: &PageIndex) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    page.model_id.hash(&mut hasher);
+    page.object_key.hash(&mut hasher);
+    page.component.as_deref().hash(&mut hasher);
+    page.address.page_slab_id.hash(&mut hasher);
+    page.address.offset.hash(&mut hasher);
+    page.address.length.hash(&mut hasher);
+    page.address.page_id().unwrap_or_default().hash(&mut hasher);
+    page.address.generation().unwrap_or_default().hash(&mut hasher);
+    hasher.finish()
+}
+
+pub(super) fn page_index_written_key(page: &PageIndex) -> String {
+    crate::index_log::page_ref_key_from_parts(
+        &page.model_id,
+        &page.object_key,
+        page.component.as_deref(),
+        page.address.page_slab_id,
+        page.address.offset,
+        page.address.length,
+        page.address.page_id().unwrap_or_default(),
+        page.address.generation().unwrap_or_default(),
+    )
+}
 /// One entry per OBJECT, with its components nested inside.
 ///
 /// This replaced two maps keyed by overlapping composites -- (model, object) and
@@ -641,7 +788,7 @@ impl From<PageRefs> for Vec<PageLookupRef> {
 pub(super) struct PageLookupRef {
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
-    pub(super) page_ref_key: Arc<str>,
+    pub(super) page_ref_key: u64,
 }
 
 /// Rust-native core index mirroring the shape:
@@ -714,7 +861,7 @@ impl CoreIndex {
             .iter()
             .flat_map(|(routing_bucket, bucket)| {
                 bucket.page_index.iter().map(move |(page_ref_key, page)| {
-                    (*routing_bucket, page_ref_key.clone(), page.clone())
+                    (*routing_bucket, *page_ref_key, page.clone())
                 })
             })
             .collect::<Vec<_>>();
@@ -723,12 +870,13 @@ impl CoreIndex {
         }
     }
 
-    /// Takes the key by shared pointer: both lookups clone the `Arc`, not the string, so the
-    /// three structures that point at a page hold one allocation between them.
+    /// Takes the handle the page index filed this page under, so the two cannot name different
+    /// things. It used to take the rendered key by shared pointer; the key is a number now and
+    /// costs nothing to copy.
     pub(super) fn insert_object_page_lookup(
         &mut self,
         routing_bucket: u32,
-        page_ref_key: Arc<str>,
+        page_ref_key: u64,
         page: &PageIndex,
     ) {
         if page.deleted {
@@ -975,7 +1123,7 @@ mod component_lookup_tests {
         for (i, component) in components.iter().enumerate() {
             index.insert_object_page_lookup(
                 i as u32,
-                Arc::from(format!("p{i}").as_str()),
+                i as u64,
                 &page(object, *component),
             );
         }
@@ -1037,11 +1185,11 @@ mod component_lookup_tests {
         for i in 0..3u32 {
             index.insert_object_page_lookup(
                 i,
-                Arc::from(format!("p{i}").as_str()),
+                i as u64,
                 &page("k", Some("dup")),
             );
         }
-        index.insert_object_page_lookup(9, Arc::from("p9"), &page("k", Some("keep")));
+        index.insert_object_page_lookup(9, 9, &page("k", Some("keep")));
         index.remove_object_page_lookup_entry("hash", "k", Some("dup"));
         assert_eq!(components_left(&index, "k"), vec![Some("keep".to_string())]);
     }

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -901,14 +901,6 @@ pub(super) fn rebuild_bucket_page_ownership(
             });
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            Arc::from(format!(
-                "{}:{}:{}:{}:{}",
-                entry.kind,
-                entry.object_key,
-                entry.component.clone().unwrap_or_default(),
-                entry.address.page_slab_id,
-                entry.address.offset
-            )),
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
@@ -1440,7 +1432,7 @@ pub(super) fn upsert_bucket_index_page_with(
             classify_bucket_layout_in_place(bucket);
         }
     }
-    let page_ref_key = page_index_ref_key(&entry);
+    let mut page_ref_key: u64 = 0;
     // Give the address the id the entry is filed under, so one field answers for both. Without
     // this, a page whose address arrived without an object id would lose the fallback identity
     // computed for it.
@@ -1473,8 +1465,8 @@ pub(super) fn upsert_bucket_index_page_with(
         }
         bucket.in_memory = true;
         bucket.object_index.insert(object_id);
-        bucket.page_index
-            .insert(page_ref_key.clone(), page_index.clone());
+        // The handle the map assigns is what the lookup records, so the two cannot disagree.
+        page_ref_key = bucket.page_index.insert(page_index.clone());
         classify_bucket_layout_in_place(bucket);
         touched_buckets.push(routing_bucket);
     }
@@ -1614,7 +1606,7 @@ pub(super) fn sync_bucket_index_object_pages(
         bucket.in_memory = true;
         bucket.object_index.insert(object_id);
         bucket.deleted_object_index.remove(&object_id);
-        let page_ref_key = page_index_ref_key(&entry);
+        let mut page_ref_key: u64 = 0;
         let page = PageIndex {
             object_key: entry.object_key,
             model_id: entry.kind,
@@ -1628,7 +1620,8 @@ pub(super) fn sync_bucket_index_object_pages(
             deleted: entry.deleted,
             log_backed: entry.log_backed,
         };
-        bucket.page_index.insert(Arc::clone(&page_ref_key), page.clone());
+        // The map assigns the handle; the lookup records the same one.
+        let page_ref_key = bucket.page_index.insert(page.clone());
         update_bucket_layout(bucket);
         // The bucket borrow has to end before the lookup, which borrows the index itself.
         if !lookup_needs_establishing {
@@ -2001,7 +1994,6 @@ pub(super) fn rebuild_bucket_first_index(
         bucket.in_memory |= true;
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            page_index_ref_key(&entry),
             PageIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2373,7 +2373,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 },
             )]
             .into_iter()
-            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
+            .map(|(_key, page): (String, PageIndex)| page)
             .collect(),
             ..BucketNode::default()
         },
@@ -2414,7 +2414,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
-            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
+            .map(|(_key, page): (String, PageIndex)| page)
             .collect(),
             ..BucketNode::default()
         },
@@ -2454,7 +2454,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
-            .map(|(key, page): (String, PageIndex)| (std::sync::Arc::from(key), page))
+            .map(|(_key, page): (String, PageIndex)| page)
             .collect(),
             ..BucketNode::default()
         },

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4030,8 +4030,8 @@ fn single_page_components_are_held_inline() {
     );
 
     // The spilled arm has to keep working: sorted, deduplicated, and reporting what it added.
-    let first = PageLookupRef { routing_bucket: 7, page_ref_key: Arc::from("bbb") };
-    let second = PageLookupRef { routing_bucket: 7, page_ref_key: Arc::from("aaa") };
+    let first = PageLookupRef { routing_bucket: 7, page_ref_key: 2 };
+    let second = PageLookupRef { routing_bucket: 7, page_ref_key: 1 };
     let mut refs = PageRefs::One(first.clone());
     assert!(!refs.insert(first.clone()), "re-inserting the same ref adds nothing");
     assert_eq!(refs.len(), 1);
@@ -4055,7 +4055,7 @@ fn page_refs_serialize_as_a_sequence() {
 
     let single = PageRefs::One(PageLookupRef {
         routing_bucket: 3,
-        page_ref_key: Arc::from("page-a"),
+        page_ref_key: 1,
     });
     let json = serde_json::to_value(&single).unwrap();
     assert!(json.is_array(), "must encode as a sequence, got {json}");
@@ -4073,7 +4073,7 @@ fn page_refs_serialize_as_a_sequence() {
     let mut pair = single.clone();
     pair.insert(PageLookupRef {
         routing_bucket: 4,
-        page_ref_key: Arc::from("page-b"),
+        page_ref_key: 2,
     });
     let round_tripped: PageRefs = serde_json::from_value(serde_json::to_value(&pair).unwrap()).unwrap();
     assert_eq!(round_tripped, pair);
@@ -4580,6 +4580,173 @@ fn deleting_an_object_does_not_allocate_per_page_scanned() {
     );
 }
 
+/// What happens to the index when the same logical object is written twice.
+///
+/// Reported, not asserted into a particular answer: the point is to find out whether the map
+/// deduplicates by key collision or through the lookup, because that decides whether the key can
+/// become an opaque assigned id.
+#[test]
+fn rewriting_a_page_does_not_reuse_its_index_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let key = "rewritten-object";
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet { key: key.to_string(), value: vec![b'a'; 64] },
+    });
+    let after_first: Vec<String> = {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .flat_map(|bucket| bucket.page_index.iter())
+            .filter(|(_, page)| page.object_key.as_ref() == key)
+            .map(|(ref_key, _)| ref_key.to_string())
+            .collect()
+    };
+
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet { key: key.to_string(), value: vec![b'b'; 64] },
+    });
+    let after_second: Vec<String> = {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .flat_map(|bucket| bucket.page_index.iter())
+            .filter(|(_, page)| page.object_key.as_ref() == key)
+            .map(|(ref_key, _)| ref_key.to_string())
+            .collect()
+    };
+
+    assert_eq!(after_first.len(), 1, "the first write must produce exactly one entry");
+    println!(
+        "
+  rewriting one object:
+    entries after the first write   {}
+    entries after the second        {}
+    key reused?                     {}
+    first  key: {}
+    second key: {}
+",
+        after_first.len(),
+        after_second.len(),
+        after_second == after_first,
+        after_first.first().map(String::as_str).unwrap_or("-"),
+        after_second.first().map(String::as_str).unwrap_or("-"),
+    );
+
+    // The property that must hold either way: one live entry per object, however that is achieved.
+    assert_eq!(
+        after_second.len(),
+        1,
+        "a rewrite must leave one entry, not accumulate them"
+    );
+}
+
+/// The same page, installed twice, is one entry with one handle.
+///
+/// This is the property the rendered string key provided for free: it WAS the key, so installing
+/// a page whose identity already appeared replaced it. A handle from a counter compiles, dumps
+/// and reloads perfectly and still breaks this -- each install takes a fresh slot, so a rebuild
+/// accumulates entries and the object counts drift apart. Three tests caught that as a wrong
+/// number; this one states the reason.
+#[test]
+fn installing_the_same_page_twice_replaces_it() {
+    let page = || crate::engine::state::PageIndex {
+        object_key: Arc::from("twice".to_string()),
+        model_id: Arc::from("string".to_string()),
+        component: None,
+        address: BlockAddress::from_parts(1, 0, 4, Some(1), Some(30), Some(3), Some(1), None),
+        dirty: false,
+        deleted: false,
+        log_backed: true,
+    };
+
+    let mut map = crate::engine::state::PageIndexMap::default();
+    let first = map.insert(page());
+    let second = map.insert(page());
+
+    assert_eq!(first, second, "the same page must land on the same handle");
+    assert_eq!(map.len(), 1, "installing it twice must not add a second entry");
+
+    // A page differing in one identity field is a different page and keeps its own slot.
+    let mut moved = page();
+    moved.address = BlockAddress::from_parts(1, 64, 4, Some(1), Some(30), Some(3), Some(1), None);
+    let third = map.insert(moved);
+    assert_ne!(first, third, "a page at another offset is not the same page");
+    assert_eq!(map.len(), 2);
+}
+
+/// The page index is keyed by a number in memory and by the old string on disk.
+///
+/// This is what makes the numeric key an in-memory change rather than a format change. Asserted on
+/// the literal key rather than by round-tripping alone: a round trip through a consistently wrong
+/// spelling would pass, and an index written now has to be readable by something expecting the old
+/// one.
+#[test]
+fn the_page_index_still_writes_string_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet { key: "dumped".to_string(), value: vec![b'v'; 32] },
+    });
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let bucket = shard
+        .bucket_index
+        .bucket_map
+        .values()
+        .find(|bucket| !bucket.page_index.is_empty())
+        .expect("the write must produce a page");
+
+    // In memory: a handle, not text.
+    let (handle, page) = bucket.page_index.iter().next().expect("one page");
+    assert!(*handle > 0, "the map assigns a handle");
+
+    // On the wire: the same rendered key it always wrote, rebuilt from the page.
+    let json = serde_json::to_value(&bucket.page_index).unwrap();
+    let written = json.as_object().expect("the wire form is a map of string keys");
+    let expected = crate::engine::state::page_index_written_key(page);
+    assert!(
+        written.contains_key(&expected),
+        "the dump must carry the rendered key {expected:?}, got {:?}",
+        written.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        expected.contains("dumped"),
+        "and that key names the object: {expected}"
+    );
+
+    // And a document in that shape loads back, with handles assigned afresh.
+    let restored: crate::engine::state::PageIndexMap = serde_json::from_value(json).unwrap();
+    assert_eq!(restored.len(), bucket.page_index.len());
+    assert!(
+        restored.iter().all(|(handle, _)| *handle > 0),
+        "every loaded page gets a handle"
+    );
+}
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key
@@ -4911,9 +5078,9 @@ fn per_record_structure_census() {
         .bucket_map
         .values()
         .flat_map(|bucket| bucket.page_index.iter())
-        .map(|(ref_key, page)| {
-            ref_key.len()
-                + page.object_key.len()
+        .map(|(_handle, page)| {
+            // The key is an inline number now, not text on the heap.
+            page.object_key.len()
                 + page.model_id.len()
                 + page.component.as_ref().map_or(0, |name| name.len())
         })
@@ -4929,7 +5096,7 @@ fn per_record_structure_census() {
             object.len()
                 + entry
                     .all_refs()
-                    .map(|page_ref| page_ref.page_ref_key.len())
+                    .map(|_page_ref| 0usize)
                     .sum::<usize>()
         })
         .sum();
@@ -10671,16 +10838,16 @@ fn what_one_page_costs_to_index() {
     let mut object_key_bytes = 0usize;
     let mut shared_bytes = 0usize;
     for bucket in shard.bucket_index.bucket_map.values() {
-        for (ref_key, page) in bucket.page_index.iter() {
+        for (_handle, page) in bucket.page_index.iter() {
             entries += 1;
-            // The map key: kind, object key, component and five numbers rendered as decimal.
-            ref_key_bytes += ref_key.len();
+            // The map key is an inline number now, not a rendered string on the heap.
+            ref_key_bytes += 0;
             // Shared with the lookup, so one allocation answers for both holders.
             object_key_bytes += page.object_key.len();
             // One allocation across every page of that kind or component, not one per page.
             shared_bytes += page.model_id.len()
                 + page.component.as_ref().map_or(0, |name| name.len());
-            heap += ref_key.len() + page.object_key.len();
+            heap += page.object_key.len();
         }
     }
     assert!(entries > 0, "the workload must produce pages, or this measures nothing");

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -210,6 +210,33 @@ pub struct IndexDeltaRecord {
     pub key_states: Vec<serde_json::Value>,
 }
 
+/// The key a page is written under, from its parts.
+///
+/// One definition, called from the page index's serialization and from the replay log, so the two
+/// cannot drift into different spellings of the same page.
+pub fn page_ref_key_from_parts(
+    kind: &str,
+    object_key: &str,
+    component: Option<&str>,
+    page_slab_id: u64,
+    offset: u64,
+    length: u64,
+    page_id: u64,
+    generation: u64,
+) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}:{}:{}",
+        kind,
+        object_key,
+        component.unwrap_or(""),
+        page_slab_id,
+        offset,
+        length,
+        page_id,
+        generation
+    )
+}
+
 /// Fold an ordered stream of delta items onto a base map keyed by `(routing_bucket,
 /// page_ref_key)`. Later items win; a `deleted` tombstone removes the key. This is the
 /// pure replay step: `base` is the page-index projection of the base snapshot and the


### PR DESCRIPTION
Every page entry carried a key built by rendering its kind, object key,
component and five numbers as decimal text -- allocated once per page and
held for the life of the index. Nothing ever looked a page up by that
text: every lookup goes through a ref the map itself handed out, so the
key was an identity, and an identity can be a number.

The handle is derived from the page rather than assigned by a counter.
It has to be: a page's identity is what makes two installs of the same
page one entry, which the rendered string used to provide for free by
being the map key. Assigning handles compiled, dumped and reloaded
cleanly and still broke that -- each install took a fresh slot, so a
rebuild accumulated entries and an object went missing between a shard
and its reload. `page_index_handle` hashes exactly the fields
`page_index_written_key` renders, so the two cannot disagree about which
page they name.

The written form is unchanged: the map still serializes as a map of the
same string keys, rebuilt from the value it is stored against, so an
index written now still loads where one written before does.

**Per page, over 2000 pages: 181.6 B -> 136.0 B.**

### Tests

- `installing_the_same_page_twice_replaces_it` states the property the
  change rests on. It fails when `insert` allocates a handle instead of
  deriving one (verified by mutation, `left: 1, right: 2`).
- `the_page_index_still_writes_string_keys` asserts the dump carries the
  literal rendered key, not merely that it round-trips -- a round trip
  through a consistently wrong spelling would pass.

Full lib suite: 1554 passed. The one failure,
`http_raft_transport_...over_tcp`, is a pre-existing intermittent: over
12 interleaved trials of the same binary pair it failed 4/12 with this
change and 2/12 on an unmodified build of the same commit it targets.
