### PR TITLE
Say what a launch does not carry

### DIFF
--- a/tools/matrixark_deployment_plan.py
+++ b/tools/matrixark_deployment_plan.py
@@ -185,12 +185,18 @@ _KEY_NAME = re.compile(r"^[A-Z][A-Z0-9_]{2,63}$")
 
 def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
          shared_dir: str = "", key_envs: Optional[List[str]] = None,
-         matrixobject_available: bool = True, endpoint_reachable: bool = False) -> Json:
+         matrixobject_available: bool = True, endpoint_reachable: bool = False,
+         configured_engine_settings: Optional[List[str]] = None) -> Json:
     """Compose one deployment. Returns the environment, plus what it will really resolve to.
 
     `blocking` is for choices that cannot produce the deployment asked for at all; `warnings` is for
     ones that produce a working deployment that differs from the request. They are separate because
     they need different answers -- a block is a mistake to fix, a warning is a fact to accept.
+
+    `configured_engine_settings` are engine variables this deployment has set locally. They are
+    passed in rather than read here on purpose: this function composes a plan from its arguments and
+    nothing else, so it stays testable and cannot pick up whatever the machine running it happens to
+    have configured.
     """
     blocking: List[str] = []
     warnings: List[str] = []
@@ -200,6 +206,18 @@ def plan(shape: str, storage: str = "", nodes: int = 0, root: str = "",
     if spec is None:
         return {"ok": False, "env": {}, "blocking": ["Unknown deployment shape %r." % shape],
                 "warnings": [], "notes": [], "shape": shape}
+
+    # A new deployment starts from the engine's own defaults. The environment this plan composes
+    # is topology and credentials -- shape, storage, key NAMES -- and carries none of the storage
+    # tuning a customer set on this deployment's Setup page. That is the right default (tuning is
+    # sized for the box it was measured on, and copying it blind would move a cache figure onto
+    # different hardware), and it is a surprise if nobody says it: the customer tuned a store, asked
+    # this page for a box, and got one that ignores every value they chose.
+    for name in sorted(set(configured_engine_settings or [])):
+        notes.append(
+            "%s is set on this deployment and is NOT carried into the launch artifact; the new "
+            "node starts at the engine default. Set it on the new node after it comes up, or add "
+            "it to the launcher that starts it." % name)
 
     count = int(nodes or spec["nodes"])
     env: Json = {}

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3069,6 +3069,27 @@ def _parse_prom_labels(line: str) -> Json:
     return out
 
 
+def _configured_engine_settings() -> list:
+    """Engine variables this deployment has explicitly set, for the plan to disclose.
+
+    Only names, never values: the plan and the artifact it produces travel, and a tuning value is
+    the least of what could ride along if this returned the settings themselves.
+    """
+    try:
+        import matrixark_gateway_config as gwconfig
+
+        snapshot = gwconfig.snapshot()
+    except Exception:  # pragma: no cover - the plan is still worth producing without this
+        return []
+    names = []
+    for items in (snapshot.get("groups") or {}).values():
+        for item in items:
+            env = item.get("env") or ""
+            if env.startswith("TS_") and item.get("source") in ("portal", "environment"):
+                names.append(env)
+    return sorted(set(names))
+
+
 def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
     """Which storage backend the datanode actually resolved. None => could not determine.
 
@@ -3436,6 +3457,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                     key_envs=list((payload or {}).get("key_envs", []) or []),
                     matrixobject_available=bool(
                         (payload or {}).get("matrixobject_available", True)),
+                    configured_engine_settings=_configured_engine_settings(),
                 )
             except (TypeError, ValueError) as exc:
                 return await _json(send, 400, {"error": "invalid_plan", "detail": str(exc)})

--- a/tools/test_matrixark_launch_carryover_disclosure.py
+++ b/tools/test_matrixark_launch_carryover_disclosure.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A launch artifact says which local settings it does not carry.
+
+The plan composes topology and credentials -- shape, storage tier, key NAMES. It carries none of
+the storage tuning a customer set on this deployment's Setup page, and that is the right default:
+tuning is sized for the box it was measured on, and copying a cache figure onto different hardware
+is worse than starting from the engine's own numbers.
+
+It is a surprise if nobody says it. The customer tuned a store, asked this page for a box, and got
+one that ignores every value they chose. So the plan now names them.
+
+Disclosure only. The environment the plan produces must be byte-identical whether or not anything
+is configured locally -- a note that changed the deployment would be a much worse bug than the
+silence it replaces.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_deployment_plan as dp  # noqa: E402
+
+VALID = {"shape": "onebox", "storage": "ebs", "root": "/srv/temporalstore"}
+
+
+def _disclosures(plan) -> list:
+    return [note for note in plan["notes"] if "NOT carried" in note]
+
+
+class ALaunchSaysWhatItDoesNotCarryTest(unittest.TestCase):
+
+    def test_a_configured_setting_is_named(self) -> None:
+        plan = dp.plan(configured_engine_settings=["TS_PAGE_INDEX_CACHE_BYTES"], **VALID)
+        notes = _disclosures(plan)
+        self.assertEqual(1, len(notes), plan["notes"])
+        self.assertIn("TS_PAGE_INDEX_CACHE_BYTES", notes[0])
+        self.assertIn("engine default", notes[0],
+                      "the note must say what the new node uses instead")
+
+    def test_nothing_configured_says_nothing(self) -> None:
+        """A page that warns unconditionally trains people to ignore it."""
+        self.assertEqual([], _disclosures(dp.plan(**VALID)))
+
+    def test_the_disclosure_does_not_change_the_deployment(self) -> None:
+        """The invariant that matters: this reports, it does not configure."""
+        plain = dp.plan(**VALID)
+        disclosed = dp.plan(
+            configured_engine_settings=["TS_PAGE_INDEX_CACHE_BYTES", "TS_VECTOR_SCALED"],
+            **VALID)
+        self.assertEqual(plain["env"], disclosed["env"],
+                         "the environment changed when a setting was disclosed; a note must not "
+                         "configure anything")
+        self.assertEqual(plain["ok"], disclosed["ok"])
+        self.assertEqual(plain["blocking"], disclosed["blocking"])
+
+    def test_names_are_deduplicated_and_ordered(self) -> None:
+        plan = dp.plan(
+            configured_engine_settings=["TS_VECTOR_SCALED", "TS_PAGE_INDEX_CACHE_BYTES",
+                                        "TS_VECTOR_SCALED"],
+            **VALID)
+        notes = _disclosures(plan)
+        self.assertEqual(2, len(notes), "a repeated name produced a repeated note")
+        self.assertIn("TS_PAGE_INDEX_CACHE_BYTES", notes[0], "notes are not in a stable order")
+
+
+class TheRouteSuppliesNamesOnlyTest(unittest.TestCase):
+
+    def test_only_names_ever_leave_the_gateway(self) -> None:
+        """The plan and its artifact travel. A value must not ride along with the name."""
+        import matrixark_v1_gateway as gateway
+
+        names = gateway._configured_engine_settings()
+        self.assertIsInstance(names, list)
+        for name in names:
+            self.assertIsInstance(name, str)
+            self.assertTrue(name.startswith("TS_"),
+                            "%r is not an engine variable name" % name)
+            self.assertNotIn("=", name, "%r looks like it carries a value" % name)
+
+    def test_it_survives_a_config_it_cannot_read(self) -> None:
+        """A plan is still worth producing when the settings cannot be loaded."""
+        import matrixark_v1_gateway as gateway
+
+        saved = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = "/nonexistent/dir/does-not-exist.json"
+        try:
+            self.assertIsInstance(gateway._configured_engine_settings(), list)
+        finally:
+            if saved is None:
+                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
+            else:
+                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = saved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The deployment plan composes topology and credentials — shape, storage tier, key **names**. It carries none of the storage tuning a customer set on this deployment.s Setup page; the plan module does not reference the settings module at all.

**That default is right.** Tuning is sized for the box it was measured on, and copying a cache figure onto different hardware is worse than starting from the engine.s own numbers.

**It is a surprise if nobody says it.** The customer tuned a store, asked this page for a box, and got one that ignores every value they chose. The plan now names them:

> `TS_PAGE_INDEX_CACHE_BYTES` is set on this deployment and is NOT carried into the launch artifact; the new node starts at the engine default. Set it on the new node after it comes up, or add it to the launcher that starts it.

**Passed in, not read inside `plan()`.** That keeps the function composing from its arguments and nothing else — it cannot pick up whatever the machine running it happens to have configured, and it stays testable without touching a config file.

**The gateway supplies names only.** A plan and its artifact travel, and a tuning value is the least of what could ride along if this returned settings rather than their names.

**Disclosure only** — the invariant worth pinning: the environment a plan produces is identical whether or not anything is configured locally. A note that changed the deployment would be a worse bug than the silence it replaces. Mutation-checked: making the note also set a value fails three tests.

Six tests, plus the existing deployment plan (24) and route (23) suites unchanged.