### PR TITLE
Say what the log actually writes

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4358,6 +4358,72 @@ mod tests {
         );
     }
 
+    /// What a record actually costs on disk AT THE DEFAULTS.
+    ///
+    /// The neighbouring size analysis builds its "today" baseline by hand, as JSON. Both encoding
+    /// flags now default ON, so that hand-built baseline is not necessarily what the log writes,
+    /// and a stale baseline overstates what is left -- which is the exact error that analysis
+    /// warns about. This one asks the store instead, with no flags set.
+    ///
+    /// Measured as the DELTA between records rather than the file size: the log preallocates in
+    /// large steps, so file size answers a different question.
+    #[test]
+    fn what_a_record_actually_costs_on_disk() {
+        for value_len in [64usize, 1024, 4096] {
+            let dir = tempfile::tempdir().unwrap();
+            let store = LocalWriteAheadLogStore::new(dir.path());
+            let value = vec![118u8; value_len];
+            let path = write_ahead_log_path(dir.path(), 1);
+
+            let append = |index: usize| {
+                store
+                    .append(
+                        1,
+                        Command::StringSet {
+                            key: format!("scale-key-{index:09}"),
+                            value: value.clone(),
+                        },
+                    )
+                    .unwrap();
+            };
+
+            // Warm past any once-only header, then measure a run of appends.
+            append(0);
+            let (_, before) = last_wal_sequence_in(&path).unwrap();
+            let runs = 16usize;
+            for index in 1..=runs {
+                append(index);
+            }
+            let (_, after) = last_wal_sequence_in(&path).unwrap();
+
+            let per_record = (after - before) as f64 / runs as f64;
+            println!(
+                "  ONDISK value {value_len:>5}B -> {per_record:>7.1} B/record ({:>5.2}x)",
+                per_record / value_len as f64
+            );
+
+            // A bound passes most easily when nothing was measured.
+            assert!(
+                after > before,
+                "the probe must observe the appends at {value_len}B"
+            );
+            assert!(
+                per_record > value_len as f64,
+                "a record cannot be smaller than the value it carries: {per_record}"
+            );
+
+            // The envelope must stay in binary territory. The text fallback carries a ~122-byte
+            // envelope and base64s the value at a flat third on top, so this bound fails wide if
+            // either default ever flips back -- which is the drift that left the neighbouring
+            // analysis describing a saving that had already been taken.
+            let envelope = per_record - value_len as f64;
+            assert!(
+                envelope < 80.0,
+                "envelope is {envelope:.0} B at {value_len}B: that is the text fallback's shape,                  not the binary one -- has a default flipped?"
+            );
+        }
+    }
+
     /// What each frame costs in TIME, not just bytes. Ignored by default: it is a measurement,
     /// and a timing assertion in the suite would be a flake generator.
     ///

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -89,13 +89,14 @@ fn unescape_newlines(bytes: &[u8]) -> Result<Vec<u8>, String> {
 
 /// TS_WAL_BINARY_RECORDS: write engine records as protobuf.
 ///
-/// Default OFF while it proves out. Reading never consults this -- a payload is decoded by what
-/// its first byte says it is -- so turning it on and off again leaves a log that still reads end
-/// to end.
+/// **Default ON.** The doc comment here used to say OFF while the code returned true and the
+/// comment inside the body said ON -- three statements, two of them wrong, about the encoding of
+/// the durability log.
+///
+/// Reading never consults this: a payload is decoded by what its first byte says it is, so a log
+/// written across the flip reads end to end in either direction, and turning it off again is not
+/// a one-way door.
 pub(crate) fn binary_records_enabled() -> bool {
-    // Default ON. Reading never consults this -- a payload is decoded by what its first byte says
-    // it is -- so a log written across the flip reads end to end in either direction, and turning
-    // it off again is not a one-way door.
     std::env::var("TS_WAL_BINARY_RECORDS")
         .map(|value| !(value == "0" || value.eq_ignore_ascii_case("false")))
         .unwrap_or(true)

--- a/crates/temporalstore-rust/src/wal_record.rs
+++ b/crates/temporalstore-rust/src/wal_record.rs
@@ -291,13 +291,16 @@ mod tests {
         assert_eq!(with_block.encode_to_vec(), vec![0x6a, 0x02, b'a', b'b']);
     }
 
-    /// What a write costs on disk in the shape the log writes today, against the binary one.
+    /// What a write costs in the TEXT FALLBACK, against the binary record.
     ///
-    /// This is the headroom still available from changing the record format, and it is much
-    /// smaller than it once was: encoding payloads compactly and shortening the log's own field
-    /// names already took most of it. Measured against the REAL record -- the type the log
-    /// serializes -- because measuring against the shape records used to have would overstate what
-    /// is left and is the kind of number that justifies a migration it should not.
+    /// This is not the headroom still available: `binary_records_enabled` and
+    /// `binary_frame_enabled` both default ON, so the text side here is the fallback the log
+    /// takes only when a flag turns it off. `what_a_record_actually_costs_on_disk` in `wal`
+    /// measures the real path and comes in BELOW the binary column below.
+    ///
+    /// This comparison used to be labelled "today", which overstated the remaining saving by
+    /// about two-fold -- the exact error the note here warned about, committed by the note. What
+    /// it is good for is what the fallback costs if anyone reaches for it.
     #[test]
     fn what_is_left_to_gain_from_a_binary_record() {
         use crate::types::Command;
@@ -413,11 +416,13 @@ mod tests {
         }
     }
 
-    /// Where a record's bytes are now, and what carrying the value raw would leave.
+    /// Where a record's bytes go IN THE TEXT FALLBACK, and what carrying the value raw leaves.
     ///
     /// A JSON document cannot hold bytes, so the value is base64 -- a flat third on top, whatever
-    /// it is. At four kilobytes that dwarfs everything else in the record, which is why the shape
-    /// of the remaining saving is not "the format" but "the payload".
+    /// it is. At four kilobytes that dwarfs everything else in the record.
+    ///
+    /// The ~122-byte envelope this reports is the fallback's, not the default path's: measured
+    /// through the store at the defaults, the envelope is about 49 bytes.
     #[test]
     fn where_a_records_bytes_are_now() {
         use crate::types::Command;


### PR DESCRIPTION
Three statements about the durability log's encoding, two of them wrong.

`binary_records_enabled` carried a doc comment saying "Default OFF while it proves out", a comment
inside its own body saying "Default ON", and a body returning `true`. The published one was the
wrong one.

Both encoding defaults are ON, so the two size analyses were measuring against a baseline the log
does not write. They build a JSON record by hand and call it "today", which overstates what is left
to gain by about two-fold. One of them carries a note warning that measuring against the shape
records used to have would "overstate what is left and is the kind of number that justifies a
migration it should not" -- and then does it.

Measured through the store at the defaults, appending real records and taking the delta between
them rather than the file size, since the log preallocates in large steps:

| value | on disk | ratio | analysis said "today" | analysis projects as the prize |
|---|---|---|---|---|
| 64 B | **113.0 B** | 1.77x | 210 B | 131 B |
| 1024 B | **1077.0 B** | 1.05x | 1491 B | 1094 B |
| 4096 B | **4149.0 B** | 1.01x | 5587 B | 4166 B |

The envelope is about **49 bytes**, not the 122 the analysis reports, and the real path already
comes in below the binary column those tests hold up as the goal.

The point of the change is the guard, not the prose: the new probe BOUNDS the envelope rather than
printing it, so this cannot drift again quietly. That bound is mutation-tested -- with
`TS_WAL_BINARY_RECORDS=0` it reads 116 B and fails, which is the state the old prose described as
current.

A size analysis that constructs its own baseline goes stale the moment a default flips, and it
goes stale silently, because it still runs green.