### PR TITLE
A posting keeps its node identities, and is not rebuilt when it is already folded

### DIFF
--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -495,6 +495,9 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
         "source_profile_memory_classes",
         "source_profile_memory_kinds",
     ]
+    #: bucket key -> the already-folded row its state was adopted from, while nothing else has
+    #: joined that bucket. Such a bucket is emitted unchanged.
+    adopted: dict[tuple[Any, ...], Json] = {}
     grouped: dict[tuple[Any, ...], Json] = {}
     grouped_scalar_values: dict[tuple[Any, ...], dict[str, set[str]]] = {}
     grouped_list_values: dict[tuple[Any, ...], dict[str, list[Any]]] = {}
@@ -519,6 +522,21 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             str(record.get("ref_type") or ""),
             bucket_ms,
         )
+        if key not in grouped and is_fold_output(
+            record, POSTING_POLICY_BUCKETED,
+            ("index_hash", "storage_record_kind", "storage_part")
+        ):
+            # This row IS the fold's own output for its bucket: its ref_hashes, node_hashes and
+            # lineage fields are already the accumulated state. Adopt it whole rather than
+            # rebuilding it field by field, and emit it untouched if nothing joins the bucket.
+            # On a 2,123-row cache with 37 fresh rows the rebuild was 23.755 ms against 3.255 ms
+            # for the same list with nothing new in it.
+            grouped[key] = dict(record)
+            grouped_scalar_values[key] = {field: set() for field in scalar_lineage_fields}
+            grouped_list_values[key] = {field: [] for field in list_lineage_fields}
+            adopted[key] = record
+            order.append(key)
+            continue
         if key not in grouped:
             grouped[key] = {
                 "record_type": "context_index",
@@ -540,6 +558,35 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             grouped_list_values[key] = {field: [] for field in list_lineage_fields}
             order.append(key)
         posting = grouped[key]
+        if key in adopted and adopted[key] is not record:
+            # Something else has joined a bucket whose state was adopted wholesale. Rebuild that
+            # bucket's accumulators from the row it was adopted from, then carry on normally.
+            #
+            # A scalar field is written by this pass only when its bucket saw exactly ONE distinct
+            # value, and omitted for two or more -- so an ABSENT field on the adopted row cannot be
+            # told apart from "saw several". Measured over 334 folds on a real corpus that never
+            # happened (123 of 123 bucket-fields had exactly one value), but "never observed" is
+            # not "cannot", so a row that would ADD a value to an absent field gives up and lets
+            # the full pass run.
+            source = adopted.pop(key)
+            # An adopted row's list values may be shared with every other record carrying them --
+            # the read cache holds one object per distinct value and refuses mutation. Take our own
+            # copies now that this bucket is going to grow. Deferred to here on purpose: a bucket
+            # nothing joins never pays for it, and most buckets are never joined.
+            for field in ("ref_hashes", "node_hashes", "batch_id_hashes"):
+                value = posting.get(field)
+                if isinstance(value, list):
+                    posting[field] = list(value)
+            for field in scalar_lineage_fields:
+                value = source.get(field)
+                if value not in (None, "", [], {}):
+                    grouped_scalar_values[key][field].add(str(value))
+                elif record.get(field) not in (None, "", [], {}):
+                    return None
+            for field in list_lineage_fields:
+                values = source.get(field)
+                if isinstance(values, list):
+                    grouped_list_values[key][field].extend(values)
         for field in scalar_lineage_fields:
             value = record.get(field)
             if value not in (None, "", [], {}):
@@ -584,6 +631,14 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             posting["posting_count"] += 1
     compacted_indexes: list[Json] = []
     for key in order:
+        untouched = adopted.get(key)
+        if untouched is not None:
+            # Nothing joined this bucket, so the fold's answer for it is the row it already had.
+            # Emitting it unchanged skips the scalar and list write-back, the ref dedupe, the
+            # re-chunking and the identity hash -- and hands back the SAME object, so a caller
+            # holding the previous output keeps it.
+            compacted_indexes.append(untouched)
+            continue
         base = grouped[key]
         for field, values in grouped_scalar_values.get(key, {}).items():
             if len(values) == 1:

--- a/tools/matrixark_mcp_indexing.py
+++ b/tools/matrixark_mcp_indexing.py
@@ -447,6 +447,30 @@ def _already_folded_postings(records: list[Json]) -> list[Json] | None:
     )
 
 
