### PR TITLE
Hold a bucket's only object id inline instead of in a set

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -317,7 +317,217 @@ pub(super) struct CoreIndex {
 }
 
 pub(super) type BucketMap = BTreeMap<u32, BucketNode>;
-pub(super) type ObjectIndex = BTreeSet<u64>;
+/// The object ids a bucket holds.
+///
+/// Almost always exactly one: keys route one to a bucket, and even an object with many components
+/// is still one object. A `BTreeSet` holding a single id costs 128 live bytes of node to carry
+/// eight bytes of id, once per bucket and so once per key.
+///
+/// The shape `BlockIndexMap` and `BlockRefs` already use here, for the same reason.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) enum ObjectIndex {
+    #[default]
+    Empty,
+    One(u64),
+    Many(BTreeSet<u64>),
+}
+
+pub(super) enum ObjectIndexIter<'a> {
+    Empty,
+    One(std::iter::Once<&'a u64>),
+    Many(std::collections::btree_set::Iter<'a, u64>),
+}
+
+impl<'a> Iterator for ObjectIndexIter<'a> {
+    type Item = &'a u64;
+    fn next(&mut self) -> Option<&'a u64> {
+        match self {
+            ObjectIndexIter::Empty => None,
+            ObjectIndexIter::One(once) => once.next(),
+            ObjectIndexIter::Many(iter) => iter.next(),
+        }
+    }
+}
+
+impl ObjectIndex {
+    pub(super) fn len(&self) -> usize {
+        match self {
+            ObjectIndex::Empty => 0,
+            ObjectIndex::One(_) => 1,
+            ObjectIndex::Many(set) => set.len(),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        matches!(self, ObjectIndex::Empty)
+    }
+
+    pub(super) fn contains(&self, id: &u64) -> bool {
+        match self {
+            ObjectIndex::Empty => false,
+            ObjectIndex::One(held) => held == id,
+            ObjectIndex::Many(set) => set.contains(id),
+        }
+    }
+
+    pub(super) fn insert(&mut self, id: u64) -> bool {
+        match self {
+            ObjectIndex::Empty => {
+                *self = ObjectIndex::One(id);
+                true
+            }
+            ObjectIndex::One(held) => {
+                if *held == id {
+                    return false;
+                }
+                let first = *held;
+                let mut set = BTreeSet::new();
+                set.insert(first);
+                set.insert(id);
+                *self = ObjectIndex::Many(set);
+                true
+            }
+            ObjectIndex::Many(set) => set.insert(id),
+        }
+    }
+
+    pub(super) fn remove(&mut self, id: &u64) -> bool {
+        match self {
+            ObjectIndex::Empty => false,
+            ObjectIndex::One(held) => {
+                if held != id {
+                    return false;
+                }
+                *self = ObjectIndex::Empty;
+                true
+            }
+            ObjectIndex::Many(set) => {
+                let removed = set.remove(id);
+                self.shrink();
+                removed
+            }
+        }
+    }
+
+    /// Give up the set once it no longer earns one, so a bucket that briefly held two objects
+    /// does not keep a node for the rest of its life.
+    fn shrink(&mut self) {
+        let len = match self {
+            ObjectIndex::Many(set) => set.len(),
+            _ => return,
+        };
+        match len {
+            0 => *self = ObjectIndex::Empty,
+            1 => {
+                let set = match std::mem::replace(self, ObjectIndex::Empty) {
+                    ObjectIndex::Many(set) => set,
+                    _ => unreachable!("just matched Many"),
+                };
+                *self = ObjectIndex::One(set.into_iter().next().expect("length is one"));
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        *self = ObjectIndex::Empty;
+    }
+
+    pub(super) fn iter(&self) -> ObjectIndexIter<'_> {
+        match self {
+            ObjectIndex::Empty => ObjectIndexIter::Empty,
+            ObjectIndex::One(id) => ObjectIndexIter::One(std::iter::once(id)),
+            ObjectIndex::Many(set) => ObjectIndexIter::Many(set.iter()),
+        }
+    }
+
+    /// The ids this holds that `other` does not.
+    pub(super) fn difference<'a>(
+        &'a self,
+        other: &'a ObjectIndex,
+    ) -> impl Iterator<Item = &'a u64> + 'a {
+        self.iter().filter(move |id| !other.contains(id))
+    }
+}
+
+impl<'a> IntoIterator for &'a ObjectIndex {
+    type Item = &'a u64;
+    type IntoIter = ObjectIndexIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for ObjectIndex {
+    type Item = u64;
+    type IntoIter = std::vec::IntoIter<u64>;
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            ObjectIndex::Empty => Vec::new().into_iter(),
+            ObjectIndex::One(id) => vec![id].into_iter(),
+            ObjectIndex::Many(set) => set.into_iter().collect::<Vec<_>>().into_iter(),
+        }
+    }
+}
+
+impl From<BTreeSet<u64>> for ObjectIndex {
+    fn from(ids: BTreeSet<u64>) -> Self {
+        ids.into_iter().collect()
+    }
+}
+
+impl Extend<u64> for ObjectIndex {
+    fn extend<I: IntoIterator<Item = u64>>(&mut self, ids: I) {
+        for id in ids {
+            self.insert(id);
+        }
+    }
+}
+
+impl<'a> Extend<&'a u64> for ObjectIndex {
+    fn extend<I: IntoIterator<Item = &'a u64>>(&mut self, ids: I) {
+        for id in ids {
+            self.insert(*id);
+        }
+    }
+}
+
+impl FromIterator<u64> for ObjectIndex {
+    fn from_iter<I: IntoIterator<Item = u64>>(ids: I) -> Self {
+        let mut index = ObjectIndex::default();
+        index.extend(ids);
+        index
+    }
+}
+
+impl Serialize for ObjectIndex {
+    /// The same sequence of ids it has always written, in the same order.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for id in self.iter() {
+            seq.serialize_element(&id)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ObjectIndex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Through `insert`, so a loaded bucket takes the shape a written one does: one id comes
+        // back held inline rather than in a set.
+        Ok(BTreeSet::<u64>::deserialize(deserializer)?
+            .into_iter()
+            .collect())
+    }
+}
+
 /// Keyed by a SHARED page-ref key: the same allocation is held by the lookups that point at this
 /// page, instead of each of the three keeping its own copy of the same ~117-byte string.
 /// Pages of one bucket, keyed by an id assigned when the page is filed.

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1745,7 +1745,7 @@ pub(super) fn update_bucket_layout(bucket: &mut BucketNode) {
         .map(|page| page.object_id())
         .collect();
     if !live_object_ids.is_empty() {
-        bucket.object_index = live_object_ids;
+        bucket.object_index = live_object_ids.into();
     } else if !bucket.page_index.is_empty() {
         bucket.object_index.clear();
     }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5491,6 +5491,58 @@ fn the_index_wire_keys_are_what_they_were() {
     );
 }
 
