### PR TITLE
Hold a bucket's only page inline instead of in a map

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -335,64 +335,202 @@ pub(super) type ObjectIndex = BTreeSet<u64>;
 /// them from a counter compiled, round-tripped, and lost an object on the first reload.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(from = "BTreeMap<String, PageIndex>")]
-pub(super) struct PageIndexMap {
-    by_key: BTreeMap<u64, PageIndex>,
+pub(super) enum PageIndexMap {
+    /// A bucket holding nothing: no map, no node, no allocation.
+    #[default]
+    Empty,
+    /// One page, held inline.
+    ///
+    /// This is the ordinary bucket. Keys route one to a bucket, so a bucket holds a single page
+    /// unless its object has components -- and a `BTreeMap` holding one entry costs 1,496 live
+    /// bytes to carry a 120-byte page, because its node is sized for eleven. Measured over a
+    /// store of 2,000 keys, the containers were about 70% of the index's live heap.
+    ///
+    /// The shape `PageRefs` already uses, for the same reason.
+    One(u64, PageIndex),
+    /// Several pages -- an object with components -- which is where a map earns its node.
+    Many(BTreeMap<u64, PageIndex>),
+}
+
+/// Iterating a page index, whichever shape it is in.
+pub(super) enum PageIndexIter<'a> {
+    Empty,
+    One(std::iter::Once<(&'a u64, &'a PageIndex)>),
+    Many(std::collections::btree_map::Iter<'a, u64, PageIndex>),
+}
+
+impl<'a> Iterator for PageIndexIter<'a> {
+    type Item = (&'a u64, &'a PageIndex);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            PageIndexIter::Empty => None,
+            PageIndexIter::One(once) => once.next(),
+            PageIndexIter::Many(iter) => iter.next(),
+        }
+    }
+}
+
+pub(super) enum PageIndexValuesMut<'a> {
+    Empty,
+    One(std::iter::Once<&'a mut PageIndex>),
+    Many(std::collections::btree_map::ValuesMut<'a, u64, PageIndex>),
+}
+
+impl<'a> Iterator for PageIndexValuesMut<'a> {
+    type Item = &'a mut PageIndex;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            PageIndexValuesMut::Empty => None,
+            PageIndexValuesMut::One(once) => once.next(),
+            PageIndexValuesMut::Many(iter) => iter.next(),
+        }
+    }
 }
 
 impl PageIndexMap {
     pub(super) fn get(&self, key: &u64) -> Option<&PageIndex> {
-        self.by_key.get(key)
+        match self {
+            PageIndexMap::Empty => None,
+            PageIndexMap::One(handle, page) => (handle == key).then_some(page),
+            PageIndexMap::Many(map) => map.get(key),
+        }
     }
 
     pub(super) fn get_mut(&mut self, key: &u64) -> Option<&mut PageIndex> {
-        self.by_key.get_mut(key)
+        match self {
+            PageIndexMap::Empty => None,
+            PageIndexMap::One(handle, page) => (&*handle == key).then_some(page),
+            PageIndexMap::Many(map) => map.get_mut(key),
+        }
     }
 
     pub(super) fn remove(&mut self, key: &u64) -> Option<PageIndex> {
-        self.by_key.remove(key)
+        match self {
+            PageIndexMap::Empty => None,
+            PageIndexMap::One(handle, _) => {
+                if handle != key {
+                    return None;
+                }
+                match std::mem::replace(self, PageIndexMap::Empty) {
+                    PageIndexMap::One(_, page) => Some(page),
+                    _ => unreachable!("just matched One"),
+                }
+            }
+            PageIndexMap::Many(map) => {
+                let removed = map.remove(key);
+                self.shrink();
+                removed
+            }
+        }
     }
 
-    /// File a page and return the handle it is filed under.
     /// Install a page and return its handle.
     ///
     /// A page with the same identity replaces the one already there rather than adding beside it,
     /// which is what the rendered string key used to do by being the key.
     pub(super) fn insert(&mut self, page: PageIndex) -> u64 {
         let handle = page_index_handle(&page);
-        self.by_key.insert(handle, page);
+        match self {
+            PageIndexMap::Empty => *self = PageIndexMap::One(handle, page),
+            PageIndexMap::One(existing, held) => {
+                if *existing == handle {
+                    *held = page;
+                } else {
+                    // A second page: this bucket has earned a map.
+                    let (first_handle, first) = match std::mem::replace(self, PageIndexMap::Empty) {
+                        PageIndexMap::One(first_handle, first) => (first_handle, first),
+                        _ => unreachable!("just matched One"),
+                    };
+                    let mut map = BTreeMap::new();
+                    map.insert(first_handle, first);
+                    map.insert(handle, page);
+                    *self = PageIndexMap::Many(map);
+                }
+            }
+            PageIndexMap::Many(map) => {
+                map.insert(handle, page);
+            }
+        }
         handle
     }
 
+    /// Return to an inline shape once a map no longer needs to be one.
+    ///
+    /// Without this, a bucket that briefly held two pages keeps a node for the rest of its life --
+    /// which is the cost this type exists to avoid.
+    fn shrink(&mut self) {
+        let len = match self {
+            PageIndexMap::Many(map) => map.len(),
+            _ => return,
+        };
+        match len {
+            0 => *self = PageIndexMap::Empty,
+            1 => {
+                let map = match std::mem::replace(self, PageIndexMap::Empty) {
+                    PageIndexMap::Many(map) => map,
+                    _ => unreachable!("just matched Many"),
+                };
+                let (handle, page) = map.into_iter().next().expect("length is one");
+                *self = PageIndexMap::One(handle, page);
+            }
+            _ => {}
+        }
+    }
+
     pub(super) fn len(&self) -> usize {
-        self.by_key.len()
+        match self {
+            PageIndexMap::Empty => 0,
+            PageIndexMap::One(..) => 1,
+            PageIndexMap::Many(map) => map.len(),
+        }
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.by_key.is_empty()
+        matches!(self, PageIndexMap::Empty)
     }
 
-    pub(super) fn iter(&self) -> std::collections::btree_map::Iter<'_, u64, PageIndex> {
-        self.by_key.iter()
+    pub(super) fn iter(&self) -> PageIndexIter<'_> {
+        match self {
+            PageIndexMap::Empty => PageIndexIter::Empty,
+            PageIndexMap::One(handle, page) => PageIndexIter::One(std::iter::once((handle, page))),
+            PageIndexMap::Many(map) => PageIndexIter::Many(map.iter()),
+        }
     }
 
