### PR TITLE
A route lookup locked the failure map to be told nothing had failed

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 MatrixArkAI
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -644,6 +644,12 @@ struct ClientInner {
     /// cleared.
     routes: RwLock<HashMap<ShardId, CachedRoute>>,
     backend_failures: Mutex<HashMap<String, BackendFailureState>>,
+    /// How many entries `backend_failures` holds, maintained under that lock.
+    ///
+    /// Read without taking the lock so the common case -- nothing has failed -- answers without
+    /// serialising. Every cached route lookup asks whether the address it chose is failing, and
+    /// on a healthy deployment the map it was locking to consult is empty.
+    backend_failure_entries: AtomicUsize,
     /// Table options by "namespace/table".
     ///
     /// A reader-writer lock, not a mutex: every table-scoped request reads this at least
@@ -795,6 +801,7 @@ impl TemporalStoreClient {
                 options,
                 routes: RwLock::default(),
                 backend_failures: Mutex::default(),
+                backend_failure_entries: AtomicUsize::new(0),
                 tables: RwLock::default(),
                 meta_sync_tables: Mutex::default(),
                 stats: Mutex::default(),

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -833,11 +833,8 @@ impl TemporalStoreClient {
         consecutive_failures: u64,
     ) {
         let now = Instant::now();
-        self.inner
-            .backend_failures
-            .lock()
-            .expect("client backend failure lock poisoned")
-            .insert(
+        self.with_backend_failures(|failures| {
+            failures.insert(
                 server_addr.into(),
                 BackendFailureState {
                     first_failed_at: now - Duration::from_millis(first_failed_ago_ms),
@@ -845,6 +842,7 @@ impl TemporalStoreClient {
                     consecutive_failures,
                 },
             );
+        });
     }
 
     pub(super) fn ensure_meta_sync_table_state(&self, namespace: &str, table_name: &str) {

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -373,32 +373,56 @@ impl TemporalStoreClient {
         Ok(server_addr)
     }
 
-    pub(super) fn record_backend_failure(&self, server_addr: &str, continuous_failed_time_ms: u64) -> bool {
+    /// The count the route lookup trusts, for tests that check it against the map.
+    #[cfg(test)]
+    pub(crate) fn backend_failure_entries_for_test(&self) -> usize {
+        self.inner
+            .backend_failure_entries
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Every mutation of the backend-failure map goes through here.
+    ///
+    /// `backend_failure_entries` is what lets the read path skip the lock, and it is only safe to
+    /// trust while it equals the map's length. Updating it at each call site is the kind of
+    /// invariant that holds until someone adds a fourth site, so there is one site: the count is
+    /// restated from the map itself, under the lock that just changed it.
+    pub(super) fn with_backend_failures<R>(
+        &self,
+        f: impl FnOnce(&mut HashMap<String, BackendFailureState>) -> R,
+    ) -> R {
         let mut failures = self
             .inner
             .backend_failures
             .lock()
             .expect("client backend failure lock poisoned");
+        let out = f(&mut failures);
+        self.inner
+            .backend_failure_entries
+            .store(failures.len(), std::sync::atomic::Ordering::Relaxed);
+        out
+    }
+
+    pub(super) fn record_backend_failure(&self, server_addr: &str, continuous_failed_time_ms: u64) -> bool {
         let now = Instant::now();
-        let state =
-            failures
+        self.with_backend_failures(|failures| {
+            let state = failures
                 .entry(server_addr.to_string())
                 .or_insert_with(|| BackendFailureState {
                     first_failed_at: now,
                     last_failed_at: now,
                     consecutive_failures: 0,
                 });
-        state.last_failed_at = now;
-        state.consecutive_failures += 1;
-        state.first_failed_at.elapsed() >= Duration::from_millis(continuous_failed_time_ms)
+            state.last_failed_at = now;
+            state.consecutive_failures += 1;
+            state.first_failed_at.elapsed() >= Duration::from_millis(continuous_failed_time_ms)
+        })
     }
 
     pub(super) fn record_backend_success(&self, server_addr: &str) {
-        self.inner
-            .backend_failures
-            .lock()
-            .expect("client backend failure lock poisoned")
-            .remove(server_addr);
+        self.with_backend_failures(|failures| {
+            failures.remove(server_addr);
+        });
     }
 
     pub(super) fn backend_failure_is_continuous(
@@ -406,6 +430,17 @@ impl TemporalStoreClient {
         server_addr: &str,
         continuous_failed_time_ms: u64,
     ) -> bool {
+        // Nothing has failed, so there is no entry to find and no reason to take the lock.
+        // Every cached route lookup reaches here, so on a healthy deployment this is the whole
+        // path: the map was being locked once per request to be told it was empty.
+        if self
+            .inner
+            .backend_failure_entries
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == 0
+        {
+            return false;
+        }
         self.inner
             .backend_failures
             .lock()

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -702,6 +702,43 @@ fn table_write_refreshes_topology_after_meta_changed_without_write_retry_budget(
 }
 
 #[test]
+fn the_backend_failure_count_tracks_the_map_it_stands_in_for() {
+    // The route lookup skips the failure-map lock when this count is zero, so the count is only
+    // safe while it equals the map's length. Every mutation goes through `with_backend_failures`
+    // for that reason; this fails if a path is ever added that does not.
+    let client = TemporalStoreClient::new("127.0.0.1:1");
+    assert_eq!(
+        client.backend_failure_entries_for_test(),
+        0,
+        "a fresh client has recorded no failures"
+    );
+
+    client.insert_backend_failure_for_test("10.0.0.1:7", 50, 10, 3);
+    assert_eq!(
+        client.backend_failure_entries_for_test(),
+        1,
+        "an inserted failure must be visible to the fast path, or the lookup skips a check it          should have made"
+    );
+
+    client.insert_backend_failure_for_test("10.0.0.2:7", 50, 10, 1);
+    assert_eq!(client.backend_failure_entries_for_test(), 2);
+
+    client.record_backend_success("10.0.0.1:7");
+    assert_eq!(
+        client.backend_failure_entries_for_test(),
+        1,
+        "clearing one address must not clear the count for the other"
+    );
+
+    client.record_backend_success("10.0.0.2:7");
+    assert_eq!(
+        client.backend_failure_entries_for_test(),
+        0,
+        "with the map empty again the lookup may go back to skipping the lock"
+    );
+}
+
+#[test]
 fn client_backend_pool_skips_cached_route_after_continuous_failure_threshold() {
     let dir = tempfile::tempdir().unwrap();
     let engine = TemporalEngine::with_local_dirs(
@@ -766,14 +803,7 @@ fn client_backend_pool_skips_cached_route_after_continuous_failure_threshold() {
         1,
         CachedRoute::for_shard(1, bad_server.clone(), "test_insert"),
     );
-    client.inner.backend_failures.lock().unwrap().insert(
-        bad_server,
-        BackendFailureState {
-            first_failed_at: Instant::now() - Duration::from_millis(20),
-            last_failed_at: Instant::now() - Duration::from_millis(10),
-            consecutive_failures: 3,
-        },
-    );
+    client.insert_backend_failure_for_test(bad_server, 20, 10, 3);
 
     let table = client.open_table(
         "ns",

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3132,6 +3132,59 @@ mod tests {
         );
     }
 
+    /// Splits the cached-route lookup into acquiring the client and using it.
+    ///
+    /// `client()` is an RwLock read plus a clone of the handle, both atomic read-modify-writes,
+    /// and the request path takes it two or three times. Run with `--ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn bench_proxy_route_lookup_split() {
+        let threads: usize = std::env::var("BENCH_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8);
+        let per_thread: usize = std::env::var("BENCH_ITERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50_000);
+
+        let proxy = std::sync::Arc::new(scoped_proxy(ProxyOptions::default()));
+        proxy
+            .client()
+            .insert_cached_route_for_test(1, "127.0.0.1:1".to_string());
+
+        for (label, hoisted) in [("client()+lookup", false), ("lookup, client hoisted", true)] {
+            let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
+            let mut handles = Vec::new();
+            for _ in 0..threads {
+                let proxy = std::sync::Arc::clone(&proxy);
+                let gate = std::sync::Arc::clone(&gate);
+                handles.push(std::thread::spawn(move || {
+                    let held = proxy.client();
+                    gate.wait();
+                    for _ in 0..per_thread {
+                        if hoisted {
+                            std::hint::black_box(&held.shard_primary_addr(1, false));
+                        } else {
+                            std::hint::black_box(&proxy.client().shard_primary_addr(1, false));
+                        }
+                    }
+                }));
+            }
+            gate.wait();
+            let start = std::time::Instant::now();
+            for handle in handles {
+                handle.join().expect("thread");
+            }
+            let elapsed = start.elapsed();
+            let ops = (threads * per_thread) as u128;
+            println!(
+                "SPLIT {label}: threads={threads} ops={ops} ns_per_op={}",
+                elapsed.as_nanos() / ops
+            );
+        }
+    }
+
     /// Per-request bookkeeping under CONCURRENCY, measured per function.
     ///
     /// Single-threaded this work is ~110ns against a request whose real cost is a network


### PR DESCRIPTION
Every cached route lookup takes a Mutex over the backend-failure map to ask whether the chosen address is failing. On a healthy deployment that map is empty, so the lock only serialises the lookups against each other -- on every request.

The map now carries a count maintained under the same lock, and the check answers without the lock when it is zero. Non-zero takes the lock exactly as before.

**Measured** at 8 threads, two separately built binaries (different SHAs), arms alternated, 5 rounds: **198-205 ns before, 151-154 ns after, 5 paired wins of 5** (~24%). For scale, admission is ~31 ns per request.

All mutations go through one function that restates the count from the map, because a count updated per call site holds only until another site appears -- the first version did that and broke the two continuous-failure tests, because a test helper inserted without it. A test now checks the count against the map across insert and remove.

`client::` 38 passed / 0 failed, `proxy::` 78 passed / 0 failed, matching main.