### PR TITLE
Two blank panels and two silent alerts, from one hole in the spec

### DIFF
--- a/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
+++ b/crates/temporalstore-rust/src/bin/ops_scale_readiness_harness.rs
@@ -13,7 +13,7 @@ struct OpsScaleReadinessReport {
     autoscale_controller_ready: bool,
     metaserver_rebalance_loop_ready: bool,
     dashboards_ready: bool,
-    grafana_metrics_parity_ready: bool,
+    grafana_metrics_coverage_ready: bool,
     grafana_metric_families: Vec<String>,
     tracing_ready: bool,
     non_raft_auth_tls_ready: bool,
@@ -80,8 +80,8 @@ fn main() {
         "crates/temporalstore-rust/src/bin/metaserver.rs",
         &["cooldown", "safe_mode", "membership"],
     );
-    let grafana_metrics_parity_ready = grafana_metrics_parity_ready(&root);
-    let dashboards_ready = grafana_metrics_parity_ready;
+    let grafana_metrics_coverage_ready = grafana_metrics_coverage_ready(&root);
+    let dashboards_ready = grafana_metrics_coverage_ready;
     let tracing_ready = file_contains(
         &root,
         "docs/ops/temporalstore-api-security-and-tracing.md",
@@ -193,7 +193,7 @@ fn main() {
                 .to_string(),
             covers: vec![
                 "autoscale/rebalance evidence".to_string(),
-                "ops dashboards/Grafana metrics parity/runbooks/tracing/auth coverage".to_string(),
+                "ops dashboards/Grafana metrics coverage/runbooks/tracing/auth coverage".to_string(),
                 "corpus family coverage".to_string(),
             ],
         },
@@ -229,7 +229,7 @@ fn main() {
     let docs = vec![
         "docs/ops/temporalstore-dashboard.json".to_string(),
         "docs/ops/temporalstore-alerts.yml".to_string(),
-        "docs/ops/temporalstore-grafana-metrics-parity.md".to_string(),
+        "docs/ops/temporalstore-grafana-metrics-coverage.md".to_string(),
         "docs/ops/temporalstore-api-security-and-tracing.md".to_string(),
         "docs/ops/temporalstore-fault-runbook.md".to_string(),
         "docs/scale_test_harness.md".to_string(),
@@ -248,7 +248,7 @@ fn main() {
     push_missing(
         &mut missing,
         dashboards_ready,
-        "Grafana dashboard, alert, and Rust metric parity evidence",
+        "Grafana dashboard, alert, and Rust metric emission evidence",
     );
     push_missing(&mut missing, tracing_ready, "tracing evidence");
     push_missing(
@@ -286,7 +286,7 @@ fn main() {
         autoscale_controller_ready,
         metaserver_rebalance_loop_ready,
         dashboards_ready,
-        grafana_metrics_parity_ready,
+        grafana_metrics_coverage_ready,
         grafana_metric_families: grafana_metric_families(),
         tracing_ready,
         non_raft_auth_tls_ready,
@@ -372,15 +372,13 @@ fn grafana_metric_families() -> Vec<String> {
         "storage_cache",
         "data_node",
         "ingestion",
-        "secondary_replication",
-        "scale_slo",
     ]
     .iter()
     .map(|family| family.to_string())
     .collect()
 }
 
-fn grafana_metrics_parity_ready(root: &Path) -> bool {
+fn grafana_metrics_coverage_ready(root: &Path) -> bool {
     let dashboard_metrics = [
         "temporalstore_production_readiness_ready",
         "temporalstore_production_readiness_service_blockers",
@@ -397,8 +395,6 @@ fn grafana_metrics_parity_ready(root: &Path) -> bool {
         "temporalstore_data_node_lifecycle_snapshot_events_total",
         "temporalstore_ingestion_kafka_lag",
         "temporalstore_ingestion_dead_letters",
-        "temporalstore_scale_write_p99_us",
-        "temporalstore_scale_error_budget_remaining",
     ];
     let alert_rules = [
         "TemporalStoreProductionReadinessBlocked",
@@ -412,7 +408,6 @@ fn grafana_metrics_parity_ready(root: &Path) -> bool {
         "TemporalStoreBlockStoreReadErrors",
         "TemporalStoreCacheMissPressure",
         "TemporalStoreIngestionDeadLetters",
-        "TemporalStoreScaleSloRegression",
     ];
     let rust_metric_tokens = [
         "temporalstore_production_readiness_ready",
@@ -435,8 +430,6 @@ fn grafana_metrics_parity_ready(root: &Path) -> bool {
         "storage_cache",
         "data_node",
         "ingestion",
-        "secondary_replication",
-        "scale_slo",
     ];
 
     file_contains(
@@ -446,7 +439,7 @@ fn grafana_metrics_parity_ready(root: &Path) -> bool {
     ) && file_contains(root, "docs/ops/temporalstore-alerts.yml", &alert_rules)
         && file_contains(
             root,
-            "docs/ops/temporalstore-grafana-metrics-parity.md",
+            "docs/ops/temporalstore-grafana-metrics-coverage.md",
             &doc_families,
         )
         && rust_sources_contain(root, &rust_metric_tokens)
@@ -482,10 +475,10 @@ fn push_missing(missing: &mut Vec<String>, ready: bool, capability: &str) {
 mod tests {
     use super::*;
 
-    // shared-corpus: ops_grafana_metrics_parity
+    // shared-corpus: ops_grafana_metrics_coverage
     #[test]
-    fn grafana_metrics_parity_contract_covers_dashboard_alerts_and_emitters() {
+    fn grafana_metrics_coverage_contract_covers_dashboard_alerts_and_emitters() {
         let root = repo_root();
-        assert!(grafana_metrics_parity_ready(&root));
+        assert!(grafana_metrics_coverage_ready(&root));
     }
 }

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3312,7 +3312,7 @@ mod tests {
 
     #[test]
     fn proxy_metrics_expose_request_policy_and_backend_counters() {
-        // shared-corpus: ops_grafana_metrics_parity
+        // shared-corpus: ops_grafana_metrics_coverage
         let proxy = ProxyService::new(ProxyOptions {
             meta_addr: "127.0.0.1:1".to_string(),
             serving_mode: ProxyServingMode::NotServing,

--- a/docs/ops/temporalstore-alerts.yml
+++ b/docs/ops/temporalstore-alerts.yml
@@ -151,23 +151,6 @@ groups:
           summary: TemporalStore cache miss pressure is high
           description: "Cache miss pressure is high. Inspect cache admission/eviction settings, tiny-cache pressure tests, and block-store refill latency."
 
-      - alert: TemporalStoreReplicaReplayFailures
-        expr: temporalstore_replica_replay_loop_consecutive_failures > 0
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: TemporalStore secondary replica replay is failing
-          description: "Secondary replay has consecutive failures. Inspect shared-store cursor state, oplog retention, and replica catch-up lag."
-
-      - alert: TemporalStoreScaleSloRegression
-        expr: temporalstore_scale_write_p99_us > 50000 or temporalstore_scale_read_p99_us > 50000
-        for: 10m
-        labels:
-          severity: warning
-        annotations:
-          summary: TemporalStore scale SLO regression
-          description: "Scale harness p99 exceeded the local readiness threshold. Re-run tools/run_ops_scale_readiness.sh --run-local-scale and inspect the SLO report."
 
       - alert: TemporalStoreIngestionDeadLetters
         expr: temporalstore_ingestion_dead_letters > 0 or temporalstore_ingestion_records_total{outcome="dead_letter"} > 0

--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -175,42 +175,6 @@
       ]
     },
     {
-      "title": "Secondary Replication Replay",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "temporalstore_replica_replay_loop_enabled"
-        },
-        {
-          "expr": "sum by (kind) (temporalstore_replica_replay_loop_events_total)"
-        },
-        {
-          "expr": "temporalstore_replica_replay_loop_consecutive_failures"
-        },
-        {
-          "expr": "temporalstore_replica_replay_loop_next_delay_ms"
-        }
-      ]
-    },
-    {
-      "title": "Scale SLO",
-      "type": "timeseries",
-      "targets": [
-        {
-          "expr": "temporalstore_scale_write_p99_us"
-        },
-        {
-          "expr": "temporalstore_scale_read_p99_us"
-        },
-        {
-          "expr": "temporalstore_scale_throughput_ops"
-        },
-        {
-          "expr": "temporalstore_scale_error_budget_remaining"
-        }
-      ]
-    },
-    {
       "title": "MatrixArk Backend SLO",
       "type": "timeseries",
       "targets": [

--- a/docs/ops/temporalstore-grafana-metrics-coverage.md
+++ b/docs/ops/temporalstore-grafana-metrics-coverage.md
@@ -146,3 +146,50 @@ which is a release decision rather than an incident.
 
 **Blank means:** no scale run has been performed against this deployment. That is the normal state
 for a production cluster and is not a fault.
+
+
+## Alerts removed because they could never fire
+
+Two rules watched metrics that nothing declares. A rule on an unemitted metric is worse than no
+rule: the panel is blank, the alert is silent, and silence reads as health. They are removed rather
+than left in place, and recorded here so the loss of intent is visible instead of implied.
+
+| removed rule | watched | why it could not fire |
+|---|---|---|
+| `TemporalStoreReplicaReplayFailures` | `temporalstore_replica_replay_loop_consecutive_failures` | No subsystem publishes it. The raft follower pipeline keeps a `consecutive_failures` counter, but that counts append-entries send failures to a peer -- a different subsystem from the shared-store secondary replay this rule described, so exporting it under this name would have made the alert fire on the wrong thing. |
+| `TemporalStoreScaleSloRegression` | `temporalstore_scale_write_p99_us`, `temporalstore_scale_read_p99_us` | Neither is declared. Both names appear in `ops_scale_readiness_harness.rs`, but only inside a hardcoded list of families it EXPECTS the dashboards and alerts to mention -- a statement of intent, not an emission. |
+
+**What is no longer watched:** secondary replica replay health, and the scale harness p99 SLO. Both
+were already unwatched; removing the rules only stops them claiming otherwise. Restoring either
+means emitting the metric first, then re-adding the rule.
+
+**The guard that now prevents this:** `validate_grafana_metrics_conformance.py` fails when a rule's
+metrics are undeclared. "Declared" means a `# HELP` or `# TYPE` line -- deliberately narrower than
+"the name appears in the Rust source", which is what let these two hide, since the expectations
+list satisfies the looser test. The check asserts its own extent first: it refuses to pass on an
+empty declaration scan, because every comparison below it would then trivially succeed.
+
+
+## Panels removed because they were blank on every deployment
+
+The same two families owned two of the twelve dashboard panels, and every metric behind them is
+undeclared, so both rendered empty wherever this dashboard was loaded.
+
+| removed panel | queried | state |
+|---|---|---|
+| Secondary Replication Replay | `temporalstore_replica_replay_loop_consecutive_failures`, `_enabled`, `_events_total`, `_next_delay_ms` | none declared |
+| Scale SLO | `temporalstore_scale_write_p99_us`, `_read_p99_us`, `_throughput_ops`, `_error_budget_remaining` | none declared |
+
+### How both got through
+
+Each family's spec entry set `"rust": []`. The validator reads that as "this family requires no
+engine-side metric", so it confirmed the panels existed and the alert rules existed, and never asked
+whether anything produced the numbers. Both families were then reported ready.
+
+`check_families_state_their_emission` now fails on an empty `rust` list. An empty list is not the
+same as no requirement: if a family genuinely has no engine-side metric, it does not belong in a
+spec whose entire purpose is tying a panel to an emission.
+
+The scale-harness readiness check carried the same names and additionally verified them against a
+document path that no longer exists, so that check returned false unconditionally. Its lists and
+its path are corrected here.

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -213,14 +213,6 @@ METRIC_FAMILIES = {
             "temporalstore_ingestion_flink_checkpoints",
         ],
     },
-    "secondary_replication": {
-        "dashboard": [
-        ],
-        "alerts": [
-        ],
-        "rust": [
-        ],
-    },
     "matrixark_backend": {
         "dashboard": [
             "matrixark_backend_qps",
@@ -249,18 +241,6 @@ METRIC_FAMILIES = {
             "matrixark_backend_ready",
         ],
     },
-    "scale_slo": {
-        "dashboard": [
-            "temporalstore_scale_write_p99_us",
-            "temporalstore_scale_read_p99_us",
-            "temporalstore_scale_throughput_ops",
-            "temporalstore_scale_error_budget_remaining",
-        ],
-        "alerts": [
-            "TemporalStoreScaleSloRegression",
-        ],
-        "rust": [],
-    },
 }
 
 
@@ -286,6 +266,97 @@ def metric_names(text: str) -> set[str]:
 # fails is one nobody runs -- which is how this one came to be red and unnoticed in the first place.
 # Each entry is either a panel to remove or a metric to add; neither is a decision this script makes.
 KNOWN_UNEMITTED: set = set()
+
+
+DECLARATION = re.compile(r"#\s*(?:HELP|TYPE)\s+((?:temporalstore|matrixark)_[A-Za-z0-9_]+)")
+
+# The engine declared 229 families when this floor was set. Deliberately far below that: it catches
+# a scan that has broken, not a release that trimmed a metric.
+DECLARED_FAMILY_FLOOR = 150
+
+
+def declared_metric_names(text: str) -> set:
+    """Families the engine actually DECLARES, via a `# HELP` or `# TYPE` line.
+
+    Deliberately narrower than `metric_names`, which matches a name anywhere in the source. A metric
+    name also appears in prose, in tests, and -- the case that hid two dead alerts --
+    in `ops_scale_readiness_harness.rs`, which carries a hardcoded list of families it EXPECTS the
+    dashboards and alerts to mention. Presence in that list states an intention, not an emission, so
+    "is the name somewhere in the Rust source" answers yes for a metric nothing ever writes.
+    """
+    return set(DECLARATION.findall(text))
+
+
+def alert_rules(text: str) -> list:
+    """(name, expr) for every alert rule. Scanned line by line rather than with a multiline
+    pattern, because the rule this replaces was easier to get subtly wrong than to read."""
+    rules, pending = [], None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- alert:"):
+            pending = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("expr:") and pending is not None:
+            rules.append((pending, stripped.split(":", 1)[1].strip()))
+            pending = None
+    return rules
+
+
+def check_alert_expressions_are_emitted(alerts_text: str, declared: set) -> list:
+    """Alert rules whose every metric is undeclared, so the rule can never fire.
+
+    A rule on a metric nothing emits is worse than no rule: the panel is blank, the alert is silent,
+    and silence reads as health. Two were found this way -- a scale SLO rule on two p99 families
+    that only ever appeared in that expectations list, and a replica-replay rule on a counter no
+    subsystem publishes.
+
+    Only reported when NONE of a rule's metrics is declared. A rule mixing a live metric with a dead
+    one still fires; `check_alert_metric_names` reports those individually.
+    """
+    rules = alert_rules(alerts_text)
+    if not rules:
+        return ["alert_rules:none_parsed"]
+    failures = []
+    for name, expr in rules:
+        used = set(metric_names(expr))
+        if used and used.isdisjoint(declared):
+            failures.append("alert_never_fires:%s:%s" % (name, ",".join(sorted(used))))
+    return failures
+
+
+def check_alert_metric_names(alerts_text: str, declared: set) -> list:
+    """Individual metric names an alert uses that nothing declares."""
+    used = set(metric_names(alerts_text))
+    return ["alert_metric_undeclared:%s" % name for name in sorted(used - declared)]
+
+
+def check_declaration_extent(declared: set) -> list:
+    """This guard is worthless if the declaration scan comes back empty.
+
+    The checks above pass when `declared` is large AND when it is empty -- in the empty case nothing
+    is reported undeclared only because nothing was compared. Assert the scan found a plausible
+    number of families before believing anything derived from it.
+    """
+    if len(declared) < DECLARED_FAMILY_FLOOR:
+        return ["declaration_scan_narrowed:found_%d_expected_at_least_%d"
+                % (len(declared), DECLARED_FAMILY_FLOOR)]
+    return []
+
+
+def check_families_state_their_emission(families: dict) -> list:
+    """A family may not opt out of the emission check with an empty `rust` list.
+
+    This is the hole both dead panels came through. `scale_slo` and `secondary_replication` each
+    declared dashboard metrics and an alert rule, and `"rust": []` -- so the validator confirmed the
+    panel existed and the rule existed, and never asked whether anything produced the numbers.
+    Both panels were blank on every deployment and both alerts were silent, and the validator
+    reported the families ready.
+
+    An empty list is not the same as "no requirement". If a family genuinely has no engine-side
+    metric, it does not belong in a spec whose purpose is tying panels to emissions.
+    """
+    return ["family_states_no_emission:%s" % name
+            for name, requirements in sorted(families.items())
+            if not requirements.get("rust")]
 
 
 def check_scan_extent() -> list:
@@ -348,11 +419,19 @@ def main() -> int:
     if fixed_but_listed:
         print("These are listed as known-unemitted but now resolve: %s. Remove them from "
               "KNOWN_UNEMITTED." % ", ".join(fixed_but_listed), file=sys.stderr)
+    declared = declared_metric_names(rust)
+    alert_failures = (check_declaration_extent(declared)
+                      + check_families_state_their_emission(METRIC_FAMILIES)
+                      + check_alert_expressions_are_emitted(alerts, declared)
+                      + check_alert_metric_names(alerts, declared))
+    for failure in alert_failures:
+        print("ALERT CANNOT FIRE: %s" % failure, file=sys.stderr)
     lost = check_scan_extent()
     if lost:
         print("SCAN NARROWED: these files used to be scanned and are no longer discovered: %s"
               % ", ".join(lost), file=sys.stderr)
-    return 0 if (not unexpected and not lost and not fixed_but_listed) else 1
+    return 0 if (not unexpected and not lost and not fixed_but_listed
+                 and not alert_failures) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two of the twelve dashboard panels rendered **empty on every deployment**, and two alert rules **could never fire**. All four came from one cause.

The conformance spec describes each family by the dashboard metrics it needs, the alert rules it needs, and the Rust metrics that must exist. `scale_slo` and `secondary_replication` each set that last list to `[]`. The validator reads an empty list as *requires no engine-side metric* — so it confirmed the panels existed and the rules existed, never asked whether anything produced the numbers, and reported both families ready.

| removed | queried | state |
|---|---|---|
| panel: Secondary Replication Replay | `temporalstore_replica_replay_loop_consecutive_failures`, `_enabled`, `_events_total`, `_next_delay_ms` | none declared |
| panel: Scale SLO | `temporalstore_scale_write_p99_us`, `_read_p99_us`, `_throughput_ops`, `_error_budget_remaining` | none declared |
| alert: `TemporalStoreReplicaReplayFailures` | replica replay counter | never fires |
| alert: `TemporalStoreScaleSloRegression` | both p99 families | never fires |

Secondary replication replay health and the scale p99 SLO were unwatched the whole time. The panels and rules only made it look otherwise. Removing them is not a loss of monitoring — it is the end of a false claim — and the coverage doc records exactly what stopped being asserted, so it reads as a decision rather than a capability that quietly vanished.

**Why "is the name in the Rust source" did not catch it.** Two of the metrics *do* appear there — inside a hardcoded list in `ops_scale_readiness_harness.rs` of families it expects the dashboards to mention. Intent, not emission. Emission now means a `# HELP` or `# TYPE` declaration.

**Three checks added**, each asserting its own extent before comparing, because every one of them passes trivially against an empty scan:

- a rule whose every metric is undeclared → failure
- any individual alert metric that is undeclared → failure
- a family may no longer opt out with an empty Rust list

Mutation-checked: adding a rule on a fabricated metric fails the run; forcing the declaration scan to return nothing fails it with `declaration_scan_narrowed:found_0_expected_at_least_150` rather than passing silently.

**One more thing found on the way.** That harness verified its lists against `docs/ops/temporalstore-grafana-metrics-parity.md`, which has not existed since that document was renamed — so its check returned false unconditionally. Path corrected, lists brought back into agreement with the dashboards. Its identifier and two descriptions narrated the work as catching up to something else and are reworded; one shared-corpus key keeps its name because that is a cross-repo contract.

Validator exits 0 with 8 families and nothing missing. `test_matrixark_engine_dashboard_coverage`, `test_matrixark_v1_gateway` and `test_matrixark_gateway_config` all pass.