### PR TITLE
Point matrixcache at the commit that stops building an unused store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 [[package]]
 name = "matrixcache"
 version = "0.1.0"
-source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=00e886e852df6919693b5f178c0770fc302c790c#00e886e852df6919693b5f178c0770fc302c790c"
+source = "git+https://github.com/matrixarkai/MatrixCache.git?rev=5b63bb7d948eacd34f99f1874907ca9da5ec9bcd#5b63bb7d948eacd34f99f1874907ca9da5ec9bcd"
 dependencies = [
  "rocksdb",
  "serde",

--- a/crates/temporalstore-rust/Cargo.toml
+++ b/crates/temporalstore-rust/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 base64 = "0.22"
 sha2 = "0.10"
 matrixraft = { package = "matrixraft", git = "https://github.com/matrixarkai/MatrixRaft.git", rev = "a4334b37ba6592e7c7192f3eaa2afe087746ccc9" }
-matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "00e886e852df6919693b5f178c0770fc302c790c", features = ["rocksdb-ssd"] }
+matrixcache = { git = "https://github.com/matrixarkai/MatrixCache.git", rev = "5b63bb7d948eacd34f99f1874907ca9da5ec9bcd", features = ["rocksdb-ssd"] }
 temporalstore-snapshot = { path = "../temporalstore-snapshot" }
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
matrixcache #22 stopped a cache with a zero-capacity SSD tier from building the store anyway.
Nothing changed here, because TemporalStore pins matrixcache by revision and the pin still
named the commit before it. This moves the pin.

The physical check, on a one-box node built from this branch:

```
  pin 00e886e   cache/rocksdb-cache-blocks present, 4,160 kB
  pin 5b63bb7d   no store; the cache directory is empty
```

Measured earlier on one box, same corpus, same seed, the two matrixcache trees differing only
by that commit:

```
  total footprint      51,852 kB -> 47,696 kB    -8.0%
  embeddings' share         67.9% ->     73.8%
  ingest p50             1.834 ms ->  1.589 ms   -13.4%
  ingest qps                526.9 ->     589.0   +11.8%
```

The throughput was the surprise and is the better reason to take this: a tier nothing could be
admitted to was still running an embedded key-value store's threads and memtable on every
one-box and raft node, and charging the write path for it. The 4 MB of disk was the visible half.

### What else the bump brings

The pin moves four commits, not one:

```
  5b63bb7d  A tier with no capacity builds no store          (the reason for this PR)
  e2e2475   Size the SSD tier memtable for a cache, not a write-heavy store
  910f225   Hold the journal open instead of reopening it per record
  9ac537a   Fix the compatibility build, which main did not compile
```

Three files across them -- `multilayer_cache.rs`, `storage_engines.rs`, `tests/mod.rs`. The two
performance commits could move these numbers on their own, which is why the footprint and
latency figures above come from an A/B that held the matrixcache tree constant and toggled only
the zero-capacity commit, rather than from comparing the old pin against the new one.

### Validated on this branch

```
  build                       clean
  one-box physical check      no store created; the cache directory is empty
  full lib suite              1,585 passed, 0 failed, 34 ignored
```

The suite matters more than usual here because three of the four commits the pin brings are not
mine.
