### PR TITLE
Appending one point to a feature series costs the whole series

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1577,6 +1577,11 @@ pub(super) fn sync_bucket_index_object_pages(
         unique_addresses.insert(page_physical_identity_key(&address), address);
     }
 
+    // Hoisted: neither changes across iterations, and each cost a String plus an Arc that copies
+    // it -- four allocations per address published, for two values. Cloning an Arc is a refcount
+    // bump.
+    let object_key_arc: Arc<str> = Arc::from(object_key);
+    let kind_arc: Arc<str> = Arc::from(kind);
     for address in unique_addresses.into_values() {
         let routing_bucket = address
             .routing_bucket()
@@ -1585,8 +1590,8 @@ pub(super) fn sync_bucket_index_object_pages(
             .object_id()
             .unwrap_or_else(|| stable_page_object_id(shard_id, kind, object_key, None));
         let entry = LiveBlockEntry {
-            object_key: Arc::from(object_key.to_string()),
-            kind: Arc::from(kind.to_string()),
+            object_key: Arc::clone(&object_key_arc),
+            kind: Arc::clone(&kind_arc),
             component: None,
             log_backed: address.page_id().is_none(),
             address,
@@ -1629,7 +1634,11 @@ pub(super) fn sync_bucket_index_object_pages(
         };
         // The map assigns the handle; the lookup records the same one.
         let page_ref_key = bucket.page_index.insert(page.clone());
-        update_bucket_layout(bucket);
+        // `object_index` was just given this object id above, so the set is already correct and only
+        // the label needs re-deriving. `update_bucket_layout` would rebuild the set by walking every
+        // page in the bucket -- once per address published, which is what made a write cost the
+        // whole object rather than the part of it being written.
+        classify_bucket_layout_in_place(bucket);
         // The bucket borrow has to end before the lookup, which borrows the index itself.
         if !lookup_needs_establishing {
             shard

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -12121,3 +12121,251 @@ fn maintaining_the_index_during_ingest_matches_rebuilding_it() {
         kind_of(&missing_after_ingest, &rebuilt)
     );
 }
+
+
+/// Does a time-range feature query cost what the RANGE holds, or what the SERIES holds?
+///
+/// The feature lane carries a quantity sampled over time, so the reader always asks for a window.
+/// Whether the lane scales is therefore whether a narrow window over a long series costs what the
+/// window holds -- not what the series holds.
+///
+/// Window fixed at 32 points, series grown 256 -> 16384. The full-range query is the control: it
+/// SHOULD grow, and if it does not then the narrow-window column is measuring nothing.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib does_a_feature_window_cost_the_window_or_the_series -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_a_feature_window_cost_the_window_or_the_series() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  series   append   window(32)   per point   full range   per point   agg(32)
+"
+    );
+
+    for series_len in [256_usize, 1024, 4096, 16384] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        // One point per millisecond, so a window in milliseconds is a window in points.
+        for index in 0..series_len {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::FeatureAppend {
+                    key: "rate".to_string(),
+                    points: vec![FeaturePoint {
+                        timestamp_ms: 1_000 + index as u64,
+                        value: format!("{index}").into_bytes(),
+                    }],
+                },
+            });
+            assert!(out.status.ok, "append {index}: {:?}", out.status);
+        }
+
+        let measure = |command: Command| {
+            let request = || ExecuteRequest { shard_id: 1, command: command.clone() };
+            let warm = engine.execute(request());
+            assert!(warm.status.ok, "{:?}", warm.status);
+            let probe = crate::alloc_probe::Probe::start();
+            let out = engine.execute(request());
+            let counts = probe.stop();
+            assert!(out.status.ok, "{:?}", out.status);
+            (counts.allocs, out.response)
+        };
+
+        // One more point onto an already-long series.
+        let (append, _) = measure(Command::FeatureAppend {
+            key: "rate".to_string(),
+            points: vec![FeaturePoint {
+                timestamp_ms: 1_000 + series_len as u64,
+                value: b"tail".to_vec(),
+            }],
+        });
+
+        // A 32-point window at the END of the series: the shape a reader actually asks for.
+        let window_start = 1_000 + (series_len as u64) - 32;
+        let (window, window_response) = measure(Command::FeatureQuery {
+            key: "rate".to_string(),
+            start_ms: window_start,
+            end_ms: window_start + 32,
+            count: None,
+        });
+        let window_points = match &window_response {
+            CommandResponse::FeaturePoints { points } => points.len(),
+            other => panic!("expected feature points, got {other:?}"),
+        };
+        assert!(
+            window_points > 0 && window_points <= 40,
+            "the window must return about 32 points, got {window_points} -- otherwise the per-point \
+             figure below is measuring a different query than the one named"
+        );
+
+        // Control: the whole series. This one SHOULD grow.
+        let (full, full_response) = measure(Command::FeatureQuery {
+            key: "rate".to_string(),
+            start_ms: 0,
+            end_ms: u64::MAX,
+            count: None,
+        });
+        let full_points = match &full_response {
+            CommandResponse::FeaturePoints { points } => points.len(),
+            other => panic!("expected feature points, got {other:?}"),
+        };
+        assert!(
+            full_points >= series_len,
+            "the control must return the whole series, got {full_points} of {series_len}"
+        );
+
+        let (agg, _) = measure(Command::FeatureAggQuery {
+            key: "rate".to_string(),
+            start_ms: window_start,
+            end_ms: window_start + 32,
+            aggregator: "count".to_string(),
+            count: None,
+        });
+
+        println!(
+            "  {series_len:>6}   {append:>6}   {window:>10}   {:>9.2}   {full:>10}   {:>9.2}   {agg:>7}",
+            window as f64 / window_points as f64,
+            full as f64 / full_points as f64,
+        );
+    }
+
+    println!(
+        "
+  window column flat    => the range narrows the read, which is the point of the lane.
+  window column growing => the query reads the whole series and filters, so every reader pays for
+                           all history ever recorded.
+  append column growing => appending one point costs more once the series is long.
+"
+    );
+}
+
+
+/// Is appending one feature point proportional to the series already there?
+///
+/// Every append below uses a FRESH timestamp, so it is genuinely an append and not an overwrite of
+/// a duplicate -- which is the flaw that made the first measurement of this ambiguous. The empty
+/// series gives the floor, so "grows with the series" can be distinguished from "costly in general",
+/// and a duplicate-timestamp append is measured beside it as its own case.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib does_appending_one_point_cost_the_series -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_appending_one_point_cost_the_series() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  series   append(fresh)   per existing point   append(duplicate)
+"
+    );
+
+    for series_len in [0_usize, 64, 256, 1024] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        for index in 0..series_len {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::FeatureAppend {
+                    key: "rate".to_string(),
+                    points: vec![FeaturePoint {
+                        timestamp_ms: 1_000 + index as u64,
+                        value: format!("{index}").into_bytes(),
+                    }],
+                },
+            });
+            assert!(out.status.ok, "build {index}: {:?}", out.status);
+        }
+
+        // A genuinely new timestamp, past everything written above.
+        let fresh_at = 500_000 + series_len as u64;
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::FeatureAppend {
+                key: "rate".to_string(),
+                points: vec![FeaturePoint {
+                    timestamp_ms: fresh_at,
+                    value: b"fresh".to_vec(),
+                }],
+            },
+        });
+        let fresh = probe.stop().allocs;
+        assert!(out.status.ok, "{:?}", out.status);
+
+        // The same timestamp again: an overwrite, not an append.
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::FeatureAppend {
+                key: "rate".to_string(),
+                points: vec![FeaturePoint {
+                    timestamp_ms: fresh_at,
+                    value: b"again".to_vec(),
+                }],
+            },
+        });
+        let duplicate = probe.stop().allocs;
+        assert!(out.status.ok, "{:?}", out.status);
+
+        // The series really is as long as claimed -- otherwise the per-point column is fiction.
+        let read = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::FeatureQuery {
+                key: "rate".to_string(),
+                start_ms: 0,
+                end_ms: u64::MAX,
+                count: None,
+            },
+        });
+        let held = match &read.response {
+            CommandResponse::FeaturePoints { points } => points.len(),
+            other => panic!("expected feature points, got {other:?}"),
+        };
+        assert!(
+            held >= series_len,
+            "expected at least {series_len} points held, found {held}"
+        );
+
+        let per = if series_len == 0 {
+            0.0
+        } else {
+            fresh as f64 / series_len as f64
+        };
+        println!("  {series_len:>6}   {fresh:>13}   {per:>18.2}   {duplicate:>17}");
+    }
+
+    println!(
+        "
+  append(fresh) flat across series lengths => appending costs what it appends.
+  append(fresh) rising with the series      => building a series is quadratic in its length.
+"
+    );
+}


