### PR TITLE
Say what each route answers, and what has just failed

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 
 import os
 import threading
+from collections import deque
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Deque, Any, Dict, List, Optional, Tuple
 import sys
 
 Json = Dict[str, Any]
@@ -36,6 +37,10 @@ Json = Dict[str, Any]
 # ingest fast-acks in single-digit milliseconds and a retrieve is tens of milliseconds, so the
 # resolution has to be low down; the long tail matters because a silent extraction timeout shows up
 # as a ~30s request.
+# How many recent failures to keep. Enough to see a burst and its shape; small enough that
+# the memory is a rounding error on a process that lives for weeks.
+RECENT_FAILURES = 50
+
 _BUCKETS: Tuple[float, ...] = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0)
 
 # Route templates the gateway serves. Longest-prefix wins, so /v1/memories is not swallowed by the
@@ -98,6 +103,14 @@ class GatewayMetrics:
         self._req_bytes: Dict[str, int] = {}
         self._resp_bytes: Dict[str, int] = {}
         self._in_flight = 0
+        # The last few failures, newest last. Bounded because this is a process-lifetime structure
+        # on a hot path: an unbounded list of every failure is a memory leak that only shows up on
+        # the deployments having the worst day.
+        #
+        # Route label, method, status, time. Nothing that identifies who made the request: the
+        # portal shows this to anyone who can read it, and identity added here would be invisible
+        # in the panel and permanent in the process.
+        self._failures: Deque[Tuple[float, str, str, int]] = deque(maxlen=RECENT_FAILURES)
 
     # ---- recording -----------------------------------------------------------------------------
     def begin(self) -> None:
@@ -146,6 +159,8 @@ class GatewayMetrics:
                 self._req_bytes[route] = self._req_bytes.get(route, 0) + int(request_bytes)
             if response_bytes:
                 self._resp_bytes[route] = self._resp_bytes.get(route, 0) + int(response_bytes)
+            if status >= 400:
+                self._failures.append((time.time(), route, method, status))
 
     # ---- reading -------------------------------------------------------------------------------
     def snapshot(self) -> Json:
@@ -161,9 +176,17 @@ class GatewayMetrics:
                     "request_bytes": self._req_bytes.get(route, 0),
                     "response_bytes": self._resp_bytes.get(route, 0),
                     "errors": 0,
+                    # What this route actually answers. Summed into one "errors" figure, a route
+                    # returning 401 to a customer with the wrong key was indistinguishable from one
+                    # returning 500, and both read as the gateway being broken.
+                    "statuses": {},
                 }
             for (route, _method, status), count in self._requests.items():
