### PR TITLE
List who has a policy override

### DIFF
--- a/tools/matrixark_tenant_policy.py
+++ b/tools/matrixark_tenant_policy.py
@@ -497,6 +497,82 @@ def tenant_policy_record(tenant_id: str, policy: Json) -> Json:
     }
 
 
+def policy_overrides(only_tenant: str = "") -> Json:
+    """Every tenant and user that has an override, and which knobs each one sets.
+
+    The policy API reads and writes one identity at a time and needs its id first, so an operator
+    could set a tenant override and then had no way to find it again -- or to answer "which of my
+    tenants have custom settings", which is the first question anyone asks of a multi-tenant
+    deployment.
+
+    Deduplicated by canonical identity. A policy is stored under every alias it should answer to --
+    the id AND its scope hash -- so walking the maps directly reports the same tenant two or three
+    times, which reads as more configuration than exists. Aliases are folded back here, and the id
+    is preferred over the hash when both are present because the id is what an operator typed.
+
+    Values are included: these knobs are booleans, integers and one choice, and none is a
+    credential. If a secret-shaped knob is ever added to the registry, this must start omitting it.
+
+    `only_tenant` restricts the answer to one tenant and everything under it. The route that serves
+    this passes the tenant derived from the API KEY, never one named in the request, because the
+    policy endpoints already hold that line: a caller must not be able to read another tenant\'s
+    settings by naming it. An unrestricted listing is available in-process for an operator tool;
+    it is deliberately not reachable over HTTP.
+    """
+    wanted = {alias for alias in _tenant_aliases(only_tenant)} if only_tenant else set()
+    with _LOCK:
+        file_tenants = dict(_FILE_CACHE.get("tenants") or {})
+        record_tenants = dict(_RECORD_POLICIES)
+        user_policies = dict(_USER_POLICIES)
+
+    def _fold(raw: dict, source: str, out: dict) -> None:
+        for key, policy in raw.items():
+            if not policy:
+                continue
+            if wanted and str(key) not in wanted:
+                continue
+            canonical = _canonical_tenant(key, raw)
+            entry = out.setdefault(canonical, {"tenant": canonical, "settings": {}, "sources": []})
+            entry["settings"].update({k: v for k, v in policy.items()})
+            if source not in entry["sources"]:
+                entry["sources"].append(source)
+
+    tenants: Json = {}
+    _fold(file_tenants, "file", tenants)
+    _fold(record_tenants, "store", tenants)
+
+    users: Json = {}
+    for key, policy in user_policies.items():
+        if not policy:
+            continue
+        tenant, _, user = str(key).partition("/")
+        if wanted and tenant not in wanted:
+            continue
+        canonical = "%s/%s" % (tenant, user) if user else str(key)
+        entry = users.setdefault(canonical, {"key": canonical, "settings": {}})
+        entry["settings"].update({k: v for k, v in policy.items()})
+
+    return {
+        "tenants": [tenants[k] for k in sorted(tenants)],
+        "users": [users[k] for k in sorted(users)],
+        "tenant_count": len(tenants),
+        "user_count": len(users),
+    }
+
+
+def _canonical_tenant(key: str, pool: dict) -> str:
+    """Prefer the readable id over its hash when a policy is stored under both."""
+    key = str(key)
+    for candidate in pool:
+        candidate = str(candidate)
+        if candidate == key:
+            continue
+        if key in _tenant_aliases(candidate):
+            # `candidate` is an id whose alias list contains `key`, so `key` is the hash form.
+            return candidate
+    return key
+
+
 def clear_tenant_policy_cache() -> None:
     """Drop every cached policy (tests, and after a control-plane rewrite)."""
     with _LOCK:

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3711,6 +3711,21 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
 
             if method == "GET":
                 params = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+                # Who in THIS tenant has an override at all. The policy endpoints answer for one
+                # identity and need its id first, so a tenant could set a user override and then
+                # have no way to find it again -- or to answer "who here has custom settings",
+                # which is the first question anyone asks after setting the second one.
+                #
+                # Scoped to the tenant from the key, like everything else on this route. The
+                # listing function can answer for every tenant and that form is not served here.
+                if (params.get("overrides") or [""])[0].strip() in ("1", "true", "yes"):
+                    listing = policy_mod.policy_overrides(only_tenant=tenant_id)
+                    return await _json(send, 200, {
+                        "tenant": tenant_id,
+                        "tenants": listing["tenants"],
+                        "users": listing["users"],
+                        "user_count": listing["user_count"],
+                    })
                 user_id = (params.get("user_id") or [""])[0].strip()
                 return await _json(send, 200,
                                    _policy_view(policy_mod, tenant_id, user_id))

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -248,6 +248,28 @@
     </div>
   </section>
 
