### PR TITLE
A command that writes no page rebuilt the whole page index

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -780,6 +780,10 @@ impl TemporalEngine {
                 });
             let rebuilt_bucket_index = !maintained_bucket_index
                 && !defer_bucket_index_reconstruct()
+                // A command that writes no page cannot have changed the page index, so rebuilding it
+                // recomputes what it already held -- measured at twice the shard's page count per
+                // call for SeenCheck and the control-state change/selection writes.
+                && !command_writes_no_page(&command)
                 && (!command_updates_bucket_index_directly(&command)
                     || shard.bucket_index.bucket_map.is_empty());
             if rebuilt_bucket_index {

--- a/crates/temporalstore-rust/src/engine/command_validation.rs
+++ b/crates/temporalstore-rust/src/engine/command_validation.rs
@@ -302,6 +302,25 @@ pub(super) fn command_updates_bucket_index_directly(command: &Command) -> bool {
     )
 }
 
+/// True when a command mutates only state that no page backs.
+///
+/// The seen sets, the control-state change and selection maps, and the token buckets live outside the
+/// page-backed models, and their durability rides the index-log `key_states` blobs rather than a page
+/// entry. So a rebuild of the page index after one of these can only recompute what it already held.
+///
+/// This is deliberately NOT folded into `command_updates_bucket_index_directly`: these commands do
+/// not update that index, and saying they do to skip the rebuild would make the predicate assert
+/// something false. They need their own reason.
+pub(super) fn command_writes_no_page(command: &Command) -> bool {
+    matches!(
+        command,
+        Command::SeenCheck { .. }
+            | Command::ControlStateChangeAdd { .. }
+            | Command::ControlStateSelectionSet { .. }
+            | Command::BucketTake { .. }
+    )
+}
+
 pub(crate) fn is_write_command(command: &Command) -> bool {
     matches!(
         command,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -13815,28 +13815,28 @@ fn which_commands_rebuild_the_whole_index_per_call() {
     );
 
     let cases: Vec<(&str, Box<dyn Fn(usize) -> Command>)> = vec![
-        ("StringSet      (listed)", Box::new(|n: usize| Command::StringSet {
+        ("StringSet     (files pages)", Box::new(|n: usize| Command::StringSet {
             key: format!("probe-{n}"),
             value: b"v".to_vec(),
         })),
-        ("ListPush       (listed)", Box::new(|n: usize| Command::ListPush {
+        ("ListPush      (files pages)", Box::new(|n: usize| Command::ListPush {
             key: "feed".to_string(),
             member: format!("e-{n}").into_bytes(),
             left: false,
         })),
-        ("SeenCheck    (missing)", Box::new(|n: usize| Command::SeenCheck {
+        ("SeenCheck      (no page)", Box::new(|n: usize| Command::SeenCheck {
             key: "seen".to_string(),
             member: format!("m-{n}").into_bytes(),
             window_ms: 60_000,
         })),
-        ("FeatureAppend(missing)", Box::new(|n: usize| Command::FeatureAppend {
+        ("FeatureAppend (maintains)", Box::new(|n: usize| Command::FeatureAppend {
             key: "rate".to_string(),
             points: vec![FeaturePoint {
                 timestamp_ms: 1_000 + n as u64,
                 value: b"v".to_vec(),
             }],
         })),
-        ("SequenceAdd  (missing)", Box::new(|n: usize| Command::SequenceAdd {
+        ("SequenceAdd   (maintains)", Box::new(|n: usize| Command::SequenceAdd {
             key: "seq".to_string(),
             rows: vec![SequenceFeatureRow {
                 timestamp_ms: 1_000 + n as u64,
@@ -13846,7 +13846,7 @@ fn which_commands_rebuild_the_whole_index_per_call() {
                 author_id: 1,
             }],
         })),
-        ("ControlChange(missing)", Box::new(|n: usize| Command::ControlStateChangeAdd {
+        ("ControlChange  (no page)", Box::new(|n: usize| Command::ControlStateChangeAdd {
             key: "visitors".to_string(),
             timestamp_ms: 1_000 + n as u64,
             value: format!("v-{n}").into_bytes(),
@@ -13863,8 +13863,112 @@ fn which_commands_rebuild_the_whole_index_per_call() {
 
     println!(
         "
-  pages tracking the store => that command rebuilds the whole index on every call.
-  pages 0                  => it is on the maintained path, as the listed controls are.
+  Every row should read 0 pages. Three reasons, and the labels say which applies:
+    files pages -- the command files its page through upsert_bucket_index_page
+    maintains   -- it files through sync_bucket_index_object_pages, which maintains the same thing
+    no page     -- it writes no page at all, so there is nothing for a rebuild to recompute
+
+  ANY row whose pages stop being zero has started rebuilding the whole index on every call again --
+  which cost 12,646 allocations and 2,048 page visits at a 1,024-key store before these were fixed.
 "
+    );
+}
+
+
+/// A command exempted from the rebuild must leave the index matching a rebuilt one.
+///
+/// `command_writes_no_page` exempts SeenCheck and the control-state change/selection writes from the
+/// post-command index rebuild, on the grounds that they mutate only non-page state. That holds today
+/// -- none of their arms appends a value or files a bucket-index page -- but it is exactly the kind
+/// of fact a later change can quietly break, and a stale index would not announce itself.
+///
+/// So this asserts the property the exemption rests on: run each exempted command against a store
+/// with real page-backed content, then compare the live index against a from-scratch rebuild.
+#[test]
+fn a_no_page_command_leaves_the_index_matching_a_rebuild() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // Page-backed content, so a rebuild has something real to reconstruct.
+    for index in 0..64_usize {
+        for command in [
+            Command::StringSet {
+                key: format!("s-{index:04}"),
+                value: format!("v-{index}").into_bytes(),
+            },
+            Command::HashSet {
+                key: "h".to_string(),
+                field: format!("f-{index:04}"),
+                value: b"v".to_vec(),
+            },
+            Command::ListPush {
+                key: "l".to_string(),
+                member: format!("e-{index:04}").into_bytes(),
+                left: false,
+            },
+        ] {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command });
+            assert!(out.status.ok, "seed {index}: {:?}", out.status);
+        }
+    }
+
+    let snapshot = |engine: &TemporalEngine| -> Vec<String> {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let mut rows: Vec<String> = shard
+            .bucket_index
+            .bucket_map
+            .iter()
+            .flat_map(|(routing_bucket, bucket)| {
+                bucket.page_index.values().map(move |page| {
+                    format!(
+                        "{routing_bucket}|{}|{}|{}",
+                        page.model_id,
+                        page.object_key,
+                        page.component.as_deref().unwrap_or("-")
+                    )
+                })
+            })
+            .collect();
+        rows.sort();
+        rows
+    };
+
+    let before = snapshot(&engine);
+    assert!(
+        before.len() >= 64,
+        "the fixture must leave real pages to reconstruct, found {}",
+        before.len()
+    );
+
+    for command in [
+        Command::SeenCheck {
+            key: "seen".to_string(),
+            member: b"m".to_vec(),
+            window_ms: 60_000,
+        },
+        Command::ControlStateChangeAdd {
+            key: "visitors".to_string(),
+            timestamp_ms: 1_000,
+            value: b"v".to_vec(),
+            precision_ms: None,
+            ttl_ms: None,
+        },
+    ] {
+        let out = engine.execute(ExecuteRequest { shard_id: 1, command });
+        assert!(out.status.ok, "exempted command: {:?}", out.status);
+    }
+
+    let after = snapshot(&engine);
+    assert_eq!(
+        before, after,
+        "an exempted command changed the page index -- the rebuild exemption in \
+         `command_writes_no_page` is no longer safe for it"
     );
 }


### PR DESCRIPTION
Four commands that write **no page at all** rebuilt the entire page index on every call.

| command | before (allocs / pages visited) | after |
|---|---:|---:|
| `SeenCheck`, store 1,024 | 12,646 / 2,048 | **60 / 0** |
| `ControlStateChangeAdd`, store 1,024 | 12,646 / 2,048 | **63 / 0** |

**211× for a membership test.** With this and #716, every command in the probe now visits zero pages.

## Why it happened

```rust
let rebuilt_bucket_index = !maintained_bucket_index
    && !defer_bucket_index_reconstruct()
    && (!command_updates_bucket_index_directly(&command) || bucket_map.is_empty());
```

The condition asks whether a command *updated* the index. It never asks whether the command could have
**changed** it. `SeenCheck`, `ControlStateChangeAdd`, `ControlStateSelectionSet` and `BucketTake`
mutate only state that no page backs — the seen sets, the control-state change and selection maps, the
token buckets — so the answer to the first question is "no" and the rebuild fires, reconstructing an
index that cannot have moved.

Verified rather than assumed: none of the four arms calls `append_value`,
`upsert_bucket_index_page`, `sync_bucket_index_object_pages` or `persist_control_state_page`. Their
durability rides the index-log `key_states` blobs, which the record format documents as carrying
exactly "the non-page maps (TTL, control-state change/selection, context nodes)".

## A separate predicate, on purpose

Adding these to `command_updates_bucket_index_directly` would remove the cost and would be false —
they do not update that index. `command_writes_no_page` states the reason that is actually true, and
keeps the two ideas distinct for the next reader.

## The guard is the point

Skipping a rebuild is safe only *while* these commands write no page. If a later change gives one a
page-writing path, the index would go stale silently — and a stale index shows up after a **reload**,
far from the change that caused it.

So the test asserts the premise, not the outcome. `a_no_page_command_leaves_the_index_matching_a_rebuild`
runs each exempted command against a store holding real page-backed content (strings, hash fields, list
entries) and compares the live page index against a from-scratch rebuild, failing with a message that
names the exemption. "We skipped a rebuild and the suite stayed green" would only show that nothing
looks.

`maintaining_the_index_during_ingest_matches_rebuilding_it` also still passes.

## Probe labels

The breadth probe's rows previously read `(missing)` — true when written, misleading now that those
commands cost 60 allocations. They now name why each row is zero (`files pages` / `maintains` /
`no page`), and the legend states the regression meaning: any row that stops being zero has started
rebuilding the whole index again.

## Verification

* The new guard passes; the ingest-equivalence test passes.
* Every command in the breadth probe: 0 pages visited.
* Full lib suite, serial.
