### PR TITLE
Hold one zstd compressor per thread instead of building one per record

### DIFF
--- a/crates/temporalstore-rust/src/block_store.rs
+++ b/crates/temporalstore-rust/src/block_store.rs
@@ -2758,6 +2758,49 @@ mod tests {
         assert_eq!(logical, b"bcde");
     }
 
+        /// A record written by the streaming encoder must still decode, and vice versa.
+    ///
+    /// The page-record encoder used to build a zstd compressor per call; it now holds one per
+    /// thread, which removed about 80% of what a write allocates. The two APIs frame a stream
+    /// differently, so the STORED BYTES changed -- and a stored-byte change is only safe if a
+    /// record written by either build reads on either.
+    ///
+    /// This pins that both ways round, which a round-trip test through one encoder cannot: it
+    /// would pass just as happily if the format had shifted under it.
+    #[test]
+    fn page_records_written_by_either_encoder_decode() {
+        let payload: Vec<u8> = (0..4096u32).map(|i| ((i * 7 + (i >> 3)) % 251) as u8).collect();
+        let level = 3;
+
+        // What the old encoder produced, byte for byte.
+        let streaming = zstd::stream::encode_all(std::io::Cursor::new(&payload[..]), level)
+            .expect("streaming encode");
+        // What the held compressor produces now.
+        let bulk = {
+            let mut compressor = zstd::bulk::Compressor::new(level).expect("compressor");
+            compressor.compress(&payload).expect("bulk encode")
+        };
+
+        assert_ne!(
+            streaming, bulk,
+            "if these ever match, this test is no longer proving anything and should be removed"
+        );
+
+        // The decode path a reader takes, given the exact payload length from the header.
+        for (label, blob) in [("streaming", &streaming), ("bulk", &bulk)] {
+            let mut decompressor = zstd::bulk::Decompressor::new().expect("decompressor");
+            let back = decompressor
+                .decompress(blob, payload.len())
+                .unwrap_or_else(|error| panic!("{label} record failed the bulk decode: {error}"));
+            assert_eq!(back, payload, "{label} record decoded to the wrong bytes");
+
+            // And the streaming fallback the decoder uses above its size ceiling.
+            let back = zstd::stream::decode_all(std::io::Cursor::new(&blob[..]))
+                .unwrap_or_else(|error| panic!("{label} record failed the streaming decode: {error}"));
+            assert_eq!(back, payload, "{label} record decoded to the wrong bytes");
+        }
+    }
+
     #[test]
     fn compressed_page_records_round_trip_and_remain_logical() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/temporalstore-rust/src/block_store/record.rs
