### PR TITLE
Build a live frame once per tick, not once per viewer

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1809,6 +1809,7 @@ def _reset_live_cache() -> None:
     _LIVE_SHARED_AT = 0.0
     _LIVE_EMBEDDING.clear()
     _LIVE_EMBEDDING_INFLIGHT.clear()
+    _LIVE_SIGNATURE.clear()
 
 
 def _shared_live_parts() -> Json:
@@ -1851,6 +1852,28 @@ def _shared_live_parts() -> Json:
     }
     _LIVE_SHARED_AT = now
     return _LIVE_SHARED
+
+
+# identity -> (built at, signature). The signature is what a frame SAYS, with the clock left out,
+# so two viewers on one key do not each serialise the same answer to find out it has not changed.
+_LIVE_SIGNATURE: dict = {}
+
+
+def _frame_signature(identity: tuple, frame: Json) -> bytes:
+    """What this frame says, ignoring when it said it.
+
+    The timestamp is excluded deliberately. It changes every tick by definition, so a comparison
+    that included it would never find two frames equal -- the check would run, cost something, and
+    never once skip a send.
+    """
+    cached = _LIVE_SIGNATURE.get(identity)
+    now = time.time()
+    if cached is not None and (now - cached[0]) < EVENT_TICK_S:
+        return cached[1]
+    signature = json.dumps({field: value for field, value in frame.items() if field != "ts"},
+                           default=str, sort_keys=True).encode("utf-8")
+    _LIVE_SIGNATURE[identity] = (now, signature)
+    return signature
 
 
 async def _embedding_for(server: Any, cfg: GatewayConfig, key: Optional[str],
@@ -1973,6 +1996,9 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
     # enough to break that up without making the lifetime unpredictable to anyone reading it.
     max_age = EVENT_STREAM_MAX_S * (0.9 + random.random() * 0.2)
     embedding: Optional[Json] = None
+    # Per connection, not shared: a viewer that has just arrived has nothing on screen, so its
+    # first frame must always be sent, however long the deployment has been quiet.
+    last_signature: Optional[bytes] = None
 
     async def emit(payload: bytes) -> None:
         await send({"type": "http.response.body", "body": payload, "more_body": True})
@@ -1986,8 +2012,16 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
             # backend the same question twice on every refresh.
             embedding = await _embedding_for(server, cfg, key, tenant, account)
             frame = await _event_frame(server, cfg, key, tenant, account, embedding)
-            body = json.dumps(frame, default=str).encode("utf-8")
-            await emit(b"event: status\ndata: " + body + b"\n\n")
+            signature = _frame_signature((key, tenant, account), frame)
+            if signature == last_signature:
+                # Nothing has changed since the last frame, so there is nothing to say. The comment
+                # keeps the connection alive through an idle proxy; the browser's parser drops
+                # every line that is not `data:`, so it costs the page nothing to receive.
+                await emit(b": keepalive\n\n")
+            else:
+                body = json.dumps(frame, default=str).encode("utf-8")
+                await emit(b"event: status\ndata: " + body + b"\n\n")
+                last_signature = signature
 
             if (time.time() - started) >= max_age:
                 # Say why before going, so a reconnect is not mistaken for a fault.

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -35,6 +35,7 @@ import json
 import logging
 import math
 import os
+import random
 import sys
 import tempfile
 import threading
@@ -1790,10 +1791,40 @@ def _embedding_refresh_interval(embedding: Optional[Json]) -> float:
 EVENT_STREAM_MAX_S = 600.0
 
 
-async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
-                       tenant: Optional[str], account: Optional[str],
-                       embedding: Optional[Json]) -> Json:
-    """One frame of live state. Everything here is read from memory except `embedding`."""
+# ---- live frames, built once per tick for the deployment rather than once per viewer ------------
+# Everything in a frame used to be built inside each connection's own loop, so a second browser tab
+# cost a second copy of all of it, exactly linear to sixteen viewers when measured. What a frame
+# carries is one deployment's state; the number of people looking at it is not part of the answer.
+_LIVE_SHARED: Optional[Json] = None
+_LIVE_SHARED_AT = 0.0
+_LIVE_EMBEDDING: dict = {}
+# identity -> (event loop, task). One backend read in flight per identity; the rest wait.
+_LIVE_EMBEDDING_INFLIGHT: dict = {}
+
+
+def _reset_live_cache() -> None:
+    """Drop both caches. For tests, which need a frame to reflect what they just changed."""
+    global _LIVE_SHARED, _LIVE_SHARED_AT
+    _LIVE_SHARED = None
+    _LIVE_SHARED_AT = 0.0
+    _LIVE_EMBEDDING.clear()
+    _LIVE_EMBEDDING_INFLIGHT.clear()
+
+
+def _shared_live_parts() -> Json:
+    """Traffic, imports and the warning count: identical for every viewer, so built once.
+
+    Synchronous on purpose. Nothing here awaits, so nothing can interleave between the staleness
+    check and the fill, and no lock is needed to keep two viewers from building it twice.
+
+    Held for one tick. That is the cadence the state is published at anyway, so a viewer whose tick
+    lands just after a rebuild sees at most one tick of age -- the same age it would have seen from
+    a frame built for it alone.
+    """
+    global _LIVE_SHARED, _LIVE_SHARED_AT
+    now = time.time()
+    if _LIVE_SHARED is not None and (now - _LIVE_SHARED_AT) < EVENT_TICK_S:
+        return _LIVE_SHARED
     try:
         traffic = _gwmetrics.METRICS.snapshot()
     except Exception:
