### PR TITLE
Teach readers the short summary field names

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -431,21 +431,39 @@ pub struct StorageSlabIntegrityReport {
     pub integrity_ok: bool,
 }
 
+/// One summary a bucket, and a dump manifest carries one per bucket.
+///
+/// The short aliases below are the first half of a two-step change, and they do nothing yet: this
+/// still WRITES the long names. A dump manifest is read by other engines during install, so a
+/// writer that emitted short names today would hand a document to a reader that has never heard of
+/// them -- and these fields carry no serde default, so that reader fails rather than degrades.
+///
+/// Teaching every reader the short names first makes the second step safe whenever it is taken.
+/// Measured on a 4,000-bucket manifest: the nine field names are 592,046 bytes of a 1,367,875-byte
+/// document -- 43% of it, once the whitespace came out. Shortening them is worth about a third of
+/// the file, and costs nothing but the wait between the two deploys.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BucketStorageSummary {
-    #[serde(rename = "routing_slot")]
+    #[serde(rename = "routing_slot", alias = "rs")]
     pub routing_bucket: u32,
+    #[serde(alias = "oc")]
     pub object_count: u64,
+    #[serde(alias = "prc")]
     pub page_ref_count: u64,
+    #[serde(alias = "lb")]
     pub logical_bytes: u64,
+    #[serde(alias = "pb")]
     pub physical_bytes: u64,
+    #[serde(alias = "doc")]
     pub dirty_object_count: u64,
+    #[serde(alias = "dg")]
     pub dirty_generation: u64,
+    #[serde(alias = "lds")]
     pub last_dump_sequence: u64,
     #[serde(default)]
-    #[serde(alias = "page_segment_ids")]
+    #[serde(alias = "page_segment_ids", alias = "psi")]
     pub page_slab_ids: Vec<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "lcz")]
     pub last_compacted_zone: Option<u64>,
 }
 

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5867,6 +5867,53 @@ fn one_component_is_held_without_a_vector() {
     assert!(list.is_empty(), "the last removal empties the list");
 }
 
+/// A bucket summary reads the short field names, and still writes the long ones.
+///
+/// This is the first half of a two-step change. A dump manifest crosses engines during install,
+/// and these fields carry no serde default, so a writer that switched to short names before every
+/// reader knew them would hand over a document the reader cannot parse at all. Readers learn
+/// first; writers switch later, if someone decides to.
+///
+/// So the property to pin is exactly this: short names parse, long names parse, and what gets
+/// written is still long.
+#[test]
+fn a_bucket_summary_reads_short_field_names_too() {
+    use crate::engine::reports::BucketStorageSummary;
+
+    let long = r#"{"routing_slot":7,"object_count":1,"page_ref_count":2,"logical_bytes":3,
+        "physical_bytes":4,"dirty_object_count":5,"dirty_generation":6,"last_dump_sequence":8,
+        "page_slab_ids":[9]}"#;
+    let short = r#"{"rs":7,"oc":1,"prc":2,"lb":3,"pb":4,"doc":5,"dg":6,"lds":8,"psi":[9]}"#;
+
+    let from_long: BucketStorageSummary =
+        serde_json::from_str(long).expect("the long names must still parse");
+    let from_short: BucketStorageSummary =
+        serde_json::from_str(short).expect("the short names must parse");
+    assert_eq!(from_long, from_short, "both spellings must mean the same summary");
+    assert_eq!(from_long.routing_bucket, 7);
+    assert_eq!(from_long.page_slab_ids, vec![9]);
+
+    // And writing is unchanged: the long names still go out, so a reader that has NOT learned the
+    // short names is unaffected by this landing.
+    let written = serde_json::to_string(&from_long).expect("serialize");
+    assert!(
+        written.contains("\"object_count\""),
+        "writing must still use the long names until every reader knows the short ones: {written}"
+    );
+    assert!(
+        !written.contains("\"oc\""),
+        "nothing should be writing short names yet: {written}"
+    );
+
+    // What the second step would be worth, on this one summary.
+    println!(
+        "  ALIASES long {} B, short {} B ({:.2}x smaller if writers ever switch)",
+        written.len(),
+        short.len(),
+        written.len() as f64 / short.len() as f64
+    );
+}
+
 /// A dump manifest written in the old array shape still loads.
 ///
 /// `index_bytes` carries the index image and is written encoded now, because the array shape costs


### PR DESCRIPTION
A dump manifest carries one summary a bucket. On a 4,000-bucket manifest the nine field names are
**592,046 bytes of a 1,367,875-byte document -- 43% of it**, once the whitespace came out.
Shortening them is worth about a third of the file.

### Why this cannot be one change

The manifest crosses engines during install, and these fields carry no serde default. A writer that
emitted `"oc"` today would hand a document to a reader that has never heard of it, and that reader
fails outright rather than degrading.

So readers learn first. **This changes no document.** Every manifest written after this looks
exactly like one written before it, so landing it is invisible to anything already running -- which
is the property that makes the second half safe whenever someone decides to take it.

### What the test pins

All three parts, because any one of them silently not holding would make the second step unsafe:

* short names parse
* long names still parse
* what gets WRITTEN is still long

It also prices the second half: 178 bytes a summary against 70, **2.54x**.

### Where the dump stands

| | manifest | amplification @64B |
|---|---|---|
| index image as an array of numbers | 4,302,195 B | 13.06x |
| image encoded | 1,812,019 B | 6.06x |
| written compact | 1,367,875 B | 4.81x |
| short names, if ever taken | ~0.9 MB | ~3.5x |

The write-ahead log and the page store were already at the size they should be -- the log record is
field-for-field the operation-log message, the block geometry is identical, and the page store
spends 74 bytes of header a record and reaches 1.01x at four kilobytes. The dump manifest was the
whole divergence.