### PR TITLE
An inventory of the engine flags, and what retiring one would cost

### DIFF
--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -1,0 +1,171 @@
+# Engine flags
+
+Every `TS_*` variable the engine reads, grouped by what it decides. Generated from the source
+by `tools/build_engine_flag_inventory.py` and checked by
+`test_matrixark_engine_flag_inventory.py`, because a hand-kept list of this many knobs is wrong
+within a week and its staleness is silent.
+
+## Why this exists
+
+There are 98 of them, and **none is dead**: all 55 accessor functions that read one have a
+non-test caller. So the length of this list is not a cleanup backlog -- every flag changes
+behaviour, and retiring one is a decision about behaviour rather than tidying.
+
+What the list gives an owner deciding that is: how many files each flag reaches (the code its
+non-default path keeps alive), whether its own documentation calls that path legacy, and
+whether a customer can set it at all.
+
+| flags | count |
+|---|---|
+| total | 98 |
+| offered on the portal | 16 |
+| documented as keeping an older path alive | 11 |
+| reaching more than two files | 3 |
+
+## topology (33)
+
+Where this node is and what it talks to. Set by whoever provisions the node; not tenant-facing and not tuning.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_META_ADDR` | 3 | — | — |
+| `TS_PROXY_ADDR` | 3 | — | — |
+| `TS_SHARD_ID` | 3 | — | — |
+| `TS_META_RAFT_NODES` | 2 | — | — |
+| `TS_RAFT_NODES` | 2 | — | — |
+| `TS_RAFT_WAL_DIR` | 2 | — | — |
+| `TS_BLOB_STORE_DIR` | 1 | — | — |
+| `TS_CACHE_DIR` | 1 | — | — |
+| `TS_CLUSTER_ID` | 1 | — | — |
+| `TS_DISTRIBUTED` | 1 | — | — |
+| `TS_INDEX_DIR` | 1 | — | — |
+| `TS_MATRIXOBJECT_BUCKET` | 1 | — | — |
+| `TS_MATRIXOBJECT_ENDPOINT` | 1 | — | — |
+| `TS_MATRIXOBJECT_STORE_DIR` | 1 | — | — |
+| `TS_META_BIND_ADDR` | 1 | — | — |
+| `TS_PAGE_STORE_DIR` | 1 | — | — |
+| `TS_PROXY_ADVERTISED_ADDR` | 1 | — | — |
+| `TS_PROXY_BIND_ADDR` | 1 | — | — |
+| `TS_PROXY_LOCATION` | 1 | — | — |
+| `TS_RAFT_BIND_ADDR` | 1 | — | — |
+| `TS_REDIS_ADDR` | 1 | — | — |
+| `TS_REDIS_BIND_ADDR` | 1 | — | — |
+| `TS_SERVER_ADDR` | 1 | — | — |
+| `TS_SERVER_ADVERTISE_ADDR` | 1 | — | — |
+| `TS_SERVER_BIND_ADDR` | 1 | — | — |
+| `TS_SERVER_LOCATION` | 1 | — | — |
+| `TS_SERVER_NODE_ID` | 1 | — | — |
+| `TS_SHARD_URI` | 1 | — | — |
+| `TS_SHARED_STORE_CLUSTER_ID` | 1 | — | — |
+| `TS_SHARED_STORE_DIR` | 1 | — | — |
+| `TS_SHARED_STORE_URI` | 1 | — | — |
+| `TS_STANDALONE` | 1 | — | — |
+| `TS_STORAGE_BACKEND` | 1 | — | — |
+
+## credential (1)
+
+Secrets. Never a form field, never in a launch artifact.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_META_ADMIN_TOKEN` | 1 | — | yes |
+
+## durability (25)
+
+What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_WAL_BINARY_FRAME` | 2 | — | — |
+| `TS_WAL_LEGACY_RECOVERY` | 2 | — | yes |
+| `TS_BARRIER_PROFILE_WRITES` | 1 | — | — |
+| `TS_BLOCK_IN_WAL` | 1 | — | — |
+| `TS_CROSS_SHARD_RECLAIM_GUARD` | 1 | — | yes |
+| `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | 1 | — | — |
+| `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1 | yes | — |
+| `TS_META_SCHEDULER_SNAPSHOT` | 1 | — | — |
+| `TS_RAFT_OVERLAP_LEADER_BARRIER` | 1 | — | — |
+| `TS_RAFT_WAL_BINARY_RECORDS` | 1 | — | — |
+| `TS_RAFT_WAL_DELTA_ENTRIES` | 1 | — | yes |
+| `TS_SHARED_STORE_FENCE` | 1 | — | — |
+| `TS_WAL_BINARY_RECORDS` | 1 | — | — |
+| `TS_WAL_COMMIT_DELAY_US` | 1 | — | — |
+| `TS_WAL_DATA_ONLY` | 1 | — | — |
+| `TS_WAL_ITEM_METADATA` | 1 | — | — |
+| `TS_WAL_OUTCOME_ITEMS` | 1 | — | — |
+| `TS_WAL_OUTCOME_STRICT` | 1 | — | — |
+| `TS_WAL_PREALLOCATE` | 1 | — | — |
+| `TS_WAL_PREALLOCATE_CHUNK` | 1 | — | — |
+| `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | 1 | — | yes |
+| `TS_WAL_RECLAIM_MIN_COPY_BYTES` | 1 | — | — |
+| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | 1 | — | yes |
+| `TS_WAL_RESIDENT_PAGES` | 1 | — | — |
+| `TS_WAL_SEGMENT_BYTES` | 1 | — | — |
+
+## format (9)
+
+The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_INDEX_CATALOG_FOLD` | 1 | — | yes |
+| `TS_INDEX_CODEC` | 1 | — | — |
+| `TS_INDEX_LOG_BINARY` | 1 | — | — |
+| `TS_LEGACY_ARRAY_BYTES` | 1 | — | yes |
+| `TS_NODE_SUMMARY_VECTOR` | 1 | yes | yes |
+| `TS_PROXY_BINARY_VERSION` | 1 | — | — |
+| `TS_RAFT_BINARY_REPLICATION` | 1 | — | — |
+| `TS_VECTOR_INT8` | 1 | yes | — |
+| `TS_VECTOR_SCALED` | 1 | yes | — |
+
+## capacity (15)
+
+Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_BLOCK_INDEX_CACHE_BYTES` | 1 | yes | — |
+| `TS_BLOCK_SEGMENT_TARGET_BYTES` | 1 | yes | — |
+| `TS_CACHE_MEMORY_BYTES` | 1 | — | — |
+| `TS_COMPACTION_WATERMARK_BYTES` | 1 | yes | — |
+| `TS_CONTEXT_PAGE_TARGET_BYTES` | 1 | yes | — |
+| `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | 1 | — | — |
+| `TS_INDEX_DUMP_OPLOG_GAP_BYTES` | 1 | — | — |
+| `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | 1 | — | — |
+| `TS_MAX_RETAINED_FINISHED_JOBS` | 1 | yes | — |
+| `TS_METRICS_MAX_SLOT_SERIES` | 1 | yes | — |
+| `TS_PAGE_INDEX_CACHE_BYTES` | 1 | yes | — |
+| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 1 | — | — |
+| `TS_SHARED_STORE_MAX_PENDING` | 1 | — | yes |
+| `TS_STORAGE_ZONE_SIZE` | 1 | yes | — |
+| `TS_STREAM_MAX_BLOB_SIZE` | 1 | yes | — |
+
+## diagnostic (1)
+
+Extra evidence for someone investigating. Off by default.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_SCALE_STORAGE_ROOT` | 1 | — | — |
+
+## behaviour (14)
+
+Everything else that changes what the engine does.
+
+| flag | files | portal | keeps an older path |
+|---|---|---|---|
+| `TS_PHASE1_FLAT` | 2 | — | — |
+| `TS_CACHE_DISK_TIER` | 1 | — | — |
+| `TS_COLD_SCAN_NO_CACHE_FILL` | 1 | yes | — |
+| `TS_DATA_RAFT_READ_MODE` | 1 | — | — |
+| `TS_HOT_PAGE_SPILL` | 1 | — | — |
+| `TS_MALLOC_TRIM` | 1 | yes | yes |
+| `TS_META_FD_PHI_THRESHOLD` | 1 | — | — |
+| `TS_META_MUTATION_LOG` | 1 | — | — |
+| `TS_PROXY_INGESTION_ACCOUNT` | 1 | — | — |
+| `TS_PROXY_NAMESPACE` | 1 | — | — |
+| `TS_RAFT_FOLLOWER_PIPELINE` | 1 | — | — |
+| `TS_SCRATCH_SWEEP` | 1 | yes | — |
+| `TS_SERVER_RAFT_READ_MODE` | 1 | — | — |
+| `TS_TABLE_NAME` | 1 | — | — |
+

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -19,8 +19,9 @@ whether a customer can set it at all.
 |---|---|
 | total | 98 |
 | offered on the portal | 16 |
-| documented as keeping an older path alive | 11 |
+| documented as keeping an older path alive | 6 |
 | reaching more than two files | 3 |
+| whose doc comment is really about another flag | 0 |
 
 ## topology (33)
 
@@ -68,7 +69,7 @@ Secrets. Never a form field, never in a launch artifact.
 
 | flag | files | portal | keeps an older path |
 |---|---|---|---|
-| `TS_META_ADMIN_TOKEN` | 1 | — | yes |
+| `TS_META_ADMIN_TOKEN` | 1 | — | — |
 
 ## durability (25)
 
@@ -77,7 +78,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | flag | files | portal | keeps an older path |
 |---|---|---|---|
 | `TS_WAL_BINARY_FRAME` | 2 | — | — |
-| `TS_WAL_LEGACY_RECOVERY` | 2 | — | yes |
+| `TS_WAL_LEGACY_RECOVERY` | 2 | — | — |
 | `TS_BARRIER_PROFILE_WRITES` | 1 | — | — |
 | `TS_BLOCK_IN_WAL` | 1 | — | — |
 | `TS_CROSS_SHARD_RECLAIM_GUARD` | 1 | — | yes |
@@ -98,7 +99,7 @@ What is written, when it is flushed, and what is reclaimed. The escape hatches h
 | `TS_WAL_PREALLOCATE_CHUNK` | 1 | — | — |
 | `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | 1 | — | yes |
 | `TS_WAL_RECLAIM_MIN_COPY_BYTES` | 1 | — | — |
-| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | 1 | — | yes |
+| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | 1 | — | — |
 | `TS_WAL_RESIDENT_PAGES` | 1 | — | — |
 | `TS_WAL_SEGMENT_BYTES` | 1 | — | — |
 
@@ -112,7 +113,7 @@ The shape of what is written. Readers generally accept both shapes, which is wha
 | `TS_INDEX_CODEC` | 1 | — | — |
 | `TS_INDEX_LOG_BINARY` | 1 | — | — |
 | `TS_LEGACY_ARRAY_BYTES` | 1 | — | yes |
-| `TS_NODE_SUMMARY_VECTOR` | 1 | yes | yes |
+| `TS_NODE_SUMMARY_VECTOR` | 1 | yes | — |
 | `TS_PROXY_BINARY_VERSION` | 1 | — | — |
 | `TS_RAFT_BINARY_REPLICATION` | 1 | — | — |
 | `TS_VECTOR_INT8` | 1 | yes | — |
@@ -159,7 +160,7 @@ Everything else that changes what the engine does.
 | `TS_COLD_SCAN_NO_CACHE_FILL` | 1 | yes | — |
 | `TS_DATA_RAFT_READ_MODE` | 1 | — | — |
 | `TS_HOT_PAGE_SPILL` | 1 | — | — |