+/// A bucket holding one object id holds it inline, and goes back to inline when it can.
+///
+/// Every bucket has one: keys route one to a bucket, and an object with many components is still
+/// one object, so the set that held it was never holding more. A `BTreeSet` with a single member
+/// costs 128 live bytes of node to carry eight bytes of id.
+///
+/// The demotion is checked too. A bucket that briefly held two objects would otherwise keep its
+/// node for the rest of its life, which is the cost being removed and shows up nowhere else.
+#[test]
+fn a_bucket_holding_one_object_holds_no_node() {
+    use crate::engine::state::ObjectIndex;
+
+    let mut index = ObjectIndex::default();
+    assert!(index.is_empty());
+
+    assert!(index.insert(7));
+    assert!(matches!(index, ObjectIndex::One(7)), "one id is held inline");
+    assert!(!index.insert(7), "the same id twice is one entry");
+    assert_eq!(index.len(), 1);
+    assert!(index.contains(&7));
+
+    assert!(index.insert(9));
+    assert!(matches!(index, ObjectIndex::Many(_)), "two ids need a set");
+    assert_eq!(index.len(), 2);
+
+    assert!(index.remove(&9));
+    assert!(
+        matches!(index, ObjectIndex::One(7)),
+        "a set that drops back to one id must give up its node"
+    );
+
+    assert!(index.remove(&7));
+    assert!(index.is_empty(), "and to nothing at all");
+    assert!(!index.remove(&7), "removing what is not there changes nothing");
+
+    // The order it iterates and writes is the order the set had.
+    let mut many = ObjectIndex::default();
+    many.extend([5u64, 1, 3]);
+    let ids: Vec<u64> = many.iter().copied().collect();
+    assert_eq!(ids, vec![1, 3, 5], "ids come out sorted, as the set gave them");
+    assert_eq!(
+        serde_json::to_string(&many).expect("serializes"),
+        "[1,3,5]",
+        "and are written as the same sequence"
+    );
+
+    // A single id writes the same shape, and reads back inline rather than as a set.
+    let one: ObjectIndex = serde_json::from_str("[4]").expect("deserializes");
+    assert!(matches!(one, ObjectIndex::One(4)), "a loaded single id is held inline");
+    assert_eq!(serde_json::to_string(&one).expect("serializes"), "[4]");
+}
+
 /// What a key costs the index in live heap.
 ///
 /// Measured as allocated-minus-freed rather than as a struct size, because the cost this bounds
