### PR TITLE
File the page a write produced, not every page its object already had

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -988,7 +988,9 @@ pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<
             entries.push(LivePageEntry {
                 object_key: page.object_key.clone(),
                 kind: page.model_id.clone(),
-                component: page.component.clone().map(|value| value.to_string()).map(Arc::from),
+                // Both sides are `Option<Arc<str>>`; going through a String allocated the text
+                // twice per page to arrive at the same pointer a clone hands back for free.
+                component: page.component.clone(),
                 address: page.address.clone(),
                 dirty: page.dirty,
                 deleted: page.deleted,
@@ -1114,17 +1116,38 @@ pub(super) fn sync_context_pages_for_object(
     // A context node's page lives in `shard.hashes` under a single field, so the rebuild derives
     // it as kind "hash" with that field as the component -- a different shape from the kinds
     // above, which carry no component. It is filed here the same way the rebuild would file it.
+    //
+    // Only the fields whose page is not already filed. This ran on every write and re-filed
+    // EVERY field of the object each time -- cloning each field name to do it -- so writing a
+    // hash cost work proportional to the fields it already had: 800 allocations per write at 100
+    // fields, 8,388 at 1,600. Filtering before the clone makes the ordinary case, where the write
+    // path already registered its own page, cost nothing here.
+    //
+    // `had_hash_pages` still asks whether the object HAS hash pages, not how many needed filing.
+    // Those differ once the filter can empty the list, and answering the second question would
+    // report an already-synced object as uncovered -- which sends the caller into a full rebuild.
+    let had_hash_pages = shard
+        .hashes
+        .get(object_key)
+        .is_some_and(|fields| !fields.is_empty());
     let hash_fields: Vec<(String, BlockAddress)> = shard
         .hashes
         .get(object_key)
         .map(|fields| {
             fields
                 .iter()
+                .filter(|(field, address)| {
+                    !shard.bucket_index.contains_object_page_address(
+                        "hash",
+                        object_key,
+                        Some(field.as_str()),
+                        address,
+                    )
+                })
                 .map(|(field, address)| (field.clone(), address.clone()))
                 .collect()
         })
         .unwrap_or_default();
-    let had_hash_pages = !hash_fields.is_empty();
     for (field, address) in hash_fields {
         // `stage: false` -- the write staged its own outcome under its own kind already, and a
         // second one would have replay install the same page twice.

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5091,6 +5091,239 @@ fn does_delete_scale_with_the_store() {
     );
 }
 
+/// Exploratory: one page per field, or one page rewritten per write?
+#[test]
+fn how_many_pages_does_a_wide_hash_hold() {
+    for fields in [10usize, 100, 400] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for i in 0..fields {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: "one".to_string(),
+                    field: format!("f{i:06}"),
+                    value: vec![b'v'; 32],
+                },
+            });
+        }
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let pages: usize = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .map(|bucket| bucket.page_index.len())
+            .sum();
+        let buckets = shard.bucket_index.bucket_map.len();
+        let lookup_refs: usize = shard
+            .bucket_index
+            .object_page_lookup
+            .iter()
+            .map(|(_m, _o, refs)| refs.by_component.iter().map(|c| c.refs.as_slice().len()).sum::<usize>())
+            .sum();
+        println!("fields {fields:5}  pages {pages:6}  buckets {buckets:4}  lookup refs {lookup_refs:6}");
+    }
+}
+
+/// Every field of a hash is filed in the bucket index after it is written.
+///
+/// The per-write sync used to re-file every field of the object each time, which made this true
+/// by brute force. It now files only the fields that are missing, so the property has to be
+/// checked rather than assumed: skipping one leaves the index quietly short of a page, and a
+/// missing page is a read that returns nothing rather than an error.
+#[test]
+fn every_field_of_a_hash_is_filed_in_the_bucket_index() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    for i in 0..64 {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: "wide".to_string(),
+                field: format!("f{i:03}"),
+                value: vec![b'v'; 32],
+            },
+        });
+    }
+    // Overwrite some, so a field's address changes and the old filing is stale.
+    for i in (0..64).step_by(5) {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: "wide".to_string(),
+                field: format!("f{i:03}"),
+                value: vec![b'w'; 48],
+            },
+        });
+    }
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let fields = shard.hashes.get("wide").expect("the hash exists");
+    assert_eq!(fields.len(), 64, "all fields written");
+
+    for (field, address) in fields.iter() {
+        assert!(
+            shard.bucket_index.contains_object_page_address(
+                "hash",
+                "wide",
+                Some(field.as_str()),
+                address
+            ),
+            "field {field} holds an address the bucket index does not have filed"
+        );
+    }
+}
+
+/// Exploratory: which bucket-visiting site grows with a wide object?
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn which_site_visits_the_pages() {
+    use crate::engine::storage_bucket_internals::bucket_visit_sites;
+    for fields in [100usize, 400, 1600] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for i in 0..fields {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: "one".to_string(),
+                    field: format!("f{i:06}"),
+                    value: vec![b'v'; 32],
+                },
+            });
+        }
+        bucket_visit_sites::reset();
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..100 {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::HashSet {
+                    key: "one".to_string(),
+                    field: format!("probe{i:04}"),
+                    value: vec![b'v'; 32],
+                },
+            });
+        }
+        let allocs = probe.stop().allocs as f64 / 100.0;
+        let (layout, clear_dirty, refresh_flags, remove_all) = bucket_visit_sites::snapshot();
+        println!(
+            "fields {fields:5}  allocs/write {allocs:8.1}  visits/write: layout {:7.1} clear_dirty {:7.1} refresh {:7.1} remove_all {:7.1}",
+            layout as f64 / 100.0,
+            clear_dirty as f64 / 100.0,
+            refresh_flags as f64 / 100.0,
+            remove_all as f64 / 100.0
+        );
+    }
+}
+
+/// Exploratory: do writes cost more as the store grows?
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn does_writing_scale_with_the_store() {
+    let cost_at = |resident: usize, wide_object: bool| -> (f64, f64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        for i in 0..resident {
+            if wide_object {
+                // Everything under ONE object key: the object's own ref list grows.
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::HashSet {
+                        key: "one".to_string(),
+                        field: format!("f{i:06}"),
+                        value: vec![b'v'; 32],
+                    },
+                });
+            } else {
+                // Spread across many object keys: the store grows, each object stays small.
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::HashSet {
+                        key: format!("h{i:06}"),
+                        field: "f".to_string(),
+                        value: vec![b'v'; 32],
+                    },
+                });
+            }
+        }
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..100 {
+            if wide_object {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::HashSet {
+                        key: "one".to_string(),
+                        field: format!("probe{i:04}"),
+                        value: vec![b'v'; 32],
+                    },
+                });
+            } else {
+                engine.execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::HashSet {
+                        key: format!("probe{i:04}"),
+                        field: "f".to_string(),
+                        value: vec![b'v'; 32],
+                    },
+                });
+            }
+        }
+        let c = probe.stop();
+        (c.allocs as f64 / 100.0, c.alloc_bytes as f64 / 100.0)
+    };
+
+    let (narrow_small, _) = cost_at(100, false);
+    let (narrow_large, _) = cost_at(1600, false);
+    let (wide_small, _) = cost_at(100, true);
+    let (wide_large, _) = cost_at(1600, true);
+    println!(
+        "many objects {narrow_small:.1} -> {narrow_large:.1}   one wide object {wide_small:.1} -> {wide_large:.1}"
+    );
+
+    // A ratio test proves nothing if neither side did any work.
+    assert!(wide_small > 1.0, "the probe must observe writes: {wide_small}");
+
+    // Writing to a store with 16x the objects already cost the same; this is the guard on it.
+    assert!(
+        narrow_large / narrow_small < 1.3,
+        "a write cost {narrow_small:.1} allocations at 100 objects and {narrow_large:.1} at 1,600"
+    );
+
+    // Writing a field to an object that already has 1,600 of them cost 8,388 allocations against
+    // 800 at 100 fields, because the per-write sync re-filed every field the object had.
+    assert!(
+        wide_large / wide_small < 1.3,
+        "a write cost {wide_small:.1} allocations at 100 fields and {wide_large:.1} at 1,600          ({:.1}x) -- the write is scaling with the object again",
+        wide_large / wide_small
+    );
+}
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key


