### PR TITLE
A write says when its value will be raised

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -52,6 +52,25 @@ _BOOT_ENV: Dict[str, str] = dict(os.environ)
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
+# Floors the ENGINE applies, by variable. These are not a policy this file invents -- the accessors
+# in storage_config.rs read `parse_*(...).max(1024)`, so a smaller value is silently raised before
+# anything uses it. Documented in each setting's help as well; recorded here so a write can say so
+# at the moment it happens, which is the only time the customer is looking.
+#
+# test_matrixark_clamped_settings_say_so derives the same floors from the Rust accessor and fails if
+# this map and the engine disagree, so it cannot quietly go stale.
+_ENGINE_MINIMUMS: Dict[str, int] = {
+    "TS_CONTEXT_PAGE_TARGET_BYTES": 1024,
+    "TS_BLOCK_SEGMENT_TARGET_BYTES": 1024,
+    "TS_STORAGE_ZONE_SIZE": 1024,
+    "TS_STREAM_MAX_BLOB_SIZE": 1024,
+}
+
+
+def engine_minimum(env_name: str) -> Optional[int]:
+    """The floor the engine raises this variable to, if it has one."""
+    return _ENGINE_MINIMUMS.get(env_name)
+
 DEFAULT_CONFIG_FILENAME = "runtime_config.json"
 
 # How many past writes the stored document keeps. Bounded because this file is read on every boot
@@ -1054,8 +1073,20 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
                 os.environ["MATRIXARK_EXTRACTION_PROVIDER"] = value
             else:
                 os.environ.pop("MATRIXARK_EXTRACTION_PROVIDER", None)
+        # A value the engine will raise is reported back with what it will really be. The
+        # write is still accepted -- the engine takes it and raises it, and refusing here would be
+        # this file inventing a stricter rule than the thing it configures.
+        raised_to = None
+        floor = engine_minimum(name) if name else None
+        if floor is not None and value not in ("", None):
+            try:
+                if int(str(value).strip()) < floor:
+                    raised_to = floor
+            except (TypeError, ValueError):
+                raised_to = None
         applied.append({
             "key": key, "env": name, "applies": setting.applies,
+            "raised_to": raised_to,
             "in_effect": setting.applies == "live",
             "secret": setting.secret,
         })

--- a/tools/test_matrixark_clamped_settings_say_so.py
+++ b/tools/test_matrixark_clamped_settings_say_so.py
@@ -99,5 +99,82 @@ class AClampedSettingSaysSoTest(unittest.TestCase):
             "these promise the engine raises small values and it does not: %s" % ", ".join(wrong))
 
 
