### PR TITLE
The cluster control plane is visible

### DIFF
--- a/docs/ops/temporalstore-cluster-coverage.md
+++ b/docs/ops/temporalstore-cluster-coverage.md
@@ -1,0 +1,57 @@
+# Cluster control plane coverage
+
+What `temporalstore-cluster-dashboard.json` watches, which process exports it, and what a blank
+panel means.
+
+**Scrape target: the metaserver**, on its own `/metrics` listener. Import this dashboard against the
+gateway and every panel comes up empty — which reads as a quiet cluster rather than as a query
+aimed at the wrong process.
+
+## Why this dashboard exists
+
+The metaserver is the control plane. It declares 41 metric families and **4 of them were on any
+dashboard**: topology version, scheduler queue depth, scheduler executions, and inventory. A
+customer running raft or shared storage could watch traffic and storage and had no way to see
+whether the cluster agreed with itself.
+
+## Panels
+
+| panel | answers | blank means |
+|---|---|---|
+| Topology Version And What Each Server Applied | is every server on the current topology | metaserver not scraped |
+| Topology Lag | how far the slowest server is behind | no servers registered, or metaserver not scraped |
+| Safety Switches | is the cluster in safe mode, is metadata change muted, is the detector paused | metaserver not scraped |
+| Convictions | how many resources have been convicted, and how many convictions are held | metaserver not scraped |
+| Damage Severity | severity of detected damage, and abnormal resource count | metaserver not scraped |
+| Shard Divergence | shards found diverged, and divergence checks skipped | metaserver not scraped |
+| Placement Shortfall | replicas the placer could not satisfy | metaserver not scraped |
+| Calibration Shortfall | groups and proxies short after calibration, and whether calibration capped | metaserver not scraped |
+| Retention Blocked Or Capped | whether retention is refusing to advance | metaserver not scraped |
+| Retention Purged | what retention has actually reclaimed | metaserver not scraped |
+| Freeze Aging | frozen resources aged out, and whether aging capped | metaserver not scraped |
+| Metaserver Requests | control-plane request volume by kind | metaserver not scraped |
+| Topology Query Latency And Failures | cost and reliability of topology queries | metaserver not scraped |
+| Scheduler Queue And Executions | control-plane backlog and execution results | metaserver not scraped |
+| Per Server: Records And Stored Bytes | per-server load, as each server reports it | no servers registered |
+| Resource State And Inventory | resource counts by state | metaserver not scraped |
+| Proxy Restarts And Attachments | proxies restarting under the control plane | no proxies attached |
+| Mutation Apply Failures | control-plane mutations that failed to apply | metaserver not scraped |
+
+## The panel worth reading first
+
+**Topology Version And What Each Server Applied.** The engine's own HELP text for
+`temporalstore_meta_server_applied_topology` says to compare it against
+`temporalstore_meta_topology_version`. A server whose applied version sits below the current one has
+not taken the latest topology, and until it does it is working from a stale view of the cluster.
+Nothing watched that comparison before this dashboard existed.
+
+## Why no panel here can be blank for the usual reason
+
+Every expression names a family the engine declares via `# HELP` or `# TYPE`, and the conformance
+validator now enforces that across **all** dashboards rather than one. It previously read only
+`temporalstore-dashboard.json`, so a panel added to any other file was checked by nothing.
+
+That strict check found one live defect on the way in:
+`temporalstore_block_store_band_oldest_age_ms`, one target among five on the page-store panel, is
+declared nowhere. The panel rendered with four series and no indication the fifth was impossible —
+a missing series is less visible than a blank panel, not more. That target is removed.

