### PR TITLE
A capped sequence read costs the cap, not the range

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -12509,3 +12509,132 @@ fn does_appending_one_point_cost_the_series() {
 "
     );
 }
+
+
+/// Does `count` narrow a sequence read, or is it applied after reading the range?
+///
+/// `SequenceQuery` carries both a time range and a `count`. The range narrowing is already
+/// established for the feature lane; the count is a separate lever and a separate question. A caller
+/// asking for "the last 8" over an open range is asking the count to narrow -- and if it is applied
+/// only after the range is read, that caller pays for all of history to be handed eight rows.
+///
+/// `history`'s bounded read is the bar: 116 allocations at every size from 8 to 256 summaries.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib does_a_sequence_count_narrow_the_read -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn does_a_sequence_count_narrow_the_read() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  rows   append   count=8 over all time   rows back   full read   rows back
+"
+    );
+
+    for series_len in [256_usize, 1024, 4096] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        for index in 0..series_len {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::SequenceAdd {
+                    key: "seq".to_string(),
+                    rows: vec![SequenceFeatureRow {
+                        timestamp_ms: 1_000 + index as u64,
+                        gid: index as u64,
+                        action_type: (index % 7) as u32,
+                        duration: (index % 13) as u32,
+                        author_id: (index % 5) as u64,
+                    }],
+                },
+            });
+            assert!(out.status.ok, "build {index}: {:?}", out.status);
+        }
+
+        let measure = |command: Command| {
+            let request = || ExecuteRequest { shard_id: 1, command: command.clone() };
+            let warm = engine.execute(request());
+            assert!(warm.status.ok, "{:?}", warm.status);
+            let probe = crate::alloc_probe::Probe::start();
+            let out = engine.execute(request());
+            let counts = probe.stop();
+            assert!(out.status.ok, "{:?}", out.status);
+            let rows = match &out.response {
+                CommandResponse::SequenceRows { rows } => rows.len(),
+                other => panic!("expected sequence rows, got {other:?}"),
+            };
+            (counts.allocs, rows)
+        };
+
+        // One more row onto an already-long series.
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::SequenceAdd {
+                key: "seq".to_string(),
+                rows: vec![SequenceFeatureRow {
+                    timestamp_ms: 900_000 + series_len as u64,
+                    gid: 7,
+                    action_type: 1,
+                    duration: 1,
+                    author_id: 1,
+                }],
+            },
+        });
+        let append = probe.stop().allocs;
+        assert!(out.status.ok, "{:?}", out.status);
+
+        // A count of 8 over the whole range: the count is the only thing that can narrow this.
+        let (counted, counted_rows) = measure(Command::SequenceQuery {
+            key: "seq".to_string(),
+            start_ms: 0,
+            end_ms: u64::MAX,
+            count: 8,
+            filters: Vec::new(),
+        });
+        assert!(
+            counted_rows > 0 && counted_rows <= 8,
+            "count=8 must return at most 8 rows, got {counted_rows} -- otherwise this column is \
+             measuring a different query than the one named"
+        );
+
+        // Control: the same range, uncapped. This one SHOULD grow.
+        let (full, full_rows) = measure(Command::SequenceQuery {
+            key: "seq".to_string(),
+            start_ms: 0,
+            end_ms: u64::MAX,
+            count: usize::MAX,
+            filters: Vec::new(),
+        });
+        assert!(
+            full_rows >= series_len,
+            "the control must read the whole series, got {full_rows} of {series_len}"
+        );
+
+        println!(
+            "  {series_len:>4}   {append:>6}   {counted:>21}   {counted_rows:>9}   {full:>9}   {full_rows:>9}"
+        );
+    }
+
+    println!(
+        "
+  count=8 flat while the control grows => the count narrows the read.
+  count=8 tracking the control          => the count is applied after reading the range, so a
+                                           bounded caller still pays for all of history.
+"
+    );
+}


### PR DESCRIPTION
`SequenceQuery` carries both a time range and a `count`, and they are separate questions. The range
narrowing is established for the feature lane; whether the **count** narrows is what decides the cost
of the shape a caller actually asks for — "the last 8" over an open range.

## The count narrows

Store held at one series, count held at 8, series grown:

| rows | count = 8 | rows back | uncapped control | rows back | append |
|---:|---:|---:|---:|---:|---:|
| 256 | **79** | 8 | 2,326 | 257 | 4,389 |
| 1,024 | **79** | 8 | 9,240 | 1,025 | 19,582 |
| 4,096 | **79** | 8 | 36,890 | 4,097 | 87,497 |

Flat at 79 while the uncapped control grows sixteenfold. The cap sits **before** the page reads —
`.range(..).take(count).filter_map(read_sequence_row)` — so only `count` rows are fetched rather than
the range being read and then trimmed.

The control growing is what makes the flat column evidence rather than an artifact; a control that
stayed flat would say the query had never been varied. The probe also asserts the capped query returns
at most 8 rows and the control returns the whole series, so neither figure can come from a query that
quietly returned something else.

## The append column is a cross-check

The sequence lane was not touched by the recent publish-loop work, yet its append lands at **4,389 and
19,582** against the feature lane's **4,389 and 19,588** on the same build — within six allocations.

Two lanes with separate commands, separate storage shapes and separate call sites agreeing to four
significant figures is what confirms the remaining per-append cost is the shared publish loop rather
than anything particular to either lane.

## One thing deliberately not changed

Filters are applied **after** the cap, so a caller asking for 8 rows matching a filter receives "of the
first 8 rows in range, those that match" — possibly none, when thousands match.

This is left alone on purpose:

* `long_sequence_query_keeps_timestamp_order_and_applies_random_filters` computes its expected value in
  exactly that order across 20 seeds. The behaviour is pinned deliberately.
* It is the order that makes `count` cheap. Filtering first is semantically nicer and forces reading
  every row in the window to know what matches — the flat 79 above becomes the 9,240 column.

Worth surfacing rather than patching: the sibling `QueryEvents` documents the opposite choice — it
filters within the bounded scan and applies its limit *after* filtering. Two query commands in one
engine, opposite meanings for the same parameter name, and nothing tells a caller which to expect.
That is a decision about what `count` means, not a change to make quietly under a test that pins it.

## Scope

Measurement only, no behaviour change. The test is `#[ignore]`, so it does not run in the ordinary
suite.
