### PR TITLE
Backpressure reported the entry it refused as the window it did not fit in

### DIFF
--- a/crates/temporalstore-rust/src/raft.rs
+++ b/crates/temporalstore-rust/src/raft.rs
@@ -3616,11 +3616,18 @@ pub enum RaftError {
     ApplySnapshotFence(String),
     #[error("raft log entry too large: bytes={bytes}, limit={limit}")]
     LogEntryTooLarge { bytes: u64, limit: u64 },
-    #[error("raft append pipeline backpressure for node {node_id}: inflight_entries={inflight_entries}, inflight_bytes={inflight_bytes}, entry_limit={entry_limit}, byte_limit={byte_limit}")]
+    #[error("raft append pipeline backpressure for node {node_id}: entry_bytes={entry_bytes} does not fit in what is left of byte_limit={byte_limit} (inflight_entries={inflight_entries}, inflight_bytes={inflight_bytes}, entry_limit={entry_limit})")]
     AppendBackpressure {
         node_id: RaftNodeId,
+        /// What the pipeline is actually holding. These are the peer's live window, not the
+        /// entry that was refused -- reporting the entry's size as `inflight_bytes` said the
+        /// window held bytes it did not, and the refusal reads as an accounting bug that is
+        /// not there.
         inflight_entries: u64,
         inflight_bytes: u64,
+        /// The single entry that did not fit in what remained. This is the number that
+        /// explains the refusal, and it has nowhere else to be reported.
+        entry_bytes: u64,
         entry_limit: u64,
         byte_limit: u64,
     },

--- a/crates/temporalstore-rust/src/raft/cluster_replication.rs
+++ b/crates/temporalstore-rust/src/raft/cluster_replication.rs
@@ -247,8 +247,9 @@ impl RaftCluster {
                 inner.persist_configured_wal()?;
                 return Err(RaftError::AppendBackpressure {
                     node_id: target_id,
-                    inflight_entries: 0,
-                    inflight_bytes: entry_bytes,
+                    inflight_entries: current_inflight_entries,
+                    inflight_bytes: current_inflight_bytes,
+                    entry_bytes,
                     entry_limit,
                     byte_limit,
                 });


### PR DESCRIPTION
`AppendBackpressure` is raised in one place, when a single log entry is larger than
what is left of the peer's byte window. It filled the error in like this:

    inflight_entries: 0,
    inflight_bytes: entry_bytes,

Neither is the pipeline's state. `inflight_entries` is a literal zero and
`inflight_bytes` is the size of the entry being refused, so the error says the window
holds no entries and yet holds 32,766 bytes -- which reads as broken accounting, and
sends whoever is looking into the byte bookkeeping rather than at the entry that did
not fit.

It cost three separate investigations of an intermittent failure before the fields
turned out to be describing something other than what they are named:

    AppendBackpressure { node_id: 2, inflight_entries: 0, inflight_bytes: 32766,
                         entry_limit: 128, byte_limit: 32768 }

The two fields now carry the peer's live window, which is what their names promise,
and the entry that was refused gets a field of its own. The message leads with the
comparison that actually explains the refusal -- the entry's size against the limit --
and keeps the window figures after it.

No behaviour change: the same condition raises the same error, and the only caller of
the variant is this one raise site.

