### PR TITLE
Show whether storage maintenance runs at all

### DIFF
--- a/docs/ops/temporalstore-alerts.yml
+++ b/docs/ops/temporalstore-alerts.yml
@@ -278,3 +278,31 @@ groups:
         annotations:
           summary: TemporalStore control-plane mutations are not applying
           description: "{{ $value }} recorded mutations would not apply in the last fifteen minutes. The control plane believes it made a change that did not take effect."
+  - name: temporalstore-storage-maintenance
+    rules:
+      - alert: TemporalStoreMaintenanceNeverRan
+        expr: absent(temporalstore_storage_manager_phase_applied)
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore storage maintenance has not run on this node
+          description: "No storage-manager phase has reported, so reclaim, index GC, expiry, eviction and compaction have not run. These metrics describe the LAST cycle, so their absence means there has not been one. The cycle is reachable at POST /server/storage/manager/cycle and nothing in the node schedules it, so on a long-lived deployment the store grows unattended."
+
+      - alert: TemporalStoreMaintenancePhaseErrors
+        expr: temporalstore_storage_manager_phase_errors > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore storage maintenance phase is failing
+          description: "Phase {{ $labels.phase }} on shard {{ $labels.shard_id }} reported {{ $value }} errors in its last cycle. A phase that fails leaves its work undone while the cycle reports as having run."
+
+      - alert: TemporalStoreMaintenancePhaseDisabled
+        expr: temporalstore_storage_manager_phase_enabled == 0
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore storage maintenance phase is switched off
+          description: "Phase {{ $labels.phase }} on shard {{ $labels.shard_id }} is disabled. That is a supported choice and it is worth seeing: the work that phase does is not happening, and nothing else does it."

--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -194,6 +194,57 @@
           "expr": "matrixark_backend_ready"
         }
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Storage Maintenance: Work Done Per Phase",
+      "targets": [
+        {
+          "expr": "temporalstore_storage_manager_phase_work"
+        },
+        {
+          "expr": "temporalstore_storage_manager_phase_applied"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Storage Maintenance: Phase Enabled And Skipped",
+      "targets": [
+        {
+          "expr": "temporalstore_storage_manager_phase_enabled"
+        },
+        {
+          "expr": "temporalstore_storage_manager_phase_skipped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Storage Maintenance: Errors And Duration",
+      "targets": [
+        {
+          "expr": "temporalstore_storage_manager_phase_errors"
+        },
+        {
+          "expr": "temporalstore_storage_manager_phase_duration_ms"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Storage Maintenance: Pressure And Floors",
+      "targets": [
+        {
+          "expr": "temporalstore_storage_manager_pressure"
+        },
+        {
+          "expr": "temporalstore_storage_manager_phase_pressure"
+        },
+        {
+          "expr": "temporalstore_storage_manager_phase_floors"
+        }
+      ]
     }
   ]
 }

--- a/docs/ops/temporalstore-grafana-metrics-coverage.md
+++ b/docs/ops/temporalstore-grafana-metrics-coverage.md
@@ -214,3 +214,37 @@ The panel title, the metric's HELP text and both alert descriptions now say so.
 `test_matrixark_readiness_gate_is_build_state.py` pins it: if a runtime read is ever added to that
 surface, the test fails and asks for the wording to be revisited, so the description cannot quietly
 become wrong in the other direction.
+
+
+## Storage maintenance, and the one thing these panels cannot tell you
+
+Ten `temporalstore_storage_manager_*` families are declared and, until now, none appeared on any
+dashboard. They describe the five phases that decide whether a store grows without bound:
+`reclaim_wal`, `index_gc`, `expire`, `evict`, `compact`.
+
+That matters more than a normal coverage hole, because **nothing in the node schedules the cycle**.
+`start_storage_manager_scheduler` exists and has exactly one caller, a test; the cycle is reachable
+only at `POST /server/storage/manager/cycle`. On a long-lived deployment nobody posts to, none of
+those phases has ever run.
+
+### What the alerts can and cannot see
+
+Every one of these metrics is a gauge describing the LAST cycle, so:
+
+| condition | detectable | how |
+|---|---|---|
+| never ran | yes | `absent(...phase_applied)` -- the metric does not exist until a cycle reports |
+| a phase failed | yes | `...phase_errors > 0` |
+| a phase is switched off | yes | `...phase_enabled == 0` |
+| **ran once, then stopped** | **no** | nothing records WHEN the last cycle was |
+
+The last row is the honest gap. A gauge of the last cycle's results looks identical whether that
+cycle was a minute ago or a month ago, so a node that ran maintenance once at startup and never
+again is indistinguishable from a healthy one. Closing it needs a timestamp -- a
+`..._last_run_seconds` gauge, or a counter that increases per cycle so `increase()` over a window
+means something. Both are engine changes and neither is made here.
+
+`absent()` rather than `increase() == 0` for the never-ran case is deliberate: `increase()` over a
+metric that does not exist returns no series, so a rule written that way would never fire on the
+condition it names. That is the exact defect removed from this file earlier -- an alert that reads
+as coverage and cannot fire.


### PR DESCRIPTION
Ten `temporalstore_storage_manager_*` families are declared and **none appeared on any dashboard**. They cover the five phases that decide whether a store grows without bound: `reclaim_wal`, `index_gc`, `expire`, `evict`, `compact`.

That is worse than a normal coverage hole, because **nothing in the node schedules the cycle**. `start_storage_manager_scheduler` exists and has exactly one caller — a test. The cycle is reachable only at `POST /server/storage/manager/cycle`. On a long-lived deployment nobody posts to, none of those phases has ever run, and nothing said so.

Four panels and three rules, chosen around what a gauge of the **last** cycle can actually show:

| condition | detectable | how |
|---|---|---|
| never ran | yes | `absent(...phase_applied)` |
| a phase failed | yes | `...phase_errors > 0` |
| a phase switched off | yes | `...phase_enabled == 0` |
| **ran once, then stopped** | **no** | nothing records *when* the last cycle was |

**The last row is written down rather than papered over.** A gauge of the last cycle looks identical whether it ran a minute ago or a month ago, so a node that ran maintenance once at startup is indistinguishable from a healthy one. Closing it needs a timestamp gauge or a per-cycle counter — an engine change, not made here.

`absent()` rather than `increase() == 0` for the never-ran case is deliberate: `increase()` over a metric that does not exist returns no series, so that rule would never fire on the condition it names. **That is the exact defect removed from this file earlier today**, and it would have been easy to reintroduce while fixing something else.