### PR TITLE
Group the setup page into tabs, from one switcher

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -103,6 +103,16 @@
                           background:var(--danger-bg)}
   .scope-chip.admin{border-color:var(--warn);color:var(--warn);background:var(--warn-bg)}
   .scope-none{color:var(--muted);font-style:italic;font-size:12px}
+  .tabs{display:flex;gap:4px;border-bottom:1px solid var(--line);margin:18px 0 16px;
+        flex-wrap:wrap}
+  .tabs button{background:none;border:0;border-bottom:2px solid transparent;color:var(--muted);
+        padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;border-radius:0;
+        cursor:pointer}
+  .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);margin-left:6px;
+        background:var(--accent);color:var(--bg);border-radius:9px;padding:0 6px;font-size:11px;
+        font-weight:650;vertical-align:1px}
+  .pane[hidden]{display:none}
 </style>
 </head>
 <body>
@@ -156,6 +166,17 @@
         <input id="ctxAccount" type="text" placeholder="acct_local" autocomplete="off">
       </div>
       <div>
+
+  <div class="tabs" role="tablist" aria-label="Key portal sections">
+    <button type="button" role="tab" id="tab-keys" aria-controls="pane-keys"
+            data-pane="keys" aria-selected="true">Keys</button>
+    <button type="button" role="tab" id="tab-policy" aria-controls="pane-policy"
+            data-pane="policy" aria-selected="false" tabindex="-1">Policy</button>
+    <button type="button" role="tab" id="tab-usage" aria-controls="pane-usage"
+            data-pane="usage" aria-selected="false" tabindex="-1">Usage</button>
+  </div>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-keys" id="pane-keys">
         <label>Tenant ID <span class="opt">(scopes the list/create views)</span></label>
         <input id="ctxTenant" type="text" placeholder="tenantA" autocomplete="off">
       </div>
@@ -237,6 +258,9 @@
       </label>
     </div>
     <div id="listMsg" class="msg" role="status" aria-live="polite"></div>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-policy" id="pane-policy" hidden>
     <div class="tablewrap">
       <table id="keysTable" style="display:none">
         <thead><tr>
@@ -259,6 +283,9 @@
     <div class="actions">
       <button id="overridesBtn" class="secondary">Refresh overrides</button>
     </div>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-usage" id="pane-usage" hidden>
     <div id="overridesMsg" class="msg" role="status" aria-live="polite"></div>
     <div class="tablewrap">
       <table id="overridesTable">
@@ -279,6 +306,7 @@
       <button id="usageBtn" class="secondary">Refresh usage</button>
     </div>
     <div id="usageMsg" class="msg" role="status" aria-live="polite"></div>
+  </section>
     <div class="tablewrap">
       <table id="usageTable" style="display:none">
         <thead><tr>
@@ -298,6 +326,73 @@
   </footer>
 </main>
 
+<script>
+/* Tabs, for every portal page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
 <script>
 "use strict";
 (function () {
@@ -618,6 +713,8 @@
       });
   }
 
+
+  window.wireTabs();
 </script>
 <script>
 /* ---------- scope catalogue ---------- */

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -302,6 +302,9 @@
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -456,7 +456,7 @@ def nav(active):
 
 TABS_JS = r"""
 <script>
-/* Tabs, for every generated page whose body declares a tablist.
+/* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
  * two copies of a behaviour that looks identical is how they stop being identical.
@@ -4534,6 +4534,7 @@ emit("catalog_portal.html", "MatrixArk — Skills & Resources", CATALOG_BODY, CA
 
 
 # ---- add the nav to the two existing pages ------------------------------------------------------
+TABS_JS_MARKER = "/* Tabs, for every portal page whose body declares a tablist."
 NAV_JS_MARKER = "/* The shared live strip."
 
 
@@ -4553,6 +4554,30 @@ def _with_nav_js(text):
     return text.replace("</body>", NAV_JS.strip() + "\n</body>", 1)
 
 
+def _with_tabs_js(text):
+    """Put the shared tab helper into a hand-maintained page that declares a tablist.
+
+    Removed and re-placed rather than replaced where it sits. The builder runs over these
+    files repeatedly, and an earlier build put the block in the wrong place -- after the
+    page's own script, so `window.wireTabs()` ran before anything defined it. Replacing in
+    place would carry that position forward for ever; taking it out and putting it back means
+    the current rule about where it goes always wins.
+
+    A page with no tablist is left exactly as it was.
+    """
+    if 'role="tablist"' not in text:
+        return text
+    if TABS_JS_MARKER in text:
+        start = text.index("<script>", text.index(TABS_JS_MARKER) - 200)
+        end = text.index("</script>", start) + len("</script>")
+        text = text[:start] + text[end:].lstrip(chr(10))
+    # Scripts run in document order, so the helper goes before the page's own.
+    if "<script>" not in text:
+        print("no <script> to place the tab helper before")
+        sys.exit(1)
+    at = text.index("<script>")
+    return text[:at] + TABS_JS.strip() + chr(10) + text[at:]
+
 def inject(filename, anchor, active):
     """Add the shared nav, or replace the one already there.
 