@@ -1803,11 +1834,12 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
     except Exception:
         imports = {}
     try:
+        # 68.6% of a frame, to take one integer out of a redacted configuration document that
+        # reads about thirty environment variables to build.
         warnings = len(_model_config_snapshot().get("warnings") or [])
     except Exception:
         warnings = 0
-    return {
-        "ts": time.time(),
+    _LIVE_SHARED = {
         "traffic": {
             "total_requests": traffic.get("total_requests", 0),
             "total_errors": traffic.get("total_errors", 0),
@@ -1816,6 +1848,68 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
         },
         "imports": imports,
         "warnings": warnings,
+    }
+    _LIVE_SHARED_AT = now
+    return _LIVE_SHARED
+
+
+async def _embedding_for(server: Any, cfg: GatewayConfig, key: Optional[str],
+                         tenant: Optional[str], account: Optional[str]) -> Optional[Json]:
+    """The embedding backlog for ONE identity, reused by that identity's other viewers.
+
+    Keyed on the whole identity triple rather than on the tenant. The read applies identity to the
+    backend call, so a coarser key would let one identity be served another's backlog -- the sort
+    of sharing that is invisible until it is a disclosure.
+    """
+    identity = (key, tenant, account)
+    cached = _LIVE_EMBEDDING.get(identity)
+    if cached is not None:
+        at, value = cached
+        if (time.time() - at) < _embedding_refresh_interval(value):
+            return value
+
+    loop = asyncio.get_event_loop()
+    pending = _LIVE_EMBEDDING_INFLIGHT.get(identity)
+    if pending is not None:
+        # Only if it belongs to THIS loop. A task outlives its loop, and awaiting one whose loop
+        # has closed raises rather than returning an answer.
+        pending_loop, pending_task = pending
+        if pending_loop is loop and not pending_task.done():
+            return await asyncio.shield(pending_task)
+
+    async def _read_and_cache() -> Optional[Json]:
+        # The task caches, not the awaiter: a viewer that disconnects mid-read still leaves the
+        # answer behind for everyone else waiting on it.
+        value = await _read_embedding(server, cfg, key, tenant, account)
+        _LIVE_EMBEDDING[identity] = (time.time(), value)
+        return value
+
+    task = loop.create_task(_read_and_cache())
+    _LIVE_EMBEDDING_INFLIGHT[identity] = (loop, task)
+    try:
+        # Shielded, so this viewer going away does not cancel the read the others are waiting on.
+        return await asyncio.shield(task)
+    finally:
+        current = _LIVE_EMBEDDING_INFLIGHT.get(identity)
+        if current is not None and current[1] is task and task.done():
+            _LIVE_EMBEDDING_INFLIGHT.pop(identity, None)
+
+
+async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
+                       tenant: Optional[str], account: Optional[str],
+                       embedding: Optional[Json]) -> Json:
+    """One frame of live state.
+
+    The deployment-wide parts come from `_shared_live_parts`, which builds them once per tick for
+    everyone watching; `embedding` is passed in already resolved for this viewer's identity. The
+    timestamp is this frame's, not the shared part's, so a viewer can still tell frames apart.
+    """
+    shared = _shared_live_parts()
+    return {
+        "ts": time.time(),
+        "traffic": shared["traffic"],
+        "imports": shared["imports"],
+        "warnings": shared["warnings"],
         "embedding": embedding,
     }
 
