### PR TITLE
Keep sharing what a large corpus repeats, on both read paths

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -748,11 +748,70 @@ def _shared_interned_value(value: Any) -> Any:
     return _copy_interned_value(value)
 
 
-#: Beyond this many distinct values a field is not repetitive enough to be worth a table entry,
-#: and the table itself would start to cost more than it saves. Measured on an attachment corpus
-#: the busiest field held 11 distinct values, so this is a runaway guard, not a working limit.
 SHARE_REPEATED_VALUES = bool_env("MATRIXARK_SHARE_REPEATED_VALUES", True)
-_SHARED_VALUE_TABLE_LIMIT = 4096
+
+#: A last-resort ceiling on the shared table, not a working limit.
+#:
+#: It used to be 4096, chosen when "the busiest field held 11 distinct values" on a 60-attachment
+#: corpus -- a runaway guard that could not plausibly bind. At 100,105 records it binds hard: the
+#: corpus holds 29,657 distinct ``vector`` values, so the table filled and every value after the
+#: 4,096th was handed back unshared. The measured cost of that one constant was 66.8 MB of
+#: duplicate vectors, 20.9% of a 320 MB cache, and nothing reported it -- the table simply stopped
+#: sharing.
+#:
+#: What keeps the table honest now is :data:`_CONTAINER_FIELD_MIN_HIT_RATE` below, which drops a
+#: field that is not actually repeating. A field still in the table is saving more than its
+#: entries cost, so growth here is self-justifying and the ceiling only has to stop something
+#: nobody foresaw.
+#:
+#: Worth knowing before raising it further: the table holds strong entries and never shrinks, so
+#: it pins its shared values for the life of the process even after the read cache that needed
+#: them is dropped. That is bounded by this ceiling -- ~118 MB at the sizes measured here -- and
+#: it tracks the process-wide read cache closely enough in practice, but a table that outlives its
+#: records is the reason not to treat this number as free.
+#:
+#: Holding the entries weakly would remove the ceiling entirely, and it is close but not free:
+#: both shared types declare ``__slots__ = ()``, which suppresses ``__weakref__``, so they reject
+#: a weak reference today and would need the slot declared back before a weak table could hold
+#: them. That is 8 bytes on each shared object -- ~250 KB across the 31,549 measured here -- and
+#: it is left for whoever needs the ceiling gone rather than folded in here.
+_SHARED_VALUE_TABLE_LIMIT = 262144
+
+#: Lookups to watch before judging a field, and the hit rate it has to clear.
+#:
+#: The string table (:func:`_shared_string`) abandons below 0.10, and containers need a HIGHER bar
+#: for a reason worth stating: a string is its own table key, so a hit at any rate is free money,
+#: but a container's key is a second copy of its spine -- ``(field, tuple(value))``. Sharing pays
+#: when ``hits * value_size > misses * key_size``, i.e. above ``key/(value + key)``. Measured here
+#: a shared vector saves ~1,015 B against a ~450 B key, so break-even is ~0.31.
+#:
+#: The bar is set just above that rather than comfortably above it, because the repetition this
+#: exists to catch sits at 0.50 EXACTLY: a chunk body is stored once as a skill_section and once
+#: as a resource_chunk, so a perfectly duplicated corpus hits every other lookup and nothing more.
+#: A bar of 0.50 would admit that case only by the width of a rounding error and would drop any
+#: corpus that is partly unique -- 2x over 70% of its rows and singletons elsewhere hits 0.35 and
+#: is still comfortably profitable. So: 0.35, above break-even and below the structural case.
+#:
+#: Break-even falls as vectors get wider -- the key spine grows with the element count while the
+#: floats it points at are shared -- so this bar gets safer at production width, not tighter.
+_CONTAINER_FIELD_WARMUP_LOOKUPS = 512
+_CONTAINER_FIELD_MIN_HIT_RATE = 0.35
+
+#: Lookups an abandoned field waits before it is judged again.
+#:
+#: The verdict must not be permanent, because it is made on the FIRST 512 lookups and a corpus can
+#: put a field's repeats after them. A store holding one vector per document followed by a second
+#: pass of duplicates would show a 0.00 hit rate throughout the warmup and be written off for the
+#: life of the process -- the same silent cliff as the fixed 4,096 ceiling this replaced, just
+#: reached a different way. Re-arming costs one increment per lookup on a field already being
+#: skipped, and bounds the damage of a wrong verdict to one window instead of the whole run.
+_CONTAINER_FIELD_REARM_LOOKUPS = 8192
+
+#: Fields that lost the test, and fields that passed it and no longer need counting.
+_SHARED_CONTAINERS_ABANDONED: dict = {}
+_SHARED_CONTAINERS_EARNED: set = set()
+#: field -> [lookups, hits], kept only until the field has earned its place or lost it.
+_SHARED_CONTAINER_STATS: dict = {}
 #: Only a value whose every entry is one of these can be keyed by its contents.
 _SHAREABLE_SCALARS = frozenset({str, int, float, bool, type(None)})
 #: flat value -> the one object every record carrying it holds. Process-wide, so two adapters
