### PR TITLE
Share a value that repeats, however many distinct ones the column holds

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -891,16 +891,27 @@ import json as _json
 import sys as _sys
 
 
-#: A field whose values keep turning out to be distinct is not worth a table: at scale the
-#: hashes and row names would flood it and crowd out the fields that DO repeat. Each field gets
-#: its own table and is abandoned once it exceeds this many distinct values. Measured on an
-#: attachment corpus the repetitive fields hold 1 to 21 distinct values, and the distinct ones
-#: (row_key, context_event_key) are unique per row, so the two separate cleanly.
-_STRING_FIELD_CARDINALITY_LIMIT = 512
-#: Longer than this and hashing the value to look it up costs more than the copy saves.
-_SHARED_STRING_MAX_LEN = 256
+#: A field is abandoned when its lookups keep MISSING -- not when it holds many distinct values.
+#:
+#: Cardinality was the first test and it is the wrong one. `text` on a chunked document holds 873
+#: distinct values over 1,743 rows, so a cardinality limit gives up on it -- yet its repetition
+#: histogram is {1: 3, 2: 870}: every value but three appears exactly TWICE, because a chunk is
+#: stored once as a skill_section and once as a resource_chunk. High cardinality and perfect
+#: repetition at the same time. Sharing those is 13.8% of the read cache.
+#:
+#: A hit rate separates the two shapes directly: `row_key` misses on essentially every lookup and
+#: is dropped after the warmup, while `text` hits half the time and is kept however many distinct
+#: values it accumulates.
+_STRING_FIELD_WARMUP_LOOKUPS = 512
+_STRING_FIELD_MIN_HIT_RATE = 0.10
+#: Longer than this and hashing to look the value up is not worth it. Raised from 256 once the
+#: cost was measured rather than assumed: hashing 1,743 values averaging 904 characters into a
+#: table takes 0.4 ms.
+_SHARED_STRING_MAX_LEN = 65536
 _SHARED_STRINGS: dict = {}
 _SHARED_STRINGS_ABANDONED: set = set()
+#: field -> [lookups, hits], kept only until the field has earned its place or lost it.
+_SHARED_STRING_STATS: dict = {}
 
 
 def _shared_string(field, value):
@@ -910,14 +921,24 @@ def _shared_string(field, value):
     table = _SHARED_STRINGS.get(field)
     if table is None:
         table = _SHARED_STRINGS[field] = {}
+        _SHARED_STRING_STATS[field] = [0, 0]
+    stats = _SHARED_STRING_STATS.get(field)
     shared = table.get(value)
+    if stats is not None:
+        stats[0] += 1
+        if shared is not None:
+            stats[1] += 1
+        elif stats[0] >= _STRING_FIELD_WARMUP_LOOKUPS:
+            if stats[1] < stats[0] * _STRING_FIELD_MIN_HIT_RATE:
+                # Its values are distinct, not repeated. Stop paying to find that out.
+                _SHARED_STRINGS_ABANDONED.add(field)
+                _SHARED_STRINGS.pop(field, None)
+                _SHARED_STRING_STATS.pop(field, None)
+                return value
+            # It has earned its place; stop counting.
+            _SHARED_STRING_STATS.pop(field, None)
     if shared is not None:
         return shared
-    if len(table) >= _STRING_FIELD_CARDINALITY_LIMIT:
-        # This field's values are distinct, not repeated. Stop paying to find that out.
-        _SHARED_STRINGS_ABANDONED.add(field)
-        _SHARED_STRINGS.pop(field, None)
-        return value
     table[value] = value
     return value
 

--- a/tools/test_matrixark_log_keys_are_shared.py
+++ b/tools/test_matrixark_log_keys_are_shared.py
@@ -96,6 +96,7 @@ class RepeatedStringValuesAreShared(unittest.TestCase):
     def setUp(self):
         adapter_module._SHARED_STRINGS.clear()
         adapter_module._SHARED_STRINGS_ABANDONED.clear()
+        adapter_module._SHARED_STRING_STATS.clear()
 
     def test_a_repeated_value_is_held_once(self):
         first = adapter_module._shared_string("record_type", "context_" + "event")
@@ -111,22 +112,52 @@ class RepeatedStringValuesAreShared(unittest.TestCase):
         self.assertIn("record_type", adapter_module._SHARED_STRINGS)
         self.assertIn("state", adapter_module._SHARED_STRINGS)
 
-    def test_a_field_of_distinct_values_is_abandoned(self):
-        limit = adapter_module._STRING_FIELD_CARDINALITY_LIMIT
+    def test_a_field_whose_lookups_keep_missing_is_abandoned(self):
+        """`row_key` holds a different value on every row, so every lookup misses."""
+        limit = adapter_module._STRING_FIELD_WARMUP_LOOKUPS
         for i in range(limit + 5):
             adapter_module._shared_string("row_key", "row-%06d" % i)
         self.assertIn("row_key", adapter_module._SHARED_STRINGS_ABANDONED)
         self.assertNotIn("row_key", adapter_module._SHARED_STRINGS,
                          "the abandoned field is still holding its values")
 