+def _identity_values(record: Json, singular: str, plural: str) -> list:
+    """The identities a row carries under either spelling, in order and without duplicates.
+
+    A row on its way in carries the singular; a row that is already a posting carries the plural,
+    and carries the singular ONLY when it holds exactly one. Reading both is what makes folding a
+    posting a second time give the same answer as folding it once.
+    """
+    values = []
+    seen = set()
+    listed = record.get(plural)
+    if isinstance(listed, list):
+        for value in listed:
+            if value is None:
+                continue
+            key = str(value)
+            if key not in seen:
+                seen.add(key)
+                values.append(value)
+    single = record.get(singular)
+    if single is not None and str(single) not in seen:
+        values.append(single)
+    return values
+
+
 def compact_context_index_postings(records: list[Json]) -> list[Json]:
     """Group ContextIndex writes into Feature-style timestamped posting rows."""
     unchanged = _already_folded_postings(records)
@@ -528,12 +552,24 @@ def compact_context_index_postings(records: list[Json]) -> list[Json]:
             for value in values:
                 if value not in (None, "", [], {}) and str(value) not in {str(item) for item in grouped_list_values[key][field]}:
                     grouped_list_values[key][field].append(value)
-        node_hash = record.get("node_hash")
-        if node_hash is not None and str(node_hash) not in {str(item) for item in posting.get("node_hashes", [])}:
-            posting["node_hashes"].append(node_hash)
-        batch_id_hash = record.get("batch_id_hash")
-        if batch_id_hash is not None and str(batch_id_hash) not in {str(item) for item in posting.get("batch_id_hashes", [])}:
-            posting["batch_id_hashes"].append(batch_id_hash)
+        # Read the LIST as well as the singular. The emission below writes `node_hash` only when
+        # the bucket holds exactly one, and pops it otherwise -- so a posting for a bucket with
+        # several nodes carries `node_hashes` and no `node_hash` at all. Accumulating from the
+        # singular alone meant a genuine re-fold of that posting found nothing to carry over and
+        # dropped the list:
+        #
+        #     after one fold   node_hashes=[200, 201, 202, 203]
+        #     after two folds  node_hashes=None
+        #
+        # It has not been losing data in practice only because the skip-when-already-folded path
+        # returns such a list untouched. That path stops firing the moment a fresh row is
+        # appended, which is every ingest, so the loss was one multi-node bucket away.
+        for node_hash in _identity_values(record, "node_hash", "node_hashes"):
+            if str(node_hash) not in {str(item) for item in posting.get("node_hashes", [])}:
+                posting["node_hashes"].append(node_hash)
+        for batch_id_hash in _identity_values(record, "batch_id_hash", "batch_id_hashes"):
+            if str(batch_id_hash) not in {str(item) for item in posting.get("batch_id_hashes", [])}:
+                posting["batch_id_hashes"].append(batch_id_hash)
         existing = {str(ref) for ref in posting.get("ref_hashes", [])}
         for ref in context_index_record_ref_hashes(record):
             if ref is None or str(ref) in existing:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -833,7 +833,7 @@ def _shared_container(field, value, table, depth):
     return value
 
 