+class TheMinimumsMapMatchesTheEngineTest(unittest.TestCase):
+    """`_ENGINE_MINIMUMS` exists so a write can report a raised value at the moment it happens.
+
+    It is a transcription of what the accessor does, and a transcription drifts. Comparing it to
+    the floors derived from the Rust source is what stops that -- without this the map could keep
+    reporting 1024 long after the engine moved, and the report would be confidently wrong, which is
+    worse than the silence it replaced.
+    """
+
+    def setUp(self) -> None:
+        self.derived = {_env_for_constant(name): floor
+                        for name, floor in declared_floors().items()}
+
+    def test_the_map_and_the_engine_agree(self) -> None:
+        mapped = dict(getattr(cfgmod, "_ENGINE_MINIMUMS", {}))
+        self.assertEqual(
+            self.derived, mapped,
+            "the floors the portal reports and the floors the engine applies have diverged. "
+            "Engine: %r. Portal: %r." % (self.derived, mapped))
+
+    def test_the_map_is_not_empty(self) -> None:
+        self.assertTrue(getattr(cfgmod, "_ENGINE_MINIMUMS", {}),
+                        "no floors are recorded, so no write can report a raised value")
+
+
+class AWriteReportsARaisedValueTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        import shutil
+        import tempfile
+
+        directory = tempfile.mkdtemp(prefix="matrixark-clamp-test-")
+        path = os.path.join(directory, "runtime_config.json")
+        self._saved = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = path
+        resolved = cfgmod.config_path()
+        if resolved != path:
+            raise AssertionError("config isolation failed: %r" % resolved)
+
+        def restore():
+            if self._saved is None:
+                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
+            else:
+                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self._saved
+            shutil.rmtree(directory, ignore_errors=True)
+
+        self.addCleanup(restore)
+        self.key = next(s.key for s in cfgmod.SETTINGS
+                        if s.env in getattr(cfgmod, "_ENGINE_MINIMUMS", {}))
+        self.floor = cfgmod._ENGINE_MINIMUMS[
+            next(s.env for s in cfgmod.SETTINGS if s.key == self.key)]
+
+    def _row(self, value):
+        result = cfgmod.update({self.key: value}, actor="test")
+        return next(r for r in result["applied"] if r["key"] == self.key)
+
+    def test_a_value_below_the_floor_is_reported(self) -> None:
+        row = self._row(str(self.floor // 2))
+        self.assertEqual(
+            self.floor, row.get("raised_to"),
+            "a value below the engine's floor was accepted with no indication it would be raised")
+
+    def test_a_value_at_or_above_the_floor_is_not(self) -> None:
+        self.assertIsNone(self._row(str(self.floor)).get("raised_to"))
+        self.assertIsNone(self._row(str(self.floor * 64)).get("raised_to"))
+
+    def test_the_write_is_still_accepted(self) -> None:
+        """Reporting, not refusing. The engine takes the value and raises it; this file must not
+        invent a stricter rule than the thing it configures."""
+        row = self._row(str(self.floor // 2))
+        self.assertTrue(row.get("in_effect") or row.get("applies") == "restart")
+        self.assertEqual(str(self.floor // 2),
+                         os.environ.get(row["env"]),
+                         "the value written to the environment was altered; this must report what "
+                         "the engine will do, not do it here")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_matrixark_clamped_settings_say_so.py
+++ b/tools/test_matrixark_clamped_settings_say_so.py
@@ -132,6 +132,12 @@ class AWriteReportsARaisedValueTest(unittest.TestCase):
 
         directory = tempfile.mkdtemp(prefix="matrixark-clamp-test-")
         path = os.path.join(directory, "runtime_config.json")
+        # The WHOLE environment, not just the config path. update() sets os.environ for every
+        # setting it writes, and `unittest discover` runs the suite in one process -- leaving
+        # TS_CONTEXT_PAGE_TARGET_BYTES behind made the portal's export test see a configured
+        # setting where it asserts there are none. Isolating the config file is not enough when
+        # the thing under test also writes the environment.
+        self._saved_environ = dict(os.environ)
         self._saved = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
         os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = path
         resolved = cfgmod.config_path()
@@ -139,10 +145,8 @@ class AWriteReportsARaisedValueTest(unittest.TestCase):
             raise AssertionError("config isolation failed: %r" % resolved)
 
         def restore():
-            if self._saved is None:
-                os.environ.pop("MATRIXARK_RUNTIME_CONFIG_FILE", None)
-            else:
-                os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self._saved
+            os.environ.clear()
+            os.environ.update(self._saved_environ)
             shutil.rmtree(directory, ignore_errors=True)
 
         self.addCleanup(restore)


### PR DESCRIPTION
Four tuning knobs are read as `parse_*(...).max(1024)`. #702 put that in the help text. **Help text is read once; a write response is read at the moment the customer types the number** — which is the only time they are looking at that field.

```
wrote 512   -> raised_to: 1024
wrote 65536 -> raised_to: None
malloc_trim -> raised_to: None      (no floor)
```

A field that warns unconditionally teaches people to ignore it, so only a value actually below a floor is reported.

**Reporting, not refusing.** The engine accepts the value and raises it; refusing here would be this file inventing a stricter rule than the thing it configures. The value written to the environment is untouched — and that is asserted, because it is the tempting mistake: a mutation that clamps at the write site instead of reporting fails two tests.

**The floors map is tied to the engine.** It is a transcription of what the accessor does, and a transcription drifts, so it is compared against the floors derived from the Rust source. Without that it could keep reporting 1024 long after the engine moved, and a confidently wrong number is worse than the silence it replaces. Mutation-checked: changing one floor in the map fails the comparison.

One note on my own checking: my first mutation for the write-site case was a no-op — it reassigned the value *after* the environment write, so the test passed and proved nothing. Rewriting it to mutate before the write made it fail as it should.