### PR TITLE
Read the encoding backlog once, not twice

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1080,6 +1080,10 @@ function liveStream(options) {
      point, and slowly once there is not. Deliberately NOT on /v1/metrics -- answering it walks the
      record log, and a scrape every fifteen seconds doing that is a self-inflicted load. */
   var encodeTimer = null, encodeMs = 0;
+  /* Whether the stream is delivering. The stream already carries the encoding backlog and calls
+     renderEncoding with it, so polling for the same number while it is live is a second read of
+     one answer -- and that endpoint walks the record log. */
+  var streamLive = false;
 
   function encodePace(draining) {
     var want = draining ? 5000 : 60000;
@@ -1088,6 +1092,14 @@ function liveStream(options) {
     encodeMs = want;
     encodeTimer = setInterval(function () {
       if (document.hidden || !$("key").value.trim()) { return; }
+      /* The fallback only. While the stream is live it delivers this, sooner than this timer
+         would ask for it -- 4s against 5 while draining, 30s against 60 when idle.
+
+         Gated on the connection, not on when a frame last arrived: an unchanged frame is no
+         longer republished, so a healthy stream on a quiet deployment sends nothing for minutes.
+         A clock cannot tell that apart from a dead connection, and would start polling precisely
+         when there is least reason to. */
+      if (streamLive) { return; }
       loadEncoding();
     }, want);
   }
@@ -2234,6 +2246,7 @@ function liveStream(options) {
     live = liveStream({
       headers: auth,
       onState: function (state, seconds) {
+        streamLive = (state === "live");
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }

--- a/tools/portal/encoding_poll_harness.js
+++ b/tools/portal/encoding_poll_harness.js
@@ -1,0 +1,162 @@
+/* Run the Setup page and check it does not read the encoding backlog twice.
+ *
+ * `onFrame` already calls renderEncoding with the backlog the stream carries. A timer also fetches
+ * /v1/admin/embeddings, and that endpoint walks the record log on the backend. While the stream is
+ * live, the timer is a second read of one answer.
+ *
+ * Source cannot answer this. Whether the timer fetches depends on a closure variable set by a
+ * callback the stream invokes on connecting -- so the page is run twice: once with a stream that
+ * connects, once with one that fails. The second run is what stops the first from being vacuous:
+ * a page that never polls at all would satisfy "does not poll while live" and be broken.
+ *
+ * Usage: node encoding_poll_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const FRAME = 'event: status\ndata: {"ts":1,"traffic":{"routes":{}},"imports":{},"warnings":0,' +
+              '"embedding":{"total":10,"encoded":10,"pending":0,"encoder":{}}}\n\n';
+
+function run(streamWorks) {
+  const fetched = [];
+  const intervals = [];
+  const els = new Map();
+
+  function makeEl(id) {
+    return {
+      id: id || "", hidden: true, innerHTML: "", textContent: "",
+      /* The timer returns early without a key. A harness that forgot would see no fetch and call
+         the gate proven. */
+      value: id === "key" ? "k-admin" : "",
+      checked: true, className: "", style: {}, dataset: {}, files: [], options: [], children: [],
+      addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+      setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+      querySelector() { return null; }, querySelectorAll() { return []; },
+      scrollIntoView() {}, focus() {}, click() {},
+      classList: { add() {}, remove() {}, toggle() {} }
+    };
+  }
+  function el(id) {
+    if (!els.has(id)) { els.set(id, makeEl(id)); }
+    return els.get(id);
+  }
+
+  function streamingResponse() {
+    let sent = false;
+    return Promise.resolve({
+      ok: true, status: 200,
+      body: {
+        getReader() {
+          return {
+            read() {
+              if (sent) { return new Promise(() => {}); }   // stays open, like a real stream
+              sent = true;
+              return Promise.resolve({ done: false, value: Buffer.from(FRAME, "utf8") });
+            }
+          };
+        }
+      },
+      json: () => Promise.resolve({}), text: () => Promise.resolve("")
+    });
+  }
+
+  function json(body) {
+    return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body),
+                             text: () => Promise.resolve(JSON.stringify(body)) });
+  }
+
+  const win = {
+    document: {
+      getElementById: (id) => el(id),
+      querySelector: () => makeEl(), querySelectorAll: () => [],
+      createElement: () => makeEl(), addEventListener() {},
+      body: makeEl(), hidden: false
+    },
+    addEventListener() {},
+    location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+    sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+    localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+    navigator: {},
+    setTimeout: () => 0,
+    setInterval: (fn, ms) => { intervals.push({ fn, ms }); return intervals.length; },
+    clearInterval() {},
+    Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+    encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+    TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+    AbortController: function () { this.abort = () => {}; this.signal = {}; },
+    FileReader: function () {}, Blob: function () {},
+    URL: { createObjectURL: () => "", revokeObjectURL() {} },
+    fetch: (url) => {
+      const u = String(url);
+      fetched.push(u);
+      if (u.indexOf("/v1/admin/events") >= 0) {
+        return streamWorks ? streamingResponse()
+                           : Promise.resolve({ ok: false, status: 503, body: null });
+      }
+      if (u.indexOf("/v1/admin/embeddings") >= 0) {
+        return json({ total: 10, encoded: 10, pending: 0, encoder: {} });
+      }
+      if (u.indexOf("/v1/admin/config") >= 0) { return json({ settings: {} }); }
+      return new Promise(() => {});
+    },
+    __matrixarkOnFrame() {}
+  };
+  win.window = win;
+
+  const names = Object.keys(win);
+  const values = names.map((k) => win[k]);
+  scripts.forEach((body, index) => {
+    try {
+      new Function(...names, body)(...values);
+    } catch (e) {
+      console.log("FAIL script " + index + " threw at load: " + e.message);
+      failures += 1;
+    }
+  });
+
+  return {
+    fetched, intervals,
+    reads: () => fetched.filter((u) => u.indexOf("/v1/admin/embeddings") >= 0).length,
+    opened: () => fetched.filter((u) => u.indexOf("/v1/admin/events") >= 0).length,
+    fire: () => intervals.forEach((t) => { try { t.fn(); } catch (e) { /* its own bug */ } })
+  };
+}
+
+async function turns(n) {
+  for (let i = 0; i < n; i += 1) { await new Promise((r) => setImmediate(r)); }
+}
+
+(async function () {
+  // ---- the stream connects: the timer must not ask for what the stream is delivering ----
+  const live = run(true);
+  await turns(30);
+  ok("the page opened the stream", live.opened() > 0,
+     "no stream was opened, so 'live' was never reached and the next check means nothing");
+  ok("the page set an interval to fall back on", live.intervals.length > 0,
+     "no timer exists, so there is nothing for the gate to stop");
+  const beforeLive = live.reads();
+  live.fire();
+  ok("while the stream is live the timer does not read the backlog",
+     live.reads() === beforeLive,
+     "the timer fetched " + (live.reads() - beforeLive) + " more time(s) while the stream was live");
+
+  // ---- the stream fails: the timer is the only source and must run ----
+  const dead = run(false);
+  await turns(30);
+  const beforeDead = dead.reads();
+  dead.fire();
+  ok("with no stream, the timer reads the backlog", dead.reads() > beforeDead,
+     "the fallback never fires, so a page whose stream is blocked shows a stale backlog for ever");
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}());

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1018,6 +1018,10 @@ function liveStream(options) {
      point, and slowly once there is not. Deliberately NOT on /v1/metrics -- answering it walks the
      record log, and a scrape every fifteen seconds doing that is a self-inflicted load. */
   var encodeTimer = null, encodeMs = 0;
+  /* Whether the stream is delivering. The stream already carries the encoding backlog and calls
+     renderEncoding with it, so polling for the same number while it is live is a second read of
+     one answer -- and that endpoint walks the record log. */
+  var streamLive = false;
 
   function encodePace(draining) {
     var want = draining ? 5000 : 60000;
@@ -1026,6 +1030,14 @@ function liveStream(options) {
     encodeMs = want;
     encodeTimer = setInterval(function () {
       if (document.hidden || !$("key").value.trim()) { return; }
+      /* The fallback only. While the stream is live it delivers this, sooner than this timer
+         would ask for it -- 4s against 5 while draining, 30s against 60 when idle.
+
+         Gated on the connection, not on when a frame last arrived: an unchanged frame is no
+         longer republished, so a healthy stream on a quiet deployment sends nothing for minutes.
+         A clock cannot tell that apart from a dead connection, and would start polling precisely
+         when there is least reason to. */
+      if (streamLive) { return; }
       loadEncoding();
     }, want);
   }
@@ -2172,6 +2184,7 @@ function liveStream(options) {
     live = liveStream({
       headers: auth,
       onState: function (state, seconds) {
+        streamLive = (state === "live");
         if (state === "live") { conn("live", "live"); }
         else if (state === "denied") { conn("live", "connected"); }
         else if (state === "retrying") { conn("down", "reconnecting in " + seconds + "s"); }

--- a/tools/test_matrixark_encoding_is_read_once.py
+++ b/tools/test_matrixark_encoding_is_read_once.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The setup page reads the encoding backlog once, not twice.
+
+`onFrame` already renders the backlog the stream carries. A timer also fetched
+`/v1/admin/embeddings`, and that endpoint walks the record log on the backend -- two reads of one
+number, per viewer, every five seconds while anything was draining. The stream is the fresher of
+the two: it refreshes at 4s while pending and 30s when idle, against the poll's 5 and 60.
+
+Run rather than read. Whether the timer fetches depends on a closure variable set by a callback the
+stream invokes when it connects, which no amount of grepping settles.
+
+The harness runs the page twice -- with a stream that connects and one that fails -- because
+"does not poll while live" is satisfied by a page that never polls at all, and that page is broken
+for anyone whose proxy buffers server-sent events.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "encoding_poll_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheBacklogIsReadOnceTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=180)
+
+    def test_the_page_does_not_read_it_twice(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode,
+                         "the setup page reads the encoding backlog twice:"
+                         + chr(10) + proc.stdout + proc.stderr)
+
+    def test_the_fallback_still_works(self) -> None:
+        """A page whose stream is blocked must still get its numbers from somewhere."""
+        out = self._run().stdout
+        self.assertIn("ok   with no stream, the timer reads the backlog", out, out)
+
+    def test_the_live_case_is_not_vacuous(self) -> None:
+        """If the stream never opened, 'it did not poll while live' would prove nothing."""
+        out = self._run().stdout
+        self.assertIn("ok   the page opened the stream", out, out)
+        self.assertIn("ok   the page set an interval to fall back on", out, out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The setup page has been rendering the encoding backlog from the live stream all along — `onFrame` calls `renderEncoding` with what the frame carries. Beside that, a timer fetched `/v1/admin/embeddings` every 5s while draining and every 60s otherwise, and that endpoint **walks the record log** on the backend.

Two reads of one number, per viewer. The free one is also the fresher: the stream refreshes at **4s while pending and 30s when idle**, against the timer's 5 and 60.

The timer becomes the fallback it should always have been — for a proxy that buffers server-sent events, a network that will not hold the connection, a key the stream was refused.

**The gate is the connection state, not a clock.** Those are different questions now that an unchanged frame is not republished: a healthy stream on a quiet deployment sends nothing for minutes, and a timer cannot tell that apart from a dead connection — it would resume polling exactly when there is least reason to.

Whether the timer fetches depends on a closure variable set by a callback the stream invokes on connecting, so reading the source cannot settle it. The harness runs the page twice — with a stream that connects and one that fails — because *"does not poll while live"* is also satisfied by a page that never polls at all, and that page is broken for anyone behind a buffering proxy. Three mutations fail it: removing the gate, forcing it on, and never recording the state.