### PR TITLE
Read the event log through the same expansion every other consumer uses

### DIFF
--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -11,6 +11,11 @@ try:  # package path
 except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
+try:  # package path
+    from tools.matrixark_mcp_local_adapter import expand_interned_records
+except ImportError:
+    from matrixark_mcp_local_adapter import expand_interned_records
+
 try:  # names owned by the parent module
     from tools.test_matrixark_codex_hook_pipeline import (
     CountingLocalAdapter,
@@ -1856,11 +1861,15 @@ class _CodexPipelinePart4:
             )
 
             self.assertEqual("ok", msg["status"])
-            records = [
+            # The writer interns repeated metadata, so a raw line carries an ``_imb`` token
+            # where ``agent_hook`` used to sit inline. ``expand_interned_records`` is the
+            # read-side inverse every other consumer goes through; it is a no-op on a log
+            # with nothing interned.
+            records = expand_interned_records([
                 json.loads(line)
                 for line in event_log.read_text(encoding="utf-8").splitlines()
                 if line.strip()
-            ]
+            ])
             assistant_events = [
                 record
                 for record in records
@@ -1922,15 +1931,21 @@ class _CodexPipelinePart4:
                 ),
                 records,
             )
+            # Postings are folded onto the batch commit that wrote them, so filtering for
+            # data_model "context_profile_entity" now matches nothing; the entity's own postings
+            # are still there under the commit. What the entity carries itself -- its roles and
+            # its codex events -- is asserted directly above, and #562 stopped writing a posting
+            # whose term the record already carries, so `source_role:` and `codex_event:` names
+            # are gone rather than merely relabelled.
             index_names = {
                 str(record.get("index_name") or "")
                 for record in records
                 if record.get("record_type") == "context_index"
-                and record.get("data_model") == "context_profile_entity"
             }
             self.assertIn("entity_type:assistant_decision", index_names)
-            self.assertIn("source_role:assistant", index_names)
-            self.assertIn("codex_event:previousassistantbackfill", index_names)
+            self.assertNotIn("source_role:assistant", index_names)
+            self.assertNotIn("codex_event:previousassistantbackfill", index_names)
+            self.assertNotIn("codex_event:userpromptsubmit:previous_assistant_backfill", index_names)
 
             pack = adapter.retrieve(
                 {


### PR DESCRIPTION
`test_user_prompt_fast_async_still_backfills_previous_assistant_rollout` read the
event log with a bare `json.loads` per line. The writer interns repeated metadata,
so a raw line carries an `_imb` bundle token where `agent_hook` used to sit inline
— all four `session_buffer_event` rows come back with `agent_hook: null`, and the
assertion looking for the `UserPromptSubmit:previous_assistant_backfill` trigger
never matched. The trigger string is in the log, inside a `matrixark_intern_dict`
sidecar.

`expand_interned_records` is the documented read-side inverse, "applied at every
raw-read choke point so no downstream consumer ever sees a token", and a no-op on
a log with nothing interned. The tests either side of this one already go through
`adapter.read_all()`; that one also compacts and drops expired rows, which this
test does not want, so it takes the expansion alone.

Reaching the index assertions then exposed the same thing #729 fixed in three
other tests: postings are folded onto the batch commit that wrote them, so
`data_model == "context_profile_entity"` matches nothing, and #562 stopped writing
a posting whose term the record already carries. `source_role:` and `codex_event:`
names are gone rather than relabelled — the entity's own `source_role` and
`source_codex_events` are asserted twenty lines above. `entity_type:assistant_decision`
stays asserted **present**, so the three absence checks cannot pass on an empty set.

**Mutation-tested** — every flip fails:

| mutation | result |
| --- | --- |
| each new `assertNotIn` → `assertIn` (3) | killed |
| `assertIn` → `assertNotIn` (positive control) | killed |
| `index_names` forced empty (vacuity guard) | killed |

This is the last of the six codex-pipeline tests; #729 took NEW ratchet failures
from 9 to 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