-    pub(super) fn values(&self) -> std::collections::btree_map::Values<'_, u64, PageIndex> {
-        self.by_key.values()
+    pub(super) fn values(&self) -> impl Iterator<Item = &PageIndex> {
+        self.iter().map(|(_handle, page)| page)
     }
 
-    pub(super) fn values_mut(&mut self) -> std::collections::btree_map::ValuesMut<'_, u64, PageIndex> {
-        self.by_key.values_mut()
+    pub(super) fn values_mut(&mut self) -> PageIndexValuesMut<'_> {
+        match self {
+            PageIndexMap::Empty => PageIndexValuesMut::Empty,
+            PageIndexMap::One(_, page) => PageIndexValuesMut::One(std::iter::once(page)),
+            PageIndexMap::Many(map) => PageIndexValuesMut::Many(map.values_mut()),
+        }
     }
 
     pub(super) fn retain(&mut self, mut keep: impl FnMut(&u64, &mut PageIndex) -> bool) {
-        self.by_key.retain(|key, page| keep(key, page));
+        match self {
+            PageIndexMap::Empty => {}
+            PageIndexMap::One(handle, page) => {
+                let handle = *handle;
+                if !keep(&handle, page) {
+                    *self = PageIndexMap::Empty;
+                }
+            }
+            PageIndexMap::Many(map) => {
+                map.retain(|handle, page| keep(handle, page));
+                self.shrink();
+            }
+        }
     }
 }
 
 impl<'a> IntoIterator for &'a PageIndexMap {
     type Item = (&'a u64, &'a PageIndex);
-    type IntoIter = std::collections::btree_map::Iter<'a, u64, PageIndex>;
+    type IntoIter = PageIndexIter<'a>;
     fn into_iter(self) -> Self::IntoIter {
-        self.by_key.iter()
+        self.iter()
     }
 }
 
@@ -412,11 +550,10 @@ impl From<BTreeMap<String, PageIndex>> for PageIndexMap {
         // The handle is recomputed from the page, not read from the file and not assigned by a
         // counter. A counter would hand out different handles than the ones the lookup refs were
         // written with, and those refs are on disk too.
-        let mut by_key = BTreeMap::new();
-        for (_written_key, page) in flat {
-            by_key.insert(page_index_handle(&page), page);
-        }
-        Self { by_key }
+        //
+        // Built through `insert`, so a loaded index takes the same shape a written one does: a
+        // bucket that loads a single page must not come back holding a map.
+        flat.into_values().collect()
     }
 }
 
