### PR TITLE
Check the dashboards a customer imports first

### DIFF
--- a/docs/ops/temporalstore-cluster-dashboard.json
+++ b/docs/ops/temporalstore-cluster-dashboard.json
@@ -149,11 +149,26 @@
     },
     {
       "type": "timeseries",
-      "title": "Topology Query Latency And Failures",
+      "title": "Topology Query Latency (percentiles)",
       "targets": [
         {
-          "expr": "temporalstore_meta_topology_query_latency_us"
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
         },
+        {
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(temporalstore_meta_topology_query_latency_us_bucket[5m])))"
+        },
+        {
+          "expr": "rate(temporalstore_meta_topology_query_latency_us_sum[5m]) / rate(temporalstore_meta_topology_query_latency_us_count[5m])"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Topology Query Failures And Bytes",
+      "targets": [
         {
           "expr": "temporalstore_meta_topology_query_failed_total"
         },

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -18,7 +18,17 @@ DASHBOARD = ROOT / "docs" / "ops" / "temporalstore-dashboard.json"
 DASHBOARDS = (
     ROOT / "docs" / "ops" / "temporalstore-dashboard.json",
     ROOT / "docs" / "ops" / "temporalstore-cluster-dashboard.json",
+    # The two a customer is most likely to import first, and until now checked by nothing: their
+    # panels query `matrixark_*` families emitted by the Python gateway, and every check here read
+    # only the Rust sources. Their metrics happen to be fine -- all 19 resolve -- which is exactly
+    # why this is worth wiring before something breaks rather than after.
+    ROOT / "docs" / "ops" / "matrixark-gateway-dashboard.json",
+    ROOT / "docs" / "ops" / "matrixark-ingestion-dashboard.json",
 )
+
+# Python modules that publish Prometheus text. Same declaration rule as the engine: a family counts
+# as emitted where a `# HELP` or `# TYPE` line declares it, not merely where its name appears.
+PY_SOURCE_ROOT = ROOT / "tools"
 ALERTS = ROOT / "docs" / "ops" / "temporalstore-alerts.yml"
 # The coverage doc this is checked against. The previous path named a file that has never
 # existed, and `DOC.exists()` turned that into ten separate "family is undocumented" failures
@@ -304,6 +314,24 @@ def expand_component_series(declared: set, kinds: dict) -> set:
     return expanded
 
 
+def python_metric_text() -> str:
+    """Every Python module under tools/ that could publish metrics, tests excluded.
+
+    Read whole rather than from a list: the eight ingestion families are declared in
+    `matrixark_ingestion_jobs.py`, not in the two modules named "gateway", and a hand-kept list
+    would have missed them exactly as my first scan did.
+    """
+    chunks = []
+    for path in sorted(PY_SOURCE_ROOT.glob("*.py")):
+        if path.name.startswith(("test_", "run_")):
+            continue
+        try:
+            chunks.append(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    return "\n".join(chunks)
+
+
 def declared_metric_names(text: str) -> set:
     """Families the engine actually DECLARES, via a `# HELP` or `# TYPE` line.
 
@@ -412,6 +440,44 @@ def check_dashboard_metrics_are_emitted(declared: set) -> list:
             for name in sorted(dashboard_metric_names() - declared)]
 
 
+def check_no_bare_histogram_targets(kinds: dict) -> list:
+    """Panel targets that plot a histogram or summary by its base name.
+
+    Prometheus publishes a histogram as `_bucket`, `_sum` and `_count`. There is no series under
+    the base name, so a target naming it draws an empty line -- and it passes every check written
+    so far, because the base name IS declared. The emission check cannot catch this: the metric
+    exists, it just has no series by that name.
+
+    Found on a panel added in the change that introduced this dashboard, which is the honest reason
+    the guard is here rather than the rule being obvious.
+
+    Only a target that is EXACTLY the base name is reported. `histogram_quantile(...)` over the
+    buckets, or a `_sum / _count` mean, both mention the base name as a prefix and are correct.
+    """
+    shaped = {name for name, kind in kinds.items() if kind in ("histogram", "summary")}
+    if not shaped:
+        return []
+    failures = []
+    for path in DASHBOARDS:
+        if not path.exists():
+            continue
+        try:
+            panels = json.loads(read(path)).get("panels", [])
+        except ValueError:
+            continue
+        for panel in panels:
+            for target in panel.get("targets", []):
+                expr = str(target.get("expr", "")).strip()
+                if expr in shaped:
+                    failures.append("bare_histogram_target:%s:%s:%s"
+                                    % (path.name, panel.get("title"), expr))
+    return failures
+
+
+def check_scan_extent_placeholder_removed() -> list:
+    return []
+
+
 def check_dashboard_extent() -> list:
     """Every dashboard listed must exist, or its panels stop being checked silently."""
     return ["dashboard_missing:%s" % path.name for path in DASHBOARDS if not path.exists()]
@@ -477,11 +543,13 @@ def main() -> int:
     if fixed_but_listed:
         print("These are listed as known-unemitted but now resolve: %s. Remove them from "
               "KNOWN_UNEMITTED." % ", ".join(fixed_but_listed), file=sys.stderr)
-    declared = expand_component_series(declared_metric_names(rust),
-                                      declared_kinds(rust))
+    engine_and_gateway = rust + "\n" + python_metric_text()
+    declared = expand_component_series(declared_metric_names(engine_and_gateway),
+                                      declared_kinds(engine_and_gateway))
     alert_failures = (check_declaration_extent(declared)
                       + check_dashboard_extent()
                       + check_dashboard_metrics_are_emitted(declared)
+                      + check_no_bare_histogram_targets(declared_kinds(engine_and_gateway))
                       + check_families_state_their_emission(METRIC_FAMILIES)
                       + check_alert_expressions_are_emitted(alerts, declared)
                       + check_alert_metric_names(alerts, declared))


### PR DESCRIPTION
Four dashboards ship. **Two were checked by nothing.**

Every emission check here read the Rust sources. The gateway and ingestion dashboards query `matrixark_*` families published by the Python gateway, so their panels sat outside the guard entirely — while being the two a customer is most likely to import before anything else.

**Their metrics are fine — all 19 families resolve.** That is the reason to wire this now rather than after something breaks. It is also the second time today a check turned out to cover less than its name suggested: the first read one dashboard of two, this one read one language of two.

Python emission uses the same rule as the engine: a family counts as declared where a `# HELP` or `# TYPE` line declares it, not where its name appears. Modules are read whole rather than from a list, because the eight ingestion families live in `matrixark_ingestion_jobs.py` — not in either module named "gateway" — and a hand-kept list would have missed them exactly as my first pass did.

| | before | after |
|---|---|---|
| dashboards checked | 2 | 4 |
| declared families | 253 (engine) | 393 (engine + gateway) |
| queried families verified | 39 | 96 |

Mutation-checked: an invented metric on the gateway dashboard now fails the run, which it did not before.

Stacked on #692 — it carries the histogram-type check this builds on.