### PR TITLE
Show what each documented route is actually serving

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -63,6 +63,10 @@ _EXACT_ROUTES = frozenset({
     "/v1/admin/events",
     "/v1/admin/config/export",
     "/v1/admin/api", "/v1/admin/routes",
+    # Documented and served, and until now unmeasured: both fell through to "other", so the
+    # traffic a customer generates composing a deployment was indistinguishable from every
+    # other unmatched path.
+    "/v1/admin/deployment", "/v1/admin/deployment/plan",
     "/v1/admin/api_key_usage", "/v1/admin/ingestion/jobs",
 })
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2138,6 +2138,35 @@ def monitoring_catalogue(datanode_url: str = "") -> Json:
     }
 
 
+def documented_routes() -> list:
+    """The route catalogue, each entry saying which edge counter it is counted under.
+
+    Served rather than derived in the page. The label comes from `route_label`, which collapses a
+    path to a bounded template; re-implementing that rule in JavaScript would put a second copy of
+    it in the tree, and the failure when the two drift is silent -- a number rendered against the
+    wrong route reads exactly like a number rendered against the right one.
+
+    `metric_shared_with` names the other documented paths counted under the same label. Eight
+    labels cover more than one: a row that showed the shared figure as its own would overstate
+    itself by however much the neighbour is used.
+    """
+    labels: dict = {}
+    for entry in ROUTE_DOCS:
+        path = str(entry.get("path", ""))
+        labels.setdefault(_gwmetrics.route_label(path), set()).add(path)
+
+    out = []
+    for entry in ROUTE_DOCS:
+        path = str(entry.get("path", ""))
+        label = _gwmetrics.route_label(path)
+        shared = sorted(labels.get(label, set()) - {path})
+        row = dict(entry)
+        row["metric"] = label
+        if shared:
+            row["metric_shared_with"] = shared
+        out.append(row)
+    return out
+
 def _grafana_asset(name: str) -> Tuple[Optional[bytes], str]:
     """One monitoring asset, or (None, "") when this deployment does not bundle it."""
     entry = _GRAFANA_ASSETS.get(name)
@@ -3487,7 +3516,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         # Served rather than written down separately so what a customer reads is what this process
         # serves. No credentials: this is documentation, and every route it names enforces its own.
         if method == "GET" and path == "/v1/admin/routes":
-            return await _json(send, 200, {"status": "ok", "routes": ROUTE_DOCS})
+            return await _json(send, 200, {"status": "ok", "routes": documented_routes()})
         if method == "GET" and path == "/v1/admin/setup":
             return await _html(send, 200, _setup_portal_html_bytes())
         if method == "GET" and path == "/v1/admin/catalog":

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -837,6 +837,16 @@
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -384,6 +384,9 @@
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -472,12 +475,56 @@
            route.summary).toLowerCase()) + '">' +
       '<div class="route-head"><span class="verb ' + esc(route.method) + '">' +
       esc(route.method) + '</span><span class="route-path">' + esc(route.path) + "</span>" +
+      '<span class="route-live" data-metric="' + esc(route.metric || "") + '"' +
+      (route.metric_shared_with
+        ? ' title="Counted together with ' + esc(route.metric_shared_with.join(", ")) + '"'
+        : "") + "></span>" +
       '<span class="route-scope">' + esc(route.scope || "no auth") + "</span></div>" +
       "<p>" + esc(route.summary) +
       (route.needs ? " Needs " + esc(route.needs) + " configured." : "") + "</p>" +
       '<button type="button" class="link curl" data-curl="' + index + '">show curl</button>' +
       "<pre>" + esc(curlFor(route)) + "</pre></div>";
   }