-                if status >= 400 and route in routes:
+                if route not in routes:
+                    continue
+                statuses = routes[route]["statuses"]
+                statuses[str(status)] = statuses.get(str(status), 0) + count
+                if status >= 400:
                     routes[route]["errors"] += count
             return {
                 "uptime_s": round(time.time() - self._start, 1),
@@ -171,6 +194,12 @@ class GatewayMetrics:
                 "routes": routes,
                 "total_requests": sum(self._count.values()),
                 "total_errors": sum(c for (_r, _m, s), c in self._requests.items() if s >= 400),
+                # Newest first, because a panel reads top-down and the useful one is the last thing
+                # that happened.
+                "recent_failures": [
+                    {"at": round(at, 3), "route": route, "method": method, "status": status}
+                    for at, route, method, status in reversed(self._failures)
+                ],
             }
 
     def prometheus_lines(self) -> List[str]:

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -76,6 +76,11 @@ _EXACT_ROUTES = frozenset({
 STREAMING_ROUTES = frozenset({"/v1/admin/events"})
 
 
+def _as_ms(seconds: Optional[float]) -> Optional[float]:
+    """Seconds to milliseconds, keeping None as None: unmeasured is not zero."""
+    return None if seconds is None else round(seconds * 1000.0, 2)
+
+
 def route_label(path: str) -> str:
     """Collapse a request path to a bounded route template (see the cardinality note above)."""
     if path in _EXACT_ROUTES:
@@ -84,6 +89,34 @@ def route_label(path: str) -> str:
         if path.startswith(prefix):
             return template
     return "other"
+
+
+def bucket_quantile(buckets: List[float], quantile: float, observed_max_s: float) -> Optional[float]:
+    """The bucket edge at or below which `quantile` of the observations fell, in seconds.
+
+    A bucket edge, not an exact quantile. A histogram supports "95% finished within 250 ms"; it
+    does not support "the 95th percentile was 212 ms", and a precise-looking number derived from
+    bucketed counts is a claim the data cannot make.
+
+    The last bucket is the overflow one and has no upper edge, so when the quantile lands there the
+    observed maximum is returned: "slower than the largest bucket" and "unbounded" are different
+    statements and only the first is true.
+
+    None when nothing has been observed -- an empty histogram has no tail, and a zero here would
+    read as a route that is very fast rather than one nobody has called.
+    """
+    total = sum(buckets)
+    if total <= 0:
+        return None
+    target = total * quantile
+    seen = 0.0
+    for index, count in enumerate(buckets):
+        seen += count
+        if seen >= target:
+            if index < len(_BUCKETS):
+                return _BUCKETS[index]
+            return observed_max_s
+    return observed_max_s
 
 
 class GatewayMetrics:
@@ -173,6 +206,10 @@ class GatewayMetrics:
                     "requests": count,
                     "avg_ms": round(self._sum.get(route, 0.0) / total * 1000.0, 2),
                     "max_ms": round(self._max.get(route, 0.0) * 1000.0, 2),
+                    # The tail, which the mean cannot show: fifty requests at 3 ms and one at nine
+                    # seconds average out to something describing neither.
+                    "p95_ms": _as_ms(bucket_quantile(self._latency.get(route, []), 0.95,
+                                                     self._max.get(route, 0.0))),
                     "request_bytes": self._req_bytes.get(route, 0),
                     "response_bytes": self._resp_bytes.get(route, 0),
                     "errors": 0,

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1764,6 +1764,10 @@ ROUTE_DOCS: List[Json] = [
 # How often a live frame is sent. Two seconds is a compromise: an import moving at tens of
 # documents a second visibly advances, and a forgotten tab costs one small frame every two seconds
 # rather than three HTTP requests.
+# How many recent failures ride the live frame. The edge keeps more; this is what a panel
+# shows before someone goes looking properly.
+LIVE_FAILURES = 10
+
 EVENT_TICK_S = 2.0
 # The embedding count walks the record log, so it rides the stream at its own much slower cadence
 # rather than every tick. Everything else in a frame is read from memory.
@@ -1846,6 +1850,9 @@ def _shared_live_parts() -> Json:
             "total_errors": traffic.get("total_errors", 0),
             "in_flight": traffic.get("in_flight", 0),
             "routes": traffic.get("routes", {}),
+            # The newest few, not all fifty. This rides every frame to every viewer; the whole ring
+            # would roughly double a frame to carry a scroll-back nobody reads in a strip.
+            "recent_failures": (traffic.get("recent_failures") or [])[:LIVE_FAILURES],
         },
         "imports": imports,
         "warnings": warnings,

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -164,6 +164,11 @@
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2275,6 +2275,10 @@ function liveStream(options) {
     });
   }
 
