### PR TITLE
Say what the production readiness gate measures

### DIFF
--- a/crates/temporalstore-rust/src/proxy/prometheus.rs
+++ b/crates/temporalstore-rust/src/proxy/prometheus.rs
@@ -211,7 +211,7 @@ impl ProxyService {
 
         let readiness = crate::production_readiness_report();
         out.push_str(
-            "# HELP temporalstore_production_readiness_ready Production readiness gate state.\n",
+            "# HELP temporalstore_production_readiness_ready Build and configuration readiness: 1 when every capability area is compiled in and configured. Does NOT observe runtime health -- it reports the same value for a healthy cluster and for one with every node down.\n",
         );
         out.push_str("# TYPE temporalstore_production_readiness_ready gauge\n");
         push_proxy_metric(

--- a/docs/ops/temporalstore-alerts.yml
+++ b/docs/ops/temporalstore-alerts.yml
@@ -8,7 +8,7 @@ groups:
           severity: warning
         annotations:
           summary: TemporalStore production readiness gate is blocked
-          description: "The readiness gate reports {{ $value }} for production readiness. Check temporalstore_production_readiness_blockers by area and follow docs/ops/temporalstore-fault-runbook.md."
+          description: "A capability area is not compiled in or not configured. This gate reads build and configuration state only -- it does not observe runtime health, so it firing is a deployment/build problem, and it staying at 1 is NOT evidence that the cluster is serving. Check temporalstore_production_readiness_blockers by area and follow docs/ops/temporalstore-fault-runbook.md."
 
       - alert: TemporalStoreProductionReadinessBlockersHigh
         expr: temporalstore_production_readiness_blockers > 0
@@ -17,7 +17,7 @@ groups:
           severity: warning
         annotations:
           summary: TemporalStore has production readiness blockers
-          description: "{{ $value }} production readiness blockers remain. Inspect per-area temporalstore_production_readiness_blockers labels."
+          description: "{{ $value }} build/configuration readiness blockers remain. Inspect per-area temporalstore_production_readiness_blockers labels. These are capability areas absent from the build or unconfigured, not runtime faults."
 
   - name: temporalstore-raft-faults
     rules:

--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -4,7 +4,7 @@
   "version": 3,
   "panels": [
     {
-      "title": "Production Readiness",
+      "title": "Build & Config Readiness (not runtime health)",
       "type": "stat",
       "targets": [
         {

--- a/docs/ops/temporalstore-grafana-metrics-coverage.md
+++ b/docs/ops/temporalstore-grafana-metrics-coverage.md
@@ -193,3 +193,24 @@ spec whose entire purpose is tying a panel to an emission.
 The scale-harness readiness check carried the same names and additionally verified them against a
 document path that no longer exists, so that check returned false unconditionally. Its lists and
 its path are corrected here.
+
+
+## What the production readiness gate does and does not mean
+
+`temporalstore_production_readiness_ready` is the dashboard's headline stat and carries two alerts.
+It is computed from **build and configuration state only**.
+
+Measured over the readiness surface: 25 functions and 1,922 lines reached from
+`production_readiness_report()`, with **zero runtime reads** -- no atomics, no filesystem, no
+clock, no network. The single environment input is raft security configuration. Nine of the
+sub-reports are built from constants; 146 hardcoded `true` values sit among them.
+
+That is a legitimate thing to compute -- it answers "was this binary built and configured with
+every capability area present". It is not a health signal, and its name, its dashboard position and
+its alert wording all read as one. **A green gate is not evidence the cluster is serving.** It
+reports the same value for a healthy cluster and for one with every node down.
+
+The panel title, the metric's HELP text and both alert descriptions now say so.
+`test_matrixark_readiness_gate_is_build_state.py` pins it: if a runtime read is ever added to that
+surface, the test fails and asks for the wording to be revisited, so the description cannot quietly
+become wrong in the other direction.

--- a/tools/test_matrixark_readiness_gate_is_build_state.py
+++ b/tools/test_matrixark_readiness_gate_is_build_state.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The production readiness gate reports build state, and now says so.
+
+temporalstore_production_readiness_ready is the headline stat on the engine dashboard and carries
+two alerts. It is computed from build and configuration state only: the sub-reports behind it read
+no atomics, no filesystem, no clock and no network, and 146 hardcoded true values sit among them.
+It reports the same value for a healthy cluster and for one with every node down.
+
+That is a reasonable thing to compute. It is not a health signal, and the metric name, its
+dashboard position and its alert wording all read as one -- which is the risk: an operator sees
+green and concludes the system is serving.
+
+This pins both halves. If a runtime read is ever added to that surface the first test fails, and
+the wording that now says it does not observe runtime health has to be revisited rather than
+quietly becoming wrong in the other direction.
+"""
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RUST_SRC = os.path.join(ROOT, "crates", "temporalstore-rust", "src")
+PROMETHEUS = os.path.join(RUST_SRC, "proxy", "prometheus.rs")
+DASHBOARD = os.path.join(ROOT, "docs", "ops", "temporalstore-dashboard.json")
+ALERTS = os.path.join(ROOT, "docs", "ops", "temporalstore-alerts.yml")
+
+GATE_FUNCTIONS = (
+    "production_readiness_report",
+    "ingestion_readiness_report",
+    "client_routing_readiness_report",
+    "proxy_serving_readiness_report",
+    "data_node_service_readiness_report",
+    "metaserver_control_plane_readiness_report",
+    "storage_production_posture_report",
+    "feature_module_production_readiness_report",
+    "context_workflow_production_readiness_report",
+    "storage_cache_dependency_matrix_report",
+    "storage_ssd_cache_pressure_readiness_report",
+    "storage_migration_corpus_readiness_report",
+)
+
+RUNTIME_READ = re.compile(
+    r"env::var|[.]load[(]Ordering|Instant::now|SystemTime::now|fs::read|fs::write|"
+    r"fs::metadata|read_to_string|[.]lock[(][)]|TcpStream|reqwest")
+
+CAVEAT = "does not observe runtime health"
+
+
+def _rust_files() -> list:
+    out = []
+    for root, _dirs, files in os.walk(RUST_SRC):
+        if "tests" in root.replace(os.sep, "/").split("/"):
+            continue
+        out.extend(os.path.join(root, name) for name in files if name.endswith(".rs"))
+    return out
+
+
+def _body(text: str, start: int) -> str:
+    open_at = text.find("{", start)
+    if open_at < 0:
+        return ""
+    depth = 0
+    for index in range(open_at, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_at:index + 1]
+    return text[open_at:]
+
+
+def _gate_bodies() -> dict:
+    found = {}
+    for path in _rust_files():
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+        for name in GATE_FUNCTIONS:
+            if name in found:
+                continue
+            match = re.search(r"\bfn\s+" + name + r"\s*[(<]", text)
+            if match:
+                found[name] = (os.path.basename(path), _body(text, match.start()))
+    return found
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+class TheGateReadsBuildStateTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.bodies = _gate_bodies()
+
+    def test_every_gate_function_was_found(self) -> None:
+        """Without this the next test passes by finding nothing to check."""
+        missing = [name for name in GATE_FUNCTIONS if name not in self.bodies]
+        self.assertEqual([], missing,
+                         "these gate functions were not found, so the scan below proves nothing "
+                         "about them: %s" % ", ".join(missing))
+
+    def test_the_gate_reads_no_runtime_state(self) -> None:
+        offenders = []
+        for name, (where, body) in sorted(self.bodies.items()):
+            hits = sorted(set(RUNTIME_READ.findall(body)))
+            if hits:
+                offenders.append("%s (%s): %s" % (name, where, ", ".join(hits)))
+        self.assertEqual(
+            [], offenders,
+            "the readiness gate now reads runtime state: %s. That may well be an improvement, but "
+            "the metric HELP text, the dashboard panel title and both alert descriptions say it "
+            "does NOT observe runtime health. Update those together with this test."
+            % "; ".join(offenders))
+
+
+class TheWordingSaysSoTest(unittest.TestCase):
+
+    def test_the_scrape_carries_the_caveat(self) -> None:
+        lines = [line for line in _read(PROMETHEUS).splitlines()
+                 if "HELP temporalstore_production_readiness_ready" in line]
+        self.assertTrue(lines, "the readiness gauge no longer declares a HELP line")
+        self.assertIn(CAVEAT, lines[0].lower(),
+                      "the HELP text stopped saying this is not a runtime health signal, which is "
+                      "the only thing stopping green being read as healthy")
+
+    def test_the_dashboard_stat_is_renamed(self) -> None:
+        quote = chr(34)
+        stale = quote + "title" + quote + ": " + quote + "Production Readiness" + quote
+        self.assertNotIn(stale, _read(DASHBOARD),
+                         "the headline stat is named as though it reports whether the deployment "
+                         "is production-ready at runtime")
+
+    def test_the_alerts_say_what_firing_means(self) -> None:
+        self.assertIn(CAVEAT, _read(ALERTS).lower(),
+                      "the readiness alert no longer explains that it watches build and "
+                      "configuration state, so an operator reads it as an outage signal")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`temporalstore_production_readiness_ready` is the **headline stat on the engine dashboard** and carries two alerts. It is computed from build and configuration state only, and nothing said so.

Measured over the surface reached from `production_readiness_report()`:

| | |
|---|---|
| functions | 25 |
| lines | 1,922 |
| **runtime reads** | **0** |

No atomics, no filesystem, no clock, no network. The single environment input is raft security configuration. Nine sub-reports are built from constants, with 146 hardcoded `true` values among them.

**So the gate reports the same value for a healthy cluster and for one with every node down.** That is a reasonable thing to compute — it answers whether this binary was built and configured with every capability area present. It is not health, and the metric name, the dashboard position and both alert descriptions all read as though it is. An operator sees green and concludes the system is serving.

I have left the computation alone and corrected the wording:

- HELP text now states it does not observe runtime health
- the panel is `Build & Config Readiness (not runtime health)`, not `Production Readiness`
- both alert annotations say firing is a build/configuration problem, and that staying at 1 is not evidence the cluster is serving
- the coverage doc records what a green gate does not mean

**The guard pins both halves.** The gate functions must stay free of runtime reads, and the wording must keep the caveat — so if someone makes the gate runtime-aware, the first test fails and asks for the wording to be revisited, rather than the description quietly becoming wrong in the other direction.

Mutation-checked three ways: reverting the HELP text, adding a runtime read to the gate, and restoring the old panel title each fail exactly one test, and all five pass again when restored. The conformance validator exits 0.