### PR TITLE
A test emptied sys.modules for the whole tree and left it that way

### DIFF
--- a/tools/test_matrixark_index_posting_coalescing.py
+++ b/tools/test_matrixark_index_posting_coalescing.py
@@ -42,11 +42,28 @@ def _emit(coalesced, chunk_count=40):
         # filter has its own tests in test_matrixark_index_consultable_terms.
         "MATRIXARK_INDEX_ONLY_CONSULTABLE_TERMS": "0",
     })
-    for name in [m for m in list(sys.modules) if m.startswith("matrixark_")]:
+    # Rebuild the three modules below so they re-read the flags just set -- and put every
+    # other module's identity back afterwards.
+    #
+    # Evicting the whole `matrixark_` tree and leaving it evicted is not free: a module that
+    # another test file already holds by name keeps pointing at the OLD object, while the next
+    # `import` anywhere rebuilds a NEW one. For a module whose state is a process-wide
+    # singleton that splits it in two. `matrixark_ingestion_jobs.REGISTRY` is one: the retry
+    # tests register a job in the registry they hold, the gateway route reads the rebuilt
+    # module's empty registry, and the route answers 404 for a job created a line earlier.
+    # Those tests pass alone and fail under discovery, which is what that looks like from
+    # outside.
+    saved = {n: m for n, m in list(sys.modules.items()) if n.startswith("matrixark_")}
+    for name in saved:
         del sys.modules[name]
-    parser = importlib.import_module("matrixark_resource_parser")
-    emitter = importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
-    core = importlib.import_module("matrixark_mcp_core")
+    try:
+        parser = importlib.import_module("matrixark_resource_parser")
+        emitter = importlib.import_module("matrixark_mcp_ingest_resource_chunk_records")
+        core = importlib.import_module("matrixark_mcp_core")
+    finally:
+        # The locals above keep the freshly built modules, which is what this function needs;
+        # sys.modules goes back to what the rest of the suite already has bound.
+        sys.modules.update(saved)
 
     newline = chr(10)
     body = (newline * 2).join(


### PR DESCRIPTION
`_emit` in test_matrixark_index_posting_coalescing rebuilds three modules so they re-read
the flags it has just set. To do that it evicted every module whose name begins with
`matrixark_`, and never put any of them back:

    for name in [m for m in list(sys.modules) if m.startswith("matrixark_")]:
        del sys.modules[name]

Rebuilding the three is the point. Evicting the rest of the tree is collateral, and it does
not end when the function does: a module that another test file already holds by name keeps
pointing at the OLD object, while the next `import` anywhere builds a NEW one. For a module
whose state is a process-wide singleton, that splits the singleton in two.

`matrixark_ingestion_jobs.REGISTRY` is one. The retry tests register a job in the registry
they hold; the gateway's retry route imports the module at request time, gets the rebuilt
copy with an empty registry, and answers 404 for a job created a line earlier. The tests
report it as `409 != 404`, `202 != 404`, `400 != 404`.

Measured at the point of failure, both sides naming the same module and the same file:

    handler: registry id=124223092909168  n=0  keys=[]
    test   : registry id=124224219891408  n=1  keys=['stub']

One entry in sys.modules, two registries.

The eviction now restores what it took: the three modules the function needs are still built
fresh, in its own locals, and every other module's identity goes back for the rest of the
suite.

Under `unittest discover` from tools/, which is how the ratchet runs it:

    before   113 failures + 26 errors,  8 of them in test_matrixark_ingestion_retry
    after    101 failures + 23 errors,  0 of them in test_matrixark_ingestion_retry

test_matrixark_index_posting_coalescing still passes on its own.

Worth knowing for the next one of these: the tests it broke pass when run per-module and
fail only in the suite, so a per-file sweep reports them green. Three neighbouring files
evict from sys.modules too, each scoped to the one module it is rebuilding.

