### PR TITLE
The storage tuning validator can run

### DIFF
--- a/tools/test_matrixark_tuning_validator_runs.py
+++ b/tools/test_matrixark_tuning_validator_runs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The storage-tuning validator has to run, not just be importable.
+
+It raised `KeyError: 'native_runtime'` on every invocation -- it read a key that no version of its
+`files` map has contained since that entry was dropped -- so it had never reported anything, right
+or wrong. Nothing noticed, because the one test that mentions it imports `EXPECTED_DEFAULTS` for a
+constant and never calls `main()`.
+
+That is the shape worth guarding against rather than the specific bug: a validator is only doing
+its job if something executes it and reads the exit code.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_storage_tuning_conformance as tuning  # noqa: E402
+
+
+class TheTuningValidatorRunsTest(unittest.TestCase):
+
+    def test_it_completes_and_agrees_with_the_engine(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = tuning.main()
+        self.assertEqual(
+            0, code,
+            "the storage tuning validator reports a disagreement between what it expects and what "
+            "the engine declares:\n%s%s" % (out.getvalue(), err.getvalue()))
+
+    def test_it_checks_a_meaningful_number_of_knobs(self) -> None:
+        """A validator that expects nothing passes everything."""
+        self.assertGreaterEqual(
+            len(tuning.EXPECTED_KNOBS), 6,
+            "only %d knobs are expected, so agreeing with the engine proves little"
+            % len(tuning.EXPECTED_KNOBS))
+        self.assertGreaterEqual(
+            len(tuning.EXPECTED_DEFAULTS), 6,
+            "only %d defaults are recorded, so the drift check below covers almost nothing"
+            % len(tuning.EXPECTED_DEFAULTS))
+
+    def test_every_expected_knob_has_a_recorded_default(self) -> None:
+        # Otherwise a knob can be listed as required and have its value drift unchecked.
+        missing = sorted(tuning.EXPECTED_KNOBS - set(tuning.EXPECTED_DEFAULTS))
+        self.assertEqual(
+            [], missing,
+            "these knobs are required to exist but no default is recorded for them, so a change "
+            "to their value is not checked: %s" % ", ".join(missing))
+
+    def test_the_engine_declares_a_default_for_each(self) -> None:
+        """The half that catches a rename: a constant that no longer exists reads as no default."""
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1]
+        found = tuning.extract_rust_defaults(
+            root / "crates" / "temporalstore-rust" / "src" / "storage_config.rs")
+        missing = sorted(set(tuning.EXPECTED_DEFAULTS) - set(found))
+        self.assertEqual(
+            [], missing,
+            "the engine declares no default constant for these, which usually means the constant "
+            "was renamed and this validator still asks for the old name: %s" % ", ".join(missing))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_storage_conformance_report_artifacts.py
+++ b/tools/test_storage_conformance_report_artifacts.py
@@ -307,12 +307,17 @@ class StorageParityReportArtifactTest(unittest.TestCase):
             scanned, failures = validate_artifacts(root)
 
         self.assertEqual(scanned, 1)
+        # Read from EXPECTED_DEFAULTS rather than written out: this assertion carried 10485760,
+        # a value the engine has never used, so correcting the expectation broke a test that was
+        # only ever checking the literal it had been given.
+        expected = EXPECTED_DEFAULTS["TS_STORAGE_ZONE_SIZE"]
         self.assertTrue(
             any(
-                "effective storage tuning `TS_STORAGE_ZONE_SIZE` drift: expected 10485760 got 123"
+                f"effective storage tuning `TS_STORAGE_ZONE_SIZE` drift: expected {expected} got 123"
                 in item
                 for item in failures
-            )
+            ),
+            f"no drift failure naming the expected value {expected}: {failures}",
         )
 
 