+    def test_a_field_that_repeats_is_kept_however_many_values_it_holds(self):
+        """The reason the test above is not a cardinality test.
+
+        `text` on a chunked document holds one distinct value per chunk -- thousands of them -- and
+        every one appears exactly twice, because a chunk is stored once as a skill_section and once
+        as a resource_chunk. Measured: 873 distinct values over 1,743 rows, histogram {1: 3, 2:
+        870}. A cardinality limit abandons that; a hit rate keeps it, and keeping it is 13.8% of
+        the read cache.
+        """
+        limit = adapter_module._STRING_FIELD_WARMUP_LOOKUPS
+        pairs = limit * 2
+        for i in range(pairs):
+            value = "chunk body number %06d, long enough to be worth sharing" % i
+            first = adapter_module._shared_string("text", value)
+            second = adapter_module._shared_string("text", value)
+            self.assertIs(first, second, "the second lookup of a repeated value missed")
+        self.assertNotIn("text", adapter_module._SHARED_STRINGS_ABANDONED,
+                         "a field that hits on half its lookups was abandoned")
+        self.assertGreater(len(adapter_module._SHARED_STRINGS.get("text") or {}), limit,
+                           "it should hold far more distinct values than the old limit allowed")
+
+    def test_a_long_value_is_shared_now_that_the_cost_was_measured(self):
+        """The cap was 256 characters on the assumption that hashing longer values did not pay.
+        Hashing 1,743 values averaging 904 characters measured 0.4 ms, so the cap is 64 KiB."""
+        body = "x" * 4000
+        self.assertIs(adapter_module._shared_string("text", body),
+                      adapter_module._shared_string("text", body))
+        enormous = "y" * (adapter_module._SHARED_STRING_MAX_LEN + 1)
+        self.assertEqual(enormous, adapter_module._shared_string("text", enormous))
+
     def test_an_abandoned_field_still_returns_its_value(self):
         adapter_module._SHARED_STRINGS_ABANDONED.add("row_key")
         self.assertEqual("abc", adapter_module._shared_string("row_key", "abc"))
 
-    def test_a_long_value_is_not_hashed(self):
+    def test_a_value_past_the_cap_is_left_alone(self):
         long_value = "x" * (adapter_module._SHARED_STRING_MAX_LEN + 1)
         self.assertEqual(long_value, adapter_module._shared_string("text", long_value))
-        self.assertNotIn("text", adapter_module._SHARED_STRINGS)
 
     def test_a_cold_read_shares_a_repeated_column(self):
         store = Path(tempfile.mkdtemp())


### PR DESCRIPTION
## What

A string column was abandoned from value sharing once it held more than 512 distinct values, on
the reasoning that such a column is full of hashes and row names and will never repeat.

That is the wrong test, and the case it gets wrong is the biggest one in the store. `text` on a
chunked document holds one distinct value per chunk — 873 over 1,743 rows — so the cardinality
limit gives up on it immediately. But its repetition histogram is:

```
{1: 3, 2: 870}
```

Every value but three appears **exactly twice**, because a chunk is written once as a
`skill_section` and once as a `resource_chunk`. High cardinality and perfect repetition at the
same time.

## The change

Abandon on the **hit rate** instead. A column whose lookups keep missing is dropped after a warmup
of 512 — still `row_key` and its kind. A column that hits is kept however many values it
accumulates.

The length cap moves with it, 256 characters to 64 KiB. It was set on the assumption that hashing
a longer value costs more than the copy saves; hashing 1,743 values averaging 904 characters into
a table measures **0.4 ms**.

## Measured

This regime is a 1 MB skill file, which produces 3,031 records:

| | before | after |
|---|---|---|
| read cache | 10.5 MB | **9.2 MB** |
| bytes per record | 3,473 | **3,023** |
| cache amplification of the source | 10.0× | **8.7×** |
| objects holding the text, for 587 rows | 586 | **294** |

At a thousand files of that size the read cache goes **10.5 GB → 9.2 GB**. On a small-attachment
corpus a cold read goes 2,951 → 2,796 B/record.

## Checks

- Served records unchanged: ordered and sorted digests identical on the same log, each arm given
  its own copy of the store.
- A column that keeps missing is still abandoned, asserted directly on `row_key`.
- A column that repeats is kept past the old limit, asserted on a synthetic `text` column with
  twice the warmup in distinct values — this is the case the change exists for.
- A value past the new cap is still left alone.
- `test_matrixark_log_keys_are_shared`, `test_matrixark_repeated_values_are_shared`,
  `test_matrixark_index*`, `test_matrixark_posting*`, `test_matrixark_skill*`,
  `test_attachment_resource_policy`, `test_latest_state_key_agreement`,
  `test_matrixark_cache_key*`, `test_matrixark_debug_records*`, `test_delete_before_extract`,
  `test_engine_purge_on_delete`, `test_matrixark_embedding_status`, `test_ingest_file_route`,
  `test_matrixark_a_flat*` all pass.
- 2 files, 69 insertions, 17 deletions, no file deletions.

## What it does not touch

The duplication itself. A skill's chunk is still written twice — once as a section, once as a
chunk — and on disk that is two copies: `resource_chunk` is 48% of the log for a skill ingest and
holds byte-identical text to `skill_section`. This shares the two copies in memory; it does not
stop them being written. Removing one is a schema question, not a caching one: `skill_section`
rows point at chunk hashes, and retrieval serves chunks for a `resource` ingest even though it
serves sections for a `skill` one.