@@ -5530,8 +5582,8 @@ fn what_a_key_costs_the_index_in_live_heap() {
     assert!(per_key > 100.0, "the probe must observe the writes: {per_key}");
 
     assert!(
-        per_key < 1500.0,
-        "a key costs {per_key:.0} live bytes; a bucket is holding a node for a single page again"
+        per_key < 1060.0,
+        "a key costs {per_key:.0} live bytes; a bucket is holding a node for a single entry again"
     );
 }
 
@@ -6336,10 +6388,10 @@ fn bucket_object_index_already_matches_a_from_scratch_recompute() {
             continue;
         }
         checked += 1;
-        let expected = if recomputed.is_empty() {
-            std::collections::BTreeSet::new()
+        let expected: crate::engine::state::ObjectIndex = if recomputed.is_empty() {
+            crate::engine::state::ObjectIndex::default()
         } else {
-            recomputed
+            recomputed.into()
         };
         if bucket.object_index != expected {
             mismatches.push(format!(
@@ -11519,7 +11571,7 @@ fn the_maintained_object_index_matches_a_full_rebuild() {
     let mut live_total = 0usize;
     for (routing_bucket, bucket) in shard.bucket_index.bucket_map.iter() {
         // What a rebuild would produce: the ids of the pages that are not deleted.
-        let rebuilt: std::collections::BTreeSet<u64> = bucket
+        let rebuilt: crate::engine::state::ObjectIndex = bucket
             .page_index
             .values()
             .filter(|page| !page.deleted)


### PR DESCRIPTION
Every bucket has exactly one object id: keys route one to a bucket, and
an object with many components is still one object, so the set holding
it was never holding more. A `BTreeSet` with a single member costs
**128 live bytes of node to carry eight bytes of id**, once per bucket
and so once per key.

Measured over 2,000 keys, live heap per key:

| | live bytes per key |
|---|---|
| before | 1,100 |
| after | **1,022** |

Less than the 128 the node costs, because the enum is eight bytes wider
inline than the set it replaces and a bucket carries two of them --
`object_index` and `deleted_object_index`. Both arms measured in the
same tree rather than against a remembered number.

`ObjectIndex` is now `Empty`, `One(id)`, or `Many(set)` -- the shape
`BlockIndexMap` and `BlockRefs` already use here.

### The demotion

Dropping back to one id returns it to `One`. Without that, a bucket that
briefly held two objects keeps its node for good, which is the cost
being removed and shows up nowhere else. Verified by mutation: never
returning to `One` fails the shape test.

### Format

Unchanged: the same sequence of ids, in the same order. A sequence
carrying one id loads back inline rather than as a set, and the test
asserts both directions on the wire, not only in memory.

Full lib suite: 1,588 passed, 0 failed.