@@ -4568,7 +4593,7 @@ def inject(filename, anchor, active):
         if not count:
             print("nav present but unrecognised in %s" % filename)
             sys.exit(1)
-        io.open(path, "w", encoding="utf-8", newline="\n").write(_with_nav_js(replaced))
+        io.open(path, "w", encoding="utf-8", newline="\n").write(_with_tabs_js(_with_nav_js(replaced)))
         print("nav refreshed in %s" % filename)
         return
     if anchor not in text:
@@ -4576,7 +4601,7 @@ def inject(filename, anchor, active):
         sys.exit(1)
     text = text.replace("</style>", NAV_CSS + "</style>", 1)
     text = text.replace(anchor, anchor + "\n" + nav(active), 1)
-    text = _with_nav_js(text)
+    text = _with_tabs_js(_with_nav_js(text))
     io.open(path, "w", encoding="utf-8", newline="\n").write(text)
     print("nav added to %s" % filename)
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -182,6 +182,9 @@ EXTRA_CSS = """
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}
@@ -451,6 +454,77 @@ def nav(active):
     return ('  <nav class="portalnav">\n' + "\n".join(parts) + LIVE_STRIP + "\n  </nav>")
 
 
+TABS_JS = r"""
+<script>
+/* Tabs, for every generated page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
+"""
+
+
 HEAD = """<!doctype html>
 <html lang="en">
 <head>
@@ -478,6 +552,19 @@ SETUP_BODY = """
 
   <div class="summary" id="summary"></div>
 
+
+  <div class="tabs" role="tablist" aria-label="Setup sections">
+    <button type="button" role="tab" id="tab-access" aria-controls="pane-access"
+            data-pane="access" aria-selected="true">Access</button>
+    <button type="button" role="tab" id="tab-settings" aria-controls="pane-settings"
+            data-pane="settings" aria-selected="false" tabindex="-1">Settings</button>
+    <button type="button" role="tab" id="tab-health" aria-controls="pane-health"
+            data-pane="health" aria-selected="false" tabindex="-1">Checks</button>
+    <button type="button" role="tab" id="tab-deployment" aria-controls="pane-deployment"
+            data-pane="deployment" aria-selected="false" tabindex="-1">Deployment</button>
+  </div>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-access" id="pane-access">
   <section>
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
@@ -505,6 +592,9 @@ SETUP_BODY = """
       its own list. Choosing here fills the field below — nothing is written until you save.</p>
     <div id="models"><div class="empty">Enter an admin key to choose models.</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-settings" id="pane-settings" hidden>
 
   <form id="settingsForm">
     <div class="toolbar">
@@ -588,6 +678,9 @@ SETUP_BODY = """
       reads as bad retrieval rather than unfinished retrieval.</p>
     <div id="encoding"><div class="empty">Enter an admin key to read the encoding state.</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-health" id="pane-health" hidden>
 
   <section>
     <h2>Endpoint test</h2>
@@ -602,9 +695,12 @@ SETUP_BODY = """
     <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
     <div id="traffic"><div class="empty">Loading…</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
 
   <section>
-    <h2>Deployment</h2>
+    <h2>Where this deployment lives</h2>
     <p class="hint" style="margin-top:0">Where this deployment lives and how it is reached. Read
       only, deliberately: repointing a storage directory or a cluster address from a browser form
       does not reconfigure a running deployment, it strands its data. Change these where the process
@@ -613,9 +709,9 @@ SETUP_BODY = """
   </section>
 
   <section>
-    <h2>Deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <h2>Launch a deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
     <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
-      topology are not editable above, and that is deliberate — repointing a running deployment's
+      topology are not editable on the Settings tab, and that is deliberate — repointing a running deployment's
       storage from a browser does not reconfigure it, it strands its data. They are chosen when a
       deployment is <em>launched</em>, which is what this composes.</p>
     <div id="liveShape" class="hint"></div>
@@ -643,7 +739,7 @@ SETUP_BODY = """
       </label>
       <label class="field"><span>Key variables</span>
         <input id="depKeys" type="text" placeholder="DEEPSEEK_API_KEY, OPENAI_API_KEY">
-        <span class="hint">Names only. Values are entered above and never appear in a plan.</span>
+        <span class="hint">Names only. Values are entered on the Settings tab and never appear in a plan.</span>
       </label>
     </div>
     <div id="depMsg" role="status" aria-live="polite"></div>
@@ -694,6 +790,7 @@ SETUP_BODY = """
     </table>
     <pre id="scrape"></pre>
   </section>
+  </section>
 """
 
 SETUP_JS = r"""
@@ -701,6 +798,8 @@ SETUP_JS = r"""
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
+
+  window.wireTabs();
 
   /* Claimed before the strip's own script runs, so it feeds from this connection instead of
      opening a second one to the same endpoint. */