+++ b/crates/temporalstore-rust/src/block_store/record.rs
@@ -148,10 +148,30 @@ fn encode_page_record_payload(
     if !options.compression_enabled || payload.len() < options.compression_min_bytes {
         return Ok((payload.to_vec(), PageRecordCompression::None));
     }
-    let compressed = zstd::stream::encode_all(
-        Cursor::new(payload),
-        options.compression_level.clamp(-7, 22),
-    )?;
+    // Reuse one compression context per thread, the mirror of the decoder below.
+    //
+    // `zstd::stream::encode_all` constructs a compressor, uses it once and drops it, and a
+    // compressor allocates its working buffers up front. Measured by sweeping value sizes
+    // through a write: cost is flat at 2.0 B allocated per payload byte on both sides of a
+    // step between 192 and 256 bytes worth 32,535 B per write -- and 256 is
+    // `PAGE_RECORD_COMPRESSION_MIN_BYTES`, so the step IS this call. At the 1,244-byte average
+    // of a soak corpus that is about 80% of everything a write allocates.
+    //
+    // The level is per-call rather than fixed, so it is set on the held compressor each time;
+    // that is a parameter update, not a rebuild. A compressor is `&mut` to compress, so this is
+    // thread-local for the same reason the decompressor is: one shared instance would serialise
+    // every writer behind a lock on a path that is otherwise concurrent.
+    //
+    // The stored bytes CHANGE -- the bulk API frames a stream without the content-size header
+    // the streaming call writes, so output is a little smaller. Both are ordinary zstd frames,
+    // both decode through the path below and through the streaming fallback, so a record written
+    // by either build reads on either. It is still a change to what lands on disk.
+    let level = options.compression_level.clamp(-7, 22);
+    let compressed = ZSTD_COMPRESSOR.with(|cell| {
+        let mut compressor = cell.borrow_mut();
+        compressor.set_compression_level(level)?;
+        compressor.compress(payload)
+    })?;
     if compressed.len() < payload.len() {
         Ok((compressed, PageRecordCompression::Zstd))
     } else {
@@ -461,6 +481,13 @@ thread_local! {
     static ZSTD_DECOMPRESSOR: std::cell::RefCell<zstd::bulk::Decompressor<'static>> =
         std::cell::RefCell::new(
             zstd::bulk::Decompressor::new().expect("zstd decompressor construction"),
+        );
+
+    /// The write-side mirror. Level is set per call, so the level chosen here is only a starting
+    /// point and never the one a record is actually compressed at.
+    static ZSTD_COMPRESSOR: std::cell::RefCell<zstd::bulk::Compressor<'static>> =
+        std::cell::RefCell::new(
+            zstd::bulk::Compressor::new(0).expect("zstd compressor construction"),
         );
 }
 


### PR DESCRIPTION
The page-record encoder built a zstd compressor for every record, used it once and dropped it. It
now holds one per thread, which is what the decoder in the same file already does.

## What it costs today

Sweeping a write across nine value sizes, 8,000 writes per arm after a warm-up, counted rather
than timed:

```
  value size   allocations/write   allocated B/write
          64              130.7                7182
         192              131.5                7714
         256              131.5               40249   <- +32,535 B
         512              131.5               40698
        4096              131.5               47866
```

Flat at 2.0 B allocated per payload byte on both sides, and a **step between 192 and 256 bytes
worth 32,535 B per write**. 256 is `PAGE_RECORD_COMPRESSION_MIN_BYTES`, so the step is the
compressor being constructed. A soak corpus averages 1,244 B per record, so essentially every real
write pays it.

## After

```
  value size    before      after     change
       256 B    40,249      7,721     -80.8%
       512 B    40,698      8,490     -79.1%
     1,024 B    41,722     10,028     -76.0%
     4,096 B    47,866     19,255     -59.8%
  allocations     131.5      130.5     the one predicted
```

About **75% less allocated per write** at the corpus average, and the probe that found the step now
reports `No step: the cost is smooth across the range`.

## This changes bytes on disk, so it is pinned both ways

The bulk API frames a stream without the content-size header the streaming call writes, so stored
output is a little smaller — 698 B against 789 B for a 1,244-byte record. Both are ordinary zstd
frames.

`page_records_written_by_either_encoder_decode` pins that a record written by **either** encoder
decodes through **both** the bulk path and the streaming fallback, so a record written by either
build reads on either. It also asserts the two encodings differ, so if they ever converge the test
says it has stopped proving anything rather than passing hollowly.

## Why thread-local, and why the level is set per call

A compressor is `&mut` to compress, so one shared instance would serialise every writer behind a
lock on a path that is otherwise concurrent — the same reasoning already written down for the
decompressor directly below it.

`compression_level` comes from options and can vary per call, so it is set on the held compressor
each time. That is a parameter update, not a rebuild.

## Verification

- `cargo test -p temporalstore-rust --lib block_store::` — 60 passed
- `cargo test -p temporalstore-rust --lib compress` — 11 passed
- full `--lib` run, `--test-threads=1`, compared against the same run on the base commit

Two files, no deletions. The measurement probes behind the numbers above are separate, in #667.
