### PR TITLE
Hold a bucket's object ids in two words instead of four

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -329,7 +329,13 @@ pub(super) enum ObjectIndex {
     #[default]
     Empty,
     One(u64),
-    Many(BTreeSet<u64>),
+    /// Boxed: this is the rare arm, and an enum is as wide as its widest.
+    ///
+    /// Held inline, the set made every `ObjectIndex` 32 bytes whether or not a set existed, and a
+    /// `BucketNode` carries two of them -- one of which, `deleted_object_index`, is Empty for the
+    /// whole life of almost every bucket. Behind a box the enum is 16, and the box is only
+    /// allocated by the buckets that actually hold more than one object.
+    Many(Box<BTreeSet<u64>>),
 }
 
 pub(super) enum ObjectIndexIter<'a> {
@@ -384,7 +390,7 @@ impl ObjectIndex {
                 let mut set = BTreeSet::new();
                 set.insert(first);
                 set.insert(id);
-                *self = ObjectIndex::Many(set);
+                *self = ObjectIndex::Many(Box::new(set));
                 true
             }
             ObjectIndex::Many(set) => set.insert(id),
@@ -423,7 +429,7 @@ impl ObjectIndex {
                     ObjectIndex::Many(set) => set,
                     _ => unreachable!("just matched Many"),
                 };
-                *self = ObjectIndex::One(set.into_iter().next().expect("length is one"));
+                *self = ObjectIndex::One((*set).into_iter().next().expect("length is one"));
             }
             _ => {}
         }
@@ -465,7 +471,7 @@ impl IntoIterator for ObjectIndex {
         match self {
             ObjectIndex::Empty => Vec::new().into_iter(),
             ObjectIndex::One(id) => vec![id].into_iter(),
-            ObjectIndex::Many(set) => set.into_iter().collect::<Vec<_>>().into_iter(),
+            ObjectIndex::Many(set) => (*set).into_iter().collect::<Vec<_>>().into_iter(),
         }
     }
 }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5787,6 +5787,35 @@ fn a_bucket_holding_one_page_holds_no_node() {
 
 
 
+/// An `ObjectIndex` is two words, so the set arm cannot widen the bucket that almost never uses it.
+///
+/// A `BucketNode` carries two of these, and one of them -- `deleted_object_index` -- is Empty for
+/// the whole life of almost every bucket. Held inline, a `BTreeSet` made both of them as wide as
+/// the arm neither was using. The number here is what stops that from silently coming back: a
+/// future arm holding anything larger than a pointer widens every bucket in the shard.
+#[test]
+fn an_object_index_costs_a_word_and_a_pointer() {
+    use crate::engine::state::ObjectIndex;
+    assert_eq!(
+        std::mem::size_of::<ObjectIndex>(),
+        2 * std::mem::size_of::<usize>(),
+        "ObjectIndex should be a discriminant and one pointer-sized payload"
+    );
+
+    // And the shape it takes is still the shape the bucket needs: one id inline, two in a set.
+    let mut index = ObjectIndex::default();
+    assert!(index.is_empty());
+    assert!(index.insert(7));
+    assert_eq!(index.len(), 1);
+    assert!(index.contains(&7));
+    assert!(index.insert(9));
+    assert_eq!(index.len(), 2);
+    assert_eq!(index.iter().copied().collect::<Vec<_>>(), vec![7, 9]);
+    // Back down to one id, the set is given up rather than kept for the bucket's life.
+    assert!(index.remove(&7));
+    assert!(matches!(index, ObjectIndex::One(9)), "one id is held inline again");
+}
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key


### PR DESCRIPTION
A `BucketNode` carries two `ObjectIndex` values, and one of them -- the deleted set -- is Empty for
the whole life of almost every bucket. Held inline, a `BTreeSet` made both of them 32 bytes wide
whether or not a set existed, because an enum is as wide as its widest arm. Boxed, the rare arm
costs a discriminant and a pointer, and only the buckets that genuinely hold more than one object
allocate anything.

A bucket holds one object id in the ordinary case: keys route one to a bucket, and an object with
many components is still one object.

**`BucketNode`: 240 -> 208 bytes. A key costs the index 1,022 -> 969 live bytes, 5.2% off.**

Measured as allocated-minus-freed over 2,000 keys, as a paired A/B in one tree with the same build
flags. That pairing is the point: an earlier number taken from a different build made the same
change look like it did nothing.

The test asserts the size rather than printing it, so a future arm holding anything larger than a
pointer cannot silently widen every bucket in the shard again. It also walks the shape -- one id
inline, two in a set, and back to inline when one is removed, since giving the set up again is
what stops a bucket that briefly held two objects from keeping a node for the rest of its life.