### PR TITLE
Engine storage knobs a customer can actually set

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -143,6 +143,14 @@ GROUPS: Dict[str, Json] = {
         "note": "What happens to a document after it is accepted: summaries, time compression, and "
                 "the background encoder drainer.",
     },
+    "storage_engine": {
+        "title": "Storage engine", "order": 55, "advanced": True,
+        "note": "How the engine stores what it has already accepted: vector width, the memory it "
+                "returns to the operating system, and the caps that stop diagnostics growing "
+                "without bound. The engine runs in this process, so these take effect on the next "
+                "write or read rather than at the next restart. Every default here is the engine's "
+                "own, checked against its source by a test.",
+    },
     "limits": {
         "title": "Rate limits and request quotas", "order": 60, "advanced": True,
         "note": "The edge's own ceilings. All of these are read when the gateway process starts, "
@@ -320,6 +328,53 @@ SETTINGS: List[Setting] = [
     Setting("ingestion.summary_refresh_limit", "ingestion", "MATRIXARK_SUMMARY_REFRESH_LIMIT",
             "Summaries refreshed per pass", "int", "64", "restart",
             "Ceiling on how many nodes one refresh pass touches."),
+    # ---- storage engine -------------------------------------------------------------------
+    # These are TS_* knobs the engine reads directly. Seven of eighty, chosen rather than exported:
+    # directories, bind addresses, cluster identity and the metaserver admin token are set by
+    # whoever provisions a node, and knobs with no documented default have nothing truthful to show
+    # in a form. Every default below is the engine's own -- see
+    # test_matrixark_engine_settings_match_the_engine.
+    Setting("storage_engine.vector_scaled", "storage_engine",
+            "TS_VECTOR_SCALED",
+            "Store vectors in the scaled form", "bool", "1", "live",
+            "On, a vector is stored uniformly scaled, which halves its bytes and leaves ranking "
+            "identical. Reads understand both forms, so this can be turned off again without "
+            "stranding anything already written."),
+    Setting("storage_engine.vector_int8", "storage_engine",
+            "TS_VECTOR_INT8",
+            "Store vectors quantized to int8", "bool", "0", "live",
+            "Off by default. Quantizing further cuts stored bytes again, but it is a quality "
+            "decision rather than a free one: measure recall on your own corpus before turning it "
+            "on. Reads understand both forms regardless."),
+    Setting("storage_engine.node_summary_vector", "storage_engine",
+            "TS_NODE_SUMMARY_VECTOR",
+            "Nodes carry a copy of their summary vector", "bool", "1", "live",
+            "On, a node record carries a copy of its L1 summary's vector so the node can be scored "
+            "before its summary is fetched. Only writes consult this: a node either carries the "
+            "copy or it does not, and reads handle both."),
+    Setting("storage_engine.malloc_trim", "storage_engine",
+            "TS_MALLOC_TRIM",
+            "Return freed memory to the operating system", "bool", "1", "live",
+            "On, the engine asks the allocator to hand back memory it is no longer using. What is "
+            "returned is memory the process was not using, so the trade is one-sided -- the escape "
+            "hatch exists because a trim costs a walk of the allocator's free lists."),
+    Setting("storage_engine.scratch_sweep", "storage_engine",
+            "TS_SCRATCH_SWEEP",
+            "Reclaim scratch directories from dead processes", "bool", "1", "live",
+            "On, scratch directories whose owning process is gone are reclaimed. Turn it off only "
+            "to keep an abandoned directory for inspection."),
+    Setting("storage_engine.max_retained_finished_jobs", "storage_engine",
+            "TS_MAX_RETAINED_FINISHED_JOBS",
+            "Completed job statuses kept queryable", "int", "64", "live",
+            "Each retained status carries its full output, and a dump output carries a serialized "
+            "index -- so an unbounded history meant one index copy retained per dump for the life "
+            "of the node. Raise it to keep more history, at that cost per entry."),
+    Setting("storage_engine.metrics_max_slot_series", "storage_engine",
+            "TS_METRICS_MAX_SLOT_SERIES",
+            "Per-slot metric series allowed per shard", "int", "1024", "live",
+            "A routing slot is derived per key, so per-slot metrics grow with key count rather "
+            "than with anything bounded. This caps how many a single shard may emit; lower it if "
+            "your metrics backend is straining on cardinality."),
     Setting("ingestion.require_model_summaries", "ingestion",
             "MATRIXARK_REQUIRE_MODEL_SUMMARIES",
             "Fail instead of writing rule summaries", "bool", "0", "live",

--- a/tools/test_matrixark_engine_settings_match_the_engine.py
+++ b/tools/test_matrixark_engine_settings_match_the_engine.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every engine knob the portal offers must show the engine's own default.
+
+The portal prints a default next to each setting, and a customer reads it as "what happens if I
+leave this alone". For the `TS_*` knobs that default lives in Rust, in the accessor that reads the
+variable -- so the portal's copy is a transcription, and a transcription drifts.
+
+Rather than trusting the number I typed, this derives the default from the accessor:
+
+* `.unwrap_or(N)` on a parsed integer means N.
+* A boolean that tests its value against `"0" | "false" | "no" | "off"` is ON unless switched off,
+  so its default is 1.
+* One testing against `"1" | "true" | "yes" | "on"` is OFF unless switched on, so its default is 0.
+
+If the engine changes a default and the portal is not updated, this fails and names both values.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_config as cfgmod  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RUST_SRC = os.path.join(ROOT, "crates", "temporalstore-rust", "src")
+
+FALSEY = ('"0" | "false" | "no" | "off"', '"0" | "false" | "no" | "off"')
+TRUTHY = ('"1" | "true" | "yes" | "on"', '"1" | "true" | "yes" | "on"')
+
+
+def _rust_files() -> list:
+    out = []
+    for root, _dirs, files in os.walk(RUST_SRC):
+        if "tests" in root.replace(os.sep, "/").split("/"):
+            continue
+        out.extend(os.path.join(root, name) for name in files if name.endswith(".rs"))
+    return out
+
+
+def _enclosing_body(text: str, at: int) -> str:
+    """The body of the fn containing `at`, by brace matching from its opening brace."""
+    fn_at = text.rfind("fn ", 0, at)
+    if fn_at < 0:
+        return ""
+    open_at = text.find("{", fn_at)
+    if open_at < 0 or open_at > at:
+        return ""
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_at:i + 1]
+    return text[open_at:]
+
+
+def engine_defaults() -> dict:
+    """env name -> the default its Rust accessor applies, as the portal would print it."""
+    defaults = {}
+    for path in _rust_files():
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+        for match in re.finditer(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"', text):
+            name = match.group(1)
+            if name in defaults:
+                continue
+            body = _enclosing_body(text, match.start())
+            if not body:
+                continue
+            numeric = re.search(r"\.unwrap_or\((\d+)\)", body)
+            if numeric:
+                defaults[name] = numeric.group(1)
+                continue
+            squashed = " ".join(body.split())
+            if '"0" | "false" | "no" | "off"' in squashed:
+                defaults[name] = "1"     # matches the OFF words, so it is on unless switched off
+            elif '"1" | "true" | "yes" | "on"' in squashed:
+                defaults[name] = "0"     # matches the ON words, so it is off unless switched on
+    return defaults
+
+
+class TheEnginesDefaultIsWhatThePortalShowsTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.engine_settings = [s for s in cfgmod.SETTINGS
+                                if s.env and s.env.startswith("TS_")]
+        self.derived = engine_defaults()
+
+    def test_the_portal_offers_engine_knobs_at_all(self) -> None:
+        self.assertGreaterEqual(
+            len(self.engine_settings), 5,
+            "the portal offers almost no engine knobs, so this file checks nothing")
+
+    def test_the_source_scan_found_defaults(self) -> None:
+        """Without this the comparison below skips every setting and reports success."""
+        self.assertGreater(
+            len(self.derived), 10,
+            "derived defaults for only %d engine knobs; the accessor scan has stopped working and "
+            "every comparison below would be skipped" % len(self.derived))
+
+    def test_every_offered_engine_knob_shows_the_engines_default(self) -> None:
+        checked = 0
+        for setting in self.engine_settings:
+            derived = self.derived.get(setting.env)
+            if derived is None:
+                continue
+            checked += 1
+            with self.subTest(env=setting.env):
+                self.assertEqual(
+                    derived, setting.default,
+                    "%s: the engine defaults to %r and the portal shows %r. A customer reads that "
+                    "number as what happens if they leave the setting alone."
+                    % (setting.env, derived, setting.default))
+        self.assertGreater(
+            checked, 4,
+            "only %d offered engine knobs could be matched to an accessor, so this test is close "
+            "to vacuous" % checked)
+
+    def test_every_offered_engine_knob_is_actually_read_by_the_engine(self) -> None:
+        read = set()
+        for path in _rust_files():
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                text = handle.read()
+            read.update(re.findall(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"', text))
+        for setting in self.engine_settings:
+            with self.subTest(env=setting.env):
+                self.assertIn(
+                    setting.env, read,
+                    "%s is offered on the portal and the engine never reads it, so setting it "
+                    "does nothing" % setting.env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The engine reads **143 environment variables**. The portal offered 77 settings. The overlap was **four** — and not one of the 80 `TS_*` engine-native knobs was reachable. Cache behaviour, vector width, allocator return, diagnostic caps: a customer tuning a deployment through the portal could not touch any of them.

**Seven are added, chosen rather than exported.**

| setting | default | what it does |
|---|---|---|
| `TS_VECTOR_SCALED` | on | halves a vector.s bytes, ranking identical |
| `TS_VECTOR_INT8` | off | quantizes further — a quality decision, not a free one |
| `TS_NODE_SUMMARY_VECTOR` | on | node carries its summary vector so it can be scored before the summary is fetched |
| `TS_MALLOC_TRIM` | on | returns freed memory to the OS |
| `TS_SCRATCH_SWEEP` | on | reclaims scratch directories from dead processes |
| `TS_MAX_RETAINED_FINISHED_JOBS` | 64 | each retained status carries its full output |
| `TS_METRICS_MAX_SLOT_SERIES` | 1024 | caps per-slot metric cardinality per shard |

**Why the other 73 are out**, stated rather than implied: 17 are directories or bind addresses and 3 are cluster identity — set by whoever provisions a node; one is the metaserver admin token and belongs in no form; 2 exist only in harnesses; and 24 have no documented default or effect, so there is nothing truthful to print beside them. Exporting the whole list would turn a tuning page into a way for a tenant to break their own store.

**Why they are labelled live.** All seven are read per call, and the engine runs *in this process* — loaded through `ctypes` — so a portal write reaches it immediately. I checked that rather than assuming it; the existing live-claim guard already classifies them through its engine route with no change needed.

**The defaults are derived, not transcribed.** A test reads each accessor and works the default out — `unwrap_or(N)` for a parsed integer, and for a boolean, which spelling of on/off its match arm tests. If the engine changes a default and the portal is not updated, the test fails and names both values. A second test rejects a setting whose variable the engine never reads, because a control that does nothing is worse than an absent one.

Mutation-checked both ways: showing `2048` where the engine uses `1024` fails; offering a knob nothing reads fails. Six config suites pass, 149 tests.