### PR DESCRIPTION
Writing one field of a hash re-filed **every field that hash already
had**. The per-write index sync collects the object's fields -- cloning
each field name to do it -- and upserts every one into the bucket index,
so the cost of a write grew with the object it was written to, and
filling a wide hash cost the square of its width.

Allocations for one write, by how many fields the object already holds:

| fields | before | after |
|---|---|---|
| 100 | 799.8 | **95.3** |
| 400 | 2,316.9 | **95.3** |
| 1,600 | **8,387.5** | **95.3** |

Writes were already flat in the size of the *store*; this makes them
flat in the size of the *object* as well.

### Why the sync exists, and what it still does

A context node's page lives in `shard.hashes` under a single field, and
its write does not register that page itself, so something has to file
it. That still happens -- for the fields that are not filed yet. An
ordinary hash write registers its own page on the way in, so the sync
now finds nothing to do.

`had_hash_pages` deliberately still asks whether the object **has** hash
pages rather than how many needed filing. Those two answers differ once
the filter can empty the list, and the second one reports an
already-synced object as uncovered -- which sends the caller into a full
rebuild, the exact cost this removes.

### Verification

`every_field_of_a_hash_is_filed_in_the_bucket_index` asserts every
field, including overwritten ones whose address changed, is filed. The
old code made that true by brute force; filing only what is missing
means it has to be checked, and a page missing from the index is a read
that returns nothing rather than an error.

Verified by mutation: re-filing every field fails the flatness bound at
10.5x.

Full lib suite: 1581 passed, 0 failed. Context (75), hash (6) and bucket
(49) suites pass individually as well.