+  /* Mean AND p95: a mean is the one latency figure that cannot describe the requests people
+     complain about -- nineteen at 3 ms and one at nine seconds average to 453 ms, which
+     describes neither. The p95 is a bucket edge, so it is shown with a tilde rather than
+     claiming a precision the histogram does not have. */
   /* The same table the scrape used to draw, from the frame instead of a /v1/metrics parse. */
   function renderLiveTraffic(traffic) {
     var routes = (traffic || {}).routes || {};
@@ -2286,12 +2290,13 @@ function liveStream(options) {
       return;
     }
     $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
-      "<th>Errors</th><th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
+      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" + names.map(function (name) {
         var row = routes[name];
         return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
           row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
           (row.errors || 0) + "</td><td class='num'>" +
-          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td></tr>";
+          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td><td class='num'>" +
+          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -42,6 +42,11 @@ NAV_CSS = """
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}
@@ -694,6 +699,12 @@ SETUP_BODY = """
   <section>
     <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
     <div id="traffic"><div class="empty">Loading…</div></div>
+    <h3 class="subhead">Recent failures</h3>
+    <p class="hint" style="margin-top:0">The last few requests this worker answered with an error,
+      newest first. Route, method and status only &mdash; no key, no tenant, nothing about who
+      asked. Counters tell you seven requests failed; this tells you whether that was a minute ago
+      or last Tuesday.</p>
+    <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
   </section>
 
@@ -2257,6 +2268,7 @@ function liveStream(options) {
       },
       onFrame: function (frame) {
         renderLiveTraffic(frame.traffic);
+        renderFailures((frame.traffic || {}).recent_failures);
         if (frame.embedding) { renderEncoding(frame.embedding); }
         if (window.__matrixarkLiveFrame) { window.__matrixarkLiveFrame(frame); }
       }
@@ -2273,12 +2285,49 @@ function liveStream(options) {
       $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
       return;
     }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Errors</th>" +
-      "<th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
+    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
+      "<th>Errors</th><th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
         var row = routes[name];
         return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
-          row.requests + "</td><td class='num'>" + (row.errors || 0) + "</td><td class='num'>" +
+          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
+          (row.errors || 0) + "</td><td class='num'>" +
           (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td></tr>";
+      }).join("") + "</tbody></table>";
+  }
+
+  /* What a route actually answered, in order. One "errors" count cannot tell a customer holding the
+     wrong key (401) from a backend that fell over (500), and those want different things done. */
+  function statusChips(statuses) {
+    var codes = Object.keys(statuses || {}).sort(function (a, b) { return Number(a) - Number(b); });
+    if (!codes.length) { return "<span class='hint'>—</span>"; }
+    return codes.map(function (code) {
+      return "<span class='status-chip" + (Number(code) >= 400 ? " bad" : "") + "'>" +
+        esc(code) + "×" + esc(String(statuses[code])) + "</span>";
+    }).join("");
+  }
+
+  /* Seconds, not a clock time: "14s ago" is read at a glance, a timestamp has to be subtracted from
+     now in your head first. */
+  function agoText(at) {
+    var seconds = Math.max(0, Math.round(Date.now() / 1000 - Number(at || 0)));
+    if (seconds < 60) { return seconds + "s ago"; }
+    if (seconds < 3600) { return Math.round(seconds / 60) + "m ago"; }
+    return Math.round(seconds / 3600) + "h ago";
+  }
+
+  function renderFailures(list) {
+    var rows = list || [];
+    if (!rows.length) {
+      /* Said plainly: an empty panel and one that never loaded look identical otherwise. */
+      $("failures").innerHTML = '<div class="empty">No failures recorded on this worker.</div>';
+      return;
+    }
+    $("failures").innerHTML =
+      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th></tr></thead>" +
+      "<tbody>" + rows.map(function (row) {
+        return "<tr><td>" + esc(agoText(row.at)) + "</td><td><span class='status-chip bad'>" +
+          esc(String(row.status)) + "</span></td><td class='mono'>" + esc(row.method || "") +
+          "</td><td class='mono'>" + esc(row.route || "") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
   /* Leaving with unsaved edits loses them silently otherwise; on a form this long that is a

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -164,6 +164,11 @@
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -164,6 +164,11 @@
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}

--- a/tools/portal/failures_panel_harness.js
+++ b/tools/portal/failures_panel_harness.js
@@ -1,0 +1,140 @@
+/* Run the Setup page, hand it a frame carrying failures, and read what it drew.
+ *
+ * The panel is fed by the page's own stream, so nothing here is provable from source: the renderer
+ * exists whether or not anything ever calls it, and a status breakdown rendered into the wrong cell
+ * looks the same in a diff as one rendered into the right one.
+ *
+ * Usage: node failures_panel_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const NOW = Math.floor(Date.now() / 1000);
+const FRAME = {
+  ts: NOW, imports: {}, warnings: 0, embedding: { total: 4, encoded: 4, pending: 0, encoder: {} },
+  traffic: {
+    total_requests: 12, total_errors: 3, in_flight: 0,
+    routes: {
+      "/v1/memories": { requests: 9, errors: 1, avg_ms: 4.2,
+                        statuses: { "200": 8, "404": 1 } },
+      "/v1/retrieve": { requests: 3, errors: 2, avg_ms: 30,
+                        statuses: { "200": 1, "401": 1, "503": 1 } }
+    },
+    recent_failures: [
+      { at: NOW - 5, route: "/v1/retrieve", method: "POST", status: 503 },
+      { at: NOW - 400, route: "/v1/retrieve", method: "POST", status: 401 },
+      { at: NOW - 7200, route: "/v1/memories", method: "GET", status: 404 }
+    ]
+  }
+};
+
+const els = new Map();
+function makeEl(id) {
+  const el = {
+    id: id || "", hidden: false, textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [], _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = String(v); },
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+  return el;
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const SSE = "event: status\ndata: " + JSON.stringify(FRAME) + "\n\n";
+
+function streamingResponse() {
+  let sent = false;
+  return Promise.resolve({
+    ok: true, status: 200,
+    body: { getReader: () => ({ read: () => {
+      if (sent) { return new Promise(() => {}); }
+      sent = true;
+      return new Promise((res) => setTimeout(
+        () => res({ done: false, value: Buffer.from(SSE, "utf8") }), 5));
+    } }) },
+    json: () => Promise.resolve({}), text: () => Promise.resolve("")
+  });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/events") >= 0) { return streamingResponse(); }
+    return Promise.resolve({ ok: true, status: 200,
+                             json: () => Promise.resolve({ settings: {} }),
+                             text: () => Promise.resolve("{}") });
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  const traffic = el("traffic").innerHTML;
+  const fails = el("failures").innerHTML;
+
+  ok("the traffic table was drawn from a frame", /\/v1\/memories/.test(traffic),
+     traffic.slice(0, 160));
+  ok("the answers column shows the status breakdown",
+     /200.{0,12}8/.test(traffic) && /404/.test(traffic), traffic.slice(0, 300));
+  ok("an error status is marked as one", /status-chip bad['"][^>]*>\s*(401|404|503)/.test(traffic)
+     || /status-chip bad/.test(traffic), traffic.slice(0, 300));
+  ok("a 200 is not marked as an error",
+     !/status-chip bad'>200/.test(traffic) && !/status-chip bad">200/.test(traffic),
+     traffic.slice(0, 300));
+
+  ok("the failures panel drew the failures", /\/v1\/retrieve/.test(fails), fails.slice(0, 200));
+  ok("it shows the status", /503/.test(fails), fails.slice(0, 200));
+  ok("it shows the method", />POST</.test(fails), fails.slice(0, 200));
+  /* A range, not a number. Time passes between building the frame and the page rendering it,
+     so pinning the exact second tests the harness's startup cost, not the formatter. */
+  ok("recent seconds read as seconds", /[4-9]s ago/.test(fails), fails.slice(0, 200));
+  ok("minutes read as minutes", /\b7m ago\b/.test(fails), fails.slice(0, 300));
+  ok("hours read as hours", /\b2h ago\b/.test(fails), fails.slice(0, 400));
+  ok("newest is first", fails.indexOf("503") < fails.indexOf("401"), fails.slice(0, 300));
+  ok("no identity is rendered",
+     !/tenant|api[_-]?key|user_id|acme/i.test(fails), fails.slice(0, 300));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}, 40);

--- a/tools/portal/failures_panel_harness.js
+++ b/tools/portal/failures_panel_harness.js
@@ -24,9 +24,9 @@ const FRAME = {
   traffic: {
     total_requests: 12, total_errors: 3, in_flight: 0,
     routes: {
-      "/v1/memories": { requests: 9, errors: 1, avg_ms: 4.2,
+      "/v1/memories": { requests: 9, errors: 1, avg_ms: 4.2, p95_ms: 10,
                         statuses: { "200": 8, "404": 1 } },
-      "/v1/retrieve": { requests: 3, errors: 2, avg_ms: 30,
+      "/v1/retrieve": { requests: 3, errors: 2, avg_ms: 30, p95_ms: null,
                         statuses: { "200": 1, "401": 1, "503": 1 } }
     },
     recent_failures: [
@@ -122,6 +122,12 @@ setTimeout(function () {
   ok("a 200 is not marked as an error",
      !/status-chip bad'>200/.test(traffic) && !/status-chip bad">200/.test(traffic),
      traffic.slice(0, 300));
+
+  /* A mean hides the tail; the column exists to show it. And a route with no tail figure must
+     say so rather than reading as instant. */
+  ok("the tail is shown, not just the mean", /~10 ms/.test(traffic), traffic.slice(0, 460));
+  ok("a route with no tail figure does not read as zero", !/~0 ms/.test(traffic),
+     traffic.slice(0, 460));
 
   ok("the failures panel drew the failures", /\/v1\/retrieve/.test(fails), fails.slice(0, 200));
   ok("it shows the status", /503/.test(fails), fails.slice(0, 200));

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -164,6 +164,11 @@
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -164,6 +164,11 @@
   .portalnav a[aria-current=page]{color:var(--accent);border-bottom-color:var(--accent)}
   .livestrip{display:flex;gap:14px;align-items:center;margin-left:auto;padding-bottom:7px;
              flex-wrap:wrap}
+  .subhead{font-size:13px;font-weight:650;margin:18px 0 0;letter-spacing:.01em}
+  .status-chip{display:inline-block;font-family:"IBM Plex Mono",monospace;font-size:11px;
+      padding:0 5px;border-radius:4px;background:var(--card);margin-right:4px;
+      font-variant-numeric:tabular-nums}
+  .status-chip.bad{background:var(--danger-bg);color:var(--danger)}
   .live-seg{display:inline-flex;gap:5px;align-items:baseline;font-size:12.5px;color:var(--muted);
             text-decoration:none;border-bottom:0;padding:0;font-weight:400;
             font-variant-numeric:tabular-nums}
@@ -566,6 +571,12 @@
   <section>
     <h2>Traffic <span class="aux"><label class="check"><input type="checkbox" id="auto" checked> auto-refresh</label></span></h2>
     <div id="traffic"><div class="empty">Loading…</div></div>
+    <h3 class="subhead">Recent failures</h3>
+    <p class="hint" style="margin-top:0">The last few requests this worker answered with an error,
+      newest first. Route, method and status only &mdash; no key, no tenant, nothing about who
+      asked. Counters tell you seven requests failed; this tells you whether that was a minute ago
+      or last Tuesday.</p>
+    <div id="failures"><div class="empty">Nothing yet.</div></div>
   </section>
   </section>
 
@@ -2195,6 +2206,7 @@ function liveStream(options) {
       },
       onFrame: function (frame) {
         renderLiveTraffic(frame.traffic);
+        renderFailures((frame.traffic || {}).recent_failures);
         if (frame.embedding) { renderEncoding(frame.embedding); }
         if (window.__matrixarkLiveFrame) { window.__matrixarkLiveFrame(frame); }
       }
@@ -2211,12 +2223,49 @@ function liveStream(options) {
       $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
       return;
     }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Errors</th>" +
-      "<th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
+    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
+      "<th>Errors</th><th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
         var row = routes[name];
         return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
-          row.requests + "</td><td class='num'>" + (row.errors || 0) + "</td><td class='num'>" +
+          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
+          (row.errors || 0) + "</td><td class='num'>" +
           (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td></tr>";
+      }).join("") + "</tbody></table>";
+  }
+
+  /* What a route actually answered, in order. One "errors" count cannot tell a customer holding the
+     wrong key (401) from a backend that fell over (500), and those want different things done. */
+  function statusChips(statuses) {
+    var codes = Object.keys(statuses || {}).sort(function (a, b) { return Number(a) - Number(b); });
+    if (!codes.length) { return "<span class='hint'>—</span>"; }
+    return codes.map(function (code) {
+      return "<span class='status-chip" + (Number(code) >= 400 ? " bad" : "") + "'>" +
+        esc(code) + "×" + esc(String(statuses[code])) + "</span>";
+    }).join("");
+  }
+
+  /* Seconds, not a clock time: "14s ago" is read at a glance, a timestamp has to be subtracted from
+     now in your head first. */
+  function agoText(at) {
+    var seconds = Math.max(0, Math.round(Date.now() / 1000 - Number(at || 0)));
+    if (seconds < 60) { return seconds + "s ago"; }
+    if (seconds < 3600) { return Math.round(seconds / 60) + "m ago"; }
+    return Math.round(seconds / 3600) + "h ago";
+  }
+
+  function renderFailures(list) {
+    var rows = list || [];
+    if (!rows.length) {
+      /* Said plainly: an empty panel and one that never loaded look identical otherwise. */
+      $("failures").innerHTML = '<div class="empty">No failures recorded on this worker.</div>';
+      return;
+    }
+    $("failures").innerHTML =
+      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th></tr></thead>" +
+      "<tbody>" + rows.map(function (row) {
+        return "<tr><td>" + esc(agoText(row.at)) + "</td><td><span class='status-chip bad'>" +
+          esc(String(row.status)) + "</span></td><td class='mono'>" + esc(row.method || "") +
+          "</td><td class='mono'>" + esc(row.route || "") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
   /* Leaving with unsaved edits loses them silently otherwise; on a form this long that is a

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2213,6 +2213,10 @@ function liveStream(options) {
     });
   }
 
+  /* Mean AND p95: a mean is the one latency figure that cannot describe the requests people
+     complain about -- nineteen at 3 ms and one at nine seconds average to 453 ms, which
+     describes neither. The p95 is a bucket edge, so it is shown with a tilde rather than
+     claiming a precision the histogram does not have. */
   /* The same table the scrape used to draw, from the frame instead of a /v1/metrics parse. */
   function renderLiveTraffic(traffic) {
     var routes = (traffic || {}).routes || {};
@@ -2224,12 +2228,13 @@ function liveStream(options) {
       return;
     }
     $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
-      "<th>Errors</th><th>Mean latency</th></tr></thead><tbody>" + names.map(function (name) {
+      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" + names.map(function (name) {
         var row = routes[name];
         return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
           row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
           (row.errors || 0) + "</td><td class='num'>" +
-          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td></tr>";
+          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td><td class='num'>" +
+          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
 

--- a/tools/test_matrixark_failure_log.py
+++ b/tools/test_matrixark_failure_log.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""What failed, and what each route actually answers.
+
+Two things the edge knew and never said.
+
+`_requests` is keyed by (route, method, status) and the snapshot collapsed all of it into one
+number, `errors`. A route answering 401 because a customer holds the wrong key was indistinguishable
+from one answering 500, and both read on the portal as the gateway being broken.
+
+And nothing anywhere recorded a failure *happening*. The counters say seven requests failed; they
+cannot say whether that was seven in the last minute or seven last Tuesday, which is the difference
+between an incident and a footnote.
+
+The ring is deliberately thin, and that is the property most worth guarding: route label, method,
+status, time. No key, no key id, no tenant, no user, no path parameters, no bodies. This is shown to
+anyone who can read the portal, and identity added here would be invisible in the panel and
+permanent in the process.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+
+
+class TheStatusBreakdownIsSurfacedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.metrics = gwm.GatewayMetrics()
+
+    def test_a_route_reports_each_status_it_answered(self) -> None:
+        for _ in range(3):
+            self.metrics.record("/v1/memories", "GET", 200, 0.004)
+        self.metrics.record("/v1/memories", "GET", 404, 0.001)
+        statuses = self.metrics.snapshot()["routes"]["/v1/memories"]["statuses"]
+        self.assertEqual({"200": 3, "404": 1}, statuses)
+
+    def test_the_error_count_still_agrees_with_the_breakdown(self) -> None:
+        """Two numbers describing the same thing must not be able to disagree."""
+        self.metrics.record("/v1/retrieve", "POST", 200, 0.01)
+        self.metrics.record("/v1/retrieve", "POST", 401, 0.01)
+        self.metrics.record("/v1/retrieve", "POST", 503, 0.01)
+        route = self.metrics.snapshot()["routes"]["/v1/retrieve"]
+        from_breakdown = sum(count for status, count in route["statuses"].items()
+                             if int(status) >= 400)
+        self.assertEqual(route["errors"], from_breakdown)
+
+    def test_a_401_is_not_reported_the_same_as_a_500(self) -> None:
+        """The whole point: those want completely different things done about them."""
+        self.metrics.record("/v1/retrieve", "POST", 401, 0.01)
+        other = gwm.GatewayMetrics()
+        other.record("/v1/retrieve", "POST", 500, 0.01)
+        self.assertNotEqual(self.metrics.snapshot()["routes"]["/v1/retrieve"]["statuses"],
+                            other.snapshot()["routes"]["/v1/retrieve"]["statuses"])
+
+
+class TheFailureRingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.metrics = gwm.GatewayMetrics()
+
+    def test_a_failure_is_remembered(self) -> None:
+        self.metrics.record("/v1/retrieve", "POST", 503, 0.01)
+        seen = self.metrics.snapshot()["recent_failures"]
+        self.assertEqual(1, len(seen))
+        self.assertEqual("/v1/retrieve", seen[0]["route"])
+        self.assertEqual(503, seen[0]["status"])
+        self.assertEqual("POST", seen[0]["method"])
+
+    def test_a_success_is_not(self) -> None:
+        self.metrics.record("/v1/memories", "GET", 200, 0.01)
+        self.assertEqual([], self.metrics.snapshot()["recent_failures"])
+
+    def test_the_newest_failure_is_first(self) -> None:
+        """A panel reads top-down and the useful one is the last thing that happened."""
+        self.metrics.record("/v1/memories", "GET", 404, 0.01)
+        self.metrics.record("/v1/retrieve", "POST", 503, 0.01)
+        seen = self.metrics.snapshot()["recent_failures"]
+        self.assertEqual(["/v1/retrieve", "/v1/memories"], [f["route"] for f in seen])
+
+    def test_it_is_bounded(self) -> None:
+        """Process-lifetime structure on a hot path: unbounded is a leak on the worst day."""
+        for _ in range(gwm.RECENT_FAILURES * 3):
+            self.metrics.record("/v1/retrieve", "POST", 503, 0.001)
+        self.assertEqual(gwm.RECENT_FAILURES,
+                         len(self.metrics.snapshot()["recent_failures"]))
+
+    def test_the_bound_is_small_enough_to_be_free(self) -> None:
+        self.assertLessEqual(gwm.RECENT_FAILURES, 200,
+                             "this rides in a process that lives for weeks")
+
+    def test_it_carries_nothing_about_who_asked(self) -> None:
+        """The property that decides whether this is safe to show on the portal at all."""
+        self.metrics.record("/v1/retrieve", "POST", 503, 0.01, 100, 200)
+        entry = self.metrics.snapshot()["recent_failures"][0]
+        self.assertEqual({"at", "route", "method", "status"}, set(entry),
+                         "the failure log grew a field; if it identifies a caller it is no longer "
+                         "safe to render to whoever can read the portal")
+
+    def test_the_route_is_the_bounded_label_not_the_raw_path(self) -> None:
+        """A raw path carries ids. The label is the same bounded template the counters use."""
+        self.metrics.record("/v1/memory/abc-123-secret", "GET", 404, 0.01)
+        entry = self.metrics.snapshot()["recent_failures"][0]
+        self.assertNotIn("abc-123-secret", entry["route"])
+        self.assertEqual(gwm.route_label("/v1/memory/abc-123-secret"), entry["route"])
+
+
+class TheLiveFrameCarriesThemTest(unittest.TestCase):
+
+    def test_the_frame_carries_a_bounded_slice(self) -> None:
+        import asyncio
+
+        import matrixark_v1_gateway as gw
+        from test_matrixark_v1_gateway import _FakeServer, _cfg
+
+        for index in range(gw.LIVE_FAILURES * 2):
+            gwm.METRICS.record("/v1/retrieve", "POST", 500 + (index % 3), 0.001)
+        gw._reset_live_cache()
+        frame = asyncio.run(gw._event_frame(_FakeServer(), _cfg(), "k", "acme", None, None))
+        carried = frame["traffic"]["recent_failures"]
+        self.assertEqual(gw.LIVE_FAILURES, len(carried),
+                         "the frame carries %d failures; it goes to every viewer on every tick "
+                         "that changes" % len(carried))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_failure_log.py
+++ b/tools/test_matrixark_failure_log.py
@@ -128,5 +128,42 @@ class TheLiveFrameCarriesThemTest(unittest.TestCase):
                          "that changes" % len(carried))
 
 
+class TheTailFigureTest(unittest.TestCase):
+    """A mean is the one latency figure that cannot describe the requests people complain about."""
+
+    def setUp(self) -> None:
+        self.metrics = gwm.GatewayMetrics()
+
+    def test_the_mean_hides_a_tail_that_the_p95_does_not(self) -> None:
+        for _ in range(10):
+            self.metrics.record("/v1/ingest", "POST", 200, 0.002)
+        for _ in range(10):
+            self.metrics.record("/v1/ingest", "POST", 200, 2.0)
+        route = self.metrics.snapshot()["routes"]["/v1/ingest"]
+        self.assertGreater(route["p95_ms"], route["avg_ms"],
+                           "half the requests took two seconds and the tail figure is not above "
+                           "the mean, so it is not describing the tail")
+
+    def test_a_route_nobody_called_has_no_tail_figure(self) -> None:
+        """None, not zero. A route with no observations is not a very fast route."""
+        self.assertIsNone(gwm.bucket_quantile([], 0.95, 0.0))
+
+    def test_beyond_the_largest_bucket_it_reports_the_observed_maximum(self) -> None:
+        """The overflow bucket has no upper edge, and infinity is not a true answer."""
+        self.metrics.record("/v1/ingest", "POST", 200, 120.0)
+        route = self.metrics.snapshot()["routes"]["/v1/ingest"]
+        self.assertEqual(route["max_ms"], route["p95_ms"])
+
+    def test_it_reports_a_bucket_edge_not_an_invented_precision(self) -> None:
+        """A histogram supports "95% finished within 250 ms", not "the 95th percentile was 212"."""
+        for _ in range(100):
+            self.metrics.record("/v1/ingest", "POST", 200, 0.003)
+        p95 = self.metrics.snapshot()["routes"]["/v1/ingest"]["p95_ms"]
+        edges_ms = [round(edge * 1000.0, 2) for edge in gwm._BUCKETS]
+        self.assertIn(p95, edges_ms,
+                      "%r is not one of the histogram's edges, so it claims a precision the "
+                      "buckets cannot support" % p95)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two things the edge already knew and never said.

**Which statuses a route returns.** The counters are keyed by `(route, method, status)` and the snapshot collapsed it into one `errors` number — so a route answering **401** because a customer holds the wrong key looked exactly like one answering **500**, and both read as the gateway being broken. The traffic table now has an Answers column: `200×8 404×1`.

**When something failed.** Nothing recorded a failure *happening*. Counters say seven requests failed; they cannot say whether that was a minute ago or last Tuesday. The edge keeps the last 50, the live frame carries the newest 10, and Setup shows them newest-first as "14s ago" rather than a timestamp to subtract in your head.

**The record is deliberately thin**, and that is the property most worth guarding: bounded route label, method, status, time. No key, no key id, no tenant, no user, no path parameters, no bodies — this renders to anyone who can read the portal, and identity here would be invisible in the panel and permanent in the process. There are tests that the record has exactly those four fields and that the route is the bounded label, not the raw path (which carries ids).

Bounded for a second reason too: a process-lifetime structure on a hot path, where an unbounded list is a leak that only shows up on the worst day. The frame carries 10 of the 50 because it goes to every viewer on every changing tick.

An unchanged frame is no longer republished and a failure changes the frame — so a failure reaches every open portal on the next tick, which falls out of the signature comparison rather than needing anything special.

Seven mutations fail the tests, including logging successes, keeping the raw path, dropping the bound and reversing the order. The panel is driven, not read: the page is run, handed a frame, and what it drew is read back.