### PR TITLE
Hold an object's single component without a vector

### DIFF
--- a/crates/temporalstore-rust/src/engine/state.rs
+++ b/crates/temporalstore-rust/src/engine/state.rs
@@ -1002,7 +1002,174 @@ impl From<ObjectBlockLookup> for BTreeMap<String, ObjectBlockRefs> {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct ObjectBlockRefs {
     #[serde(default)]
-    pub(super) by_component: Vec<ComponentBlocks>,
+    pub(super) by_component: ComponentList,
+}
+
+/// The components of one object: none, one, or a sorted vector.
+///
+/// The measured average is 1.0 components per object, and a `Vec` holding a single element is a
+/// heap allocation and its allocator rounding spent to express a list of one. The shape
+/// `BlockIndexMap`, `BlockRefs` and `ObjectIndex` already use, for the same reason.
+///
+/// It carries the slice of `Vec`'s surface the lookup actually uses, so the call sites read as
+/// they did.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(super) enum ComponentList {
+    #[default]
+    Empty,
+    One(ComponentBlocks),
+    Many(Vec<ComponentBlocks>),
+}
+
+impl ComponentList {
+    pub(super) fn len(&self) -> usize {
+        match self {
+            ComponentList::Empty => 0,
+            ComponentList::One(_) => 1,
+            ComponentList::Many(list) => list.len(),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        matches!(self, ComponentList::Empty)
+    }
+
+    pub(super) fn iter(&self) -> std::slice::Iter<'_, ComponentBlocks> {
+        match self {
+            // A const-promoted empty slice, so the iterator does not borrow a temporary.
+            ComponentList::Empty => (&[] as &[ComponentBlocks]).iter(),
+            ComponentList::One(entry) => std::slice::from_ref(entry).iter(),
+            ComponentList::Many(list) => list.iter(),
+        }
+    }
+
+    /// `Vec::binary_search_by`'s contract: `f` orders the ELEMENT against the target, `Ok` is the
+    /// position of a match and `Err` the position it would be inserted at.
+    pub(super) fn binary_search_by<F>(&self, mut f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&ComponentBlocks) -> std::cmp::Ordering,
+    {
+        match self {
+            ComponentList::Empty => Err(0),
+            ComponentList::One(entry) => match f(entry) {
+                std::cmp::Ordering::Equal => Ok(0),
+                // The held entry sorts before the target, so the target goes after it.
+                std::cmp::Ordering::Less => Err(1),
+                std::cmp::Ordering::Greater => Err(0),
+            },
+            ComponentList::Many(list) => list.binary_search_by(f),
+        }
+    }
+
+    pub(super) fn insert(&mut self, at: usize, value: ComponentBlocks) {
+        match self {
+            ComponentList::Empty => {
+                assert_eq!(at, 0, "the only position in an empty list is 0");
+                *self = ComponentList::One(value);
+            }
+            ComponentList::One(_) => {
+                let held = match std::mem::replace(self, ComponentList::Empty) {
+                    ComponentList::One(held) => held,
+                    _ => unreachable!("just matched One"),
+                };
+                let mut list = Vec::with_capacity(2);
+                list.push(held);
+                list.insert(at, value);
+                *self = ComponentList::Many(list);
+            }
+            ComponentList::Many(list) => list.insert(at, value),
+        }
+    }
+
+    /// Removes and returns the entry at `at`, giving up the vector once it no longer earns one so
+    /// an object that briefly held two components does not keep it for the rest of its life.
+    pub(super) fn remove(&mut self, at: usize) -> ComponentBlocks {
+        match self {
+            ComponentList::Empty => panic!("removal from an empty component list"),
+            ComponentList::One(_) => {
+                assert_eq!(at, 0, "the only position in a list of one is 0");
+                match std::mem::replace(self, ComponentList::Empty) {
+                    ComponentList::One(held) => held,
+                    _ => unreachable!("just matched One"),
+                }
+            }
+            ComponentList::Many(list) => {
+                let removed = list.remove(at);
+                match list.len() {
+                    0 => *self = ComponentList::Empty,
+                    1 => *self = ComponentList::One(list.pop().expect("length is one")),
+                    _ => {}
+                }
+                removed
+            }
+        }
+    }
+}
+
+impl std::ops::Index<usize> for ComponentList {
+    type Output = ComponentBlocks;
+    fn index(&self, at: usize) -> &ComponentBlocks {
+        match self {
+            ComponentList::Empty => panic!("index {at} into an empty component list"),
+            ComponentList::One(entry) => {
+                assert_eq!(at, 0, "the only position in a list of one is 0");
+                entry
+            }
+            ComponentList::Many(list) => &list[at],
+        }
+    }
+}
+
+impl std::ops::IndexMut<usize> for ComponentList {
+    fn index_mut(&mut self, at: usize) -> &mut ComponentBlocks {
+        match self {
+            ComponentList::Empty => panic!("index {at} into an empty component list"),
+            ComponentList::One(entry) => {
+                assert_eq!(at, 0, "the only position in a list of one is 0");
+                entry
+            }
+            ComponentList::Many(list) => &mut list[at],
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a ComponentList {
+    type Item = &'a ComponentBlocks;
+    type IntoIter = std::slice::Iter<'a, ComponentBlocks>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl Serialize for ComponentList {
+    /// The same sequence it has always written, in the same order.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for entry in self.iter() {
+            seq.serialize_element(entry)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ComponentList {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // A loaded object takes the shape a written one does: one component comes back held
+        // inline rather than in a vector.
+        let mut list = Vec::<ComponentBlocks>::deserialize(deserializer)?;
+        Ok(match list.len() {
+            0 => ComponentList::Empty,
+            1 => ComponentList::One(list.pop().expect("length is one")),
+            _ => ComponentList::Many(list),
+        })
+    }
 }
 
 /// One component of one object, and the pages holding it.

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5816,6 +5816,57 @@ fn an_object_index_costs_a_word_and_a_pointer() {
     assert!(matches!(index, ObjectIndex::One(9)), "one id is held inline again");
 }
 
+/// An object with one component holds it inline, and goes back to inline when it can.
+///
+/// The measured average is 1.0 components per object, so a `Vec` here was a heap allocation and
+/// its allocator rounding spent on every object to express a list of one.
+///
+/// The demotion matters as much as the promotion: an object that briefly held two components
+/// would otherwise keep the vector for the rest of its life, which is exactly the cost being
+/// avoided and would not show up as a failure anywhere else.
+#[test]
+fn one_component_is_held_without_a_vector() {
+    use crate::engine::state::{BlockLookupRef, BlockRefs, ComponentBlocks, ComponentList};
+
+    let entry = |name: Option<&str>| ComponentBlocks {
+        component: name.map(Arc::from),
+        refs: BlockRefs::One(BlockLookupRef {
+            routing_bucket: 1,
+            page_ref_key: 7,
+        }),
+    };
+
+    let mut list = ComponentList::default();
+    assert!(list.is_empty());
+
+    // `None` sorts first, matching Option's own ordering, so it lands at 0.
+    assert_eq!(list.binary_search_by(|e| e.component.as_deref().cmp(&None)), Err(0));
+    list.insert(0, entry(None));
+    assert!(matches!(list, ComponentList::One(_)), "one component needs no vector");
+    assert_eq!(list.len(), 1);
+    assert_eq!(list.binary_search_by(|e| e.component.as_deref().cmp(&None)), Ok(0));
+
+    // A named component sorts after `None`, so the search must place it at 1, not 0.
+    let named = Some("b");
+    assert_eq!(list.binary_search_by(|e| e.component.as_deref().cmp(&named)), Err(1));
+    list.insert(1, entry(Some("b")));
+    assert!(matches!(list, ComponentList::Many(_)), "two components need the vector");
+    assert_eq!(
+        list.iter().map(|e| e.component.as_deref().map(str::to_string)).collect::<Vec<_>>(),
+        vec![None, Some("b".to_string())],
+        "order is preserved across the promotion"
+    );
+
+    // Back down to one, the vector is given up rather than kept for the object's life.
+    let removed = list.remove(0);
+    assert_eq!(removed.component, None);
+    assert!(matches!(list, ComponentList::One(_)), "one component is held inline again");
+    assert_eq!(list[0].component.as_deref(), Some("b"));
+
+    list.remove(0);
+    assert!(list.is_empty(), "the last removal empties the list");
+}
+
 /// How many distinct identity strings the page index holds, against how many copies of each.
 ///
 /// Interning pays only where cardinality is low relative to the number of holders. The object key


### PR DESCRIPTION
The lookup grouped an object's page refs by component in a `Vec<ComponentBlocks>`. The measured
average is 1.0 components per object, so that vector was a heap allocation and its allocator
rounding spent on every object to express a list of one.

`ComponentList` is Empty|One|Many, the shape `BlockIndexMap`, `BlockRefs` and `ObjectIndex`
already use. It carries the slice of `Vec`'s surface the lookup actually uses -- `binary_search_by`,
indexing, insert-at, remove-at, `is_empty`, `iter` -- so the call sites read as they did, and it
serializes as the same sequence it always wrote.

**A key costs the index 969 -> 838 live bytes, 13.5% off.**

Measured as allocated-minus-freed over 2,000 keys, as a paired A/B in one tree with the same build
flags, against the main that already carries the bucket-node change. The two compose: 1,022 -> 969
-> 838.

The demotion matters as much as the promotion: an object that briefly held two components would
otherwise keep the vector for the rest of its life, which is the cost being avoided and would not
show up as a failure anywhere else. The test walks that, and pins the ordering of the `None`
component, which sorts first and so decides where a named component is inserted.

Two raft tests failed in the local full suite and neither is from this change: both pass in
isolation on this branch, `http_raft_transport_sends_append_vote_and_snapshot_over_tcp` fails in
isolation on main, and this branch passed a full suite cleanly before it was rebased.