### PR DESCRIPTION
The feature lane carries a quantity sampled over time, so a reader always asks for a window. Whether
the lane scales is therefore whether a narrow window over a long series costs what the window holds.
Two harnesses, one per side of that — and the write side turned out to be quadratic.

## The read side is right

Window held at 32 points, series grown 256 → 16,384:

| series | window(32) | per point | full range | per point |
|---:|---:|---:|---:|---:|
| 256 | 115 | 3.48 | 791 | 3.08 |
| 1,024 | 115 | 3.48 | 3,097 | 3.02 |

The window column is **flat**, and the full-range control **grows** — which is what makes the flat
column mean something. A control that stayed flat too would say the query was never varied. The probe
also asserts the window actually returns ~32 points, so the per-point figure cannot be computed from a
query that quietly returned something else.

## The write side is quadratic

Appending one point costs 181 allocations to an empty series and 45,904 to a 1,024-point one — the
same operation, **254× the cost**.

The first version of this measurement warmed and measured on the **same timestamp**, so the probed
call was overwriting a duplicate rather than appending — a different path. Both are measured now, with
a fresh timestamp for the append column, and they agree to within one allocation.

## Two costs removed

Both sit in the loop that publishes addresses into the bucket index, and both are paid once per
address for something that does not vary per address.

