### PR TITLE
The rendered page key outlived its last caller

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1294,22 +1294,6 @@ pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePag
     entries
 }
 
-/// The key a page is filed under, as ONE allocation shared by every structure that points at the
-/// page: the bucket's `page_index`, and the two object lookups.
-pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> Arc<str> {
-    Arc::from(format!(
-        "{}:{}:{}:{}:{}:{}:{}:{}",
-        entry.kind,
-        entry.object_key,
-        entry.component.as_deref().unwrap_or(""),
-        entry.address.page_slab_id,
-        entry.address.offset,
-        entry.address.length,
-        entry.address.page_id().unwrap_or_default(),
-        entry.address.generation().unwrap_or_default()
-    ))
-}
-
 pub(super) fn page_physical_identity_key(
     address: &BlockAddress,
 ) -> (


### PR DESCRIPTION
Keying the page index by a handle removed the last thing that looked a page up by
text. The function that rendered that text stayed behind:

    pub(super) fn page_index_ref_key(entry: &LivePageEntry) -> Arc<str> {
        Arc::from(format!("{}:{}:{}:{}:{}:{}:{}:{}", ...eight fields...))
    }

Its own definition is now the only mention of it in the crate, and nothing outside
the crate names it either.

Worth deleting rather than leaving: it builds an eight-field string and an `Arc` per
call, which is precisely the allocation per page entry the handle change was made to
stop paying. Left in place it is one `use` away from being called again by someone
reaching for "the key a page is filed under" -- and its doc comment still says the
bucket's `page_index` and the two object lookups all share it, which stopped being
true when the handle replaced it.

Nothing flagged it. `dead_code` does not fire here: the item is `pub(super)` in a module
the crate re-exports, so rustc treats it as reachable from outside and stops asking
whether anything inside actually calls it. The same build warns about a dozen genuinely
unused private items and says nothing about this one -- which is worth knowing, because
it means the lint will not catch the next function left behind this way either.

`cargo check --all-targets` is clean and the library suite is unchanged; the removal is
verified by there being no caller for the compiler to complain about.

