### PR TITLE
Name the index types after blocks, and pin what the index writes

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -2392,7 +2392,7 @@ fn fold_delta_page_items(
         // The record's key is not carried into memory: the map assigns a handle, and the
         // record's spelling is only rebuilt when the index is written back out.
         bucket.page_index.insert(
-            PageIndex {
+            BlockIndex {
                 object_key: Arc::from(item.object_key.clone()),
                 model_id: Arc::from(item.model_id.clone()),
                 component: item.component.clone().map(Arc::from),
@@ -3616,7 +3616,7 @@ fn object_manager_stats(
                             .bucket_index
                             .object_page_lookup
                             .values()
-                            .map(crate::engine::state::ObjectPageRefs::total_refs)
+                            .map(crate::engine::state::ObjectBlockRefs::total_refs)
                             .sum::<usize>()
                     }),
                     shard.dirty_objects.len(),

--- a/crates/temporalstore-rust/src/engine/compaction.rs
+++ b/crates/temporalstore-rust/src/engine/compaction.rs
@@ -52,7 +52,7 @@ pub(super) fn compaction_utility_report(
 
 pub(super) fn model_compaction_policy_reports(
     shard: &ShardState,
-    entries: &[LivePageEntry],
+    entries: &[LiveBlockEntry],
     slab_page_counts: &BTreeMap<u64, u64>,
 ) -> Vec<ModelCompactionPolicyReport> {
     #[derive(Default)]

--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -283,7 +283,7 @@ pub(super) struct CoreIndex {
     #[serde(rename = "slot_map")]
     pub(super) bucket_map: BucketMap,
     #[serde(default)]
-    pub(super) object_page_lookup: ObjectPageLookup,
+    pub(super) object_page_lookup: ObjectBlockLookup,
     /// One shared copy of each page kind, so a page holds a pointer rather than its own string.
     ///
     /// Measured over 2700 pages: `model_id` had 2 distinct values and 2700 copies -- 1350 copies
@@ -334,8 +334,8 @@ pub(super) type ObjectIndex = BTreeSet<u64>;
 /// disk, so a handle has to mean the same page in every process that reads the file. Assigning
 /// them from a counter compiled, round-tripped, and lost an object on the first reload.
 #[derive(Debug, Default, Clone, Deserialize)]
-#[serde(from = "BTreeMap<String, PageIndex>")]
-pub(super) enum PageIndexMap {
+#[serde(from = "BTreeMap<String, BlockIndex>")]
+pub(super) enum BlockIndexMap {
     /// A bucket holding nothing: no map, no node, no allocation.
     #[default]
     Empty,
@@ -346,77 +346,77 @@ pub(super) enum PageIndexMap {
     /// bytes to carry a 120-byte page, because its node is sized for eleven. Measured over a
     /// store of 2,000 keys, the containers were about 70% of the index's live heap.
     ///
-    /// The shape `PageRefs` already uses, for the same reason.
-    One(u64, PageIndex),
+    /// The shape `BlockRefs` already uses, for the same reason.
+    One(u64, BlockIndex),
     /// Several pages -- an object with components -- which is where a map earns its node.
-    Many(BTreeMap<u64, PageIndex>),
+    Many(BTreeMap<u64, BlockIndex>),
 }
 
 /// Iterating a page index, whichever shape it is in.
-pub(super) enum PageIndexIter<'a> {
+pub(super) enum BlockIndexIter<'a> {
     Empty,
-    One(std::iter::Once<(&'a u64, &'a PageIndex)>),
-    Many(std::collections::btree_map::Iter<'a, u64, PageIndex>),
+    One(std::iter::Once<(&'a u64, &'a BlockIndex)>),
+    Many(std::collections::btree_map::Iter<'a, u64, BlockIndex>),
 }
 
-impl<'a> Iterator for PageIndexIter<'a> {
-    type Item = (&'a u64, &'a PageIndex);
+impl<'a> Iterator for BlockIndexIter<'a> {
+    type Item = (&'a u64, &'a BlockIndex);
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            PageIndexIter::Empty => None,
-            PageIndexIter::One(once) => once.next(),
-            PageIndexIter::Many(iter) => iter.next(),
+            BlockIndexIter::Empty => None,
+            BlockIndexIter::One(once) => once.next(),
+            BlockIndexIter::Many(iter) => iter.next(),
         }
     }
 }
 
-pub(super) enum PageIndexValuesMut<'a> {
+pub(super) enum BlockIndexValuesMut<'a> {
     Empty,
-    One(std::iter::Once<&'a mut PageIndex>),
-    Many(std::collections::btree_map::ValuesMut<'a, u64, PageIndex>),
+    One(std::iter::Once<&'a mut BlockIndex>),
+    Many(std::collections::btree_map::ValuesMut<'a, u64, BlockIndex>),
 }
 
-impl<'a> Iterator for PageIndexValuesMut<'a> {
-    type Item = &'a mut PageIndex;
+impl<'a> Iterator for BlockIndexValuesMut<'a> {
+    type Item = &'a mut BlockIndex;
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            PageIndexValuesMut::Empty => None,
-            PageIndexValuesMut::One(once) => once.next(),
-            PageIndexValuesMut::Many(iter) => iter.next(),
+            BlockIndexValuesMut::Empty => None,
+            BlockIndexValuesMut::One(once) => once.next(),
+            BlockIndexValuesMut::Many(iter) => iter.next(),
         }
     }
 }
 
-impl PageIndexMap {
-    pub(super) fn get(&self, key: &u64) -> Option<&PageIndex> {
+impl BlockIndexMap {
+    pub(super) fn get(&self, key: &u64) -> Option<&BlockIndex> {
         match self {
-            PageIndexMap::Empty => None,
-            PageIndexMap::One(handle, page) => (handle == key).then_some(page),
-            PageIndexMap::Many(map) => map.get(key),
+            BlockIndexMap::Empty => None,
+            BlockIndexMap::One(handle, page) => (handle == key).then_some(page),
+            BlockIndexMap::Many(map) => map.get(key),
         }
     }
 
-    pub(super) fn get_mut(&mut self, key: &u64) -> Option<&mut PageIndex> {
+    pub(super) fn get_mut(&mut self, key: &u64) -> Option<&mut BlockIndex> {
         match self {
-            PageIndexMap::Empty => None,
-            PageIndexMap::One(handle, page) => (&*handle == key).then_some(page),
-            PageIndexMap::Many(map) => map.get_mut(key),
+            BlockIndexMap::Empty => None,
+            BlockIndexMap::One(handle, page) => (&*handle == key).then_some(page),
+            BlockIndexMap::Many(map) => map.get_mut(key),
         }
     }
 
-    pub(super) fn remove(&mut self, key: &u64) -> Option<PageIndex> {
+    pub(super) fn remove(&mut self, key: &u64) -> Option<BlockIndex> {
         match self {
-            PageIndexMap::Empty => None,
-            PageIndexMap::One(handle, _) => {
+            BlockIndexMap::Empty => None,
+            BlockIndexMap::One(handle, _) => {
                 if handle != key {
                     return None;
                 }
-                match std::mem::replace(self, PageIndexMap::Empty) {
-                    PageIndexMap::One(_, page) => Some(page),
+                match std::mem::replace(self, BlockIndexMap::Empty) {
+                    BlockIndexMap::One(_, page) => Some(page),
                     _ => unreachable!("just matched One"),
                 }
             }
-            PageIndexMap::Many(map) => {
+            BlockIndexMap::Many(map) => {
                 let removed = map.remove(key);
                 self.shrink();
                 removed
@@ -428,26 +428,26 @@ impl PageIndexMap {
     ///
     /// A page with the same identity replaces the one already there rather than adding beside it,
     /// which is what the rendered string key used to do by being the key.
-    pub(super) fn insert(&mut self, page: PageIndex) -> u64 {
-        let handle = page_index_handle(&page);
+    pub(super) fn insert(&mut self, page: BlockIndex) -> u64 {
+        let handle = block_index_handle(&page);
         match self {
-            PageIndexMap::Empty => *self = PageIndexMap::One(handle, page),
-            PageIndexMap::One(existing, held) => {
+            BlockIndexMap::Empty => *self = BlockIndexMap::One(handle, page),
+            BlockIndexMap::One(existing, held) => {
                 if *existing == handle {
                     *held = page;
                 } else {
                     // A second page: this bucket has earned a map.
-                    let (first_handle, first) = match std::mem::replace(self, PageIndexMap::Empty) {
-                        PageIndexMap::One(first_handle, first) => (first_handle, first),
+                    let (first_handle, first) = match std::mem::replace(self, BlockIndexMap::Empty) {
+                        BlockIndexMap::One(first_handle, first) => (first_handle, first),
                         _ => unreachable!("just matched One"),
                     };
                     let mut map = BTreeMap::new();
                     map.insert(first_handle, first);
                     map.insert(handle, page);
-                    *self = PageIndexMap::Many(map);
+                    *self = BlockIndexMap::Many(map);
                 }
             }
-            PageIndexMap::Many(map) => {
+            BlockIndexMap::Many(map) => {
                 map.insert(handle, page);
             }
         }
@@ -460,18 +460,18 @@ impl PageIndexMap {
     /// which is the cost this type exists to avoid.
     fn shrink(&mut self) {
         let len = match self {
-            PageIndexMap::Many(map) => map.len(),
+            BlockIndexMap::Many(map) => map.len(),
             _ => return,
         };
         match len {
-            0 => *self = PageIndexMap::Empty,
+            0 => *self = BlockIndexMap::Empty,
             1 => {
-                let map = match std::mem::replace(self, PageIndexMap::Empty) {
-                    PageIndexMap::Many(map) => map,
+                let map = match std::mem::replace(self, BlockIndexMap::Empty) {
+                    BlockIndexMap::Many(map) => map,
                     _ => unreachable!("just matched Many"),
                 };
                 let (handle, page) = map.into_iter().next().expect("length is one");
-                *self = PageIndexMap::One(handle, page);
+                *self = BlockIndexMap::One(handle, page);
             }
             _ => {}
         }
@@ -479,46 +479,46 @@ impl PageIndexMap {
 
     pub(super) fn len(&self) -> usize {
         match self {
-            PageIndexMap::Empty => 0,
-            PageIndexMap::One(..) => 1,
-            PageIndexMap::Many(map) => map.len(),
+            BlockIndexMap::Empty => 0,
+            BlockIndexMap::One(..) => 1,
+            BlockIndexMap::Many(map) => map.len(),
         }
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        matches!(self, PageIndexMap::Empty)
+        matches!(self, BlockIndexMap::Empty)
     }
 
-    pub(super) fn iter(&self) -> PageIndexIter<'_> {
+    pub(super) fn iter(&self) -> BlockIndexIter<'_> {
         match self {
-            PageIndexMap::Empty => PageIndexIter::Empty,
-            PageIndexMap::One(handle, page) => PageIndexIter::One(std::iter::once((handle, page))),
-            PageIndexMap::Many(map) => PageIndexIter::Many(map.iter()),
+            BlockIndexMap::Empty => BlockIndexIter::Empty,
+            BlockIndexMap::One(handle, page) => BlockIndexIter::One(std::iter::once((handle, page))),
+            BlockIndexMap::Many(map) => BlockIndexIter::Many(map.iter()),
         }
     }
 
-    pub(super) fn values(&self) -> impl Iterator<Item = &PageIndex> {
+    pub(super) fn values(&self) -> impl Iterator<Item = &BlockIndex> {
         self.iter().map(|(_handle, page)| page)
     }
 
-    pub(super) fn values_mut(&mut self) -> PageIndexValuesMut<'_> {
+    pub(super) fn values_mut(&mut self) -> BlockIndexValuesMut<'_> {
         match self {
-            PageIndexMap::Empty => PageIndexValuesMut::Empty,
-            PageIndexMap::One(_, page) => PageIndexValuesMut::One(std::iter::once(page)),
-            PageIndexMap::Many(map) => PageIndexValuesMut::Many(map.values_mut()),
+            BlockIndexMap::Empty => BlockIndexValuesMut::Empty,
+            BlockIndexMap::One(_, page) => BlockIndexValuesMut::One(std::iter::once(page)),
+            BlockIndexMap::Many(map) => BlockIndexValuesMut::Many(map.values_mut()),
         }
     }
 
-    pub(super) fn retain(&mut self, mut keep: impl FnMut(&u64, &mut PageIndex) -> bool) {
+    pub(super) fn retain(&mut self, mut keep: impl FnMut(&u64, &mut BlockIndex) -> bool) {
         match self {
-            PageIndexMap::Empty => {}
-            PageIndexMap::One(handle, page) => {
+            BlockIndexMap::Empty => {}
+            BlockIndexMap::One(handle, page) => {
                 let handle = *handle;
                 if !keep(&handle, page) {
-                    *self = PageIndexMap::Empty;
+                    *self = BlockIndexMap::Empty;
                 }
             }
-            PageIndexMap::Many(map) => {
+            BlockIndexMap::Many(map) => {
                 map.retain(|handle, page| keep(handle, page));
                 self.shrink();
             }
@@ -526,17 +526,17 @@ impl PageIndexMap {
     }
 }
 
-impl<'a> IntoIterator for &'a PageIndexMap {
-    type Item = (&'a u64, &'a PageIndex);
-    type IntoIter = PageIndexIter<'a>;
+impl<'a> IntoIterator for &'a BlockIndexMap {
+    type Item = (&'a u64, &'a BlockIndex);
+    type IntoIter = BlockIndexIter<'a>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
 /// Collecting pages assigns handles, the same as inserting them one at a time.
-impl FromIterator<PageIndex> for PageIndexMap {
-    fn from_iter<I: IntoIterator<Item = PageIndex>>(pages: I) -> Self {
+impl FromIterator<BlockIndex> for BlockIndexMap {
+    fn from_iter<I: IntoIterator<Item = BlockIndex>>(pages: I) -> Self {
         let mut map = Self::default();
         for page in pages {
             map.insert(page);
@@ -545,8 +545,8 @@ impl FromIterator<PageIndex> for PageIndexMap {
     }
 }
 
-impl From<BTreeMap<String, PageIndex>> for PageIndexMap {
-    fn from(flat: BTreeMap<String, PageIndex>) -> Self {
+impl From<BTreeMap<String, BlockIndex>> for BlockIndexMap {
+    fn from(flat: BTreeMap<String, BlockIndex>) -> Self {
         // The handle is recomputed from the page, not read from the file and not assigned by a
         // counter. A counter would hand out different handles than the ones the lookup refs were
         // written with, and those refs are on disk too.
@@ -557,7 +557,7 @@ impl From<BTreeMap<String, PageIndex>> for PageIndexMap {
     }
 }
 
-impl Serialize for PageIndexMap {
+impl Serialize for BlockIndexMap {
     /// Writes the same map of rendered keys, in the same order, without copying the index first.
     ///
     /// Hand-written rather than `#[serde(into = ...)]`, which is defined as
@@ -573,9 +573,9 @@ impl Serialize for PageIndexMap {
         S: serde::Serializer,
     {
         use serde::ser::SerializeMap;
-        let mut entries: Vec<(String, &PageIndex)> = self
+        let mut entries: Vec<(String, &BlockIndex)> = self
             .values()
-            .map(|page| (page_index_written_key(page), page))
+            .map(|page| (block_index_written_key(page), page))
             .collect();
         entries.sort_by(|left, right| left.0.cmp(&right.0));
 
@@ -597,10 +597,10 @@ impl Serialize for PageIndexMap {
 /// Two processes holding the same page must compute the same handle or those refs point at
 /// nothing -- which is what a counter did, silently, until a reload lost an object.
 ///
-/// Hashes exactly the fields [`page_index_written_key`] renders, so the handle and the written
+/// Hashes exactly the fields [`block_index_written_key`] renders, so the handle and the written
 /// key always name the same page. Equal identity therefore lands on one slot, which is also how
 /// this map keeps a rewrite from accumulating a second entry for the same page.
-pub(super) fn page_index_handle(page: &PageIndex) -> u64 {
+pub(super) fn block_index_handle(page: &BlockIndex) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     page.model_id.hash(&mut hasher);
@@ -614,7 +614,7 @@ pub(super) fn page_index_handle(page: &PageIndex) -> u64 {
     hasher.finish()
 }
 
-pub(super) fn page_index_written_key(page: &PageIndex) -> String {
+pub(super) fn block_index_written_key(page: &BlockIndex) -> String {
     crate::index_log::page_ref_key_from_parts(
         &page.model_id,
         &page.object_key,
@@ -649,15 +649,15 @@ pub(super) fn page_index_written_key(page: &PageIndex) -> String {
 /// concatenated. A lookup walks two maps instead of building a string.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
-    from = "BTreeMap<String, ObjectPageRefs>",
-    into = "BTreeMap<String, ObjectPageRefs>"
+    from = "BTreeMap<String, ObjectBlockRefs>",
+    into = "BTreeMap<String, ObjectBlockRefs>"
 )]
-pub(super) struct ObjectPageLookup {
-    by_model: BTreeMap<Arc<str>, BTreeMap<Arc<str>, ObjectPageRefs>>,
+pub(super) struct ObjectBlockLookup {
+    by_model: BTreeMap<Arc<str>, BTreeMap<Arc<str>, ObjectBlockRefs>>,
 }
 
-impl ObjectPageLookup {
-    pub(super) fn get(&self, model_id: &str, object_key: &str) -> Option<&ObjectPageRefs> {
+impl ObjectBlockLookup {
+    pub(super) fn get(&self, model_id: &str, object_key: &str) -> Option<&ObjectBlockRefs> {
         self.by_model.get(model_id)?.get(object_key)
     }
 
@@ -665,7 +665,7 @@ impl ObjectPageLookup {
         &mut self,
         model_id: &str,
         object_key: &str,
-    ) -> Option<&mut ObjectPageRefs> {
+    ) -> Option<&mut ObjectBlockRefs> {
         self.by_model.get_mut(model_id)?.get_mut(object_key)
     }
 
@@ -677,10 +677,10 @@ impl ObjectPageLookup {
         &mut self,
         model_id: &Arc<str>,
         object_key: &Arc<str>,
-    ) -> &mut ObjectPageRefs {
+    ) -> &mut ObjectBlockRefs {
         let objects = self.by_model.entry(Arc::clone(model_id)).or_default();
         if !objects.contains_key(object_key.as_ref()) {
-            objects.insert(Arc::clone(object_key), ObjectPageRefs::default());
+            objects.insert(Arc::clone(object_key), ObjectBlockRefs::default());
         }
         objects
             .get_mut(object_key.as_ref())
@@ -696,7 +696,7 @@ impl ObjectPageLookup {
         Some(stored.as_ptr())
     }
 
-    pub(super) fn remove(&mut self, model_id: &str, object_key: &str) -> Option<ObjectPageRefs> {
+    pub(super) fn remove(&mut self, model_id: &str, object_key: &str) -> Option<ObjectBlockRefs> {
         let objects = self.by_model.get_mut(model_id)?;
         let removed = objects.remove(object_key);
         if objects.is_empty() {
@@ -718,12 +718,12 @@ impl ObjectPageLookup {
         self.by_model.clear();
     }
 
-    pub(super) fn values(&self) -> impl Iterator<Item = &ObjectPageRefs> {
+    pub(super) fn values(&self) -> impl Iterator<Item = &ObjectBlockRefs> {
         self.by_model.values().flat_map(BTreeMap::values)
     }
 
     /// Model and object for every entry, for the places that used to read the composite key.
-    pub(super) fn iter(&self) -> impl Iterator<Item = (&Arc<str>, &Arc<str>, &ObjectPageRefs)> {
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&Arc<str>, &Arc<str>, &ObjectBlockRefs)> {
         self.by_model.iter().flat_map(|(model, objects)| {
             objects.iter().map(move |(object, refs)| (model, object, refs))
         })
@@ -743,9 +743,9 @@ fn take_lookup_part(input: &str) -> Option<(&str, &str)> {
     Some((&input[start..end], &input[end + 1..]))
 }
 
-impl From<BTreeMap<String, ObjectPageRefs>> for ObjectPageLookup {
-    fn from(flat: BTreeMap<String, ObjectPageRefs>) -> Self {
-        let mut nested: BTreeMap<Arc<str>, BTreeMap<Arc<str>, ObjectPageRefs>> = BTreeMap::new();
+impl From<BTreeMap<String, ObjectBlockRefs>> for ObjectBlockLookup {
+    fn from(flat: BTreeMap<String, ObjectBlockRefs>) -> Self {
+        let mut nested: BTreeMap<Arc<str>, BTreeMap<Arc<str>, ObjectBlockRefs>> = BTreeMap::new();
         for (key, refs) in flat {
             // A key that does not parse is skipped rather than guessed at: inventing a model for
             // it would file the object somewhere no lookup would ever look.
@@ -767,8 +767,8 @@ impl From<BTreeMap<String, ObjectPageRefs>> for ObjectPageLookup {
     }
 }
 
-impl From<ObjectPageLookup> for BTreeMap<String, ObjectPageRefs> {
-    fn from(nested: ObjectPageLookup) -> Self {
+impl From<ObjectBlockLookup> for BTreeMap<String, ObjectBlockRefs> {
+    fn from(nested: ObjectBlockLookup) -> Self {
         let mut flat = BTreeMap::new();
         for (model, objects) in nested.by_model {
             for (object, refs) in objects {
@@ -784,23 +784,23 @@ impl From<ObjectPageLookup> for BTreeMap<String, ObjectPageRefs> {
 /// A sorted vector rather than a map because the measured average is 1.0 components per object: a
 /// B-tree holding a single entry is a node and an allocation spent to express a list of one.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(super) struct ObjectPageRefs {
+pub(super) struct ObjectBlockRefs {
     #[serde(default)]
-    pub(super) by_component: Vec<ComponentPages>,
+    pub(super) by_component: Vec<ComponentBlocks>,
 }
 
 /// One component of one object, and the pages holding it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(super) struct ComponentPages {
+pub(super) struct ComponentBlocks {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) component: Option<Arc<str>>,
     /// Sorted and deduplicated, and held inline when there is only one -- which is all of them.
-    /// Insertion goes through `PageRefs::insert`, which keeps both invariants.
+    /// Insertion goes through `BlockRefs::insert`, which keeps both invariants.
     #[serde(default)]
-    pub(super) refs: PageRefs,
+    pub(super) refs: BlockRefs,
 }
 
-impl ObjectPageRefs {
+impl ObjectBlockRefs {
     /// Where this component sits, or where it would be inserted. `None` sorts first, matching
     /// `Option`'s own ordering, so the vector's order is the order a caller would expect.
     pub(super) fn position(&self, component: Option<&str>) -> Result<usize, usize> {
@@ -808,14 +808,14 @@ impl ObjectPageRefs {
             .binary_search_by(|entry| entry.component.as_deref().cmp(&component))
     }
 
-    pub(super) fn refs_for(&self, component: Option<&str>) -> Option<&[PageLookupRef]> {
+    pub(super) fn refs_for(&self, component: Option<&str>) -> Option<&[BlockLookupRef]> {
         self.position(component)
             .ok()
             .map(|at| self.by_component[at].refs.as_slice())
     }
 
     /// Every page ref of this object, across every component, in component order.
-    pub(super) fn all_refs(&self) -> impl Iterator<Item = &PageLookupRef> {
+    pub(super) fn all_refs(&self) -> impl Iterator<Item = &BlockLookupRef> {
         self.by_component.iter().flat_map(|entry| entry.refs.iter())
     }
 
@@ -857,14 +857,14 @@ pub(super) fn intern_shared(pool: &mut std::collections::HashSet<Arc<str>>, kind
 ///
 /// Serializes as a sequence exactly as the vector did, so the on-disk index is unchanged.
 #[derive(Debug, Clone, Eq, Serialize, Deserialize)]
-#[serde(from = "Vec<PageLookupRef>", into = "Vec<PageLookupRef>")]
-pub(super) enum PageRefs {
-    One(PageLookupRef),
-    Many(Vec<PageLookupRef>),
+#[serde(from = "Vec<BlockLookupRef>", into = "Vec<BlockLookupRef>")]
+pub(super) enum BlockRefs {
+    One(BlockLookupRef),
+    Many(Vec<BlockLookupRef>),
 }
 
-impl PageRefs {
-    pub(super) fn as_slice(&self) -> &[PageLookupRef] {
+impl BlockRefs {
+    pub(super) fn as_slice(&self) -> &[BlockLookupRef] {
         match self {
             Self::One(value) => std::slice::from_ref(value),
             Self::Many(values) => values.as_slice(),
@@ -878,13 +878,13 @@ impl PageRefs {
         }
     }
 
-    pub(super) fn iter(&self) -> std::slice::Iter<'_, PageLookupRef> {
+    pub(super) fn iter(&self) -> std::slice::Iter<'_, BlockLookupRef> {
         self.as_slice().iter()
     }
 
     /// Insert keeping the refs sorted and free of duplicates, which is what the set this replaced
     /// did. Reports whether anything was added, which is what the ref counter is kept from.
-    pub(super) fn insert(&mut self, value: PageLookupRef) -> bool {
+    pub(super) fn insert(&mut self, value: BlockLookupRef) -> bool {
         match self {
             Self::One(existing) => match value.cmp(existing) {
                 std::cmp::Ordering::Equal => false,
@@ -908,7 +908,7 @@ impl PageRefs {
     }
 }
 
-impl Default for PageRefs {
+impl Default for BlockRefs {
     fn default() -> Self {
         Self::Many(Vec::new())
     }
@@ -917,14 +917,14 @@ impl Default for PageRefs {
 /// Compared by contents, so a one-element spilled arm and an inline one are the same refs. Without
 /// this, a value read back from an index written before this change could compare unequal to the
 /// identical value built in memory.
-impl PartialEq for PageRefs {
+impl PartialEq for BlockRefs {
     fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
-impl From<Vec<PageLookupRef>> for PageRefs {
-    fn from(mut refs: Vec<PageLookupRef>) -> Self {
+impl From<Vec<BlockLookupRef>> for BlockRefs {
+    fn from(mut refs: Vec<BlockLookupRef>) -> Self {
         if refs.len() == 1 {
             Self::One(refs.pop().expect("length just checked"))
         } else {
@@ -933,24 +933,24 @@ impl From<Vec<PageLookupRef>> for PageRefs {
     }
 }
 
-impl From<PageRefs> for Vec<PageLookupRef> {
-    fn from(refs: PageRefs) -> Self {
+impl From<BlockRefs> for Vec<BlockLookupRef> {
+    fn from(refs: BlockRefs) -> Self {
         match refs {
-            PageRefs::One(value) => vec![value],
-            PageRefs::Many(values) => values,
+            BlockRefs::One(value) => vec![value],
+            BlockRefs::Many(values) => values,
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(super) struct PageLookupRef {
+pub(super) struct BlockLookupRef {
     #[serde(rename = "routing_slot")]
     pub(super) routing_bucket: u32,
     pub(super) page_ref_key: u64,
 }
 
 /// Rust-native core index mirroring the shape:
-/// Index -> BucketMap -> BucketNode -> PageIndex/ObjectIndex.
+/// Index -> BucketMap -> BucketNode -> BlockIndex/ObjectIndex.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub(super) struct BucketNode {
     #[serde(rename = "routing_slot")]
@@ -971,7 +971,7 @@ pub(super) struct BucketNode {
     #[serde(default, alias = "deleted_object_ids")]
     pub(super) deleted_object_index: ObjectIndex,
     #[serde(default, alias = "page_refs")]
-    pub(super) page_index: PageIndexMap,
+    pub(super) page_index: BlockIndexMap,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -985,7 +985,7 @@ pub(super) enum BucketLayoutState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct PageIndex {
+pub(super) struct BlockIndex {
     pub(super) object_key: Arc<str>,
     pub(super) model_id: Arc<str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -996,7 +996,7 @@ pub(super) struct PageIndex {
     pub(super) log_backed: bool,
 }
 
-impl PageIndex {
+impl BlockIndex {
     /// The object this page belongs to.
     ///
     /// Held once, in the address, rather than beside it. The entry used to carry its own copy and
@@ -1035,7 +1035,7 @@ impl CoreIndex {
         &mut self,
         routing_bucket: u32,
         page_ref_key: u64,
-        page: &PageIndex,
+        page: &BlockIndex,
     ) {
         if page.deleted {
             return;
@@ -1044,7 +1044,7 @@ impl CoreIndex {
             let entry = self
                 .object_page_lookup
                 .entry(&page.model_id, &page.object_key);
-            let value = PageLookupRef {
+            let value = BlockLookupRef {
                 routing_bucket,
                 page_ref_key,
             };
@@ -1055,9 +1055,9 @@ impl CoreIndex {
                     // case never allocates and there is no empty state in between.
                     entry.by_component.insert(
                         at,
-                        ComponentPages {
+                        ComponentBlocks {
                             component: page.component.clone(),
-                            refs: PageRefs::One(value),
+                            refs: BlockRefs::One(value),
                         },
                     );
                     true
@@ -1077,7 +1077,7 @@ impl CoreIndex {
         model_id: &str,
         object_key: &str,
         component: Option<&str>,
-    ) -> Option<&[PageLookupRef]> {
+    ) -> Option<&[BlockLookupRef]> {
         self.object_page_lookup
             .get(model_id, object_key)
             .and_then(|entry| entry.refs_for(component))
@@ -1088,7 +1088,7 @@ impl CoreIndex {
         &self,
         model_id: &str,
         object_key: &str,
-    ) -> Option<&ObjectPageRefs> {
+    ) -> Option<&ObjectBlockRefs> {
         self.object_page_lookup.get(model_id, object_key)
     }
 
@@ -1291,8 +1291,8 @@ mod component_lookup_tests {
     use super::*;
 
     /// A page carrying nothing but the identity the lookup keys on.
-    fn page(object: &str, component: Option<&str>) -> PageIndex {
-        PageIndex {
+    fn page(object: &str, component: Option<&str>) -> BlockIndex {
+        BlockIndex {
             object_key: Arc::from(object.to_string()),
             model_id: Arc::from("hash".to_string()),
             component: component.map(str::to_string).map(Arc::from),

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -198,7 +198,7 @@ impl StorageManagerPhaseExecutor {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct LivePageEntry {
+pub(super) struct LiveBlockEntry {
     pub(super) object_key: Arc<str>,
     pub(super) kind: Arc<str>,
     pub(super) component: Option<Arc<str>>,
@@ -219,8 +219,8 @@ pub(super) fn live_page_entry(
     kind: impl Into<String>,
     component: Option<String>,
     address: BlockAddress,
-) -> LivePageEntry {
-    LivePageEntry {
+) -> LiveBlockEntry {
+    LiveBlockEntry {
         object_key: Arc::from(object_key.into()),
         kind: Arc::from(kind.into()),
         component: component.map(Arc::from),
@@ -358,7 +358,7 @@ pub(super) fn storage_index_snapshot_with_samples(
     snapshot
 }
 
-pub(super) fn storage_gc_ref(entry: &LivePageEntry) -> String {
+pub(super) fn storage_gc_ref(entry: &LiveBlockEntry) -> String {
     match entry.component.as_deref() {
         Some(component) if !component.is_empty() => {
             format!("{}:{}:{}", entry.kind, entry.object_key, component)
@@ -811,7 +811,7 @@ fn note_site(site: &std::sync::atomic::AtomicU64, count: usize) {
     note_bucket_page_visits(count);
 }
 
-pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
+pub(super) fn collect_live_page_entries(shard: &ShardState) -> Vec<LiveBlockEntry> {
     let entries = if !shard.bucket_index.bucket_map.is_empty() {
         collect_bucket_index_live_page_entries(shard)
     } else {
@@ -901,7 +901,7 @@ pub(super) fn rebuild_bucket_page_ownership(
             });
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            PageIndex {
+            BlockIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
                 component: entry.component.clone(),
@@ -981,11 +981,11 @@ pub(super) fn rebuild_unserialized_model_maps_from_bucket_index(shard: &mut Shar
     }
 }
 
-pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
+pub(super) fn collect_bucket_index_live_page_entries(shard: &ShardState) -> Vec<LiveBlockEntry> {
     let mut entries = Vec::new();
     for bucket in shard.bucket_index.bucket_map.values() {
         for page in bucket.page_index.values() {
-            entries.push(LivePageEntry {
+            entries.push(LiveBlockEntry {
                 object_key: page.object_key.clone(),
                 kind: page.model_id.clone(),
                 // Both sides are `Option<Arc<str>>`; going through a String allocated the text
@@ -1174,7 +1174,7 @@ pub(super) fn sync_context_pages_for_object(
     true
 }
 
-pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LivePageEntry> {
+pub(super) fn collect_model_live_page_entries(shard: &ShardState) -> Vec<LiveBlockEntry> {
     let mut entries = Vec::new();
     entries.extend(
         shard
@@ -1371,7 +1371,7 @@ pub(super) fn upsert_bucket_index_page_with(
             meta: false,
         });
     }
-    let entry = LivePageEntry {
+    let entry = LiveBlockEntry {
         // One allocation of this object's identity, shared by the page entry and the lookup.
         object_key: Arc::from(object_key),
         kind: crate::engine::state::intern_shared(&mut shard.bucket_index.kind_pool, kind),
@@ -1390,7 +1390,7 @@ pub(super) fn upsert_bucket_index_page_with(
         shard
             .bucket_index
             .page_refs_for(&entry.kind, &entry.object_key, entry.component.as_deref())
-            .map(<[crate::engine::state::PageLookupRef]>::to_vec)
+            .map(<[crate::engine::state::BlockLookupRef]>::to_vec)
     } else {
         None
     };
@@ -1445,7 +1445,7 @@ pub(super) fn upsert_bucket_index_page_with(
     // computed for it.
     let mut address = entry.address;
     address.set_object_id(Some(object_id));
-    let page_index = PageIndex {
+    let page_index = BlockIndex {
         object_key: entry.object_key,
         model_id: entry.kind,
         component: entry.component.clone(),
@@ -1584,7 +1584,7 @@ pub(super) fn sync_bucket_index_object_pages(
         let object_id = address
             .object_id()
             .unwrap_or_else(|| stable_page_object_id(shard_id, kind, object_key, None));
-        let entry = LivePageEntry {
+        let entry = LiveBlockEntry {
             object_key: Arc::from(object_key.to_string()),
             kind: Arc::from(kind.to_string()),
             component: None,
@@ -1614,7 +1614,7 @@ pub(super) fn sync_bucket_index_object_pages(
         bucket.object_index.insert(object_id);
         bucket.deleted_object_index.remove(&object_id);
         let mut page_ref_key: u64 = 0;
-        let page = PageIndex {
+        let page = BlockIndex {
             object_key: entry.object_key,
             model_id: entry.kind,
             component: entry.component.clone(),
@@ -2001,7 +2001,7 @@ pub(super) fn rebuild_bucket_first_index(
         bucket.in_memory |= true;
         bucket.object_index.insert(object_id);
         bucket.page_index.insert(
-            PageIndex {
+            BlockIndex {
                 object_key: entry.object_key,
                 model_id: entry.kind,
                 component: entry.component.clone(),
@@ -2526,7 +2526,7 @@ pub(super) fn insert_context_event_views(
     }
 }
 
-pub(super) fn expected_live_page_object_id(shard_id: ShardId, entry: &LivePageEntry) -> u64 {
+pub(super) fn expected_live_page_object_id(shard_id: ShardId, entry: &LiveBlockEntry) -> u64 {
     stable_page_object_id(
         shard_id,
         &entry.kind,

--- a/crates/temporalstore-rust/src/engine/storage_reporting.rs
+++ b/crates/temporalstore-rust/src/engine/storage_reporting.rs
@@ -48,7 +48,7 @@ pub(super) fn storage_object_lifecycle_report_for_buckets_from_model_maps(
 fn object_lifecycle_report_from_entries(
     shard_id: ShardId,
     shard: &ShardState,
-    entries: Vec<LivePageEntry>,
+    entries: Vec<LiveBlockEntry>,
     selected_buckets: &BTreeSet<u32>,
     routing_bucket_for_key: impl Fn(&str) -> u32,
 ) -> StorageObjectLifecycleReport {

--- a/crates/temporalstore-rust/src/engine/tests/part3.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part3.rs
@@ -2372,7 +2372,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             object_index: [30].into_iter().collect(),
             page_index: [(
                 "string:k::1:0".to_string(),
-                PageIndex {
+                BlockIndex {
                     object_key: Arc::from("k".to_string()),
                     model_id: Arc::from("string".to_string()),
                     component: None,
@@ -2383,7 +2383,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 },
             )]
             .into_iter()
-            .map(|(_key, page): (String, PageIndex)| page)
+            .map(|(_key, page): (String, BlockIndex)| page)
             .collect(),
             ..BucketNode::default()
         },
@@ -2400,7 +2400,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             page_index: [
                 (
                     "feature:k::2:0".to_string(),
-                    PageIndex {
+                    BlockIndex {
                         object_key: Arc::from("feature-key".to_string()),
                         model_id: Arc::from("feature".to_string()),
                         component: None,
@@ -2412,7 +2412,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
                 (
                     "feature:k::2:4".to_string(),
-                    PageIndex {
+                    BlockIndex {
                         object_key: Arc::from("feature-key".to_string()),
                         model_id: Arc::from("feature".to_string()),
                         component: None,
@@ -2424,7 +2424,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
-            .map(|(_key, page): (String, PageIndex)| page)
+            .map(|(_key, page): (String, BlockIndex)| page)
             .collect(),
             ..BucketNode::default()
         },
@@ -2440,7 +2440,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
             page_index: [
                 (
                     "hash:k:a:3:0".to_string(),
-                    PageIndex {
+                    BlockIndex {
                         object_key: Arc::from("hash-key".to_string()),
                         model_id: Arc::from("hash".to_string()),
                         component: Some(Arc::from("a".to_string())),
@@ -2452,7 +2452,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
                 (
                     "hash:k:b:3:1".to_string(),
-                    PageIndex {
+                    BlockIndex {
                         object_key: Arc::from("hash-key".to_string()),
                         model_id: Arc::from("hash".to_string()),
                         component: Some(Arc::from("b".to_string())),
@@ -2464,7 +2464,7 @@ fn bucket_store_reports_all_layout_states_and_runtime_flags() {
                 ),
             ]
             .into_iter()
-            .map(|(_key, page): (String, PageIndex)| page)
+            .map(|(_key, page): (String, BlockIndex)| page)
             .collect(),
             ..BucketNode::default()
         },

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -3856,7 +3856,7 @@ fn bucket_runtime_flags_match_full_sweep() {
 /// ingest never releases. It is also the set whose per-entry iteration made the heartbeat
 /// shard-sized.
 ///
-/// Each `PageIndex` already carries `dirty`. If the two agree, the set is derivable from the
+/// Each `BlockIndex` already carries `dirty`. If the two agree, the set is derivable from the
 /// pages and its per-record String is duplicated state. If they disagree, it is carrying
 /// something the flags cannot express, and this test says exactly what -- which is the part worth
 /// knowing before anyone tries to remove it.
@@ -4060,7 +4060,7 @@ fn components_of_one_object_stay_separate() {
 /// from the outside and cost an allocation each, so the arm is asserted directly.
 #[test]
 fn single_page_components_are_held_inline() {
-    use crate::engine::state::{PageLookupRef, PageRefs};
+    use crate::engine::state::{BlockLookupRef, BlockRefs};
 
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
@@ -4087,8 +4087,8 @@ fn single_page_components_are_held_inline() {
     for entry in shard.bucket_index.object_page_lookup.values() {
         for component in &entry.by_component {
             match component.refs {
-                PageRefs::One(_) => inline += 1,
-                PageRefs::Many(_) => spilled += 1,
+                BlockRefs::One(_) => inline += 1,
+                BlockRefs::Many(_) => spilled += 1,
             }
         }
     }
@@ -4100,9 +4100,9 @@ fn single_page_components_are_held_inline() {
     );
 
     // The spilled arm has to keep working: sorted, deduplicated, and reporting what it added.
-    let first = PageLookupRef { routing_bucket: 7, page_ref_key: 2 };
-    let second = PageLookupRef { routing_bucket: 7, page_ref_key: 1 };
-    let mut refs = PageRefs::One(first.clone());
+    let first = BlockLookupRef { routing_bucket: 7, page_ref_key: 2 };
+    let second = BlockLookupRef { routing_bucket: 7, page_ref_key: 1 };
+    let mut refs = BlockRefs::One(first.clone());
     assert!(!refs.insert(first.clone()), "re-inserting the same ref adds nothing");
     assert_eq!(refs.len(), 1);
     assert!(refs.insert(second.clone()), "a second ref is an addition");
@@ -4121,9 +4121,9 @@ fn single_page_components_are_held_inline() {
 /// back as an inline one.
 #[test]
 fn page_refs_serialize_as_a_sequence() {
-    use crate::engine::state::{PageLookupRef, PageRefs};
+    use crate::engine::state::{BlockLookupRef, BlockRefs};
 
-    let single = PageRefs::One(PageLookupRef {
+    let single = BlockRefs::One(BlockLookupRef {
         routing_bucket: 3,
         page_ref_key: 1,
     });
@@ -4133,19 +4133,19 @@ fn page_refs_serialize_as_a_sequence() {
     assert_eq!(json[0]["routing_slot"], 3);
 
     // A one-element sequence written by the previous shape comes back inline, not spilled.
-    let restored: PageRefs = serde_json::from_value(json).unwrap();
+    let restored: BlockRefs = serde_json::from_value(json).unwrap();
     assert!(
-        matches!(restored, PageRefs::One(_)),
+        matches!(restored, BlockRefs::One(_)),
         "a one-element sequence should load into the inline arm"
     );
     assert_eq!(restored, single);
 
     let mut pair = single.clone();
-    pair.insert(PageLookupRef {
+    pair.insert(BlockLookupRef {
         routing_bucket: 4,
         page_ref_key: 2,
     });
-    let round_tripped: PageRefs = serde_json::from_value(serde_json::to_value(&pair).unwrap()).unwrap();
+    let round_tripped: BlockRefs = serde_json::from_value(serde_json::to_value(&pair).unwrap()).unwrap();
     assert_eq!(round_tripped, pair);
     assert_eq!(round_tripped.len(), 2);
 }
@@ -4463,7 +4463,7 @@ fn the_nested_lookup_still_serializes_as_the_flat_composite() {
     );
 
     // And a document in that shape loads back into the nested form.
-    let restored: crate::engine::state::ObjectPageLookup =
+    let restored: crate::engine::state::ObjectBlockLookup =
         serde_json::from_value(json).unwrap();
     assert!(
         restored.get("string", "nested-key").is_some(),
@@ -4735,7 +4735,7 @@ fn rewriting_a_page_does_not_reuse_its_index_key() {
 /// number; this one states the reason.
 #[test]
 fn installing_the_same_page_twice_replaces_it() {
-    let page = || crate::engine::state::PageIndex {
+    let page = || crate::engine::state::BlockIndex {
         object_key: Arc::from("twice".to_string()),
         model_id: Arc::from("string".to_string()),
         component: None,
@@ -4745,7 +4745,7 @@ fn installing_the_same_page_twice_replaces_it() {
         log_backed: true,
     };
 
-    let mut map = crate::engine::state::PageIndexMap::default();
+    let mut map = crate::engine::state::BlockIndexMap::default();
     let first = map.insert(page());
     let second = map.insert(page());
 
@@ -4957,7 +4957,7 @@ fn the_page_index_still_writes_string_keys() {
     // On the wire: the same rendered key it always wrote, rebuilt from the page.
     let json = serde_json::to_value(&bucket.page_index).unwrap();
     let written = json.as_object().expect("the wire form is a map of string keys");
-    let expected = crate::engine::state::page_index_written_key(page);
+    let expected = crate::engine::state::block_index_written_key(page);
     assert!(
         written.contains_key(&expected),
         "the dump must carry the rendered key {expected:?}, got {:?}",
@@ -4969,7 +4969,7 @@ fn the_page_index_still_writes_string_keys() {
     );
 
     // And a document in that shape loads back, with handles assigned afresh.
-    let restored: crate::engine::state::PageIndexMap = serde_json::from_value(json).unwrap();
+    let restored: crate::engine::state::BlockIndexMap = serde_json::from_value(json).unwrap();
     assert_eq!(restored.len(), bucket.page_index.len());
     assert!(
         restored.iter().all(|(handle, _)| *handle > 0),
@@ -5394,6 +5394,103 @@ fn does_writing_scale_with_the_store() {
     );
 }
 
+/// Every key the shard index writes, listed.
+///
+/// A guard for renaming Rust identifiers without moving the format under the data. Most of these
+/// fields carry no `serde` attribute, so their Rust name IS their wire name -- renaming one
+/// changes what is written, and an index written by the new code would not be read by the old.
+/// Listing them makes that visible in a diff instead of silent.
+#[test]
+fn the_index_wire_keys_are_what_they_were() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        8 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::StringSet { key: "wire".to_string(), value: vec![b'v'; 32] },
+    });
+    engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::HashSet {
+            key: "wire-hash".to_string(),
+            field: "f".to_string(),
+            value: vec![b'v'; 32],
+        },
+    });
+
+    let shards = engine.shards.read().expect("shards lock poisoned");
+    let shard = shards.get(&1).expect("shard 1 loaded");
+    let value = serde_json::to_value(&shard.bucket_index).expect("the index serializes");
+
+    // Every object key that appears anywhere in the document, deduplicated.
+    fn collect(value: &serde_json::Value, into: &mut std::collections::BTreeSet<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, child) in map {
+                    into.insert(key.clone());
+                    collect(child, into);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    collect(item, into);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut keys = std::collections::BTreeSet::new();
+    collect(&value, &mut keys);
+
+    // The rendered page keys are data, not field names: they are built from the object's own
+    // identity, so they vary with the test's keys rather than with the format.
+    keys.retain(|key| !key.contains(':') && !key.chars().all(|c| c.is_ascii_digit()));
+
+    let listed: Vec<&str> = keys.iter().map(String::as_str).collect();
+    assert_eq!(
+        listed,
+        vec![
+            "address",
+            "b",
+            "by_component",
+            "component",
+            "deleted",
+            "deleted_object_index",
+            "dirty",
+            "dirty_generation",
+            "g",
+            "in_memory",
+            "l",
+            "last_dump_sequence",
+            "layout",
+            "loading",
+            "log_backed",
+            "meta_loaded",
+            "model_id",
+            "o",
+            "object_index",
+            "object_key",
+            "object_page_lookup",
+            "oi",
+            "page_index",
+            "page_ref_key",
+            "pi",
+            "ps",
+            "refs",
+            "routing_slot",
+            "rs",
+            "slot_map",
+            "ttl_ms",
+        ],
+        "the index writes different keys than it did; a rename reached the format"
+    );
+}
+
 /// What a key costs the index in live heap.
 ///
 /// Measured as allocated-minus-freed rather than as a struct size, because the cost this bounds
@@ -5449,7 +5546,7 @@ fn what_a_key_costs_the_index_in_live_heap() {
 /// would not show up as a failure anywhere else.
 #[test]
 fn a_bucket_holding_one_page_holds_no_node() {
-    use crate::engine::state::PageIndexMap;
+    use crate::engine::state::BlockIndexMap;
 
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
@@ -5478,7 +5575,7 @@ fn a_bucket_holding_one_page_holds_no_node() {
             .find(|bucket| bucket.page_index.len() == 1)
             .expect("the write must produce a bucket holding one page");
         assert!(
-            matches!(bucket.page_index, PageIndexMap::One(..)),
+            matches!(bucket.page_index, BlockIndexMap::One(..)),
             "a bucket holding one page must hold it inline"
         );
     }
@@ -5504,7 +5601,7 @@ fn a_bucket_holding_one_page_holds_no_node() {
             .find(|bucket| bucket.page_index.len() > 1)
             .expect("three fields must share a bucket");
         assert!(
-            matches!(bucket.page_index, PageIndexMap::Many(_)),
+            matches!(bucket.page_index, BlockIndexMap::Many(_)),
             "several pages belong in a map"
         );
     }
@@ -5535,7 +5632,7 @@ fn a_bucket_holding_one_page_holds_no_node() {
             .expect("the remaining field must still be filed");
         assert_eq!(bucket.page_index.len(), 1, "two of three fields were removed");
         assert!(
-            matches!(bucket.page_index, PageIndexMap::One(..)),
+            matches!(bucket.page_index, BlockIndexMap::One(..)),
             "a map that drops back to one page must give up its node"
         );
     }
@@ -5643,7 +5740,7 @@ fn page_index_identity_string_cardinality() {
     component   {:>5} distinct, {:>6} holders ({:>7.1} each), {:>4} allocations behind {:>6} B of referenced text
     object_key  {:>5} distinct, {:>6} copies  ({:>7.1} copies each, {:>6} B held)
 
-    PageIndex is {} B before its heap strings
+    BlockIndex is {} B before its heap strings
 ",
         distinct_models.len(), pages, share(distinct_models.len(), pages),
         model_allocations.len(), model_bytes,
@@ -5651,7 +5748,7 @@ fn page_index_identity_string_cardinality() {
         share(distinct_components.len(), components_present),
         component_allocations.len(), component_bytes,
         distinct_keys.len(), pages, share(distinct_keys.len(), pages), key_bytes,
-        std::mem::size_of::<crate::engine::state::PageIndex>(),
+        std::mem::size_of::<crate::engine::state::BlockIndex>(),
     );
 }
 
@@ -5748,7 +5845,7 @@ fn object_page_lookup_occupancy_census() {
     components holding exactly one ref  {single_ref_components:>6}  ({:>5.1}%)
     components holding more             {multi_ref_components:>6}  ({:>5.1}%)
 
-    sizes: ObjectPageRefs {:>3} B, ComponentPages {:>3} B, PageRefs {:>3} B, PageLookupRef {:>3} B
+    sizes: ObjectBlockRefs {:>3} B, ComponentBlocks {:>3} B, BlockRefs {:>3} B, BlockLookupRef {:>3} B
     a one-component one-ref object: {:>3} B inline + {:>3} B for the component vector,
     and the ref itself rides inside the component rather than in an allocation of its own
 ",
@@ -5756,12 +5853,12 @@ fn object_page_lookup_occupancy_census() {
         pct(multi_component, objects),
         pct(single_ref_components, components_total),
         pct(multi_ref_components, components_total),
-        std::mem::size_of::<crate::engine::state::ObjectPageRefs>(),
-        std::mem::size_of::<crate::engine::state::ComponentPages>(),
-        std::mem::size_of::<crate::engine::state::PageRefs>(),
-        std::mem::size_of::<crate::engine::state::PageLookupRef>(),
-        std::mem::size_of::<crate::engine::state::ObjectPageRefs>(),
-        std::mem::size_of::<crate::engine::state::ComponentPages>(),
+        std::mem::size_of::<crate::engine::state::ObjectBlockRefs>(),
+        std::mem::size_of::<crate::engine::state::ComponentBlocks>(),
+        std::mem::size_of::<crate::engine::state::BlockRefs>(),
+        std::mem::size_of::<crate::engine::state::BlockLookupRef>(),
+        std::mem::size_of::<crate::engine::state::ObjectBlockRefs>(),
+        std::mem::size_of::<crate::engine::state::ComponentBlocks>(),
     );
 }
 
@@ -5769,7 +5866,7 @@ fn object_page_lookup_occupancy_census() {
 ///
 /// Resident memory is ~2.8-3.9 KB per record depending on key length, and a key byte costs 14.1
 /// bytes of it -- the same string is held by `strings`, by the composite keys of
-/// `object_page_lookup` and `object_component_lookup`, and again inside each `PageIndex`.
+/// `object_page_lookup` and `object_component_lookup`, and again inside each `BlockIndex`.
 /// Extrapolating to a zero-length key still leaves ~2581 B per record, so most of the bill is
 /// fixed per-record structure rather than the key.
 ///
@@ -5834,7 +5931,7 @@ fn per_record_structure_census() {
         .bucket_index
         .object_page_lookup
         .values()
-        .map(crate::engine::state::ObjectPageRefs::total_refs)
+        .map(crate::engine::state::ObjectBlockRefs::total_refs)
         .sum();
     let component_lookup_keys: usize = shard
         .bucket_index
@@ -6121,7 +6218,7 @@ fn maintained_component_page_ref_total_matches_the_walk() {
         .bucket_index
         .object_page_lookup
         .values()
-        .map(crate::engine::state::ObjectPageRefs::total_refs)
+        .map(crate::engine::state::ObjectBlockRefs::total_refs)
         .sum();
     let maintained = shard
         .bucket_index
@@ -11598,9 +11695,9 @@ fn whether_a_context_page_reaches_the_bucket_index() {
 /// undercounts a struct whose fields are `String`.
 #[test]
 fn what_one_page_costs_to_index() {
-    use crate::engine::state::PageIndex;
+    use crate::engine::state::BlockIndex;
 
-    let inline = std::mem::size_of::<PageIndex>();
+    let inline = std::mem::size_of::<BlockIndex>();
     let address_inline = std::mem::size_of::<crate::block_store::BlockAddress>();
     let string_inline = std::mem::size_of::<String>();
     let option_string_inline = std::mem::size_of::<Option<String>>();

--- a/crates/temporalstore-rust/src/index_log.rs
+++ b/crates/temporalstore-rust/src/index_log.rs
@@ -148,7 +148,7 @@ impl Default for IndexItemKind {
 /// field set is the native Rust page-index projection -- `routing_bucket`/`page_ref_key`
 /// locate the entry in the bucket map, and `address`/`size`/`in_log`/`deleted`/`model_id`/
 /// `object_id`/`page_id` mirror the durable page metadata so replay reconstructs the same
-/// `PageIndex` the whole-index serialization would have produced. `deleted` is a
+/// `BlockIndex` the whole-index serialization would have produced. `deleted` is a
 /// tombstone: replaying it removes the entry.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IndexItem {


### PR DESCRIPTION
The storage vocabulary is half migrated: `BlockAddress`,
`LocalBlockStore`, `block_id` and `block_size` are already named for
blocks, while the types around them still say page. This renames that
family to match:

`PageIndex`, `PageIndexMap`, `PageIndexIter`, `PageIndexValuesMut`,
`PageLookupRef`, `PageRefs`, `ObjectPageRefs`, `ObjectPageLookup`,
`ComponentPages`, `LivePageEntry`, and the `page_index_handle` /
`page_index_written_key` helpers.

**Type and helper names only.** Their fields carry no `page`, so nothing
here reaches the format.

### The guard

`the_index_wire_keys_are_what_they_were` lists every key the shard index
writes. Most of those fields carry no `serde` attribute, so a field's
Rust name **is** its wire name -- renaming one changes what is written,
and an index written by the new code would not be read by the old. The
list makes that visible in a diff instead of silent.

Verified by mutation: making the `page_index` field write itself as
`block_index` fails the test.

### What this deliberately does not do

**Field names are left alone.** 103 page-named fields on serialized
structs carry no serde attribute -- among them
`WriteAheadLogRecord::staged_pages`, `RaftSnapshotStateImage::next_page_id`,
and `StorageTuningConfig::page_index_cache_bytes`, which is a key in a
user's config file. Renaming those needs a pinned wire name apiece.

**String literals are left alone entirely.** The same words appear in
env var names, metric labels, on-disk file names and report text, where
they are contracts rather than identifiers. The one file where this
rename reached a string, `engine/reports.rs`, is restored untouched.

### On the other terms

`zone` and `segment` are **not** safe to sweep the same way, so they are
not in this change. Most `zone` sites are availability-zone tags in
`meta/location.rs`, unrelated to the storage `zone -> band` mapping, and
`segment` covers path segments and WAL segments as well as storage
segments. Only `page` turned out to be unambiguous across the crate.
