### PR TITLE
Bound socket reads by the call deadline, not a two-second constant

### DIFF
--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -3772,15 +3772,39 @@ class MatrixArkRustProxyClient:
         self._record_call_metrics(op, kwargs, response, elapsed_ms, failed=False, lane=group, wait_ms=wait_ms)
         return response
 
+    # Connecting to a live daemon socket returns immediately, so the connect keeps a
+    # short ceiling: a stale socket file should fail fast rather than spend the call's
+    # whole budget. Reads are a different question -- see `_call_socket_json`.
+    SOCKET_CONNECT_TIMEOUT_CEILING_S = 2.0
+
     def _call_socket_json(self, op: str, payload: str) -> Json:
-        deadline = time.monotonic() + max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
+        # The read timeout tracks what is LEFT of the deadline. It used to be a constant
+        # `min(2.0, ...)`, which no `--request-timeout-ms` could raise, so any response
+        # slower than two seconds became a timeout -- and since `_call_json` re-raises
+        # instead of falling back to the lane path, the call simply failed. A ContextPack
+        # over a large store takes longer than that, so hook retrieval failed open with
+        # no context and nothing in the logs but "TimeoutError: timed out".
+        budget_s = max(2.0, self.request_timeout_ms / 1000.0 + 2.0)
+        deadline = time.monotonic() + budget_s
+        connect_timeout_s = min(
+            self.SOCKET_CONNECT_TIMEOUT_CEILING_S,
+            max(0.1, self.request_timeout_ms / 1000.0),
+        )
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-            client.settimeout(min(2.0, max(0.1, self.request_timeout_ms / 1000.0)))
+            client.settimeout(connect_timeout_s)
             client.connect(self._proxy_socket)
             client.sendall(payload.encode("utf-8"))
             stream = client.makefile("rb")
-            while time.monotonic() < deadline:
-                line = stream.readline()
+            while True:
+                remaining_s = deadline - time.monotonic()
+                if remaining_s <= 0:
+                    break
+                # Re-armed per read so a partial answer cannot extend the total budget.
+                client.settimeout(remaining_s)
+                try:
+                    line = stream.readline()
+                except socket.timeout:
+                    break
                 if not line:
                     break
                 if not line.strip().startswith(b"{"):
@@ -3789,7 +3813,10 @@ class MatrixArkRustProxyClient:
                     return json.loads(line.decode("utf-8"))
                 except json.JSONDecodeError as exc:
                     raise MatrixArkError(f"Rust TemporalStore {op} daemon returned invalid JSON: {line[:200]!r}") from exc