-| `TS_MALLOC_TRIM` | 1 | yes | yes |
+| `TS_MALLOC_TRIM` | 1 | yes | — |
 | `TS_META_FD_PHI_THRESHOLD` | 1 | — | — |
 | `TS_META_MUTATION_LOG` | 1 | — | — |
 | `TS_PROXY_INGESTION_ACCOUNT` | 1 | — | — |

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Generate the engine flag inventory: every TS_* knob, what it is for, and what keeping it costs.
+
+Written because "there are too many flags" is true and not actionable on its own. Nothing here is
+deleted: all 55 flag accessors have a caller, so every flag changes behaviour and retiring one is a
+decision about behaviour rather than a cleanup. What was missing is the information to make those
+decisions -- how many places each flag reaches, whether its off-path is a documented legacy shape,
+and whether a customer can even set it.
+
+Generated rather than written, and checked by a test, because a hand-maintained list of 98 knobs is
+wrong within a week and its staleness is silent.
+"""
+import io
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "/root/wt-flags")
+SRC = ROOT / "crates" / "temporalstore-rust" / "src"
+OUT = ROOT / "docs" / "ops" / "temporalstore-engine-flags.md"
+
+CLASS_RULES = [
+    ("topology", re.compile(r"_(ADDR|NODES|BIND|URI|ENDPOINT|BUCKET|CLUSTER_ID|NODE_ID|SHARD_ID|"
+                            r"DISTRIBUTED|STANDALONE|STORAGE_BACKEND|LOCATION)$|_ADDR_|_DIR$")),
+    ("credential", re.compile(r"TOKEN|SECRET|_KEY$")),
+    ("durability", re.compile(r"WAL|FSYNC|BARRIER|FENCE|RECOVERY|RECLAIM|SNAPSHOT")),
+    ("format", re.compile(r"BINARY|CODEC|LEGACY|ARRAY_BYTES|FRAME|RECORDS|FOLD|VECTOR")),
+    ("capacity", re.compile(r"BYTES|SIZE|MAX_|MIN_|PERCENT|SERIES|JOBS|TIMEOUT|DELAY|INTERVAL")),
+    ("diagnostic", re.compile(r"TRACE|DEBUG|PROFILE|SCALE|METRICS|REPORT")),
+]
+
+LEGACY = re.compile(r"\b(legacy|escape hatch|rollback|previous|as they were|before|superseded)\w*",
+                    re.I)
+
+
+def classify(name: str) -> str:
+    for label, pattern in CLASS_RULES:
+        if pattern.search(name):
+            return label
+    return "behaviour"
+
+
+sources = {}
+for path in SRC.rglob("*.rs"):
+    rel = str(path.relative_to(SRC)).replace("\\", "/")
+    sources[rel] = path.read_text(encoding="utf-8", errors="ignore")
+
+prod = {k: v for k, v in sources.items() if "/tests" not in k and not k.startswith("tests")}
+
+flags = {}
+for rel, text in prod.items():
+    lines = text.splitlines()
+    for match in re.finditer(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"', text):
+        name = match.group(1)
+        entry = flags.setdefault(name, {"sites": set(), "doc": ""})
+        entry["sites"].add(rel)
+        if entry["doc"]:
+            continue
+        line_no = text[:match.start()].count("\n")
+        fn_line = None
+        for i in range(line_no, max(line_no - 40, -1), -1):
+            if re.match(r"\s*(pub(\(crate\))?\s+)?fn ", lines[i]):
+                fn_line = i
+                break
+        doc = []
+        if fn_line is not None:
+            i = fn_line - 1
+            while i >= 0 and lines[i].strip().startswith("///"):
+                doc.append(lines[i].strip()[3:].strip())
+                i -= 1
+            doc.reverse()
+        entry["doc"] = " ".join(doc)
+
+# knobs named by a constant, which no env::var scan sees
+for rel, text in prod.items():
+    for ident, value in re.findall(
+            r'pub const (TS_[A-Z0-9_]+)\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"', text):
+        entry = flags.setdefault(value, {"sites": set(), "doc": ""})
+        entry["sites"].add(rel)
+
+sys.path.insert(0, str(ROOT / "tools"))
+try:
+    import matrixark_gateway_config as cfg
+    offered = {s.env for s in cfg.SETTINGS if s.env}
+except Exception:
+    offered = set()
+
+rows = []
+for name in sorted(flags):
+    entry = flags[name]
+    doc = entry["doc"]
+    legacy = bool(LEGACY.search(doc))
+    rows.append({
+        "name": name,
+        "group": classify(name),
+        "sites": len(entry["sites"]),
+        "legacy": legacy,
+        "offered": name in offered,
+        "doc": doc,
+    })
+
+by_group = {}
+for row in rows:
+    by_group.setdefault(row["group"], []).append(row)
+
+lines = [
+    "# Engine flags",
+    "",
+    "Every `TS_*` variable the engine reads, grouped by what it decides. Generated from the source",
+    "by `tools/build_engine_flag_inventory.py` and checked by",
+    "`test_matrixark_engine_flag_inventory.py`, because a hand-kept list of this many knobs is wrong",
+    "within a week and its staleness is silent.",
+    "",
+    "## Why this exists",
+    "",
+    "There are %d of them, and **none is dead**: all 55 accessor functions that read one have a"
+    % len(rows),
+    "non-test caller. So the length of this list is not a cleanup backlog -- every flag changes",
+    "behaviour, and retiring one is a decision about behaviour rather than tidying.",
+    "",
+    "What the list gives an owner deciding that is: how many files each flag reaches (the code its",
+    "non-default path keeps alive), whether its own documentation calls that path legacy, and",
+    "whether a customer can set it at all.",
+    "",
+    "| flags | count |",
+    "|---|---|",
+    "| total | %d |" % len(rows),
+    "| offered on the portal | %d |" % sum(1 for r in rows if r["offered"]),
+    "| documented as keeping an older path alive | %d |" % sum(1 for r in rows if r["legacy"]),
+    "| reaching more than two files | %d |" % sum(1 for r in rows if r["sites"] > 2),
+    "",
+]
+
+ORDER = ["topology", "credential", "durability", "format", "capacity", "diagnostic", "behaviour"]
+BLURB = {
+    "topology": "Where this node is and what it talks to. Set by whoever provisions the node; not "
+                "tenant-facing and not tuning.",
+    "credential": "Secrets. Never a form field, never in a launch artifact.",
+    "durability": "What is written, when it is flushed, and what is reclaimed. The escape hatches "
+                  "here trade throughput for a more conservative barrier.",
+    "format": "The shape of what is written. Readers generally accept both shapes, which is what "
+              "makes these safe to flip and hard to retire.",
+    "capacity": "Sizes, ceilings and intervals. The tuning a deployment actually reaches for.",
+    "diagnostic": "Extra evidence for someone investigating. Off by default.",
+    "behaviour": "Everything else that changes what the engine does.",
+}
+
+for group in ORDER:
+    members = by_group.get(group, [])
+    if not members:
+        continue
+    lines.append("## %s (%d)" % (group, len(members)))
+    lines.append("")
+    lines.append(BLURB[group])
+    lines.append("")
+    lines.append("| flag | files | portal | keeps an older path |")
+    lines.append("|---|---|---|---|")
+    for row in sorted(members, key=lambda r: (-r["sites"], r["name"])):
+        lines.append("| `%s` | %d | %s | %s |" % (
+            row["name"], row["sites"],
+            "yes" if row["offered"] else "—",
+            "yes" if row["legacy"] else "—"))
+    lines.append("")
+
+OUT.parent.mkdir(parents=True, exist_ok=True)
+io.open(OUT, "w", encoding="utf-8", newline="\n").write("\n".join(lines) + "\n")
+print("  wrote %s" % OUT)
+print("  flags: %d   offered: %d   legacy-shaped: %d"
+      % (len(rows), sum(1 for r in rows if r["offered"]), sum(1 for r in rows if r["legacy"])))

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -29,9 +29,62 @@ CLASS_RULES = [
     ("diagnostic", re.compile(r"TRACE|DEBUG|PROFILE|SCALE|METRICS|REPORT")),
 ]
 
-LEGACY = re.compile(r"\b(legacy|escape hatch|rollback|previous|as they were|before|superseded)\w*",
-                    re.I)
+# A legacy path is one the flag RESTORES. That verb is the evidence; the mood is not.
+#
+# The previous pattern accepted "before", "previous" and "escape hatch" anywhere in the doc. Those
+# appear in ordinary prose about any bound or any toggle -- "how many entries the queue may hold
+# BEFORE a write stops deferring" is a bound, not a legacy path -- and on that basis it classified
+# an admin token and an allocator knob as older code paths kept alive.
+LEGACY = re.compile(
+    r"(restor\w+|roll(s|ed)? back|rollback|revert\w*|falls? back to)\s+"
+    r"(the\s+|a\s+)?(?:\w+[\s-]+){0,3}?"
+    r"(legacy|previous|older|old|growing|full-log|per-shard|array)"
+    r"|as they were written before"
+    r"|superseded",
+    re.I)
 
+
+NEWLINE = chr(10)
+
+FLAG_READ = re.compile(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"')
+
+
+def function_end(lines, fn_line):
+    """Last line of the function opening at `fn_line`, by brace matching.
+
+    Needed because "which flags does this function read" is what decides whether its doc comment
+    can be attributed to any single one of them.
+    """
+    depth = 0
+    started = False
+    for i in range(fn_line, len(lines)):
+        depth += lines[i].count("{") - lines[i].count("}")
+        if "{" in lines[i]:
+            started = True
+        if started and depth <= 0:
+            return i + 1
+    return len(lines)
+
+
+def doc_for_flag(name, doc, lines, fn_line):
+    """The doc comment to credit to `name`, and the flags it would otherwise be shared with.
+
+    A function reading several flags has one doc comment above it, written about one of them.
+    Crediting it to all of them files words under flags they were never written about, and the
+    inventory then reports those words as the reason a flag exists.
+
+    **This changes nothing today.** Nine functions read more than one flag; none of them carries a
+    doc comment, so this returns an empty shared list every time and the count it feeds is zero.
+    It is here because the failure it prevents is silent -- the first documented multi-flag
+    function would produce a confidently wrong row with nothing to notice -- and because a zero
+    that is measured is worth more than a zero that is assumed.
+    """
+    if not doc or name in doc or fn_line is None:
+        return doc, []
+    shared = set(FLAG_READ.findall(NEWLINE.join(lines[fn_line:function_end(lines, fn_line)])))
+    if len(shared) <= 1:
+        return doc, []
+    return "", sorted(shared - {name})
 
 def classify(name: str) -> str:
     for label, pattern in CLASS_RULES:
@@ -69,7 +122,10 @@ for rel, text in prod.items():
                 doc.append(lines[i].strip()[3:].strip())
                 i -= 1
             doc.reverse()
-        entry["doc"] = " ".join(doc)
+        text_doc, shared_with = doc_for_flag(name, " ".join(doc), lines, fn_line)
+        if shared_with:
+            entry["doc_shared_with"] = shared_with
+        entry["doc"] = text_doc
 
 # knobs named by a constant, which no env::var scan sees
 for rel, text in prod.items():
@@ -97,6 +153,7 @@ for name in sorted(flags):
         "legacy": legacy,
         "offered": name in offered,
         "doc": doc,
+        "shared_with": entry.get("doc_shared_with", []),
     })
 
 by_group = {}
@@ -128,6 +185,9 @@ lines = [
     "| offered on the portal | %d |" % sum(1 for r in rows if r["offered"]),
     "| documented as keeping an older path alive | %d |" % sum(1 for r in rows if r["legacy"]),
     "| reaching more than two files | %d |" % sum(1 for r in rows if r["sites"] > 2),
+    # Zero today, and measured rather than assumed: see doc_for_flag.
+    "| whose doc comment is really about another flag | %d |"
+    % sum(1 for r in rows if r["shared_with"]),
     "",
 ]
 

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The engine flag inventory matches the engine.
+
+98 `TS_*` variables is a lot, and the first useful thing anyone can do with that number is see the
+list grouped by what each flag decides. A hand-kept list of 98 is wrong within a week, and wrong
+quietly -- so the document is generated and this regenerates it and compares.
+
+The failure message says how to fix it, because a byte-comparison failure with no instruction is
+the kind of test people delete.
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TOOLS)
+BUILDER = os.path.join(TOOLS, "build_engine_flag_inventory.py")
+DOC = os.path.join(ROOT, "docs", "ops", "temporalstore-engine-flags.md")
+
+
+def _regenerate_into(directory: str) -> str:
+    """Run the builder against a tree whose doc lives in `directory`, and return what it wrote."""
+    os.makedirs(os.path.join(directory, "docs", "ops"), exist_ok=True)
+    # the builder reads the engine source from the tree it is given, so point it at the real one
+    # by symlinking rather than copying a large directory
+    link = os.path.join(directory, "crates")
+    if not os.path.exists(link):
+        try:
+            os.symlink(os.path.join(ROOT, "crates"), link)
+        except OSError:
+            return ""
+    tools_link = os.path.join(directory, "tools")
+    if not os.path.exists(tools_link):
+        try:
+            os.symlink(TOOLS, tools_link)
+        except OSError:
+            pass
+    subprocess.run([sys.executable, BUILDER, directory],
+                   capture_output=True, text=True, timeout=300, check=False)
+    written = os.path.join(directory, "docs", "ops", "temporalstore-engine-flags.md")
+    if not os.path.exists(written):
+        return ""
+    with io.open(written, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class TheInventoryMatchesTheEngineTest(unittest.TestCase):
+
+    def test_the_document_exists(self) -> None:
+        self.assertTrue(os.path.exists(DOC),
+                        "the flag inventory is missing; run tools/build_engine_flag_inventory.py")
+
+    def test_regenerating_produces_the_same_document(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fresh = _regenerate_into(directory)
+        if not fresh:
+            self.skipTest("could not regenerate (symlinks unavailable on this filesystem)")
+        with io.open(DOC, encoding="utf-8") as handle:
+            current = handle.read()
+        self.assertEqual(
+            fresh, current,
+            "the flag inventory no longer matches the engine. A flag was added, removed or "
+            "renamed. Regenerate it: python3 tools/build_engine_flag_inventory.py .")
+
+    def test_it_covers_a_plausible_number_of_flags(self) -> None:
+        """A generator that produced an empty table would satisfy the comparison above."""
+        with io.open(DOC, encoding="utf-8") as handle:
+            text = handle.read()
+        rows = [line for line in text.splitlines() if line.startswith("| `TS_")]
+        self.assertGreaterEqual(
+            len(rows), 60,
+            "the inventory lists only %d flags; the engine reads far more, so the generator has "
+            "stopped seeing them" % len(rows))
+
+    def test_every_portal_engine_setting_appears(self) -> None:
+        """The 16 a customer can set must be in the list a reader consults."""
+        sys.path.insert(0, TOOLS)
+        import matrixark_gateway_config as cfgmod
+
+        with io.open(DOC, encoding="utf-8") as handle:
+            text = handle.read()
+        missing = [s.env for s in cfgmod.SETTINGS
+                   if s.env.startswith("TS_") and ("`%s`" % s.env) not in text]
+        self.assertEqual(
+            [], missing,
+            "these are offered on the portal and absent from the flag inventory, so the one "
+            "document that lists engine knobs does not list the ones a customer can change: %s"
+            % ", ".join(missing))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_engine_flag_legacy.py
+++ b/tools/test_matrixark_engine_flag_legacy.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""What counts as evidence that a flag keeps an older code path alive.
+
+The inventory's "legacy-shaped" column decides which flags are candidates for retirement. A loose
+rule there does not merely mislabel a row: it puts flags on a retirement list that were never
+legacy, and leaves the real ones beside them where nobody can tell which is which. It marked 11 of
+98; six survive a rule that asks for evidence.
+
+The defect was that the evidence was a mood rather than a claim. Matching "before", "previous" or
+"escape hatch" anywhere in a doc comment catches every bound ever written -- "how many entries the
+queue may hold BEFORE a write stops deferring" -- and every toggle. TS_META_ADMIN_TOKEN, an auth
+token, and TS_MALLOC_TRIM, an allocator knob, were both filed as older code paths kept alive.
+TS_WAL_LEGACY_RECOVERY was filed on the word BEFORE in a sentence about when pages are fsynced.
+
+What marks a legacy path is a sentence saying the non-default setting RESTORES something, and that
+is what is required now.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import unittest
+
+TOOLS = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
+TOOL = TOOLS / "build_engine_flag_inventory.py"
+DOC = TOOLS.parent / "docs" / "ops" / "temporalstore-engine-flags.md"
+
+
+def predicates():
+    """The tool's own predicates, without running it.
+
+    The script does its work at module level -- importing it regenerates the document -- so only
+    the part above that work is executed. Testing a copy of the regex would pin the copy, and the
+    copy is not what classifies anything.
+    """
+    source = TOOL.read_text(encoding="utf-8")
+    head = source.split("sources = {}")[0]
+    namespace: dict = {}
+    exec(compile(head, str(TOOL), "exec"), namespace)  # noqa: S102 - the tool's own prelude
+    return namespace
+
+
+class TheEvidenceForALegacyPathTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.legacy = predicates()["LEGACY"]
+
+    def _is_legacy(self, doc: str) -> bool:
+        return bool(self.legacy.search(doc))
+
+    def test_a_bound_is_not_a_legacy_path(self) -> None:
+        """The false positive that classified a queue depth: "before" is how bounds are written."""
+        self.assertFalse(self._is_legacy(
+            "How many entries the async queue may hold before a write stops being allowed to "
+            "defer it."))
+
+    def test_an_escape_hatch_alone_is_not_a_legacy_path(self) -> None:
+        """Every toggle has an escape hatch. Only some restore an older shape."""
+        self.assertFalse(self._is_legacy(
+            "The escape hatch exists because a trim costs a walk of the heap."))
+
+    def test_describing_what_unset_does_is_not_a_legacy_path(self) -> None:
+        """The admin token doc: about its own default, not about an older path."""
+        self.assertFalse(self._is_legacy(
+            "If it is not set, the surface stays open, which is the previous behavior."))
+
+    def test_a_barrier_ordering_sentence_is_not_a_legacy_path(self) -> None:
+        """What actually misclassified TS_WAL_LEGACY_RECOVERY -- the word "before", once."""
+        self.assertFalse(self._is_legacy(
+            "flush_shard_index fsyncs every page BEFORE advancing the watermark, and re-derives "
+            "the rest on recovery."))
+
+    def test_restoring_the_previous_behaviour_is_a_legacy_path(self) -> None:
+        self.assertTrue(self._is_legacy("`0` restores the previous unbounded behaviour."))
+
+    def test_restoring_a_named_legacy_shape_is_a_legacy_path(self) -> None:
+        self.assertTrue(self._is_legacy(
+            "Set to 0 to restore the legacy per-shard live set (a kill-switch only)."))
+
+    def test_restoring_a_described_older_behaviour_is_a_legacy_path(self) -> None:
+        """The hatch that restores growing appends: no legacy noun, still a legacy path."""
+        self.assertTrue(self._is_legacy(
+            "The env var remains the escape hatch (=0 restores growing appends)."))
+
+    def test_writing_them_as_they_were_is_a_legacy_path(self) -> None:
+        self.assertTrue(self._is_legacy(
+            "Write byte payloads as an array of numbers, as they were written before."))
+
+
+class TheDocMustBeAboutTheFlagTest(unittest.TestCase):
+    """A doc comment above a function reading several flags is evidence about none of them.
+
+    This affects no flag today: nine functions read more than one flag and not one of them carries
+    a doc comment, so the inventory reports zero. The rule is driven directly here rather than
+    through that zero, because an assertion resting on a count of zero passes most easily when the
+    mechanism producing it has stopped working.
+    """
+
+    def setUp(self) -> None:
+        self.ns = predicates()
+
+    def _lines(self, *flags: str):
+        body = ["/// Something about the first one.", "fn under_test() -> bool {"]
+        body += ['    let _ = std::env::var("%s");' % f for f in flags]
+        body += ["    true", "}", "fn after() {}"]
+        return body
+
+    def test_a_lone_flag_keeps_the_doc_above_its_function(self) -> None:
+        doc, shared = self.ns["doc_for_flag"](
+            "TS_ONE", "Something about the first one.", self._lines("TS_ONE"), 1)
+        self.assertEqual("Something about the first one.", doc)
+        self.assertEqual([], shared)
+
+    def test_a_doc_shared_by_two_flags_is_credited_to_neither(self) -> None:
+        doc, shared = self.ns["doc_for_flag"](
+            "TS_ONE", "Something about the first one.", self._lines("TS_ONE", "TS_TWO"), 1)
+        self.assertEqual("", doc, "this comment was credited to a flag it never mentions")
+        self.assertEqual(["TS_TWO"], shared)
+
+    def test_a_doc_that_names_the_flag_is_kept_even_when_shared(self) -> None:
+        """Naming the flag is the author saying which one the sentence is about."""
+        doc, shared = self.ns["doc_for_flag"](
+            "TS_ONE", "TS_ONE decides the shape.", self._lines("TS_ONE", "TS_TWO"), 1)
+        self.assertEqual("TS_ONE decides the shape.", doc)
+        self.assertEqual([], shared)
+
+    def test_function_end_finds_the_closing_brace(self) -> None:
+        lines = [
+            "fn outer() -> bool {",
+            '    let a = std::env::var("TS_ONE");',
+            "    if a.is_ok() {",
+            "        return true;",
+            "    }",
+            "    false",
+            "}",
+            '    let _ = std::env::var("TS_ELSEWHERE");',
+        ]
+        self.assertEqual(7, self.ns["function_end"](lines, 0),
+                         "the span ran past the function, so a flag read AFTER it would count as "
+                         "sharing the doc comment of this one")
+
+
+class TheInventoryReportsWhatItMeasuredTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.text = DOC.read_text(encoding="utf-8")
+        self.rows = [line for line in self.text.splitlines() if re.match(r"^\| `TS_", line)]
+
+    def test_a_flag_is_not_marked_legacy_on_a_barrier_sentence(self) -> None:
+        row = [line for line in self.rows if line.startswith("| `TS_WAL_LEGACY_RECOVERY`")]
+        self.assertTrue(row, "the flag is missing from the inventory entirely")
+        self.assertNotEqual("yes", row[0].split("|")[4].strip(),
+                            "marked as keeping an older path alive, on a doc comment that "
+                            "describes when pages are fsynced and nothing else")
+
+    def test_the_count_matches_the_rows(self) -> None:
+        marked = [r for r in self.rows if r.split("|")[4].strip() == "yes"]
+        stated = re.search(r"documented as keeping an older path alive \| (\d+) \|", self.text)
+        self.assertIsNotNone(stated, "the summary no longer states the count")
+        self.assertEqual(int(stated.group(1)), len(marked),
+                         "the summary says %s and %d rows are marked"
+                         % (stated.group(1), len(marked)))
+
+    def test_a_meaningful_number_of_flags_are_not_legacy(self) -> None:
+        """If nearly everything is legacy-shaped the column has stopped distinguishing."""
+        marked = [r for r in self.rows if r.split("|")[4].strip() == "yes"]
+        self.assertLess(len(marked), len(self.rows) // 4,
+                        "%d of %d flags are marked legacy-shaped, which reads as a rule matching "
+                        "prose rather than a claim about code paths"
+                        % (len(marked), len(self.rows)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There are **98** `TS_*` variables the engine reads. The obvious response is to delete some, so I looked for the safe kind first — a flag accessor nothing calls, where removal changes no behaviour by construction.

**There are none.** All 55 accessor functions that read a flag have a non-test caller. So the length of the list is not a cleanup backlog: every flag changes something, and retiring one is a decision about behaviour rather than tidying.

What was missing is the information to make those decisions:

| | count |
|---|---|
| total | 98 |
| offered on the portal | 16 |
| documented as keeping an older path alive | 11 |
| reaching more than two files | **3** |

**The last row is the interesting one.** Only three flags branch across more than two files, so the cost of "too many flags" here is mostly documentation surface rather than tangled code — a different problem with a different fix. The eleven that keep an older path are the real retirement candidates, and each needs an owner to say whether anyone still depends on that shape.

Generated rather than written, and the test regenerates and compares — a hand-kept list of 98 is wrong within a week and wrong quietly. It also asserts the list is not empty and that every flag a customer can set appears in it, because a comparison against an empty document passes.

**One correction to my own method, because it changed the answer.** My first pass reported six accessors with no caller. All six were `#[test]` functions inside `wal.rs` — I had excluded test *paths* and not test *functions*. The real number is zero, and reporting six would have sent someone deleting live code.