### PR TITLE
Route a keyed command without taking the table-cache lock

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -1122,14 +1122,15 @@ impl TemporalStoreTable {
         self.table_options()
     }
 
+    /// The table's options as they stand now, not as they stood when the table was taken.
+    ///
+    /// Read live on purpose: a table re-synced after a split changes its shard count, and a
+    /// handle taken before that must not keep hashing keys over the old one. `shard_id_for_key`
+    /// calls this, so it runs for every keyed command -- through the snapshot rather than the
+    /// map's lock, which every such command was otherwise taking.
     fn table_options(&self) -> TableOptions {
         self.client
-            .inner
-            .tables
-            .read()
-            .expect("client table cache lock poisoned")
-            .get(&self.combined_name)
-            .cloned()
+            .with_tables(|tables| tables.get(&self.combined_name).cloned())
             .unwrap_or_else(|| self.options.clone())
     }
 

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -702,6 +702,56 @@ fn table_write_refreshes_topology_after_meta_changed_without_write_retry_budget(
 }
 
 #[test]
+fn a_split_table_routes_keys_over_its_new_shard_count() {
+    // `shard_id_for_key` reads the table's options through the per-thread snapshot. A table that
+    // is re-synced after a split has more shards, and a handle taken before that must pick the
+    // change up: routing over the old count sends keys to a shard that no longer owns them, and
+    // nothing fails while it happens.
+    let client = TemporalStoreClient::new("127.0.0.1:1");
+    let table = client.open_table(
+        "ns",
+        "tbl",
+        TableOptions {
+            shard_count: 4,
+            first_shard_id: 100,
+            ..TableOptions::default()
+        },
+    );
+
+    // Spread keys over the four shards and remember where they landed.
+    let before: Vec<_> = (0..32)
+        .map(|i| table.shard_id_for_key(&format!("k{i}")))
+        .collect();
+    assert!(
+        before.iter().any(|shard| *shard >= 100 && *shard < 104),
+        "keys must land inside the four shards the table was opened with"
+    );
+    assert!(
+        before.iter().all(|shard| *shard < 104),
+        "no key may land outside them: {before:?}"
+    );
+
+    // The split: same table, eight shards. Same thread, so the snapshot taken above is in hand.
+    let _resynced = client.open_table(
+        "ns",
+        "tbl",
+        TableOptions {
+            shard_count: 8,
+            first_shard_id: 100,
+            ..TableOptions::default()
+        },
+    );
+
+    let after: Vec<_> = (0..32)
+        .map(|i| table.shard_id_for_key(&format!("k{i}")))
+        .collect();
+    assert!(
+        after.iter().any(|shard| *shard >= 104),
+        "after the split some key must route into the new shards -- none here means this handle          is still hashing over the four it was opened with: {after:?}"
+    );
+}
+
+#[test]
 fn a_table_opened_after_a_lookup_is_still_found() {
     // Table lookups read a per-thread snapshot of the open-table map, refreshed only when the
     // version moves. A thread that has already looked one up holds a snapshot; if opening a table

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3316,6 +3316,59 @@ mod tests {
         );
     }
 
+    /// What routing one keyed command costs, under concurrency.
+    ///
+    /// `shard_id_for_key` reads the table's options so a table re-synced after a split routes on
+    /// its new shard count. That read is per COMMAND, not per request -- a batch pays it once per
+    /// command in the batch. Run with `--ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn bench_proxy_shard_id_for_key() {
+        let threads: usize = std::env::var("BENCH_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8);
+        let per_thread: usize = std::env::var("BENCH_ITERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50_000);
+
+        let proxy = std::sync::Arc::new(scoped_proxy(ProxyOptions::default()));
+        let table = std::sync::Arc::new(proxy.client().open_table(
+            "ns",
+            "tbl",
+            crate::client::TableOptions {
+                shard_count: 16,
+                ..crate::client::TableOptions::default()
+            },
+        ));
+
+        let gate = std::sync::Arc::new(std::sync::Barrier::new(threads + 1));
+        let mut handles = Vec::new();
+        for t in 0..threads {
+            let table = std::sync::Arc::clone(&table);
+            let gate = std::sync::Arc::clone(&gate);
+            handles.push(std::thread::spawn(move || {
+                let key = format!("tenant:{t}:key");
+                gate.wait();
+                for _ in 0..per_thread {
+                    std::hint::black_box(table.shard_id_for_key(&key));
+                }
+            }));
+        }
+        gate.wait();
+        let start = std::time::Instant::now();
+        for handle in handles {
+            handle.join().expect("bench thread panicked");
+        }
+        let elapsed = start.elapsed();
+        let ops = (threads * per_thread) as u128;
+        println!(
+            "BENCH shard_id_for_key threads={threads} ops={ops} ns_per_op={}",
+            elapsed.as_nanos() / ops
+        );
+    }
+
     /// Per-request bookkeeping under CONCURRENCY, measured per function.
     ///
     /// Single-threaded this work is ~110ns against a request whose real cost is a network


### PR DESCRIPTION
`shard_id_for_key` reads the table's options so a table re-synced after a split routes over its new shard count. That read took the open-table map's lock, and it happens **per command** -- a batch pays it once per command, not once per batch.

It now reads through the per-thread snapshot the map already has. The read stays live: the snapshot drops when the map's version moves, which is what a re-sync does.

**Measured**, two separately built binaries (different SHAs), arms alternated, 10 rounds at 8 threads: **85-95 ns before, 5-16 ns after, 10 paired wins of 10** (~84%).

A test opens a table over four shards, routes keys across them, re-opens it over eight and requires some key to reach the new ones. With the version bump removed every key stays in the original four -- keys going to a shard that no longer owns them, with nothing reporting it.

`client::` 41/0, `proxy::` 80/0, `table` 66/0, `context` 76/0.