@@ -437,7 +574,6 @@ impl Serialize for PageIndexMap {
     {
         use serde::ser::SerializeMap;
         let mut entries: Vec<(String, &PageIndex)> = self
-            .by_key
             .values()
             .map(|page| (page_index_written_key(page), page))
             .collect();

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5324,6 +5324,155 @@ fn does_writing_scale_with_the_store() {
     );
 }
 
+/// What a key costs the index in live heap.
+///
+/// Measured as allocated-minus-freed rather than as a struct size, because the cost this bounds
+/// was never in the struct: a bucket held its single page in a `BTreeMap`, whose node is sized
+/// for eleven entries and cost 1,496 live bytes to carry 120 bytes of page. Holding one page
+/// inline took a key from 2,336 live bytes to 1,085.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn what_a_key_costs_the_index_in_live_heap() {
+    let cost_at = |keys: usize| -> f64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..keys {
+            engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::StringSet {
+                    key: format!("k{i:07}"),
+                    value: vec![b'v'; 64],
+                },
+            });
+        }
+        let counts = probe.stop();
+        (counts.alloc_bytes as i64 - counts.free_bytes as i64) as f64 / keys as f64
+    };
+
+    let per_key = cost_at(2000);
+    println!("live heap: {per_key:.0} bytes per key");
+
+    // A bound passes most easily when nothing was measured.
+    assert!(per_key > 100.0, "the probe must observe the writes: {per_key}");
+
+    assert!(
+        per_key < 1500.0,
+        "a key costs {per_key:.0} live bytes; a bucket is holding a node for a single page again"
+    );
+}
+
+/// A bucket holding one page holds it inline, and goes back to inline when it can.
+///
+/// Keys route one to a bucket, so most buckets hold a single page. A `BTreeMap` holding one entry
+/// costs 1,496 live bytes to carry a 120-byte page, because its node is sized for eleven -- which
+/// made the containers about 70% of the index's live heap.
+///
+/// The demotion matters as much as the promotion: a bucket that briefly held two pages would
+/// otherwise keep its node for the rest of its life, which is exactly the cost being avoided and
+/// would not show up as a failure anywhere else.
+#[test]
+fn a_bucket_holding_one_page_holds_no_node() {
+    use crate::engine::state::PageIndexMap;
+
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // One page under an object: inline.
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet {
+            key: "solo".to_string(),
+            value: vec![b'v'; 32],
+        },
+    });
+    {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let bucket = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .find(|bucket| bucket.page_index.len() == 1)
+            .expect("the write must produce a bucket holding one page");
+        assert!(
+            matches!(bucket.page_index, PageIndexMap::One(..)),
+            "a bucket holding one page must hold it inline"
+        );
+    }
+
+    // Several components of one object: a map, which is what a map is for.
+    for field in ["a", "b", "c"] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashSet {
+                key: "wide".to_string(),
+                field: field.to_string(),
+                value: vec![b'v'; 32],
+            },
+        });
+    }
+    {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let bucket = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .find(|bucket| bucket.page_index.len() > 1)
+            .expect("three fields must share a bucket");
+        assert!(
+            matches!(bucket.page_index, PageIndexMap::Many(_)),
+            "several pages belong in a map"
+        );
+    }
+
+    // Down to one again: back to inline, not a map with one entry left in it.
+    for field in ["a", "b"] {
+        engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::HashDelete {
+                key: "wide".to_string(),
+                field: field.to_string(),
+            },
+        });
+    }
+    {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let bucket = shard
+            .bucket_index
+            .bucket_map
+            .values()
+            .find(|bucket| {
+                bucket
+                    .page_index
+                    .values()
+                    .any(|page| &*page.object_key == "wide")
+            })
+            .expect("the remaining field must still be filed");
+        assert_eq!(bucket.page_index.len(), 1, "two of three fields were removed");
+        assert!(
+            matches!(bucket.page_index, PageIndexMap::One(..)),
+            "a map that drops back to one page must give up its node"
+        );
+    }
+}
+
+
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key


### PR DESCRIPTION
Keys route one to a bucket, so a bucket holds a single page unless its
object has components. That page sat in a `BTreeMap`, whose node is
sized for eleven entries and costs **1,496 live bytes to carry 120 bytes
of page**. One such node existed per key.

Measured over 2,000 keys, live heap per key:

| | live bytes per key |
|---|---|
| before | 2,336 |
| after | **1,085** |

The page index is now `Empty`, `One(handle, page)`, or `Many(map)` --
the shape `PageRefs` already uses in this file, for the same reason.

The struct grows and the heap shrinks: a bucket node goes from 120 to
224 bytes inline, because it now carries the page rather than a pointer
to a node holding it. The node it replaces was 1,496 bytes, so a key
ends up 1,251 bytes lighter.

### `Many` still earns its keep

An object with many components puts all of them in one bucket, and that
is what a map is for -- a sorted `Vec` would memmove the lot on every
insert. Only the single-page case avoids it.

### The demotion is the half that is easy to miss

Dropping back to one page returns the bucket to `One`. Without that, a
bucket that briefly held two pages keeps its node for the rest of its
life -- the whole cost being removed here, and it would not show up as a
failure anywhere else. `a_bucket_holding_one_page_holds_no_node` covers
all three transitions: inline, promoted to a map, and back.

### Format

Unchanged. The index still serializes as the same map of rendered keys,
and a load builds through `insert`, so a bucket that loads a single page
comes back holding it inline rather than in a map.

### Verification

Mutation, both directions: giving every bucket a map fails the heap
bound at 2,524 live bytes per key; never returning to `One` fails the
shape test.

Full lib suite: 1,582 passed, 0 failed. The page-index, bucket, context,
hash, delete, scaling, dump and lookup suites (227 tests) pass
individually as well.