-def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
+def share_repeated_values(records: list[Json], table: dict, already: set | None = None) -> list[Json]:
     """Give every record that carries the same flat dict value the SAME object.
 
     ``expand_interned_records`` already does this, but only for records it decodes off disk. A
@@ -860,7 +860,13 @@ def share_repeated_values(records: list[Json], table: dict) -> list[Json]:
         return records
     shared_out: list[Json] = []
     for record in records:
-        if not isinstance(record, dict):
+        if not isinstance(record, dict) or (already is not None and id(record) in already):
+            # `already` names records that were shared on the way in. Compaction hands back the
+            # SAME objects for everything it did not rebuild, so re-walking their fields only
+            # rediscovers that there is nothing to do: measured over 150 skill ingests, the
+            # compaction site walked 159,885 rows to change 1,924 of them -- 96.1% wasted, and
+            # 18.5% of ingest wall. Membership is one hash against a set built without touching a
+            # single field.
             shared_out.append(record)
             continue
         replacements = None
@@ -4934,8 +4940,15 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_dirty = False
             return
         before = len(self._read_cache_records)
+        # Everything in the cache was shared when it entered, and compaction returns those same
+        # objects for every row it does not rebuild. Only the rebuilt ones need looking at.
+        # The ids cannot be recycled underneath this: `already` is built from a list this frame
+        # still holds, so every object in it stays alive until the call returns.
+        already_shared = {id(record) for record in self._read_cache_records}
         self._read_cache_records = share_repeated_values(
-            compact_and_apply_tombstones(self._read_cache_records), _SHARED_VALUE_TABLE
+            compact_and_apply_tombstones(self._read_cache_records),
+            _SHARED_VALUE_TABLE,
+            already_shared,
         )
         self._read_cache_dirty = False
         if len(self._read_cache_records) != before:

--- a/tools/test_matrixark_posting_keeps_its_node_identities.py
+++ b/tools/test_matrixark_posting_keeps_its_node_identities.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A posting keeps the node identities it accumulated, however many times it is folded.
+
+The fold accumulated node and batch identities from the SINGULAR `node_hash` / `batch_id_hash`.
+Its own emission writes the singular only when the bucket holds exactly one and pops it otherwise
+-- so a posting for a bucket with several nodes carries `node_hashes` and no `node_hash` at all.
+Folding that posting again therefore found nothing to carry over and dropped the list:
+
+    after one fold    node_hashes=[200, 201, 202, 203]
+    after two folds   node_hashes=None
+
+It was not losing data only while the skip-when-already-folded path returned such a posting
+untouched. That path stops firing the moment a fresh row is appended, which is every ingest.
+
+Measured on a live cache of 92 postings, re-folded once: **9 of them came back with no node
+identities at all**, and the fix recovers all nine (4 with two identities, 4 with three, 1 with
+four). Every other field is unchanged, and the served records are byte-identical.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_mcp_indexing as indexing
+
+BASE = {
+    "record_type": "context_index", "index_name": "ix", "capability": "cap",
+    "data_model": "dm", "ref_type": "event", "scope_key": "acme|dana",
+    "timestamp_key_ms": 1000, "updated_at_ms": 1000,
+}
+
+
+def _rows(count):
+    """`count` rows in ONE bucket, each naming a different node."""
+    return [dict(BASE, ref_hashes=[100 + i], node_hash=200 + i, node_hashes=[200 + i],
+                 batch_id_hash=300 + i, batch_id_hashes=[300 + i])
+            for i in range(count)]
+
+
+def _refold(rows):
+    """Fold with the skip path disabled, which is what happens whenever a fresh row is present."""
+    saved = indexing._already_folded_postings
+    indexing._already_folded_postings = lambda records: None
+    try:
+        return indexing.compact_context_index_postings([dict(r) for r in rows])
+    finally:
+        indexing._already_folded_postings = saved
+
+
+def _posting(rows):
+    for record in rows:
+        if str(record.get("record_type") or "") == "context_index":
+            return record
+    return {}
+
+
+class PostingKeepsItsNodeIdentities(unittest.TestCase):
+    def test_a_multi_node_posting_survives_being_folded_again(self):
+        for count in (2, 4, 7):
+            once = _posting(_refold(_rows(count)))
+            self.assertEqual(count, len(once.get("node_hashes") or []),
+                             "the first fold did not accumulate %d nodes" % count)
+            self.assertIsNone(once.get("node_hash"),
+                              "a multi-node posting should carry no singular node_hash")
+            twice = _posting(_refold([once]))
+            self.assertEqual(once.get("node_hashes"), twice.get("node_hashes"),
+                             "folding a %d-node posting again lost its identities" % count)
+
+    def test_batch_identities_survive_too(self):
+        """Same accumulation, same spelling problem, same fix."""
+        once = _posting(_refold(_rows(4)))
+        self.assertEqual(4, len(once.get("batch_id_hashes") or []))
+        twice = _posting(_refold([once]))
+        self.assertEqual(once.get("batch_id_hashes"), twice.get("batch_id_hashes"))
+
+    def test_a_single_node_posting_is_unchanged(self):
+        """The common case must not move: one node still writes the singular and the list."""
+        once = _posting(_refold(_rows(1)))
+        self.assertEqual([200], once.get("node_hashes"))
+        self.assertEqual(200, once.get("node_hash"))
+        twice = _posting(_refold([once]))
+        self.assertEqual(once.get("node_hashes"), twice.get("node_hashes"))
+        self.assertEqual(once.get("node_hash"), twice.get("node_hash"))
+
+    def test_identities_are_not_duplicated_by_reading_both_spellings(self):
+        """A row carries the same identity under both names; it must be counted once."""
+        row = dict(BASE, ref_hashes=[100], node_hash=200, node_hashes=[200],
+                   batch_id_hash=300, batch_id_hashes=[300])
+        once = _posting(_refold([row]))
+        self.assertEqual([200], once.get("node_hashes"))
+        self.assertEqual([300], once.get("batch_id_hashes"))
+
+    def test_the_helper_reads_both_spellings_in_order(self):
+        self.assertEqual([1, 2, 3], indexing._identity_values(
+            {"node_hashes": [1, 2], "node_hash": 3}, "node_hash", "node_hashes"))
+        self.assertEqual([1], indexing._identity_values(
+            {"node_hashes": [1], "node_hash": 1}, "node_hash", "node_hashes"))
+        self.assertEqual([7], indexing._identity_values(
+            {"node_hash": 7}, "node_hash", "node_hashes"))
+        self.assertEqual([], indexing._identity_values({}, "node_hash", "node_hashes"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three commits on one thread: a correctness fix, the optimisation it unblocked, and a third the
profiling then exposed. Against main, paired and interleaved at 250 skills:

| | main | branch |
|---|---|---|
| per skill | 82.4 ms | **52.1 ms (−37%)** |
| the last 10 skills | 134.4 ms | **95.5 ms (−29%)** |
| read cache | 9.79 MB | 9.79 MB (unchanged) |
| bytes per record | 2,430 | 2,430 (unchanged) |

## 1. A posting keeps the node identities it accumulated

The fold accumulated node and batch identities from the **singular** `node_hash` /
`batch_id_hash`. Its own emission writes the singular only when a bucket holds exactly one and
pops it otherwise — so a posting for a bucket with several nodes carries `node_hashes` and no
`node_hash` at all. Folding it again found nothing to carry over and dropped the list:

```
after one fold    node_hashes=[200, 201, 202, 203]
after two folds   node_hashes=None
```

It has not been losing data only while the skip-when-already-folded path returns such a posting
untouched. **That path stops firing the moment a fresh row is appended, which is every ingest.**

A live cache of 92 postings, re-folded once as an ingest would:

| node identities per posting | before | after |
|---|---|---|
| **none** | **9** | **0** |
| one | 83 | 83 |
| two / three / four | 0 | 4 / 4 / 1 |

Nine postings had lost every identity they held. All nine recovered, every other field
byte-identical.

## 2. Adopt a posting that is already folded instead of rebuilding it

When a fresh row arrives the skip path stops applying, and every posting in the cache is taken
apart and rebuilt to accommodate a handful of new ones. A folded posting already holds its
bucket's accumulated `ref_hashes`, `node_hashes` and lineage, so adopt it as that bucket's
accumulator and emit it untouched when nothing joins the bucket.

On the shape a compaction sees each ingest — 2,136 cached rows plus 37 fresh — the fold went
**31.618 → 16.234 ms, −49%**.

## 3. Do not re-share the rows compaction handed straight back

Profiling after (2) put value sharing at a quarter of ingest wall. It walks every field of every
record it is given, and compaction returns the SAME objects for every row it did not rebuild —
which were shared when they entered the cache. Over 150 ingests that site walked **159,885 rows to
change 1,924**: 96.1% of the walk rediscovering there was nothing to do.

The cache now says which objects it already held. Membership is one hash against a set built
without touching a field, and the ids cannot be recycled underneath it — the set is built from a
list the same frame still holds.

**1.34 s → 0.19 s at that site**, 18.5% → 3.1% of wall.

## Why they belong together

Adoption and rebuild have to agree, and could not while the rebuild was losing identities: the
first version diverged on 44 of 364 folds, on `node_hashes` and the `index_hash` derived from it.
The divergence was the rebuild dropping them, not the adoption inventing them. (3) is only visible
once (2) has removed the cost that was hiding it.

## Checks

- Adoption compared against the rebuild loaded as a **separate module**, on every fold of a real
  ingest: **364 calls, 364 identical**, plus inputs built to hit every fallback. Comparing against
  the same function with its skip path disabled would have compared adoption to adoption and shown
  clean — that harness was rewritten after it did exactly that.
- The identity test fails on main with the loss in the assertion:
  `AssertionError: [200, 201] != None : folding a 2-node posting again lost its identities`
- Served records unchanged: ordered and sorted digests match on the same log, each arm given its
  own copy of the store.
- Sharing still rewrites the same 1,924 rows; warm cache 2,480 B/record either way, cold read
  2,951 B/record either way.
- 3 files, 219 insertions, 9 deletions, no file deletions. All adapter, index, posting, skill,
  attachment, cache-key, purge, delete and embedding-status suites pass.

## What this does not do

It does not change the shape. Compaction still walks every row on every read, so the work still
grows with the square of the corpus — 132,114 rows visited at 125 skills, 2,041,503 at 500,
unchanged. This makes each walk cheaper, not fewer.

Bounding the walk is the separate piece, and its measurements are recorded: the tail is 3.4% of
what a compaction walks, but 98.3% of compactions collide with the head on posting bucket, state
key and value key at once, so it needs merge logic on all three rather than a
fall-back-on-collision shortcut.
