### PR TITLE
The flag inventory regenerates the repository it was run from

### DIFF
--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -15,7 +15,12 @@ import pathlib
 import re
 import sys
 
-ROOT = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "/root/wt-flags")
+# Default to the repository this script lives in. It used to default to an absolute path to
+# one particular checkout on one particular machine, so running it anywhere else regenerated
+# the document from a tree the caller had never heard of -- or from nothing at all. The test
+# always passes a directory, so it never touched the default and never saw this.
+ROOT = pathlib.Path(sys.argv[1] if len(sys.argv) > 1
+                    else pathlib.Path(__file__).resolve().parent.parent)
 SRC = ROOT / "crates" / "temporalstore-rust" / "src"
 OUT = ROOT / "docs" / "ops" / "temporalstore-engine-flags.md"
 

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -94,5 +94,34 @@ class TheInventoryMatchesTheEngineTest(unittest.TestCase):
             % ", ".join(missing))
 
 
+class TheDefaultRootIsThisRepositoryTest(unittest.TestCase):
+    """Run with no argument, the builder must regenerate THIS checkout.
+
+    It used to default to an absolute path naming one worktree on one machine, so running it
+    anywhere else rewrote the document from a tree the caller had never heard of. Every test here
+    passes a directory explicitly, which is why the default went unexercised -- so these assert on
+    the default itself rather than through a run.
+    """
+
+    def setUp(self) -> None:
+        with io.open(BUILDER, encoding="utf-8") as handle:
+            self.source = handle.read()
+
+    def test_no_absolute_path_to_somebody_checkout(self) -> None:
+        for bad in ('"/root/', "'/root/", '"/home/', "'/home/", '"C:'):
+            self.assertNotIn(bad, self.source,
+                             "the builder names an absolute path on one machine, so it does not "
+                             "regenerate the repository it was run from")
+
+    def test_the_default_follows_the_script(self) -> None:
+        line = [l for l in self.source.splitlines() if l.startswith("ROOT = ")]
+        self.assertTrue(line, "ROOT is no longer assigned where this test can see it")
+        window = self.source[self.source.index("ROOT = "):]
+        window = window[:window.index("SRC =")]
+        self.assertIn("__file__", window,
+                      "the default root is not derived from the script location, so it depends on "
+                      "where the caller happens to be")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Run with no argument, the builder rebuilt the document from `/root/wt-flags` — an absolute path to one worktree on one machine, written into the tool. On any other checkout that regenerates from a tree the caller has never heard of; on a machine without that directory it inventories nothing.

Found by running the tool from a second worktree and watching it report writing a file in the first one.

**Why nothing caught it:** every test passes a directory explicitly — the byte-identical check builds into a temp directory with a symlink to `crates` — so the default was never exercised. The failure message even tells you to pass `.`, which is the shape of a default nobody expects to work.

The new tests assert on the default itself rather than through a run: no absolute path naming a particular checkout, and a root derived from the script's own location. Restoring the hardcoded path fails them.