### PR TITLE
Write the page index without copying it or building its keys twice

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -333,8 +333,8 @@ pub(super) type ObjectIndex = BTreeSet<u64>;
 /// The handle is NOT free to choose: the lookup's refs hold handles and the lookup is written to
 /// disk, so a handle has to mean the same page in every process that reads the file. Assigning
 /// them from a counter compiled, round-tripped, and lost an object on the first reload.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(from = "BTreeMap<String, PageIndex>", into = "BTreeMap<String, PageIndex>")]
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(from = "BTreeMap<String, PageIndex>")]
 pub(super) struct PageIndexMap {
     by_key: BTreeMap<u64, PageIndex>,
 }
@@ -420,12 +420,34 @@ impl From<BTreeMap<String, PageIndex>> for PageIndexMap {
     }
 }
 
-impl From<PageIndexMap> for BTreeMap<String, PageIndex> {
-    fn from(map: PageIndexMap) -> Self {
-        map.by_key
-            .into_values()
-            .map(|page| (page_index_written_key(&page), page))
-            .collect()
+impl Serialize for PageIndexMap {
+    /// Writes the same map of rendered keys, in the same order, without copying the index first.
+    ///
+    /// Hand-written rather than `#[serde(into = ...)]`, which is defined as
+    /// `T::from(self.clone()).serialize(..)`: that duplicates the whole index twice over -- once
+    /// cloning it, once building the converted map -- before a byte is written.
+    ///
+    /// The sort is not incidental. The map this used to convert into was keyed by the rendered
+    /// string, so it emitted entries in string order; this map is keyed by a handle and iterates
+    /// in hash order. Writing them as they come would reorder every dump, which is a change to
+    /// the bytes on disk rather than to how they are produced.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut entries: Vec<(String, &PageIndex)> = self
+            .by_key
+            .values()
+            .map(|page| (page_index_written_key(page), page))
+            .collect();
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (key, page) in &entries {
+            map.serialize_entry(key, page)?;
+        }
+        map.end()
     }
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4690,6 +4690,118 @@ fn installing_the_same_page_twice_replaces_it() {
     assert_eq!(map.len(), 2);
 }
 
+/// Writing the page index does not build a second copy of it first.
+///
+/// `#[serde(into = "...")]` is defined as `T::from(self.clone()).serialize(..)`, so it duplicates
+/// the whole map -- once for the clone, once for the converted map -- before a byte is written.
+/// The `Arc`s inside are refcount bumps rather than allocations, so what this actually counts is
+/// the duplicated map structure, which is why it is measured rather than asserted.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn dumping_the_page_index_does_not_copy_it_first() {
+    let dump_a_shard_of = |pages: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for field in 0..pages {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: "dumped".to_string(),
+                    field: format!("f{field}"),
+                    value: vec![b'v'; 16],
+                },
+            });
+        }
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let bucket = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .find(|b| !b.page_index.is_empty())
+            .expect("the writes must produce pages");
+
+        let probe = crate::alloc_probe::Probe::start();
+        let json = serde_json::to_string(&bucket.page_index).expect("the index serializes");
+        let counts = probe.stop();
+        assert!(!json.is_empty());
+        counts.allocs
+    };
+
+    let small = dump_a_shard_of(20);
+    let large = dump_a_shard_of(200);
+    println!("dump allocations: {small} at 20 pages, {large} at 200 pages");
+
+    // An upper bound passes most easily when nothing was measured, so prove the probe saw work.
+    assert!(small > 0, "the probe must observe the dump: {small}");
+
+    // Writing a page costs its key and little else. Copying the index first, or building that key
+    // with `format!` (which allocates its own buffer and then allocates again to return it), put
+    // this near four.
+    let per_page = (large.saturating_sub(small)) as f64 / 180.0;
+    assert!(
+        per_page < 2.0,
+        "dumping cost {per_page:.2} allocations per page ({small} at 20, {large} at 200)"
+    );
+}
+
+/// The dump lists pages in written-key order.
+///
+/// Worth pinning because the in-memory key stopped being the written one. The index used to be
+/// serialized by converting it into a map keyed by the rendered string, which emitted entries in
+/// string order for free. This map is keyed by a handle and iterates in hash order, so anything
+/// writing it has to restore that order deliberately -- otherwise the bytes on disk change even
+/// though every entry is still present and correct.
+#[test]
+fn the_page_index_dump_is_ordered_by_its_written_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for field in 0..24 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: "ordered".to_string(),
+                field: format!("f{field:02}"),
+                value: vec![b'v'; 16],
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let bucket = shard
+        .bucket_index
+        .bucket_map
+        .values()
+        .find(|b| b.page_index.len() > 4)
+        .expect("the writes must produce several pages in one bucket");
+
+    let json = serde_json::to_string(&bucket.page_index).expect("the index serializes");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let keys: Vec<&String> = value
+        .as_object()
+        .expect("a map of rendered keys")
+        .keys()
+        .collect();
+
+    assert!(keys.len() > 4, "need several keys to see an order: {keys:?}");
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "the dump must be ordered by written key");
+}
+
 /// The page index is keyed by a number in memory and by the old string on disk.
 ///
 /// This is what makes the numeric key an in-memory change rather than a format change. Asserted on

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -302,17 +302,24 @@ pub fn page_ref_key_from_parts(
     page_id: u64,
     generation: u64,
 ) -> String {
-    format!(
-        "{}:{}:{}:{}:{}:{}:{}:{}",
-        kind,
-        object_key,
-        component.unwrap_or(""),
-        page_slab_id,
-        offset,
-        length,
-        page_id,
-        generation
-    )
+    // Built into one buffer rather than with `format!`, which allocates its own and then
+    // allocates again to hand back a String. This runs once per page on every dump of the index,
+    // where it was the largest single source of allocations.
+    use std::fmt::Write as _;
+    let component = component.unwrap_or("");
+    // Five u64 at their widest, plus the seven separators.
+    let mut key = String::with_capacity(kind.len() + object_key.len() + component.len() + 7 + 100);
+    key.push_str(kind);
+    key.push(':');
+    key.push_str(object_key);
+    key.push(':');
+    key.push_str(component);
+    // `write!` into a String appends in place; it does not allocate.
+    let _ = write!(
+        key,
+        ":{page_slab_id}:{offset}:{length}:{page_id}:{generation}"
+    );
+    key
 }
 
 /// Fold an ordered stream of delta items onto a base map keyed by `(routing_bucket,