-        raise MatrixArkError(f"Rust TemporalStore {op} daemon timed out waiting for response from {self._proxy_socket}")
+        raise MatrixArkError(
+            f"Rust TemporalStore {op} daemon timed out waiting for response from "
+            f"{self._proxy_socket} after {budget_s:.1f}s"
+        )
 
     def _record_call_metrics(
         self,

--- a/tools/matrixark_rust_proxy_daemon.py
+++ b/tools/matrixark_rust_proxy_daemon.py
@@ -296,9 +296,25 @@ class RustProxyDaemon:
         self._log_file.flush()
 
 
+def ping_timeout_seconds() -> float:
+    """How long a health check waits before calling the daemon dead.
+
+    Callers treat a failed ping as "no daemon": they then start one, and a second daemon
+    unlinks the first one's socket on bind, so the loser spawns its own proxy and reloads
+    the store per invocation. A fixed 2 s made that happen on a merely busy box -- a ping
+    measured 2.4 s under load with the daemon perfectly healthy. Bounded, but generous
+    enough that "busy" is not read as "dead".
+    """
+    raw = os.environ.get("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS", "10000")
+    try:
+        return max(0.5, int(str(raw).strip()) / 1000.0)
+    except ValueError:
+        return 10.0
+
+
 def ping(socket_path: Path) -> Json:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-        client.settimeout(2.0)
+        client.settimeout(ping_timeout_seconds())
         client.connect(str(socket_path))
         client.sendall(b'{"op":"__daemon_health"}\n')
         return json.loads(client.makefile("rb").readline().decode("utf-8"))

--- a/tools/test_matrixark_rust_proxy_socket_deadline.py
+++ b/tools/test_matrixark_rust_proxy_socket_deadline.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The warm-proxy socket read is bounded by the call's deadline, not by a constant.
+
+`_call_socket_json` once armed the socket with `min(2.0, request_timeout_ms / 1000)`
+and never re-armed it, so a response slower than two seconds raised `TimeoutError` no
+matter what `--request-timeout-ms` said. `_call_json` re-raises rather than falling back
+to the process-lane path, so the call failed outright -- and a ContextPack over a large
+store is always slower than two seconds, which is how hook retrieval came to fail open
+with no context and nothing in the logs but "TimeoutError: timed out".
+
+These tests drive a real Unix socket that answers late, so they exercise the timeout the
+socket is actually armed with rather than asserting on the source text.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import matrixark_mcp_temporal_adapters as adapters  # noqa: E402
+import matrixark_rust_proxy_daemon as proxy_daemon  # noqa: E402
+
+
+class RustProxySocketDeadlineTest(unittest.TestCase):
+    def _serve_late(self, socket_path: str, delay_s: float, response: str) -> None:
+        """Accept one connection, wait, then answer -- a slow but healthy daemon."""
+        ready = threading.Event()
+
+        def run() -> None:
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(socket_path)
+            server.listen(1)
+            server.settimeout(60.0)
+            ready.set()
+            try:
+                conn, _ = server.accept()
+            except OSError:
+                server.close()
+                return
+            with conn:
+                try:
+                    conn.recv(65536)
+                    time.sleep(delay_s)
+                    conn.sendall(response.encode("utf-8"))
+                except OSError:
+                    pass
+            server.close()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        self.assertTrue(ready.wait(10.0), "socket server did not come up")
+        self.addCleanup(thread.join, 5.0)
+
+    def _client(self, socket_path: str, request_timeout_ms: int) -> adapters.MatrixArkRustProxyClient:
+        previous = os.environ.get("MATRIXARK_RUST_PROXY_SOCKET")
+        os.environ["MATRIXARK_RUST_PROXY_SOCKET"] = socket_path
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_RUST_PROXY_SOCKET", None)
+            else:
+                os.environ["MATRIXARK_RUST_PROXY_SOCKET"] = previous
+
+        self.addCleanup(restore)
+        client = adapters.MatrixArkRustProxyClient(
+            proxy_path="matrixark_rust_proxy",
+            metaserver="local",
+            namespace="ns",
+            table="table",
+            request_timeout_ms=request_timeout_ms,
+            io_timeout_ms=request_timeout_ms,
+        )
+        self.assertEqual(client._proxy_socket, socket_path)
+        return client
+
+    def test_read_waits_past_two_seconds_when_the_request_timeout_allows_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = os.path.join(tmp, "slow.sock")
+            self._serve_late(socket_path, delay_s=3.0, response='{"ok": true, "value": "slow-answer"}\n')
+            client = self._client(socket_path, request_timeout_ms=20000)
+
+            started = time.monotonic()
+            response = client._call_json("get_string", key="k")
+            elapsed_s = time.monotonic() - started
+
+        self.assertEqual(response.get("value"), "slow-answer")
+        # The answer only exists after the old fixed cap would have fired: without the
+        # wait, this is the assertion that fails, and it cannot pass vacuously.
+        self.assertGreaterEqual(elapsed_s, 3.0)
+
+    def test_read_still_gives_up_at_the_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = os.path.join(tmp, "hung.sock")
+            self._serve_late(socket_path, delay_s=30.0, response='{"ok": true}\n')
+            client = self._client(socket_path, request_timeout_ms=100)
+
+            started = time.monotonic()
+            with self.assertRaises(adapters.MatrixArkError) as caught:
+                client._call_json("get_string", key="k")
+            elapsed_s = time.monotonic() - started
+
+        self.assertIn("timed out", str(caught.exception))
+        self.assertIn("get_string", str(caught.exception))
+        # Bounded above by the budget -- max(2s, timeout + 2s) -- and below by it too,
+        # so a connect that failed outright cannot pass as a well-behaved deadline.
+        self.assertGreaterEqual(elapsed_s, 1.5)
+        self.assertLess(elapsed_s, 15.0)
+
+    def test_connect_keeps_its_short_ceiling(self) -> None:
+        """A large request timeout must not make a stale socket file hang the call."""
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = os.path.join(tmp, "absent.sock")
+            client = self._client(socket_path, request_timeout_ms=600000)
+
+            started = time.monotonic()
+            with self.assertRaises(OSError):
+                client._call_json("get_string", key="k")
+            elapsed_s = time.monotonic() - started
+
+        self.assertLess(elapsed_s, 5.0)
+
+
+class DaemonPingTimeoutTest(unittest.TestCase):
+    """A busy daemon must not be mistaken for a dead one.
+
+    Callers treat a failed ping as "no daemon" and start their own, and a second daemon
+    unlinks the first one's socket on bind -- so a ping that gives up too early costs a
+    cold-spawned proxy per hook invocation, not just a retry.
+    """
+
+    def _serve_health_late(self, socket_path: str, delay_s: float) -> None:
+        ready = threading.Event()
+
+        def run() -> None:
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(socket_path)
+            server.listen(1)
+            server.settimeout(60.0)
+            ready.set()
+            try:
+                conn, _ = server.accept()
+            except OSError:
+                server.close()
+                return
+            with conn:
+                try:
+                    conn.recv(65536)
+                    time.sleep(delay_s)
+                    conn.sendall(b'{"ok":true,"mode":"rust_proxy_daemon"}\n')
+                except OSError:
+                    pass
+            server.close()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        self.assertTrue(ready.wait(10.0), "socket server did not come up")
+        self.addCleanup(thread.join, 5.0)
+
+    def test_ping_waits_for_a_busy_daemon(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = os.path.join(tmp, "busy.sock")
+            self._serve_health_late(socket_path, delay_s=3.0)
+
+            started = time.monotonic()
+            answer = proxy_daemon.ping(Path(socket_path))
+            elapsed_s = time.monotonic() - started
+
+        self.assertTrue(answer.get("ok"))
+        self.assertGreaterEqual(elapsed_s, 3.0)
+
+    def test_ping_timeout_is_configurable_and_bounded(self) -> None:
+        previous = os.environ.get("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS")
+        self.addCleanup(
+            lambda: os.environ.__setitem__("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS", previous)
+            if previous is not None
+            else os.environ.pop("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS", None)
+        )
+
+        os.environ.pop("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS", None)
+        self.assertGreaterEqual(proxy_daemon.ping_timeout_seconds(), 5.0)
+
+        os.environ["MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS"] = "25000"
+        self.assertEqual(proxy_daemon.ping_timeout_seconds(), 25.0)
+
+        os.environ["MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS"] = "not-a-number"
+        self.assertGreaterEqual(proxy_daemon.ping_timeout_seconds(), 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_call_socket_json` armed the warm-proxy socket with `min(2.0, request_timeout_ms / 1000)` and
never re-armed it, so any answer slower than two seconds raised `TimeoutError` no matter what
`--request-timeout-ms` asked for. `_call_json` re-raises rather than falling back to the
process-lane path, so the call failed outright.

For an agent hook that is not a corner case. A ContextPack assembled over a large store takes
longer than two seconds, so retrieval failed on every turn, fail-open swallowed it, and the only
trace was `TimeoutError: timed out`. Measured on a live box: plain socket reads answered in 24 ms
while every pack died at the ceiling.

## What changed

- The read timeout is re-armed before each read from what is **left** of the deadline the method
  already computed, so `--request-timeout-ms` means what it says.
- The connect keeps a short ceiling (`SOCKET_CONNECT_TIMEOUT_CEILING_S`), so a stale socket file
  still fails fast instead of spending the whole budget.
- A bounded wait now raises `MatrixArkError ... after Ns` naming the socket and the budget,
  instead of a bare `TimeoutError`.
- `matrixark_rust_proxy_daemon.ping()` carried the same two-second constant. A health check that
  reads a busy daemon as a dead one makes every caller start its own, and a second daemon unlinks
  the first one's socket on bind, so the loser spawns its own proxy and reloads the store per
  call. It is now `MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS`, default 10 s, floored at 0.5 s. A ping
  measured 2.4 s on a busy box with the daemon perfectly healthy.

## Tests

`tools/test_matrixark_rust_proxy_socket_deadline.py` drives real Unix sockets that answer late, so
it exercises the timeout the socket is actually armed with rather than asserting on source text:

- a 3 s answer succeeds when the request timeout allows it, and the test asserts it waited at
  least 3 s, so it cannot pass vacuously;
- a server that never answers still fails at the budget, with the elapsed time bounded on both
  sides, so a connect that failed outright cannot pass as a well-behaved deadline;
- connect keeps its ceiling under a 600 s request timeout;
- the ping waits for a busy daemon, and its timeout is configurable and bounded.

4 of the 5 fail against this branch's base; all 5 pass with the change.