+
+  /* The last traffic seen, so a re-render (filtering, mostly) can repaint rather than blank the
+     counters until the next frame two seconds later. */
+  var lastTraffic = null;
+
+  /* This page defines esc() and not n(). Reaching for the strip's helper compiled fine, threw a
+     ReferenceError on the first frame, and the strip catches each watcher's error so that one
+     panel cannot break the rest -- so it failed in total silence. */
+  function num(value) {
+    return Number(value || 0).toLocaleString();
+  }
+
+  function paintTraffic(traffic) {
+    lastTraffic = traffic || lastTraffic;
+    var routes = (lastTraffic || {}).routes || {};
+    Array.prototype.forEach.call(document.querySelectorAll(".route-live"), function (cell) {
+      var label = cell.getAttribute("data-metric");
+      if (!label) { cell.textContent = ""; return; }
+      var seen = routes[label];
+      if (!seen) {
+        /* The frame arrived and this route is not in it, which means nothing has been recorded
+           against it -- that is a fact, not a gap. Before any frame arrives this function has not
+           run at all, so the cell stays empty rather than claiming a zero nobody reported. */
+        cell.className = "route-live quiet";
+        cell.textContent = "no requests yet";
+        return;
+      }
+      var bits = [num(seen.requests) + (Number(seen.requests) === 1 ? " request" : " requests")];
+      if (seen.errors) {
+        bits.push(num(seen.errors) + (Number(seen.errors) === 1 ? " error" : " errors"));
+      }
+      if (seen.avg_ms) { bits.push(seen.avg_ms + " ms avg"); }
+      cell.className = "route-live" + (seen.errors ? " bad" : "");
+      cell.textContent = bits.join(" \u00b7 ");
+    });
+  }
+
+  /* Through the queue: this script runs before the nav block defines the register function. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) { paintTraffic((frame || {}).traffic); });
 
   function render() {
     var query = $("filter").value.trim().toLowerCase();
@@ -499,6 +546,11 @@
     $("routes").innerHTML = html ||
       '<section><div class="empty">Nothing matches that.</div></section>';
   }
+
+  /* A re-render replaces every cell, so the counters have to go back on. Without this, filtering
+     blanks them until the next frame. */
+  var renderRoutes = render;
+  render = function () { renderRoutes(); if (lastTraffic) { paintTraffic(null); } };
 
   $("routes").addEventListener("click", function (ev) {
     var button = ev.target.closest ? ev.target.closest("[data-curl]") : null;
@@ -543,6 +595,16 @@
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/api_traffic_harness.js
+++ b/tools/portal/api_traffic_harness.js
@@ -1,0 +1,153 @@
+/* Run the API page and check each route row reports what that route has served.
+ *
+ * The page builds its rows as an HTML string, so a stub whose querySelectorAll returns nothing
+ * would let every assertion pass without a single cell being painted. The routes container parses
+ * what the page assigns to it and hands back real cells, which is the only way the painting is
+ * actually exercised.
+ *
+ * Usage: node api_traffic_harness.js <api_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* Two documented routes sharing one counter, and one with a counter of its own. */
+const ROUTES = [
+  { group: "Memory", method: "GET", path: "/v1/memories", summary: "List memories.",
+    scope: "read", metric: "/v1/memories" },
+  { group: "Memory", method: "GET", path: "/v1/memory/{id}", summary: "One memory.",
+    scope: "read", metric: "/v1/memory/{id}",
+    metric_shared_with: ["/v1/memory/{id}/history"] },
+  { group: "Memory", method: "GET", path: "/v1/memory/{id}/history", summary: "Its history.",
+    scope: "read", metric: "/v1/memory/{id}",
+    metric_shared_with: ["/v1/memory/{id}"] },
+  { group: "Admin", method: "GET", path: "/v1/admin/scopes", summary: "Scopes.",
+    scope: "admin", metric: "/v1/admin/scopes" },
+];
+
+const FRAME = {
+  ts: 1, imports: {}, warnings: 0, embedding: { total: 1 },
+  traffic: {
+    total_requests: 9, total_errors: 2, in_flight: 0,
+    routes: {
+      "/v1/memories": { requests: 7, errors: 0, avg_ms: 4.5 },
+      "/v1/memory/{id}": { requests: 2, errors: 2, avg_ms: 11 }
+    }
+  }
+};
+
+let cells = [];
+function parseCells(html) {
+  cells = [...String(html || "").matchAll(/<span class="route-live" data-metric="([^"]*)"([^>]*)>/g)]
+    .map((m) => ({
+      metric: m[1], attrs: m[2], textContent: "", className: "route-live",
+      getAttribute(k) { return k === "data-metric" ? this.metric : null; }
+    }));
+}
+
+function makeEl(id) {
+  const el = {
+    id: id || "", hidden: false, textContent: "", value: "", checked: false, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = v; if (this.id === "routes") { parseCells(v); } },
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+  return el;
+}
+
+const els = new Map();
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(),
+    querySelectorAll: (sel) => (sel === ".route-live" ? cells : []),
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: { clipboard: { writeText() {} } },
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    if (String(url).indexOf("/v1/admin/routes") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve({ status: "ok", routes: ROUTES }) });
+    }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  ok("the page rendered its routes", cells.length === ROUTES.length,
+     "parsed " + cells.length + " live cells from " + ROUTES.length + " routes");
+
+  const before = cells.map((c) => c.textContent).join("");
+  ok("nothing is claimed before a frame arrives", before === "",
+     "a cell said " + JSON.stringify(before) + " before anything reported traffic");
+
+  /* Deliver a frame the way the strip does. */
+  (win.__matrixarkFrameQueue || []).push;
+  if (typeof win.__matrixarkLiveFrame === "function") { win.__matrixarkLiveFrame(FRAME); }
+
+  const byMetric = {};
+  cells.forEach((c) => { (byMetric[c.metric] = byMetric[c.metric] || []).push(c); });
+
+  const busy = (byMetric["/v1/memories"] || [])[0];
+  ok("a route that has served requests says so", busy && /7 requests/.test(busy.textContent),
+     busy ? busy.textContent : "no cell for /v1/memories");
+  ok("its average latency is shown", busy && /4\.5 ms avg/.test(busy.textContent),
+     busy ? busy.textContent : "");
+  ok("a route with no errors is not marked bad", busy && busy.className.indexOf("bad") < 0,
+     busy ? busy.className : "");
+
+  const failing = (byMetric["/v1/memory/{id}"] || [])[0];
+  ok("errors are reported", failing && /2 errors/.test(failing.textContent),
+     failing ? failing.textContent : "");
+  ok("a route with errors is marked", failing && failing.className.indexOf("bad") >= 0,
+     failing ? failing.className : "");
+
+  const quiet = (byMetric["/v1/admin/scopes"] || [])[0];
+  ok("a route absent from the frame reports no requests rather than staying blank",
+     quiet && /no requests yet/.test(quiet.textContent), quiet ? quiet.textContent : "");
+
+  const shared = cells.filter((c) => /title="Counted together with/.test(c.attrs));
+  ok("rows that share a counter say whose number they are showing", shared.length === 2,
+     shared.length + " of the two shared rows carry the note");
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}, 30);

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -264,6 +264,9 @@ EXTRA_CSS = """
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -297,6 +300,16 @@ NAV_JS = r'''<script>
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();
@@ -2582,8 +2595,10 @@ CATALOG_JS = r"""
     return originalLoad(keepMessage);
   };
 
