### PR TITLE
Frame a record into a buffer that lives longer than the record

### DIFF
--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -139,10 +139,27 @@ pub(crate) fn encode_frame(payload: &[u8]) -> Vec<u8> {
 
 /// Encode with whichever frame new writes are configured to use.
 pub(crate) fn encode_record(payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    encode_record_into(payload, &mut out);
+    out
+}
+
+/// Encode into a caller-owned buffer, so an append can reuse one instead of allocating a frame
+/// per record.
+///
+/// The buffer is CLEARED, not appended to: a caller reusing a scratch buffer wants this record,
+/// not this record after the last one. Its capacity survives, which is the point -- a steady
+/// workload stops allocating here after the first few writes.
+pub(crate) fn encode_record_into(payload: &[u8], out: &mut Vec<u8>) {
+    out.clear();
     if binary_frame_enabled() {
-        encode_frame(payload)
+        out.reserve(payload.len() + 10);
+        out.push(FRAME_MAGIC_V3);
+        write_varint(payload.len() as u64, out);
+        out.extend_from_slice(&crate::checksum::crc32c(payload).to_le_bytes());
+        out.extend_from_slice(payload);
     } else {
-        encode_line(payload)
+        out.extend_from_slice(&encode_line(payload));
     }
 }
 

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -891,6 +891,12 @@ struct WriteAheadLogInner {
     /// Safe to hold open: `flock` guards against OTHER PROCESSES, and threads inside this one are
     /// already serialised by the mutex around this struct.
     append_lock_by_shard: HashMap<ShardId, std::sync::Arc<File>>,
+    /// Reused to frame each record, instead of allocating a frame per append.
+    ///
+    /// The frame is the payload plus about ten bytes, so allocating one per write allocated the
+    /// whole record again every time -- four kilobytes an append at a four-kilobyte value. Kept
+    /// here so its capacity survives; a steady workload stops allocating for it entirely.
+    encode_scratch: Vec<u8>,
     // Set only by Default: the store owns its minted scratch directory, and the last
     // clone's drop removes it. Never set for a caller-supplied root.
     scratch: Option<std::sync::Arc<crate::scratch::ScratchDirGuard>>,
@@ -953,6 +959,7 @@ impl LocalWriteAheadLogStore {
             inner: Arc::new(Mutex::new(WriteAheadLogInner {
                 root,
                 append_lock_by_shard: HashMap::new(),
+                encode_scratch: Vec::new(),
                 scratch: None,
                 stats: WriteAheadLogStats::default(),
                 last_sequence_by_shard: HashMap::new(),
@@ -2895,7 +2902,11 @@ fn append_record_locked(
     // Frame the record with a length + SHA-256 digest so a later value-preserving bit-flip in
     // this committed line is detected on read (see `crate::log_framing`). Offsets/stats below
     // use the real byte length, so framing is transparent to the append report and replication.
-    let bytes = crate::log_framing::encode_record(&encode_wal_payload(record)?);
+    let payload = encode_wal_payload(record)?;
+    // Taken out and returned below: framing borrows the buffer while the rest of `inner` is still
+    // needed, and `mem::take` is the cheap way to say that without splitting the struct.
+    let mut bytes = std::mem::take(&mut inner.encode_scratch);
+    crate::log_framing::encode_record_into(&payload, &mut bytes);
     // Close the block if this record will not fit in what is left of it, and start the next.
     //
     // A record is never split across the boundary: the one that does not fit moves whole into
@@ -3048,13 +3059,18 @@ fn append_record_locked(
             .or_default();
         *durable_sequence = (*durable_sequence).max(record.sequence);
     }
+    let size = bytes.len() as u64;
+    // Give the buffer back with its capacity, which is the whole reason it was borrowed. An early
+    // return above simply drops it and the next append allocates once -- correct either way, just
+    // not free that once.
+    inner.encode_scratch = bytes;
     Ok(WriteAheadLogAppendReport {
         shard_id: record.shard_id,
         requested_sequence: record.sequence,
         current_sequence: record.sequence,
         appended: true,
         offset,
-        size: bytes.len() as u64,
+        size,
         persistent_bytes,
     })
 }


### PR DESCRIPTION
Every append built the payload, then allocated a second buffer to hold the payload plus about ten
bytes of frame, and copied it in. That second allocation is the whole record again, on every write.

The design this is measured against keeps one long-lived operation-log message and a reusable
buffer on its logger rather than minting them per write. This does the same for the frame: the
buffer lives on the log's inner state, `encode_record_into` clears and refills it, and its capacity
survives.

| value | allocations an append | bytes allocated |
|---|---|---|
| 64 B | 34.0 -> **33.0** | 9,201 -> 9,096 |
| 256 B | 33.0 | 10,172 -> 9,873 |
| 1024 B | 33.0 | 14,013 -> 12,950 |
| 4096 B | 33.9 | 29,390 -> **25,271 (-14%)** |

The count drops by one; the bytes drop by roughly the size of a record, so the saving grows with
the payload -- which is the right shape, since it removes the cost that scales.

The buffer is taken with `mem::take` and returned on the success path, so the rest of the inner
state stays usable while it is borrowed. An early return drops it and the next append allocates
once: correct either way, just not free that once. `encode_record` is unchanged for its other
callers and now allocates a buffer and delegates.

`distributed_raft_chunks_large_sequence_add_under_default_entry_limit` failed once in the local
full suite and is not from this: it passes 3/3 in isolation on this branch and 3/3 on main, and it
failed the same way on an unrelated branch earlier in the week.