### PR TITLE
Topology query latency, as percentiles that can draw

### DIFF
--- a/docs/ops/temporalstore-cluster-dashboard.json
+++ b/docs/ops/temporalstore-cluster-dashboard.json
@@ -149,11 +149,26 @@
     },
     {
       "type": "timeseries",
-      "title": "Topology Query Latency And Failures",
+      "title": "Topology Query Latency (percentiles)",
       "targets": [
         {
-          "expr": "temporalstore_meta_topology_query_latency_us"
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
         },
+        {
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
+        },
+        {
+          "expr": "rate(temporalstore_meta_topology_query_latency_us_sum[5m]) / rate(temporalstore_meta_topology_query_latency_us_count[5m])"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Topology Query Failures And Bytes",
+      "targets": [
         {
           "expr": "temporalstore_meta_topology_query_failed_total"
         },

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -412,6 +412,44 @@ def check_dashboard_metrics_are_emitted(declared: set) -> list:
             for name in sorted(dashboard_metric_names() - declared)]
 
 
+def check_no_bare_histogram_targets(kinds: dict) -> list:
+    """Panel targets that plot a histogram or summary by its base name.
+
+    Prometheus publishes a histogram as `_bucket`, `_sum` and `_count`. There is no series under
+    the base name, so a target naming it draws an empty line -- and it passes every check written
+    so far, because the base name IS declared. The emission check cannot catch this: the metric
+    exists, it just has no series by that name.
+
+    Found on a panel added in the change that introduced this dashboard, which is the honest reason
+    the guard is here rather than the rule being obvious.
+
+    Only a target that is EXACTLY the base name is reported. `histogram_quantile(...)` over the
+    buckets, or a `_sum / _count` mean, both mention the base name as a prefix and are correct.
+    """
+    shaped = {name for name, kind in kinds.items() if kind in ("histogram", "summary")}
+    if not shaped:
+        return []
+    failures = []
+    for path in DASHBOARDS:
+        if not path.exists():
+            continue
+        try:
+            panels = json.loads(read(path)).get("panels", [])
+        except ValueError:
+            continue
+        for panel in panels:
+            for target in panel.get("targets", []):
+                expr = str(target.get("expr", "")).strip()
+                if expr in shaped:
+                    failures.append("bare_histogram_target:%s:%s:%s"
+                                    % (path.name, panel.get("title"), expr))
+    return failures
+
+
+def check_scan_extent_placeholder_removed() -> list:
+    return []
+
+
 def check_dashboard_extent() -> list:
     """Every dashboard listed must exist, or its panels stop being checked silently."""
     return ["dashboard_missing:%s" % path.name for path in DASHBOARDS if not path.exists()]
@@ -482,6 +520,7 @@ def main() -> int:
     alert_failures = (check_declaration_extent(declared)
                       + check_dashboard_extent()
                       + check_dashboard_metrics_are_emitted(declared)
+                      + check_no_bare_histogram_targets(declared_kinds(rust))
                       + check_families_state_their_emission(METRIC_FAMILIES)
                       + check_alert_expressions_are_emitted(alerts, declared)
                       + check_alert_metric_names(alerts, declared))


### PR DESCRIPTION
The cluster dashboard I added in #657 plotted `temporalstore_meta_topology_query_latency_us` directly. **It is a histogram.** Prometheus publishes a histogram as `_bucket`, `_sum` and `_count`, with no series under the base name — so that line drew nothing, on a dashboard added specifically to stop shipping panels that cannot render.

It is now p50, p90 and p99 over the buckets, plus the mean from `_sum` over `_count`. The mean earns its place: rising with a flat p99 is the whole distribution slowing rather than a tail problem, and a percentile cannot show that. Failures and bytes move to their own panel — they are counters and belong on a different axis.

**None of the existing checks could catch this.** The metric *is* declared, so the emission test passes. The name *is* in the source. The defect is that no series exists under that name, which only the declared TYPE reveals. A check now rejects a target that is exactly a histogram or summary base name.

Only an exact match is reported: `histogram_quantile(...)` over the buckets and a `_sum`/`_count` mean both mention the base name and are correct.

Verified across every dashboard — no bare histogram target remains anywhere. Mutation-checked: restoring the bare target fails the run with `bare_histogram_target:...`.

This is the third defect in this family, and the shape is consistent: a panel or rule that passes every check written so far and still cannot draw. #652 was metrics nothing emits, #671 was the reverse — a guard rejecting correct histogram usage — and this is the base name that looks emitted and has no series.