--- a/docs/ops/temporalstore-cluster-dashboard.json
+++ b/docs/ops/temporalstore-cluster-dashboard.json
@@ -1,0 +1,223 @@
+{
+  "title": "TemporalStore Cluster (metaserver control plane)",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Topology Version And What Each Server Applied",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_topology_version"
+        },
+        {
+          "expr": "temporalstore_meta_server_applied_topology"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Topology Lag (current minus slowest server)",
+      "targets": [
+        {
+          "expr": "max(temporalstore_meta_topology_version) - min(temporalstore_meta_server_applied_topology)"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Safety Switches: Safe Mode, Change Muted, Detector Paused",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_location_safe_mode"
+        },
+        {
+          "expr": "temporalstore_meta_change_muted"
+        },
+        {
+          "expr": "temporalstore_meta_detector_paused"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Convictions",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_convicted_total"
+        },
+        {
+          "expr": "temporalstore_meta_conviction_held_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Damage Severity",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_damage_severity"
+        },
+        {
+          "expr": "temporalstore_meta_abnormal_resources"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Shard Divergence",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_shard_divergence"
+        },
+        {
+          "expr": "temporalstore_meta_shard_divergence_total"
+        },
+        {
+          "expr": "temporalstore_meta_divergence_skipped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Placement Shortfall",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_placement_short"
+        },
+        {
+          "expr": "temporalstore_meta_placement_short_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Calibration Shortfall",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_calibration_shortfall_groups"
+        },
+        {
+          "expr": "temporalstore_meta_calibration_shortfall_proxies"
+        },
+        {
+          "expr": "temporalstore_meta_calibration_capped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Retention Blocked Or Capped",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_retention_blocked"
+        },
+        {
+          "expr": "temporalstore_meta_retention_capped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Retention Purged",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_retention_purged_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Freeze Aging",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_freeze_aged_total"
+        },
+        {
+          "expr": "temporalstore_meta_freeze_aging_capped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Metaserver Requests",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_requests_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Topology Query Latency And Failures",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_topology_query_latency_us"
+        },
+        {
+          "expr": "temporalstore_meta_topology_query_failed_total"
+        },
+        {
+          "expr": "temporalstore_meta_topology_query_bytes_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduler Queue And Executions",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_scheduler_queue_depth"
+        },
+        {
+          "expr": "temporalstore_meta_scheduler_executions_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Per Server: Records And Stored Bytes",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_server_records"
+        },
+        {
+          "expr": "temporalstore_meta_server_storage_bytes"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Resource State And Inventory",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_resource_state"
+        },
+        {
+          "expr": "temporalstore_meta_inventory"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Proxy Restarts And Attachments",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_proxy_restarts"
+        },
+        {
+          "expr": "temporalstore_meta_proxy_attachments_total"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Mutation Apply Failures",
+      "targets": [
+        {
+          "expr": "temporalstore_meta_mutation_apply_failed_total"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -126,9 +126,6 @@
         },
         {
           "expr": "temporalstore_block_store_band_bytes"
-        },
-        {
-          "expr": "temporalstore_block_store_band_oldest_age_ms"
         }
       ]
     },

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1922,6 +1922,12 @@ _GRAFANA_ASSETS = {
     # had no way to find out the engine was monitorable at all.
     "engine": ("../docs/ops/temporalstore-dashboard.json", "application/json"),
     "engine-alerts": ("../docs/ops/temporalstore-alerts.yml", "text/yaml; charset=utf-8"),
+    # The metaserver is the control plane, and 37 of its 41 declared families were on no
+    # dashboard at all: convictions, placement shortfalls, shard divergence, safe mode, and
+    # the topology version each server last applied. A customer running raft or shared
+    # storage could see traffic and storage, and nothing about whether the cluster agreed
+    # with itself.
+    "cluster": ("../docs/ops/temporalstore-cluster-dashboard.json", "application/json"),
 }
 _GRAFANA_CACHE: dict[str, Optional[bytes]] = {}
 
@@ -1942,7 +1948,15 @@ _MONITORING_ASSETS: tuple = (
      "filename": "temporalstore-dashboard.json", "scrape": "engine",
      "covers": "Raft commit, apply and lease; metaserver scheduler and topology; proxy routing, "
                "admission and quarantine; object and page store lifecycle; cache pressure; data "
-               "node lifecycle; ingestion lag and dead letters; replica replay; and the scale SLO."},
+               "node lifecycle; and ingestion lag and dead letters. Replica replay and the scale "
+               "SLO are no longer listed here: nothing emits their series, so those panels were "
+               "blank on every deployment and have been removed."},
+    {"asset": "cluster", "kind": "dashboard", "label": "Cluster control plane",
+     "filename": "temporalstore-cluster-dashboard.json", "scrape": "engine",
+     "covers": "Whether the cluster agrees with itself: the topology version each server last "
+               "applied against the current one, safe mode and change-muted switches, "
+               "convictions and damage severity, shard divergence, placement and calibration "
+               "shortfalls, retention blocked or capped, and per-server records and bytes."},
     {"asset": "alerts", "kind": "rules", "label": "Gateway alert rules",
      "filename": "matrixark-gateway-alerts.yml", "scrape": "gateway",
      "covers": "Retrieval running on hash vectors, extraction with no model call, live "

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -13,6 +13,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD = ROOT / "docs" / "ops" / "temporalstore-dashboard.json"
+# Every dashboard whose panels query engine families. The validator read only the first one
+# for as long as it existed, so a panel added to any other file was checked by nothing.
+DASHBOARDS = (
+    ROOT / "docs" / "ops" / "temporalstore-dashboard.json",
+    ROOT / "docs" / "ops" / "temporalstore-cluster-dashboard.json",
+)
 ALERTS = ROOT / "docs" / "ops" / "temporalstore-alerts.yml"
 # The coverage doc this is checked against. The previous path named a file that has never
 # existed, and `DOC.exists()` turned that into ten separate "family is undocumented" failures
@@ -359,6 +365,33 @@ def check_families_state_their_emission(families: dict) -> list:
             if not requirements.get("rust")]
 
 
+def dashboard_metric_names() -> set:
+    """Every engine family named by a panel expression, across all dashboards."""
+    used = set()
+    for path in DASHBOARDS:
+        if path.exists():
+            used |= metric_names(read(path))
+    return used
+
+
+def check_dashboard_metrics_are_emitted(declared: set) -> list:
+    """Panel expressions naming a family nothing declares.
+
+    The alert side of this was added first and found two rules that could never fire. The dashboard
+    side was still using the loose test -- name appears somewhere in the Rust source -- and it hid a
+    quieter version of the same defect: `temporalstore_block_store_band_oldest_age_ms`, one target
+    among five on a panel that therefore rendered with four series and no sign the fifth was
+    impossible. A blank panel is at least visible. A missing series is not.
+    """
+    return ["dashboard_metric_undeclared:%s" % name
+            for name in sorted(dashboard_metric_names() - declared)]
+
+
+def check_dashboard_extent() -> list:
+    """Every dashboard listed must exist, or its panels stop being checked silently."""
+    return ["dashboard_missing:%s" % path.name for path in DASHBOARDS if not path.exists()]
+
+
 def check_scan_extent() -> list:
     """Names from the floor that discovery no longer returns.
 
@@ -421,6 +454,8 @@ def main() -> int:
               "KNOWN_UNEMITTED." % ", ".join(fixed_but_listed), file=sys.stderr)
     declared = declared_metric_names(rust)
     alert_failures = (check_declaration_extent(declared)
+                      + check_dashboard_extent()
+                      + check_dashboard_metrics_are_emitted(declared)
                       + check_families_state_their_emission(METRIC_FAMILIES)
                       + check_alert_expressions_are_emitted(alerts, declared)
                       + check_alert_metric_names(alerts, declared))


### PR DESCRIPTION
The metaserver **is** the control plane, and **37 of its 41 declared metric families were on no dashboard at all**. Only topology version, scheduler queue depth, scheduler executions and inventory were watched. A customer running raft or shared storage could see traffic and storage, and had no way to see whether the cluster agreed with itself.

Unwatched until now: convictions and conviction holds, damage severity, abnormal resources, shard divergence, placement shortfall, calibration shortfall, retention blocked or capped, freeze aging, safe mode, change-muted, detector paused, mutation apply failures, proxy restarts, and the topology version each server last applied.

**18 panels over 35 families**, grouped by the question an operator is asking rather than by metric name, plus a coverage document giving each panel what it answers and what a blank one means. The portal serves it as a new monitoring asset, scraped from the engine listeners where the metaserver publishes — the doc says so, because importing it against the gateway would render every panel empty and read as a quiet cluster.

**The panel worth reading first** is `Topology Version And What Each Server Applied`. The engine.s own HELP text for `temporalstore_meta_server_applied_topology` says to compare it against `temporalstore_meta_topology_version` — a server below the current version is working from a stale view of the cluster. Nothing watched that comparison.

**The validator now reads every temporalstore dashboard**, and applies the strict emission test to panel expressions rather than only to alert rules. It read one file for as long as it existed, so a panel added to any other was checked by nothing — precisely what a second dashboard would have walked into.

That strict test found a live defect on the way in: `temporalstore_block_store_band_oldest_age_ms` is declared nowhere and was one target among five on the page-store panel. That panel rendered four series with no indication the fifth was impossible. **A missing series is less visible than a blank panel, not more.** Target removed.

Also corrected: the engine asset description still advertised replica replay and the scale SLO to customers, whose panels I removed in #652 for being permanently blank.

Mutation-checked: a panel querying an invented family fails with `dashboard_metric_undeclared`, and hiding the new dashboard fails with `dashboard_missing` rather than silently checking one file again. Gateway, dashboard-coverage and config suites all pass.