### PR TITLE
Every counter write serialises the whole counter

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part2.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part2.rs
@@ -4660,3 +4660,124 @@ fn walonly_recovery_rederives_feature_trim_under_single_barrier() {
     assert_eq!(after, vec![30, 40, 50]);
 }
 
+
+
+/// What does the default control-state write cost as the counter grows?
+///
+/// `persist_control_state_page` serialises the WHOLE counter series to JSON and appends it as a
+/// page, once per increment -- so a counter holding n points re-writes all n on the n+1th. The
+/// function already carries the escape (`async_storage && control_coalesce_persist`), but `flag()`
+/// resolves an absent flag to false, so the whole-series rewrite is the default.
+///
+/// The coalesced mode's crash-safety is settled by
+/// `control_state_coalesced_write_survives_restart_via_wal_replay`. This measures the price of the
+/// default instead. Both arms run in the same test against separate engines: comparing arms across
+/// runs on a shared box compares load as much as code.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_one_control_state_increment_costs_as_the_counter_grows -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_one_control_state_increment_costs_as_the_counter_grows() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    // One arm: build a counter of `points`, then measure ONE more increment onto it.
+    let arm = |points: usize, coalesce: bool| -> (u64, u64, u64) {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            8 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let mut config = Config {
+            version: 2,
+            async_storage: true,
+            ..Config::default()
+        };
+        if coalesce {
+            config
+                .extend_config
+                .insert("control_coalesce_persist".to_string(), "on".to_string());
+        }
+        assert!(engine.set_config(SetConfigRequest { shard_id: 1, config }).ok);
+
+        for index in 0..points {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ControlStateIncrement {
+                    key: "hits".to_string(),
+                    timestamp_ms: 1_000 + index as u64,
+                    amount: 1,
+                },
+            });
+            assert!(out.status.ok, "build {index}: {:?}", out.status);
+        }
+
+        let writes_before = engine.block_store().stats().writes;
+        let probe = crate::alloc_probe::Probe::start();
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ControlStateIncrement {
+                key: "hits".to_string(),
+                timestamp_ms: 500_000 + points as u64,
+                amount: 1,
+            },
+        });
+        let counts = probe.stop();
+        assert!(out.status.ok, "{:?}", out.status);
+        let pages = engine.block_store().stats().writes - writes_before;
+
+        // The counter must actually hold what was put in it, or the cost above is the cost of
+        // doing nothing. Every increment was 1, and there are points + 1 of them.
+        let total = match engine
+            .execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ControlStateQuery {
+                    key: "hits".to_string(),
+                    start_ms: 0,
+                    end_ms: u64::MAX,
+                    aggregator: "sum".to_string(),
+                },
+            })
+            .response
+        {
+            CommandResponse::Integer { value } => value,
+            other => panic!("expected Integer, got {other:?}"),
+        };
+        assert_eq!(
+            total,
+            points as i64 + 1,
+            "the counter must hold every increment, or this measures the cost of doing nothing"
+        );
+
+        (counts.allocs as u64, counts.alloc_bytes as u64, pages as u64)
+    };
+
+    println!(
+        "
+  counter   DEFAULT allocs   bytes   pages     COALESCED allocs   bytes   pages
+"
+    );
+
+    for points in [64_usize, 256, 1024] {
+        let (d_allocs, d_bytes, d_pages) = arm(points, false);
+        let (c_allocs, c_bytes, c_pages) = arm(points, true);
+        println!(
+            "  {points:>7}   {d_allocs:>14}   {d_bytes:>5}   {d_pages:>5}     {c_allocs:>16}   {c_bytes:>5}   {c_pages:>5}"
+        );
+    }
+
+    println!(
+        "
+  DEFAULT rising with the counter => every increment re-writes the whole series.
+  COALESCED flat                  => the escape works, and the WAL carries durability.
+"
+    );
+}


### PR DESCRIPTION
`persist_control_state_page` serialises the **whole** counter series to JSON and appends it, on every
write:

```rust
let Ok(bytes) = serde_json::to_vec(series) else { return false; };
```

So a counter holding n points re-writes all n on the n+1th. This measures what that costs, and what
the escape beside it already saves.

## What it costs

One increment onto an existing counter, both arms in the same run against separate engines:

| counter points | default allocs | default bytes | coalesced allocs | coalesced bytes |
|---:|---:|---:|---:|---:|
| 64 | 72 | 15,634 | 46 | 2,937 |
| 256 | 75 | 50,979 | 47 | 3,135 |
| 1,024 | **78** | **191,492** | 46 | **2,940** |

**The allocation count is flat and the cost is linear.** 72 → 78 reads like a write that does not care
how large the counter is; the bytes are 15.6 KB → 191 KB, which is 187 B per counter point
(187 × 1024 = 191,488 against 191,492 measured) — the whole series, every time.

The divergence between those two columns is the point of reporting both. `serde_json::to_vec(series)` is a *single* allocation
whose size is proportional to the series, so counting allocations measures the wrong thing here. Page
counts were blind too: both arms wrote **zero** pages, because with `async_storage` on the default's
append is buffered rather than materialised. Of the three obvious instruments, only bytes saw it.

Coalesced is flat at ~2.9 KB regardless of length — **65× less at 1,024 points, and widening**. On a
counter with 40k points the default allocates roughly 7.5 MB to record one increment.

The probe asserts the counter actually holds every increment in both arms, so neither figure can be
the cost of doing nothing.

## The series is also unbounded

`control_state` is `HashMap<String, BTreeMap<u64, i64>>` — one entry per distinct timestamp, and
nothing trims it. `trim_timestamped_series` is called by the feature and sequence lanes at four sites
and by **none** of the five counter sites; there is no counter equivalent of `feature_max_size`. So the
series grows without bound *and* every write re-serialises all of it.

## A default worth reconsidering — but not flipped here

The escape already exists four lines above the serialisation:

```rust
if async_storage && shard.control_coalesce_persist { return true; }
```

`ControlConfig::flag` resolves an absent flag with `unwrap_or(false)`, so it is off unless a deployment
asks, and the whole-series rewrite is what everyone runs. Three arguments for turning it on, none of
them from this change:

* **Crash-safety is already established.** `control_state_coalesced_write_survives_restart_via_wal_replay`
  turns the flag on, asserts no per-write page is materialised, restarts the engine and reads the value
  back.
* **The other two families already work this way.** The code's own comment calls coalesced mode "the
  same model control_state_changes/fol already use", and `stage_component_outcome` confirms it — one WAL
  item per value, O(1). Only the counter family pays a whole-series rewrite for the same guarantee.
* **One flag covers the whole surface.** All five counter write commands route through this one
  function: `ControlStateIncrement`, `ControlStateIncrementWithOptions`, `ControlStateSet`,
  `ControlStateSetAndGet`, `ControlStateSetAndGetWithOptions`.

It is **not** flipped in this change. Changing it moves durability for counter writes from a
materialised page to WAL replay, and that is a product decision about the durability model rather than
a performance edit — the measurement is here so the decision can be made on numbers.

## Scope

Measurement only, no behaviour change. The test is `#[ignore]`, so it does not run in the ordinary
suite; it completes in about 3 seconds.
