### PR TITLE
A histogram is declared once and published as three series

### DIFF
--- a/tools/test_matrixark_histogram_component_series.py
+++ b/tools/test_matrixark_histogram_component_series.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A histogram is declared once and published as three series.
+
+The conformance validator fails a dashboard or alert that names a metric nothing declares. That is
+the right rule and it had a hole on the correct side: Prometheus renders a histogram as `_bucket`,
+`_sum` and `_count` from a SINGLE `# TYPE ... histogram` declaration, so comparing raw names
+reports every proper use of a histogram as undeclared.
+
+Nothing queried the one histogram in the engine yet, so the check was not failing -- it was waiting
+to fail the first person who added a latency percentile panel. The obvious way to make that
+failure go away is to delete the panel, which is the opposite of what the validator exists to do.
+
+A guard that rejects correct usage does more damage than one that misses a defect, because the
+person it stops is doing the right thing.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_grafana_metrics_conformance as conformance  # noqa: E402
+
+
+class AHistogramPublishesThreeSeriesTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.rust = conformance.rust_metric_text()
+        self.base = conformance.declared_metric_names(self.rust)
+        self.kinds = conformance.declared_kinds(self.rust)
+        self.expanded = conformance.expand_component_series(self.base, self.kinds)
+
+    def test_the_engine_declares_at_least_one_histogram(self) -> None:
+        """Without one, everything below passes by having nothing to expand."""
+        shaped = {name: kind for name, kind in self.kinds.items()
+                  if kind in ("histogram", "summary")}
+        self.assertTrue(
+            shaped,
+            "no histogram or summary is declared, so the expansion this file checks is a no-op "
+            "and its other tests prove nothing")
+
+    def test_every_component_series_of_a_histogram_is_accepted(self) -> None:
+        for name, kind in sorted(self.kinds.items()):
+            if kind not in ("histogram", "summary"):
+                continue
+            for suffix in conformance.COMPONENT_SUFFIXES:
+                with self.subTest(metric=name + suffix):
+                    self.assertIn(
+                        name + suffix, self.expanded,
+                        "%s%s is how Prometheus publishes a %s, and the validator would report a "
+                        "panel using it as querying an undeclared metric"
+                        % (name, suffix, kind))
+
+    def test_a_component_suffix_on_an_undeclared_family_is_still_rejected(self) -> None:
+        # The expansion must not become a blanket amnesty for anything ending in _bucket.
+        self.assertNotIn("temporalstore_not_a_real_family_bucket", self.expanded)
+        self.assertNotIn("temporalstore_not_a_real_family_sum", self.expanded)
+
+    def test_a_gauge_does_not_gain_component_series(self) -> None:
+        gauges = [name for name, kind in self.kinds.items() if kind == "gauge"]
+        self.assertTrue(gauges, "no gauge declared, so this check is vacuous")
+        for name in gauges[:20]:
+            with self.subTest(metric=name):
+                self.assertNotIn(name + "_bucket", self.expanded,
+                                 "%s is a gauge; it publishes no bucket series" % name)
+
+    def test_expansion_only_adds(self) -> None:
+        self.assertTrue(self.base.issubset(self.expanded),
+                        "expansion dropped a base declaration, which would newly reject panels "
+                        "that were previously fine")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -281,6 +281,29 @@ DECLARATION = re.compile(r"#\s*(?:HELP|TYPE)\s+((?:temporalstore|matrixark)_[A-Z
 DECLARED_FAMILY_FLOOR = 150
 
 
+TYPE_LINE = re.compile(r"#\s*TYPE\s+((?:temporalstore|matrixark)_[A-Za-z0-9_]+)\s+(\w+)")
+
+# Prometheus renders a histogram as three series -- `_bucket`, `_sum`, `_count` -- from ONE
+# declaration of the base name. Same for a summary. Comparing raw names would report every correct
+# use of a histogram as undeclared, and the natural way to "fix" that failure is to delete the
+# panel, which is the opposite of what this file is for.
+COMPONENT_SUFFIXES = ("_bucket", "_sum", "_count")
+
+
+def declared_kinds(text: str) -> dict:
+    """family -> declared type, from `# TYPE` lines."""
+    return {name: kind for name, kind in TYPE_LINE.findall(text)}
+
+
+def expand_component_series(declared: set, kinds: dict) -> set:
+    """`declared`, plus the component series each histogram or summary actually publishes."""
+    expanded = set(declared)
+    for name, kind in kinds.items():
+        if kind in ("histogram", "summary"):
+            expanded.update(name + suffix for suffix in COMPONENT_SUFFIXES)
+    return expanded
+
+
 def declared_metric_names(text: str) -> set:
     """Families the engine actually DECLARES, via a `# HELP` or `# TYPE` line.
 
@@ -336,6 +359,8 @@ def check_alert_metric_names(alerts_text: str, declared: set) -> list:
 
 
 def check_declaration_extent(declared: set) -> list:
+    # Counted on the EXPANDED set, which is what callers pass. The floor stays far below the real
+    # figure either way; it catches a scan that has broken, not a release that trimmed metrics.
     """This guard is worthless if the declaration scan comes back empty.
 
     The checks above pass when `declared` is large AND when it is empty -- in the empty case nothing
@@ -452,7 +477,8 @@ def main() -> int:
     if fixed_but_listed:
         print("These are listed as known-unemitted but now resolve: %s. Remove them from "
               "KNOWN_UNEMITTED." % ", ".join(fixed_but_listed), file=sys.stderr)
-    declared = declared_metric_names(rust)
+    declared = expand_component_series(declared_metric_names(rust),
+                                      declared_kinds(rust))
     alert_failures = (check_declaration_extent(declared)
                       + check_dashboard_extent()
                       + check_dashboard_metrics_are_emitted(declared)


### PR DESCRIPTION
Follow-up on my own change. The strict emission check compares dashboard and alert metric names against what the engine declares — but Prometheus renders a histogram as `_bucket`, `_sum` and `_count` from a **single** `# TYPE ... histogram` declaration, so comparing raw names reports every correct use of a histogram as querying an undeclared metric.

`temporalstore_meta_topology_query_latency_us` is declared a histogram and publishes exactly those three. Nothing queries it yet, so the check was not failing — **it was waiting to fail the first person who added a latency percentile panel**, and the obvious way to make that failure go away is to delete the panel.

A guard that rejects correct usage does more damage than one that misses a defect, because the person it stops is doing the right thing.

A component suffix now resolves to its base only when that base is declared `histogram` or `summary`, so this is not a blanket amnesty for anything ending in `_bucket`. Expansion only adds: **253 base families become 259**.

The tests assert their own premise first — that at least one histogram is declared, and that gauges gain no component series — because both of the checks below them pass trivially against an engine that declares no histograms at all. Mutation-checked: disabling the expansion fails the suite.