### PR TITLE
Two wrappers whose only effect would be to undo an optimisation

### DIFF
--- a/crates/temporalstore-rust/src/context_workflow/query.rs
+++ b/crates/temporalstore-rust/src/context_workflow/query.rs
@@ -88,14 +88,6 @@ pub(super) fn context_query_matches_plan(plan: &ContextQueryPlan, text: &str) ->
     matched_groups > 0
 }
 
-#[allow(dead_code)]
-pub(super) fn context_query_understanding_debug(
-    request: &ContextRetrieveRequest,
-) -> ContextQueryUnderstandingDebug {
-    let plan = context_query_plan(&request.query);
-    context_query_understanding_debug_for_plan(request, &plan)
-}
-
 pub(super) fn context_query_understanding_debug_for_plan(
     request: &ContextRetrieveRequest,
     plan: &ContextQueryPlan,
@@ -766,12 +758,6 @@ pub(super) fn context_query_terms(query: &str) -> Vec<String> {
         .map(|term| term.trim().to_ascii_lowercase())
         .filter(|term| term.len() >= 3 && !is_context_query_stopword(term))
         .collect()
-}
-
-#[allow(dead_code)]
-pub(super) fn context_query_term_groups(query: &str) -> Vec<Vec<String>> {
-    let terms = context_query_terms(query);
-    context_query_term_groups_from_terms(&terms)
 }
 
 pub(super) fn context_query_term_groups_from_terms(terms: &[String]) -> Vec<Vec<String>> {


### PR DESCRIPTION
`context_query_term_groups` and `context_query_understanding_debug` each compute an
intermediate and hand it to the variant that does the work:

    pub(super) fn context_query_term_groups(query: &str) -> Vec<Vec<String>> {
        let terms = context_query_terms(query);
        context_query_term_groups_from_terms(&terms)
    }

Computing that intermediate per call is the thing "Optimize Rust context retrieval
fanout" removed: it changed the callers to derive the terms and the plan once and pass
them to `_from_terms` and `_for_plan`. The wrappers were left behind, and the same
commit put `#[allow(dead_code)]` on both -- the lint was silenced rather than the
leftover deleted.

So they are not merely unused, they are a trap. The short name is the one a caller
reaches for, and taking it silently reinstates the per-call work the optimisation
exists to avoid.

Neither has a caller: a word-boundary search of the whole repository finds exactly one
mention of each, its own declaration. The variants they delegate to are live, at five
and three mentions.

If either is wanted later as a convenience entry point, it is two lines to write back
-- with a comment saying so, which is what an `allow(dead_code)` should carry and this
one never did.