-  if (window.__matrixarkOnFrame) {
-    window.__matrixarkOnFrame(function (frame) {
+  /* Through the queue. This script runs before the nav block defines the register function,
+     so calling it directly registered nothing at all -- the watcher below never ran. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) {
       var total = (frame.embedding || {}).total;
       if (total == null) { return; }
       if (lastStoredTotal === null) { lastStoredTotal = total; return; }
@@ -2601,7 +2616,6 @@ CATALOG_JS = r"""
         ? "The store changed — this list has been refreshed."
         : "Items were removed from the store — this list has been refreshed.", "info");
     });
-  }
 
   $("filter").addEventListener("input", function () { load(); });
   $("rtype").addEventListener("change", function () { load(); });
@@ -4165,8 +4179,10 @@ EXPLORE_JS = r"""
       .catch(function () { watchedJob = null; });
   }
 
-  if (window.__matrixarkOnFrame) {
-    window.__matrixarkOnFrame(function (frame) {
+  /* Through the queue. This script runs before the nav block defines the register function,
+     so calling it directly registered nothing at all -- the watcher below never ran. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) {
       if (!watchedJob) { return; }
       var active = ((frame.imports || {}).active || []).filter(function (j) {
         return j.job_id === watchedJob.id;
@@ -4176,7 +4192,6 @@ EXPLORE_JS = r"""
          Only conclude it ended once it has actually been seen running. */
       if (watchedJob.seen) { finishBatchJob(); }
     });
-  }
 
   $("batchPreview").addEventListener("click", function () { submitBatch(true); });
   $("batchRun").addEventListener("click", function () { submitBatch(false); });
