### PR TITLE
Watch the raft runtime's faults

### DIFF
--- a/docs/ops/temporalstore-alerts.yml
+++ b/docs/ops/temporalstore-alerts.yml
@@ -306,3 +306,45 @@ groups:
         annotations:
           summary: TemporalStore storage maintenance phase is switched off
           description: "Phase {{ $labels.phase }} on shard {{ $labels.shard_id }} is disabled. That is a supported choice and it is worth seeing: the work that phase does is not happening, and nothing else does it."
+  - name: temporalstore-raft-runtime-faults
+    rules:
+      - alert: TemporalStoreRaftMinorityPartitionRejections
+        expr: increase(temporalstore_raft_matrixraft_minority_partition_write_rejections[10m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: TemporalStore raft is rejecting writes from a minority partition
+          description: "{{ $value }} writes were rejected in the last ten minutes because this node is in a minority partition. The rejection is correct -- accepting them would risk divergence -- and it means part of the cluster cannot serve writes. Check majority and peer liveness."
+
+      - alert: TemporalStoreRaftSnapshotSendFailing
+        expr: increase(temporalstore_raft_matrixraft_peer_snapshot_send_failed[30m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore raft snapshot sends are failing
+          description: "{{ $value }} snapshot sends failed in the last thirty minutes. A follower that cannot receive a snapshot cannot catch up, and a follower that never catches up eventually pins log reclaim."
+
+      - alert: TemporalStoreRaftPeerOffline
+        expr: temporalstore_raft_matrixraft_peer_offline_timeout_reached == 1
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: TemporalStore raft peer has crossed its offline timeout
+          description: "A peer has been past its configured offline timeout for ten minutes. Unlike the stale-read gauges next to it on the dashboard, this one reading 1 is a fault rather than a protection being enforced."
+
+      - alert: TemporalStoreRaftLeaderTransferTimeouts
+        expr: increase(temporalstore_raft_matrixraft_peer_transfer_leader_timeouts[30m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore raft leader transfer is timing out
+          description: "{{ $value }} leader transfers timed out in the last thirty minutes. A transfer that cannot complete leaves leadership where it is, so a planned drain or upgrade will not move off this node."
+
+      - alert: TemporalStoreRaftLaggingFollowerReads
+        expr: increase(temporalstore_raft_matrixraft_lagging_follower_read_rejections[15m]) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: TemporalStore raft is rejecting reads from a lagging follower
+          description: "{{ $value }} follower reads were rejected for lag in the last fifteen minutes. Reads are being served correctly by refusing stale data; the follower behind them is not keeping up."

--- a/docs/ops/temporalstore-cluster-dashboard.json
+++ b/docs/ops/temporalstore-cluster-dashboard.json
@@ -233,6 +233,129 @@
           "expr": "temporalstore_meta_mutation_apply_failed_total"
         }
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Partition Rejections",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_minority_partition_read_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_minority_partition_write_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_lagging_follower_read_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_stale_leader_lease_rejections"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Read Path Rejections",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_read_index_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_lease_read_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_bounded_stale_read_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_bounded_stale_read_accepted"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_bounded_stale_read_requests"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Snapshot Transfer Faults",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_snapshot_send_failed"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_snapshot_send_timeouts"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_snapshot_install_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_snapshot_backpressure_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_snapshot_retry_count"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Peer Append And Reorder",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_append_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_stale_term_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_reorder_entries_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_reorder_entry_timeouts"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_offline_timeout_rejections"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Elections And Leader Transfer",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_local_peer_election_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_local_peer_pre_vote_rejections"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_pre_vote_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_transfer_leader_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_transfer_leader_timeouts"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Raft: Protections On (1 = enforcing) And Faults Present",
+      "targets": [
+        {
+          "expr": "temporalstore_raft_matrixraft_stale_follower_read_rejected"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_stale_follower_write_rejected"
+        },
+        {
+          "expr": "temporalstore_proxy_account_enforcement"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_peer_offline_timeout_reached"
+        },
+        {
+          "expr": "temporalstore_raft_matrixraft_snapshot_send_timeout_present"
+        }
+      ]
     }
   ]
 }

--- a/docs/ops/temporalstore-dashboard.json
+++ b/docs/ops/temporalstore-dashboard.json
@@ -245,6 +245,15 @@
           "expr": "temporalstore_storage_manager_phase_floors"
         }
       ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Shard Rate Limit: Allowed And Refused",
+      "targets": [
+        {
+          "expr": "temporalstore_shard_rate_limit_total"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Thirty declared families whose **own help text describes a fault** were on no dashboard. Twenty-five are raft runtime counters: minority-partition read and write rejections, lagging follower reads, snapshot sends failing, leader transfers timing out, election and pre-vote rejections.

These are the signals that say a raft cluster is degraded, and none was shown anywhere. **Six panels and five rules; zero fault-shaped families remain unwatched.**

**The rules are deliberately fewer than the panels.** Most of these counters are worth *seeing* and would be noise to page on — a read-index rejection is the system declining to serve stale data, which is it working correctly. The five chosen are where rising means someone should look: writes refused for minority partition, snapshots failing to send, a peer past its offline timeout, leader transfer timing out, follower reads refused for lag.

**The distinction that shaped this change.** A fault-shaped word in a metric name is not enough:

| metric | help | 1 means |
|---|---|---|
| `..._stale_follower_read_rejected` | "Whether stale follower reads are rejected" | a protection is **on** |
| `..._peer_offline_timeout_reached` | "Whether a peer has crossed the configured offline timeout" | a peer is **gone** |

Identical grammar, opposite meaning. Alerting on the first would page someone because the system is defending itself — the same error as a guard that rejects correct usage. So the gauges sit on their own panel that names both kinds, and only the second gets a rule.

Validator green; every referenced family is declared.