### PR TITLE
Capture a write's membership only when the write removed some

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -666,6 +666,16 @@ impl TemporalEngine {
         if block_in_wal::enabled() {
             block_in_wal::begin_write();
         }
+        // What the touched keys held before this command, so the capture below can be
+        // skipped when nothing was removed. Sizes only -- no allocation.
+        let membership_before: Vec<(String, usize)> = command_object_keys(&command)
+            .into_iter()
+            .map(|key| {
+                let size = key_membership_size(shard, &key);
+                (key, size)
+            })
+            .collect();
+
         let outcome = execute_on_shard(
             &self.cache,
             &self.page_store,
@@ -1006,7 +1016,26 @@ impl TemporalEngine {
                         false,
                     ),
                 };
-                let key_states = capture_key_states(shard, &delta_command_keys);
+                // Capture the authoritative membership only when this write could have
+                // removed some.
+                //
+                // The capture exists so a reload after WAL replay does not resurrect an entry
+                // the write evicted or tombstoned -- reconstruction from physical pages would
+                // otherwise find it again. A write that only ADDED leaves nothing to resurrect:
+                // replay rebuilds the same membership from the same pages.
+                //
+                // It is not free. Capturing serializes every entry the per-key maps hold for the
+                // key, so appending to a node that held 850 events serialized all 850 -- 8,647 of
+                // the 8,838 allocations a message write cost, and the reason filling a node cost
+                // the square of its length.
+                let membership_shrank = membership_before.iter().any(|(key, before)| {
+                    key_membership_size(shard, key) < *before
+                });
+                let key_states = if membership_shrank {
+                    capture_key_states(shard, &delta_command_keys)
+                } else {
+                    Vec::new()
+                };
                 // `durable` fsyncs the delta record before returning. Deferred on the raft
                 // apply path (raft log is the durability source) and, under the single-barrier
                 // default, on the single-node path too: the record is still written (so the
@@ -2221,6 +2250,25 @@ fn collect_command_index_items(
 /// fields were 308 bytes of a 656-byte index-log record.
 ///
 /// Opaque JSON so the index-log layer stays decoupled from the concrete `ShardState` field types.
+/// How many entries the per-key maps hold for `key`, added up.
+///
+/// Counting, not capturing: thirteen `len()` calls and no allocation, against serializing every
+/// entry those maps hold for the key. Used to decide whether the capture below is needed at all.
+fn key_membership_size(shard: &ShardState, key: &str) -> usize {
+    shard.features.get(key).map_or(0, |v| v.len())
+        + usize::from(shard.expires_at_ms.contains_key(key))
+        + shard.control_state_changes.get(key).map_or(0, |v| v.len())
+        + usize::from(shard.control_state_selection.contains_key(key))
+        + shard.context_nodes.get(key).map_or(0, |_| 1)
+        + shard.context_events.get(key).map_or(0, |v| v.len())
+        + shard.context_indexes.get(key).map_or(0, |v| v.len())
+        + shard.context_audits.get(key).map_or(0, |v| v.len())
+        + shard.context_children.get(key).map_or(0, |v| v.len())
+        + shard.context_summaries.get(key).map_or(0, |v| v.len())
+        + shard.context_compressions.get(key).map_or(0, |v| v.len())
+        + shard.context_entities.get(key).map_or(0, |v| v.len())
+}
+
 fn capture_key_states(shard: &ShardState, keys: &[String]) -> Vec<serde_json::Value> {
     keys.iter()
         .map(|key| {

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5543,6 +5543,7 @@ fn a_bucket_holding_one_object_holds_no_node() {
     assert_eq!(serde_json::to_string(&one).expect("serializes"), "[4]");
 }
 
+
 /// Writing a message does not cost the length of its node's history.
 ///
 /// The per-write index sync files every page its object has. Each upsert drops the entry's


### PR DESCRIPTION
Every write serialized the per-key maps for the keys it touched into
JSON, to record the membership it left behind. For a key holding a
series that is the **whole series**: appending to a node holding 850
events serialized all 850 -- 8,647 of the 8,838 allocations a message
write cost, and the reason filling a node cost the square of its length.

Allocations per message written, by how many events its node already
holds:

| events on the node | before | after |
|---|---|---|
| 50 | 963 | **189** |
| 200 | 2,490 | **189** |
| 800 | 8,592 | **189** |

Flat, and 126x lower than the 23,822 it was two changes ago.

### The rule

The capture exists so a reload does not resurrect an entry a write
evicted or tombstoned: reconstruction from physical pages would find it
again, so the write records what it left behind. A write that only
**added** leaves nothing to resurrect -- replay rebuilds the same
membership from the same pages.

So the capture now runs only when a touched key's membership shrank.
Deciding that is thirteen `len()` calls and no allocation.

### What I could not prove

**The whole suite -- 1,603 tests -- passes with the capture disabled on
every write**, not just on appends. The mechanism has no coverage at all.

This change is strictly more conservative than that mutant, and keeps
the capture for exactly the case the mechanism describes. But a test
that fails when it is wrongly skipped does not exist to be satisfied,
and I would rather say so than imply the green suite means more than it
does.

I wrote such a test and **threw it away**: it asserted a deleted message
stays deleted across unload/load, and it passed with the capture removed
entirely. `apply_key_states` runs during index-log delta folding on a
cold reload, which that path does not reach. Shipping it would have
looked like coverage without being any.

Two things worth a second opinion from someone closer to the durability
design:

- whether the capture is still load-bearing at all, given nothing tests
  it;
- and if it is, a test through the delta-fold path would be worth more
  than this change.

An `#[ignore]`d test, `what_capturing_a_writes_key_states_costs`,
already measured this exact cost -- "JSON on a write path is worth a
number rather than a suspicion" -- and stopped there.

Full lib suite: 1,592 passed, 0 failed.

---

### It is also a disk-space fix, by more than it is an allocation one

Measured after the fact, writing 8,000 messages of 64-byte text across
20 nodes, and reading the files off disk:

| index log | before | after |
|---|---|---|
| total | **86.3 MB** | **1.47 MB** |
| per message | 10,787 B | **183 B** |

The captured membership was written into every delta record, so each
record carried its node's whole series. That is 59x less index-log on
disk.

Per message, everything under `indexes/` together:

| | before | after |
|---|---|---|
| index log | 10,787 B | 183 B |
| WAL | 98 B | 98 B |
| base index | 16 B | 16 B |
| **total** | **10,901 B** | **297 B** |

For a 64-byte payload that is amplification of 170x before and **4.6x**
after.

Two notes on method, since both nearly misled me:

- At 200 messages the WAL looked like 1,311 B/message. It is a 256 KB
  preallocated file; the number was an artifact of dividing it by too
  few messages. At 8,000 it settles at 98 B.
- The base index is **16 B per message**, which is where this wants to
  be and is worth stating alongside the rest.
