### PR TITLE
docs: point plugin marketplace command at matrixarkai/TemporalStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ turn, plus recall/remember tools.
 ### Claude Code (marketplace plugin)
 
 ```text
-/plugin marketplace add bjmeetsfo/TemporalStore
+/plugin marketplace add matrixarkai/TemporalStore
 /plugin install matrixark-memory@temporalstore
 ```
 

--- a/integrations/PLUGINS.md
+++ b/integrations/PLUGINS.md
@@ -30,7 +30,7 @@ bash integrations/install-matrixark-plugins.sh --agent both --matrixark-home "$(
 ### Claude Code
 
 ```
-/plugin marketplace add bjmeetsfo/TemporalStore
+/plugin marketplace add matrixarkai/TemporalStore
 /plugin install matrixark-memory@temporalstore
 ```
 Set `matrixark_home` to your checkout path when enabling (or `export MATRIXARK_HOME=...`).

--- a/integrations/claude-plugin/README.md
+++ b/integrations/claude-plugin/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/matrixarkai/TemporalStore
 ## Install (marketplace)
 
 ```
-/plugin marketplace add bjmeetsfo/TemporalStore
+/plugin marketplace add matrixarkai/TemporalStore
 /plugin install matrixark-memory@temporalstore
 ```
 


### PR DESCRIPTION
### Problem

The Claude Code install snippet tells users to run:

```text
/plugin marketplace add bjmeetsfo/TemporalStore
```

`bjmeetsfo/TemporalStore` returns 404 — the repository does not exist. Because the marketplace never gets added, the following `/plugin install matrixark-memory@temporalstore` cannot resolve either, so the documented Claude Code install path fails completely.

### Why `matrixarkai` is the right owner

The repository already says so in two places:

- `.claude-plugin/marketplace.json` declares `"repository": "https://github.com/matrixarkai/TemporalStore"`.
- `integrations/claude-plugin/README.md` uses `git clone https://github.com/matrixarkai/TemporalStore` a few lines above the broken command.

Looks like a leftover from a development fork that was later removed.

### Change

Points the marketplace command at `matrixarkai/TemporalStore` in the three files that carry the stale owner:

- `README.md`
- `integrations/PLUGINS.md`
- `integrations/claude-plugin/README.md`

Docs only, +3/-3, no code paths touched.