**The per-address bucket rescan.** `update_bucket_layout` rebuilds a bucket's `object_index` by
walking every page in it, then labels the layout. The publish loop called it once per address, so
writing n addresses walked the bucket n times. The function's own documentation already says this scan
is redundant on the write path, and `classify_bucket_layout_in_place` exists for exactly that and is
already used at three other sites — this one was missed.

Applied at the **insert site only**, where `object_index.insert(object_id)` runs a few lines above so
the set is correct before the label is re-derived. The removal site earlier in the same function
**keeps** the scan: it drops pages with `retain` and never touches `object_index`, so it genuinely
depends on the rebuild to drop the ids. Load, recovery and reconstruct paths keep it for the same
reason. `bucket_object_index_already_matches_a_from_scratch_recompute` is the invariant, and it passes.

**The re-allocated name.** `Arc::from(object_key.to_string())` and the same for `kind` cost two
allocations each — a String, then the Arc that copies it — so publishing n addresses allocated 4n
times for two values that never change. Hoisted out of the loop, cloning the Arc per iteration
instead, which is a refcount bump.

| series | before | rescan fixed | both |
|---:|---:|---:|---:|
| 0 | 181 | 177 | 175 |
| 64 | 2,467 | 2,006 | 1,748 |
| 256 | 10,350 | 8,031 | 7,005 |
| 1,024 | **45,904** | 34,110 | **30,012** |

35% off, and the read path is untouched.

## What is deliberately left

The remaining growth is structural: every append still materialises the whole series and re-publishes
it, because `sync_bucket_index_object_pages` tears the object's pages down and re-inserts them.

Making that additive looks sound — `BlockIndexMap::insert` is keyed by page handle and replaces on
equality, so re-inserting an unchanged page is a no-op, and removals only happen on a trim. It is not
attempted here because #662 is open against these same two files and reworks the very `object_index`
this change reads; that refactor belongs on top of it, not underneath it.

## Verification

Full lib suite, serial: **1,590 passed, 0 failed**. Both new tests are `#[ignore]`, so they do not run
in the ordinary suite.
