### PR TITLE
Count a cached-route hit without taking the stats lock

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -643,6 +643,12 @@ struct ClientInner {
     /// is atomic. It writes only when a route is fetched, replaced by a topology sync, or
     /// cleared.
     routes: RwLock<HashMap<ShardId, CachedRoute>>,
+    /// Cached-route hits, counted outside `stats`.
+    ///
+    /// Every request that finds its route cached lands here, and taking the stats mutex to add one
+    /// serialised those requests against each other. It is folded into `ClientStats` when the
+    /// stats are read, so callers see the same number; only the write side stops taking a lock.
+    route_cache_hits: AtomicU64,
     backend_failures: Mutex<HashMap<String, BackendFailureState>>,
     /// How many entries `backend_failures` holds, maintained under that lock.
     ///
@@ -800,6 +806,7 @@ impl TemporalStoreClient {
             inner: Arc::new(ClientInner {
                 options,
                 routes: RwLock::default(),
+                route_cache_hits: AtomicU64::new(0),
                 backend_failures: Mutex::default(),
                 backend_failure_entries: AtomicUsize::new(0),
                 tables: RwLock::default(),

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -567,7 +567,14 @@ impl TemporalStoreClient {
     }
 
     pub fn stats(&self) -> ClientStats {
-        *self.inner.stats.lock().expect("client stats lock poisoned")
+        let mut stats = *self.inner.stats.lock().expect("client stats lock poisoned");
+        // Counted without the lock on the request path; folded in here so callers -- including the
+        // proxy, which takes a delta against the previous read -- see one monotonic number.
+        stats.route_cache_hits += self
+            .inner
+            .route_cache_hits
+            .load(std::sync::atomic::Ordering::Relaxed);
+        stats
     }
 
     pub fn preflight_report(&self) -> ClientPreflightReport {

--- a/crates/temporalstore-rust/src/client/client_routing.rs
+++ b/crates/temporalstore-rust/src/client/client_routing.rs
@@ -319,10 +319,8 @@ impl TemporalStoreClient {
                             .continuous_backend_failures += 1;
                     } else {
                         self.inner
-                            .stats
-                            .lock()
-                            .expect("client stats lock poisoned")
-                            .route_cache_hits += 1;
+                            .route_cache_hits
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         return Ok(server_addr);
                     }
                 }


### PR DESCRIPTION
A request that finds its route cached took the client's stats mutex to add one to `route_cache_hits` -- the last lock on that path, serialising the requests that had no other work to do.

The count moves to an atomic and is folded into `ClientStats` on read, so every reader sees the same monotonic number, including the proxy's delta against its previous read. Only the write side changes.

**Measured** at 8 threads, two separately built binaries (different SHAs), arms alternated: **137-148 ns before, 125-137 ns after, 14 paired wins of 15** (~8%).

`client::` 39 passed / 0 failed, `proxy::` 78 passed / 0 failed.