### PR TITLE
Say when a value is raised

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -348,17 +348,19 @@ SETTINGS: List[Setting] = [
             "TS_BLOCK_SEGMENT_TARGET_BYTES",
             "Target size of a block segment", "int", "1073741824", "live",
             "The unit page-slab reclaim works in. A slab is retained while any loaded shard still "
-            "references it, so larger slabs mean fewer, coarser reclaims."),
+            "references it, so larger slabs mean fewer, coarser reclaims. Values below 1 KiB are "
+            "raised to it."),
     Setting("storage_engine.storage_zone_size", "storage_engine",
             "TS_STORAGE_ZONE_SIZE",
             "Storage zone size", "int", "1073741824", "live",
             "The span the band and zone catalog accounts in. It sets the granularity of what "
-            "compaction and the catalog can talk about, not how much is stored."),
+            "compaction and the catalog can talk about, not how much is stored. Values below 1 KiB "
+            "are raised to it."),
     Setting("storage_engine.stream_max_blob_size", "storage_engine",
             "TS_STREAM_MAX_BLOB_SIZE",
             "Largest streamed blob", "int", "10485760", "live",
             "The ceiling on a single streamed payload. Raising it admits larger objects and raises "
-            "the peak memory a single request can hold."),
+            "the peak memory a single request can hold. Values below 1 KiB are raised to it."),
     Setting("storage_engine.compaction_watermark_bytes", "storage_engine",
             "TS_COMPACTION_WATERMARK_BYTES",
             "Compaction watermark", "int", "268435456", "live",

--- a/tools/test_matrixark_clamped_settings_say_so.py
+++ b/tools/test_matrixark_clamped_settings_say_so.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A setting the engine clamps must say so on the page.
+
+Four of the storage tuning knobs are read as `parse_*(...).max(1024)`. A customer who sets 512 gets
+1024, and nothing on the page or in the response says the value was changed -- which is the same
+shape as every other defect found in this area: something accepted that silently resolves to
+something else.
+
+The floors are derived from the accessor rather than written down here. A list of "these four clamp"
+would be correct today and wrong the moment a fifth gains a floor or one loses it, and the failure
+mode of that staleness is silence -- the same silence the check exists to remove.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_config as cfgmod  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TUNING = os.path.join(ROOT, "crates", "temporalstore-rust", "src", "storage_config.rs")
+
+# `field: parse_usize(get(TS_NAME), defaults.field,)  .max(1024),`  -- the clamp may sit on the
+# next line, so the pattern spans whitespace rather than assuming a layout.
+CLAMPED = re.compile(
+    r"get\((TS_[A-Z0-9_]+)\)[^;]*?\)\s*\.\s*(?:max|min|clamp)\(\s*([0-9_]+)",
+    re.S)
+
+
+def declared_floors() -> dict:
+    """env name -> the floor its accessor applies."""
+    if not os.path.exists(TUNING):
+        return {}
+    with open(TUNING, encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
+    start = text.find("pub fn from_getter")
+    if start < 0:
+        return {}
+    body = text[start:text.find("\n    }\n", start)]
+    floors = {}
+    for match in CLAMPED.finditer(body):
+        floors[match.group(1)] = int(match.group(2).replace("_", ""))
+    return floors
+
+
+def _env_for_constant(identifier: str) -> str:
+    """The variable a knob constant holds, which is not always its identifier."""
+    with open(TUNING, encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
+    match = re.search(r'pub const %s\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"'
+                      % re.escape(identifier), text)
+    return match.group(1) if match else identifier
+
+
+class AClampedSettingSaysSoTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.floors = {_env_for_constant(name): floor
+                       for name, floor in declared_floors().items()}
+        self.by_env = {s.env: s for s in cfgmod.SETTINGS if s.env}
+
+    def test_the_scan_found_clamps(self) -> None:
+        """Without a floor to find, every assertion below passes by checking nothing."""
+        self.assertGreaterEqual(
+            len(self.floors), 3,
+            "found %d clamped knobs in the tuning accessor; the pattern has stopped matching and "
+            "the checks below would pass silently" % len(self.floors))
+
+    def test_every_clamped_setting_mentions_its_floor(self) -> None:
+        silent = []
+        for env, floor in sorted(self.floors.items()):
+            setting = self.by_env.get(env)
+            if setting is None:
+                continue          # not offered on the page; nothing to mislead a customer with
+            help_text = (setting.help or "").lower()
+            readable = "1 kib" if floor == 1024 else str(floor)
+            if "raised" not in help_text or readable not in help_text:
+                silent.append("%s (floor %d)" % (env, floor))
+        self.assertEqual(
+            [], silent,
+            "the engine raises these to a floor and the page does not say so, so a customer who "
+            "sets a smaller value is told nothing and gets a different one: %s" % ", ".join(silent))
+
+    def test_an_unclamped_setting_does_not_claim_a_floor(self) -> None:
+        """The opposite error: text promising a clamp that the engine does not apply."""
+        wrong = []
+        for env, setting in sorted(self.by_env.items()):
+            if env in self.floors or not env.startswith("TS_"):
+                continue
+            if "raised to it" in (setting.help or "").lower():
+                wrong.append(env)
+        self.assertEqual(
+            [], wrong,
+            "these promise the engine raises small values and it does not: %s" % ", ".join(wrong))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Four storage tuning knobs are read as `parse_*(...).max(1024)`. **A customer who sets 512 gets 1024**, and nothing on the page or in the response says the value was changed.

That is the same shape as everything else in this area: something accepted that silently resolves to something else.

| setting | floor |
|---|---|
| `TS_CONTEXT_PAGE_TARGET_BYTES` | 1 KiB |
| `TS_BLOCK_SEGMENT_TARGET_BYTES` | 1 KiB |
| `TS_STORAGE_ZONE_SIZE` | 1 KiB |
| `TS_STREAM_MAX_BLOB_SIZE` | 1 KiB |

I had documented the floor on **one** of the four and not the other three, which is worse than documenting none — a reader who checks one field and finds it thorough has no reason to doubt the next.

**The floors are derived from the accessor, not listed in the test.** A list would be right today and wrong the moment a fifth knob gains a floor or one loses it, and the failure mode of that staleness is silence — exactly what the check exists to remove. Deriving also handles the knob whose constant identifier is not the variable it holds: `TS_BLOCK_SLAB_TARGET_BYTES` carries `TS_BLOCK_SEGMENT_TARGET_BYTES`, and a hand-written list would have recorded the wrong name.

The opposite error is checked too — help text promising a clamp the engine does not apply. Mutation-checked both ways: dropping a floor note fails, and adding a false one fails.