### PR DESCRIPTION
Dumping the index cost 3.9 allocations per page. Two causes, both in the
writing rather than in what was written.

**The map was copied before it was written.** It was serialized with
`#[serde(into = "...")]`, which is defined as
`T::from(self.clone()).serialize(..)`: that duplicates the whole index
twice over -- once cloning it, once building the converted map -- before
a byte comes out. It is now written in place.

**Each key was built twice.** `format!` allocates a buffer and then
allocates again to return a `String`. One page's key is now one buffer,
appended to with `write!`, which does not allocate.

| dump of 200 pages | allocations | per page |
|---|---|---|
| before | 780 | 3.9 |
| after | **212** | **1.0** |

Worth noting which half mattered: removing the copy alone took 780 to
731. The key building was the rest. I expected the opposite, which is
why both are measured rather than argued.

### Output is unchanged, including its order

Not automatic. The map this used to convert into was keyed by the
rendered string, so it emitted entries in string order; this map is
keyed by a handle and iterates in hash order. Writing entries as they
come would have reordered every dump on disk while leaving all of them
present and correct. The writer sorts, and
`the_page_index_dump_is_ordered_by_its_written_key` pins it.

### Verification

`dumping_the_page_index_does_not_copy_it_first` asserts the probe
observed work before asserting a bound, then bounds the per-page cost.
Restoring `format!` fails it at 3.68 per page.

Full lib suite: 1578 passed, 0 failed.
