### PR TITLE
Hold each repeated value and key name once, and stop re-reading the store per attachment

### DIFF
--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -55,53 +55,73 @@ class _LocalAdapterContextNodeMixin:
         return self.default_session_node_path(envelope.get("scope", {}))
 
     def _existing_node_embedding_refs(self, current_model_ref: str) -> set[int]:
-        """Node hashes that already have a usable `context_node` embedding for this model.
+        """Node hashes that already have a usable embedding for this model.
 
-        Walking the whole log is fine on the JSONL backend, where `read_all()` is an in-memory
-        list. It is NOT fine on a native backend, where `read_all()` is a full record-log read
-        shipped over the proxy and re-run through the serving pipeline -- and
-        `ensure_context_node_path` runs three times per ingest. The native adapter overrides this
-        with a keyed lookup; see `MatrixArkTemporalStoreDirectAdapter._existing_node_embedding_refs`.
+        Answered from an index the adapter keeps, not by walking the store. This runs on every
+        ingest -- `ensure_context_node_path` is called several times per one -- and was one of the
+        remaining reads of the whole record set per write.
+
+        The index is built from one read the first time it is asked, folded forward on every
+        append, and dropped whenever the read cache is, so it cannot outlive the view it came from.
         """
-        refs: set[int] = set()
-        for record in self.read_all():
-            record_type = str(record.get("record_type") or "")
-            # A node embedding now lives ON the node: fold_embedding_records moves the vector onto
-            # the owner and drops the separate context_embedding row. Looking only for that row
-            # found nothing in any log written since, so every node was reported un-embedded and
-            # re-embedded on every ingest -- 60 embeddings for 3 distinct nodes over 20 ingests.
-            if record_type == "context_node":
-                meta = record.get("embedding_meta")
-                if not isinstance(meta, dict):
-                    continue
-                if str(meta.get("model_ref") or "") != current_model_ref:
-                    continue
-                if not record.get("vector") and not record_vector(record):
-                    continue
-                try:
-                    refs.add(int(record.get("node_hash")))
-                except (TypeError, ValueError):
-                    pass
-                continue
-            # Logs written before the fold carry the embedding as its own row.
-            if (
-                record_type != "context_embedding"
-                or record.get("ref_type") != "node"
-                or record.get("ref_hash") is None
-            ):
-                continue
-            if (
-                record.get("embedding_type") != "context_node"
-                or str(record.get("model_ref") or "") != current_model_ref
-                or not record_vector(record)
-                or not record.get("vector")
-            ):
-                continue
+        index = getattr(self, "_node_embedding_refs_index", None)
+        if index is None:
+            index = {}
+            for record in self.read_all():
+                self._note_node_embedding_ref(index, record)
+            self._node_embedding_refs_index = index
+        return set(index.get(current_model_ref, ()))
+
+    @staticmethod
+    def _node_embedding_ref_of(record):
+        """(model_ref, node_hash) for a row that carries a node embedding, else None.
+
+        A node embedding now lives ON the node: fold_embedding_records moves the vector onto the
+        owner and drops the separate context_embedding row, which is where every vector in a new
+        log is. Looking only for that row found nothing in any log written since, so every node was
+        reported un-embedded and re-embedded on every ingest -- 60 embeddings for 3 distinct nodes
+        over 20 ingests. Logs written before the fold still carry the separate row.
+        """
+        if not isinstance(record, dict):
+            return None
+        record_type = str(record.get("record_type") or "")
+        if record_type == "context_node":
+            meta = record.get("embedding_meta")
+            if not isinstance(meta, dict):
+                return None
+            model_ref = str(meta.get("model_ref") or "")
+            if not model_ref:
+                return None
+            if not record.get("vector") and not record_vector(record):
+                return None
             try:
-                refs.add(int(record.get("ref_hash")))
+                return (model_ref, int(record.get("node_hash")))
             except (TypeError, ValueError):
-                continue
-        return refs
+                return None
+        if (
+            record_type != "context_embedding"
+            or record.get("ref_type") != "node"
+            or record.get("ref_hash") is None
+            or record.get("embedding_type") != "context_node"
+            or not record_vector(record)
+            or not record.get("vector")
+        ):
+            return None
+        model_ref = str(record.get("model_ref") or "")
+        if not model_ref:
+            return None
+        try:
+            return (model_ref, int(record.get("ref_hash")))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _note_node_embedding_ref(cls, index, record) -> None:
+        pair = cls._node_embedding_ref_of(record)
+        if pair is None:
+            return
+        model_ref, node_hash = pair
+        index.setdefault(model_ref, set()).add(node_hash)
 
     def _record_node_embedding_ref(self, node_hash: int, current_model_ref: str) -> None:
         """Note that a node embedding now exists. No-op here; the log IS the record.

--- a/tools/matrixark_local_adapter_context_node.py
+++ b/tools/matrixark_local_adapter_context_node.py
@@ -65,8 +65,27 @@ class _LocalAdapterContextNodeMixin:
         """
         refs: set[int] = set()
         for record in self.read_all():
+            record_type = str(record.get("record_type") or "")
+            # A node embedding now lives ON the node: fold_embedding_records moves the vector onto
+            # the owner and drops the separate context_embedding row. Looking only for that row
+            # found nothing in any log written since, so every node was reported un-embedded and
+            # re-embedded on every ingest -- 60 embeddings for 3 distinct nodes over 20 ingests.
+            if record_type == "context_node":
+                meta = record.get("embedding_meta")
+                if not isinstance(meta, dict):
+                    continue
+                if str(meta.get("model_ref") or "") != current_model_ref:
+                    continue
+                if not record.get("vector") and not record_vector(record):
+                    continue
+                try:
+                    refs.add(int(record.get("node_hash")))
+                except (TypeError, ValueError):
+                    pass
+                continue
+            # Logs written before the fold carry the embedding as its own row.
             if (
-                record.get("record_type") != "context_embedding"
+                record_type != "context_embedding"
                 or record.get("ref_type") != "node"
                 or record.get("ref_hash") is None
             ):

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -187,13 +187,29 @@ def _profile_provenance_overflow(previous_profile, *, refs_all, events_all):
 class _LocalAdapterIngestMixin:
     _MEMORY_UPSERT_ARG_KEYS = ("expires_at", "ttl_seconds", "retention_cutoff_ts", "identity_key", "truth_class")
 
+    def _coalesced_ingest_impl(self, args: Json, *, hook: Json | None = None) -> Json:
+        """Run the ingest, then write the appends it buffered as one batch.
+
+        The flush lives here rather than at the end of ``_ingest_impl`` because that returns from
+        many places; this catches every one. A failed ingest ABORTS instead of flushing, so a
+        half-written record set never reaches the log and a pooled thread cannot inherit an active
+        buffer.
+        """
+        try:
+            result = self._ingest_impl(args, hook=hook)
+        except BaseException:
+            self._abort_append_coalescing()
+            raise
+        self._flush_append_coalescing()
+        return result
+
     def ingest(self, args: Json, *, hook: Json | None = None) -> Json:
         """Public ingest entry. Fast-path is byte-identical to the core ingest; when any
         PurchaseMemory field (expires_at / ttl_seconds / retention_cutoff_ts / identity_key /
         truth_class) is present it layers per-record TTL stamping, a keyed-upsert truth-rank guard,
         and a scope-level retention-cutoff marker on top of the unchanged core ingest."""
         if not any(key in args for key in self._MEMORY_UPSERT_ARG_KEYS):
-            return self._ingest_impl(args, hook=hook)
+            return self._coalesced_ingest_impl(args, hook=hook)
         envelope = normalize_envelope(args, default_kind="message")
         # Pin ingestion_time_ms so the core re-normalization inside _ingest_impl is deterministic
         # (event_id_hash derives from it); the caller's other fields already round-trip through args.
@@ -201,7 +217,7 @@ class _LocalAdapterIngestMixin:
         identity_key = str(envelope.get("identity_key") or "")
         self._push_ingest_stamp(envelope)
         try:
-            result = self._ingest_impl(args, hook=hook)
+            result = self._coalesced_ingest_impl(args, hook=hook)
         finally:
             self._pop_ingest_stamp()
         if isinstance(result, dict):
@@ -543,6 +559,12 @@ class _LocalAdapterIngestMixin:
             prior_context=prior_context,
         )
         self._observe_model_latency("extraction", (time.perf_counter() - extraction_started_perf) * 1000.0)
+        # Every remaining write in this ingest is one append of one record -- 45 of them for a
+        # skill, each opening the log and running the whole batch pipeline for a single row, which
+        # measured 53% of ingest wall. They are one consecutive run with no read after this point,
+        # which is exactly the condition _begin_append_coalescing documents, so the run becomes one
+        # append_many. ingest() owns the flush and the abort.
+        self._begin_append_coalescing()
         text = text_from_messages(envelope["messages"])
         # A resource/skill document already lives in its chunk records and behind its raw URI, so
         # carrying it a THIRD time as event text is pure duplication -- measured at 1.05x source

--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -27,6 +27,24 @@ def _segments_enabled(scope) -> bool:
     return bool(extract_segments_enabled(scope))
 
 
+def _context_debug_records_enabled() -> bool:
+    """Gate: write context_debug_record rows at all.
+
+    MATRIXARK_CONTEXT_DEBUG_RECORDS defaults OFF and the compact writer already honours it, but
+    the two writers in this module did not, so the rows were written whatever the knob said. The
+    pack strips ``metadata_debug`` from every served item (DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS),
+    so they were carried in memory and never served: 12.1% of the read cache.
+
+    Imported lazily and defaulting to OFF when the module is absent, matching the other gates
+    here: a missing policy module must not start writing rows nobody asked for.
+    """
+    try:
+        from matrixark_mcp_serving_records import context_debug_records_enabled
+    except Exception:  # pragma: no cover - policy module absent
+        return False
+    return bool(context_debug_records_enabled())
+
+
 def _segment_access_scope_enabled() -> bool:
     """Gate: write context_segment records WITH a tenant/user/session access_scope so a
     scored segment passes access_scope_matches_before_scoring instead of being dropped
@@ -830,7 +848,11 @@ class _LocalAdapterIngestMixin:
                         }
                     )
                     skill_debug_metadata = debug_resource_metadata(parsed_skill.metadata)
-                    if skill_debug_metadata or parsed_skill.text:
+                    # MATRIXARK_CONTEXT_DEBUG_RECORDS gates these and defaults OFF, but only the
+                    # compact writer asked. These two wrote regardless, and the pack strips
+                    # metadata_debug from every served item, so the rows were carried and never
+                    # read: 12.1% of the cache.
+                    if _context_debug_records_enabled() and (skill_debug_metadata or parsed_skill.text):
                         self.append(
                             {
                                 "record_type": "context_debug_record",
@@ -1172,7 +1194,7 @@ class _LocalAdapterIngestMixin:
                         "updated_at_ms": envelope["ingestion_time_ms"],
                     }
                 )
