### PR TITLE
Say which conformance gates cannot run, and why

### DIFF
--- a/tools/validate_page_block_metrics_conformance.py
+++ b/tools/validate_page_block_metrics_conformance.py
@@ -44,6 +44,26 @@ REQUIRED_METRICS = [
 ]
 
 
+def _scale_report_absent_message() -> str:
+    """Why this validator cannot run, in one line an operator can act on.
+
+    This compares a published contract against `tools/run_matrixark_rust_scale_report.py`, and that
+    file is not in this repository -- `git log --all` finds no trace of it ever having been here,
+    while five files still refer to it. With one side of the comparison missing there is nothing to
+    check, so the honest outcome is a stated failure rather than a traceback (which reads as a bug
+    in the validator) or a zero exit (which reads as conformance verified).
+
+    Resolving it is a decision, not a fix: either the runner belongs in this repository, or these
+    validators are describing a comparison this repository cannot make.
+    """
+    return (
+        "cannot run: %s is absent from this repository, and it is the runner this validates the "
+        "published contract against. Five files still refer to it and no version of this "
+        "repository has contained it. Either it belongs here, or this validator does not."
+        % SCALE_REPORT
+    )
+
+
 def _extract_page_block_metric_names_from_runner() -> list[str]:
     tree = ast.parse(SCALE_REPORT.read_text(encoding="utf-8"), filename=str(SCALE_REPORT))
     for node in tree.body:
@@ -57,6 +77,9 @@ def _extract_page_block_metric_names_from_runner() -> list[str]:
 
 
 def main() -> int:
+    if not SCALE_REPORT.exists():
+        print(_scale_report_absent_message(), file=sys.stderr)
+        return 1
     contract_text = CONTRACT.read_text(encoding="utf-8")
     runner_metrics = _extract_page_block_metric_names_from_runner()
     missing = []

--- a/tools/validate_storage_engine_9_phase_conformance.py
+++ b/tools/validate_storage_engine_9_phase_conformance.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
-"""Run the conformance storage-engine parity gates phase by phase.
+"""Run the conformance storage-engine gates phase by phase.
 
-This is the umbrella gate for the nine storage parity phases:
+This is the umbrella gate for the nine storage conformance phases:
 
 1. canonical public contract
 2. read/write/cold-scan sequences
@@ -11,8 +11,8 @@ This is the umbrella gate for the nine storage parity phases:
 4. page/block/slot/index behavior
 5. multi-layer cache behavior
 6. eviction, GC, compaction, and reclaim
-7. public config parity
-8. metrics/report parity
+7. public config agreement
+8. metrics/report agreement
 9. shared storage/proxy/Raft evidence
 
 It intentionally composes the focused validators instead of duplicating their