@@ -768,10 +827,40 @@ _SHARE_MAX_DEPTH = 3
 
 
 def _lookup_shared(field, key, value, table, shared_type):
-    """Return the one object held for this value, creating it if the table has room."""
+    """Return the one object held for this value, if the field is worth holding a table for."""
     entry = table.get(key)
-    if entry is not None:
+    if field in _SHARED_CONTAINERS_EARNED:
+        if entry is not None:
+            return entry
+        if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
+            return value
+        entry = table[key] = shared_type(value)
         return entry
+    skipped = _SHARED_CONTAINERS_ABANDONED.get(field)
+    if skipped is not None:
+        if skipped[0] < _CONTAINER_FIELD_REARM_LOOKUPS:
+            skipped[0] += 1
+            return value
+        # Its window is up. Judge it again on fresh evidence rather than on a verdict reached
+        # before the corpus had shown what it holds.
+        del _SHARED_CONTAINERS_ABANDONED[field]
+    stats = _SHARED_CONTAINER_STATS.get(field)
+    if stats is None:
+        stats = _SHARED_CONTAINER_STATS[field] = [0, 0]
+    stats[0] += 1
+    if entry is not None:
+        stats[1] += 1
+        return entry
+    if stats[0] >= _CONTAINER_FIELD_WARMUP_LOOKUPS:
+        if stats[1] < stats[0] * _CONTAINER_FIELD_MIN_HIT_RATE:
+            # Its values are distinct, not repeated, so every entry is a key with no copy behind
+            # it to pay for. Stop, and leave the entries already made -- they are bounded by the
+            # warmup and re-deriving which ones to drop would cost more than they hold.
+            _SHARED_CONTAINERS_ABANDONED[field] = [0]
+            _SHARED_CONTAINER_STATS.pop(field, None)
+            return value
+        _SHARED_CONTAINERS_EARNED.add(field)
+        _SHARED_CONTAINER_STATS.pop(field, None)
     if len(table) >= _SHARED_VALUE_TABLE_LIMIT:
         return value
     entry = table[key] = shared_type(value)
@@ -4567,7 +4656,21 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             with self._durable_read_cache_head_path().open("r", encoding="utf-8") as handle:
                 head = json.load(handle)
             with self._durable_read_cache_path().open("r", encoding="utf-8") as handle:
-                payload = json.load(handle)
+                # Decode the snapshot exactly as the log is decoded. Both paths return the same
+                # records, so they have to return them at the same cost, and a bare json.load
+                # here does not: it gives every record a private copy of every repeated VALUE.
+                # Key names are not the problem on this path -- the whole snapshot is one decode
+                # call and the decoder memoises key strings within a call -- which is exactly why
+                # this went unnoticed. Values get no such treatment, and they are the larger half:
+                # a chunk body is stored once as a skill_section and once as a resource_chunk, so
+                # the text of a chunked document arrives twice and was held twice.
+                #
+                # Measured on a 217 MB snapshot of 100,105 records: 4,233 B/record bare against
+                # 3,196 B/record through the hook -- 24.5%, for 0.8 s of decode paid once per
+                # process. The delta tail below already used the hook, so until now a store served
+                # from its snapshot held a cache a third larger than the same store served from
+                # its log, for byte-identical content.
+                payload = json.load(handle, object_pairs_hook=_interned_pairs)
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return None
         if not isinstance(head, dict) or not isinstance(payload, dict):