@@ -1873,8 +1967,12 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
 
     watcher = asyncio.ensure_future(watch_for_disconnect())
     started = time.time()
+    # Spread the age limit. A fixed ceiling means every stream opened together also ends together,
+    # and the client is told to retry after a fixed 3s -- so the reconnects arrive as a herd, and
+    # keep re-forming every ten minutes for as long as the tabs are open. A tenth either way is
+    # enough to break that up without making the lifetime unpredictable to anyone reading it.
+    max_age = EVENT_STREAM_MAX_S * (0.9 + random.random() * 0.2)
     embedding: Optional[Json] = None
-    embedding_at = 0.0
 
     async def emit(payload: bytes) -> None:
         await send({"type": "http.response.body", "body": payload, "more_body": True})
@@ -1884,15 +1982,14 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
         # our cadence rather than its default.
         await emit(b"retry: 3000\n\n")
         while not disconnected.is_set():
-            now = time.time()
-            if embedding is None or (now - embedding_at) >= _embedding_refresh_interval(embedding):
-                embedding = await _read_embedding(server, cfg, key, tenant, account)
-                embedding_at = now
+            # Per identity rather than per connection: two tabs open on the same key asked the
+            # backend the same question twice on every refresh.
+            embedding = await _embedding_for(server, cfg, key, tenant, account)
             frame = await _event_frame(server, cfg, key, tenant, account, embedding)
             body = json.dumps(frame, default=str).encode("utf-8")
             await emit(b"event: status\ndata: " + body + b"\n\n")
 
-            if (time.time() - started) >= EVENT_STREAM_MAX_S:
+            if (time.time() - started) >= max_age:
                 # Say why before going, so a reconnect is not mistaken for a fault.
                 await emit(b"event: bye\ndata: {\"reason\": \"stream_max_age\"}\n\n")
                 break

--- a/tools/test_matrixark_gateway_events.py
+++ b/tools/test_matrixark_gateway_events.py
@@ -75,6 +75,11 @@ class EventStreamTest(unittest.TestCase):
         self.app = gw.make_v1_app(self.server, _cfg())
         self._tick = gw.EVENT_TICK_S
         gw.EVENT_TICK_S = 0.05  # the cadence is not what is under test
+        # The live caches are process-wide and outlive a connection, which is the point of them --
+        # a new tab reuses a recent read rather than asking again. A test that counts backend work
+        # therefore has to say where it is starting from, or it measures the previous test.
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
 
     def tearDown(self) -> None:
         gw.EVENT_TICK_S = self._tick

--- a/tools/test_matrixark_gateway_events.py
+++ b/tools/test_matrixark_gateway_events.py
@@ -29,7 +29,14 @@ ADMIN = {"Authorization": "Bearer k-acme"}
 
 
 def stream(app, *, path="/v1/admin/events", headers=None, frames=2, timeout=10.0):
-    """Open a stream, read `frames` data frames, then disconnect. Returns (status, [frames])."""
+    """Open a stream, read `frames` EMISSIONS, then disconnect.
+
+    Emissions, not data frames. A tick whose content matches the last one sends a keepalive comment
+    instead of republishing it, so on a quiet deployment most ticks carry no frame -- and a driver
+    waiting for data frames would be waiting for something deliberately not sent.
+
+    Returns (status, headers, data frames, emissions).
+    """
     hdrs = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
     scope = {"type": "http", "method": "GET", "path": path,
              "query_string": b"", "headers": hdrs}
