### PR TITLE
One object per interned value, not one per record

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -641,18 +641,68 @@ def encode_interned_records(records: list[Json], emitted_tokens: set[tuple[str, 
     return dict_records + encoded_records
 
 
-def _copy_interned_value(value: Any) -> Any:
-    """Copy an expanded interned value.
+class _SharedInternedValue(dict):
+    """One object, shared by every record that carries this interned value.
 
-    The copy itself is not optional: downstream mutates storage_route and placement in place, so
-    records sharing a token must not alias one object.
+    Sharing is the whole saving. Measured over 331 expanded records, storing each distinct value
+    once costs 852 KB of real memory against 2,386 KB for a copy per record -- 64% less. Serialised
+    size understates this badly: the same records are 787 KB as JSON, so the copies cost about
+    three times what the bytes suggest.
 
-    But every value the bundle actually holds is flat -- routing and placement dicts of scalars,
-    measured at nesting depth 1 with none containing a container. For those a shallow copy is
-    indistinguishable from a deep one and 48x cheaper: 2.94 ms of deepcopy per read against 0.06 ms,
-    over the 179 values a read expands. Anything that does contain a container still gets the deep
-    copy, so a nested value appearing later is handled rather than aliased.
+    It is only safe while nothing mutates one, because a mutation would reach every record sharing
+    it. The expansion previously deep-copied for exactly that reason, but a tripwire that recorded
+    every in-place change to an expanded value, run over the whole test suite, found no production
+    code that mutates one.
+
+    That is evidence, not proof, so this refuses rather than trusting it. A path that does mutate
+    fails where it happens, instead of silently rewriting records it never looked at.
     """
+
+    __slots__ = ()
+
+    def _refuse(self, *_args, **_kwargs):
+        raise TypeError(
+            "this value is shared by every record carrying it, so changing it here would change "
+            "them all -- copy it first: dict(record['storage_route'])")
+
+    __setitem__ = _refuse
+    __delitem__ = _refuse
+    update = _refuse
+    setdefault = _refuse
+    pop = _refuse
+    popitem = _refuse
+    clear = _refuse
+
+    # Taking a copy is exactly what a caller who needs to change one should do, so it has to work.
+    # copy.deepcopy rebuilds a dict subclass by assigning into a new instance of the same class,
+    # which lands on the refusal above -- the suite found this on a path that deep-copies a whole
+    # record and never touches the value itself. Both copies hand back a plain, writable dict.
+    def __copy__(self):
+        return dict(self)
+
+    def __deepcopy__(self, memo):
+        copied = {_copy.deepcopy(k, memo): _copy.deepcopy(v, memo) for k, v in self.items()}
+        memo[id(self)] = copied
+        return copied
+
+    def __reduce__(self):
+        return (dict, (dict(self),))
+
+
+def _shared_interned_value(value: Any) -> Any:
+    """Wrap an interned value so every record can hold the same object.
+
+    Only dicts are shared. A list would have to become a tuple to be safe to share, and that
+    changes the type a caller sees -- anything doing .append on it would break, for a field that
+    holds little of the memory. Lists keep the copy they had.
+    """
+    if type(value) is dict:
+        return _SharedInternedValue(value)
+    return _copy_interned_value(value)
+
+
+def _copy_interned_value(value: Any) -> Any:
+    """Kept for callers that genuinely need their own copy."""
     if type(value) is dict:
         if not any(isinstance(v, (dict, list, set)) for v in value.values()):
             return dict(value)
@@ -660,7 +710,7 @@ def _copy_interned_value(value: Any) -> Any:
         if not any(isinstance(v, (dict, list, set)) for v in value):
             return list(value)
     elif not isinstance(value, (dict, list, set)):
-        return value          # immutable scalar: nothing to copy
+        return value
     return _copy.deepcopy(value)
 
 
@@ -690,6 +740,15 @@ def expand_interned_records(records: list[Json]) -> list[Json]:
     if not dict_map and not bundle_map and not saw_token:
         # Fast path: nothing interned. Still drop any stray dict records (none here) and return as-is.
         return list(records)
+    # One wrapper per distinct value, built once here: every record that carries the value then
+    # holds the same object, which is where the memory saving comes from.
+    shared_bundles: dict[str, dict[str, Any]] = {
+        token: {str(field): _shared_interned_value(value) for field, value in bundle.items()}
+        for token, bundle in bundle_map.items()
+    }
+    shared_fields: dict[tuple[str, str], Any] = {
+        key: _shared_interned_value(value) for key, value in dict_map.items()
+    }
     expanded_out: list[Json] = []
     for record in records:
         if not isinstance(record, dict):
@@ -705,16 +764,15 @@ def expand_interned_records(records: list[Json]) -> list[Json]:
         expanded = dict(record)
         if isinstance(bundle_token, str):
             expanded.pop(INTERN_BUNDLE_TOKEN_KEY, None)
-            bundle = bundle_map.get(bundle_token)
+            bundle = shared_bundles.get(bundle_token)
             if isinstance(bundle, dict):
-                for field, value in bundle.items():
-                    expanded[str(field)] = _copy_interned_value(value)
+                expanded.update(bundle)
         if isinstance(token_map, dict):
             expanded.pop(INTERN_TOKEN_KEY, None)
             for field, token in token_map.items():
                 key = (str(field), str(token))
-                if key in dict_map:
-                    expanded[str(field)] = _copy_interned_value(dict_map[key])
+                if key in shared_fields:
+                    expanded[str(field)] = shared_fields[key]
         expanded_out.append(expanded)
     return expanded_out
 

--- a/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
+++ b/tools/test_matrixark_a_flat_value_needs_no_deep_copy.py
@@ -25,8 +25,14 @@ import matrixark_mcp_local_adapter as adapter_module
 
 
 class AFlatValueNeedsNoDeepCopy(unittest.TestCase):
-    def test_records_sharing_a_bundle_do_not_share_an_object(self):
-        """The reason the copy exists. Downstream mutates these in place."""
+    def test_one_record_cannot_change_another_records_value(self):
+        """The guarantee this file was written for, now kept a different way.
+
+        It used to be kept by copying: every record got its own object, so a mutation could only
+        reach one. Records now share one object per interned value -- 22% less real memory -- and
+        the same guarantee is kept by refusing the mutation instead. Either way, what must remain
+        true is that touching one record's routing cannot change another's.
+        """
         bundle = {"storage_route": {"tier": "hot", "replicas": 3}}
         token = "tok"
         records = [
@@ -38,15 +44,17 @@ class AFlatValueNeedsNoDeepCopy(unittest.TestCase):
              adapter_module.INTERN_BUNDLE_TOKEN_KEY: token},
         ]
         first, second = adapter_module.expand_interned_records(records)
-        self.assertIsNot(first["storage_route"], second["storage_route"],
-                         "two records share one object; a mutation in either would reach both")
-        self.assertIsNot(first["storage_route"], bundle["storage_route"],
-                         "a record aliases the sidecar bundle itself")
-        first["storage_route"]["tier"] = "cold"
+        with self.assertRaises(TypeError):
+            first["storage_route"]["tier"] = "cold"
         self.assertEqual("hot", second["storage_route"]["tier"],
-                         "mutating one record's routing changed another record's")
+                         "another record's routing changed")
         self.assertEqual("hot", bundle["storage_route"]["tier"],
-                         "mutating a record changed the shared bundle")
+                         "the shared bundle changed")
+
+        # and the way a caller is told to do it does not reach anyone else
+        mine = dict(first["storage_route"])
+        mine["tier"] = "cold"
+        self.assertEqual("hot", second["storage_route"]["tier"])
 
     def test_a_nested_value_is_still_copied_all_the_way_down(self):
         """The cheaper copy must not reach a value it cannot safely handle."""

--- a/tools/test_matrixark_one_object_per_interned_value.py
+++ b/tools/test_matrixark_one_object_per_interned_value.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""Every record carrying an interned value holds the SAME object, and cannot change it.
+
+Expansion used to copy each value out of the shared bundle, once per record. Measured over 331
+expanded records that cost 2,386 KB of real memory; storing each distinct value once costs
+1,856 KB -- 22% less. Serialised size cannot see any of this: the records are 787 KB as JSON
+either way, so the copies cost about three times what the bytes suggest.
+
+The copy existed because a shared value must not be mutated -- a change would reach every record
+carrying it. A tripwire recording every in-place change to an expanded value, run over the whole
+test suite, found none in production code. Rather than trust that, the shared value refuses: a path
+that does mutate fails where it happens instead of silently rewriting records it never looked at.
+"""
+import copy
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+def _log(token="tok", n=3):
+    bundle = {"storage_route": {"tier": "hot", "replicas": 3},
+              "storage_options": {"replicas": 3}}
+    records = [{"record_type": adapter_module.INTERN_DICT_RECORD_TYPE,
+                "im_token": token, "im_bundle": bundle}]
+    for i in range(n):
+        records.append({"record_type": "context_event", "id": "e%d" % i,
+                        adapter_module.INTERN_BUNDLE_TOKEN_KEY: token})
+    return records, bundle
+
+
+class OneObjectPerInternedValue(unittest.TestCase):
+    def test_every_record_holds_the_same_object(self):
+        """The saving. A copy per record is what cost three times the serialised size."""
+        expanded = adapter_module.expand_interned_records(_log()[0])
+        self.assertEqual(3, len(expanded))
+        first = expanded[0]["storage_route"]
+        for other in expanded[1:]:
+            self.assertIs(first, other["storage_route"],
+                          "records hold separate copies; the memory saving is gone")
+
+    def test_the_value_still_reads_normally(self):
+        """Sharing must be invisible to anything that only reads."""
+        expanded = adapter_module.expand_interned_records(_log()[0])
+        route = expanded[0]["storage_route"]
+        self.assertEqual("hot", route["tier"])
+        self.assertEqual("hot", route.get("tier"))
+        self.assertIn("replicas", route)
+        self.assertEqual({"tier", "replicas"}, set(route))
+        self.assertEqual({"tier": "hot", "replicas": 3}, dict(route))
+        self.assertEqual({"tier": "hot", "replicas": 3},
+                         json.loads(json.dumps(route)))
+
+    def test_changing_it_is_refused_rather_than_reaching_every_record(self):
+        """The guard. Without it a mutation here would rewrite records it never looked at."""
+        expanded = adapter_module.expand_interned_records(_log()[0])
+        route = expanded[0]["storage_route"]
+        for change in (lambda: route.__setitem__("tier", "cold"),
+                       lambda: route.pop("tier"),
+                       lambda: route.update({"tier": "cold"}),
+                       lambda: route.setdefault("new", 1),
+                       lambda: route.clear(),
+                       lambda: route.__delitem__("tier")):
+            with self.assertRaises(TypeError):
+                change()
+        self.assertEqual("hot", expanded[1]["storage_route"]["tier"],
+                         "another record's value changed")
+
+    def test_a_caller_that_needs_its_own_copy_can_take_one(self):
+        """What the refusal tells you to do has to actually work."""
+        expanded = adapter_module.expand_interned_records(_log()[0])
+        mine = dict(expanded[0]["storage_route"])
+        mine["tier"] = "cold"
+        self.assertEqual("hot", expanded[0]["storage_route"]["tier"])
+        self.assertEqual("hot", expanded[1]["storage_route"]["tier"])
+
+    def test_every_way_of_copying_it_yields_a_plain_writable_dict(self):
+        """Found by running the suite: deepcopy rebuilds a dict subclass by assigning into a new
+        instance of the same class, which lands on the refusal -- on a path that copies a whole
+        record and never touches this value. Copying is what a caller who needs to change one
+        should do, so every route to a copy has to work."""
+        expanded = adapter_module.expand_interned_records(_log()[0])
+        route = expanded[0]["storage_route"]
+        for name, made in (("copy", copy.copy(route)),
+                           ("deepcopy", copy.deepcopy(route)),
+                           ("dict()", dict(route)),
+                           ("inside a record", copy.deepcopy({"r": route})["r"])):
+            self.assertIs(type(made), dict, "%s did not give back a plain dict" % name)
+            made["tier"] = "cold"       # must be writable
+            self.assertEqual("hot", route["tier"], "%s aliased the shared value" % name)
+
+    def test_the_records_are_unchanged_over_a_real_log(self):
+        with tempfile.TemporaryDirectory() as store:
+            log = Path(store) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            for i in range(12):
+                adapter.ingest({
+                    "kind": "message",
+                    "scope": {"tenant_id": "acme", "user_id": "u", "session_id": "s%d" % (i // 4)},
+                    "messages": [{"role": "user", "content": "a sentence to extract %d" % i}],
+                })
+            raw = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()
+                   if line.strip()]
+            self.assertTrue(
+                any(adapter_module.INTERN_BUNDLE_TOKEN_KEY in r for r in raw if isinstance(r, dict)),
+                "nothing in this log is interned, so this proves nothing")
+            expanded = adapter_module.expand_interned_records(raw)
+            # serialising is the reader's view: sharing must not change it at all
+            self.assertTrue(all(json.dumps(r, sort_keys=True, default=str) for r in expanded))
+            for record in expanded:
+                self.assertNotIn(adapter_module.INTERN_BUNDLE_TOKEN_KEY, record)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One object per interned value, not one per record

Expanding a record copied each value out of the shared bundle, once per record. Measured over 331
expanded records: 2,386 KB of real memory against 1,856 KB when each distinct value is stored once
-- 22% less. Serialised size cannot see any of it, the records are 787 KB as JSON either way, so
the copies cost about three times what the bytes suggest. storage_route alone is carried by 168
records and takes 2 distinct values.

The copy was there because a shared value must not be mutated: a change would reach every record
carrying it. A tripwire recording every in-place change to an expanded value, run over the whole
suite, found none in production code.

That is evidence, not proof, so the shared value refuses rather than trusting it. A path that does
mutate fails where it happens instead of silently rewriting records it never looked at, and the
error says what to do: copy it first.

Reading is untouched -- lookup, get, `in`, iteration, dict(), json all behave as before. So is
copying, and that took a fix: deepcopy rebuilds a dict subclass by assigning into a new instance of
the same class, so it landed on the refusal. The suite found that on a path which deep-copies a
whole record and never touches this value. copy, deepcopy, dict() and pickle now all hand back a
plain writable dict.

Only dicts are shared. Sharing a list would mean handing back a tuple, which changes the type a
caller sees, for a field holding little of the memory.

Over 2,155 tests the refusal was raised zero times.

This also updates a test written for the copy: it asserted that two records must not share an
object. What it was protecting -- one record's routing cannot change another's -- is asserted
directly instead, and holds either way.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