--- a/tools/test_matrixark_sharing_survives_a_large_corpus.py
+++ b/tools/test_matrixark_sharing_survives_a_large_corpus.py
@@ -1,0 +1,133 @@
+"""A field that repeats must keep being shared however many distinct values it holds.
+
+The shared table used to stop at 4,096 entries -- a ceiling picked when the busiest field on the
+measured corpus held 11 distinct values, so it could not plausibly bind. At 100,105 records it
+binds: that corpus holds 29,657 distinct vectors, so every value past the 4,096th was handed back
+unshared, silently, costing 66.8 MB of duplicates. What replaces the ceiling is a per-field
+hit-rate test, so the guard falls on fields that do not repeat instead of on whichever field
+happened to fill the table first.
+
+The corpus modelled here is the one that matters: a chunk body is stored once as a skill_section
+and once as a resource_chunk, so duplicates arrive in adjacent pairs.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_mcp_local_adapter as adapter_module
+
+
+DISTINCT = 6000         # comfortably past the old 4,096 ceiling
+VECTOR_WIDTH = 8
+
+
+def _paired_rows(distinct, copies=2, field="vector"):
+    """``distinct`` values, each repeated ``copies`` times, duplicates adjacent."""
+    return [
+        {"record_type": "skill_section",
+         "node_id": "n-%d" % i,
+         field: [float((i // copies) * VECTOR_WIDTH + d) for d in range(VECTOR_WIDTH)]}
+        for i in range(distinct * copies)
+    ]
+
+
+def _all_distinct_rows(count, field="unique_ids"):
+    return [
+        {"record_type": "skill_section",
+         "node_id": "n-%d" % i,
+         field: [float(i * VECTOR_WIDTH + d) for d in range(VECTOR_WIDTH)]}
+        for i in range(count)
+    ]
+
+
+class SharingSurvivesALargeCorpus(unittest.TestCase):
+    #: Named rather than referenced directly so the fixture also runs against a build that has not
+    #: got them yet -- the ceiling assertion should then fail on its own claim, which is the only
+    #: way to know it discriminates, instead of erroring in setUp on a missing attribute.
+    _TABLES = ("_SHARED_VALUE_TABLE", "_SHARED_CONTAINERS_ABANDONED",
+               "_SHARED_CONTAINERS_EARNED", "_SHARED_CONTAINER_STATS")
+
+    def setUp(self):
+        # These tables are process-wide by design, so a test that reads them has to start clean --
+        # and has to put back what it found, or it decides the behaviour of every test discovery
+        # happens to run after it.
+        self._saved = {}
+        for name in self._TABLES:
+            table = getattr(adapter_module, name, None)
+            if table is None:
+                continue
+            self._saved[name] = table.copy()
+            table.clear()
+
+    def tearDown(self):
+        for name, saved in self._saved.items():
+            table = getattr(adapter_module, name)
+            table.clear()
+            table.update(saved)
+
+    def test_a_repeating_field_is_shared_past_the_old_ceiling(self):
+        rows = _paired_rows(DISTINCT)
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+
+        objects = {id(record["vector"]) for record in shared}
+        self.assertEqual(
+            len(objects), DISTINCT,
+            "%d rows over %d distinct vectors held %d objects; sharing stopped part way through "
+            "the corpus" % (len(shared), DISTINCT, len(objects)),
+        )
+
+    def test_the_values_are_unchanged_by_sharing(self):
+        """Non-vacuity, and the property that actually matters: sharing must not alter content."""
+        rows = _paired_rows(DISTINCT)
+        originals = [list(record["vector"]) for record in rows]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+        self.assertEqual(len(shared), len(originals))
+        self.assertGreater(len(originals), 0)
+        for original, record in zip(originals, shared):
+            self.assertEqual(list(record["vector"]), original)
+
+    def test_a_field_that_never_repeats_is_dropped(self):
+        """The guard has to land somewhere -- on the field that is not repeating, now."""
+        rows = _all_distinct_rows(DISTINCT, field="unique_ids")
+        adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+
+        self.assertIn(
+            "unique_ids", getattr(adapter_module, "_SHARED_CONTAINERS_ABANDONED", {}),
+            "a field whose values are all distinct kept earning table entries that nothing will "
+            "ever look up",
+        )
+        self.assertLess(
+            len(adapter_module._SHARED_VALUE_TABLE), DISTINCT,
+            "the abandoned field should have stopped adding entries well before the end",
+        )
+
+    def test_an_abandoned_field_still_returns_its_values(self):
+        """Giving up on sharing must never change what the record holds."""
+        rows = _all_distinct_rows(DISTINCT, field="unique_ids")
+        originals = [list(record["unique_ids"]) for record in rows]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+        for original, record in zip(originals, shared):
+            self.assertEqual(list(record["unique_ids"]), original)
+
+    def test_a_field_whose_repeats_arrive_late_is_judged_again(self):
+        """The verdict is reached on the first 512 lookups, so it must not be permanent.
+
+        Here every distinct value is seen once before any of them repeats -- the warmup sees a
+        0.00 hit rate and gives up. Without re-arming, the field would stay abandoned for the life
+        of the process and the whole second half would go unshared.
+        """
+        distinct = _all_distinct_rows(DISTINCT, field="vector")
+        rows = distinct + [dict(record) for record in distinct]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+
+        objects = {id(record["vector"]) for record in shared}
+        self.assertLess(
+            len(objects), len(rows),
+            "a field abandoned during the warmup was never judged again, so nothing in the "
+            "repeating half was shared",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_snapshot_decodes_like_the_log.py
+++ b/tools/test_matrixark_snapshot_decodes_like_the_log.py
@@ -1,0 +1,84 @@
+"""The durable snapshot must decode to the same objects the log decodes to.
+
+Both paths return the same records, so they have to return them at the same cost. A bare
+json.load on the snapshot gives every record a private copy of every repeated VALUE -- so a
+store served from its snapshot held a cache a third larger than the same store served from its
+log, for byte-identical content.
+"""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_mcp_local_adapter as adapter_module
+
+
+SHARED_TEXT = "the same section body, stored under two record types"
+
+
+class SnapshotDecodesLikeTheLog(unittest.TestCase):
+    def _store_with_a_snapshot(self):
+        store = Path(tempfile.mkdtemp())
+        log = store / "events.jsonl"
+        rows = [
+            {"record_type": "skill_section", "node_id": "n-%d" % i, "text": SHARED_TEXT}
+            for i in range(6)
+        ]
+        head = {"schema_version": adapter_module.LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
+                "record_count": len(rows), "delta_count": 0}
+        log.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+        snap = log.with_name(log.name + ".read-cache.json")
+        snap.write_text(json.dumps({"records": rows}), encoding="utf-8")
+        return store, log, snap, head, rows
+
+    def _decode_snapshot(self, snap):
+        """Decode through the adapter's own snapshot reader, not a hand-rolled copy."""
+        store, log, real_snap, head, rows = self._store_with_a_snapshot()
+        adapter = adapter_module.MatrixArkLocalAdapter(log)
+        head["cache_key"] = adapter._cache_key_str()
+        signature = adapter._jsonl_cache_signature_detail()
+        head["signature"] = signature
+        adapter._durable_read_cache_head_path().write_text(json.dumps(head), encoding="utf-8")
+        loaded = adapter._load_durable_read_cache(signature)
+        return loaded, rows
+
+    def test_the_snapshot_reader_returns_records(self):
+        """Non-vacuity: if the reader rejects the snapshot every other assertion passes emptily."""
+        loaded, rows = self._decode_snapshot(None)
+        self.assertIsNotNone(loaded, "the snapshot reader rejected the snapshot, so the sharing "
+                                     "assertions below would pass against nothing")
+        self.assertEqual(len(loaded), len(rows))
+        self.assertTrue(all(r["text"] == SHARED_TEXT for r in loaded))
+
+    def test_a_repeated_value_is_one_object(self):
+        loaded, _ = self._decode_snapshot(None)
+        self.assertIsNotNone(loaded)
+        objects = {id(record["text"]) for record in loaded}
+        self.assertEqual(
+            len(objects), 1,
+            "%d records carry the same text and the snapshot decoded it into %d separate "
+            "objects; the log path decodes it into one" % (len(loaded), len(objects)),
+        )
+
+    def test_key_names_are_interned(self):
+        """This one held before the value fix too, and it is worth saying why.
+
+        The snapshot is decoded in a SINGLE json.load call, and the decoder memoises key
+        strings within a call -- so keys were already shared here and only values were not. That
+        is what made the duplication easy to miss. Pinned so a future change that decodes the
+        snapshot incrementally does not quietly lose the property.
+        """
+        loaded, _ = self._decode_snapshot(None)
+        self.assertIsNotNone(loaded)
+        for name in ("record_type", "node_id", "text"):
+            objects = {id(key) for record in loaded for key in record if key == name}
+            self.assertEqual(
+                len(objects), 1,
+                "key %r was decoded into %d separate string objects" % (name, len(objects)),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects found while measuring a corpus of 1,000 files at 1 MB each — 100,105 records, a 217 MB
snapshot. Together they cost 42.8% of the read cache.

## 1. The durable snapshot decoded differently from the log

`read_all()` has two paths. The JSONL replay decodes each line through `loads_with_interned_keys`,
which interns key names and shares repeated string values. The snapshot decoded with a bare
`json.load`. Same store, same records, different cost:

| path | B/record |
|---|---|
| JSONL replay (cold) | 3,195 |
| durable snapshot (every warm read) | 4,233 |

The snapshot is the path that serves. The delta tail three lines below it already used the hook.

Keys were never the problem here — the snapshot is a single `json.load` and CPython memoises key
strings within one call — so only *values* were duplicated, on one path, which is what made it easy
to miss. The fix passes `object_pairs_hook=_interned_pairs`, so both paths now answer the same.

## 2. The shared-value table stopped at 4,096 entries

`_SHARED_VALUE_TABLE_LIMIT = 4096`, documented as "a runaway guard, not a working limit" because
the corpus it was calibrated on held 11 distinct values in its busiest field. This corpus holds
29,657 distinct vectors: the table filled, and every value after the 4,096th was handed back
unshared. Nothing reported it — sharing simply stopped. Cost: 66.8 MB of duplicate vectors.

The ceiling is replaced by a per-field hit-rate test, the same shape as the string table's, so the
guard now falls on fields that do not repeat rather than on whichever field filled the table first.

Two things are deliberately different from the string version:

- **A higher bar.** A string *is* its own table key, so a hit at any rate is free. A container's
  key is a second copy of its spine, so sharing only pays above `key / (value + key)` — ~0.31 here
  (a shared vector saves ~1,015 B against a ~450 B key). The bar is 0.35: above break-even, and
  deliberately *below* the 0.50 that perfect 2x duplication produces, since a chunk body is stored
  once as a `skill_section` and once as a `resource_chunk` and lands exactly on 0.50.
- **The verdict is not permanent.** It is reached on the first 512 lookups, and a corpus can put a
  field's repeats after them — a store written as one pass of distinct values followed by a second
  pass of duplicates would show a 0.00 hit rate throughout the warmup and be written off for the
  life of the process. Abandoned fields are judged again after 8,192 lookups.

## Measured

100,105 records, one store copy per arm (reading a store rewrites its snapshot, so the arms cannot
share one):

| | cache | B/record | peak RSS |
|---|---|---|---|
| before | 0.424 GB | 4,233 | 1,229 MB |
| after | 0.242 GB | 2,420 | 804 MB |

**−42.8% per record, −425 MB resident.** RSS falls further than the cache does because duplicate
strings inflate allocator arenas as well. Both read paths now report the same size.

What is left: `metadata`, 99,320 objects for 49,641 distinct values, 6.7% of the cache. It is a
nested dict, so it never qualifies for sharing at all — that needs its own change and is not
attempted here.

## Tests

Both defects are pinned by tests that fail on `main` on their own assertions, not on a missing
attribute:

- the snapshot test reports 6 objects for a value 6 records share;
- the ceiling test reports 7,904 objects for 6,000 distinct values — 4,096 shared plus 1,904 pairs
  that never were, which is the ceiling arithmetic exactly.

The suite was run under `unittest discover` on three trees to attribute the result: main, the code
change alone, and the code change with the new tests. The code change alone fails no test that main
does not already fail.
