### PR TITLE
Tests that looked for a posting where the record already answers

### DIFF
--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -1642,16 +1642,21 @@ class _CodexPipelinePart4:
                 ),
                 records,
             )
+            # Postings are folded onto the batch commit that wrote them, so filtering for
+            # data_model "context_profile_entity" now matches nothing; the entity's own postings
+            # are still there under the commit. What the entity carries itself -- its roles and
+            # its codex events -- is asserted directly above, and #562 stopped writing a posting
+            # whose term the record already carries, so `source_role:` and `codex_event:` names
+            # are gone rather than merely relabelled.
             index_names = {
                 str(record.get("index_name") or "")
                 for record in records
                 if record.get("record_type") == "context_index"
-                and record.get("data_model") == "context_profile_entity"
             }
             self.assertIn("entity_type:assistant_decision", index_names)
-            self.assertIn("source_role:assistant", index_names)
-            self.assertIn("codex_event:previousassistantbackfill", index_names)
-            self.assertIn("codex_event:userpromptsubmit:previous_assistant_backfill", index_names)
+            self.assertNotIn("source_role:assistant", index_names)
+            self.assertNotIn("codex_event:previousassistantbackfill", index_names)
+            self.assertNotIn("codex_event:userpromptsubmit:previous_assistant_backfill", index_names)
 
             pack = adapter.retrieve(
                 {
@@ -2034,15 +2039,18 @@ class _CodexPipelinePart4:
                 ),
                 records,
             )
+            # Same shape as the idle-preflush test above: postings are folded onto the batch
+            # commit that wrote them, so the "context_profile_entity" data_model matches
+            # nothing, and #562 stopped writing a posting whose term the record already
+            # carries -- which is what `source_role:` and `codex_event:` were.
             index_names = {
                 str(record.get("index_name") or "")
                 for record in records
                 if record.get("record_type") == "context_index"
-                and record.get("data_model") == "context_profile_entity"
             }
             self.assertIn("entity_type:tool_evidence", index_names)
-            self.assertIn("source_role:tool", index_names)
-            self.assertIn("codex_event:previoustooloutputbackfill", index_names)
+            self.assertNotIn("source_role:tool", index_names)
+            self.assertNotIn("codex_event:previoustooloutputbackfill", index_names)
 
             pack = adapter.retrieve(
                 {
@@ -2903,6 +2911,12 @@ class _CodexPipelinePart4:
                 prefiltered["records"],
             )
 
+    # The inventory below counts context_segment rows, and segments are OFF by default
+    # (tenant knob extract_segments / MATRIXARK_EXTRACT_SEGMENTS, default False), so without
+    # this the count is 0. Patched per test rather than at module scope, for the same reason
+    # the sibling tests give: the suite is one process, and setting it wider would flip the
+    # knob for the tests that assert it is off.
+    @mock.patch.dict(os.environ, {"MATRIXARK_EXTRACT_SEGMENTS": "1"})
     def test_retrieve_serving_pack_hides_inventory_until_metrics_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -1920,9 +1920,23 @@ class _CodexPipelinePart5:
                 if record.get("record_type") == "context_index"
                 and record.get("data_model") == "context_profile_entity"
             }
-            self.assertIn("source_role:assistant", index_names)
+            # The llm/model -> assistant normalisation is proven above, on the records: the
+            # events carry source_role "assistant" with original_source_role in {llm, model},
+            # and the profile decision carries source_roles ["assistant", "user"]. This block
+            # re-checked the same thing through a posting, and #562 stopped writing a posting
+            # whose term the record it points at already carries -- `source_role` is exactly
+            # such a field, so all three of these names are gone rather than just the aliases.
+            self.assertNotIn("source_role:assistant", index_names)
             self.assertNotIn("source_role:llm", index_names)
             self.assertNotIn("source_role:model", index_names)
+            # ...and the entity really was indexed, so the three checks above cannot pass just
+            # because nothing was written at all.
+            indexed = {
+                record.get("index_name")
+                for record in records
+                if record.get("record_type") == "context_index"
+            }
+            self.assertIn("entity_type:assistant_decision", indexed)
 
             pack = adapter.retrieve(
                 {


### PR DESCRIPTION
Four assertions in the codex pipeline tests went looking for index postings that are no
longer written, or are written somewhere else. Measured at the point of failure rather
than inferred -- printing what IS indexed, in the test that fails:

    context_index total=7
    data_models = {'context_batch_commit': 7}
    names = ['classification:batch_memory', 'entity_type:assistant_decision',
             'entity_type:memory_feature_profile', 'event_type:dialogue_batch',
             'segment_topic:task_decision', 'source_type:message', 'status:observed']

Two separate things had happened, and they need different answers:

  * `entity_type:*` postings are still written, but folded onto the batch commit, so a
    filter on `data_model == "context_profile_entity"` matches nothing;
  * `source_role:*` and `codex_event:*` postings are gone, which is what "Drop
    owner-derivable postings once, for every writer" (#562) set out to do -- the term
    restated a field the record already carries.

So the filters drop the data_model clause and the derivable names are asserted ABSENT.
Each of those tests already proves the same content on the records themselves -- the
alias test asserts source_roles and source_role_counts and original_source_role on the
entities, which is where llm/model -> assistant is actually established -- so nothing
is left unverified by this. Each keeps one posting asserted PRESENT, so the checks
cannot pass on a run where indexing wrote nothing at all.

Separately, `test_retrieve_serving_pack_hides_inventory_until_metrics_requested` counts
context_segment rows while segments are off by default (tenant knob extract_segments,
MATRIXARK_EXTRACT_SEGMENTS, default False). It now asks for them the way its five
sibling tests do, per test rather than at module scope -- the suite is one process and a
wider setting would flip the knob under the tests that assert it is off.

Under `unittest discover` from tools/, which is how the ratchet runs it:

    before   101 failures + 23 errors
    after     99 failures + 23 errors

TWO of these are not finished, and are left failing on purpose rather than quietened:

  * `test_retrieve_serving_pack...` now gets past the segment count and stops on
    `inventory["profile"]["context_indexes"] >= 1`, which is 0 because those postings are
    attributed to the batch commit. Whether the profile layer should report indexes that
    are folded elsewhere is a question about the inventory, not about the test.
  * `test_batch_extract_assigns_role_specific_event_types` asks the secondary-index
    prefilter for `event_type:tool_evidence` and reads 0 postings. Pointing the same
    prefilter at a posting that still exists makes it pass, so the mechanism works and it
    is the dropped postings that break it: a prefilter needs the posting precisely to
    avoid reading the record the term would be derived from.

