### PR TITLE
Look a table up without taking the table-cache lock

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -160,6 +160,11 @@ impl Default for RequestOptions {
     }
 }
 
+fn next_client_instance_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TableOptions {
     pub table_id: u64,
@@ -663,7 +668,20 @@ struct ClientInner {
     /// only when a table is opened, refreshed by the metaserver sync, or dropped. Under a
     /// mutex those reads serialized against each other for no reason, which made resolving
     /// a cached table the most expensive thing the proxy did per request.
-    tables: RwLock<HashMap<String, TableOptions>>,
+    /// The open tables, behind an `Arc` so a reader can hold the map without holding the lock.
+    ///
+    /// Every namespaced request looks a table up here. Taking the read lock for it is an atomic
+    /// read-modify-write, so the requests serialise against each other on a map that changes only
+    /// when a table is opened or closed. Readers take a per-thread snapshot instead, refreshed
+    /// when `tables_version` moves.
+    tables: RwLock<Arc<HashMap<String, TableOptions>>>,
+    tables_version: AtomicU64,
+    /// Distinguishes this client from any other on the same thread.
+    ///
+    /// The snapshot is thread-local, so every client a thread touches shares it. Two freshly
+    /// built clients are both on version 0; keyed by version alone they would read each other's
+    /// tables.
+    instance_id: u64,
     meta_sync_tables: Mutex<HashMap<String, ClientMetaSyncTableState>>,
     stats: Mutex<ClientStats>,
     /// Topology version this client last heard from the metaserver.
@@ -809,7 +827,9 @@ impl TemporalStoreClient {
                 route_cache_hits: AtomicU64::new(0),
                 backend_failures: Mutex::default(),
                 backend_failure_entries: AtomicUsize::new(0),
-                tables: RwLock::default(),
+                tables: RwLock::new(Arc::new(HashMap::new())),
+                tables_version: AtomicU64::new(0),
+                instance_id: next_client_instance_id(),
                 meta_sync_tables: Mutex::default(),
                 stats: Mutex::default(),
                 known_topology_version: AtomicU64::new(0),
@@ -826,11 +846,9 @@ impl TemporalStoreClient {
         let namespace = namespace.into();
         let table_name = table_name.into();
         let combined_name = table_combine_name(&namespace, &table_name);
-        self.inner
-            .tables
-            .write()
-            .expect("client table cache lock poisoned")
-            .insert(combined_name.clone(), options.clone());
+        self.with_tables_mut(|tables| {
+            tables.insert(combined_name.clone(), options.clone())
+        });
         self.ensure_meta_sync_table_state(&namespace, &table_name);
         self.inner
             .stats
@@ -858,6 +876,52 @@ impl TemporalStoreClient {
         Ok(self.open_table(namespace, table_name, options))
     }
 
+    /// Every change to the open-table map goes through here.
+    ///
+    /// The map is published by moving `tables_version`, which is what makes a reader's snapshot
+    /// stale. Bumping it at each call site is an invariant that holds until someone adds another
+    /// site, so there is one site. Released after the write so an Acquire load that sees the new
+    /// version also sees the new map.
+    pub(crate) fn with_tables_mut<R>(
+        &self,
+        f: impl FnOnce(&mut HashMap<String, TableOptions>) -> R,
+    ) -> R {
+        let mut guard = self
+            .inner
+            .tables
+            .write()
+            .expect("client table cache lock poisoned");
+        let out = f(Arc::make_mut(&mut guard));
+        self.inner.tables_version.fetch_add(1, Ordering::Release);
+        out
+    }
+
+    /// Run `f` against the open-table map without taking its lock.
+    ///
+    /// The snapshot is refreshed only when `tables_version` moves, which happens when a table is
+    /// opened, closed or re-synced -- never on a request. Keyed by instance as well as version so
+    /// one client's tables are never served to another on the same thread.
+    fn with_tables<R>(&self, f: impl FnOnce(&HashMap<String, TableOptions>) -> R) -> R {
+        thread_local! {
+            static SNAPSHOT: std::cell::RefCell<Option<(u64, u64, Arc<HashMap<String, TableOptions>>)>> =
+                const { std::cell::RefCell::new(None) };
+        }
+        let instance = self.inner.instance_id;
+        let version = self.inner.tables_version.load(Ordering::Acquire);
+        SNAPSHOT.with(|cell| {
+            let Ok(mut slot) = cell.try_borrow_mut() else {
+                let tables = Arc::clone(&self.inner.tables.read().expect("client table cache lock poisoned"));
+                return f(&tables);
+            };
+            if !matches!(&*slot, Some((id, seen, _)) if *id == instance && *seen == version) {
+                let fresh = Arc::clone(&self.inner.tables.read().expect("client table cache lock poisoned"));
+                *slot = Some((instance, version, fresh));
+            }
+            let (_, _, tables) = slot.as_ref().expect("just filled");
+            f(tables)
+        })
+    }
+
     pub fn cached_table(
         &self,
         namespace: impl Into<String>,
@@ -867,13 +931,7 @@ impl TemporalStoreClient {
         let table_name = table_name.into();
         let combined_name = table_combine_name(&namespace, &table_name);
         // A read, so it shares the lock with every request doing the same.
-        let options = self
-            .inner
-            .tables
-            .read()
-            .expect("client table cache lock poisoned")
-            .get(&combined_name)
-            .cloned()?;
+        let options = self.with_tables(|tables| tables.get(&combined_name).cloned())?;
         Some(TemporalStoreTable {
             client: self.clone(),
             namespace,

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -184,11 +184,7 @@ impl TemporalStoreClient {
                 })
             })
             .collect::<Vec<_>>();
-        self.inner
-            .tables
-            .write()
-            .expect("client table cache lock poisoned")
-            .insert(table_key.clone(), options.clone());
+        self.with_tables_mut(|tables| tables.insert(table_key.clone(), options.clone()));
 
         // "unchanged" means the metaserver did not rebuild the shard list because we already
         // have this version -- so the response carries NO shards, and running the route
@@ -538,11 +534,9 @@ impl TemporalStoreClient {
 
     pub fn close_table(&self, table: &TemporalStoreTable) -> Result<(), ClientError> {
         let removed = self
-            .inner
-            .tables
-            .write()
-            .expect("client table cache lock poisoned")
-            .remove(&table_combine_name(table.namespace(), table.table_name()))
+            .with_tables_mut(|tables| {
+                tables.remove(&table_combine_name(table.namespace(), table.table_name()))
+            })
             .is_some();
         self.inner
             .stats
@@ -631,12 +625,7 @@ impl TemporalStoreClient {
     }
 
     pub fn native_partition_set_report(&self) -> Vec<ClientPartitionSetReport> {
-        let tables = self
-            .inner
-            .tables
-            .read()
-            .expect("client table cache lock poisoned")
-            .clone();
+        let tables = self.with_tables(|tables| tables.clone());
         let routes = self
             .inner
             .routes

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -702,6 +702,39 @@ fn table_write_refreshes_topology_after_meta_changed_without_write_retry_budget(
 }
 
 #[test]
+fn a_table_opened_after_a_lookup_is_still_found() {
+    // Table lookups read a per-thread snapshot of the open-table map, refreshed only when the
+    // version moves. A thread that has already looked one up holds a snapshot; if opening a table
+    // does not move the version, that thread never sees the new table and every request for it
+    // takes the miss path to the metaserver instead.
+    let client = TemporalStoreClient::new("127.0.0.1:1");
+    let _first = client.open_table("ns", "a", TableOptions::default());
+    assert!(
+        client.cached_table("ns", "a").is_some(),
+        "the table just opened is in the cache"
+    );
+
+    // Same thread, so the snapshot taken above is the one in hand.
+    let _second = client.open_table("ns", "b", TableOptions::default());
+    assert!(
+        client.cached_table("ns", "b").is_some(),
+        "a table opened after this thread cached a snapshot must still be found -- a miss here          means the open did not move the version"
+    );
+
+    // And closing must reach it too, or a closed table keeps being served from a stale snapshot.
+    let first = client.cached_table("ns", "a").expect("still open");
+    client.close_table(&first).expect("close");
+    assert!(
+        client.cached_table("ns", "a").is_none(),
+        "a closed table must leave the snapshot too"
+    );
+    assert!(
+        client.cached_table("ns", "b").is_some(),
+        "closing one table must not drop the other"
+    );
+}
+
+#[test]
 fn the_backend_failure_count_tracks_the_map_it_stands_in_for() {
     // The route lookup skips the failure-map lock when this count is zero, so the count is only
     // safe while it equals the map's length. Every mutation goes through `with_backend_failures`


### PR DESCRIPTION
Every namespaced request looks its table up in the client's open-table map under that map's read lock. A read lock is still an atomic read-modify-write, so requests serialise over a map that changes only when a table is opened, closed or re-synced.

The map moves behind an `Arc`; readers take a per-thread snapshot refreshed when `tables_version` moves, and writers copy-on-write through one function that bumps the version after the change.

**Measured**, two separately built binaries (different SHAs), arms alternated, 10 rounds per width: **118-127 -> 106-109 ns at 8 threads**, **212-238 -> 185-218 ns at 2**, **20 paired wins of 20** (~12%).

The snapshot is keyed by client instance as well as version -- it is thread-local, and two freshly built clients are both on version 0, so version alone would let them read each other's tables.

A test opens a table after a lookup has cached a snapshot and requires it to be found, then closes one and requires that to land; it fails with the version bump removed.

This does not make the lookup *scale* -- what remains is the client Arc cloned twice per request, already recorded on the benchmark.

`client::` 40/0, `proxy::` 79/0, `table` 65/0, `context` 76/0.