@@ -89,12 +89,12 @@ PHASES: tuple[Phase, ...] = (
     ),
     Phase(
         7,
-        "public config parity",
+        "public config agreement",
         ("validate_storage_tuning_conformance.py",),
     ),
     Phase(
         8,
-        "metrics/report parity",
+        "metrics/report agreement",
         (
             "validate_page_block_metrics_conformance.py",
             "validate_grafana_metrics_conformance.py",
@@ -125,10 +125,23 @@ PHASES: tuple[Phase, ...] = (
 )
 
 
-def run_validator(script_name: str) -> None:
+def run_validator(script_name: str) -> str:
+    """Run one validator and say what happened: "ok", "absent" or "failed".
+
+    This used to raise on the first problem, which made the gate report whichever validator it
+    reached first and nothing about the rest. Three of the validators it names have never existed
+    in this repository, so the first phase raised FileNotFoundError and the other eight phases were
+    never even attempted -- the output looked like one broken file rather than an umbrella gate
+    that cannot complete here.
+
+    Absent and failed are kept apart on purpose. A failing validator is a conformance result. An
+    absent one is a statement about which files this repository contains, and the two want
+    different decisions.
+    """
     script = TOOLS / script_name
     if not script.exists():
-        raise FileNotFoundError(f"missing validator: {script}")
+        print(f"    ABSENT: {script_name} is not in this repository")
+        return "absent"
     completed = subprocess.run(
         [sys.executable, str(script)],
         cwd=ROOT,
@@ -140,12 +153,14 @@ def run_validator(script_name: str) -> None:
     if completed.stdout:
         print(completed.stdout.rstrip())
     if completed.returncode != 0:
-        raise RuntimeError(f"{script_name} failed with exit code {completed.returncode}")
+        print(f"    FAILED: {script_name} exited {completed.returncode}")
+        return "failed"
+    return "ok"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Run the nine conformance storage-engine parity phases."
+        description="Run the nine conformance storage-engine phases."
     )
     parser.add_argument(
         "--loops",
@@ -158,20 +173,36 @@ def main() -> int:
         parser.error("--loops must be at least 1")
 
     total_validator_runs = 0
+    absent: list[str] = []
+    failed: list[str] = []
     for loop in range(1, args.loops + 1):
-        print(f"storage_engine_parity_loop={loop}/{args.loops}")
+        print(f"storage_engine_loop={loop}/{args.loops}")
         for phase in PHASES:
             print(f"phase_{phase.number}: {phase.name}")
             for validator in phase.validators:
                 print(f"  validator={validator}")
-                run_validator(validator)
+                outcome = run_validator(validator)
                 total_validator_runs += 1
+                if outcome == "absent" and validator not in absent:
+                    absent.append(validator)
+                elif outcome == "failed" and validator not in failed:
+                    failed.append(validator)
 
     print(
-        "storage_engine_9_phase_parity_passed "
+        "storage_engine_9_phase_summary "
         f"loops={args.loops} phases={len(PHASES)} "
-        f"validator_runs={total_validator_runs}"
+        f"validator_runs={total_validator_runs} "
+        f"absent={len(absent)} failed={len(failed)}"
     )
+    for name in absent:
+        print(f"  absent: {name}")
+    for name in failed:
+        print(f"  failed: {name}")
+    if absent or failed:
+        # Not "passed". An umbrella gate that reports success while naming validators it could not
+        # run is worse than one that says plainly it could not complete.
+        return 1
+    print("storage_engine_9_phase_passed")
     return 0
 
 

--- a/tools/validate_storage_engine_9_phase_conformance.py
+++ b/tools/validate_storage_engine_9_phase_conformance.py
@@ -22,6 +22,7 @@ logic, so a failing phase points back to the exact lower-level gate to fix.
 from __future__ import annotations
 
 import argparse
+import json
 import pathlib
 import subprocess
 import sys
@@ -125,6 +126,49 @@ PHASES: tuple[Phase, ...] = (
 )
 
 
+def _coverage_state_note() -> str:
+    """What the case corpus says about its own wiring, quoted rather than paraphrased.
+
+    Without this the summary above reads as decay -- eight validators absent, eight failing, as
+    though something rotted. It is the opposite: these gates were written ahead of the runner they
+    check against, and `compat/unified_temporalstore_cases.json` records that per family, in a
+    `status` of `temporary_static_surface_gate` and a `blocker` naming the missing piece.
+
+    Printed from the corpus rather than restated here, so it cannot drift out of step with what the
+    corpus actually claims.
+    """
+    corpus = ROOT / "compat" / "unified_temporalstore_cases.json"
+    if not corpus.exists():
+        return ""
+    try:
+        rows = json.loads(corpus.read_text(encoding="utf-8"))["coverage"]["native_adapter_coverage"]
+    except (KeyError, ValueError, OSError):
+        return ""
+    counts: dict[str, int] = {}
+    blocker = ""
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        counts[str(row.get("status"))] = counts.get(str(row.get("status")), 0) + 1
+        if not blocker and row.get("blocker"):
+            blocker = str(row["blocker"])
+    if not counts:
+        return ""
+    tally = ", ".join(f"{name}={count}" for name, count in sorted(counts.items()))
+    lines = [
+        "",
+        "coverage state, from compat/unified_temporalstore_cases.json:",
+        f"  families by status: {tally}",
+    ]
+    if blocker:
+        lines.append(f"  blocker: {blocker}")
+    lines.append(
+        "  These gates are ahead of the runner they check against, not decayed. An absent "
+        "validator here is work not yet wired, which the corpus records per family."
+    )
+    return "\n".join(lines)
+
+
 def run_validator(script_name: str) -> str:
     """Run one validator and say what happened: "ok", "absent" or "failed".
 
@@ -198,6 +242,9 @@ def main() -> int:
         print(f"  absent: {name}")
     for name in failed:
         print(f"  failed: {name}")
+    note = _coverage_state_note()
+    if note:
+        print(note)
     if absent or failed:
         # Not "passed". An umbrella gate that reports success while naming validators it could not
         # run is worse than one that says plainly it could not complete.

--- a/tools/validate_storage_lifecycle_conformance.py
+++ b/tools/validate_storage_lifecycle_conformance.py
@@ -560,7 +560,29 @@ REQUIRED_SCALE_REPORT_CONFIG_BINDINGS = {
 
 
 
+def _scale_report_absent_message() -> str:
+    """Why this validator cannot run, in one line an operator can act on.
+
+    This compares a published contract against `tools/run_matrixark_rust_scale_report.py`, and that
+    file is not in this repository -- `git log --all` finds no trace of it ever having been here,
+    while five files still refer to it. With one side of the comparison missing there is nothing to
+    check, so the honest outcome is a stated failure rather than a traceback (which reads as a bug
+    in the validator) or a zero exit (which reads as conformance verified).
+
+    Resolving it is a decision, not a fix: either the runner belongs in this repository, or these
+    validators are describing a comparison this repository cannot make.
+    """
+    return (
+        "cannot run: %s is absent from this repository, and it is the runner this validates the "
+        "published contract against. Five files still refer to it and no version of this "
+        "repository has contained it. Either it belongs here, or this validator does not."
+        % SCALE_REPORT
+    )
+
+
 def validate_contract_and_runner() -> list[str]:
+    if not SCALE_REPORT.exists():
+        return [_scale_report_absent_message()]
     failures: list[str] = []
     contract_text = CONTRACT.read_text(encoding="utf-8")
     runner_text = SCALE_REPORT.read_text(encoding="utf-8")


### PR DESCRIPTION
The nine-phase umbrella gate raised `FileNotFoundError` on its **first** phase, so the other eight were never attempted. The output looked like one broken file rather than a gate that cannot complete in this repository.

It runs every phase now and reports an inventory:

```
storage_engine_9_phase_summary loops=1 phases=9 validator_runs=32 absent=8 failed=8
```

**Absent and failing are kept apart deliberately.** A failing validator is a conformance result. An absent one is a statement about which files this repository contains. They want different decisions, and collapsing them loses that.

It returns non-zero when either list is non-empty — an umbrella gate that reports success while naming validators it could not run is worse than one that says plainly it could not complete.

**Two validators it drives died the same way**, on `tools/run_matrixark_rust_scale_report.py` — the file that has never existed here and took six test modules down in #625. Five files still refer to it. Both now say so in one line instead of a traceback, because a traceback reads as a bug in the validator and a zero exit would read as conformance verified, when the truth is that one side of the comparison is missing.

Resolving that is a decision, not a fix: either the runner belongs in this repository, or these validators describe a comparison this repository cannot make. Three further validators the gate names have never been here either.

Also drops provenance wording from the umbrella gate.s prose and phase labels. Two occurrences remain and are left alone — they name absent files, so renaming them would only invent a different name for something that is not there.

`validate_storage_tuning_conformance.py` appears in the failing list here; #690 fixes that one separately.