+  <!-- ======================= Policy overrides ======================= -->
+  <section class="card">
+    <h2>Policy overrides</h2>
+    <p class="hint">Who in this tenant has settings of their own. Calls
+      <code>GET /v1/admin/policy?overrides=1</code>. The tenant comes from your key, so this lists
+      your tenant and nobody else&#39;s. A row means that identity resolves some knob differently
+      from the deployment default &mdash; the thing you cannot otherwise find without already
+      knowing which id to ask about.</p>
+    <div class="actions">
+      <button id="overridesBtn" class="secondary">Refresh overrides</button>
+    </div>
+    <div id="overridesMsg" class="msg" role="status" aria-live="polite"></div>
+    <div class="tablewrap">
+      <table id="overridesTable">
+        <thead>
+          <tr><th>identity</th><th>level</th><th>settings</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
   <!-- ============================ Usage ============================ -->
   <section class="card">
     <h2>Live edge usage</h2>
@@ -523,6 +545,7 @@
 
   // ---- wire up ---------------------------------------------------------------------------------
   $("saveConn").onclick = saveConn;
+  $("overridesBtn").onclick = loadOverrides;
   $("clearKey").onclick = function () { SS.removeItem("mtx_admin_key"); $("adminKey").value = ""; reflectStatus(); setInlineMsg("connMsg", "Key cleared."); };
   $("adminKey").addEventListener("change", function () { SS.setItem("mtx_admin_key", $("adminKey").value.trim()); reflectStatus(); });
   $("createBtn").onclick = createKey;
@@ -531,6 +554,70 @@
   $("usageBtn").onclick = loadUsage;
   loadConn();
 })();
+
+  /* ---------- policy overrides ---------- */
+  /* Per-tenant telemetry deliberately does not exist: /v1/metrics carries no tenant identity, so
+     that it stays safe to scrape without credentials. That is why this view lives on this
+     admin-gated page rather than a dashboard panel -- the same reason per-key usage does. */
+  function renderOverrides(payload) {
+    var tb = $("overridesTable").querySelector("tbody");
+    tb.innerHTML = "";
+    var rows = [];
+    (payload.tenants || []).forEach(function (t) {
+      rows.push({ id: t.tenant, level: "tenant", settings: t.settings || {} });
+    });
+    (payload.users || []).forEach(function (u) {
+      rows.push({ id: u.key, level: "user", settings: u.settings || {} });
+    });
+    if (!rows.length) {
+      tb.innerHTML = "<tr><td colspan='3' class='hint'>No overrides. Every identity in this " +
+        "tenant resolves the deployment defaults.</td></tr>";
+      return;
+    }
+    rows.forEach(function (row) {
+      var names = Object.keys(row.settings).sort();
+      var shown = names.map(function (n) {
+        return escapeHtml(n) + "=" + escapeHtml(String(row.settings[n]));
+      }).join(", ");
+      var tr = document.createElement("tr");
+      tr.innerHTML =
+        "<td class='mono'>" + escapeHtml(row.id || "") + "</td>" +
+        "<td>" + escapeHtml(row.level) + "</td>" +
+        "<td class='mono'>" + shown + "</td>";
+      tb.appendChild(tr);
+    });
+  }
+
+  function loadOverrides() {
+    var msg = $("overridesMsg");
+    msg.textContent = "Loading...";
+    /* A GATEWAY endpoint, so it takes the gateway base and the admin key from the Connection
+       panel, the same way loadCatalog does. apiFetch() targets the management base and would send
+       this to the wrong host. */
+    var key = ($("adminKey") || {}).value || "";
+    var base = ($("gwBase") || {}).value || "";
+    if (!key.trim()) {
+      msg.textContent = "Paste an admin API key in the Connection panel first.";
+      return;
+    }
+    fetch((base || "") + "/v1/admin/policy?overrides=1",
+          { headers: { Authorization: "Bearer " + key.trim() } })
+      .then(function (r) {
+        if (!r.ok) { throw new Error("HTTP " + r.status); }
+        return r.json();
+      })
+      .then(function (payload) {
+        renderOverrides(payload);
+        var n = (payload.tenants || []).length + (payload.users || []).length;
+        msg.textContent = n
+          ? (n + (n === 1 ? " identity" : " identities") + " with settings of their own")
+          : "No overrides in this tenant.";
+      })
+      .catch(function (err) {
+        msg.textContent = "Could not read overrides: " + err.message;
+      });
+  }
+
 </script>
 <script>
 /* ---------- scope catalogue ---------- */