--- a/tools/validate_storage_tuning_conformance.py
+++ b/tools/validate_storage_tuning_conformance.py
@@ -26,7 +26,10 @@ EXPECTED_KNOBS = {
 EXPECTED_DEFAULTS = {
     "TS_CONTEXT_PAGE_TARGET_BYTES": 65536,
     "TS_BLOCK_SEGMENT_TARGET_BYTES": 1073741824,
-    "TS_STORAGE_ZONE_SIZE": 10485760,
+    # 1 GiB. Was recorded here as 10 MiB, which never matched the engine: DEFAULT_STORAGE_ZONE_SIZE
+    # has a single commit in this repository and has been `1 << 30` since it landed. The old figure
+    # came from the launcher script this validator used to cross-check, and outlived it.
+    "TS_STORAGE_ZONE_SIZE": 1073741824,
     "TS_STREAM_MAX_BLOB_SIZE": 10485760,
     "TS_COMPACTION_WATERMARK_BYTES": 268435456,
     "TS_COLD_SCAN_NO_CACHE_FILL": True,
@@ -66,7 +69,10 @@ def extract_rust_defaults(path: pathlib.Path) -> dict[str, object]:
     text = path.read_text(encoding="utf-8")
     constant_map = {
         "TS_CONTEXT_PAGE_TARGET_BYTES": "DEFAULT_CONTEXT_PAGE_TARGET_BYTES",
-        "TS_BLOCK_SEGMENT_TARGET_BYTES": "DEFAULT_BLOCK_SEGMENT_TARGET_BYTES",
+        # The identifier does not match the variable name for this one: the engine declares
+        # `pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES"`, and its
+        # default constant is named after the identifier, not the variable.
+        "TS_BLOCK_SEGMENT_TARGET_BYTES": "DEFAULT_BLOCK_SLAB_TARGET_BYTES",
         "TS_STORAGE_ZONE_SIZE": "DEFAULT_STORAGE_ZONE_SIZE",
         "TS_STREAM_MAX_BLOB_SIZE": "DEFAULT_STREAM_MAX_BLOB_SIZE",
         "TS_COMPACTION_WATERMARK_BYTES": "DEFAULT_COMPACTION_WATERMARK_BYTES",
@@ -99,8 +105,11 @@ def main() -> int:
         if absent:
             missing.append(f"{label} ({path}) missing: {', '.join(absent)}")
 
+    # One source, deliberately. This once cross-checked a launcher script that set each knob
+    # with a shell default; that script no longer exists, and reading a missing key raised
+    # KeyError on every run -- so this validator has not reported anything, correct or otherwise,
+    # since the entry was removed.
     default_sources = {
-        "native_runtime": extract_runtime_defaults(files["native_runtime"]),
         "rust_config": extract_rust_defaults(files["rust_config"]),
     }
     for label, defaults in default_sources.items():
@@ -116,7 +125,7 @@ def main() -> int:
             print(line, file=sys.stderr)
         return 1
 
-    print("storage tuning parity knobs present:")
+    print("storage tuning knobs agreeing with the engine:")
     for name in sorted(EXPECTED_KNOBS):
         print(f"- {name}={EXPECTED_DEFAULTS[name]}")
     return 0


### PR DESCRIPTION
It raised `KeyError: 'native_runtime'` on **every** invocation — reading a key no version of its `files` map has held since that entry was dropped. It has never reported anything, correct or otherwise.

Nothing noticed because the one test that mentions it imports `EXPECTED_DEFAULTS` for a constant and never calls `main()`. **A validator is only doing its job when something executes it and reads the exit code**, so there is now a test that does.

Running it surfaced two disagreements it had been unable to report:

- It asked for `DEFAULT_BLOCK_SEGMENT_TARGET_BYTES`, which does not exist. The engine declares `pub const TS_BLOCK_SLAB_TARGET_BYTES: &str = "TS_BLOCK_SEGMENT_TARGET_BYTES"` — the identifier and the variable name differ, and the default constant is named after the *identifier*. Asking for the wrong constant reads as "no default declared" rather than as a rename.
- It expected `TS_STORAGE_ZONE_SIZE` to be **10 MiB**. The engine has used **1 GiB** throughout — `DEFAULT_STORAGE_ZONE_SIZE` has a single commit in this repository's history. The 10 MiB figure came from the launcher script this validator used to cross-check, and outlived it; no shell script in `tools/` sets any of these knobs with a default any more.

**The stale figure had spread.** `test_storage_conformance_report_artifacts` asserted a failure message containing `expected 10485760`, so correcting the expectation broke a test that was only ever checking the literal it had been handed. It now derives the value from `EXPECTED_DEFAULTS`, which is what it meant to assert.

Also drops a provenance word from a line this prints.

Mutation-checked: restoring the dangling key fails; restoring the stale expectation fails.

**Found on the way, not fixed here:** `validate_storage_engine_9_phase_conformance.py` dies on `run_matrixark_rust_scale_report.py`, the module that has never existed in this repository and that took down six test modules in #625. Its blast radius includes two conformance validators as well.