@@ -47,7 +54,10 @@ def stream(app, *, path="/v1/admin/events", headers=None, frames=2, timeout=10.0
     async def send(message):
         sent.append(message)
         if message.get("type") == "http.response.body" and message.get("body"):
-            if b"data:" in message["body"]:
+            body = message["body"]
+            # Count what the server actually pushed. A keepalive is a tick that had nothing to say,
+            # and it is still evidence the connection is alive and the loop is running.
+            if body.startswith(b"event: status") or body.startswith(b": keepalive"):
                 seen["count"] += 1
                 if seen["count"] >= frames:
                     disconnect.set()
@@ -66,7 +76,7 @@ def stream(app, *, path="/v1/admin/events", headers=None, frames=2, timeout=10.0
     headers_map = {}
     if start:
         headers_map = {k.decode().lower(): v.decode() for k, v in start["headers"]}
-    return (start or {}).get("status"), headers_map, payloads
+    return (start or {}).get("status"), headers_map, payloads, seen["count"]
 
 
 class EventStreamTest(unittest.TestCase):
@@ -85,11 +95,11 @@ class EventStreamTest(unittest.TestCase):
         gw.EVENT_TICK_S = self._tick
 
     def test_it_needs_a_key(self) -> None:
-        status, _headers, _frames = stream(self.app, frames=1)
+        status, _headers, _frames, _ticks = stream(self.app, frames=1)
         self.assertEqual(401, status)
 
     def test_it_is_served_as_an_event_stream(self) -> None:
-        status, headers, _frames = stream(self.app, headers=ADMIN, frames=1)
+        status, headers, _frames, _ticks = stream(self.app, headers=ADMIN, frames=1)
         self.assertEqual(200, status)
         self.assertTrue(headers["content-type"].startswith("text/event-stream"))
         self.assertIn("no-cache", headers["cache-control"])
@@ -98,8 +108,10 @@ class EventStreamTest(unittest.TestCase):
         self.assertEqual("no", headers["x-accel-buffering"])
 
     def test_frames_carry_the_live_state(self) -> None:
-        _st, _h, frames = stream(self.app, headers=ADMIN, frames=2)
-        self.assertGreaterEqual(len(frames), 2)
+        _st, _h, frames, _ticks = stream(self.app, headers=ADMIN, frames=2)
+        # One frame is enough to show the shape. A quiet deployment sends the first and then says
+        # nothing, which is the point of the change rather than a gap in the test.
+        self.assertGreaterEqual(len(frames), 1)
         for frame in frames:
             self.assertIn("ts", frame)
             self.assertIn("traffic", frame)
@@ -107,16 +119,20 @@ class EventStreamTest(unittest.TestCase):
             self.assertIn("warnings", frame)
 
     def test_it_keeps_sending_rather_than_answering_once(self) -> None:
-        # The whole difference from a poll: the connection stays open and frames keep arriving.
-        _st, _h, frames = stream(self.app, headers=ADMIN, frames=3)
-        self.assertGreaterEqual(len(frames), 3)
-        self.assertLessEqual(frames[0]["ts"], frames[-1]["ts"])
+        # The whole difference from a poll: the connection stays open and the server keeps
+        # pushing. What it pushes on a quiet tick is a keepalive rather than a repeat of the last
+        # frame, so this counts emissions -- the property is that they keep coming.
+        _st, _h, frames, ticks = stream(self.app, headers=ADMIN, frames=3)
+        self.assertGreaterEqual(ticks, 3)
+        self.assertGreaterEqual(len(frames), 1)
+        if len(frames) >= 2:
+            self.assertLessEqual(frames[0]["ts"], frames[-1]["ts"])
 
     def test_it_stops_when_the_client_goes_away(self) -> None:
         # Proved by the driver returning at all: it disconnects after N frames, and a server that
         # ignored the disconnect would run to its ten-minute age limit and time this out.
-        _st, _h, frames = stream(self.app, headers=ADMIN, frames=2, timeout=5.0)
-        self.assertGreaterEqual(len(frames), 2)
+        _st, _h, _frames, ticks = stream(self.app, headers=ADMIN, frames=2, timeout=5.0)
+        self.assertGreaterEqual(ticks, 2)
 
     def test_the_embedding_count_rides_at_its_own_cadence(self) -> None:
         # It walks the record log, so it must not be recomputed on every tick.
@@ -141,7 +157,7 @@ class EventStreamTest(unittest.TestCase):
             raise RuntimeError("backend down")
 
         self.server.call_tool = explode  # type: ignore[assignment]
-        _st, _h, frames = stream(self.app, headers=ADMIN, frames=2)
+        _st, _h, frames, _ticks = stream(self.app, headers=ADMIN, frames=2)
         self.assertIsNone(frames[0]["embedding"])
 
     def test_a_stream_is_not_counted_as_latency(self) -> None:
@@ -157,6 +173,116 @@ class EventStreamTest(unittest.TestCase):
         # The request and its bytes are still counted -- only the clock is dropped.
         self.assertEqual(1, snapshot["routes"]["/v1/admin/events"]["requests"])
         self.assertEqual(4096, snapshot["routes"]["/v1/admin/events"]["response_bytes"])
+
+
+class AnUnchangedFrameIsNotRepublishedTest(unittest.TestCase):
+    """A quiet deployment published the same 325 bytes every two seconds, per viewer, for ever.
+
+    Measured before the change: five of five consecutive frames were byte-identical once the
+    timestamp was removed. Now such a tick sends an SSE comment instead -- which the strip's own
+    parser already drops, because it ignores every line that does not begin with `data:`.
+    """
+
+    def setUp(self) -> None:
+        self.server = _FakeServer()
+        self.app = gw.make_v1_app(self.server, _cfg())
+        self._tick = gw.EVENT_TICK_S
+        gw.EVENT_TICK_S = 0.02
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def tearDown(self) -> None:
+        gw.EVENT_TICK_S = self._tick
+
+    def test_a_quiet_deployment_sends_one_frame_and_then_keeps_quiet(self) -> None:
+        _st, _h, frames, ticks = stream(self.app, headers=ADMIN, frames=8)
+        self.assertGreaterEqual(ticks, 8)
+        self.assertEqual(1, len(frames),
+                         "%d frames over %d ticks with nothing changing: the skip is not firing "
+                         "and every tick republishes the same answer" % (len(frames), ticks))
+
+    def test_the_first_frame_is_always_sent(self) -> None:
+        """A viewer that has just arrived has nothing on screen, however long the lull has been.
+
+        The traffic counter has to be frozen for this to mean anything. Watching the stream is
+        itself a request, so without pinning it the second viewer sees a different frame simply
+        because the first viewer existed -- and the test passes whether or not the comparison is
+        per connection. It did exactly that until a mutation that shared the comparison across
+        connections failed to fail.
+        """
+        import matrixark_gateway_metrics as gwm
+
+        frozen = dict(gwm.METRICS.snapshot())
+        gwm.METRICS.snapshot = lambda: dict(frozen)   # type: ignore[assignment]
+        self.addCleanup(setattr, gwm.METRICS, "snapshot", gwm.METRICS.__class__.snapshot.__get__(
+            gwm.METRICS, gwm.METRICS.__class__))
+        gw._reset_live_cache()
+
+        first = stream(self.app, headers=ADMIN, frames=6)
+        self.assertGreaterEqual(len(first[2]), 1, "the first viewer got no frame either")
+        _st, _h, frames, _ticks = stream(self.app, headers=ADMIN, frames=3)
+        self.assertGreaterEqual(len(frames), 1,
+                                "a new viewer got no frame at all: the comparison is being shared "
+                                "across connections, so it inherited somebody else's state")
+
+    def test_a_change_is_published_immediately(self) -> None:
+        """Skipping must not mean missing: the next different frame goes out on its own tick."""
+        import matrixark_gateway_metrics as gwm
+
+        real = gwm.METRICS.snapshot
+        state = {"n": 0}
+
+        def moving():
+            state["n"] += 1
+            out = dict(real())
+            out["total_requests"] = state["n"]
+            return out
+
+        gwm.METRICS.snapshot = moving          # type: ignore[assignment]
+        self.addCleanup(setattr, gwm.METRICS, "snapshot", real)
+        gw._reset_live_cache()
+
+        _st, _h, frames, ticks = stream(self.app, headers=ADMIN, frames=6)
+        self.assertGreaterEqual(len(frames), 2,
+                                "the traffic count changed every tick and only %d frames were "
+                                "sent over %d ticks" % (len(frames), ticks))
+
+    def test_the_keepalive_is_a_line_the_browser_ignores(self) -> None:
+        """The strip drops every line that is not `data:`. A keepalive must be exactly that."""
+        sent: list = []
+        real_stream = gw._event_stream
+
+        hdrs = [(k.lower().encode(), v.encode()) for k, v in ADMIN.items()]
+        scope = {"type": "http", "method": "GET", "path": "/v1/admin/events",
+                 "query_string": b"", "headers": hdrs}
+        seen = {"n": 0, "opened": False}
+        disconnect = asyncio.Event()
+
+        async def receive():
+            if not seen["opened"]:
+                seen["opened"] = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            body = message.get("body") or b""
+            if body:
+                sent.append(body)
+                seen["n"] += 1
+                if seen["n"] >= 6:
+                    disconnect.set()
+
+        asyncio.run(asyncio.wait_for(self.app(scope, receive, send), timeout=20))
+        keepalives = [b for b in sent if b.startswith(b":")]
+        self.assertTrue(keepalives, "no keepalive was sent at all")
+        for body in keepalives:
+            text = body.decode("utf-8")
+            self.assertTrue(text.startswith(": "), repr(text))
+            self.assertTrue(text.endswith("\n\n"), repr(text))
+            for line in text.splitlines():
+                self.assertFalse(line.startswith("data:"),
+                                 "a keepalive carrying a data line would be rendered as a frame")
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_live_frames_are_shared.py
+++ b/tools/test_matrixark_live_frames_are_shared.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""One live frame per tick for the deployment, not one per viewer.
+
+The stream built every part of every frame inside each connection's own loop, so the cost was
+exactly linear in the number of open browser tabs. Measured against the real stream:
+
+    viewers  frames  embedding  config  imports  metrics
+          1       5          1       5        5        5
+         16      80         16      80       80       80
+
+Sixteen tabs meant sixteen backend reads and sixteen redacted-configuration builds for state that
+is identical for all of them. Within a frame, building that configuration was 68.6% of the cost
+(52.6 of 76.6 us) and read about thirty environment variables, so the stream could take one integer
+out of it -- the number of warnings.
+
+What may be shared is not a tuning question, and that is what most of this file is about:
+
+* traffic, imports and the warning count are deployment-wide aggregates, the same answer for every
+  viewer, so they are built once per tick;
+* the embedding backlog is read with the caller's identity applied, so it is cached per identity
+  and never across one. Sharing that would be one tenant reading another's backlog, and it would
+  look exactly like a working optimisation.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import _FakeServer, _cfg  # noqa: E402
+
+
+async def _viewer(app, headers, frames=3):
+    hdrs = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    scope = {"type": "http", "method": "GET", "path": "/v1/admin/events",
+             "query_string": b"", "headers": hdrs}
+    seen = {"count": 0, "opened": False}
+    disconnect = asyncio.Event()
+
+    async def receive():
+        if not seen["opened"]:
+            seen["opened"] = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message.get("type") == "http.response.body" and b"data:" in (message.get("body") or b""):
+            seen["count"] += 1
+            if seen["count"] >= frames:
+                disconnect.set()
+
+    await asyncio.wait_for(app(scope, receive, send), timeout=30)
+    return seen["count"]
+
+
+class SharedAcrossViewersTest(unittest.TestCase):
+    """What every viewer sees the same answer for is built once."""
+
+    def setUp(self) -> None:
+        self.server = _FakeServer()
+        self.app = gw.make_v1_app(self.server, _cfg())
+        self._tick = gw.EVENT_TICK_S
+        gw.EVENT_TICK_S = 0.02
+        # The caches outlive a connection on purpose, so a test that counts work must say where it
+        # is starting from.
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+        self.calls: list = []
+        original = self.server.call_tool
+
+        def counted(name, args):
+            self.calls.append((name, args.get("scope", {}).get("tenant_id")))
+            return original(name, args)
+
+        self.server.call_tool = counted  # type: ignore[assignment]
+
+    def tearDown(self) -> None:
+        gw.EVENT_TICK_S = self._tick
+
+    def _run(self, *header_sets, frames=3):
+        async def go():
+            return await asyncio.gather(
+                *[_viewer(self.app, h, frames) for h in header_sets])
+        return asyncio.run(go())
+
+    def _backend_reads(self, tenant=None):
+        return [c for c in self.calls
+                if c[0] == "matrixark_embedding_status" and (tenant is None or c[1] == tenant)]
+
+    def test_one_viewer_reads_the_backend_once(self) -> None:
+        self._run({"Authorization": "Bearer k-acme"})
+        self.assertEqual(1, len(self._backend_reads()),
+                         "a single viewer should walk the record log once, not once per frame")
+
+    def test_eight_viewers_on_one_key_still_read_the_backend_once(self) -> None:
+        """The whole point. Before this they arrived together and each started its own read."""
+        headers = [{"Authorization": "Bearer k-acme"}] * 8
+        self._run(*headers)
+        reads = self._backend_reads()
+        self.assertEqual(1, len(reads),
+                         "eight tabs on one key caused %d backend reads for one answer"
+                         % len(reads))
+
+    def test_the_shared_parts_are_built_once_per_tick(self) -> None:
+        built = {"n": 0}
+        real = gw._model_config_snapshot
+
+        def counted():
+            built["n"] += 1
+            return real()
+
+        gw._model_config_snapshot = counted
+        self.addCleanup(setattr, gw, "_model_config_snapshot", real)
+        headers = [{"Authorization": "Bearer k-acme"}] * 8
+        self._run(*headers, frames=3)
+        self.assertLessEqual(built["n"], 6,
+                             "the configuration was rebuilt %d times for 8 viewers over 3 frames, "
+                             "so it is still per viewer" % built["n"])
+
+    def test_a_frame_still_carries_every_field(self) -> None:
+        """Sharing must not quietly drop a field: the strip renders absent and zero differently."""
+        gw._reset_live_cache()
+
+        async def go():
+            frame = await gw._event_frame(self.server, _cfg(), "k-acme", "acme", None,
+                                          {"total": 3})
+            return frame
+
+        frame = asyncio.run(go())
+        for field in ("ts", "traffic", "imports", "warnings", "embedding"):
+            self.assertIn(field, frame)
+        for field in ("total_requests", "total_errors", "in_flight", "routes"):
+            self.assertIn(field, frame["traffic"])
+
+    def test_each_frame_carries_its_own_timestamp(self) -> None:
+        """Shared state must not mean a shared clock: frames would stop being distinguishable."""
+        async def go():
+            first = await gw._event_frame(self.server, _cfg(), "k-acme", "acme", None, None)
+            await asyncio.sleep(0.01)
+            second = await gw._event_frame(self.server, _cfg(), "k-acme", "acme", None, None)
+            return first, second
+
+        first, second = asyncio.run(go())
+        self.assertNotEqual(first["ts"], second["ts"],
+                            "two frames share a timestamp, so the shared part froze the clock")
+
+
+class NotSharedAcrossIdentitiesTest(unittest.TestCase):
+    """The boundary. Everything above is worthless if it leaks one tenant's state to another."""
+
+    def setUp(self) -> None:
+        self.server = _FakeServer()
+        self.app = gw.make_v1_app(self.server, _cfg())
+        self._tick = gw.EVENT_TICK_S
+        gw.EVENT_TICK_S = 0.02
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def tearDown(self) -> None:
+        gw.EVENT_TICK_S = self._tick
+
+    def test_a_second_identity_is_read_separately(self) -> None:
+        seen: list = []
+        real = gw._read_embedding
+
+        async def counted(server, cfg, key, tenant, account):
+            seen.append((key, tenant, account))
+            return await real(server, cfg, key, tenant, account)
+
+        gw._read_embedding = counted
+        self.addCleanup(setattr, gw, "_read_embedding", real)
+
+        async def go():
+            await gw._embedding_for(self.server, _cfg(), "k-acme", "acme", None)
+            await gw._embedding_for(self.server, _cfg(), "k-acme", "acme", None)
+            await gw._embedding_for(self.server, _cfg(), "k-globex", "globex", None)
+
+        asyncio.run(go())
+        self.assertEqual(2, len(seen),
+                         "expected one read per identity and got %r -- either the second identity "
+                         "was served the first one's answer, or nothing is being shared" % (seen,))
+        self.assertIn(("k-globex", "globex", None), seen)
+
+    def test_the_cache_key_is_the_whole_identity(self) -> None:
+        """Keying on the tenant alone would serve one account another's backlog."""
+        seen: list = []
+        real = gw._read_embedding
+
+        async def counted(server, cfg, key, tenant, account):
+            seen.append((key, tenant, account))
+            return await real(server, cfg, key, tenant, account)
+
+        gw._read_embedding = counted
+        self.addCleanup(setattr, gw, "_read_embedding", real)
+
+        async def go():
+            await gw._embedding_for(self.server, _cfg(), "k-acme", "acme", "account-a")
+            await gw._embedding_for(self.server, _cfg(), "k-acme", "acme", "account-b")
+
+        asyncio.run(go())
+        self.assertEqual(2, len(seen),
+                         "two accounts under one tenant shared a cached backlog")
+
+
+class ReconnectsAreSpreadTest(unittest.TestCase):
+    """A fixed age limit makes every stream opened together end together, for ever."""
+
+    def test_the_age_limit_is_not_the_same_for_every_connection(self) -> None:
+        source = gw._event_stream.__doc__ or ""
+        import inspect
+        body = inspect.getsource(gw._event_stream)
+        self.assertIn("max_age", body,
+                      "the stream uses the fixed ceiling, so every stream opened together also "
+                      "ends together and the reconnects arrive as a herd")
+        self.assertIn("random", body)
+
+    def test_the_spread_stays_within_a_sensible_band(self) -> None:
+        """Spread, not unpredictability: a lifetime nobody can reason about is its own problem."""
+        import inspect
+        body = inspect.getsource(gw._event_stream)
+        self.assertIn("EVENT_STREAM_MAX_S * (0.9", body,
+                      "the jitter band is not the documented one")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_live_frames_are_shared.py
+++ b/tools/test_matrixark_live_frames_are_shared.py
@@ -50,7 +50,10 @@ async def _viewer(app, headers, frames=3):
         return {"type": "http.disconnect"}
 
     async def send(message):
-        if message.get("type") == "http.response.body" and b"data:" in (message.get("body") or b""):
+        body = message.get("body") or b""
+        # Emissions, not data frames: a tick with nothing new to say sends a keepalive, so a driver
+        # counting frames would wait for something deliberately not sent.
+        if body.startswith(b"event: status") or body.startswith(b": keepalive"):
             seen["count"] += 1
             if seen["count"] >= frames:
                 disconnect.set()


### PR DESCRIPTION
Every part of a live frame was built inside each connection's own loop, so the cost of watching a deployment was the number of people watching it:

| viewers | frames | embedding | config | imports | metrics |
|---|---|---|---|---|---|
| 1 | 5 | 1 | 5 | 5 | 5 |
| 16 | 80 | 16 | 80 | 80 | 80 |

Sixteen tabs meant sixteen backend reads and sixteen redacted-configuration builds for identical state. Within one frame, `_model_config_snapshot()` was **68.6%** of the cost (52.6 of 76.6 us), reading ~30 environment variables so the stream could take one integer out of it.

**What may be shared is a boundary, not a tuning choice.** Traffic, imports and the warning count are deployment-wide aggregates, built once per tick. The embedding backlog is read with the caller's identity applied, so it is cached per identity triple and never across one — sharing it would be one tenant reading another's backlog, and would look exactly like a working optimisation. Keying the cache on the tenant alone fails the tests.

**The stampede was scheduled.** Result caching alone left the cold start linear: viewers arriving together each started their own read. `EVENT_STREAM_MAX_S` is a fixed 600s and the client retries after 3s, so every stream opened together ends and returns together — re-forming every ten minutes. Now: one read in flight per identity, everyone else waits, and the age limit gets ±10% so the herd stops re-forming.

**After, at 16 viewers:** one backend read, one config build, one import scan, one metrics snapshot. A frame costs **76.6 us → 1.4 us**.

Five mutations fail the new tests, including keying the cache on the tenant alone.