### PR TITLE
Read a byte setting in units

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -866,6 +866,24 @@ function liveStream(options) {
     return '<input type="text"' + attr + ' spellcheck="false" value="' + esc(f.value || "") + '">';
   }
 
+  /* A byte count is stored as bytes and read by a person. 1073741824 and 268435456 differ by a
+     factor of four and look the same at a glance, which is the sort of thing that gets a cache
+     sized wrong. The stored value is untouched -- this only adds a reading of it.
+
+     Applies to any setting whose variable ends in _BYTES, so it covers the two quota settings
+     that predate the engine group as well. */
+  function byteHint(f) {
+    if (!f.env || !/_BYTES$/.test(f.env)) { return ""; }
+    var raw = (f.value === "" || f.value == null) ? f.default : f.value;
+    var size = Number(raw);
+    if (!isFinite(size) || size <= 0) { return ""; }
+    var units = ["B", "KiB", "MiB", "GiB", "TiB"], step = 0;
+    while (size >= 1024 && step < units.length - 1) { size /= 1024; step += 1; }
+    var shown = (step === 0 || size >= 10) ? String(Math.round(size))
+      : String(Math.round(size * 10) / 10);
+    return ' <span class="env">= ' + shown + " " + units[step] + "</span>";
+  }
+
   function fieldHtml(f) {
     var badges = "";
     if (f.essential) { badges += '<span class="badge essential">required</span>'; }
@@ -885,7 +903,8 @@ function liveStream(options) {
       ((f.value || "") !== (f.default == null ? "" : String(f.default)));
     var reset = resettable
       ? '<button type="button" class="link reset" data-reset="' + esc(f.key) + '">reset</button>' : "";
-    var help = esc(f.help) + (f.env ? ' <span class="env">' + esc(f.env) + "</span>" : "");
+    var help = esc(f.help) + (f.env ? ' <span class="env">' + esc(f.env) + "</span>" : "") +
+      byteHint(f);
     var longCls = f.help.length > 190 ? " long" : "";
     return '<div class="field" data-field="' + esc(f.key) + '" data-essential="' +
       (f.essential ? "1" : "0") + '" data-search="' +

--- a/tools/portal/byte_hint_harness.js
+++ b/tools/portal/byte_hint_harness.js
@@ -1,0 +1,96 @@
+/* Run the Setup page's byteHint against real settings shapes and report what it produced.
+ *
+ * Grepping the built page proves the function is present, not that it fires: a hint appended to a
+ * variable nothing renders, or a pattern that never matches the variable names actually shipped,
+ * both leave the same source text in the file. byteHint is pure, so it is extracted and called --
+ * the thing under test is what it returns for a given field.
+ *
+ * Cases are the settings the portal really offers, including the two quota knobs that predate the
+ * engine group, so a pattern matching only TS_* would be caught here.
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join("\n");
+
+const start = scripts.indexOf("function byteHint(");
+if (start < 0) {
+  console.log("FAIL byteHint is not in the built page");
+  process.exit(1);
+}
+let depth = 0;
+let end = -1;
+for (let i = scripts.indexOf("{", start); i < scripts.length; i += 1) {
+  if (scripts[i] === "{") {
+    depth += 1;
+  } else if (scripts[i] === "}") {
+    depth -= 1;
+    if (depth === 0) { end = i + 1; break; }
+  }
+}
+if (end < 0) {
+  console.log("FAIL could not brace-match byteHint");
+  process.exit(1);
+}
+const byteHint = new Function(scripts.slice(start, end) + "; return byteHint;")();
+
+let failures = 0;
+
+const cases = [
+  { env: "TS_BLOCK_SEGMENT_TARGET_BYTES", value: "1073741824", expect: "1 GiB" },
+  { env: "TS_COMPACTION_WATERMARK_BYTES", value: "268435456", expect: "256 MiB" },
+  { env: "TS_CONTEXT_PAGE_TARGET_BYTES", value: "65536", expect: "64 KiB" },
+  { env: "TS_INDEX_DUMP_WAL_GAP_BYTES", value: "1048576", expect: "1 MiB" },
+  { env: "MATRIXARK_QUOTA_MAX_BLOB_BYTES", value: "5368709120", expect: "5 GiB" },
+  { env: "MATRIXARK_QUOTA_MAX_BODY_BYTES", value: "16777216", expect: "16 MiB" },
+  { env: "TS_PAGE_INDEX_CACHE_BYTES", value: "", default: "67108864", expect: "64 MiB" },
+  { env: "TS_STREAM_MAX_BLOB_SIZE_BYTES", value: "1500000", expect: "1.4 MiB" }
+];
+
+for (const c of cases) {
+  const out = byteHint({ env: c.env, value: c.value, default: c.default });
+  if (!out.includes(c.expect)) {
+    console.log("FAIL " + c.env + ": expected " + c.expect + ", got " + JSON.stringify(out));
+    failures += 1;
+  } else {
+    console.log("ok   " + c.env + " -> " + c.expect);
+  }
+}
+
+for (const env of ["TS_VECTOR_SCALED", "TS_MAX_RETAINED_FINISHED_JOBS", "MATRIXARK_HTTP_PORT"]) {
+  const out = byteHint({ env: env, value: "1024" });
+  if (out !== "") {
+    console.log("FAIL " + env + " is not a byte count and gained " + JSON.stringify(out));
+    failures += 1;
+  } else {
+    console.log("ok   " + env + " -> no hint");
+  }
+}
+
+for (const bad of ["", "auto", "0", "-1"]) {
+  const out = byteHint({ env: "TS_PAGE_INDEX_CACHE_BYTES", value: bad, default: "" });
+  if (out !== "") {
+    console.log("FAIL unreadable value " + JSON.stringify(bad) + " produced " + JSON.stringify(out));
+    failures += 1;
+  }
+}
+
+/* Wiring. Everything above would still pass if nothing called byteHint. This one is a SOURCE check
+ * rather than a behavioural one, and worth naming as such: fieldHtml builds its help text from
+ * several pieces and closes over page state, so it cannot be lifted out and called the way byteHint
+ * can. What is verified here is that the help construction references byteHint at all. */
+const NEEDLE = "var help = esc(f.help)";
+const at = scripts.indexOf(NEEDLE);
+if (at < 0) {
+  console.log("FAIL the help construction is gone; the hint cannot reach a field");
+  failures += 1;
+} else if (!scripts.slice(at, at + 300).includes("byteHint(f)")) {
+  console.log("FAIL byteHint is defined but the help text never calls it");
+  failures += 1;
+} else {
+  console.log("ok   help text calls byteHint (source check)");
+}
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -808,6 +808,24 @@ function liveStream(options) {
     return '<input type="text"' + attr + ' spellcheck="false" value="' + esc(f.value || "") + '">';
   }
 
+  /* A byte count is stored as bytes and read by a person. 1073741824 and 268435456 differ by a
+     factor of four and look the same at a glance, which is the sort of thing that gets a cache
+     sized wrong. The stored value is untouched -- this only adds a reading of it.
+
+     Applies to any setting whose variable ends in _BYTES, so it covers the two quota settings
+     that predate the engine group as well. */
+  function byteHint(f) {
+    if (!f.env || !/_BYTES$/.test(f.env)) { return ""; }
+    var raw = (f.value === "" || f.value == null) ? f.default : f.value;
+    var size = Number(raw);
+    if (!isFinite(size) || size <= 0) { return ""; }
+    var units = ["B", "KiB", "MiB", "GiB", "TiB"], step = 0;
+    while (size >= 1024 && step < units.length - 1) { size /= 1024; step += 1; }
+    var shown = (step === 0 || size >= 10) ? String(Math.round(size))
+      : String(Math.round(size * 10) / 10);
+    return ' <span class="env">= ' + shown + " " + units[step] + "</span>";
+  }
+
   function fieldHtml(f) {
     var badges = "";
     if (f.essential) { badges += '<span class="badge essential">required</span>'; }
@@ -827,7 +845,8 @@ function liveStream(options) {
       ((f.value || "") !== (f.default == null ? "" : String(f.default)));
     var reset = resettable
       ? '<button type="button" class="link reset" data-reset="' + esc(f.key) + '">reset</button>' : "";
-    var help = esc(f.help) + (f.env ? ' <span class="env">' + esc(f.env) + "</span>" : "");
+    var help = esc(f.help) + (f.env ? ' <span class="env">' + esc(f.env) + "</span>" : "") +
+      byteHint(f);
     var longCls = f.help.length > 190 ? " long" : "";
     return '<div class="field" data-field="' + esc(f.key) + '" data-essential="' +
       (f.essential ? "1" : "0") + '" data-search="' +

--- a/tools/test_matrixark_byte_settings_read_in_units.py
+++ b/tools/test_matrixark_byte_settings_read_in_units.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A byte-valued setting is shown in units a person reads, and only where that is true.
+
+Nine settings on the Setup page hold a byte count, and they were rendered as raw integers.
+1073741824 and 268435456 differ by a factor of four and look the same at a glance, which is how a
+cache gets sized wrong by someone reading carefully.
+
+Run rather than grepped. The built page containing `byteHint` proves the function is present, not
+that it fires: a hint appended to a variable nothing renders, or a pattern that never matches the
+variable names actually shipped, leave identical source text behind. The harness extracts the
+function from the built page and calls it.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "byte_hint_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page's own JS cannot be run")
+class AByteSettingReadsInUnitsTest(unittest.TestCase):
+
+    def test_the_harness_passes_every_case(self) -> None:
+        proc = subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=120)
+        self.assertEqual(0, proc.returncode,
+                         "the Setup page's byteHint did not render every case as expected:\n%s%s"
+                         % (proc.stdout, proc.stderr))
+        self.assertIn("PASS", proc.stdout)
+
+    def test_the_harness_checks_a_meaningful_number_of_cases(self) -> None:
+        """A harness that asserts nothing passes everything."""
+        proc = subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=120)
+        checked = sum(1 for line in proc.stdout.splitlines() if line.startswith("ok "))
+        self.assertGreaterEqual(
+            checked, 8,
+            "the harness reported only %d checks, so passing it says little" % checked)
+
+
+class EveryByteSettingIsCoveredTest(unittest.TestCase):
+    """The hint keys off a `_BYTES` suffix, so a byte setting named otherwise gets nothing."""
+
+    def test_no_byte_shaped_setting_is_missed_by_the_suffix_rule(self) -> None:
+        import matrixark_gateway_config as cfgmod
+
+        suspicious = []
+        for setting in cfgmod.SETTINGS:
+            if setting.kind != "int" or not setting.env:
+                continue
+            if setting.env.endswith("_BYTES"):
+                continue
+            # A setting whose help talks about bytes but whose name does not end in _BYTES would
+            # render as a bare integer with no hint, and nothing else would notice.
+            help_text = (setting.help or "").lower()
+            if "bytes" in help_text and "per" not in help_text:
+                suspicious.append("%s (%s)" % (setting.key, setting.env))
+        self.assertEqual(
+            [], suspicious,
+            "these look like byte counts but do not end in _BYTES, so they render without a "
+            "readable size: %s" % ", ".join(suspicious))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Nine settings on the Setup page hold a byte count and were rendered as raw integers. **1073741824 and 268435456 differ by a factor of four and look the same at a glance** — which is how a cache gets sized wrong by someone reading carefully.

Each now carries a reading of itself:

| setting | shown as |
|---|---|
| `TS_BLOCK_SEGMENT_TARGET_BYTES` | 1 GiB |
| `TS_COMPACTION_WATERMARK_BYTES` | 256 MiB |
| `TS_PAGE_INDEX_CACHE_BYTES` | 64 MiB |
| `TS_CONTEXT_PAGE_TARGET_BYTES` | 64 KiB |
| `MATRIXARK_QUOTA_MAX_BLOB_BYTES` | 5 GiB |

The stored value is untouched — this adds a hint beside it. Keyed off a `_BYTES` suffix, so it covers the two quota settings that predate the engine group as well as the seven added with it.

**Tested by running the page.s own JS**, not by grepping the built file. A hint appended to a variable nothing renders, and a pattern that never matches the variable names actually shipped, leave identical source text behind. The harness lifts `byteHint` out of the built page and calls it across the real settings — including the cases that must produce **nothing**: a bool, a plain count, a port, and values that cannot be read as a size, because an unreadable value must not render `NaN B`.

**One check in that harness is a source check and says so.** Everything else would still pass if nothing called `byteHint`, and `fieldHtml` closes over page state so it cannot be lifted out the same way. What that check verifies is that the help construction references it. Mutation-checked: unwiring the call fails the harness.

A companion test also flags any integer setting whose help mentions bytes but whose name does not end in `_BYTES` — those would render bare, and nothing else would notice.