--- a/tools/portal/overrides_panel_harness.js
+++ b/tools/portal/overrides_panel_harness.js
@@ -1,0 +1,122 @@
+/* Run the key portal's overrides renderer against real payload shapes.
+ *
+ * The page loading without throwing proves nothing about this panel: renderOverrides only runs on
+ * a button press, so a call to a helper that does not exist -- which is exactly the bug this
+ * harness was written after -- loads clean and fails when someone clicks.
+ *
+ * The renderer touches one table body, so it gets a stub that remembers what was written rather
+ * than a full DOM.
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join("\n");
+
+function extract(name) {
+  const start = scripts.indexOf("function " + name + "(");
+  if (start < 0) { return null; }
+  let depth = 0;
+  for (let i = scripts.indexOf("{", start); i < scripts.length; i += 1) {
+    if (scripts[i] === "{") { depth += 1; }
+    else if (scripts[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return scripts.slice(start, i + 1); }
+    }
+  }
+  return null;
+}
+
+const renderSrc = extract("renderOverrides");
+const escapeSrc = extract("escapeHtml");
+if (!renderSrc) { console.log("FAIL renderOverrides is not in the page"); process.exit(1); }
+if (!escapeSrc) { console.log("FAIL escapeHtml is not in the page"); process.exit(1); }
+
+let failures = 0;
+const body = { innerHTML: "", appendChild(node) { this.innerHTML += node.innerHTML; } };
+const table = { querySelector: () => body };
+const doc = { createElement: () => ({ innerHTML: "" }) };
+const factory = new Function(
+  "$", "document",
+  escapeSrc + "\n" + renderSrc + "\n; return renderOverrides;");
+const renderOverrides = factory(() => table, doc);
+
+function run(label, payload, checks) {
+  body.innerHTML = "";
+  try {
+    renderOverrides(payload);
+  } catch (err) {
+    console.log("FAIL " + label + " threw: " + err.message);
+    failures += 1;
+    return;
+  }
+  for (const [what, ok] of checks(body.innerHTML)) {
+    if (ok) { console.log("ok   " + label + " -- " + what); }
+    else {
+      console.log("FAIL " + label + " -- " + what + "\n     got: " + body.innerHTML.slice(0, 200));
+      failures += 1;
+    }
+  }
+}
+
+run("a tenant override", { tenants: [{ tenant: "acme", settings: { top_k_per_layer: 24 } }], users: [] },
+    (html) => [
+      ["names the tenant", html.includes("acme")],
+      ["names the level", html.includes("tenant")],
+      ["shows the setting and value", html.includes("top_k_per_layer=24")],
+    ]);
+
+run("a user override", { tenants: [], users: [{ key: "acme/alice", settings: { recall_reinforcement: false } }] },
+    (html) => [
+      ["names the identity", html.includes("acme/alice")],
+      ["marks it as a user row", html.includes("user")],
+      ["shows the value", html.includes("recall_reinforcement=false")],
+    ]);
+
+run("nothing set", { tenants: [], users: [] },
+    (html) => [
+      ["says there are no overrides rather than rendering an empty table",
+       html.toLowerCase().includes("no overrides")],
+    ]);
+
+run("missing keys entirely", {},
+    (html) => [["survives a payload with no arrays", html.length > 0]]);
+
+// A settings value must not be able to inject markup into the page.
+run("a hostile value", { tenants: [{ tenant: "acme", settings: { note: "<img src=x onerror=alert(1)>" } }], users: [] },
+    (html) => [
+      ["escapes the value", !html.includes("<img")],
+      ["still shows the row", html.includes("acme")],
+    ]);
+
+
+/* Wiring. Everything above proves the RENDERER works, and this panel shipped three separate ways of
+ * being broken while the renderer was fine: a call to a helper the page does not define, missing
+ * markup, and a button nothing listened to. Each loaded clean and each failed on click.
+ *
+ * These are SOURCE checks and are labelled as such -- driving the real click path needs the whole
+ * page environment, which is what page_watchers_harness covers. What is verified here is that the
+ * ids the renderer reaches for exist in the markup, and that the button calls the loader. */
+const needs = ["overridesTable", "overridesMsg", "overridesBtn"];
+for (const id of needs) {
+  if (!page.includes('id="' + id + '"')) {
+    console.log("FAIL the page has no element with id " + id + " (source check)");
+    failures += 1;
+  } else {
+    console.log("ok   markup has #" + id + " (source check)");
+  }
+}
+/* Both idioms are in use on this page: `$("id").onclick = fn` in the main script and
+ * `el("id").addEventListener("click", fn)` further down. Accepting only one made this check
+ * fail against correctly wired code, which is a guard rejecting correct usage. */
+const wired = /overridesBtn"?\)?\s*\.onclick\s*=\s*loadOverrides/.test(page)
+  || /overridesBtn[\s\S]{0,160}addEventListener\(\s*["']click["']\s*,\s*loadOverrides/.test(page);
+if (!wired) {
+  console.log("FAIL nothing calls loadOverrides on click (source check)");
+  failures += 1;
+} else {
+  console.log("ok   the refresh button calls loadOverrides (source check)");
+}
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/test_matrixark_overrides_panel.py
+++ b/tools/test_matrixark_overrides_panel.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The overrides panel renders, and renders safely.
+
+Per-tenant telemetry deliberately does not exist -- `/v1/metrics` carries no tenant identity so it
+stays safe to scrape without credentials -- so this view lives on an admin-gated page rather than a
+dashboard, the same place per-key usage lives.
+
+Run rather than grepped, and this one has a reason beyond principle: the first version of the panel
+called `adminHeaders()`, a helper that does not exist on that page. The page loaded fine, because
+the renderer only runs on a button press. Grepping for the function name would have found it and
+called it present.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "overrides_panel_harness.js")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page's own JS cannot be run")
+class TheOverridesPanelRendersTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=120)
+
+    def test_every_case_renders(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode,
+                         "the overrides panel did not render as expected:\n%s%s"
+                         % (proc.stdout, proc.stderr))
+        self.assertIn("PASS", proc.stdout)
+
+    def test_a_hostile_setting_value_cannot_inject_markup(self) -> None:
+        """Settings are tenant-supplied. A value reaching the page unescaped is an injection."""
+        proc = self._run()
+        self.assertIn("escapes the value", proc.stdout)
+        self.assertNotIn("FAIL a hostile value", proc.stdout)
+
+    def test_the_harness_checks_a_meaningful_number_of_cases(self) -> None:
+        proc = self._run()
+        checked = sum(1 for line in proc.stdout.splitlines() if line.startswith("ok "))
+        self.assertGreaterEqual(checked, 8,
+                                "only %d checks ran, so passing says little" % checked)
+
+
+class ThePanelUsesHelpersThatExistTest(unittest.TestCase):
+    """The bug that prompted the harness: a call to a helper the page does not define."""
+
+    def test_no_call_to_an_undefined_page_helper(self) -> None:
+        with open(PAGE, encoding="utf-8") as handle:
+            page = handle.read()
+        for helper in ("adminHeaders",):
+            self.assertNotIn(
+                helper + "(", page,
+                "%s() is called and not defined on this page, so the panel fails on click while "
+                "the page loads clean" % helper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_policy_overrides_listing.py
+++ b/tools/test_matrixark_policy_overrides_listing.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Who has a policy override, and only within one tenant.
+
+The policy endpoints read and write one identity at a time and need its id first. So a tenant could
+set a user override and then have no way to find it again, or to answer "who here has custom
+settings" -- which is the first question anyone asks after setting the second one.
+
+Two properties matter more than the listing itself:
+
+* **Aliases fold.** A policy is stored under every identity it answers to, the id AND its scope
+  hash, so walking the maps directly reports each tenant two or three times. That reads as more
+  configuration than exists, which is worse than no listing.
+* **Isolation holds.** The policy route derives the tenant from the API KEY and never from the
+  request, precisely so a caller cannot read another tenant's settings by naming it. A listing is
+  the easiest possible way to break that, so the served form is scoped and the unrestricted form is
+  reachable in-process only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_tenant_policy as policy  # noqa: E402
+
+
+class ListingWhoHasAnOverrideTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        policy.clear_tenant_policy_cache()
+        self.addCleanup(policy.clear_tenant_policy_cache)
+
+    def test_nothing_set_lists_nothing(self) -> None:
+        """A page that always shows rows teaches people the rows mean nothing."""
+        out = policy.policy_overrides()
+        self.assertEqual(0, out["tenant_count"], out["tenants"])
+
+    def test_a_tenant_override_is_listed_with_its_settings(self) -> None:
+        policy.set_tenant_policy("acme", {"top_k_per_layer": 24})
+        out = policy.policy_overrides()
+        names = [t["tenant"] for t in out["tenants"]]
+        self.assertIn("acme", names)
+        entry = next(t for t in out["tenants"] if t["tenant"] == "acme")
+        self.assertEqual(24, entry["settings"].get("top_k_per_layer"))
+
+    def test_aliases_fold_to_one_row(self) -> None:
+        """The id and its hash are two keys for one tenant; two tenants must not read as four."""
+        policy.set_tenant_policy("acme", {"top_k_per_layer": 24})
+        policy.set_tenant_policy("globex", {"recall_reinforcement": False})
+        out = policy.policy_overrides()
+        self.assertEqual(2, out["tenant_count"],
+                         "expected two tenants, got %r -- aliases are not folding"
+                         % [t["tenant"] for t in out["tenants"]])
+
+    def test_the_readable_id_is_preferred_over_its_hash(self) -> None:
+        policy.set_tenant_policy("acme", {"top_k_per_layer": 24})
+        out = policy.policy_overrides()
+        names = [t["tenant"] for t in out["tenants"]]
+        self.assertIn("acme", names,
+                      "the listing reports %r rather than the id an operator typed" % names)
+
+    def test_scoping_to_one_tenant_excludes_the_others(self) -> None:
+        """The property the served route depends on."""
+        policy.set_tenant_policy("acme", {"top_k_per_layer": 24})
+        policy.set_tenant_policy("globex", {"recall_reinforcement": False})
+        scoped = policy.policy_overrides(only_tenant="acme")
+        names = [t["tenant"] for t in scoped["tenants"]]
+        self.assertEqual(["acme"], names,
+                         "a tenant-scoped listing returned another tenant: %r" % names)
+
+    def test_scoping_to_a_tenant_with_nothing_set_is_empty(self) -> None:
+        policy.set_tenant_policy("acme", {"top_k_per_layer": 24})
+        self.assertEqual([], policy.policy_overrides(only_tenant="nobody")["tenants"])
+
+
+class TheServedFormIsScopedTest(unittest.TestCase):
+    """The route must pass the key's tenant, not one from the request."""
+
+    def test_the_route_passes_only_tenant(self) -> None:
+        import inspect
+
+        import matrixark_v1_gateway as gateway
+
+        source = inspect.getsource(gateway)
+        self.assertIn("policy_overrides(only_tenant=tenant_id)", source,
+                      "the overrides listing is served unscoped, so one tenant can read another "
+                      "tenant's settings -- the exact thing the tenant-from-the-key rule prevents")
+
+    def test_the_route_does_not_take_a_tenant_from_the_request(self) -> None:
+        import inspect
+
+        import matrixark_v1_gateway as gateway
+
+        source = inspect.getsource(gateway)
+        self.assertNotIn('policy_overrides(only_tenant=params', source)
+        self.assertNotIn('policy_overrides(only_tenant=payload', source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A tenant can set per-user and per-tenant settings, and **nothing could tell it who has any**. The policy endpoints answer for one identity and need that id first — so you could set a user override and then have no way to find it again, or to answer *who here has custom settings*, which is the first question anyone asks after setting the second one.

`GET /v1/admin/policy?overrides=1` answers it.

**Two things mattered more than the listing.**

**Aliases fold.** A policy is stored under every identity it answers to — the id *and* its scope hash — so walking the maps directly reports each tenant two or three times. A listing showing four rows for two tenants is worse than no listing: it reads as configuration that does not exist. The readable id wins over the hash, because the id is what someone typed.

**Isolation holds.** This route derives the tenant from the API key and never from the request, precisely so a caller cannot read another tenant.s settings by naming one:

> *"The tenant comes from the KEY, never from the request: a caller must not be able to read or rewrite another tenant.s settings by naming it."*

An unscoped listing is the easiest possible way to break that. **I wrote the unscoped form first**, then checked it against that rule before wiring it up. The served form is scoped to the key.s tenant; the unrestricted form stays in-process for an operator tool and is not reachable over HTTP. A test asserts the route passes the key-derived tenant and not one from the request or payload.

Mutation-checked: dropping the alias fold fails two tests; ignoring the tenant scope fails two.

`test_tenant_policy` has one failure on this branch — `test_two_tenants_one_store_get_different_storage` — which fails identically on clean main.