### PR TITLE
A ten-entry list slice copied the whole list

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1224,12 +1224,11 @@ pub(crate) fn execute_on_shard(
                     mutated,
                 };
             }
-            let addresses: Vec<BlockAddress> = shard
-                .lists
-                .get(&key)
-                .map(|list| list.values().cloned().collect())
-                .unwrap_or_default();
-            let length = addresses.len() as i64;
+            // The length comes from the map itself -- `ListLen` below takes the same number the
+            // same way. Copying every address to obtain it, and to index a slice of it, meant a
+            // ten-entry page of a four-thousand-entry list copied four thousand addresses.
+            let list = shard.lists.get(&key);
+            let length = list.map_or(0, |list| list.len()) as i64;
             let resolve = |index: i64| -> i64 {
                 if index < 0 {
                     length + index
@@ -1242,10 +1241,19 @@ pub(crate) fn execute_on_shard(
             let members = if from > to || length == 0 {
                 Vec::new()
             } else {
-                addresses[from as usize..=to as usize]
-                    .iter()
-                    .filter_map(|address| read_page_bytes(cache, page_store, shard_id, address))
-                    .collect()
+                // A BTreeMap iterates in key order, which is the list's order -- the same order the
+                // materialised Vec had. Only the requested span is visited.
+                let wanted = (to - from + 1) as usize;
+                list.map(|list| {
+                    list.values()
+                        .skip(from as usize)
+                        .take(wanted)
+                        .filter_map(|address| {
+                            read_page_bytes(cache, page_store, shard_id, address)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
             };
             CommandResponse::Members { members }
         }

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -12645,3 +12645,115 @@ fn does_a_sequence_count_narrow_the_read() {
 "
     );
 }
+
+
+/// What does `ListRange` cost as the list grows, asked for a fixed slice?
+///
+/// The arm clones EVERY address in the list into a fresh Vec, purely to learn `length` and index a
+/// slice; only the slice is then read from pages. `ListLen` beside it takes the same length from
+/// `BTreeMap::len` for free, which is what shows the materialisation buys nothing.
+///
+/// `ListLen` is the control here: flat by construction, so if it moves the harness is the suspect.
+///
+///   cargo test --features alloc-probe -p temporalstore-rust --lib what_a_fixed_list_slice_costs_as_the_list_grows -- --ignored --nocapture --test-threads=1
+#[test]
+#[ignore]
+fn what_a_fixed_list_slice_costs_as_the_list_grows() {
+    let canary = crate::alloc_probe::Probe::start();
+    let sink: Vec<u8> = Vec::with_capacity(8192);
+    assert!(
+        canary.stop().allocs > 0,
+        "counting allocator not installed -- rerun with `--features alloc-probe`"
+    );
+    drop(sink);
+
+    println!(
+        "
+  entries   range(first 10)   bytes   returned      len   bytes     push
+"
+    );
+
+    for size in [256_usize, 1024, 4096] {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            64 * 1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+
+        for index in 0..size {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: Command::ListPush {
+                    key: "feed".to_string(),
+                    member: format!("entry-{index:08}").into_bytes(),
+                    left: false,
+                },
+            });
+            assert!(out.status.ok, "push {index}: {:?}", out.status);
+        }
+
+        let measure = |command: Command| {
+            let request = || ExecuteRequest { shard_id: 1, command: command.clone() };
+            let warm = engine.execute(request());
+            assert!(warm.status.ok, "{:?}", warm.status);
+            let probe = crate::alloc_probe::Probe::start();
+            let out = engine.execute(request());
+            let counts = probe.stop();
+            assert!(out.status.ok, "{:?}", out.status);
+            (counts.allocs, counts.alloc_bytes, out.response)
+        };
+
+        // Ten entries out of `size` -- the shape a caller paging a feed actually asks for.
+        let (range_allocs, range_bytes, range_response) = measure(Command::ListRange {
+            key: "feed".to_string(),
+            start: 0,
+            stop: 9,
+        });
+        let returned = match &range_response {
+            CommandResponse::Members { members } => members.len(),
+            other => panic!("expected members, got {other:?}"),
+        };
+        assert_eq!(
+            returned, 10,
+            "the slice must return exactly 10 entries, got {returned} -- otherwise this column is \
+             not the cost of the query it is named for"
+        );
+
+        // Control: the length, which comes straight from BTreeMap::len.
+        let (len_allocs, len_bytes, len_response) = measure(Command::ListLen {
+            key: "feed".to_string(),
+        });
+        match &len_response {
+            CommandResponse::Integer { value } => assert_eq!(
+                *value as usize, size,
+                "the control must report the whole list, or it is measuring the wrong list"
+            ),
+            other => panic!("expected an integer, got {other:?}"),
+        }
+
+        let (push_allocs, _, _) = measure(Command::ListPush {
+            key: "feed".to_string(),
+            member: b"one-more".to_vec(),
+            left: false,
+        });
+
+        println!(
+            "  {size:>7}   {range_allocs:>15}   {range_bytes:>5}   {returned:>8}   {len_allocs:>6}   {len_bytes:>5}   {push_allocs:>6}"
+        );
+    }
+
+    println!(
+        "
+  range BYTES flat  => the slice costs the slice. Watch the bytes, not the count: the whole-list
+                       copy was ONE Vec, so the allocation count was already flat at ~41 while the
+                       bytes ran 17,926 -> 263,686. A count-only probe would have called this clean.
+  range bytes rising => the whole list is being copied again before the slice is taken.
+  len flat           => the control works, so the columns above mean what they say.
+  push rising        => expected here, and NOT this arm's doing: a push clones one cache key per
+                       entry the list already holds, inside invalidate_record. Separate finding.
+"
+    );
+}


### PR DESCRIPTION
`ListRange` materialised every address in the list to hand back a slice of it:

```rust
let addresses: Vec<BlockAddress> = shard.lists.get(&key)
    .map(|list| list.values().cloned().collect())   // all n
    .unwrap_or_default();
let length = addresses.len() as i64;
```

That `Vec` exists for two things — a length, and indexing. `ListLen`, immediately below it in the same
file, takes the identical length from `BTreeMap::len` for free, so the length never needed the copy;
and the slice can be walked with `skip`/`take`, which is what the code then does with the `Vec` anyway.

## Measured

Slice held at ten entries, list grown:

| entries | range(10) allocs | bytes before | bytes after | returned | len (control) |
|---:|---:|---:|---:|---:|---:|
| 256 | 41 | 17,926 | **1,542** | 10 | 8 |
| 1,024 | 41 | 67,078 | **1,542** | 10 | 8 |
| 4,096 | 41 | 263,686 | **1,542** | 10 | 8 |

**171× fewer bytes** at 4,096 entries, and constant across a sixteenfold list.

**Watch the bytes, not the count.** The allocation count was 42 before and 41 after — the whole-list
copy was a *single* `Vec`, so counting allocations showed nothing while the bytes ran 17,926 → 263,686.
A count-only probe would have called this clean. `ListLen` is the control and never moves.

## What is unchanged

The `push` column stays at 16,488 allocations on a 4,096-entry list. That is a **separate** cost, not
this arm's doing: every push clones one cache key per entry the list already holds, inside
`invalidate_record`, which also affects `ZSetAdd` identically (16,491 at the same size). It needs a
change in a different repo and is not addressed here — the probe's legend says so, so the column is not
read as a regression in this change.

`skip(n)` on a `BTreeMap` iterator is a walk rather than a seek, so a deep offset still steps over the
entries it skips. What is removed is the *copying* of every address; for a caller paging from the
front — the common case, and what this measures — the walk is short.

## Verification

* Existing list tests: 13 passed, 0 failed.
* The probe asserts the slice returns exactly ten entries and that the control reports the whole list,
  so neither column can come from a query that quietly returned something else.
* Full lib suite, serial.
* The harness is `#[ignore]`, so it does not run in the ordinary suite.
