### PR TITLE
Key the retrieval caches by a scope that two tenants cannot share

### DIFF
--- a/tools/matrixark_local_adapter_retrieval.py
+++ b/tools/matrixark_local_adapter_retrieval.py
@@ -206,7 +206,9 @@ class _LocalAdapterRetrievalMixin:
         """
 
         allowed_types = record_types or RETRIEVAL_HOT_RECORD_TYPES
-        scope_key = canonical_scope_key(scope)
+        # cache_scope_key, not canonical_scope_key: the canonical one is "" for an unnormalised
+        # scope, and every tenant would then share one cache entry.
+        scope_key = cache_scope_key(scope)
         secondary_key = tuple(sorted(tuple(sorted(group)) for group in (secondary_index_groups or [])))
         selected_key = tuple(sorted(int(item) for item in (selected_node_hashes or set())))
         cache_key = (

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -633,7 +633,9 @@ class _LocalAdapterRetrieveMixin:
         )
         pack_cache_key = (
             self._retrieval_records_cache_generation,
-            canonical_scope_key(scope),
+            # See cache_scope_key: canonical_scope_key is "" for an unnormalised scope, which
+            # would put every tenant on one cache entry.
+            cache_scope_key(scope),
             query,
             question_type,
             retrieval_session_scope,

--- a/tools/matrixark_mcp_core_identity.py
+++ b/tools/matrixark_mcp_core_identity.py
@@ -403,6 +403,36 @@ def canonical_scope_key(scope: Json) -> str:
     )
 
 
+def cache_scope_key(scope: Json) -> tuple:
+    """A scope key safe to put in a CACHE key, which canonical_scope_key is not.
+
+    canonical_scope_key returns "" for a scope carrying neither scope_key nor tenant_hash -- which
+    is exactly the shape of the documented public scope, {tenant_id, user_id, session_id}. Empty
+    is a fine answer to "what is this scope's canonical name"; it is a dangerous one for a cache
+    key, because every tenant then shares one entry and the second to ask a question is served the
+    first one's answer.
+
+    Reproduced against a shared adapter called with raw scopes: tenant B asked for its own data
+    and was given tenant A's, from both the retrieval-records cache and the context-pack cache.
+    The MCP entry point normalises the scope first, so the served paths are not affected today --
+    but nothing here said so, and a caller that skips normalisation gets cross-tenant answers with
+    no error to notice.
+
+    So this falls back to the raw identifiers rather than to "". It returns a tuple so the two
+    cases can never collide with each other.
+    """
+    canonical = canonical_scope_key(scope)
+    if canonical:
+        return ("k", canonical)
+    return (
+        "raw",
+        str(scope.get("tenant_id") or ""),
+        str(scope.get("user_id") or ""),
+        str(scope.get("session_id") or ""),
+        str(scope.get("agent_id") or ""),
+    )
+
+
 def serving_scope_ref(scope: Json) -> Json:
     key = canonical_scope_key(scope)
     return {"scope_key": key} if key else {}

--- a/tools/matrixark_mcp_identity.py
+++ b/tools/matrixark_mcp_identity.py
@@ -307,6 +307,35 @@ def canonical_scope_key(scope: Json) -> str:
     )
 
 
+def cache_scope_key(scope: Json) -> tuple:
+    """A scope key safe to put in a CACHE key, which canonical_scope_key is not.
+
+    canonical_scope_key returns "" for a scope that carries neither scope_key nor tenant_hash --
+    which is exactly the shape of the documented public scope, {tenant_id, user_id, session_id}.
+    Empty is a fine answer to "what is this scope's canonical name"; it is a dangerous one for a
+    cache key, because every tenant then shares one entry and the second to ask a question is
+    served the first one's answer.
+
+    Reproduced against a shared adapter called with raw scopes: tenant B asked for its own data
+    and received tenant A's. The MCP entry point normalises the scope before this point, so the
+    served paths are not affected -- but nothing here says so, and a caller that skips
+    normalisation gets cross-tenant answers with no error to notice.
+
+    So this falls back to the raw identifiers rather than to "". It returns a tuple to keep the
+    two cases from ever colliding with each other.
+    """
+    canonical = canonical_scope_key(scope)
+    if canonical:
+        return ("k", canonical)
+    return (
+        "raw",
+        str(scope.get("tenant_id") or ""),
+        str(scope.get("user_id") or ""),
+        str(scope.get("session_id") or ""),
+        str(scope.get("agent_id") or ""),
+    )
+
+
 def serving_scope_ref(scope: Json) -> Json:
     key = canonical_scope_key(scope)
     return {"scope_key": key} if key else {}

--- a/tools/test_matrixark_cache_key_separates_tenants.py
+++ b/tools/test_matrixark_cache_key_separates_tenants.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""One adapter serving two tenants must not answer one of them with the other's pack.
+
+`canonical_scope_key` returns "" for a scope carrying neither `scope_key` nor `tenant_hash` --
+which is exactly the shape of the documented public scope, {tenant_id, user_id, session_id}. Both
+the retrieval-records cache and the context-pack cache keyed on it, so with a raw scope every
+tenant shared one entry and the second to ask a question was served the first one's answer.
+
+Reproduced on one adapter with two tenants: tenant B asked what its own pet was called and was
+given tenant A's. Clearing EITHER cache alone did not help, because both keys collapsed the same
+way -- which is what made it look like a selection bug rather than a key bug.
+
+The MCP entry point normalises the scope before this point, so the served paths were not affected.
+That is not something to rely on: nothing at the cache said so, and a caller skipping
+normalisation got cross-tenant answers with no error to notice.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_local_adapter as adapter_module
+import matrixark_mcp_core_identity as core_identity
+import matrixark_mcp_identity as identity
+
+ACME = {"tenant_id": "acme", "user_id": "dana", "session_id": "s1"}
+GLOBEX = {"tenant_id": "globex", "user_id": "rui", "session_id": "s1"}
+QUERY = "what is my pet called"
+
+
+def _seed(log):
+    adapter = adapter_module.MatrixArkLocalAdapter(log)
+    for scope, turns in (
+        (ACME, [("user", "My dog is called Mochi."), ("assistant", "Mochi noted.")]),
+        (GLOBEX, [("user", "My cat is called Pixel."), ("assistant", "Pixel noted.")]),
+    ):
+        for role, content in turns:
+            adapter.ingest({"kind": "message", "scope": scope,
+                            "messages": [{"role": role, "content": content}], "finalize": True})
+    for scope in (ACME, GLOBEX):
+        for name, args in (("session_commit", {"scope": scope}),
+                           ("refresh_summaries", {"scope": scope, "limit": 20})):
+            try:
+                getattr(adapter, name)(args)
+            except Exception:
+                pass
+    return adapter
+
+
+def _served(adapter, scope):
+    pack = adapter.retrieve({"scope": scope, "query": QUERY})
+    return json.dumps(pack.get("selected_refs") or [], default=str)
+
+
+class CacheKeySeparatesTenants(unittest.TestCase):
+    def setUp(self):
+        with adapter_module._LOCAL_READ_CACHE_LOCK:
+            adapter_module._LOCAL_READ_CACHE.clear()
+
+    def test_the_second_tenant_is_not_served_the_first_ones_pack(self):
+        log = Path(tempfile.mkdtemp()) / "events.jsonl"
+        _seed(log)
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+
+        first = _served(adapter, ACME)
+        self.assertIn("Mochi", first, "the first tenant did not get its own content, so the "
+                                      "second getting it would prove nothing")
+        second = _served(adapter, GLOBEX)
+        self.assertNotIn("Mochi", second, "the second tenant was served the first tenant's content")
+        self.assertIn("Pixel", second, "the second tenant was not served its own content")
+
+    def test_a_raw_scope_still_produces_a_distinguishing_cache_key(self):
+        """The mechanism, stated directly: canonical_scope_key collapses, the cache key must not."""
+        for module in (core_identity, identity):
+            self.assertEqual("", module.canonical_scope_key(ACME),
+                             "%s: a raw scope is expected to have no canonical key" % module.__name__)
+            self.assertEqual("", module.canonical_scope_key(GLOBEX))
+            self.assertNotEqual(
+                module.cache_scope_key(ACME), module.cache_scope_key(GLOBEX),
+                "%s: two tenants share one cache key" % module.__name__)
+
+    def test_a_normalised_scope_still_uses_its_canonical_key(self):
+        """The fallback must not take over when there IS a canonical key to use."""
+        for module in (core_identity, identity):
+            normalised = {"scope_key": "tenant|user|session"}
+            self.assertEqual(("k", "tenant|user|session"), module.cache_scope_key(normalised))
+            self.assertNotEqual(module.cache_scope_key(normalised), module.cache_scope_key(ACME))
+
+    def test_both_copies_of_the_helper_agree(self):
+        """There are two identity modules and the live path resolves core_identity. A behavioural
+        check rather than a shared symbol, which is how the twins are already treated here."""
+        for scope in (ACME, GLOBEX, {"scope_key": "x"}, {}):
+            self.assertEqual(core_identity.cache_scope_key(scope), identity.cache_scope_key(scope),
+                             "the two copies disagree for %r" % (scope,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`canonical_scope_key` returns `""` for a scope carrying neither `scope_key` nor `tenant_hash` —
which is exactly the shape of the documented public scope, `{tenant_id, user_id, session_id}`. The
retrieval-records cache and the context-pack cache both key on it, so with a raw scope every
tenant shares one entry, and the second to ask a question is served the first one's answer.

Reproduced on one adapter with two tenants. Tenant B asked what its own pet was called and was
handed tenant A's:

```
family_profile = is called Mochi
```

| one adapter, tenant A asks first | A's content | B's own content |
|---|---|---|
| B asks second | **served to B** | missing |
| pack cache cleared in between | still served | missing |
| records cache cleared in between | still served | missing |
| both cleared | not served | served |

Clearing *either* cache alone did not help, because both keys collapse the same way — which is
what made this look like a selection problem rather than a key problem.

## Reachability

**The MCP entry point normalises the scope before this point, and through it tenant B gets its own
content.** No production caller invokes `adapter.retrieve()` with a raw scope; the only callers are
tests. So this is a latent hazard, not a live leak, and it is filed as one.

It is still worth closing. Nothing at the cache said the normalisation was load-bearing, and a
caller that skipped it got cross-tenant answers with no error to notice.

## The change

`cache_scope_key` falls back to the raw identifiers instead of to `""`, and returns a tuple so the
canonical and raw cases cannot collide with each other. `canonical_scope_key` is left alone: it has
58 callers, and `""` is a reasonable answer to "what is this scope's canonical name" — just not to
"what should this cache be keyed by".

It is added to **both** identity modules. There are two, both define `canonical_scope_key`, and
the live path resolves `matrixark_mcp_core_identity` — not the one an import search finds first. A
test asserts the two agree rather than sharing a symbol, which is how this codebase already treats
the pair.

## Checks

- The regression test fails without the fix, with the leaked row printed in the assertion, and
  passes with it.
- A control asserts tenant A gets its own content first, so "B was not served A's" cannot pass
  vacuously by serving nothing.
- `test_matrixark_retrieve*`, `test_matrixark_mem0*`, `test_matrixark_skill*`,
  `test_attachment_resource_policy`, `test_matrixark_index*`, `test_engine_purge_on_delete`,
  `test_delete_before_extract`, `test_matrixark_embedding_status` all pass.
- 5 files, 168 insertions, 2 deletions, no file deletions.