@@ -4459,12 +4474,56 @@ API_JS = r"""
            route.summary).toLowerCase()) + '">' +
       '<div class="route-head"><span class="verb ' + esc(route.method) + '">' +
       esc(route.method) + '</span><span class="route-path">' + esc(route.path) + "</span>" +
+      '<span class="route-live" data-metric="' + esc(route.metric || "") + '"' +
+      (route.metric_shared_with
+        ? ' title="Counted together with ' + esc(route.metric_shared_with.join(", ")) + '"'
+        : "") + "></span>" +
       '<span class="route-scope">' + esc(route.scope || "no auth") + "</span></div>" +
       "<p>" + esc(route.summary) +
       (route.needs ? " Needs " + esc(route.needs) + " configured." : "") + "</p>" +
       '<button type="button" class="link curl" data-curl="' + index + '">show curl</button>' +
       "<pre>" + esc(curlFor(route)) + "</pre></div>";
   }
+
+  /* The last traffic seen, so a re-render (filtering, mostly) can repaint rather than blank the
+     counters until the next frame two seconds later. */
+  var lastTraffic = null;
+
+  /* This page defines esc() and not n(). Reaching for the strip's helper compiled fine, threw a
+     ReferenceError on the first frame, and the strip catches each watcher's error so that one
+     panel cannot break the rest -- so it failed in total silence. */
+  function num(value) {
+    return Number(value || 0).toLocaleString();
+  }
+
+  function paintTraffic(traffic) {
+    lastTraffic = traffic || lastTraffic;
+    var routes = (lastTraffic || {}).routes || {};
+    Array.prototype.forEach.call(document.querySelectorAll(".route-live"), function (cell) {
+      var label = cell.getAttribute("data-metric");
+      if (!label) { cell.textContent = ""; return; }
+      var seen = routes[label];
+      if (!seen) {
+        /* The frame arrived and this route is not in it, which means nothing has been recorded
+           against it -- that is a fact, not a gap. Before any frame arrives this function has not
+           run at all, so the cell stays empty rather than claiming a zero nobody reported. */
+        cell.className = "route-live quiet";
+        cell.textContent = "no requests yet";
+        return;
+      }
+      var bits = [num(seen.requests) + (Number(seen.requests) === 1 ? " request" : " requests")];
+      if (seen.errors) {
+        bits.push(num(seen.errors) + (Number(seen.errors) === 1 ? " error" : " errors"));
+      }
+      if (seen.avg_ms) { bits.push(seen.avg_ms + " ms avg"); }
+      cell.className = "route-live" + (seen.errors ? " bad" : "");
+      cell.textContent = bits.join(" \u00b7 ");
+    });
+  }
+
+  /* Through the queue: this script runs before the nav block defines the register function. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) { paintTraffic((frame || {}).traffic); });
 
   function render() {
     var query = $("filter").value.trim().toLowerCase();
@@ -4486,6 +4545,11 @@ API_JS = r"""
     $("routes").innerHTML = html ||
       '<section><div class="empty">Nothing matches that.</div></section>';
   }
