### PR TITLE
Check for expiry without allocating four keys to look up

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2983,16 +2983,47 @@ fn remove_if_expired(shard: &mut ShardState, key: &str) -> bool {
     // restart clock here would let a key that was live at leader-time (and thus took the
     // "exists" branch of a logged conditional write) appear expired on recovery, silently
     // dropping a durably-committed write and diverging the recovered state from the leader.
+    // Nothing can have expired if nothing has an expiry. Checked before anything else because
+    // this runs on every command -- 51 call sites -- and the walk below used to build four owned
+    // keys, one of them with `format!`, purely to look them up and drop them again.
+    if shard.expires_at_ms.is_empty() {
+        return false;
+    }
+
     let now = resolve_now_ms();
     let mut removed = false;
-    for record_key in associated_record_keys(key) {
-        if shard
+
+    let expired = |shard: &ShardState, candidate: &str, now: u64| {
+        shard
             .expires_at_ms
-            .get(&record_key)
-            .map(|expires_at| *expires_at <= now)
-            .unwrap_or(false)
-        {
-            removed |= delete_record_exact(shard, &record_key);
+            .get(candidate)
+            .is_some_and(|expires_at| *expires_at <= now)
+    };
+
+    // The key as given. `BTreeMap<String, _>` looks up by `&str`, so this needs no owned copy.
+    if expired(shard, key, now) {
+        removed |= delete_record_exact(shard, key);
+    }
+
+    if key.starts_with("control_state:") {
+        return removed;
+    }
+
+    // The control-state families. Built into one buffer that is rewritten per family rather than
+    // a fresh `String` apiece.
+    let mut candidate = String::with_capacity("control_state:".len() + 4 + key.len());
+    for family in [
+        ControlStateFamily::Counter,
+        ControlStateFamily::Distinct,
+        ControlStateFamily::Selection,
+    ] {
+        candidate.clear();
+        candidate.push_str("control_state:");
+        candidate.push_str(control_state_family_name(family));
+        candidate.push(':');
+        candidate.push_str(key);
+        if expired(shard, &candidate, now) {
+            removed |= delete_record_exact(shard, &candidate);
         }
     }
     removed

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -4802,6 +4802,54 @@ fn the_page_index_dump_is_ordered_by_its_written_key() {
     assert_eq!(keys, sorted, "the dump must be ordered by written key");
 }
 
+/// A command does not allocate to discover that nothing has expired.
+///
+/// Lazy expiry runs on every command -- 51 call sites -- and used to build four owned keys per
+/// call to look them up in a map that, on a store with no TTLs, is empty. One of those keys came
+/// from `format!`. All four were dropped immediately after the lookup.
+///
+/// Counted as allocations rather than time because the allocation is the whole cost: the work
+/// this does on a store without expiries is a single `is_empty` check.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn a_command_does_not_allocate_to_check_expiry() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let reads = |n: usize| -> f64 {
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..n {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringGet {
+                    key: format!("absent{i:04}"),
+                },
+            });
+        }
+        probe.stop().allocs as f64 / n as f64
+    };
+
+    let per_read = reads(200);
+    println!("miss costs {per_read:.1} allocations");
+
+    // An upper bound passes most easily when nothing happened, so prove work was observed.
+    assert!(per_read > 1.0, "the probe must observe the reads: {per_read}");
+
+    // The expiry check accounted for five of these. The rest is the lookup itself, which this
+    // bound deliberately leaves room for -- it is here to catch the per-command allocation
+    // coming back, not to freeze the whole read path.
+    assert!(
+        per_read < 38.0,
+        "a read cost {per_read:.1} allocations; lazy expiry is allocating again"
+    );
+}
+
 /// The page index is keyed by a number in memory and by the old string on disk.
 ///
 /// This is what makes the numeric key an in-memory change rather than a format change. Asserted on


### PR DESCRIPTION
Lazy expiry runs on every command -- 51 call sites -- and began by
building a `Vec` of four owned keys: the key itself, and one per
control-state family, the last three via `format!`. All four were looked
up in a map and dropped. On a store with no TTLs that map is empty, so
the work was four allocations to learn nothing.

It now returns immediately when nothing has an expiry, looks the key up
by reference rather than copying it, and builds the family candidates in
one reused buffer instead of a `String` apiece.

Five allocations off every operation:

| | before | after |
|---|---|---|
| StringGet (miss) | 40.1 | **35.1** |
| StringGet (hit) | 116.4 | **111.4** |
| StringSet (new key) | 136.7 | **131.7** |
| HashSet (new field) | 555.4 | **550.8** |

The early return accounts for one of those five and the borrowed lookups
for the other four. Both are kept: a store that does use TTLs only gets
the second.

Verified by mutation: the previous version fails the bound at 40.3
allocations per read. An earlier, weaker mutation -- removing only the
early return -- moved it to 36.3 and still passed, so the bound is
checked against the original function rather than against a single
line of it.

Full lib suite: 1577 passed, 0 failed.
