### PR TITLE
The reclaim plan decodes each dump index once, not once per bucket

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
+++ b/crates/temporalstore-rust/src/engine/storage_lifecycle_methods.rs
@@ -638,24 +638,53 @@ impl TemporalEngine {
         let mut durable_index_log_frontier = u64::MAX;
         let mut covered_bucket_count = 0usize;
 
+        // Decode each manifest's index ONCE, not once per bucket.
+        //
+        // This sat inside the loop below, so every bucket re-deserialized every manifest's
+        // WHOLE shard index out of JSON and rebuilt the generation fingerprints for every
+        // bucket in it -- identical work, repeated once per bucket. The manifests are read
+        // before the loop and do not change while the plan is computed, so one pass produces
+        // the same answer every visit would have.
+        //
+        // The cost was quadratic in the corpus: a real (non-dry-run) WAL reclaim took 6.5s at
+        // 1k records, 23s at 2k and 100s at 4k -- x4 per doubling -- and a 40k shard did not
+        // finish in ten minutes with a core pegged at 100%. Reclaim is the only thing that
+        // removes WAL and index-log bytes, so a shard large enough to need it was a shard on
+        // which it could not run.
+        let manifest_fingerprints = manifests
+            .iter()
+            .map(|manifest| {
+                crate::engine::decode_index_bytes(&manifest.index_bytes)
+                    .ok()
+                    .map(|manifest_state| {
+                        bucket_generation_fingerprints_by_bucket(&manifest_state)
+                    })
+            })
+            .collect::<Vec<_>>();
+
         for summary in &bucket_summaries {
-            let matching_manifest = manifests.iter().rev().find(|manifest| {
-                let Ok(manifest_state) =
-                    crate::engine::decode_index_bytes(&manifest.index_bytes)
-                else {
-                    return false;
-                };
-                let manifest_bucket_fingerprints =
-                    bucket_generation_fingerprints_by_bucket(&manifest_state);
-                manifest.bucket_summaries.iter().any(|manifest_summary| {
-                    bucket_dump_summary_matches_current_generation(
-                        manifest_summary,
-                        summary,
-                        &manifest_bucket_fingerprints,
-                        &current_bucket_fingerprints,
-                    )
+            let matching_manifest = manifests
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(manifest_index, manifest)| {
+                    // A manifest whose index will not decode matched nothing before and
+                    // matches nothing now.
+                    let Some(manifest_bucket_fingerprints) =
+                        manifest_fingerprints[*manifest_index].as_ref()
+                    else {
+                        return false;
+                    };
+                    manifest.bucket_summaries.iter().any(|manifest_summary| {
+                        bucket_dump_summary_matches_current_generation(
+                            manifest_summary,
+                            summary,
+                            manifest_bucket_fingerprints,
+                            &current_bucket_fingerprints,
+                        )
+                    })
                 })
-            });
+                .map(|(_, manifest)| manifest);
             let Some(manifest) = matching_manifest else {
                 missing_bucket_generations.push(summary.routing_bucket);
                 continue;

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -1667,6 +1667,68 @@ fn bucket_dump_manifest_prune_is_blocked_by_raft_snapshot_reference() {
 }
 
 // shared-corpus: storage_wal_index_gc_generation_retention
+/// Each manifest must be judged against ITS OWN fingerprints.
+///
+/// The plan decodes every manifest's index once, up front, and indexes into that by position
+/// while walking buckets -- so a mis-paired index would judge one manifest's buckets against
+/// another's fingerprints and anchor reclaim on the wrong dump. THREE manifests, because an
+/// off-by-one can coincidentally pick the right one out of two.
+///
+/// This guards the shape of the lookup, not the old behaviour: before, the decode happened
+/// inside the loop and could not be mispaired -- it was merely quadratic, taking 100s at 4k
+/// records and not finishing at all at 40k.
+#[test]
+fn the_reclaim_plan_pairs_each_manifest_with_its_own_fingerprints() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    let mut manifests = Vec::new();
+    for round in 0..3 {
+        assert!(
+            engine
+                .execute(ExecuteRequest {
+                    shard_id: 1,
+                    command: Command::StringSet {
+                        key: "reclaim-slot".to_string(),
+                        value: format!("v{round}").into_bytes(),
+                    },
+                })
+                .status
+                .ok
+        );
+        manifests.push(engine.create_bucket_dump_manifest(1, Vec::new()).unwrap());
+    }
+
+    // Strictly increasing, or the assertion below cannot tell the three apart.
+    assert!(manifests[1].wal_sequence > manifests[0].wal_sequence);
+    assert!(manifests[2].wal_sequence > manifests[1].wal_sequence);
+
+    let plan = engine.storage_wal_reclaim_plan(1, Vec::new(), Vec::new());
+
+    // The newest manifest is the only one whose fingerprints still match the live state, so it
+    // is the one the frontier must anchor on. Pairing manifest N with manifest N-1's
+    // fingerprints would anchor on an older dump and reclaim a span that dump does not cover.
+    assert_eq!(
+        plan.durable_bucket_generation_frontier_wal_sequence, manifests[2].wal_sequence,
+        "the frontier must anchor on the newest matching manifest: {plan:?}"
+    );
+    assert!(
+        plan.retained_manifest_ids
+            .contains(&manifests[2].manifest_id),
+        "the newest manifest must be retained: {plan:?}"
+    );
+    assert!(
+        plan.missing_bucket_generations.is_empty(),
+        "every live bucket is covered by the newest dump: {plan:?}"
+    );
+}
+
 #[test]
 fn storage_wal_index_gc_reclaim_requires_durable_generation_and_retention_release() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
A real WAL reclaim did not come back on any shard worth reclaiming. Measured, one fresh
one-box node per size, `enable_wal_reclaim` only, `dry_run: false`:

```
   1,000 records     6.46 s
   2,000 records    23.13 s   x3.6 for 2x the records
   4,000 records    99.94 s   x4.3 for 2x the records
   8,000 records    did not finish in 240 s
  40,000 records    did not finish in 600 s
```

x4 per doubling is O(n²); extrapolating from 4k puts 40k at roughly **2.8 hours**, and 100k at
seventeen. Throughout, one thread sits at **100.0% CPU in state R** — a compute loop, not a
deadlock.

### Where it went

`gdb` on that thread, sampled twice twenty seconds apart, identical frames both times:

```
#9  engine::decode_index_bytes()
#10 <TemporalEngine>::storage_wal_reclaim_plan()
#11 run_storage_manager_cycle()
```

with serde_json deserializing `ShardState` -> `CoreIndex...` -> `BucketNode...` above it. In
`storage_wal_reclaim_plan`:

```rust
for summary in &bucket_summaries {                       // once per bucket
    let matching = manifests.iter().rev().find(|manifest| {
        let Ok(state) = decode_index_bytes(&manifest.index_bytes) else { return false };
        let fps = bucket_generation_fingerprints_by_bucket(&state);
        ...
    });
}
```

Every bucket re-deserialized every manifest's **whole shard index** out of JSON and rebuilt the
generation fingerprints for every bucket in it. The manifests are read before the loop and do
not change while the plan is computed, so it was identical work repeated once per bucket.

Decoding once per manifest into a `Vec<Option<_>>` before the loop, and indexing into it inside:

```
   1,000 records     6.46 s ->   0.42 s
   4,000 records    99.94 s ->   1.88 s     53x
  16,000 records         -- ->  10.39 s
  40,000 records    (600 s+) ->  42.88 s
```

Fitting the exponent rather than eyeballing it, on this branch:

```
  before   1k ->  2k   n^1.84        after   1k ->  4k   n^1.08
           2k ->  4k   n^2.11                4k -> 16k   n^1.23
                                            16k -> 40k   n^1.55
                                     overall 1k -> 40k   n^1.25
```

So the quadratic is gone, but this is **not linear** and the exponent climbs with n — there is a
second, milder superlinearity above this one that this change does not touch. Worth saying
plainly rather than calling it fixed.

### Why this matters more than it looks

Reclaim is the only thing that removes WAL and index-log bytes. Before this, a shard large
enough to need reclaim was a shard on which reclaim could not run.

Two things hid it. Nothing starts a scheduler for the storage-manager cycle in any binary — the
schedulers exist and are tested, but no `src/bin` calls them and nothing in the repo POSTs the
endpoint — so this path only runs when an operator triggers it by hand. And the **dry run of all
eight stages finishes in 13.5 s on the same 40k shard**, because the cost is entirely in the
mutating path. Validating GC with `dry_run: true` reports a healthy cycle either way.

### The test

`the_reclaim_plan_pairs_each_manifest_with_its_own_fingerprints` guards the new lookup rather
than the old bug: the decode used to sit inside the loop where it could not be mispaired, so
what needs holding now is that `manifests[i]` is judged against `manifest_fingerprints[i]`.

Three manifests, not two, because an off-by-one can coincidentally pick the right one out of
two. Verified to fail when the pairing is deliberately broken — with `manifest_fingerprints[0]`
the plan comes back `safe_to_reclaim: false`, `covered_bucket_count: 0`,
`missing_bucket_generations: [3083603860]`, so a mispairing does not merely choose the wrong
dump, it refuses reclaim outright.