+
+  /* A re-render replaces every cell, so the counters have to go back on. Without this, filtering
+     blanks them until the next frame. */
+  var renderRoutes = render;
+  render = function () { renderRoutes(); if (lastTraffic) { paintTraffic(null); } };
 
   $("routes").addEventListener("click", function (ev) {
     var button = ev.target.closest ? ev.target.closest("[data-curl]") : null;

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -384,6 +384,9 @@
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -693,8 +696,10 @@
     return originalLoad(keepMessage);
   };
 
-  if (window.__matrixarkOnFrame) {
-    window.__matrixarkOnFrame(function (frame) {
+  /* Through the queue. This script runs before the nav block defines the register function,
+     so calling it directly registered nothing at all -- the watcher below never ran. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) {
       var total = (frame.embedding || {}).total;
       if (total == null) { return; }
       if (lastStoredTotal === null) { lastStoredTotal = total; return; }
@@ -712,7 +717,6 @@
         ? "The store changed — this list has been refreshed."
         : "Items were removed from the store — this list has been refreshed.", "info");
     });
-  }
 
   $("filter").addEventListener("input", function () { load(); });
   $("rtype").addEventListener("change", function () { load(); });
@@ -758,6 +762,16 @@
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -384,6 +384,9 @@
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -1570,8 +1573,10 @@
       .catch(function () { watchedJob = null; });
   }
 
-  if (window.__matrixarkOnFrame) {
-    window.__matrixarkOnFrame(function (frame) {
+  /* Through the queue. This script runs before the nav block defines the register function,
+     so calling it directly registered nothing at all -- the watcher below never ran. */
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) {
       if (!watchedJob) { return; }
       var active = ((frame.imports || {}).active || []).filter(function (j) {
         return j.job_id === watchedJob.id;
@@ -1581,7 +1586,6 @@
          Only conclude it ended once it has actually been seen running. */
       if (watchedJob.seen) { finishBatchJob(); }
     });
-  }
 
   $("batchPreview").addEventListener("click", function () { submitBatch(true); });
   $("batchRun").addEventListener("click", function () { submitBatch(false); });
@@ -1820,6 +1824,16 @@
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/frame_registration_harness.js
+++ b/tools/portal/frame_registration_harness.js
@@ -1,0 +1,190 @@
+/* Do the pages that ask for live frames actually get them?
+ *
+ * `window.__matrixarkOnFrame` is defined by the shared nav script, which `emit` places AFTER the
+ * page's own script -- deliberately, because the nav block checks whether the page has already
+ * claimed the stream, and running first would give some pages two.
+ *
+ * That ordering means a page registering at the top level of its own script calls a function that
+ * does not exist yet. Guarded with `if (window.__matrixarkOnFrame)`, the guard is false and the
+ * watcher is never registered: the feature is gone, in source, silently.
+ *
+ * page_watchers_harness cannot see this -- its stub defines __matrixarkOnFrame up front, so every
+ * page looks like it registers. This runs the scripts in document order against a window that
+ * starts without it, as a browser does, and asks of each script that tries to register: was the
+ * function there when you called it?
+ *
+ * Usage: node frame_registration_harness.js <page.html> [...]
+ */
+"use strict";
+const fs = require("fs");
+
+function makeEl(id) {
+  return {
+    hidden: true, innerHTML: "", textContent: "",
+    /* The nav stream is inert without a key, like every page. A harness that left this empty would
+       see no frames and blame the wiring. */
+    value: id === "key" ? "k-admin" : "",
+    checked: false, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+
+const REGISTERS = /window\.__matrixarkOnFrame\s*\(/;
+const QUEUES = /__matrixarkFrameQueue/;
+
+function inspect(path) {
+  const page = fs.readFileSync(path, "utf8");
+  const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+  /* Deliberately absent. Whether the page finds it is the whole question. */
+  const win = {
+    document: {
+      getElementById: (id) => makeEl(id), querySelector: () => makeEl(), querySelectorAll: () => [],
+      createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+    },
+    addEventListener() {},
+    location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+    sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+    localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+    navigator: {},
+    setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+    Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+    encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+    TextDecoder: function () { this.decode = () => ""; },
+    AbortController: function () { this.abort = () => {}; this.signal = {}; },
+    FileReader: function () {}, Blob: function () {},
+    URL: { createObjectURL: () => "", revokeObjectURL() {} },
+    fetch: () => new Promise(() => {})
+  };
+  win.window = win;
+
+  /* A stream that answers, so the nav block reaches its watchers. Registering is not the same as
+     receiving, and the difference is the whole point of the fix. */
+  const FRAME = 'event: status' + String.fromCharCode(10) + 'data: {"ts":1,"traffic":{"routes":{}},' +
+                '"imports":{},"warnings":0,"embedding":{"total":7}}' +
+                String.fromCharCode(10) + String.fromCharCode(10);
+  let sent = false;
+  win.fetch = (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/events") < 0) {
+      /* Answer, rather than hang. Setup and Overview run their own stream and only start it after
+         a config load succeeds -- against a fetch that never resolves they never open one, and the
+         harness would report a wiring failure that belongs to the harness. */
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve({ settings: {} }),
+                               text: () => Promise.resolve("{}") });
+    }
+    return Promise.resolve({
+      ok: true, status: 200,
+      body: { getReader: () => ({ read: () => {
+        if (sent) { return new Promise(() => {}); }
+        sent = true;
+        /* Delivered on a real timer, not immediately. Resolved promises run on the microtask queue
+           and would deliver the only frame before the probe watcher below has registered -- the
+           harness would then report a wiring failure that is its own. */
+        return new Promise((res) => setTimeout(
+          () => res({ done: false, value: Buffer.from(FRAME, "utf8") }), 5));
+      } }) }
+    });
+  };
+  win.TextDecoder = function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); };
+
+  /* Seeded the way a page seeds it: pushed BEFORE any script runs. A watcher already waiting is
+     the case the drain exists for, and without seeding it the harness only ever proves that
+     registering AFTER the nav script works -- which is a different claim, and one that passes even
+     with the drain deleted. */
+  const early = { got: 0 };
+  win.__matrixarkFrameQueue = [];
+  win.__matrixarkFrameQueue.push(function () { early.got += 1; });
+
+  const names = Object.keys(win);
+  const values = names.map((k) => win[k]);
+
+  const attempts = [];
+  scripts.forEach((body, index) => {
+    const wantsToRegister = REGISTERS.test(body);
+    const queues = QUEUES.test(body);
+    const availableBefore = typeof win.__matrixarkOnFrame === "function";
+    try {
+      new Function(...names, body)(...values);
+    } catch (e) { /* a page that throws at load is another harness's business */ }
+    if (wantsToRegister || queues) {
+      attempts.push({ index, availableBefore, queues });
+    }
+  });
+  return { path, attempts, win, early,
+           defines: typeof win.__matrixarkOnFrame === "function" };
+}
+
+/* Register one more watcher the way a page does, then let the stream deliver. If it arrives, the
+   queue drained, the nav kept accepting after the drain, and frames reach watchers. */
+function deliversFrames(win) {
+  return new Promise((resolve) => {
+    let got = false;
+    const queue = win.__matrixarkFrameQueue;
+    if (!queue || typeof queue.push !== "function") { resolve(null); return; }
+    queue.push(function () { got = true; });
+    setTimeout(() => {
+      if (got) { resolve("stream"); return; }
+      /* A page that runs its own stream claims it, and the nav block then never opens one -- it is
+         fed by the page calling __matrixarkLiveFrame. Driving that page's whole load path is a
+         different harness's job, so the hand-off itself is exercised here: if a frame put through
+         it reaches the watcher, the registration and dispatch are sound. */
+      if (typeof win.__matrixarkLiveFrame === "function") {
+        try {
+          win.__matrixarkLiveFrame({ ts: 1, traffic: {}, imports: {}, warnings: 0,
+                                     embedding: { total: 7 } });
+        } catch (e) { /* reported below as a non-delivery */ }
+        setTimeout(() => resolve(got ? "own-stream" : false), 5);
+        return;
+      }
+      resolve(false);
+    }, 25);
+  });
+}
+
+let failures = 0;
+(async function () {
+for (const path of process.argv.slice(2)) {
+  const r = inspect(path);
+  const name = path.split(/[\\/]/).pop();
+  const direct = r.attempts.filter((a) => !a.queues);
+  if (!r.attempts.length) {
+    console.log("--   " + name + ": does not ask for frames");
+    continue;
+  }
+  const dead = direct.filter((a) => !a.availableBefore);
+  if (dead.length) {
+    console.log("FAIL " + name + ": script " + dead.map((a) => a.index).join(",") +
+                " registers a frame watcher before anything defines one, so it never registers");
+    failures += 1;
+  } else {
+    const delivered = await deliversFrames(r.win);
+    if (r.early.got === 0) {
+      console.log("FAIL " + name + ": a watcher queued before the nav script never received a " +
+                  "frame -- what pages queue is not being drained");
+      failures += 1;
+      continue;
+    }
+    if (delivered === "stream") {
+      console.log("ok   " + name + ": a watcher registers AND receives a frame");
+    } else if (delivered === "own-stream") {
+      console.log("ok   " + name + ": a watcher receives a frame through the page's own stream");
+    } else if (delivered === null) {
+      console.log("FAIL " + name + ": no frame queue exists after load, so nothing can register");
+      failures += 1;
+    } else {
+      console.log("FAIL " + name + ": a watcher registers and never receives a frame");
+      failures += 1;
+    }
+  }
+}
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);
+}());

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -727,6 +727,16 @@
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -384,6 +384,9 @@
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -870,6 +873,16 @@ function liveStream(options) {
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/portal/page_watchers_harness.js
+++ b/tools/portal/page_watchers_harness.js
@@ -25,6 +25,10 @@ function makeEl() {
 }
 
 const registered = [];
+/* Held by reference. The nav script drains this and then REPLACES window.__matrixarkFrameQueue
+   with its own pusher, so reading that property afterwards finds the replacement and not what
+   the page put in. The array itself still holds it. */
+const queued = [];
 const win = {
   document: {
     getElementById: () => makeEl(),
@@ -54,7 +58,19 @@ const win = {
   Blob: function () {},
   URL: { createObjectURL: () => "", revokeObjectURL() {} },
   fetch: () => new Promise(() => {}),          /* never resolves: nothing here needs a response */
-  __matrixarkOnFrame(callback) { registered.push(callback); }
+  __matrixarkOnFrame(callback) { registered.push(callback); },
+  /* Pages register by pushing here, not by calling __matrixarkOnFrame directly: the nav script
+     that defines that function is emitted after the page's own, so calling it at page-script time
+     registered nothing at all. Counting only direct calls made this harness report a watcher for
+     pages that had none -- it defines the function up front, so the ordering bug it would have
+     caught cannot happen here. frame_registration_harness runs the scripts in document order and
+     is what actually proves delivery; this one counts intent, and now counts both ways of
+     expressing it. */
+  /* A plain array, because the nav script drains it with forEach. An object with only a
+     push() satisfied the pages and threw in the nav block -- the harness has to be the
+     shape both halves of the protocol expect. Pages push here; the nav drains it through
+     __matrixarkOnFrame above, so a queued watcher lands in the same count as a direct one. */
+  __matrixarkFrameQueue: queued
 };
 win.window = win;
 
@@ -76,5 +92,5 @@ scripts.forEach((body, index) => {
 process.stdout.write(JSON.stringify({
   scripts: scripts.length,
   threwAtLoad: failures,
-  frameWatchers: registered.length
+  frameWatchers: registered.length + queued.length
 }, null, 2));

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -384,6 +384,9 @@
   .verb.PUT{background:var(--warn-soft);color:var(--warn)}
   .route-path{font-family:"IBM Plex Mono",monospace;font-size:13.5px;font-weight:600;
               overflow-wrap:anywhere}
+  .route-live{font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+  .route-live.bad{color:var(--danger)}
+  .route-live.quiet{opacity:.6}
   .route-scope{margin-left:auto;font-size:11.5px;font-family:"IBM Plex Mono",monospace;
                color:var(--faint);white-space:nowrap}
   .route p{margin:6px 0 0;font-size:13.5px;color:var(--muted);line-height:1.55;max-width:78ch}
@@ -2255,6 +2258,16 @@ function liveStream(options) {
   window.__matrixarkOnFrame = function (callback) {
     if (typeof callback === "function") { watchers.push(callback); }
   };
+  /* This script is emitted AFTER the page's own -- deliberately, so a page running its own stream
+     can claim it before this one decides whether to open a second. The cost of that ordering was
+     that a page registering at its top level called a function that did not exist yet, and two
+     did: the catalog stopped re-listing when the store grew, and nothing looked wrong.
+
+     So pages push to a queue. Whatever is waiting is drained here, and the queue is then replaced
+     by an object whose `push` IS the registration, so a page loading later goes through the same
+     call and nothing has to know which script ran first. */
+  (window.__matrixarkFrameQueue || []).forEach(window.__matrixarkOnFrame);
+  window.__matrixarkFrameQueue = { push: window.__matrixarkOnFrame };
 
   function n(value) {
     return Number(value || 0).toLocaleString();

--- a/tools/test_matrixark_api_traffic.py
+++ b/tools/test_matrixark_api_traffic.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The API page reports what each documented route is actually serving.
+
+The page lists 55 routes and said nothing about whether any of them was used, while the edge had
+been counting every one and the live stream had been carrying those counters to every page.
+
+Three things have to be true for that to be worth showing.
+
+**Every documented route is measured.** The edge collapses paths to a bounded set of labels and
+anything unmatched becomes `other`. Two documented endpoints were landing there --
+`/v1/admin/deployment` and `/v1/admin/deployment/plan` -- so the traffic a customer generated
+composing a deployment was indistinguishable from every other unmatched path. A route that is
+documented and unmeasured is the kind of gap nothing complains about, so it is asserted here.
+
+**The page is told which counter is which.** 55 paths map to 46 labels. The server says which,
+because re-deriving `route_label` in JavaScript would put a second copy of that rule in the tree,
+and when two copies drift the failure is a number rendered against the wrong route -- which looks
+exactly like a number rendered against the right one.
+
+**A shared counter says so.** Four documented paths are counted with a neighbour. A row showing
+that figure as its own overstates itself by however much the neighbour is used.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+sys.path.insert(0, TOOLS)
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+import matrixark_v1_gateway as gw  # noqa: E402
+
+
+class EveryDocumentedRouteIsMeasuredTest(unittest.TestCase):
+
+    def test_no_documented_route_falls_into_other(self) -> None:
+        unmeasured = [entry["path"] for entry in gw.ROUTE_DOCS
+                      if gwm.route_label(entry["path"]) == "other"]
+        self.assertEqual([], unmeasured,
+                         "these are documented and served but counted under 'other', so their "
+                         "traffic cannot be told apart from any unmatched path: %r" % unmeasured)
+
+    def test_every_route_is_served_with_its_counter(self) -> None:
+        rows = gw.documented_routes()
+        self.assertEqual(len(gw.ROUTE_DOCS), len(rows))
+        missing = [r["path"] for r in rows if not r.get("metric")]
+        self.assertEqual([], missing, "served without naming a counter: %r" % missing)
+
+    def test_the_catalogue_constant_is_not_mutated(self) -> None:
+        """Serving must not enrich the module-level list, or it accumulates on every request."""
+        gw.documented_routes()
+        gw.documented_routes()
+        self.assertFalse(any("metric" in entry for entry in gw.ROUTE_DOCS),
+                         "documented_routes() wrote into ROUTE_DOCS, so the catalogue grows a "
+                         "field per call and the second response differs from the first")
+
+    def test_a_shared_counter_names_who_it_is_shared_with(self) -> None:
+        rows = gw.documented_routes()
+        by_label: dict = {}
+        for row in rows:
+            by_label.setdefault(row["metric"], []).append(row["path"])
+        for row in rows:
+            others = sorted(set(by_label[row["metric"]]) - {row["path"]})
+            if others:
+                self.assertEqual(others, row.get("metric_shared_with"),
+                                 "%s is counted with %r and does not say so"
+                                 % (row["path"], others))
+            else:
+                self.assertNotIn("metric_shared_with", row,
+                                 "%s claims to share a counter with nothing" % row["path"])
+
+    def test_the_shared_case_actually_occurs(self) -> None:
+        """If nothing shared a counter, the rule above would be vacuous."""
+        rows = gw.documented_routes()
+        shared = [r for r in rows if r.get("metric_shared_with")]
+        self.assertTrue(shared, "no route shares a counter, so the shared-counter rule is untested")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePageShowsThoseCountersTest(unittest.TestCase):
+
+    def _run(self, harness, *pages):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, harness)] + [os.path.join(PORTAL, p) for p in pages],
+            capture_output=True, text=True, timeout=180)
+
+    def test_each_row_reports_its_traffic(self) -> None:
+        proc = self._run("api_traffic_harness.js", "api_portal.html")
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_nothing_is_claimed_before_a_frame_arrives(self) -> None:
+        """A route reading '0 requests' when nobody has reported is the strip's own rule broken."""
+        out = self._run("api_traffic_harness.js", "api_portal.html").stdout
+        self.assertIn("ok   nothing is claimed before a frame arrives", out, out)
+
+    def test_an_unused_route_says_so_rather_than_staying_blank(self) -> None:
+        out = self._run("api_traffic_harness.js", "api_portal.html").stdout
+        self.assertIn("ok   a route absent from the frame reports no requests", out, out)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class EveryPageThatAsksForFramesGetsThemTest(unittest.TestCase):
+    """Two pages asked for live frames and received none, in production, silently.
+
+    `window.__matrixarkOnFrame` is defined by the nav script, which is emitted after the page's own
+    -- deliberately, so a page running its own stream can claim it first. A page registering at its
+    top level therefore called a function that did not exist yet, and guarded with
+    `if (window.__matrixarkOnFrame)` the guard was simply false.
+
+    `page_watchers_harness` could not catch it: its stub defines the function up front, so every
+    page registered there. This runs the scripts in document order against a window that starts
+    without it.
+    """
+
+    def test_every_page_that_registers_a_watcher_receives_a_frame(self) -> None:
+        pages = sorted(p for p in os.listdir(PORTAL) if p.endswith(".html"))
+        proc = subprocess.run(
+            ["node", os.path.join(PORTAL, "frame_registration_harness.js")]
+            + [os.path.join(PORTAL, p) for p in pages],
+            capture_output=True, text=True, timeout=180)
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_watcher_queued_before_the_nav_script_still_receives(self) -> None:
+        """The case the queue exists for, and the one a late-registering probe cannot prove."""
+        pages = ["catalog_portal.html", "explore_portal.html"]
+        proc = subprocess.run(
+            ["node", os.path.join(PORTAL, "frame_registration_harness.js")]
+            + [os.path.join(PORTAL, p) for p in pages],
+            capture_output=True, text=True, timeout=180)
+        self.assertNotIn("never received a frame", proc.stdout, proc.stdout)
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The API page lists 55 endpoints and said nothing about whether any was ever used, while the edge counted every one and the live stream already carried those counters to every page.

**Two documented endpoints were unmeasured.** `/v1/admin/deployment` and `/v1/admin/deployment/plan` fell through to `other`, so the traffic from composing a deployment was indistinguishable from any unmatched path. There is now an assertion that no documented route lands in `other`.

**Two pages asked for live frames and received none.** `window.__matrixarkOnFrame` is defined by the nav script, emitted *after* the page's own — deliberately, so a page with its own stream can claim it first. So the catalog and explore pages called a function that did not exist yet; guarded with `if (window.__matrixarkOnFrame)`, the guard was false and nothing registered. The catalog stopped re-listing when the store grew, in production, silently.

Two tests asserted those pages subscribe **and passed the whole time** — their harness defines the function up front, so the ordering bug it would have caught cannot occur inside it. Pages now register through a queue the nav drains and then replaces with a pusher, so the same call works before or after. `frame_registration_harness` runs scripts in document order against a window that starts without the function, and seeds the queue *before* load — without that it would only prove late registration works, which passes with the drain deleted.

**The panel.** 55 paths map to 46 counters, so the server says which counter each route is counted under rather than the page re-deriving `route_label` in JS. Four paths are counted with a neighbour and say so. Nothing is claimed before a frame arrives.

Mine, and why the harness earns its keep: the painter called `n()`, a helper the strip defines and this page does not — it threw a ReferenceError on the first frame, which the strip's per-watcher catch swallowed. It failed exactly like the bug it was written to fix.