-                if chunk_debug_metadata:
+                if chunk_debug_metadata and _context_debug_records_enabled():
                     self.append(
                         {
                             "record_type": "context_debug_record",

--- a/tools/matrixark_mcp_core.py
+++ b/tools/matrixark_mcp_core.py
@@ -2457,6 +2457,42 @@ def _chunked_refs(refs: list[Any], *, limit: int) -> list[list[Any]]:
     return [refs[index:index + cap] for index in range(0, len(refs), cap)] or [[]]
 
 
+#: This module carries its own copy of the posting fold, and it groups by data_model where the
+#: copy in matrixark_mcp_indexing groups by capability -- different keys, different policy string.
+#: Compaction resolves THIS one. The skip-when-already-folded helper is shared with the other copy
+#: rather than written twice, because two copies of this fold have already drifted once.
+_CORE_POSTING_POLICY = "bucketed_by_scope_data_model_index_time"
+_ALREADY_FOLDED_POSTINGS = None
+
+
+def _core_posting_bucket_key(record: Json):
+    index_name = str(record.get("index_name") or "")
+    data_model = str(record.get("data_model") or "")
+    if not index_name or not data_model:
+        return None
+    return (
+        str(record.get("scope_key") or ""),
+        data_model,
+        index_name,
+        str(record.get("ref_type") or ""),
+        context_index_time_bucket(record.get("timestamp_key_ms") or record.get("updated_at_ms")),
+    )
+
+
+def _core_already_folded_postings(records: list[Json]):
+    """Resolved once: compaction calls this for every read, and an import per call was already
+    measured as 82.9% of what keying a record costs."""
+    global _ALREADY_FOLDED_POSTINGS
+    helper = _ALREADY_FOLDED_POSTINGS
+    if helper is None:
+        try:
+            from tools.matrixark_mcp_indexing import already_folded_postings as helper
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_indexing import already_folded_postings as helper
+        _ALREADY_FOLDED_POSTINGS = helper
+    return helper(records, _CORE_POSTING_POLICY, _core_posting_bucket_key, ("index_hash",))
+
+
 def compact_context_index_postings(records: list[Json]) -> list[Json]:
     """Group ContextIndex writes into Feature-style timestamped posting rows.
 
@@ -2465,6 +2501,9 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
     timestamp bucket. Grouping keeps index rows bounded by terms and buckets,
     while ref_hashes carries the posting list.
     """
+    unchanged = _core_already_folded_postings(records)
+    if unchanged is not None:
+        return unchanged
     scalar_lineage_fields = [
         "memory_scope",
         "session_continuity",

--- a/tools/matrixark_mcp_core_compact.py
+++ b/tools/matrixark_mcp_core_compact.py
@@ -531,6 +531,14 @@ def materialize_serving_record_batch(records: list[Json]) -> list[Json]:
         materialized.extend(materialize_serving_records(record))
     return compact_context_index_postings(materialized)
 
+#: Resolved once. The import used to run on EVERY call, and compaction calls this for every
+#: record it holds -- 285,928 times over 200 skill ingests. Resolving it per call made the
+#: delegating wrapper 3.3x the cost of the function it delegates to, which was 18% of the
+#: dominant compaction stage. Which of the two module paths wins is unchanged; it is just
+#: decided once instead of a quarter of a million times.
+_SERVING_LATEST_CONTEXT_STATE_KEY = None
+
+
 def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
     """Return the logical latest-state key for versionless context records.
 
@@ -541,15 +549,19 @@ def latest_context_state_key(record: Json) -> tuple[Any, ...] | None:
     their append-log rows and every status transition accumulated, which is the cost that
     identity exists to remove.
     """
-    try:
-        from tools.matrixark_mcp_serving_records import (
-            latest_context_state_key as _serving_latest_context_state_key,
-        )
-    except ImportError:  # Direct script execution from tools/.
-        from matrixark_mcp_serving_records import (
-            latest_context_state_key as _serving_latest_context_state_key,
-        )
-    return _serving_latest_context_state_key(record)
+    global _SERVING_LATEST_CONTEXT_STATE_KEY
+    delegate = _SERVING_LATEST_CONTEXT_STATE_KEY
+    if delegate is None:
+        try:
+            from tools.matrixark_mcp_serving_records import (
+                latest_context_state_key as delegate,
+            )
+        except ImportError:  # Direct script execution from tools/.
+            from matrixark_mcp_serving_records import (
+                latest_context_state_key as delegate,
+            )
+        _SERVING_LATEST_CONTEXT_STATE_KEY = delegate
+    return delegate(record)
 
 
 def compact_latest_context_state_records(records: list[Json]) -> list[Json]:

--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -354,8 +354,104 @@ def _chunked_refs(refs: list[Any], *, limit: int) -> list[list[Any]]:
     return [refs[index:index + cap] for index in range(0, len(refs), cap)] or [[]]
 
 
+#: The value compact_context_index_postings stamps on a row it has folded. A row carrying it has
+#: already been through the whole grouping pass.
+POSTING_POLICY_BUCKETED = "bucketed_by_scope_capability_index_time"
+
+
+def is_fold_output(record: Json, policy: str, stamped: tuple) -> bool:
+    """True when this row is one the fold itself produced, not merely one that looks like it.
+
+    The policy marker alone is not enough. The fold also stamps fields (``index_hash``, and in the
+    indexing copy ``storage_record_kind`` / ``storage_part``) and DROPS ``node_hashes`` /
+    ``batch_id_hashes`` when they are empty, so a row carrying the policy string but missing those
+    is not its output and passing it through would skip work that changes it. An equivalence check
+    against the full pass caught exactly that.
+    """
+    if str(record.get("posting_policy") or "") != policy:
+        return False
+    for field in stamped:
+        if not record.get(field):
+            return False
+    for field in ("node_hashes", "batch_id_hashes"):
+        if field in record and not record.get(field):
+            return False                    # the fold would have removed it
+    for field in ("ref_hash", "chunk_hash"):
+        if field in record:
+            return False                    # the fold would have popped it
+    refs = record.get("ref_hashes")
+    if not isinstance(refs, list) or len(refs) > MAX_SECONDARY_INDEX_REFS_PER_POSTING:
+        return False                        # would be re-chunked into several parts
+    if len(refs) != len({str(ref) for ref in refs}):
+        return False                        # the fold would dedupe these
+    return True
+
+
+def already_folded_postings(records: list[Json], policy: str, key_of, stamped: tuple):
+    """Return the fold's own answer without doing the fold, when it provably cannot change anything.
+
+    Compaction re-folds the read cache on every read, and the cache holds the fold's OWN output --
+    so the pass re-groups rows that are already grouped and rebuilds them byte for byte. Measured
+    on a skill corpus the fold coalesces NOTHING at any size (63->63, 113->113, 213->213, 413->413
+    rows) while costing about 57 microseconds per posting in grouping plus 9 in identity hashing.
+
+    The fold is idempotent -- fold(fold(x)) == fold(x) row for row -- so when every posting is
+    already folded and no two share a bucket, each group has one member that is already its own
+    output and the answer is the input. Anything else (a fresh row, two rows in one bucket, a
+    posting at the ref limit that would be re-chunked) returns None and the full pass runs.
+
+    ``key_of`` returns the bucket key, or None for a row the fold passes through. It is taken as an
+    argument because there are two copies of this fold and they group by different things -- one by
+    data_model, one by capability -- so one shared helper is parameterised rather than copied a
+    third time.
+    """
+    passthrough: list[Json] = []
+    postings: list[Json] = []
+    seen_keys = set()
+    for record in records:
+        if str(record.get("record_type") or "") != "context_index":
+            passthrough.append(record)
+            continue
+        key = key_of(record)
+        if key is None:
+            passthrough.append(record)      # the full pass treats these the same way
+            continue
+        if not is_fold_output(record, policy, stamped):
+            return None                     # not the fold's own output: the real pass has work
+        if key in seen_keys:
+            return None                     # two rows in one bucket: they must be merged
+        seen_keys.add(key)
+        postings.append(record)
+    return passthrough + postings
+
+
+def _indexing_bucket_key(record: Json):
+    index_name = str(record.get("index_name") or "")
+    capability = context_index_capability(record)
+    if not index_name or not capability:
+        return None
+    return (
+        str(record.get("scope_key") or ""),
+        capability,
+        str(record.get("data_model") or ""),
+        index_name,
+        str(record.get("ref_type") or ""),
+        context_index_time_bucket(record.get("timestamp_key_ms") or record.get("updated_at_ms")),
+    )
+
+
+def _already_folded_postings(records: list[Json]) -> list[Json] | None:
+    return already_folded_postings(
+        records, POSTING_POLICY_BUCKETED, _indexing_bucket_key,
+        ("index_hash", "storage_record_kind", "storage_part"),
+    )
+
+
 def compact_context_index_postings(records: list[Json]) -> list[Json]:
     """Group ContextIndex writes into Feature-style timestamped posting rows."""
+    unchanged = _already_folded_postings(records)
+    if unchanged is not None:
+        return unchanged
     scalar_lineage_fields = [
         "memory_scope",
         "session_continuity",

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -777,6 +777,37 @@ import json as _json
 import sys as _sys
 
 
+#: A field whose values keep turning out to be distinct is not worth a table: at scale the
+#: hashes and row names would flood it and crowd out the fields that DO repeat. Each field gets
+#: its own table and is abandoned once it exceeds this many distinct values. Measured on an
+#: attachment corpus the repetitive fields hold 1 to 21 distinct values, and the distinct ones
+#: (row_key, context_event_key) are unique per row, so the two separate cleanly.
+_STRING_FIELD_CARDINALITY_LIMIT = 512
+#: Longer than this and hashing the value to look it up costs more than the copy saves.
+_SHARED_STRING_MAX_LEN = 256
+_SHARED_STRINGS: dict = {}
+_SHARED_STRINGS_ABANDONED: set = set()
+
+
+def _shared_string(field, value):
+    """Return the one copy of ``value`` held for ``field``, or ``value`` if it is not worth it."""
+    if len(value) > _SHARED_STRING_MAX_LEN or field in _SHARED_STRINGS_ABANDONED:
+        return value
+    table = _SHARED_STRINGS.get(field)
+    if table is None:
+        table = _SHARED_STRINGS[field] = {}
+    shared = table.get(value)
+    if shared is not None:
+        return shared
+    if len(table) >= _STRING_FIELD_CARDINALITY_LIMIT:
+        # This field's values are distinct, not repeated. Stop paying to find that out.
+        _SHARED_STRINGS_ABANDONED.add(field)
+        _SHARED_STRINGS.pop(field, None)
+        return value
+    table[value] = value
+    return value
+
+
 def _interned_pairs(pairs):
     """Build a decoded object with its keys interned.
 
@@ -789,7 +820,14 @@ def _interned_pairs(pairs):
     Interning is free of meaning: the strings compare equal either way, so nothing above this can
     tell the difference.
     """
-    return {_sys.intern(key) if type(key) is str else key: value for key, value in pairs}
+    out = {}
+    for key, value in pairs:
+        if type(key) is str:
+            key = _sys.intern(key)
+            if type(value) is str and value:
+                value = _shared_string(key, value)
+        out[key] = value
+    return out
 
 
 def loads_with_interned_keys(line: str):
@@ -5706,11 +5744,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             if cached is not None:
                 cached_size, cached_mtime_ns, cached_records = cached
                 if cached_size == size and cached_mtime_ns == mtime_ns:
-                    records = list(cached_records)
+                    # Share ONCE, then hand the same list to every holder. Sharing only
+                    # into the adapter's cache left the process cache, the durable snapshot and
+                    # the returned list holding the unshared originals, so both were alive at
+                    # once and a cold read kept 120 copies of a value with ONE distinct value.
+                    records = share_repeated_values(
+                        list(cached_records), _SHARED_VALUE_TABLE
+                    )
                     with self._read_cache_lock:
-                        self._read_cache_records = share_repeated_values(
-                            list(records), _SHARED_VALUE_TABLE
-                        )
+                        self._read_cache_records = list(records)
                         self._read_cache_value_keys = None
                         self._read_cache_state_keys = None
                         self._read_cache_size = size
@@ -5721,11 +5763,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 _LOCAL_READ_CACHE_DIRTY.discard(cache_key)
         durable_records = self._load_durable_read_cache(signature)
         if durable_records is not None:
-            records = list(durable_records)
+            records = share_repeated_values(list(durable_records), _SHARED_VALUE_TABLE)
             with self._read_cache_lock:
-                self._read_cache_records = share_repeated_values(
-                    list(records), _SHARED_VALUE_TABLE
-                )
+                self._read_cache_records = list(records)
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
@@ -5760,9 +5800,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 or self._read_cache_size != size
                 or self._read_cache_mtime_ns != mtime_ns
             )
-            self._read_cache_records = share_repeated_values(
-                list(records), _SHARED_VALUE_TABLE
-            )
+            records = share_repeated_values(list(records), _SHARED_VALUE_TABLE)
+            self._read_cache_records = list(records)
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -773,6 +773,30 @@ def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
     return shared_out
 
 
+import json as _json
+import sys as _sys
+
+
+def _interned_pairs(pairs):
+    """Build a decoded object with its keys interned.
+
+    The JSON decoder memoises key strings within ONE call, but the log is read a line at a time,
+    so every record gets its own copy of every key it carries. Measured over a cold read of 914
+    records: **148 distinct key names, backed by 16,743 separate string objects** holding 1,009.7
+    KB -- 1,000.3 KB of which is one name repeated. That is close to half the cold cache, spent on
+    148 short strings.
+
+    Interning is free of meaning: the strings compare equal either way, so nothing above this can
+    tell the difference.
+    """
+    return {_sys.intern(key) if type(key) is str else key: value for key, value in pairs}
+
+
+def loads_with_interned_keys(line: str):
+    """``json.loads`` for one log line, sharing key strings with every other line."""
+    return _json.loads(line, object_pairs_hook=_interned_pairs)
+
+
 def _copy_interned_value(value: Any) -> Any:
     """Kept for callers that genuinely need their own copy."""
     if type(value) is dict:
@@ -4391,7 +4415,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if delta_count:
             try:
                 with self._durable_read_cache_delta_path().open("r", encoding="utf-8") as handle:
-                    tail = [json.loads(line) for line in handle if line.strip()]
+                    tail = [loads_with_interned_keys(line) for line in handle if line.strip()]
             except (FileNotFoundError, json.JSONDecodeError, OSError):
                 return None
             if len(tail) != delta_count:
@@ -4941,7 +4965,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         if not line or INTERN_DICT_RECORD_TYPE not in line:
                             continue
                         try:
-                            record = json.loads(line)
+                            record = loads_with_interned_keys(line)
                         except json.JSONDecodeError:
                             continue
                         if isinstance(record, dict) and str(record.get("record_type") or "") == INTERN_DICT_RECORD_TYPE:
@@ -4984,7 +5008,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         if not line or "context_model_registry" not in line:
                             continue
                         try:
-                            record = json.loads(line)
+                            record = loads_with_interned_keys(line)
                         except json.JSONDecodeError:
                             continue
                         if isinstance(record, dict) and str(record.get("record_type") or "") == "context_model_registry":
@@ -5725,7 +5749,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     for line in handle:
                         line = line.strip()
                         if line:
-                            records.append(json.loads(line))
+                            records.append(loads_with_interned_keys(line))
         # Expand interned metadata BEFORE compaction/caching so the read cache, durable cache, and
         # every downstream consumer see fully-expanded, token-free records.
         records = expand_interned_records(records)
@@ -6816,7 +6840,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     for line in handle:
                         line = line.strip()
                         if line:
-                            raw.append(json.loads(line))
+                            raw.append(loads_with_interned_keys(line))
         return expand_interned_records(raw)
 
     def _count_raw_tombstones(self) -> int:
@@ -6854,7 +6878,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     for line in handle:
                         line = line.strip()
                         if line:
-                            raw.append(json.loads(line))
+                            raw.append(loads_with_interned_keys(line))
             tombstone_count = sum(
                 1 for record in raw
                 if str(record.get("record_type") or "") == MEMORY_TOMBSTONE_RECORD_TYPE

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4061,6 +4061,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # (record_type, field) -> {value: record}, kept current as records are appended so an
         # embedding can find its owner without reading the whole set. None until first use.
         self._embedding_owner_index: dict[tuple[str, str], dict[Any, Json]] | None = None
+        # dirty_hash -> the newest summary-dirty or refresh-audit row, so the outstanding set
+        # can be answered without reading everything. None until first use.
+        self._summary_dirty_index: dict[Any, Json] | None = None
         # The keys the compacted cache already holds, kept current so a write can tell whether
         # it supersedes anything without scanning. None means unknown -- rebuilt on the next
         # compaction.
@@ -4469,6 +4472,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_records = None
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
+            self._summary_dirty_index = None
             self._read_cache_size = -1
             self._read_cache_mtime_ns = -1
             self._read_cache_source = "empty"
@@ -4695,6 +4699,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_records = None
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
+                self._summary_dirty_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -4725,6 +4730,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     self._read_cache_value_keys = None
                     self._read_cache_state_keys = None
                 self._note_embedding_owners(records)
+                if self._summary_dirty_index is not None:
+                    for record in records:
+                        self._note_summary_dirty_row(self._summary_dirty_index, record)
                 durable_epoch = self._read_cache_compaction_epoch
             if size >= 0:
                 self._read_cache_size = size
@@ -4739,6 +4747,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_records = None
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
+                self._summary_dirty_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -4878,29 +4887,56 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             kept.append(record)
         return kept
 
+    #: The only two row types the outstanding-dirty answer depends on.
+    _SUMMARY_DIRTY_TYPES = ("context_summary_dirty", "context_summary_refresh_audit")
+
+    def _summary_dirty_rows(self) -> list[Json]:
+        """The newest summary-dirty and refresh-audit row per dirty_hash.
+
+        This was answered by scanning the whole live view twice, once per append -- 40 of the 85
+        full reads a twenty-attachment ingest performs. Those two types are a small fraction of the
+        store, so the adapter keeps just them, built from one read the first time and folded
+        forward on every append. Newest wins per dirty_hash, which is what compaction does with
+        these rows.
+        """
+        index = self._summary_dirty_index
+        if index is None:
+            index = {}
+            try:
+                live = self.read_all()
+            except (OSError, ValueError):
+                live = []
+            for record in live:
+                self._note_summary_dirty_row(index, record)
+            self._summary_dirty_index = index
+        return list(index.values())
+
+    @staticmethod
+    def _note_summary_dirty_row(index: dict[Any, Json], record: Json) -> None:
+        if not isinstance(record, dict):
+            return
+        if str(record.get("record_type") or "") not in MatrixArkLocalAdapter._SUMMARY_DIRTY_TYPES:
+            return
+        dirty_hash = record.get("dirty_hash")
+        if dirty_hash is None:
+            return
+        index[dirty_hash] = record
+
     def _outstanding_dirty_nodes(self) -> set[tuple[str, Any]]:
-        """(scope_key, node_hash) pairs with an uncompleted pending context_summary_dirty marker in the
-        current live view. Computed from read_all() so it always reflects durable+own state -- a node is
-        reported outstanding only if a pending marker is really present, so coalescing can never drop
-        the last marker for a node that still needs regeneration."""
+        """(scope_key, node_hash) pairs with an uncompleted pending context_summary_dirty marker.
+
+        A node is reported outstanding only if a pending marker is really present, so coalescing can
+        never drop the last marker for a node that still needs regeneration.
+        """
+        rows = self._summary_dirty_rows()
         completed: set[Any] = set()
-        pending: dict[tuple[str, Any], Any] = {}
-        try:
-            live = self.read_all()
-        except (OSError, ValueError):
-            return set()
-        for record in live:
-            if not isinstance(record, dict):
-                continue
-            rt = str(record.get("record_type") or "")
-            if rt not in ("context_summary_dirty", "context_summary_refresh_audit"):
-                continue
+        for record in rows:
             dirty_hash = record.get("dirty_hash")
-            status = record.get("status")
-            if dirty_hash is not None and status in ("completed", "refreshed"):
+            if dirty_hash is not None and record.get("status") in ("completed", "refreshed"):
                 completed.add(dirty_hash)
-        for record in live:
-            if not isinstance(record, dict) or str(record.get("record_type") or "") != "context_summary_dirty":
+        pending: set[tuple[str, Any]] = set()
+        for record in rows:
+            if str(record.get("record_type") or "") != "context_summary_dirty":
                 continue
             if record.get("status") != "pending":
                 continue
@@ -4908,9 +4944,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             node_hash = record.get("node_hash")
             if node_hash is None or dirty_hash in completed:
                 continue
-            key = (str(record.get("scope_key") or _canonical_scope_key_of(record)), node_hash)
-            pending[key] = record
-        return set(pending.keys())
+            pending.add(
+                (str(record.get("scope_key") or _canonical_scope_key_of(record)), node_hash)
+            )
+        return pending
 
     def _coalesce_summary_dirty(self, records: list[Json]) -> list[Json]:
         """Drop redundant pending summary-dirty markers for a (scope, node) that already has an
@@ -5483,6 +5520,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_records = []
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
+                self._summary_dirty_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -5537,6 +5575,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_records = list(records)
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
+                self._summary_dirty_index = None
                 self._read_cache_size = size
                 self._read_cache_mtime_ns = mtime_ns
                 self._read_cache_source = "durable"
@@ -5570,6 +5609,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_records = list(records)
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
+            self._summary_dirty_index = None
             self._read_cache_size = size
             self._read_cache_mtime_ns = mtime_ns
             self._read_cache_source = "jsonl"

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -3467,7 +3467,17 @@ def _latest_value_record_key_by_type(record: Json) -> tuple[Any, ...] | None:
     if record_type == "skill_registry_update":
         return (record_type, record.get("skill_hash"))
     if record_type == "resource_import_task":
-        return (record_type, record.get("resource_import_task_hash"))
+        # Every writer of this row writes `task_hash`; nothing writes
+        # `resource_import_task_hash`, which is what this asked for. So the key was
+        # (record_type, None) for every one of them, and compaction skips a key with an empty
+        # part -- these rows were never superseded and accumulated three per attachment. The old
+        # name is still accepted, for a log that somehow carries it.
+        return (
+            record_type,
+            record.get("task_hash")
+            if record.get("task_hash") is not None
+            else record.get("resource_import_task_hash"),
+        )
     return None
 
 

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4067,6 +4067,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # model_ref -> {node_hash}, so 'is this node already embedded' does not read the
         # store. None until first use; see _existing_node_embedding_refs.
         self._node_embedding_refs_index: dict[str, set[int]] | None = None
+        # The resolved event-log path, which never changes. Path.resolve walks the path and
+        # stats each component, and this was recomputed at a dozen sites on every append.
+        self._resolved_cache_key: str | None = None
+        self._resolved_paths: dict[Path, str] = {}
         # The keys the compacted cache already holds, kept current so a write can tell whether
         # it supersedes anything without scanning. None means unknown -- rebuilt on the next
         # compaction.
@@ -4264,7 +4268,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             mtime_ns = int(stat.st_mtime_ns)
             total_size += size
             max_mtime_ns = max(max_mtime_ns, mtime_ns)
-            entries.append({"path": str(path.resolve()), "size": size, "mtime_ns": mtime_ns})
+            # Resolving is a walk over every component; the retained paths do not move, so the
+            # resolved form is remembered per path rather than recomputed on each signature.
+            resolved = self._resolved_paths.get(path)
+            if resolved is None:
+                resolved = str(path.resolve())
+                self._resolved_paths[path] = resolved
+            entries.append({"path": resolved, "size": size, "mtime_ns": mtime_ns})
         if total_size <= 0 and max_mtime_ns < 0:
             return {"total_size": -1, "max_mtime_ns": -1, "paths": []}
         return {"total_size": total_size, "max_mtime_ns": max_mtime_ns, "paths": entries}
@@ -4287,7 +4297,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return None
         if head.get("schema_version") != LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION:
             return None
-        if head.get("cache_key") != str(self.event_log.resolve()):
+        if head.get("cache_key") != self._cache_key_str():
             return None
         if head.get("signature") != signature:
             return None
@@ -4320,7 +4330,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         try:
             with self._durable_read_cache_head_path().open("r", encoding="utf-8") as handle:
                 head = json.load(handle)
-            if head.get("cache_key") != str(self.event_log.resolve()):
+            if head.get("cache_key") != self._cache_key_str():
                 return ""
             if head.get("schema_version") != LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION:
                 return ""
@@ -4334,7 +4344,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         try:
             with self._durable_read_cache_head_path().open("r", encoding="utf-8") as handle:
                 head = json.load(handle)
-            if head.get("cache_key") != str(self.event_log.resolve()):
+            if head.get("cache_key") != self._cache_key_str():
                 return (0, 0)
             if head.get("schema_version") != LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION:
                 return (0, 0)
@@ -4380,7 +4390,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             epoch is not None
             and appended > 0
             and self._durable_read_cache_state
-            == (str(self.event_log.resolve()), base_count, delta_count, epoch)
+            == (self._cache_key_str(), base_count, delta_count, epoch)
         )
         if not contiguous and appended > 0 and base_count > 0:
             # The list handed over is often the process-wide one, shared by every adapter over this
@@ -4401,7 +4411,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             with tmp.open("w", encoding="utf-8") as handle:
                 json.dump({
                     "schema_version": LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
-                    "cache_key": str(self.event_log.resolve()),
+                    "cache_key": self._cache_key_str(),
                     "signature": signature,
                     "record_count": record_count,
                     "delta_count": deltas,
@@ -4429,7 +4439,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         handle.write(json.dumps(record, separators=(",", ":")) + "\n")
                 write_head(base_count, delta_count + appended)
                 self._durable_read_cache_state = (
-                    str(self.event_log.resolve()), base_count, delta_count + appended, epoch
+                    self._cache_key_str(), base_count, delta_count + appended, epoch
                 )
                 self._durable_read_cache_last_write_ms = now
                 return
@@ -4443,7 +4453,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         payload = {
             "schema_version": LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
-            "cache_key": str(self.event_log.resolve()),
+            "cache_key": self._cache_key_str(),
             "signature": signature,
             "record_count": len(records),
             "records": records,
@@ -4460,7 +4470,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 pass
             write_head(len(records), 0)
             self._durable_read_cache_state = (
-                str(self.event_log.resolve()), len(records), 0, epoch
+                self._cache_key_str(), len(records), 0, epoch
             )
             self._durable_read_cache_last_write_ms = now
         except OSError:
@@ -4470,7 +4480,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 pass
 
     def _clear_jsonl_read_caches(self) -> None:
-        cache_key = str(self.event_log.resolve())
+        cache_key = self._cache_key_str()
         with self._read_cache_lock:
             self._read_cache_records = None
             self._read_cache_value_keys = None
@@ -4648,6 +4658,18 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 if value is not None:
                     bucket[value] = record
 
+    def _cache_key_str(self) -> str:
+        """The resolved event-log path, computed once.
+
+        Path.resolve() walks every component and stats it. This value is the same for the life
+        of the adapter, and it was being recomputed at each of a dozen call sites on every
+        append -- 428 filesystem stats per attachment came through here and the retained-path
+        scan beside it.
+        """
+        if self._resolved_cache_key is None:
+            self._resolved_cache_key = str(self.event_log.resolve())
+        return self._resolved_cache_key
+
     def _compact_read_cache_if_dirty_locked(self) -> None:
         """Compact the cache if records were appended since the last compaction.
 
@@ -4682,7 +4704,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         """
         if not records:
             return
-        cache_key = str(self.event_log.resolve())
+        cache_key = self._cache_key_str()
         signature = self._jsonl_cache_signature_detail()
         size = int(signature.get("total_size", -1))
         mtime_ns = int(signature.get("max_mtime_ns", -1))
@@ -5531,7 +5553,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         return filter_live_memory_records(self._read_all_compacted())
 
     def _read_all_compacted(self) -> list[Json]:
-        cache_key = str(self.event_log.resolve())
+        cache_key = self._cache_key_str()
         paths = self._retained_jsonl_paths()
         if not paths:
             with self._read_cache_lock:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -760,6 +760,79 @@ _SHAREABLE_SCALARS = frozenset({str, int, float, bool, type(None)})
 _SHARED_VALUE_TABLE: dict = {}
 
 
+#: How far to look inside a record for a container worth sharing. The repetitive ones sit one
+#: level down -- `embedding_meta.node_path` was 100 rows holding ONE value, `envelope.storage_route`
+#: 20 rows holding one -- and nothing useful was found below three. A cap keeps a record that nests
+#: deeply from costing a walk proportional to its whole shape on every append.
+_SHARE_MAX_DEPTH = 3
+
+
+def _lookup_shared(field, key, value, table, shared_type):
+    """Return the one object held for this value, creating it if the table has room."""
+    entry = table.get(key)
+    if entry is not None:
+        return entry
+    if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
+        return value
+    entry = table[key] = shared_type(value)
+    return entry
+
+
+def _shared_container(field, value, table, depth):
+    """Share ``value`` if it is a flat container, else rebuild it around whatever inside it is.
+
+    Returns the SAME object when nothing changed, which is what lets a caller skip the copy: a
+    record whose values are all unshareable is passed through untouched rather than duplicated.
+
+    A container is only rebuilt on the path down to a replacement, so the caller's own nested
+    dicts are never written to -- the copy stops as soon as there is nothing below worth sharing.
+    """
+    kind = type(value)          # exact type: an already-shared value is a subclass and is skipped
+    if kind is dict:
+        if not value:
+            return value
+        if all(type(v) in _SHAREABLE_SCALARS for v in value.values()):
+            try:
+                return _lookup_shared(field, (field, tuple(sorted(value.items()))), value,
+                                      table, _SharedInternedValue)
+            except TypeError:
+                return value    # keys of mixed type do not sort
+        if depth >= _SHARE_MAX_DEPTH:
+            return value
+        replacements = None
+        for sub_field, sub_value in value.items():
+            if type(sub_value) not in (dict, list):
+                continue
+            shared = _shared_container(str(sub_field), sub_value, table, depth + 1)
+            if shared is not sub_value:
+                if replacements is None:
+                    replacements = {}
+                replacements[sub_field] = shared
+        if replacements is None:
+            return value
+        rebuilt = dict(value)
+        rebuilt.update(replacements)
+        return rebuilt
+    if kind is list:
+        if not value:
+            return value
+        if all(type(v) in _SHAREABLE_SCALARS for v in value):
+            return _lookup_shared(field, (field, tuple(value)), value, table, _SharedInternedList)
+        if depth >= _SHARE_MAX_DEPTH:
+            return value
+        rebuilt = None
+        for index, item in enumerate(value):
+            if type(item) not in (dict, list):
+                continue
+            shared = _shared_container(field, item, table, depth + 1)
+            if shared is not item:
+                if rebuilt is None:
+                    rebuilt = list(value)
+                rebuilt[index] = shared
+        return value if rebuilt is None else rebuilt
+    return value
+
+
 def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
     """Give every record that carries the same flat dict value the SAME object.
 
@@ -792,30 +865,13 @@ def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
             continue
         replacements = None
         for field, value in record.items():
-            kind = type(value)
-            if kind is dict:
-                if not value or not all(type(v) in _SHAREABLE_SCALARS for v in value.values()):
-                    continue      # empty, or holds a container -- cannot be keyed cheaply
-                try:
-                    key = (field, tuple(sorted(value.items())))
-                except TypeError:
-                    continue      # keys of mixed type do not sort
-            elif kind is list:
-                if not value or not all(type(v) in _SHAREABLE_SCALARS for v in value):
-                    continue
-                key = (field, tuple(value))
-            else:
+            if type(value) not in (dict, list):
                 continue
-            shared = table.get(key)
-            if shared is None:
-                if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
-                    continue
-                shared = (_SharedInternedValue(value) if kind is dict
-                          else _SharedInternedList(value))
-                table[key] = shared
-            if replacements is None:
-                replacements = {}
-            replacements[field] = shared
+            shared = _shared_container(field, value, table, 0)
+            if shared is not value:
+                if replacements is None:
+                    replacements = {}
+                replacements[field] = shared
         if replacements is None:
             shared_out.append(record)
         else:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4064,6 +4064,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # dirty_hash -> the newest summary-dirty or refresh-audit row, so the outstanding set
         # can be answered without reading everything. None until first use.
         self._summary_dirty_index: dict[Any, Json] | None = None
+        # model_ref -> {node_hash}, so 'is this node already embedded' does not read the
+        # store. None until first use; see _existing_node_embedding_refs.
+        self._node_embedding_refs_index: dict[str, set[int]] | None = None
         # The keys the compacted cache already holds, kept current so a write can tell whether
         # it supersedes anything without scanning. None means unknown -- rebuilt on the next
         # compaction.
@@ -4473,6 +4476,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None
+            self._node_embedding_refs_index = None
             self._read_cache_size = -1
             self._read_cache_mtime_ns = -1
             self._read_cache_source = "empty"
@@ -4700,6 +4704,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -4733,14 +4738,23 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 if self._summary_dirty_index is not None:
                     for record in records:
                         self._note_summary_dirty_row(self._summary_dirty_index, record)
+                if self._node_embedding_refs_index is not None:
+                    for record in records:
+                        self._note_node_embedding_ref(self._node_embedding_refs_index, record)
                 durable_epoch = self._read_cache_compaction_epoch
             if size >= 0:
                 self._read_cache_size = size
                 self._read_cache_mtime_ns = mtime_ns
-                if self._read_cache_records is not None:
-                    # The snapshot is served to a cold reader without re-compacting, so it has to
-                    # be compact when written.
-                    self._compact_read_cache_if_dirty_locked()
+                if self._read_cache_records is not None and not self._read_cache_dirty:
+                    # A cold reader is served the snapshot without re-compacting, so only a
+                    # COMPACT cache may be copied into it.
+                    #
+                    # Compacting here to make that true undid the deferral: the copy is taken on
+                    # every append, so every append compacted after all. It was 322 compactions
+                    # over 40 attachments, 112,965 records visited, 28% of the time an ingest
+                    # took. A write already declines to rewrite the base and lets the next read
+                    # refresh the snapshot; declining to extend it while the cache is dirty is
+                    # the same trade, and the read that compacts will refresh it.
                     durable_epoch = self._read_cache_compaction_epoch
                     durable_records = list(self._read_cache_records)
             else:
@@ -4748,6 +4762,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -5521,6 +5536,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -5576,6 +5592,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._node_embedding_refs_index = None
                 self._read_cache_size = size
                 self._read_cache_mtime_ns = mtime_ns
                 self._read_cache_source = "durable"
@@ -5610,6 +5627,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None
+            self._node_embedding_refs_index = None
             self._read_cache_size = size
             self._read_cache_mtime_ns = mtime_ns
             self._read_cache_source = "jsonl"

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -703,6 +703,76 @@ def _shared_interned_value(value: Any) -> Any:
     return _copy_interned_value(value)
 
 
+#: Beyond this many distinct values a field is not repetitive enough to be worth a table entry,
+#: and the table itself would start to cost more than it saves. Measured on an attachment corpus
+#: the busiest field held 11 distinct values, so this is a runaway guard, not a working limit.
+SHARE_REPEATED_VALUES = bool_env("MATRIXARK_SHARE_REPEATED_VALUES", True)
+_SHARED_VALUE_TABLE_LIMIT = 4096
+#: Only a value whose every entry is one of these can be keyed by its contents.
+_SHAREABLE_SCALARS = frozenset({str, int, float, bool, type(None)})
+#: flat value -> the one object every record carrying it holds. Process-wide, so two adapters
+#: over the same store share as well.
+_SHARED_VALUE_TABLE: dict = {}
+
+
+def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
+    """Give every record that carries the same flat dict value the SAME object.
+
+    ``expand_interned_records`` already does this, but only for records it decodes off disk. A
+    record that reaches the cache from the append path was built field by field in memory and
+    never passed through it, so it holds a private dict for a value the corpus repeats endlessly.
+    Measured over 914 cached records from 60 attachments: ``storage_options`` was held as 673
+    separate objects for **11 distinct values** and ``storage_route`` as 793 objects for **2**.
+    Sharing one object per distinct value reclaims **49.9% of the cache** -- 3,877 B/record down
+    to 1,944 B/record.
+
+    Each record is shallow-copied first, so the shared value is only ever reachable through the
+    cache. The record the caller passed in keeps its own private dicts and stays writable; only
+    the copy the cache holds points at a value that refuses mutation.
+
+    Only flat dicts qualify: a value containing a container cannot be keyed cheaply, and a list
+    would have to change type to be safe to share (see :func:`_shared_interned_value`).
+
+    ``vector`` looks like the next candidate -- 363 objects for 145 values, 8.5% of the cache --
+    but that is an artefact of a corpus built from repeated text. Real ingest embeds distinct
+    documents, so almost every vector is unique: sharing them would hash every vector on the
+    append path and collapse nothing. It is left out deliberately, not overlooked.
+    """
+    if not SHARE_REPEATED_VALUES:
+        return records
+    shared_out: list[Json] = []
+    for record in records:
+        if not isinstance(record, dict):
+            shared_out.append(record)
+            continue
+        replacements = None
+        for field, value in record.items():
+            if type(value) is not dict or not value:
+                continue
+            if not all(type(v) in _SHAREABLE_SCALARS for v in value.values()):
+                continue          # holds a container -- cannot be keyed cheaply
+            try:
+                key = (field, tuple(sorted(value.items())))
+            except TypeError:
+                continue          # keys of mixed type do not sort
+            shared = table.get(key)
+            if shared is None:
+                if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
+                    continue
+                shared = _SharedInternedValue(value)
+                table[key] = shared
+            if replacements is None:
+                replacements = {}
+            replacements[field] = shared
+        if replacements is None:
+            shared_out.append(record)
+        else:
+            copied = dict(record)
+            copied.update(replacements)
+            shared_out.append(copied)
+    return shared_out
+
+
 def _copy_interned_value(value: Any) -> Any:
     """Kept for callers that genuinely need their own copy."""
     if type(value) is dict:
@@ -4694,7 +4764,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_dirty = False
             return
         before = len(self._read_cache_records)
-        self._read_cache_records = compact_and_apply_tombstones(self._read_cache_records)
+        self._read_cache_records = share_repeated_values(
+            compact_and_apply_tombstones(self._read_cache_records), _SHARED_VALUE_TABLE
+        )
         self._read_cache_dirty = False
         if len(self._read_cache_records) != before:
             self._read_cache_compaction_epoch += 1
@@ -4766,7 +4838,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     # 3.7 million key computations over 250 attachments, 36% of the time.
                     value_keys.update(k for k in new_value if k is not None)
                     state_keys.update(k for k in new_state if k is not None)
-                self._read_cache_records.extend(records)
+                self._read_cache_records.extend(
+                    share_repeated_values(records, _SHARED_VALUE_TABLE)
+                )
                 if not appends_only:
                     self._read_cache_dirty = True
                 self._note_embedding_owners(records)
@@ -5610,7 +5684,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 if cached_size == size and cached_mtime_ns == mtime_ns:
                     records = list(cached_records)
                     with self._read_cache_lock:
-                        self._read_cache_records = records
+                        self._read_cache_records = share_repeated_values(
+                            list(records), _SHARED_VALUE_TABLE
+                        )
                         self._read_cache_value_keys = None
                         self._read_cache_state_keys = None
                         self._read_cache_size = size
@@ -5623,7 +5699,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if durable_records is not None:
             records = list(durable_records)
             with self._read_cache_lock:
-                self._read_cache_records = list(records)
+                self._read_cache_records = share_repeated_values(
+                    list(records), _SHARED_VALUE_TABLE
+                )
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
@@ -5658,7 +5736,9 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 or self._read_cache_size != size
                 or self._read_cache_mtime_ns != mtime_ns
             )
-            self._read_cache_records = list(records)
+            self._read_cache_records = share_repeated_values(
+                list(records), _SHARED_VALUE_TABLE
+            )
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -643,6 +643,51 @@ def encode_interned_records(records: list[Json], emitted_tokens: set[tuple[str, 
     return dict_records + encoded_records
 
 
+class _SharedInternedList(list):
+    """The list counterpart of :class:`_SharedInternedValue`.
+
+    Sharing a list was left out when values were first shared, on the grounds that making it safe
+    meant turning it into a tuple, which changes the type a caller sees and breaks anything doing
+    ``.append``. A list subclass keeps the type -- ``isinstance``, indexing, iteration and JSON
+    encoding all behave -- and refuses the mutation instead, so a path that does append fails
+    where it happens rather than silently rewriting records it never looked at.
+
+    Worth 11.8% of a cold read, of which `node_path` alone is 3.6%: 147 objects for THREE distinct
+    values.
+    """
+
+    __slots__ = ()
+
+    def _refuse(self, *_args, **_kwargs):
+        raise TypeError(
+            "this list is shared by every record carrying it, so changing it here would change "
+            "them all -- copy it first: list(record['node_path'])")
+
+    __setitem__ = _refuse
+    __delitem__ = _refuse
+    append = _refuse
+    extend = _refuse
+    insert = _refuse
+    pop = _refuse
+    remove = _refuse
+    clear = _refuse
+    sort = _refuse
+    reverse = _refuse
+    __iadd__ = _refuse
+    __imul__ = _refuse
+
+    def __copy__(self):
+        return list(self)
+
+    def __deepcopy__(self, memo):
+        copied = [_copy.deepcopy(v, memo) for v in self]
+        memo[id(self)] = copied
+        return copied
+
+    def __reduce__(self):
+        return (list, (list(self),))
+
+
 class _SharedInternedValue(dict):
     """One object, shared by every record that carries this interned value.
 
@@ -747,19 +792,26 @@ def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
             continue
         replacements = None
         for field, value in record.items():
-            if type(value) is not dict or not value:
+            kind = type(value)
+            if kind is dict:
+                if not value or not all(type(v) in _SHAREABLE_SCALARS for v in value.values()):
+                    continue      # empty, or holds a container -- cannot be keyed cheaply
+                try:
+                    key = (field, tuple(sorted(value.items())))
+                except TypeError:
+                    continue      # keys of mixed type do not sort
+            elif kind is list:
+                if not value or not all(type(v) in _SHAREABLE_SCALARS for v in value):
+                    continue
+                key = (field, tuple(value))
+            else:
                 continue
-            if not all(type(v) in _SHAREABLE_SCALARS for v in value.values()):
-                continue          # holds a container -- cannot be keyed cheaply
-            try:
-                key = (field, tuple(sorted(value.items())))
-            except TypeError:
-                continue          # keys of mixed type do not sort
             shared = table.get(key)
             if shared is None:
                 if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
                     continue
-                shared = _SharedInternedValue(value)
+                shared = (_SharedInternedValue(value) if kind is dict
+                          else _SharedInternedList(value))
                 table[key] = shared
             if replacements is None:
                 replacements = {}

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -16,6 +16,7 @@ try:
     from tools.matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
     from tools.matrixark_mcp_core import compact_context_pack_for_serving_flat as compact_context_pack_for_serving
     from tools.matrixark_mcp_serving_records import (
+        latest_context_state_key,
         compact_latest_context_state_records,
         context_debug_records_enabled,
         materialize_serving_record_batch,
@@ -25,6 +26,7 @@ except ModuleNotFoundError:  # Direct script execution from tools/.
     from matrixark_mcp_core import _mcp_debug_log  # import * skips underscore names
     from matrixark_mcp_core import compact_context_pack_for_serving_flat as compact_context_pack_for_serving
     from matrixark_mcp_serving_records import (
+        latest_context_state_key,
         compact_latest_context_state_records,
         context_debug_records_enabled,
         materialize_serving_record_batch,
@@ -3382,7 +3384,58 @@ def compression_context_index_records(record: Json) -> list[Json]:
     ]
 
 
+# One field name for the identity of a WAL row, on every row.
+#
+# The same concept -- what makes this row supersede an earlier one -- was spelled nine ways
+# across twelve record types: node_hash, child_ref_hash, event_id_hash, summary_hash,
+# ref_hash, entity_hash, dirty_hash, skill_hash, resource_hash, resource_import_task_hash,
+# node_id. Every reader that wanted a row identity had to know all twelve, and a new type
+# meant editing each of them.
+#
+# A row now carries its identity under ROW_KEY_FIELD. The per-type knowledge stays in one
+# function, is applied once at write, and readers use the field.
+ROW_KEY_FIELD = "row_key"
+
+
+def canonical_row_key(record: Json) -> str | None:
+    """The identity of a WAL row as one string, or None when the row has no usable identity.
+
+    A row whose key has an empty part is NOT compacted -- compact_latest_value_records leaves
+    it alone rather than letting an absent hash collide with another absent one. Collapsing the
+    key to a single string would hide that from the guard, so the same test is applied here and
+    such a row simply gets no key.
+    """
+    key = _latest_value_record_key_by_type(record)
+    if key is None:
+        return None
+    if any(part in (None, "") for part in key[1:]):
+        return None
+    try:
+        return json.dumps(list(key), separators=(",", ":"), default=str, sort_keys=False)
+    except (TypeError, ValueError):
+        return None
+
+
+def stamp_row_keys(records: list[Json]) -> list[Json]:
+    """Give every row its identity under the shared field name, once, at write time."""
+    for record in records or ():
+        if not isinstance(record, dict) or ROW_KEY_FIELD in record:
+            continue
+        key = canonical_row_key(record)
+        if key is not None:
+            record[ROW_KEY_FIELD] = key
+    return records
+
+
 def latest_value_record_key(record: Json) -> tuple[Any, ...] | None:
+    """Prefer the row's own key. Rows written before it existed are keyed by type."""
+    stamped = record.get(ROW_KEY_FIELD)
+    if isinstance(stamped, str) and stamped:
+        return (stamped,)
+    return _latest_value_record_key_by_type(record)
+
+
+def _latest_value_record_key_by_type(record: Json) -> tuple[Any, ...] | None:
     record_type = str(record.get("record_type") or "")
     if record_type == "context_node":
         return (record_type, record.get("node_hash"))
@@ -4005,6 +4058,14 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # Set when records were appended to the cache without compacting it -- see
         # _compact_read_cache_if_dirty_locked.
         self._read_cache_dirty = False
+        # (record_type, field) -> {value: record}, kept current as records are appended so an
+        # embedding can find its owner without reading the whole set. None until first use.
+        self._embedding_owner_index: dict[tuple[str, str], dict[Any, Json]] | None = None
+        # The keys the compacted cache already holds, kept current so a write can tell whether
+        # it supersedes anything without scanning. None means unknown -- rebuilt on the next
+        # compaction.
+        self._read_cache_value_keys: set[Any] | None = None
+        self._read_cache_state_keys: set[Any] | None = None
         self._read_cache_size = -1
         self._read_cache_mtime_ns = -1
         self._read_cache_source = "empty"
@@ -4406,6 +4467,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         cache_key = str(self.event_log.resolve())
         with self._read_cache_lock:
             self._read_cache_records = None
+            self._read_cache_value_keys = None
+            self._read_cache_state_keys = None
             self._read_cache_size = -1
             self._read_cache_mtime_ns = -1
             self._read_cache_source = "empty"
@@ -4524,6 +4587,59 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             except Exception:
                 pass
 
+    #: A batch carrying one of these cannot be applied by appending: a tombstone or cutoff
+    #: removes records that came BEFORE it, a context_index posting is rebuilt and coalesced
+    #: across the whole set, and a pipeline-task or audit row is footprint-bounded across it.
+    _COMPACTION_IS_NOT_LOCAL = frozenset({
+        "context_index",
+        "matrixark_async_pipeline_task",
+        "context_extraction_audit",
+    })
+
+    @staticmethod
+    def _batch_is_local(records: list[Json]) -> bool:
+        """True when nothing in the batch can affect a record already in the cache."""
+        for record in records:
+            if not isinstance(record, dict):
+                return False
+            record_type = str(record.get("record_type") or "")
+            if record_type in MatrixArkLocalAdapter._COMPACTION_IS_NOT_LOCAL:
+                return False
+            if "tombstone" in record_type or "retention_cutoff" in record_type:
+                return False
+        return True
+
+    def _cache_keys_locked(self):
+        """The keys the compacted cache holds, built once and then kept current."""
+        if self._read_cache_value_keys is None or self._read_cache_state_keys is None:
+            records = self._read_cache_records or []
+            self._read_cache_value_keys = {latest_value_record_key(r) for r in records}
+            self._read_cache_state_keys = {latest_context_state_key(r) for r in records}
+            self._read_cache_value_keys.discard(None)
+            self._read_cache_state_keys.discard(None)
+        return self._read_cache_value_keys, self._read_cache_state_keys
+
+    def _note_embedding_owners(self, records: list[Json]) -> None:
+        """Fold newly appended records into whichever owner buckets have been built.
+
+        Only existing buckets are updated: a (type, field) nobody has asked about is built
+        from a read when first needed, and includes these records by then. Later records
+        overwrite earlier ones, which is the newest-wins answer the backwards scan gave.
+        """
+        index = self._embedding_owner_index
+        if not index:
+            return
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            record_type = record.get("record_type")
+            for (indexed_type, field), bucket in index.items():
+                if indexed_type != record_type:
+                    continue
+                value = record.get(field)
+                if value is not None:
+                    bucket[value] = record
+
     def _compact_read_cache_if_dirty_locked(self) -> None:
         """Compact the cache if records were appended since the last compaction.
 
@@ -4577,6 +4693,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 # stamp the current signature onto a list missing their records, and a cold
                 # reader would silently lose them. Drop it; the next read re-derives from disk.
                 self._read_cache_records = None
+                self._read_cache_value_keys = None
+                self._read_cache_state_keys = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -4584,8 +4702,29 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 # Extend now, compact when something reads. Compacting here walked the whole cache
                 # on every append, which is what made ingest quadratic in the corpus: 27 records
                 # land per attachment, so 50 attachments took 105 s against 12 s for 20.
+                # A batch that supersedes nothing needs no compaction at all: every stage of
+                # the pipeline leaves the existing records exactly as they were, so the cache
+                # is still compact after appending. Measured over an attachment ingest, half
+                # of all cache updates are of that shape. The keys are kept current, so
+                # deciding costs the size of the BATCH, not of the cache.
+                appends_only = False
+                if self._batch_is_local(records):
+                    value_keys, state_keys = self._cache_keys_locked()
+                    new_value = [latest_value_record_key(r) for r in records]
+                    new_state = [latest_context_state_key(r) for r in records]
+                    appends_only = not (
+                        any(k is not None and k in value_keys for k in new_value)
+                        or any(k is not None and k in state_keys for k in new_state)
+                    )
+                    if appends_only:
+                        value_keys.update(k for k in new_value if k is not None)
+                        state_keys.update(k for k in new_state if k is not None)
                 self._read_cache_records.extend(records)
-                self._read_cache_dirty = True
+                if not appends_only:
+                    self._read_cache_dirty = True
+                    self._read_cache_value_keys = None
+                    self._read_cache_state_keys = None
+                self._note_embedding_owners(records)
                 durable_epoch = self._read_cache_compaction_epoch
             if size >= 0:
                 self._read_cache_size = size
@@ -4598,6 +4737,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     durable_records = list(self._read_cache_records)
             else:
                 self._read_cache_records = None
+                self._read_cache_value_keys = None
+                self._read_cache_state_keys = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -4849,10 +4990,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._stamp_ingest_fields(materialize_serving_record_batch([record]))
         )
         records = drop_vectors_for_opted_out_tenants(records)
-        records = fold_embedding_records(records, resolve_owner=self._embedding_owner_resolver())
-        records = drop_owner_derivable_postings(
-            records, resolve_owner=self._embedding_owner_resolver()
-        )
+        # One resolver for both, so the record set is read once per write rather than once per
+        # fold. Each resolver reads on first use and indexes; two of them read twice.
+        # Every row leaves here carrying its identity under the one shared name.
+        stamp_row_keys(records)
+        resolve_owner = self._embedding_owner_resolver()
+        records = fold_embedding_records(records, resolve_owner=resolve_owner)
+        records = drop_owner_derivable_postings(records, resolve_owner=resolve_owner)
         if not records:
             return
         if self._queue_batched_records(records):
@@ -4888,10 +5032,13 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # materialization so the metadata that rides along under embedding_meta is exactly the
         # shape the separate record used to persist in.
         records = drop_vectors_for_opted_out_tenants(records)
-        records = fold_embedding_records(records, resolve_owner=self._embedding_owner_resolver())
-        records = drop_owner_derivable_postings(
-            records, resolve_owner=self._embedding_owner_resolver()
-        )
+        # One resolver for both, so the record set is read once per write rather than once per
+        # fold. Each resolver reads on first use and indexes; two of them read twice.
+        # Every row leaves here carrying its identity under the one shared name.
+        stamp_row_keys(records)
+        resolve_owner = self._embedding_owner_resolver()
+        records = fold_embedding_records(records, resolve_owner=resolve_owner)
+        records = drop_owner_derivable_postings(records, resolve_owner=resolve_owner)
         if not records:
             return
         if self._queue_batched_records(records):
@@ -4931,28 +5078,30 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         The index is built per (record_type, field) on first use, and later records overwrite
         earlier ones, which is the same newest-wins answer the backwards scan gave.
         """
-        records: list[Json] | None = None
-        indexes: dict[tuple[str, str], dict[Any, Json]] = {}
-
         def resolve(record_type: str, field: str, ref_hash: Any) -> Json | None:
-            nonlocal records
-            if records is None:
-                try:
-                    records = self.read_all()
-                except Exception:
-                    records = []
-            key = (record_type, field)
-            index = indexes.get(key)
+            index = self._embedding_owner_index
             if index is None:
                 index = {}
-                for record in records:
+                self._embedding_owner_index = index
+            key = (record_type, field)
+            bucket = index.get(key)
+            if bucket is None:
+                # First question about this (type, field): build it from one read, then keep
+                # it current on every append. Rebuilding per write meant 765 resolvers and
+                # 400 full reads over twenty attachments.
+                bucket = {}
+                try:
+                    known = self.read_all()
+                except Exception:
+                    known = []
+                for record in known:
                     if record.get("record_type") != record_type:
                         continue
                     value = record.get(field)
                     if value is not None:
-                        index[value] = record
-                indexes[key] = index
-            return index.get(ref_hash)
+                        bucket[value] = record
+                index[key] = bucket
+            return bucket.get(ref_hash)
 
         return resolve
 
@@ -5332,6 +5481,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if not paths:
             with self._read_cache_lock:
                 self._read_cache_records = []
+                self._read_cache_value_keys = None
+                self._read_cache_state_keys = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
                 self._read_cache_source = "empty"
@@ -5371,6 +5522,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     records = list(cached_records)
                     with self._read_cache_lock:
                         self._read_cache_records = records
+                        self._read_cache_value_keys = None
+                        self._read_cache_state_keys = None
                         self._read_cache_size = size
                         self._read_cache_mtime_ns = mtime_ns
                         self._read_cache_source = "process"
@@ -5382,6 +5535,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             records = list(durable_records)
             with self._read_cache_lock:
                 self._read_cache_records = list(records)
+                self._read_cache_value_keys = None
+                self._read_cache_state_keys = None
                 self._read_cache_size = size
                 self._read_cache_mtime_ns = mtime_ns
                 self._read_cache_source = "durable"
@@ -5413,6 +5568,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 or self._read_cache_mtime_ns != mtime_ns
             )
             self._read_cache_records = list(records)
+            self._read_cache_value_keys = None
+            self._read_cache_state_keys = None
             self._read_cache_size = size
             self._read_cache_mtime_ns = mtime_ns
             self._read_cache_source = "jsonl"

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4726,14 +4726,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         any(k is not None and k in value_keys for k in new_value)
                         or any(k is not None and k in state_keys for k in new_state)
                     )
-                    if appends_only:
-                        value_keys.update(k for k in new_value if k is not None)
-                        state_keys.update(k for k in new_state if k is not None)
+                    # Extend either way. The sets exist only to answer 'could this batch
+                    # supersede something', and a SUPERSET answers that safely: it can say yes
+                    # when the answer is no, which costs a compaction that was not needed, but
+                    # it can never say no when the answer is yes. Discarding them on a
+                    # colliding batch meant rebuilding from the whole cache on the next one --
+                    # 3.7 million key computations over 250 attachments, 36% of the time.
+                    value_keys.update(k for k in new_value if k is not None)
+                    state_keys.update(k for k in new_state if k is not None)
                 self._read_cache_records.extend(records)
                 if not appends_only:
                     self._read_cache_dirty = True
-                    self._read_cache_value_keys = None
-                    self._read_cache_state_keys = None
                 self._note_embedding_owners(records)
                 if self._summary_dirty_index is not None:
                     for record in records:

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -118,7 +118,11 @@ class InterningCase(_FlagGuard):
             path = Path(tmp) / "events.jsonl"
             adapter = mcp.MatrixArkLocalAdapter(path)
             server = mcp.MatrixArkMcpServer(adapter, access_mode="dev")
-            self._ingest_turns(server, 50)
+            # The store writes far fewer records for the same input than it used to -- the
+            # redundant node embeddings are gone -- so 50 turns no longer produces a corpus
+            # big enough for this ratio to be about interning rather than about corpus size.
+            # The guard below says so rather than letting the threshold drift.
+            self._ingest_turns(server, 110)
             # Snapshot a FROZEN log, as the reload tests already do. Reading while the background
             # extraction workers are still appending measured a different corpus every run -- 762,
             # 687 and 681 records across three runs of the same 50 fixed turns -- and the ratio
@@ -138,8 +142,19 @@ class InterningCase(_FlagGuard):
         self.assertGreater(len(records), 600,
                            f"only {len(records)} records: too small to measure interning against, "
                            f"so the ratio below would be reporting corpus size")
-        self.assertGreaterEqual(reduction, 50.0,
-                                f"interning reclaimed only {reduction:.1f}% (< 50%) "
+        # 45%, not the 50% this was calibrated at, and the reason is worth keeping.
+        #
+        # The store no longer writes the redundancy this ratio used to reclaim. Every node was
+        # being re-embedded on each ingest -- 60 embeddings for 3 nodes over 20 ingests -- and
+        # those near-identical rows were exactly what interning collapsed. On the same fifty turns
+        # the corpus went from 773 records and 2,316 KB to 438 records and 1,420 KB: 43% fewer
+        # rows and 39% fewer bytes for identical input.
+        #
+        # So the percentage fell (51.1% -> 50.0%) while the bytes improved by far more than the
+        # difference. A ratio measures what is left to reclaim, not how well the store is doing;
+        # asserting the old number would report the improvement as a regression.
+        self.assertGreaterEqual(reduction, 45.0,
+                                f"interning reclaimed only {reduction:.1f}% (< 45%) "
                                 f"over {len(records)} records")
 
     def test_codec_roundtrip_is_byte_identical(self):

--- a/tools/test_matrixark_debug_records_honour_their_gate.py
+++ b/tools/test_matrixark_debug_records_honour_their_gate.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""context_debug_record rows are written only when the knob that gates them says so.
+
+MATRIXARK_CONTEXT_DEBUG_RECORDS defaults OFF, and compact_context_debug_record already honoured
+it. The two writers on the ingest path did not: they guarded on whether debug metadata existed,
+which it always does, so the rows were written whatever the knob said.
+
+Nothing served them. The context pack lists ``metadata_debug`` in
+DEFAULT_HIDDEN_DEBUG_LINEAGE_FIELDS and strips it from every item, and a field-access trace over
+retrieve, get_all and compaction touched no field of these rows at all. They were 12.1% of the
+read cache, carried and never read.
+
+Measured over 12 skills: 505.7 KB -> 446.6 KB, 11.7% less, with retrieval returning the same refs
+and the same tokens for every query.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+import matrixark_local_adapter_ingest as ingest_module
+
+_BLANK = chr(10) + chr(10)
+
+
+def _skill_text(index, sections=5):
+    parts = ["# Runbook %d" % index, "A procedure for case %d." % index]
+    for step in range(sections):
+        parts.append("## Step %d" % step)
+        parts.append("Drain the queue for case %d step %d." % (index, step))
+    return _BLANK.join(parts)
+
+
+def _ingest(count=6):
+    log = Path(tempfile.mkdtemp()) / "events.jsonl"
+    adapter = adapter_module.MatrixArkLocalAdapter(log)
+    scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+    for i in range(count):
+        adapter.ingest({
+            "kind": "skill", "scope": scope, "text": _skill_text(i),
+            "metadata": {"raw_uri": "file:///s/r-%05d.md" % i, "title": "r-%05d" % i},
+        })
+    return adapter, scope, adapter.read_all()
+
+
+def _debug_rows(records):
+    return [r for r in records
+            if str(r.get("record_type") or "") == "context_debug_record"]
+
+
+class DebugRecordsHonourTheirGate(unittest.TestCase):
+    def setUp(self):
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+        self._previous = os.environ.get("MATRIXARK_CONTEXT_DEBUG_RECORDS")
+
+    def tearDown(self):
+        if self._previous is None:
+            os.environ.pop("MATRIXARK_CONTEXT_DEBUG_RECORDS", None)
+        else:
+            os.environ["MATRIXARK_CONTEXT_DEBUG_RECORDS"] = self._previous
+
+    def test_none_are_written_when_the_gate_is_off(self):
+        _, _, records = _ingest()
+        self.assertGreater(len(records), 0, "nothing was ingested, so this proves nothing")
+        self.assertEqual([], _debug_rows(records),
+                         "debug rows were written with the gate off")
+
+    def test_the_gate_actually_turns_them_on(self):
+        """Off-by-default is only meaningful if ON still works -- otherwise this test would
+        pass just as well against a writer that was deleted."""
+        original = ingest_module._context_debug_records_enabled
+        ingest_module._context_debug_records_enabled = lambda: True
+        try:
+            _, _, records = _ingest()
+        finally:
+            ingest_module._context_debug_records_enabled = original
+        self.assertGreater(len(_debug_rows(records)), 0,
+                           "the gate cannot turn the rows back on")
+
+    def test_retrieval_is_unchanged_without_them(self):
+        """An ANSWER test: the queries must return something, and the same something."""
+        adapter, scope, _ = _ingest(count=8)
+        answered = 0
+        for query in ("drain the queue for case 3", "runbook 5", "step 2"):
+            refs = adapter.retrieve({"scope": scope, "query": query}).get("selected_refs") or []
+            answered += 1 if refs else 0
+        self.assertEqual(3, answered,
+                         "a query returned nothing, which would make this test vacuous")
+
+    def test_the_gate_defaults_off_and_fails_closed(self):
+        """A missing policy module must not start writing rows nobody asked for."""
+        self.assertNotIn("MATRIXARK_CONTEXT_DEBUG_RECORDS", os.environ,
+                         "the environment already sets the knob, so the default is untested here")
+        real = sys.modules.pop("matrixark_mcp_serving_records", None)
+        sys.modules["matrixark_mcp_serving_records"] = None   # force the import to fail
+        try:
+            self.assertFalse(ingest_module._context_debug_records_enabled(),
+                             "an unimportable policy module was read as permission to write")
+        finally:
+            if real is not None:
+                sys.modules["matrixark_mcp_serving_records"] = real
+            else:
+                sys.modules.pop("matrixark_mcp_serving_records", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_log_keys_are_shared.py
+++ b/tools/test_matrixark_log_keys_are_shared.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One string per key name across the whole log, not one per record.
+
+The JSON decoder memoises key strings within a single call, but the log is read a line at a time,
+so before this every record carried its own copy of every key name. Measured over a cold read of
+914 records: 148 distinct key names backed by **16,743 separate string objects**, holding 1,009.7
+KB of which 1,000.3 KB was one name repeated.
+
+Interning them took a cold read from 6,484 B/record to 4,532 B/record -- 30% -- with the served
+records byte-identical and read latency unchanged.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+class LogKeysAreShared(unittest.TestCase):
+    def setUp(self):
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+        adapter_module._SHARED_VALUE_TABLE.clear()
+
+    def _written_log(self, count=6):
+        store = Path(tempfile.mkdtemp())
+        log = store / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        body = "\n\n".join("## S%d\n\nrunbook %d." % (i, i) for i in range(4))
+        scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "s0"}
+        for i in range(count):
+            adapter.ingest({
+                "kind": "resource", "scope": scope,
+                "text": "# A %d\n\n%s" % (i, body),
+                "metadata": {"raw_uri": "file:///d/a-%d.md" % i, "title": "a-%d" % i},
+            })
+        return log
+
+    def test_two_lines_parsed_separately_share_their_key_strings(self):
+        """The exact thing the plain decoder does not do."""
+        line = json.dumps({"record_type": "context_event", "node_hash": 1})
+        first = adapter_module.loads_with_interned_keys(line)
+        second = adapter_module.loads_with_interned_keys(line)
+        for key in ("record_type", "node_hash"):
+            a = next(k for k in first if k == key)
+            b = next(k for k in second if k == key)
+            self.assertIs(a, b, "%r is a separate object in each record" % key)
+
+    def test_a_cold_read_holds_one_object_per_key_name(self):
+        log = self._written_log()
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+        records = adapter_module.MatrixArkLocalAdapter(log).read_all()
+        self.assertGreater(len(records), 1, "one record proves nothing about sharing")
+
+        objects_per_name = {}
+        for record in records:
+            for key in record.keys():
+                objects_per_name.setdefault(key, set()).add(id(key))
+        repeated = {k: len(v) for k, v in objects_per_name.items() if len(v) > 1}
+        self.assertEqual({}, repeated,
+                         "these key names are backed by more than one string object")
+
+    def test_interning_does_not_change_what_was_decoded(self):
+        """Interning is invisible: the strings compare equal either way."""
+        for payload in (
+            {"record_type": "context_event", "updated_at_ms": 17, "scope": {"tenant_id": "acme"}},
+            {"a": [1, {"b": "c"}], "": None, "9": 9.5, "unicode key é": True},
+        ):
+            line = json.dumps(payload)
+            self.assertEqual(json.loads(line), adapter_module.loads_with_interned_keys(line))
+
+    def test_a_non_string_key_is_left_alone(self):
+        """JSON object keys are always strings, but the hook must not assume it and crash."""
+        self.assertEqual(
+            {"1": "a"}, adapter_module._interned_pairs([("1", "a")]))
+        self.assertEqual(
+            {2: "b"}, adapter_module._interned_pairs([(2, "b")]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_log_keys_are_shared.py
+++ b/tools/test_matrixark_log_keys_are_shared.py
@@ -84,5 +84,76 @@ class LogKeysAreShared(unittest.TestCase):
             {2: "b"}, adapter_module._interned_pairs([(2, "b")]))
 
 
+class RepeatedStringValuesAreShared(unittest.TestCase):
+    """A value that repeats down a column is held once, and a column of distinct values is not paid for.
+
+    Sharing the strings a column repeats is worth 11.3% of a cold read. The risk is the opposite
+    column: `row_key` holds 149 distinct values over 149 rows, and at scale those would flood a
+    table and crowd out the columns that do repeat. Each field is abandoned once it proves itself
+    distinct, so the two kinds separate on their own.
+    """
+
+    def setUp(self):
+        adapter_module._SHARED_STRINGS.clear()
+        adapter_module._SHARED_STRINGS_ABANDONED.clear()
+
+    def test_a_repeated_value_is_held_once(self):
+        first = adapter_module._shared_string("record_type", "context_" + "event")
+        second = adapter_module._shared_string("record_type", "context_" + "event")
+        self.assertEqual(first, second)
+        self.assertIs(first, second, "the same value in two records is two objects")
+
+    def test_two_fields_do_not_share_a_table(self):
+        """Cardinality is a property of the column, so one busy column must not poison another."""
+        a = adapter_module._shared_string("record_type", "x" * 5)
+        b = adapter_module._shared_string("state", "x" * 5)
+        self.assertEqual(a, b)
+        self.assertIn("record_type", adapter_module._SHARED_STRINGS)
+        self.assertIn("state", adapter_module._SHARED_STRINGS)
+
+    def test_a_field_of_distinct_values_is_abandoned(self):
+        limit = adapter_module._STRING_FIELD_CARDINALITY_LIMIT
+        for i in range(limit + 5):
+            adapter_module._shared_string("row_key", "row-%06d" % i)
+        self.assertIn("row_key", adapter_module._SHARED_STRINGS_ABANDONED)
+        self.assertNotIn("row_key", adapter_module._SHARED_STRINGS,
+                         "the abandoned field is still holding its values")
+
+    def test_an_abandoned_field_still_returns_its_value(self):
+        adapter_module._SHARED_STRINGS_ABANDONED.add("row_key")
+        self.assertEqual("abc", adapter_module._shared_string("row_key", "abc"))
+
+    def test_a_long_value_is_not_hashed(self):
+        long_value = "x" * (adapter_module._SHARED_STRING_MAX_LEN + 1)
+        self.assertEqual(long_value, adapter_module._shared_string("text", long_value))
+        self.assertNotIn("text", adapter_module._SHARED_STRINGS)
+
+    def test_a_cold_read_shares_a_repeated_column(self):
+        store = Path(tempfile.mkdtemp())
+        log = store / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        blank = chr(10) + chr(10)
+        body = blank.join("## S%d%srunbook %d." % (i, blank, i) for i in range(4))
+        scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "s0"}
+        for i in range(6):
+            adapter.ingest({"kind": "resource", "scope": scope,
+                            "text": "# A %d%s%s" % (i, blank, body),
+                            "metadata": {"raw_uri": "file:///d/a-%d.md" % i,
+                                         "title": "a-%d" % i}})
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+        records = adapter_module.MatrixArkLocalAdapter(log).read_all()
+        objects, values = set(), set()
+        for record in records:
+            value = record.get("record_type")
+            if isinstance(value, str):
+                objects.add(id(value))
+                values.add(value)
+        self.assertGreater(len(records), len(values),
+                           "every row has its own type, so nothing repeats")
+        self.assertEqual(len(objects), len(values),
+                         "record_type is %d objects for %d values"
+                         % (len(objects), len(values)))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_posting_fold_skips_folded_rows.py
+++ b/tools/test_matrixark_posting_fold_skips_folded_rows.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The posting fold does not re-fold rows it already folded.
+
+Compaction re-folds the read cache on every read, and the cache holds the fold's OWN output. The
+fold coalesces nothing at any corpus size -- 63 rows to 63 postings, 113 to 113, 213 to 213, 413
+to 413 -- yet it rebuilt each one, at about 57 microseconds of grouping plus 9 of identity hashing
+per posting.
+
+The fold is idempotent, so when every posting is already its own output and no two share a bucket,
+the answer is the input. Measured paired against the live chain on 1,423 records:
+
+  the state stage    18.356 -> 5.128 ms   -72%
+  whole compaction   23.993 -> 10.493 ms  -56%
+  skill ingest       147.5 -> 88.7 ms/skill at 200 skills, -40%
+
+What makes this safe is the equivalence check below rather than the argument above: the fast path
+must return exactly what the full pass returns. It caught a first version that accepted any row
+carrying the policy string, when the fold also stamps index_hash and storage fields and drops
+empty hash lists.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_indexing as indexing
+import matrixark_mcp_local_adapter as adapter_module
+
+_BLANK = chr(10) + chr(10)
+
+
+def _norm(rows):
+    return [json.dumps(r, sort_keys=True, default=str) for r in rows]
+
+
+def _full_fold(rows):
+    """The pass with the fast path disabled -- the answer everything is checked against."""
+    saved = indexing._already_folded_postings
+    indexing._already_folded_postings = lambda records: None
+    try:
+        return indexing.compact_context_index_postings(list(rows))
+    finally:
+        indexing._already_folded_postings = saved
+
+
+def _posting(bucket, refs, folded=True):
+    row = {
+        "record_type": "context_index", "index_name": "ix%d" % bucket, "capability": "cap",
+        "data_model": "dm", "ref_type": "event", "scope_key": "acme|dana",
+        "timestamp_key_ms": 1000 * bucket, "updated_at_ms": 1000 * bucket,
+        "ref_hashes": list(refs), "posting_count": len(refs), "posting_part": 0,
+    }
+    if folded:
+        row.update({"posting_policy": indexing.POSTING_POLICY_BUCKETED,
+                    "index_hash": 12345 + bucket,
+                    "storage_record_kind": "index", "storage_part": "index"})
+    return row
+
+
+def _skill_text(index, sections=5):
+    parts = ["# Runbook %d" % index, "A procedure for case %d." % index]
+    for step in range(sections):
+        parts.append("## Step %d" % step)
+        parts.append("Drain the queue for case %d step %d." % (index, step))
+    return _BLANK.join(parts)
+
+
+def _real_records(count=12):
+    with adapter_module._LOCAL_READ_CACHE_LOCK:
+        adapter_module._LOCAL_READ_CACHE.clear()
+    adapter = adapter_module.MatrixArkLocalAdapter(Path(tempfile.mkdtemp()) / "events.jsonl")
+    scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+    for i in range(count):
+        adapter.ingest({"kind": "skill", "scope": scope, "text": _skill_text(i),
+                        "metadata": {"raw_uri": "file:///s/r-%05d.md" % i, "title": "r-%05d" % i}})
+    return adapter.read_all()
+
+
+class PostingFoldSkipsFoldedRows(unittest.TestCase):
+    def test_it_returns_exactly_what_the_full_pass_returns(self):
+        records = _real_records()
+        self.assertIsNotNone(indexing._already_folded_postings(list(records)),
+                             "the fast path did not fire, so this compares nothing")
+        self.assertEqual(_norm(_full_fold(records)),
+                         _norm(indexing.compact_context_index_postings(list(records))))
+
+    def test_the_cache_really_does_hold_the_folds_own_output(self):
+        """The premise. If the cache stopped holding folded rows this would stop paying, and the
+        test should say so rather than quietly passing."""
+        records = _real_records()
+        postings = [r for r in records
+                    if str(r.get("record_type") or "") == "context_index"]
+        self.assertGreater(len(postings), 0, "no postings, so this proves nothing")
+        self.assertEqual(_norm(postings), _norm(_full_fold(postings)),
+                         "the cached postings are not the fold's own output any more")
+
+    def test_a_row_that_is_not_the_folds_output_falls_back(self):
+        """The policy string alone must not be enough: the fold also stamps and strips fields."""
+        looks_folded = _posting(0, [1, 2])
+        looks_folded.pop("index_hash")
+        for rows, why in (
+            ([looks_folded], "missing index_hash"),
+            ([_posting(0, [1], folded=False)], "not folded at all"),
+            ([_posting(3, [1]), _posting(3, [2])], "two rows in one bucket"),
+            ([dict(_posting(0, [1]), node_hashes=[])], "an empty list the fold would drop"),
+            ([dict(_posting(0, [1]), ref_hash=7)], "a field the fold would pop"),
+            ([_posting(0, [1, 1])], "duplicate refs the fold would collapse"),
+            ([_posting(0, list(range(indexing.MAX_SECONDARY_INDEX_REFS_PER_POSTING + 2)))],
+             "over the ref limit, would be re-chunked"),
+        ):
+            self.assertIsNone(indexing._already_folded_postings([dict(r) for r in rows]),
+                              "took the fast path with %s" % why)
+            self.assertEqual(_norm(_full_fold(rows)),
+                             _norm(indexing.compact_context_index_postings([dict(r) for r in rows])),
+                             "the fallback changed the answer for %s" % why)
+
+    def test_it_fires_on_rows_that_are_the_folds_output(self):
+        """Otherwise every assertion above would pass against a fast path that never runs."""
+        rows = [_posting(i, [i * 10, i * 10 + 1]) for i in range(5)]
+        folded = _full_fold(rows)
+        self.assertIsNotNone(indexing._already_folded_postings(list(folded)),
+                             "the fast path does not recognise the fold's own output")
+
+    def test_non_index_rows_pass_through_in_order(self):
+        rows = [{"record_type": "context_event", "id": 1}, _posting(0, [1]),
+                {"record_type": "skill_section", "id": 2}, _posting(1, [2])]
+        folded = _full_fold(rows)
+        self.assertEqual(_norm(_full_fold(folded)),
+                         _norm(indexing.compact_context_index_postings(list(folded))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_repeated_values_are_shared.py
+++ b/tools/test_matrixark_repeated_values_are_shared.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A value the corpus repeats is held once, not once per record.
+
+``expand_interned_records`` already shares one object per distinct value, but only for records it
+decodes off disk. A record that reaches the read cache from the append path was built field by
+field in memory and never passed through it, so it kept a private dict for a value the corpus
+repeats endlessly. Measured over 914 cached records from 60 attachments, ``storage_options`` was
+held as 673 separate objects for 11 distinct values and ``storage_route`` as 793 objects for 2.
+
+Sharing them took the cache from 3,877 B/record to 2,323 B/record -- 40% -- with the served
+records byte-identical, which is asserted here.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+
+def _ingest(adapter, count):
+    body = "\n\n".join("## S%d\n\nrunbook %d." % (i, i) for i in range(4))
+    scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "s0"}
+    for i in range(count):
+        adapter.ingest({
+            "kind": "resource",
+            "scope": scope,
+            "text": "# A %d\n\n%s" % (i, body),
+            "metadata": {"raw_uri": "file:///d/a-%d.md" % i, "title": "a-%d" % i},
+        })
+
+
+class RepeatedValuesAreShared(unittest.TestCase):
+    def setUp(self):
+        adapter_module._SHARED_VALUE_TABLE.clear()
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    def test_records_written_in_memory_share_one_object_per_value(self):
+        """The append path, which is the one that was not covered."""
+        store = Path(tempfile.mkdtemp())
+        adapter = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl")
+        _ingest(adapter, 8)
+        cached = adapter._read_cache_records
+        self.assertIsNotNone(cached, "nothing reached the cache, so this proves nothing")
+
+        for field in ("storage_route", "storage_options"):
+            values, objects = set(), set()
+            for record in cached:
+                value = record.get(field)
+                # A value holding a container is deliberately left alone -- it cannot be keyed
+                # by its contents cheaply -- so only the shareable ones are the claim here.
+                if not isinstance(value, dict) or not value:
+                    continue
+                if not all(type(v) in adapter_module._SHAREABLE_SCALARS for v in value.values()):
+                    continue
+                objects.add(id(value))
+                values.add(json.dumps(value, sort_keys=True, default=str))
+            self.assertGreater(len(values), 0, "%s never appeared in a shareable form" % field)
+            self.assertEqual(
+                len(objects), len(values),
+                "%s is held as %d objects for %d distinct values"
+                % (field, len(objects), len(values)))
+
+    def test_sharing_does_not_change_what_is_served(self):
+        """The whole point is that this is invisible above the cache.
+
+        ONE log, read twice. Ingesting separately per setting compares two different ingests --
+        the timestamps and generated ids differ, so the digests could never match and the
+        comparison would say nothing about sharing.
+        """
+        store = Path(tempfile.mkdtemp())
+        log = store / "events.jsonl"
+        _ingest(adapter_module.MatrixArkLocalAdapter(log), 6)
+
+        served = {}
+        for enabled in (False, True):
+            adapter_module._SHARED_VALUE_TABLE.clear()
+            with adapter_module._LOCAL_READ_CACHE_LOCK:
+                adapter_module._LOCAL_READ_CACHE.clear()
+            previous = adapter_module.SHARE_REPEATED_VALUES
+            adapter_module.SHARE_REPEATED_VALUES = enabled
+            try:
+                records = adapter_module.MatrixArkLocalAdapter(log).read_all()
+                served[enabled] = [json.dumps(r, sort_keys=True, default=str) for r in records]
+            finally:
+                adapter_module.SHARE_REPEATED_VALUES = previous
+
+        self.assertGreater(len(served[True]), 0, "nothing was served, so this proves nothing")
+        self.assertEqual(len(served[False]), len(served[True]), "the record COUNT changed")
+        self.assertEqual(served[False], served[True],
+                         "the served records changed, in content or in order")
+
+    def test_a_shared_value_refuses_to_be_changed(self):
+        """A mutation would reach every record carrying the value, so it must fail loudly."""
+        store = Path(tempfile.mkdtemp())
+        adapter = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl")
+        _ingest(adapter, 4)
+        shared = next(
+            (r["storage_route"] for r in adapter._read_cache_records
+             if isinstance(r.get("storage_route"), adapter_module._SharedInternedValue)),
+            None)
+        self.assertIsNotNone(shared, "no storage_route was shared")
+        with self.assertRaises(TypeError):
+            shared["tier"] = "cold"
+        self.assertEqual(dict(shared), dict(shared), "copying it must still work")
+
+    def test_the_caller_record_is_left_writable(self):
+        """Sharing happens on the copy the cache keeps, never on the caller's own record."""
+        mine = {"record_type": "context_event", "storage_route": {"tier": "hot"}}
+        table = {}
+        out = adapter_module.share_repeated_values([mine], table)
+        self.assertIsNot(out[0], mine, "the caller's record was replaced in place")
+        mine["storage_route"]["tier"] = "cold"      # must not raise
+        self.assertEqual("hot", out[0]["storage_route"]["tier"],
+                         "the cache copy followed the caller's mutation")
+
+    def test_a_value_holding_a_container_is_left_alone(self):
+        """It cannot be keyed by its contents cheaply, so it keeps its own object."""
+        nested = {"record_type": "context_event", "envelope": {"tags": ["a"], "tier": "hot"}}
+        table = {}
+        out = adapter_module.share_repeated_values([nested], table)
+        self.assertIs(out[0], nested, "a record with nothing shareable should pass straight through")
+        self.assertEqual({}, table)
+
+    def test_the_table_stops_growing(self):
+        """A field with unbounded distinct values must not turn the table into a leak."""
+        table = {}
+        limit = adapter_module._SHARED_VALUE_TABLE_LIMIT
+        records = [{"record_type": "context_event", "storage_route": {"n": i}}
+                   for i in range(limit + 50)]
+        adapter_module.share_repeated_values(records, table)
+        self.assertLessEqual(len(table), limit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_repeated_values_are_shared.py
+++ b/tools/test_matrixark_repeated_values_are_shared.py
@@ -120,12 +120,36 @@ class RepeatedValuesAreShared(unittest.TestCase):
         self.assertEqual("hot", out[0]["storage_route"]["tier"],
                          "the cache copy followed the caller's mutation")
 
-    def test_a_value_holding_a_container_is_left_alone(self):
-        """It cannot be keyed by its contents cheaply, so it keeps its own object."""
-        nested = {"record_type": "context_event", "envelope": {"tags": ["a"], "tier": "hot"}}
+    def test_a_container_inside_a_value_is_reached(self):
+        """Sharing descends: the repetitive containers sit one level down, not at the top.
+
+        `embedding_meta.node_path` was 100 rows holding ONE value and `envelope.storage_route`
+        20 rows holding one, so stopping at the top of a record left 5.8% of the cache behind.
+        """
         table = {}
-        out = adapter_module.share_repeated_values([nested], table)
-        self.assertIs(out[0], nested, "a record with nothing shareable should pass straight through")
+        first = {"record_type": "context_event", "envelope": {"tags": ["a"], "tier": "hot"}}
+        second = {"record_type": "context_event", "envelope": {"tags": ["a"], "tier": "warm"}}
+        out = adapter_module.share_repeated_values([first, second], table)
+        self.assertIs(out[0]["envelope"]["tags"], out[1]["envelope"]["tags"],
+                      "the same nested list in two records is two objects")
+        self.assertEqual(["a"], list(out[0]["envelope"]["tags"]))
+
+    def test_reaching_inside_does_not_write_to_the_callers_record(self):
+        """Only the path down to a replacement is rebuilt; the caller keeps its own objects."""
+        mine = {"record_type": "context_event", "envelope": {"tags": ["a"], "tier": "hot"}}
+        out = adapter_module.share_repeated_values([mine], {})
+        self.assertIsNot(out[0]["envelope"], mine["envelope"],
+                         "the caller's nested dict was rebuilt in place")
+        mine["envelope"]["tags"].append("b")      # must not raise
+        self.assertEqual(["a"], list(out[0]["envelope"]["tags"]),
+                         "the caller's change reached the shared copy")
+
+    def test_nothing_shareable_means_no_copy(self):
+        """A record with no container at all is passed straight through."""
+        table = {}
+        plain = {"record_type": "context_event", "node_hash": 7, "state": "done"}
+        out = adapter_module.share_repeated_values([plain], table)
+        self.assertIs(out[0], plain)
         self.assertEqual({}, table)
 
     def test_the_table_stops_growing(self):
@@ -181,13 +205,25 @@ class RepeatedListsAreShared(unittest.TestCase):
         mine.append("b")
         self.assertEqual(["a"], list(shared), "the copy reached the shared list")
 
-    def test_a_list_holding_a_container_is_left_alone(self):
+    def test_a_container_inside_a_list_is_reached(self):
+        """A list of dicts is rebuilt around whatever inside it is worth sharing."""
         table = {}
-        record = {"record_type": "context_node", "tags": [{"k": "v"}]}
-        out = adapter_module.share_repeated_values([record], table)
-        self.assertIs(out[0], record)
-        self.assertEqual({}, table)
+        first = {"record_type": "context_node", "tags": [{"k": "v"}]}
+        second = {"record_type": "context_node", "tags": [{"k": "v"}]}
+        out = adapter_module.share_repeated_values([first, second], table)
+        self.assertIs(out[0]["tags"][0], out[1]["tags"][0],
+                      "the same dict inside two lists is two objects")
+        self.assertEqual([{"k": "v"}], [dict(d) for d in out[0]["tags"]])
 
+    def test_nesting_deeper_than_the_cap_is_left_alone(self):
+        """A record that nests deeply must not cost a walk of its whole shape on every append."""
+        deep = {"k": ["leaf"]}
+        for _ in range(adapter_module._SHARE_MAX_DEPTH + 2):
+            deep = {"down": deep}
+        table = {}
+        adapter_module.share_repeated_values([{"record_type": "x", "top": deep}], table)
+        self.assertEqual([], [k for k in table if k[0] == "k"],
+                         "the walk went past the depth cap")
     def test_a_shared_list_survives_json_and_copying(self):
         """It is serialised on the way out and deep-copied by callers that need their own."""
         import copy as copy_module

--- a/tools/test_matrixark_repeated_values_are_shared.py
+++ b/tools/test_matrixark_repeated_values_are_shared.py
@@ -138,5 +138,66 @@ class RepeatedValuesAreShared(unittest.TestCase):
         self.assertLessEqual(len(table), limit)
 
 
+class RepeatedListsAreShared(unittest.TestCase):
+    """A list a column repeats is held once too.
+
+    Sharing lists was left out when values were first shared, because making one safe meant
+    turning it into a tuple and changing the type a caller sees. A list SUBCLASS keeps the type
+    and refuses the mutation instead. Worth 11.8% of a cold read; `node_path` alone was 147
+    objects for THREE distinct values.
+    """
+
+    def test_a_repeated_flat_list_is_held_once(self):
+        table = {}
+        records = [{"record_type": "context_node", "node_path": ["a", "b"]},
+                   {"record_type": "context_node", "node_path": ["a", "b"]}]
+        first, second = adapter_module.share_repeated_values(records, table)
+        self.assertEqual(["a", "b"], first["node_path"])
+        self.assertIs(first["node_path"], second["node_path"],
+                      "the same path in two records is two objects")
+
+    def test_a_shared_list_refuses_every_way_of_changing_it(self):
+        table = {}
+        shared = adapter_module.share_repeated_values(
+            [{"record_type": "context_node", "node_path": ["a"]}], table)[0]["node_path"]
+        self.assertIsInstance(shared, list, "a caller must still see a list")
+        for change in (lambda: shared.append("b"),
+                       lambda: shared.extend(["b"]),
+                       lambda: shared.insert(0, "b"),
+                       lambda: shared.pop(),
+                       lambda: shared.clear(),
+                       lambda: shared.sort(),
+                       lambda: shared.reverse(),
+                       lambda: shared.__setitem__(0, "b")):
+            with self.assertRaises(TypeError):
+                change()
+        self.assertEqual(["a"], list(shared), "a refused change still happened")
+
+    def test_the_way_a_caller_is_told_to_change_one_works(self):
+        table = {}
+        shared = adapter_module.share_repeated_values(
+            [{"record_type": "context_node", "node_path": ["a"]}], table)[0]["node_path"]
+        mine = list(shared)
+        mine.append("b")
+        self.assertEqual(["a"], list(shared), "the copy reached the shared list")
+
+    def test_a_list_holding_a_container_is_left_alone(self):
+        table = {}
+        record = {"record_type": "context_node", "tags": [{"k": "v"}]}
+        out = adapter_module.share_repeated_values([record], table)
+        self.assertIs(out[0], record)
+        self.assertEqual({}, table)
+
+    def test_a_shared_list_survives_json_and_copying(self):
+        """It is serialised on the way out and deep-copied by callers that need their own."""
+        import copy as copy_module
+        table = {}
+        shared = adapter_module.share_repeated_values(
+            [{"record_type": "context_node", "node_path": ["a", "b"]}], table)[0]["node_path"]
+        self.assertEqual('["a", "b"]', json.dumps(shared))
+        copied = copy_module.deepcopy(shared)
+        copied.append("c")
+        self.assertEqual(["a", "b"], list(shared))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_skill_sections_stored_once.py
+++ b/tools/test_matrixark_skill_sections_stored_once.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A skill's sections and chunks are stored once, not twice.
+
+An ingest issues its writes as 45 separate one-record appends, so every stage of the batch
+pipeline saw one row at a time and could never notice that two of them were the same row. Writing
+the run as one batch -- which is what ``_begin_append_coalescing`` exists for, and what the run
+already qualified for, having no read after its first -- let the dedup see both.
+
+Measured over 25 skills: 100 ``skill_section`` rows for 50 distinct texts, and the same for
+``resource_chunk``. Every second one was an exact repeat.
+
+Retrieval is unchanged: the same four queries return the same 26 refs and the same 434 tokens
+before and after, so the duplicates were pure storage cost.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+
+_BLANK = chr(10) + chr(10)
+
+
+def _skill_text(index, sections=6):
+    parts = ["# Runbook %d" % index, "A procedure for case %d." % index]
+    for step in range(sections):
+        parts.append("## Step %d" % step)
+        parts.append("Drain the queue for case %d step %d." % (index, step))
+    return _BLANK.join(parts)
+
+
+def _ingest_skills(adapter, count):
+    scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+    for i in range(count):
+        adapter.ingest({
+            "kind": "skill",
+            "scope": scope,
+            "text": _skill_text(i),
+            "metadata": {"raw_uri": "file:///s/r-%05d.md" % i, "title": "r-%05d" % i},
+        })
+    return scope
+
+
+class SkillSectionsStoredOnce(unittest.TestCase):
+    def setUp(self):
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    def _store(self, count=4):
+        log = Path(tempfile.mkdtemp()) / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        scope = _ingest_skills(adapter, count)
+        return adapter, scope, adapter.read_all()
+
+    def test_no_section_or_chunk_is_stored_twice(self):
+        _, _, records = self._store()
+        for record_type in ("skill_section", "resource_chunk"):
+            bodies = Counter()
+            for record in records:
+                if str(record.get("record_type") or "") != record_type:
+                    continue
+                bodies[str(record.get("text") or record.get("body") or "")] += 1
+            self.assertGreater(sum(bodies.values()), 0,
+                               "no %s was written, so this proves nothing" % record_type)
+            repeats = {body[:60]: n for body, n in bodies.items() if n > 1}
+            self.assertEqual({}, repeats,
+                             "%s rows repeated: %s" % (record_type, repeats))
+
+    def test_the_run_is_written_as_one_batch(self):
+        """One durable write per ingest, not one per record."""
+        adapter_calls = []
+        original = adapter_module.MatrixArkLocalAdapter.append_many
+
+        def counting(self, records, *a, **k):
+            adapter_calls.append(len(records))
+            return original(self, records, *a, **k)
+
+        adapter_module.MatrixArkLocalAdapter.append_many = counting
+        try:
+            log = Path(tempfile.mkdtemp()) / "events.jsonl"
+            adapter = adapter_module.MatrixArkLocalAdapter(log)
+            _ingest_skills(adapter, 2)
+        finally:
+            adapter_module.MatrixArkLocalAdapter.append_many = original
+
+        self.assertTrue(adapter_calls, "the run was not batched at all")
+        self.assertGreater(max(adapter_calls), 1,
+                           "every batch carried one record, so nothing was coalesced")
+
+    def test_a_failed_ingest_writes_nothing_it_buffered(self):
+        """An abort must not leave a half-written record set, nor an active buffer behind."""
+        log = Path(tempfile.mkdtemp()) / "events.jsonl"
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        boom = RuntimeError("ingest failed")
+
+        original = type(adapter)._ingest_impl
+
+        def failing(self, args, **kwargs):
+            self._begin_append_coalescing()
+            self.append({"record_type": "skill_section", "text": "half written"})
+            raise boom
+
+        type(adapter)._ingest_impl = failing
+        try:
+            with self.assertRaises(RuntimeError):
+                adapter.ingest({"kind": "skill", "scope": {"tenant_id": "acme"}, "text": "x"})
+        finally:
+            type(adapter)._ingest_impl = original
+
+        tls = getattr(adapter, "_append_coalesce_tls_obj", None)
+        self.assertFalse(getattr(tls, "active", False),
+                         "a failed ingest left its buffer active for the next one on this thread")
+        self.assertEqual([], getattr(tls, "buffer", []), "the aborted records are still buffered")
+        if log.exists():
+            self.assertNotIn("half written", log.read_text(encoding="utf-8"),
+                             "an aborted ingest reached the log")
+
+    def test_retrieval_is_unchanged_by_storing_them_once(self):
+        """An ANSWER test: the queries must return something, and the same something."""
+        adapter, scope, records = self._store(count=8)
+        answered = 0
+        for query in ("drain the queue for case 3", "runbook 5", "step 2"):
+            pack = adapter.retrieve({"scope": scope, "query": query})
+            refs = pack.get("selected_refs") or []
+            answered += 1 if refs else 0
+        self.assertEqual(3, answered,
+                         "a query returned nothing, which would make this test vacuous")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Attachment ingest was quadratic in the corpus, and the read cache held a private copy of nearly
everything. Eleven commits: the first seven cut the work per attachment, the last four cut what
the cache holds.

## Latency

Attachment ingest, paired on a quiet machine, ms per attachment:

| attachments | before | after |
|---|---|---|
| 100 | 244, 246 | 49, 32 |
| 250 | 747, 616 | 45, 49 |

1,000 attachments did not finish in 90 minutes before. It now takes **2.7 minutes**.

Deterministic counters per 20 attachments, which is what this was tuned against, since the machine
is too noisy to tune against wall time:

| | before | after |
|---|---|---|
| full reads of the store | 561 | 27 |
| log path resolutions | 2,742 | 2 |
| node embeddings (3 nodes) | 60 | 3 |

## Memory

| | before | after |
|---|---|---|
| cache read cold off disk | 6,249 B/record | **2,967 B/record  (-52.5%)** |
| cache written in memory | 3,753 B/record | **2,127 B/record  (-43.3%)** |

Four things the cache held per record that only need holding once.

**Repeated values.** Records decoded off disk already shared one object per distinct value, but a
record reaching the cache from the append path was built in memory and never passed through that.
`storage_options` was held as 673 objects for **11** distinct values, `storage_route` as 793 for
**2**.

**Key names.** The decoder shares key strings within one call, but the log is read a line at a
time. A cold read of 914 records held 148 key names as **16,743 separate string objects** --
1,009.7 KB, of which 1,000.3 KB was one name repeated.

**Sharing once rather than into one holder.** The read path shared into the adapter's cache but
handed the process cache, the durable snapshot and the caller the unshared originals, so both
lists were alive and no caller saw a saving.

**A column's repeated strings and lists.** `record_type` was 311 objects for 15 values,
`node_path` 147 for **three**. The risk is the opposite column -- `row_key` holds 149 distinct
values over 149 rows and would flood a shared table at scale -- so each field gets its own table
and is abandoned for good once it exceeds 512 distinct values. That also handles vectors without
naming them: they repeat in a corpus built from repeated text, and in real ingest they do not.

Lists are shared by a subclass that keeps the type and refuses mutation, rather than by turning
them into tuples. The refusal was run as a tripwire over the whole test sweep: zero paths mutate
one.

Wall time is unchanged by all of it: ingest 2.28 s -> 2.19 s over 120 attachments, cold read 12.3
/ 14.5 / 12.9 ms -> 12.7 / 13.8 / 12.7 ms.

## Correctness

Four defects found and fixed on the way: a forget that reported success and applied nothing; a
method called and never defined; every node re-embedded on every ingest; and three contradictory
`resource_import_task` statuses served at once, because the compaction key read a field the
writers do not write.

Every memory commit is checked the same way: the served records must be byte-identical, ordered
and sorted digests both, and a warm cache must agree with a cold re-read of its own log. Two
measurement rules this needed -- read ONE log twice rather than ingesting once per arm, which
would only compare two sets of timestamps; and give each build its own COPY of the store, because
reading leaves a durable snapshot the next build loads instead of decoding. Without the second,
a 30% win reads as a 15% regression.

## What was tried and dropped

Making individual record types applicable without compacting. It cannot pay: one attachment writes
blocking batches of five different types, so covering four still compacts once per attachment.
Three separate partial designs moved 44 dirty markings to 42. Removing compaction entirely is
worth 24% of wall at 1k, and only a design covering every type at once can collect any of it.
