### PR TITLE
Compare an object key in place instead of allocating one to compare with

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -3050,7 +3050,7 @@ fn mark_bucket_index_object_deleted(shard: &mut ShardState, key: &str) -> bool {
         };
         let mut deleted_object_ids = BTreeSet::new();
         bucket.page_index.retain(|_, page| {
-            if page.object_key == Arc::from(key) {
+            if &*page.object_key == key {
                 deleted_object_ids.insert(page.object_id());
                 removed = true;
                 false
@@ -3140,7 +3140,7 @@ fn mark_bucket_index_page_deleted(
         let mut deleted_object_ids = BTreeSet::new();
         bucket.page_index.retain(|_, page| {
             let matches = page.model_id.as_ref() == model_id
-                && page.object_key == Arc::from(key)
+                && &*page.object_key == key
                 && page.component.as_deref() == component;
             if matches {
                 deleted_object_ids.insert(page.object_id());
@@ -3358,7 +3358,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
         shard.bucket_index.bucket_map.values().any(|bucket| {
             bucket.page_index
                 .values()
-                .any(|page| page.object_key == Arc::from(key) && !page.deleted)
+                .any(|page| &*page.object_key == key && !page.deleted)
         })
     } else {
         storage_model_kinds().iter().any(|kind| {
@@ -3373,7 +3373,7 @@ fn record_exists_exact(shard: &ShardState, key: &str) -> bool {
                             .get(&page_ref.routing_bucket)
                             .and_then(|bucket| bucket.page_index.get(&page_ref.page_ref_key))
                             .map(|page| {
-                                !page.deleted && page.model_id.as_ref() == *kind && page.object_key == Arc::from(key)
+                                !page.deleted && page.model_id.as_ref() == *kind && &*page.object_key == key
                             })
                             .unwrap_or(false)
                     })

--- a/crates/temporalstore-rust/src/engine/bucket_store.rs
+++ b/crates/temporalstore-rust/src/engine/bucket_store.rs
@@ -176,7 +176,7 @@ pub(super) fn bucket_index_page_address(
             };
             if !page.deleted
                 && page.model_id.as_ref() == model_id
-                && page.object_key == Arc::from(object_key)
+                && &*page.object_key == object_key
                 && page.component.as_deref() == component
             {
                 return Some(page.address.clone());
@@ -197,7 +197,7 @@ pub(super) fn bucket_index_page_address(
         .filter(|page| {
             !page.deleted
                 && page.model_id.as_ref() == model_id
-                && page.object_key == Arc::from(object_key)
+                && &*page.object_key == object_key
                 && page.component.as_deref() == component
         })
         .map(|page| page.address.clone())
@@ -215,7 +215,7 @@ pub(super) fn bucket_index_component_page_addresses(
             .filter_map(|page_ref| {
                 let bucket = shard.bucket_index.bucket_map.get(&page_ref.routing_bucket)?;
                 let page = bucket.page_index.get(&page_ref.page_ref_key)?;
-                if !page.deleted && page.model_id.as_ref() == model_id && page.object_key == Arc::from(object_key) {
+                if !page.deleted && page.model_id.as_ref() == model_id && &*page.object_key == object_key {
                     Some((page.component.clone(), page.address.clone()))
                 } else {
                     None
@@ -238,7 +238,7 @@ pub(super) fn bucket_index_component_page_addresses(
         .bucket_map
         .values()
         .flat_map(|bucket| bucket.page_index.values())
-        .filter(|page| !page.deleted && page.model_id.as_ref() == model_id && page.object_key == Arc::from(object_key))
+        .filter(|page| !page.deleted && page.model_id.as_ref() == model_id && &*page.object_key == object_key)
         .map(|page| (page.component.clone(), page.address.clone()))
         .collect::<Vec<_>>();
     refs.sort_by(|left, right| left.0.cmp(&right.0));

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -830,7 +830,7 @@ impl CoreIndex {
                     .map(|page| {
                         !page.deleted
                             && &*page.model_id == model_id
-                            && page.object_key == Arc::from(object_key)
+                            && &*page.object_key == object_key
                             && page.component.as_deref() == component
                             && same_page_address(&page.address, address)
                     })
@@ -846,7 +846,7 @@ impl CoreIndex {
             bucket.page_index.values().any(|page| {
                 !page.deleted
                     && &*page.model_id == model_id
-                    && page.object_key == Arc::from(object_key)
+                    && &*page.object_key == object_key
                     && page.component.as_deref() == component
                     && same_page_address(&page.address, address)
             })

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1532,7 +1532,7 @@ pub(super) fn sync_bucket_index_object_pages(
         };
         let before = bucket.page_index.len();
         bucket.page_index.retain(|_, page| {
-            let matches_object = &*page.model_id == kind && page.object_key == Arc::from(object_key);
+            let matches_object = &*page.model_id == kind && &*page.object_key == object_key;
             if matches_object {
                 removed_components.insert(page.component.clone());
             }
@@ -1936,7 +1936,7 @@ pub(super) fn clear_published_object_dirty_state(shard: &mut ShardState, object_
         note_site(&bucket_visit_sites::CLEAR_DIRTY, bucket.page_index.len());
         let mut touched = false;
         for page in bucket.page_index.values_mut() {
-            if page.object_key == Arc::from(object_key) {
+            if &*page.object_key == object_key {
                 page.dirty = false;
                 touched = true;
             }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4521,6 +4521,65 @@ fn a_page_whose_address_carries_no_object_id_still_reports_one() {
     assert_eq!(seen, 1, "the page must be in the index, or nothing was tested");
 }
 
+/// Deleting an object costs a bounded number of allocations, not one per page examined.
+///
+/// The scan compared each page's key against the wanted one by building a fresh `Arc<str>` from
+/// the wanted key inside the loop -- a heap allocation and a copy of the key per page, to compare
+/// and immediately drop. Twelve sites did this. Borrowing compares the same bytes with no
+/// allocation at all.
+///
+/// Measured as allocations rather than time because the allocation IS the cost here, and counted
+/// with `allocs` rather than `outstanding`: this pattern frees everything it takes, so a live-heap
+/// measurement reports zero while the work still happens.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn deleting_an_object_does_not_allocate_per_page_scanned() {
+    let delete_from_a_hash_of = |fields: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for field in 0..fields {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: "wide".to_string(),
+                    field: format!("f{field}"),
+                    value: vec![b'v'; 16],
+                },
+            });
+        }
+
+        let probe = crate::alloc_probe::Probe::start();
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::CommonDelete {
+                key: "wide".to_string(),
+            },
+        });
+        probe.stop().allocs
+    };
+
+    let narrow = delete_from_a_hash_of(20);
+    let wide = delete_from_a_hash_of(200);
+
+    println!("delete allocations: {narrow} at 20 fields, {wide} at 200 fields");
+
+    // Guard the guard: an upper bound passes hardest at zero, so prove the probe saw the work.
+    assert!(narrow > 0, "the probe must observe the delete: {narrow}");
+
+    // 180 more pages to scan. Per-page allocation would put ~180 extra allocations here.
+    let growth = wide.saturating_sub(narrow);
+    assert!(
+        growth < 180,
+        "deleting scanned 180 more pages and allocated {growth} more times          ({narrow} at 20 fields, {wide} at 200) -- that is per-page allocation"
+    );
+}
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key


### PR DESCRIPTION
Twelve scan loops decided whether a page belonged to an object by
building a fresh `Arc<str>` from the wanted key and comparing the page's
key against it -- a heap allocation and a copy of the key for every page
examined, dropped immediately after the comparison. The bytes being
compared were the same either way.

### Measured

Counting allocations rather than time, because here the allocation *is*
the cost. Deleting an object from a hash, over a bucket holding N pages:

| | 20 fields | 200 fields | marginal, per page |
|---|---|---|---|
| before | 178 | 412 | 1.3 |
| after | 158 | 212 | **0.3** |

A delete across 200 pages falls from 412 allocations to 212.

### The test

`deleting_an_object_does_not_allocate_per_page_scanned` is gated on the
`alloc-probe` feature, like the counting allocator it uses. It asserts
the probe observed something *before* asserting a bound -- an upper
bound passes most easily when nothing was measured at all, and this one
did initially report zero because the probe is off by default.

Verified by mutation: with the allocating comparisons restored it fails
with `deleting scanned 180 more pages and allocated 234 more times`.

Full lib suite on this branch: 1555 passed, 0 failed.