@@ -1298,6 +1397,10 @@ function liveStream(options) {
     renderModels();
     var group = el.closest("details");
     if (group) { group.open = true; }
+    /* This control is on the Access tab and the field it just set is on the Settings tab. Without
+       moving there, the scroll below is a no-op on a hidden pane and the "save it" message points
+       at a save bar the person cannot see. */
+    window.showTab("settings");
     el.scrollIntoView({ block: "center" });
     /* Deliberately not saved here. A model change is worth seeing next to whatever else is
        pending -- a key that has not been filled in yet, most of all. */
@@ -1534,6 +1637,9 @@ function liveStream(options) {
     $("dirtyCount").innerHTML = keys.length
       ? "<b>" + keys.length + "</b> unsaved change" + (keys.length === 1 ? "" : "s")
       : "No unsaved changes";
+    /* The save bar lives inside a pane now, so it is invisible from any other tab. Without this
+       a field can be edited, a tab switched, and nothing on screen says the change is unsaved. */
+    window.markTab("settings", keys.length);
     $("save").disabled = !keys.length;
   }
 
@@ -1589,7 +1695,7 @@ function liveStream(options) {
       .catch(function (e) {
         if (e === 401 || e === 403) {
           conn("live", "connected");
-          $("groups").innerHTML = '<section><div class="empty">Enter an admin-scoped key above to ' +
+          $("groups").innerHTML = '<section><div class="empty">Enter an admin-scoped key on the Access tab to ' +
             "load and change this deployment’s configuration.</div></section>";
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';
@@ -3175,17 +3281,7 @@ EXPLORE_JS = r"""
   }
 
   /* ---------- tabs ---------- */
-  Array.prototype.forEach.call(document.querySelectorAll(".tabs button"), function (button) {
-    button.addEventListener("click", function () {
-      Array.prototype.forEach.call(document.querySelectorAll(".tabs button"), function (b) {
-        b.setAttribute("aria-selected", String(b === button));
-      });
-      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
-        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
-      });
-      if (button.dataset.pane === "browse") { loadBrowse(); }
-    });
-  });
+  window.wireTabs(function (pane) { if (pane === "browse") { loadBrowse(); } });
 
   /* ---------- ask ---------- */
   /* The response shape differs between backends and versions; pick the first list of items that
@@ -4415,9 +4511,15 @@ TAIL = """
 
 def emit(filename, title, body, js, active):
     css = BASE_CSS + NAV_CSS + EXTRA_CSS
+    rendered = body % {"nav": nav(active)}
+    # Only pages that declare a tablist carry the helper, so a page without tabs is byte for byte
+    # what it was and a page that grows tabs picks it up without anyone remembering to wire it.
+    page_js = js.strip()
+    if 'role="tablist"' in rendered:
+        page_js = TABS_JS.strip() + "\n" + page_js
     html = (HEAD % {"title": title, "css": css}
-            + (body % {"nav": nav(active)})
-            + (TAIL % {"js": js.strip(), "navjs": NAV_JS.strip()}))
+            + rendered
+            + (TAIL % {"js": page_js, "navjs": NAV_JS.strip()}))
     path = os.path.join(PORTAL, filename)
     io.open(path, "w", encoding="utf-8", newline="\n").write(html)
     print("wrote %s (%d bytes)" % (path, len(html)))

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -302,6 +302,9 @@
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -580,7 +580,7 @@
 
 </div>
 <script>
-/* Tabs, for every generated page whose body declares a tablist.
+/* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
  * two copies of a behaviour that looks identical is how they stop being identical.

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -302,6 +302,9 @@
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}
@@ -577,6 +580,73 @@
 
 </div>
 <script>
+/* Tabs, for every generated page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
+<script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
@@ -629,17 +699,7 @@
   }
 
   /* ---------- tabs ---------- */
-  Array.prototype.forEach.call(document.querySelectorAll(".tabs button"), function (button) {
-    button.addEventListener("click", function () {
-      Array.prototype.forEach.call(document.querySelectorAll(".tabs button"), function (b) {
-        b.setAttribute("aria-selected", String(b === button));
-      });
-      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
-        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
-      });
-      if (button.dataset.pane === "browse") { loadBrowse(); }
-    });
-  });
+  window.wireTabs(function (pane) { if (pane === "browse") { loadBrowse(); } });
 
   /* ---------- ask ---------- */
   /* The response shape differs between backends and versions; pick the first list of items that

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -302,6 +302,9 @@
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -666,7 +666,7 @@
 
 </div>
 <script>
-/* Tabs, for every generated page whose body declares a tablist.
+/* Tabs, for every portal page whose body declares a tablist.
  *
  * Shared rather than per page. The explore page had the only copy and this is the second caller;
  * two copies of a behaviour that looks identical is how they stop being identical.

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -302,6 +302,9 @@
                padding:8px 12px;font-weight:550;font-size:13.5px;margin-bottom:-1px;
                border-radius:0}
   .tabs button[aria-selected=true]{color:var(--accent);border-bottom-color:var(--accent)}
+  .tabs button[data-badge]:not([data-badge=""])::after{content:attr(data-badge);
+      margin-left:6px;background:var(--accent);color:var(--bg);border-radius:9px;
+      padding:0 6px;font-size:11px;font-weight:650;vertical-align:1px}
   .pane[hidden]{display:none}
   .polrow{display:grid;grid-template-columns:1fr auto auto;gap:10px;align-items:center;
           padding:9px 0;border-bottom:1px solid var(--line)}
@@ -421,6 +424,19 @@
 
   <div class="summary" id="summary"></div>
 
+
+  <div class="tabs" role="tablist" aria-label="Setup sections">
+    <button type="button" role="tab" id="tab-access" aria-controls="pane-access"
+            data-pane="access" aria-selected="true">Access</button>
+    <button type="button" role="tab" id="tab-settings" aria-controls="pane-settings"
+            data-pane="settings" aria-selected="false" tabindex="-1">Settings</button>
+    <button type="button" role="tab" id="tab-health" aria-controls="pane-health"
+            data-pane="health" aria-selected="false" tabindex="-1">Checks</button>
+    <button type="button" role="tab" id="tab-deployment" aria-controls="pane-deployment"
+            data-pane="deployment" aria-selected="false" tabindex="-1">Deployment</button>
+  </div>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-access" id="pane-access">
   <section>
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
@@ -448,6 +464,9 @@
       its own list. Choosing here fills the field below — nothing is written until you save.</p>
     <div id="models"><div class="empty">Enter an admin key to choose models.</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-settings" id="pane-settings" hidden>
 
   <form id="settingsForm">
     <div class="toolbar">
@@ -531,6 +550,9 @@
       reads as bad retrieval rather than unfinished retrieval.</p>
     <div id="encoding"><div class="empty">Enter an admin key to read the encoding state.</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-health" id="pane-health" hidden>
 
   <section>
     <h2>Endpoint test</h2>
@@ -545,9 +567,12 @@
     <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
     <div id="traffic"><div class="empty">Loading…</div></div>
   </section>
+  </section>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-deployment" id="pane-deployment" hidden>
 
   <section>
-    <h2>Deployment</h2>
+    <h2>Where this deployment lives</h2>
     <p class="hint" style="margin-top:0">Where this deployment lives and how it is reached. Read
       only, deliberately: repointing a storage directory or a cluster address from a browser form
       does not reconfigure a running deployment, it strands its data. Change these where the process
@@ -556,9 +581,9 @@
   </section>
 
   <section>
-    <h2>Deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
+    <h2>Launch a deployment <span class="aux"><button class="link" id="copyEnv" type="button">copy env file</button></span></h2>
     <p class="hint" style="margin-top:0">The storage directories, the metaserver address and the
-      topology are not editable above, and that is deliberate — repointing a running deployment's
+      topology are not editable on the Settings tab, and that is deliberate — repointing a running deployment's
       storage from a browser does not reconfigure it, it strands its data. They are chosen when a
       deployment is <em>launched</em>, which is what this composes.</p>
     <div id="liveShape" class="hint"></div>
@@ -586,7 +611,7 @@
       </label>
       <label class="field"><span>Key variables</span>
         <input id="depKeys" type="text" placeholder="DEEPSEEK_API_KEY, OPENAI_API_KEY">
-        <span class="hint">Names only. Values are entered above and never appear in a plan.</span>
+        <span class="hint">Names only. Values are entered on the Settings tab and never appear in a plan.</span>
       </label>
     </div>
     <div id="depMsg" role="status" aria-live="polite"></div>
@@ -637,12 +662,82 @@
     </table>
     <pre id="scrape"></pre>
   </section>
+  </section>
 
 </div>
+<script>
+/* Tabs, for every generated page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
 <script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
+
+  window.wireTabs();
 
   /* Claimed before the strip's own script runs, so it feeds from this connection instead of
      opening a second one to the same endpoint. */
@@ -1240,6 +1335,10 @@ function liveStream(options) {
     renderModels();
     var group = el.closest("details");
     if (group) { group.open = true; }
+    /* This control is on the Access tab and the field it just set is on the Settings tab. Without
+       moving there, the scroll below is a no-op on a hidden pane and the "save it" message points
+       at a save bar the person cannot see. */
+    window.showTab("settings");
     el.scrollIntoView({ block: "center" });
     /* Deliberately not saved here. A model change is worth seeing next to whatever else is
        pending -- a key that has not been filled in yet, most of all. */
@@ -1476,6 +1575,9 @@ function liveStream(options) {
     $("dirtyCount").innerHTML = keys.length
       ? "<b>" + keys.length + "</b> unsaved change" + (keys.length === 1 ? "" : "s")
       : "No unsaved changes";
+    /* The save bar lives inside a pane now, so it is invisible from any other tab. Without this
+       a field can be edited, a tab switched, and nothing on screen says the change is unsaved. */
+    window.markTab("settings", keys.length);
     $("save").disabled = !keys.length;
   }
 
@@ -1531,7 +1633,7 @@ function liveStream(options) {
       .catch(function (e) {
         if (e === 401 || e === 403) {
           conn("live", "connected");
-          $("groups").innerHTML = '<section><div class="empty">Enter an admin-scoped key above to ' +
+          $("groups").innerHTML = '<section><div class="empty">Enter an admin-scoped key on the Access tab to ' +
             "load and change this deployment’s configuration.</div></section>";
           $("presets").innerHTML = '<div class="empty">Enter an admin key to see the presets.</div>';
           $("models").innerHTML = '<div class="empty">Enter an admin key to choose models.</div>';

--- a/tools/portal/tabs_harness.js
+++ b/tools/portal/tabs_harness.js
@@ -75,7 +75,11 @@ const doc = {
 };
 
 /* ---------- the page's own helper ---------- */
-const src = scripts.find((s) => s.includes("window.wireTabs"));
+/* The DEFINITION, not a call. "window.wireTabs" also matches the page calling it, and which
+   block comes first differs between generated pages (helper injected before the page script)
+   and hand-maintained ones (appended before </body>), so matching loosely picks a different
+   block per page and runs the page instead of the helper. */
+const src = scripts.find((s) => s.includes("window.wireTabs = function"));
 if (!src) { console.log("FAIL the page carries no tab helper"); process.exit(1); }
 const win = {};
 new Function("window", "document", src)(win, doc);

--- a/tools/portal/tabs_harness.js
+++ b/tools/portal/tabs_harness.js
@@ -1,0 +1,185 @@
+/* Run a portal page's tabs the way someone using them would, with a mouse and with a keyboard.
+ *
+ * The markup cannot answer the questions that matter. Whether a tablist responds to an arrow key,
+ * whether exactly one pane is ever visible, whether the tab a screen reader reports as selected is
+ * the pane actually on screen -- all of that is behaviour, and a page whose tabs are wired to
+ * nothing looks in source exactly like a page whose tabs work. The panel on the key portal shipped
+ * broken three times for precisely that reason.
+ *
+ * So the tab buttons and panes are read out of the real page, the real helper is executed against
+ * them, and events are dispatched through the listeners it registered.
+ *
+ * Usage: node tabs_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* ---------- the page's own tabs and panes ---------- */
+function attr(tag, name) {
+  const m = tag.match(new RegExp(name + '="([^"]*)"'));
+  return m ? m[1] : null;
+}
+
+const tabTags = [...page.matchAll(/<button[^>]*role="tab"[\s\S]*?>/g)].map((m) => m[0]);
+const paneTags = [...page.matchAll(/<section[^>]*class="pane"[\s\S]*?>/g)].map((m) => m[0]);
+
+if (!tabTags.length) { console.log("FAIL the page declares no tabs"); process.exit(1); }
+
+/* ---------- a DOM just wide enough ---------- */
+function makeEl(spec) {
+  const listeners = {};
+  const attrs = Object.assign({}, spec.attrs);
+  return {
+    id: spec.id,
+    hidden: !!spec.hidden,
+    tabIndex: 0,
+    focused: false,
+    dataset: Object.assign({}, spec.dataset),
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    dispatch(type, event) { (listeners[type] || []).forEach((fn) => fn(event || {})); },
+    listens(type) { return (listeners[type] || []).length > 0; },
+    setAttribute(k, v) { attrs[k] = String(v); },
+    getAttribute(k) { return k in attrs ? attrs[k] : null; },
+    focus() { this.focused = true; },
+    /* Real buttons have this, and showTab uses it to reach the same path a person's click takes. */
+    click() { this.dispatch("click"); },
+  };
+}
+
+const tabs = tabTags.map((tag) => makeEl({
+  id: attr(tag, "id"),
+  dataset: { pane: attr(tag, "data-pane") },
+  attrs: { "aria-selected": attr(tag, "aria-selected") || "false" },
+}));
+const panes = paneTags.map((tag) => makeEl({ id: attr(tag, "id"), hidden: /\shidden[\s>]/.test(tag) }));
+
+const byId = new Map();
+tabs.concat(panes).forEach((el) => byId.set(el.id, el));
+
+const doc = {
+  querySelectorAll(selector) {
+    if (selector === ".tabs button") { return tabs; }
+    if (selector === ".pane") { return panes; }
+    return [];
+  },
+  getElementById(id) { return byId.get(id) || null; },
+};
+
+/* ---------- the page's own helper ---------- */
+const src = scripts.find((s) => s.includes("window.wireTabs"));
+if (!src) { console.log("FAIL the page carries no tab helper"); process.exit(1); }
+const win = {};
+new Function("window", "document", src)(win, doc);
+ok("the page defines wireTabs", typeof win.wireTabs === "function");
+ok("the page defines markTab", typeof win.markTab === "function");
+
+/* ---------- structure: every tab has its pane, and the reverse ---------- */
+const paneIds = new Set(panes.map((p) => p.id));
+const missing = tabs.filter((t) => !paneIds.has("pane-" + t.dataset.pane));
+ok("every tab points at a pane that exists", missing.length === 0,
+   missing.map((t) => t.id + " -> pane-" + t.dataset.pane).join(", "));
+const tabTargets = new Set(tabs.map((t) => "pane-" + t.dataset.pane));
+const orphans = panes.filter((p) => !tabTargets.has(p.id));
+ok("every pane is reachable from a tab", orphans.length === 0,
+   orphans.map((p) => p.id).join(", "));
+
+/* ---------- wiring ---------- */
+const shown = [];
+win.wireTabs((pane) => shown.push(pane));
+
+function visible() { return panes.filter((p) => !p.hidden).map((p) => p.id); }
+function selected() {
+  return tabs.filter((t) => t.getAttribute("aria-selected") === "true").map((t) => t.id);
+}
+
+ok("exactly one pane is visible after wiring", visible().length === 1, visible().join(", "));
+ok("exactly one tab is selected after wiring", selected().length === 1, selected().join(", "));
+ok("the visible pane is the one the selected tab controls",
+   visible()[0] === "pane-" + tabs.find((t) => t.getAttribute("aria-selected") === "true").dataset.pane);
+ok("only the selected tab is in the tab order",
+   tabs.every((t) => t.tabIndex === (t.getAttribute("aria-selected") === "true" ? 0 : -1)),
+   tabs.map((t) => t.id + ":" + t.tabIndex).join(" "));
+
+/* ---------- mouse ---------- */
+const third = tabs[Math.min(2, tabs.length - 1)];
+third.dispatch("click");
+ok("clicking a tab shows its pane", visible().join() === "pane-" + third.dataset.pane);
+ok("clicking a tab leaves exactly one pane visible", visible().length === 1, visible().join(", "));
+ok("clicking a tab selects only it", selected().join() === third.id, selected().join(", "));
+ok("the caller is told which pane was shown", shown[shown.length - 1] === third.dataset.pane,
+   JSON.stringify(shown));
+
+/* ---------- keyboard ---------- */
+ok("tabs listen for keys at all", tabs.every((t) => t.listens("keydown")));
+
+function press(tab, key) {
+  let prevented = false;
+  tab.dispatch("keydown", { key, preventDefault() { prevented = true; } });
+  return prevented;
+}
+
+const first = tabs[0];
+const last = tabs[tabs.length - 1];
+
+first.dispatch("click");
+press(first, "ArrowRight");
+ok("ArrowRight moves to the next tab", selected().join() === tabs[1].id, selected().join(", "));
+ok("the arrow key moves focus with the selection", tabs[1].focused);
+
+press(tabs[1], "ArrowLeft");
+ok("ArrowLeft moves back", selected().join() === first.id, selected().join(", "));
+
+press(first, "ArrowLeft");
+ok("ArrowLeft from the first tab wraps to the last", selected().join() === last.id,
+   selected().join(", "));
+
+press(last, "ArrowRight");
+ok("ArrowRight from the last tab wraps to the first", selected().join() === first.id,
+   selected().join(", "));
+
+press(first, "End");
+ok("End jumps to the last tab", selected().join() === last.id, selected().join(", "));
+press(last, "Home");
+ok("Home jumps to the first tab", selected().join() === first.id, selected().join(", "));
+
+ok("a handled key stops the page scrolling under it", press(first, "ArrowRight") === true);
+ok("an unrelated key is left alone", press(first, "PageDown") === false);
+const before = selected().join();
+press(tabs[1], "Enter");
+ok("Enter does not change the selection", selected().join() === before);
+
+/* ---------- the badge ---------- */
+const anyTab = tabs[0];
+win.markTab(anyTab.dataset.pane, 3);
+ok("markTab puts a count on the tab", anyTab.getAttribute("data-badge") === "3",
+   String(anyTab.getAttribute("data-badge")));
+win.markTab(anyTab.dataset.pane, 0);
+ok("a count of zero clears the badge rather than showing 0",
+   anyTab.getAttribute("data-badge") === "", String(anyTab.getAttribute("data-badge")));
+win.markTab("no-such-pane", 5);
+ok("marking a pane that does not exist is survivable", true);
+
+/* ---------- showing a pane from code ---------- */
+ok("the page defines showTab", typeof win.showTab === "function");
+if (typeof win.showTab === "function") {
+  first.dispatch("click");
+  var target = tabs[tabs.length - 1];
+  win.showTab(target.dataset.pane);
+  ok("showTab selects the pane it was given", selected().join() === target.id, selected().join(", "));
+  ok("showTab leaves exactly one pane visible", visible().length === 1, visible().join(", "));
+  win.showTab("no-such-pane");
+  ok("showTab on a pane that does not exist changes nothing",
+     selected().join() === target.id, selected().join(", "));
+}
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/test_matrixark_portal_tabs.py
+++ b/tools/test_matrixark_portal_tabs.py
@@ -28,7 +28,7 @@ TOOLS = os.path.dirname(os.path.abspath(__file__))
 PORTAL = os.path.join(TOOLS, "portal")
 HARNESS = os.path.join(PORTAL, "tabs_harness.js")
 
-TABBED = ["setup_portal.html", "explore_portal.html"]
+TABBED = ["setup_portal.html", "explore_portal.html", "api_key_portal.html"]
 
 # Every heading the setup page carried before it was grouped into panes.
 SETUP_HEADINGS = [
@@ -145,6 +145,43 @@ class NoSentencePointsAcrossATabTest(unittest.TestCase):
         self.assertIn('showTab("settings")', self.text,
                       "the model picker writes a settings field from another tab and never "
                       "shows it, so the change and its save bar stay invisible")
+
+
+class TheHandMaintainedPagesGetTheHelperTest(unittest.TestCase):
+    """The key portal is not generated, so the builder injects the helper the way it injects nav.
+
+    Two things can go wrong with an injector that runs on every build: it can stack, defining the
+    helper once per build, or it can reach a page that has no tabs.
+    """
+
+    def test_the_key_portal_has_exactly_one_copy(self) -> None:
+        self.assertEqual(1, page("api_key_portal.html").count("window.wireTabs = function"),
+                         "the builder stacked the helper, so it is defined more than once")
+
+    def test_a_page_without_tabs_is_left_alone(self) -> None:
+        text = page("ingestion_portal.html")
+        self.assertNotIn('role="tablist"', text, "this test is about a page that has no tabs")
+        self.assertNotIn("wireTabs", text,
+                         "the helper was injected into a page with nothing to switch")
+
+    def test_the_helper_is_defined_before_it_is_called(self) -> None:
+        """Scripts run in document order. Appended last, the helper is undefined when called."""
+        for name in TABBED:
+            with self.subTest(page=name):
+                text = page(name)
+                defined = text.index("window.wireTabs = function")
+                called = text.index("window.wireTabs(")
+                self.assertLess(defined, called,
+                                "%s calls the tab helper before the block defining it, which "
+                                "throws on load and stops the rest of that script" % name)
+
+    def test_the_connection_step_is_not_behind_a_tab(self) -> None:
+        """Every pane needs a key first. A step you must take before any tab works is not a tab."""
+        text = page("api_key_portal.html")
+        above = text.split('<div class="tabs"', 1)[0]
+        self.assertIn("Connection", above,
+                      "the connection panel moved behind a tab, so the other tabs look broken "
+                      "until you find it")
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_portal_tabs.py
+++ b/tools/test_matrixark_portal_tabs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal's tabs, driven rather than read.
+
+Tabs are the one part of a page whose source says least about it. Markup declaring `role="tab"` on
+a button wired to nothing is indistinguishable, by inspection, from markup whose tabs work -- the
+overrides panel on the key portal shipped broken three separate times on exactly that, each time
+loading clean and failing on click. So the tab code is executed here against the tabs and panes
+read out of the real generated page.
+
+Two properties beyond "it switches":
+
+* **Nothing was lost.** The setup page had twelve sections in one column before they were grouped
+  into four panes. A regrouping that silently drops one is the obvious way this goes wrong, and it
+  would look fine on screen -- the remaining tabs still work.
+* **One implementation.** The explore page had tabs first, with its switching code inline. This
+  runs the same harness against both pages, so a helper that works on one and not the other fails
+  here rather than in front of someone.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "tabs_harness.js")
+
+TABBED = ["setup_portal.html", "explore_portal.html"]
+
+# Every heading the setup page carried before it was grouped into panes.
+SETUP_HEADINGS = [
+    "Access", "Start from a provider", "Models", "Retrieval settings", "Recent changes",
+    "Move this configuration", "Encoding", "Endpoint test", "Traffic",
+    "Where this deployment lives", "Launch a deployment", "Grafana",
+]
+
+
+def page(name: str) -> str:
+    with open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheTabsWorkTest(unittest.TestCase):
+
+    def _run(self, name: str):
+        return subprocess.run(["node", HARNESS, os.path.join(PORTAL, name)],
+                              capture_output=True, text=True, timeout=180)
+
+    def test_every_tabbed_page_passes(self) -> None:
+        for name in TABBED:
+            with self.subTest(page=name):
+                proc = self._run(name)
+                self.assertEqual(0, proc.returncode,
+                                 "%s: %s%s" % (name, proc.stdout, proc.stderr))
+
+    def test_the_keyboard_is_actually_exercised(self) -> None:
+        """A tablist answering only to the mouse is the state this change was made to leave."""
+        out = self._run("setup_portal.html").stdout
+        for what in ("ArrowRight moves to the next tab",
+                     "ArrowLeft from the first tab wraps to the last",
+                     "Home jumps to the first tab"):
+            self.assertIn("ok   " + what, out, out)
+
+    def test_a_meaningful_number_of_checks_run(self) -> None:
+        out = self._run("setup_portal.html").stdout
+        checked = sum(1 for line in out.splitlines() if line.startswith("ok "))
+        self.assertGreaterEqual(checked, 20, "only %d checks ran, so passing says little" % checked)
+
+
+class NothingWasLostInTheRegroupingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.text = page("setup_portal.html")
+
+    def test_every_section_survived(self) -> None:
+        for heading in SETUP_HEADINGS:
+            self.assertIn(heading, self.text,
+                          "the setup page no longer mentions %r, so grouping into tabs dropped it"
+                          % heading)
+
+    def test_every_section_is_inside_a_pane(self) -> None:
+        """A section left outside the panes is visible on every tab, which is not a tab at all."""
+        outside = self.text.split('<section class="pane"', 1)[0]
+        self.assertNotIn("<h2>", outside,
+                         "a section sits above the first pane and will show on every tab")
+
+    def test_the_two_deployment_sections_are_told_apart(self) -> None:
+        """Both were called Deployment: one is read-only, one composes a launch."""
+        self.assertIn("Where this deployment lives", self.text)
+        self.assertIn("Launch a deployment", self.text)
+        self.assertNotIn("<h2>Deployment</h2>", self.text,
+                         "two sections still carry the same heading")
+
+
+class OnlyPagesWithTabsCarryTheHelperTest(unittest.TestCase):
+    """A page without tabs should be untouched by this, and stay that way."""
+
+    def test_the_helper_travels_with_the_tablist(self) -> None:
+        for name in os.listdir(PORTAL):
+            if not name.endswith(".html"):
+                continue
+            with self.subTest(page=name):
+                text = page(name)
+                has_tabs = 'role="tablist"' in text
+                has_helper = "window.wireTabs" in text
+                self.assertEqual(has_tabs, has_helper,
+                                 "%s: tablist=%s but helper=%s" % (name, has_tabs, has_helper))
+
+    def test_there_is_exactly_one_implementation(self) -> None:
+        """Two copies of a switcher is how two pages that look alike stop behaving alike."""
+        for name in TABBED:
+            text = page(name)
+            self.assertEqual(1, text.count("window.wireTabs = function"),
+                             "%s carries more than one tab implementation" % name)
+            self.assertNotIn('Array.prototype.forEach.call(document.querySelectorAll(".tabs button")',
+                             text, "%s still has its own inline copy of the switcher" % name)
+
+
+class NoSentencePointsAcrossATabTest(unittest.TestCase):
+    """Grouping a page into panes invalidates every "above" and "below" that crosses one.
+
+    Targeted rather than general: these four were found by mapping each line to its pane, and a
+    rule broad enough to catch any directional word would flag every legitimate "the table below"
+    within a single pane. What this stops is these four coming back.
+    """
+
+    def setUp(self) -> None:
+        self.text = page("setup_portal.html")
+
+    def test_the_known_crossings_stay_fixed(self) -> None:
+        for phrase, why in [
+            ("not editable above", "the storage fields are on the Settings tab"),
+            ("entered above", "secret values are on the Settings tab"),
+            ("key above", "the admin key field is on the Access tab"),
+            ("configuration below", "the save bar is on the Settings tab"),
+        ]:
+            self.assertNotIn(phrase, self.text, "%r points across a tab: %s" % (phrase, why))
+
+    def test_a_write_into_another_pane_takes_you_there(self) -> None:
+        """Picking a model sets a field on the Settings tab; without this it lands unseen."""
+        self.assertIn('showTab("settings")', self.text,
+                      "the model picker writes a settings field from another tab and never "
+                      "shows it, so the change and its save bar stay invisible")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The setup page was twelve sections in one column. They group into four tabs: Access, Settings, Checks, Deployment.

The explore page already had tabs with its switcher inline. Rather than a second copy, the switcher moves to a shared helper both pages call, and it travels only with a tablist so pages without tabs are unchanged.

Two additions, now that two pages depend on it:

* **Keyboard.** The old switcher bound click only. Arrows, Home and End now work, with roving tabindex.
* **A hidden save bar speaks.** The settings form and its unsaved-changes counter sit behind a tab now; the tab carries the count so an unsaved edit is not invisible.

**Grouping invalidates directional wording.** Four sentences crossed a tab boundary, each found by mapping the line to its pane. Three were wording. The fourth lost work: picking a model on Access writes a field on Settings, scrolled to it (a no-op while hidden) and said to save "below" — the save bar was on another tab. That one now moves you to where the change landed.

**An existing harness caught a real coupling.** The page called `wireTabs()` bare, which resolves in a browser but threw in three harnesses that pass `window` as a parameter — aborting the script block, so the monitoring table and deployment chooser stopped being defined. Calls now go through `window` explicitly.

Verified by running the code, not reading it: `tabs_harness.js` drives the real helper against both tabbed pages. Nine mutations fail it, including reverting to click-only. All 34 portal-touching modules pass; the three reds on this branch are red on main too.