### PR TITLE
The storage tuning family, and the scan that could not see it

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -334,6 +334,56 @@ SETTINGS: List[Setting] = [
     # whoever provisions a node, and knobs with no documented default have nothing truthful to show
     # in a form. Every default below is the engine's own -- see
     # test_matrixark_engine_settings_match_the_engine.
+    # ---- storage engine: page and slab geometry -------------------------------------------
+    # These are read through StorageTuningConfig::from_getter, which passes a name constant to a
+    # closure -- so they never appear beside env::var and a name-literal scan of the engine does
+    # not see them at all. Eighteen knobs hide that way; these nine are the tuning family.
+    Setting("storage_engine.context_page_target_bytes", "storage_engine",
+            "TS_CONTEXT_PAGE_TARGET_BYTES",
+            "Target size of a context page", "int", "65536", "live",
+            "How large a page grows before the engine starts another. Smaller pages read less per "
+            "lookup and cost more of them; larger pages amortise better and waste more on a partial "
+            "read. Values below 1 KiB are raised to it."),
+    Setting("storage_engine.block_slab_target_bytes", "storage_engine",
+            "TS_BLOCK_SEGMENT_TARGET_BYTES",
+            "Target size of a block segment", "int", "1073741824", "live",
+            "The unit page-slab reclaim works in. A slab is retained while any loaded shard still "
+            "references it, so larger slabs mean fewer, coarser reclaims."),
+    Setting("storage_engine.storage_zone_size", "storage_engine",
+            "TS_STORAGE_ZONE_SIZE",
+            "Storage zone size", "int", "1073741824", "live",
+            "The span the band and zone catalog accounts in. It sets the granularity of what "
+            "compaction and the catalog can talk about, not how much is stored."),
+    Setting("storage_engine.stream_max_blob_size", "storage_engine",
+            "TS_STREAM_MAX_BLOB_SIZE",
+            "Largest streamed blob", "int", "10485760", "live",
+            "The ceiling on a single streamed payload. Raising it admits larger objects and raises "
+            "the peak memory a single request can hold."),
+    Setting("storage_engine.compaction_watermark_bytes", "storage_engine",
+            "TS_COMPACTION_WATERMARK_BYTES",
+            "Compaction watermark", "int", "268435456", "live",
+            "How much uncompacted growth is tolerated before compaction is due. Lower compacts more "
+            "often for steadier size; higher defers the work and lets the store run larger."),
+    Setting("storage_engine.cold_scan_no_cache_fill", "storage_engine",
+            "TS_COLD_SCAN_NO_CACHE_FILL",
+            "Cold scans do not fill the cache", "bool", "1", "live",
+            "On, a scan that misses does not evict warm entries to make room for pages it will not "
+            "read again. Turn it off only if your workload rescans the same cold range."),
+    Setting("storage_engine.page_index_cache_bytes", "storage_engine",
+            "TS_PAGE_INDEX_CACHE_BYTES",
+            "Page index cache", "int", "67108864", "live",
+            "Memory held for page index entries. This is resident memory the process keeps, so it "
+            "is a direct trade of footprint against lookup latency."),
+    Setting("storage_engine.block_index_cache_bytes", "storage_engine",
+            "TS_BLOCK_INDEX_CACHE_BYTES",
+            "Block index cache", "int", "67108864", "live",
+            "Memory held for block index entries. Same trade as the page index cache, on the block "
+            "side."),
+    Setting("storage_engine.index_dump_wal_gap_bytes", "storage_engine",
+            "TS_INDEX_DUMP_WAL_GAP_BYTES",
+            "WAL growth before an index dump", "int", "1048576", "live",
+            "How much undumped WAL growth triggers a background index dump. A dump writes the "
+            "served index, so lowering this makes dumps more frequent and each recovery shorter."),
     Setting("storage_engine.vector_scaled", "storage_engine",
             "TS_VECTOR_SCALED",
             "Store vectors in the scaled form", "bool", "1", "live",

--- a/tools/test_matrixark_engine_settings_match_the_engine.py
+++ b/tools/test_matrixark_engine_settings_match_the_engine.py
@@ -61,6 +61,51 @@ def _enclosing_body(text: str, at: int) -> str:
     return text[open_at:]
 
 
+SIZE_CONST = re.compile(r"pub const (DEFAULT_[A-Z0-9_]+)\s*:\s*\w+\s*=\s*([^;]+);")
+
+
+def _evaluate(expr: str):
+    """Evaluate a default constant's initialiser: integers, `*`, `<<`, and the two bool words.
+
+    Restricted to that character set on purpose -- these come from source this test reads, and a
+    guard that evaluates arbitrary text from a file it scans is a worse problem than the drift it
+    is trying to catch.
+    """
+    text = expr.strip()
+    if text in ("true", "false"):
+        return "1" if text == "true" else "0"
+    if not re.fullmatch(r"[0-9_ ()*<+]+", text):
+        return None
+    try:
+        return str(eval(text, {"__builtins__": {}}, {}))  # noqa: S307 - charset restricted above
+    except Exception:
+        return None
+
+
+def tuning_defaults() -> dict:
+    """Knobs read through a getter closure, whose default lives in a DEFAULT_* constant.
+
+    `StorageTuningConfig::from_getter` passes a name CONSTANT to a closure, so these knobs never
+    appear beside `env::var` and no scan that looks there can find them. Their defaults come from
+    `StorageTuningConfig::default()`, field by field, from `DEFAULT_<KNOB>`.
+    """
+    defaults = {}
+    for path in _rust_files():
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+        constants = {name: _evaluate(value) for name, value in SIZE_CONST.findall(text)}
+        # (identifier, env name it holds) -- these are not always the same, and the default
+        # constant is named after the IDENTIFIER while the portal must show the NAME.
+        declared = re.findall(
+            r'pub const (TS_[A-Z0-9_]+)\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"',
+            text)
+        for identifier, env_name in declared:
+            value = constants.get("DEFAULT_" + identifier[len("TS_"):])
+            if value is not None:
+                defaults[env_name] = value
+    return defaults
+
+
 def engine_defaults() -> dict:
     """env name -> the default its Rust accessor applies, as the portal would print it."""
     defaults = {}
@@ -91,7 +136,8 @@ class TheEnginesDefaultIsWhatThePortalShowsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.engine_settings = [s for s in cfgmod.SETTINGS
                                 if s.env and s.env.startswith("TS_")]
-        self.derived = engine_defaults()
+        self.derived = dict(tuning_defaults())
+        self.derived.update(engine_defaults())
 
     def test_the_portal_offers_engine_knobs_at_all(self) -> None:
         self.assertGreaterEqual(
@@ -123,12 +169,34 @@ class TheEnginesDefaultIsWhatThePortalShowsTest(unittest.TestCase):
             "only %d offered engine knobs could be matched to an accessor, so this test is close "
             "to vacuous" % checked)
 
+    def test_no_offered_engine_knob_escapes_the_derivation(self) -> None:
+        """Every knob on the page must have a default this test can check.
+
+        Without this, adding a setting whose default cannot be derived quietly reduces coverage --
+        the loop above skips it and still reports success, which is how an unverified number gets
+        onto a customer-facing page.
+        """
+        unchecked = [s.env for s in self.engine_settings if s.env not in self.derived]
+        self.assertEqual(
+            [], unchecked,
+            "these engine knobs are offered and their default cannot be derived from the source, "
+            "so nothing checks the number shown: %s" % ", ".join(unchecked))
+
     def test_every_offered_engine_knob_is_actually_read_by_the_engine(self) -> None:
+        # Two ways a knob reaches the environment, and the second is the one that matters here.
+        # A literal `env::var("TS_X")` is easy to see. The storage-tuning family is read through
+        # `StorageTuningConfig::from_getter`, which passes a name CONSTANT to a closure that calls
+        # `env::var(name)` -- so those names never appear beside `env::var` at all. A declared
+        # `pub const TS_X: &str = "TS_X"` exists to name a knob, so it counts as a read.
         read = set()
         for path in _rust_files():
             with open(path, encoding="utf-8", errors="replace") as handle:
                 text = handle.read()
             read.update(re.findall(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"', text))
+            # the NAME the constant holds, not the identifier that holds it
+            read.update(re.findall(
+                r'pub const TS_[A-Z0-9_]+\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"',
+                text))
         for setting in self.engine_settings:
             with self.subTest(env=setting.env):
                 self.assertIn(

--- a/tools/test_matrixark_every_live_claim_is_checked.py
+++ b/tools/test_matrixark_every_live_claim_is_checked.py
@@ -86,6 +86,21 @@ def _rust_per_call_env_names() -> set:
                 static_at = max(head.rfind("static "), head.rfind("const "))
                 if fn_at > static_at:
                     names.add(match.group(1))
+            # A second route this scan could not see at all. The storage-tuning family is read by
+            # `StorageTuningConfig::from_getter`, which passes a name CONSTANT to a closure calling
+            # `env::var(name)` -- so those names never appear beside `env::var`, exactly the blind
+            # spot this file was written to close on the Python side.
+            #
+            # The name a constant HOLDS is the variable an operator sets, and it is not always the
+            # identifier: `pub const TS_BLOCK_SLAB_TARGET_BYTES: &str =
+            # "TS_BLOCK_SEGMENT_TARGET_BYTES"`. Resolve by value.
+            #
+            # Counted as per-call because the accessors call `StorageTuningConfig::from_env()` on
+            # each use and nothing caches the result -- checked, not assumed. If that ever gains a
+            # OnceLock, these become restart settings and this admission is wrong.
+            names.update(re.findall(
+                r'pub const TS_[A-Z0-9_]+\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"',
+                text))
     return names
 
 def _resolver_environ_scopes() -> dict:

--- a/tools/test_matrixark_gateway_config_audit.py
+++ b/tools/test_matrixark_gateway_config_audit.py
@@ -145,7 +145,21 @@ def _scan() -> Dict[str, List[Tuple[str, str, int]]]:
             continue
         path = os.path.join(TOOLS, entry)
         try:
-            tree = ast.parse(open(path, encoding="utf-8", errors="replace").read(), filename=entry)
+            source = open(path, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        # A file that never touches the environment cannot be capturing a setting from it. This
+        # scan collects string CONSTANTS equal to a setting's variable name, which is a good proxy
+        # inside a module that reads config and a false positive inside one that merely lists names
+        # -- the storage conformance validators name 24 and 8 knobs between them and call
+        # os.environ zero times, and every one of those names was reported as captured at import.
+        #
+        # A rule rather than another exclusion entry: the list would need a line per validator, and
+        # would go stale the moment someone adds the next one.
+        if "os.environ" not in source and "getenv" not in source:
+            continue
+        try:
+            tree = ast.parse(source, filename=entry)
         except SyntaxError:
             continue
         visitor = _Sites(wanted)
@@ -168,8 +182,21 @@ def _scan() -> Dict[str, List[Tuple[str, str, int]]]:
 
 SITES = _scan()
 
+# How many settings the scan found a site for when this floor was set. It guards the skip rule
+# above: if that rule ever excludes too much, every label test below passes by comparing nothing.
+SCAN_COVERAGE_FLOOR = 40
+
 
 class AppliesLabelTest(unittest.TestCase):
+    def test_the_scan_still_reaches_the_readers(self) -> None:
+        """Both label tests skip a setting with no sites, so a narrowed scan reads as success."""
+        with_sites = sum(1 for name in SITES if SITES[name])
+        self.assertGreaterEqual(
+            with_sites, SCAN_COVERAGE_FLOOR,
+            "the audit found readers for only %d settings; it reached at least %d when this floor "
+            "was set, so the skip rule in _scan is excluding too much"
+            % (with_sites, SCAN_COVERAGE_FLOOR))
+
     def test_every_import_time_reader_is_labelled_restart(self) -> None:
         """The direction that misleads a customer: claiming a change is live when it cannot be."""
         wrong: List[str] = []


### PR DESCRIPTION
Nine more engine knobs reach the portal — context page target (64 KiB), block segment target (1 GiB), zone size (1 GiB), max streamed blob (10 MiB), compaction watermark (256 MiB), cold-scan cache fill, the page and block index caches (64 MiB each), and the WAL growth that triggers an index dump (1 MiB). **Sixteen engine settings now.**

These are the knobs a size or latency question actually turns on, and **my earlier survey missed every one of them.** It matched `env::var("TS_...")` with a literal. `StorageTuningConfig::from_getter` passes a name *constant* to a closure that calls `env::var(name)`, so those names never appear beside `env::var` at all.

That is the same blind spot I had just finished fixing in the Python config audit — reproduced in my own tool, two hours later. **The engine reads 98 `TS_*` knobs, not the 80 I reported.**

Three guards had the hole and are widened together: this file.s default derivation, its is-the-engine-actually-reading-this check, and the live-claim guard.s engine route.

**The guards then caught a real bug in this change.** A knob constant.s *identifier* is not always the name it holds — `pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES"` — and I used the identifier, so the setting named a variable nothing reads. Resolution is by value everywhere now.

**Labelled live after checking, not assuming:** the accessors call `StorageTuningConfig::from_env()` on each use and nothing caches the result. If that ever gains a `OnceLock` these become restart settings, and the comment admitting them says so.

**One more, separately.** The config audit reported seven of these as captured at import inside two storage conformance validators. Those validators name 24 and 8 knobs between them and call `os.environ` **zero** times — naming a variable is not reading it. The scan now skips a file that never touches the environment. That is a rule rather than another exclusion entry, which would need a line per validator and go stale at the next one, and it asserts its own reach so the rule cannot quietly empty the scan.

151 tests across six config suites. Mutation-checked both ways: a default the engine does not use fails; a knob whose default cannot be derived fails.