### PR TITLE
Readiness reports what the probe found

### DIFF
--- a/docs/CLOUD_API_REFERENCE.md
+++ b/docs/CLOUD_API_REFERENCE.md
@@ -166,7 +166,11 @@ require `admin:*` — so a data-only key is `403 insufficient_scope` on `matrixa
 `session_id` are also checked against the key's `allowed_user_ids` / `allowed_session_ids`.
 
 ### `GET /v1/healthz` · `GET /v1/readyz` — probes (no auth)
-`/healthz` → `{"status":"ok"}`. `/readyz` → `{"ready":true,"datanode":"ok|unknown|unreachable"}`.
+`/healthz` → `200 {"status":"ok"}` whenever the process is alive; it does not consult the
+datanode, because a liveness probe that fails on a dependency gets the container restarted and
+that fixes nothing. `/readyz` → `{"ready":<bool>,"datanode":"ok|erroring|unreachable"}`, with
+**200 only when the datanode can serve** and **503 otherwise** -- a gateway whose backend is
+down takes itself out of rotation rather than accepting requests it cannot fulfil.
 
 > **Back-compat:** any non-`/v1` path is delegated to the legacy front (`/api/ingest`, `/api/retrieve`,
 > `/api/session_commit`, `/mcp`, `/healthz`).

--- a/docs/DEPLOY_CLOUD_API.md
+++ b/docs/DEPLOY_CLOUD_API.md
@@ -19,7 +19,7 @@ After you deploy the Cloud API, hand customers the **[Enterprise Onboarding](./e
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | `GET` | `/v1/healthz` | Liveness | `200 {"status":"ok"}` |
-| `GET` | `/v1/readyz` | Readiness (shallow datanode probe) | `200 {"ready":true,"datanode":"ok"}` |
+| `GET` | `/v1/readyz` | Readiness (shallow datanode probe) | `200 {"ready":true,"datanode":"ok"}`, or `503 {"ready":false,"datanode":"erroring\|unreachable"}` when the datanode cannot serve |
 | `POST` | `/v1/ingest` | Write resources/skills/session events (async, fast-ack) | `202 {"accepted":n,"scope":...}` |
 | `POST` | `/v1/session/commit` | Close a window; extract entities & summaries | `200` |
 | `POST` | `/v1/retrieve` | Ranked, token-budgeted ContextPack | `200` |

--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -149,6 +149,12 @@ class GatewayMetrics:
         # in the panel and permanent in the process.
         self._failures: Deque[Tuple[float, str, str, int]] = deque(maxlen=RECENT_FAILURES)
 
+        # The last datanode probe: (state, when). Set by the readiness route, published on scrape.
+        # Not probed here -- a metrics endpoint that opens an outbound connection is one that can
+        # hang, and scraping would put the datanode's health check on Prometheus's cadence times
+        # every worker.
+        self._datanode: Optional[Tuple[str, float]] = None
+
     # ---- recording -----------------------------------------------------------------------------
     def begin(self) -> None:
         with self._lock:
@@ -198,6 +204,11 @@ class GatewayMetrics:
                 self._resp_bytes[route] = self._resp_bytes.get(route, 0) + int(response_bytes)
             if status >= 400:
                 self._failures.append((time.time(), route, method, status))
+
+    def note_datanode(self, state: str) -> None:
+        """Record what the readiness probe just found."""
+        with self._lock:
+            self._datanode = (str(state), time.time())
 
     # ---- reading -------------------------------------------------------------------------------
     def snapshot(self) -> Json:
@@ -303,6 +314,36 @@ class GatewayMetrics:
         for route in sorted(resp_bytes):
             lines.append('matrixark_gateway_response_bytes_total{route="%s"} %g'
                          % (route, resp_bytes[route]))
+        with self._lock:
+            probed = self._datanode
+
+        # The families are DECLARED always and SAMPLED only once something has looked.
+        #
+        # Those are different claims and both matter. A 0 before any probe would say the datanode
+        # is down when the truth is that nobody has asked, and an alert cannot tell those apart. But
+        # a family that appears only after the first probe is a family the conformance check cannot
+        # find, and an alert on a series nothing declares is an alert that can never fire -- which
+        # is exactly what that check refused, correctly, when this was written the other way.
+        #
+        # Prometheus allows HELP and TYPE with no samples, which says precisely this: the metric
+        # exists and has no value yet.
+        lines += [
+            "# HELP matrixark_gateway_datanode_reachable Whether the datanode answered the last "
+            "readiness probe (1) or could not serve (0). No sample until readiness has run.",
+            "# TYPE matrixark_gateway_datanode_reachable gauge",
+        ]
+        if probed is not None:
+            lines.append("matrixark_gateway_datanode_reachable %d"
+                         % (1 if probed[0] == "ok" else 0))
+        lines += [
+            "# HELP matrixark_gateway_datanode_probe_age_seconds Age of that answer. A gauge with "
+            "no age reads as current, and a stale 1 would say fine for ever.",
+            "# TYPE matrixark_gateway_datanode_probe_age_seconds gauge",
+        ]
+        if probed is not None:
+            lines.append("matrixark_gateway_datanode_probe_age_seconds %.3f"
+                         % max(0.0, time.time() - probed[1]))
+
         return lines
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -3520,6 +3520,9 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             # liveness probe that fails on a dependency gets the container restarted, which fixes
             # nothing and loses whatever it was doing.
             datanode = await asyncio.to_thread(_probe_datanode, cfg)
+            # Recorded so monitoring can see it too. The orchestrator acts on the status code;
+            # without a series nobody can alert on a backend that has been down for two minutes.
+            _gwmetrics.METRICS.note_datanode(datanode)
             ready = datanode == "ok"
             return await _json(send, 200 if ready else 503,
                                {"ready": ready, "datanode": datanode})

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1564,7 +1564,9 @@ ROUTE_DOCS: List[Json] = [
     {"group": "Health", "method": "GET", "path": "/v1/healthz", "scope": None,
      "summary": "Liveness. Answers as long as the process is up."},
     {"group": "Health", "method": "GET", "path": "/v1/readyz", "scope": None,
-     "summary": "Readiness, including whether the datanode answers."},
+     "summary": "Readiness. 200 only when the datanode can serve; 503 with "
+                "\"datanode\": \"erroring\" or \"unreachable\" when it cannot, so a gateway "
+                "with a backend that is down takes itself out of rotation."},
     {"group": "Health", "method": "GET", "path": "/v1/metrics", "scope": None,
      "summary": "Prometheus scrape. Aggregate counters only, so it needs no credentials."},
 
@@ -3305,8 +3307,17 @@ def _probe_storage_backend(cfg: GatewayConfig) -> Optional[Json]:
         return None
 
 
-def _probe_datanode(cfg: GatewayConfig) -> Optional[bool]:
-    """Best-effort readiness probe against the datanode. None => could not determine (never fatal)."""
+def _probe_datanode(cfg: GatewayConfig) -> str:
+    """What the datanode is doing, by name: "ok", "erroring" or "unreachable".
+
+    It used to return a tri-state bool whose two failure states were reported under names that had
+    them the wrong way round. None meant the connection failed -- nothing listening -- and was
+    reported as "unknown"; False meant the datanode answered with a 5xx and was reported as
+    "unreachable". The reassuring word described the worse state.
+
+    There is no fourth state for "no datanode configured": `datanode_url` always resolves, so a
+    connection failure is a failure to reach something that should be there.
+    """
     try:
         conn = cfg.blob_connection_factory(cfg)
         conn.putrequest("GET", "/health")
@@ -3318,9 +3329,11 @@ def _probe_datanode(cfg: GatewayConfig) -> Optional[bool]:
             pass
         status = int(getattr(resp, "status", 0) or 0)
         _safe_close(conn)
-        return status < 500
+        return "ok" if status < 500 else "erroring"
     except Exception:
-        return None
+        # Could not connect at all. This is the state that was called "unknown", and it is the
+        # least ambiguous of the three.
+        return "unreachable"
 
 
 # ================================================================================================
@@ -3498,9 +3511,18 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         if method == "GET" and path == "/v1/healthz":
             return await _json(send, 200, {"status": "ok"})
         if method == "GET" and path == "/v1/readyz":
-            probe = await asyncio.to_thread(_probe_datanode, cfg)
-            datanode = "unknown" if probe is None else ("ok" if probe else "unreachable")
-            return await _json(send, 200, {"ready": True, "datanode": datanode})
+            # Answers 503 when the datanode cannot serve. It used to answer 200 with
+            # `"ready": true` whatever the probe found, so a gateway with an unreachable backend
+            # stayed in rotation and was handed requests it could not fulfil -- the one thing a
+            # readiness probe exists to prevent.
+            #
+            # `/v1/healthz` is unchanged and still answers 200 whenever the process is alive: a
+            # liveness probe that fails on a dependency gets the container restarted, which fixes
+            # nothing and loses whatever it was doing.
+            datanode = await asyncio.to_thread(_probe_datanode, cfg)
+            ready = datanode == "ok"
+            return await _json(send, 200 if ready else 503,
+                               {"ready": ready, "datanode": datanode})
 
         # ---- key-management portal UI (static HTML, no auth to FETCH) ------------------------
         # Returns the self-contained portal page. Fetching the static page needs no auth; every

--- a/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
+++ b/tools/temporalstore-prometheus/matrixark-gateway-alerts.yml
@@ -74,6 +74,22 @@ groups:
             5xx only -- 4xx is the caller's to fix and is deliberately excluded so an expired
             customer key cannot page the operator.
 
+      - alert: MatrixArkGatewayDatanodeUnreachable
+        expr: >-
+          matrixark_gateway_datanode_reachable == 0
+            and matrixark_gateway_datanode_probe_age_seconds < 120
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "The gateway cannot reach its datanode ({{ $labels.instance }})"
+          description: >-
+            The readiness probe found the datanode erroring or unreachable, so this worker is
+            answering /v1/readyz with 503 and should already be out of rotation. Paired with
+            the probe age deliberately: the gauge is written by the readiness route, so if
+            nothing calls readiness the last answer sits there unchanged -- and a stale 0 would
+            page somebody about a backend that recovered an hour ago.
+
       - alert: MatrixArkGatewayBackendTimeouts
         expr: sum by (instance) (rate(matrixark_gateway_requests_total{status="504"}[5m])) > 0
         for: 10m

--- a/tools/test_matrixark_gateway_routes.py
+++ b/tools/test_matrixark_gateway_routes.py
@@ -24,7 +24,7 @@ from typing import Set
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import matrixark_v1_gateway as gw  # noqa: E402
-from test_matrixark_v1_gateway import _FakeServer, _cfg, drive  # noqa: E402
+from test_matrixark_v1_gateway import _factory_for, _FakeResponse, _FakeServer, _cfg, drive  # noqa: E402
 
 SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "matrixark_v1_gateway.py")
 
@@ -135,7 +135,13 @@ class RouteDocsTest(unittest.TestCase):
         allowed to refuse.
         """
         server = _FakeServer()
-        app = gw.make_v1_app(server, _cfg())
+        # With a datanode that answers. /v1/readyz is documented as 200 only while the datanode can
+        # serve -- it answers 503 otherwise, which is the point of the route -- so a sweep with no
+        # datanode would be asserting that a readiness probe cannot report unready. Giving it a
+        # healthy one exercises the documented example rather than excluding the route from the
+        # sweep.
+        app = gw.make_v1_app(server, _cfg(
+            blob_connection_factory=_factory_for(_FakeResponse(200))))
         headers = {"Authorization": "Bearer k-acme"}
         checked = 0
         for entry in gw.ROUTE_DOCS:

--- a/tools/test_matrixark_readiness_reports_what_it_found.py
+++ b/tools/test_matrixark_readiness_reports_what_it_found.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Readiness reports what the probe found.
+"""Readiness reports what the probe found, and monitoring can see it too.
 
 `/v1/readyz` probed the datanode, learned it could not serve, and answered
 `200 {"ready": true}` regardless. Orchestrators route on the status code, so a gateway whose
@@ -12,11 +12,11 @@ readiness probe, and a metaserver that cannot serve fails its readiness probe. T
 was missed.
 
 The two failure labels were also the wrong way round, which is why reading the body did not give it
-away. The probe returned None when the connection failed -- nothing listening at all -- and that
-was reported as `"unknown"`; it returned False when the datanode answered with a 5xx, and that was
-reported as `"unreachable"`. The reassuring word described the worse state.
+away. The probe returned None when the connection failed -- nothing listening -- and that was
+reported as `"unknown"`; it returned False when the datanode answered with a 5xx, reported as
+`"unreachable"`. The reassuring word described the worse state.
 
-The only test here before was the happy path, which is exactly why none of this was caught.
+The only test on this route before was the happy path, which is exactly why none of it was caught.
 """
 from __future__ import annotations
 
@@ -28,33 +28,51 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import matrixark_v1_gateway as gw  # noqa: E402
-from test_matrixark_v1_gateway import (  # noqa: E402
-    _cfg, _factory_for, _FakeResponse, _FakeServer, drive,
-)
+
+
+def _helpers():
+    """The gateway suite's fixtures, imported when a test runs rather than at module import.
+
+    Under `unittest discover` a module is reachable as both `tools.X` and bare `X`, so importing
+    one test module from another at import time pulls a second copy of it into the run and shifts
+    what every later module sees. Locally that changed nothing; in CI it moved five unrelated
+    tests, none of which this change touches. Deferring the import keeps this module's presence
+    from reordering the suite.
+    """
+    from test_matrixark_v1_gateway import (
+        _cfg, _factory_for, _FakeResponse, _FakeServer, drive,
+    )
+    return _cfg, _factory_for, _FakeResponse, _FakeServer, drive
 
 
 def _refusing(_cfg_unused):
     raise OSError("connection refused")
 
 
-class ReadinessReportsWhatItFoundTest(unittest.TestCase):
+class _WithGatewayFixtures(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.server = _FakeServer()
+        super().setUp()
+        (self.cfg, self.factory_for, self.FakeResponse,
+         FakeServer, self.drive) = _helpers()
+        self.server = FakeServer()
 
-    def _readyz(self, factory):
-        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=factory))
-        status, _headers, body = drive(app, method="GET", path="/v1/readyz")
+    def readyz(self, factory):
+        app = gw.make_v1_app(self.server, self.cfg(blob_connection_factory=factory))
+        status, _headers, body = self.drive(app, method="GET", path="/v1/readyz")
         return status, json.loads(body)
 
+
+class ReadinessReportsWhatItFoundTest(_WithGatewayFixtures):
+
     def test_a_healthy_datanode_is_ready(self) -> None:
-        status, body = self._readyz(_factory_for(_FakeResponse(200)))
+        status, body = self.readyz(self.factory_for(self.FakeResponse(200)))
         self.assertEqual(200, status)
         self.assertTrue(body["ready"])
         self.assertEqual("ok", body["datanode"])
 
     def test_a_datanode_answering_5xx_is_not_ready(self) -> None:
-        status, body = self._readyz(_factory_for(_FakeResponse(503)))
+        status, body = self.readyz(self.factory_for(self.FakeResponse(503)))
         self.assertEqual(503, status,
                          "the probe found a datanode that cannot serve and the gateway still "
                          "reported itself routable")
@@ -62,7 +80,7 @@ class ReadinessReportsWhatItFoundTest(unittest.TestCase):
         self.assertEqual("erroring", body["datanode"])
 
     def test_a_datanode_that_cannot_be_reached_is_not_ready(self) -> None:
-        status, body = self._readyz(_refusing)
+        status, body = self.readyz(_refusing)
         self.assertEqual(503, status)
         self.assertFalse(body["ready"])
         self.assertEqual("unreachable", body["datanode"],
@@ -71,20 +89,20 @@ class ReadinessReportsWhatItFoundTest(unittest.TestCase):
 
     def test_the_status_code_and_the_body_agree(self) -> None:
         """A load balancer reads the code and a human reads the body; they must say one thing."""
-        for factory in (_factory_for(_FakeResponse(200)), _factory_for(_FakeResponse(500)),
-                        _refusing):
-            status, body = self._readyz(factory)
+        for factory in (self.factory_for(self.FakeResponse(200)),
+                        self.factory_for(self.FakeResponse(500)), _refusing):
+            status, body = self.readyz(factory)
             self.assertEqual(status == 200, body["ready"],
                              "HTTP %s with ready=%r" % (status, body["ready"]))
 
     def test_the_datanode_state_is_one_of_the_named_ones(self) -> None:
-        for factory in (_factory_for(_FakeResponse(200)), _factory_for(_FakeResponse(500)),
-                        _refusing):
-            _status, body = self._readyz(factory)
+        for factory in (self.factory_for(self.FakeResponse(200)),
+                        self.factory_for(self.FakeResponse(500)), _refusing):
+            _status, body = self.readyz(factory)
             self.assertIn(body["datanode"], {"ok", "erroring", "unreachable"})
 
 
-class LivenessIsNotReadinessTest(unittest.TestCase):
+class LivenessIsNotReadinessTest(_WithGatewayFixtures):
     """`/v1/healthz` must keep answering 200 while the process is alive.
 
     A liveness probe that fails on a dependency gets the container killed and restarted, which
@@ -92,12 +110,9 @@ class LivenessIsNotReadinessTest(unittest.TestCase):
     Readiness takes it out of rotation; liveness decides whether it should exist at all.
     """
 
-    def setUp(self) -> None:
-        self.server = _FakeServer()
-
     def test_liveness_survives_a_datanode_that_is_gone(self) -> None:
-        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=_refusing))
-        status, _headers, body = drive(app, method="GET", path="/v1/healthz")
+        app = gw.make_v1_app(self.server, self.cfg(blob_connection_factory=_refusing))
+        status, _headers, body = self.drive(app, method="GET", path="/v1/healthz")
         self.assertEqual(200, status,
                          "liveness failed because a dependency is down, so the orchestrator will "
                          "restart a process that has nothing wrong with it")
@@ -105,31 +120,31 @@ class LivenessIsNotReadinessTest(unittest.TestCase):
 
     def test_readiness_and_liveness_disagree_when_they_should(self) -> None:
         """The whole point of having two: same process, different questions, different answers."""
-        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=_refusing))
-        live, _h1, _b1 = drive(app, method="GET", path="/v1/healthz")
-        ready, _h2, _b2 = drive(app, method="GET", path="/v1/readyz")
+        app = gw.make_v1_app(self.server, self.cfg(blob_connection_factory=_refusing))
+        live, _h1, _b1 = self.drive(app, method="GET", path="/v1/healthz")
+        ready, _h2, _b2 = self.drive(app, method="GET", path="/v1/readyz")
         self.assertEqual(200, live)
         self.assertEqual(503, ready)
 
 
-class TheProbeNamesItsStatesTest(unittest.TestCase):
+class TheProbeNamesItsStatesTest(_WithGatewayFixtures):
 
     def test_it_returns_a_name_rather_than_a_tri_state_bool(self) -> None:
         """None/False/True read fine at the call site and were reported under swapped names."""
-        self.assertEqual("ok", gw._probe_datanode(_cfg(
-            blob_connection_factory=_factory_for(_FakeResponse(204)))))
-        self.assertEqual("erroring", gw._probe_datanode(_cfg(
-            blob_connection_factory=_factory_for(_FakeResponse(500)))))
-        self.assertEqual("unreachable", gw._probe_datanode(_cfg(
-            blob_connection_factory=_refusing)))
+        self.assertEqual("ok", gw._probe_datanode(
+            self.cfg(blob_connection_factory=self.factory_for(self.FakeResponse(204)))))
+        self.assertEqual("erroring", gw._probe_datanode(
+            self.cfg(blob_connection_factory=self.factory_for(self.FakeResponse(500)))))
+        self.assertEqual("unreachable", gw._probe_datanode(
+            self.cfg(blob_connection_factory=_refusing)))
 
     def test_a_4xx_from_the_datanode_is_still_serving(self) -> None:
         """The datanode answered. A 404 on /health is a wrong path, not a dead backend."""
-        self.assertEqual("ok", gw._probe_datanode(_cfg(
-            blob_connection_factory=_factory_for(_FakeResponse(404)))))
+        self.assertEqual("ok", gw._probe_datanode(
+            self.cfg(blob_connection_factory=self.factory_for(self.FakeResponse(404)))))
 
 
-class MonitoringCanSeeItTooTest(unittest.TestCase):
+class MonitoringCanSeeItTooTest(_WithGatewayFixtures):
     """The orchestrator acts on the status code. Nobody else could see the probe at all.
 
     Without a series, a deployment cannot alert on "the backend has been unreachable for two
@@ -137,11 +152,12 @@ class MonitoringCanSeeItTooTest(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        super().setUp()
         import matrixark_gateway_metrics as gwm
         self.gwm = gwm
         self.metrics = gwm.GatewayMetrics()
 
-    def _series(self, name):
+    def series(self, name):
         return [l for l in self.metrics.prometheus_lines()
                 if l.startswith(name) and not l.startswith("#")]
 
@@ -153,12 +169,12 @@ class MonitoringCanSeeItTooTest(unittest.TestCase):
 
     def test_there_is_no_sample_before_anything_has_looked(self) -> None:
         """A 0 would say the datanode is down when the truth is that nobody has asked."""
-        self.assertEqual([], self._series("matrixark_gateway_datanode_reachable"))
+        self.assertEqual([], self.series("matrixark_gateway_datanode_reachable"))
 
     def test_a_healthy_probe_reads_one(self) -> None:
         self.metrics.note_datanode("ok")
         self.assertEqual(["matrixark_gateway_datanode_reachable 1"],
-                         self._series("matrixark_gateway_datanode_reachable"))
+                         self.series("matrixark_gateway_datanode_reachable"))
 
     def test_either_failure_reads_zero(self) -> None:
         for state in ("erroring", "unreachable"):
@@ -171,15 +187,22 @@ class MonitoringCanSeeItTooTest(unittest.TestCase):
     def test_the_answer_comes_with_its_age(self) -> None:
         """A gauge with no age reads as current, and a stale 1 says fine for ever."""
         self.metrics.note_datanode("ok")
-        age = self._series("matrixark_gateway_datanode_probe_age_seconds")
+        age = self.series("matrixark_gateway_datanode_probe_age_seconds")
         self.assertEqual(1, len(age), age)
         self.assertLess(float(age[0].split()[-1]), 5.0)
 
     def test_calling_readiness_records_it(self) -> None:
-        """The route is what writes the gauge; if it does not, the series never moves."""
+        """The route writes the gauge; if it does not, the series never moves.
+
+        This touches the process-wide METRICS, because that is the object the route writes to, and
+        puts back what it found. The suite runs every module in one process, and a global left
+        holding this test's state becomes a failure attributed to whichever module runs next.
+        """
+        before = getattr(self.gwm.METRICS, "_datanode", None)
+        self.addCleanup(setattr, self.gwm.METRICS, "_datanode", before)
         self.gwm.METRICS.note_datanode("ok")
-        app = gw.make_v1_app(_FakeServer(), _cfg(blob_connection_factory=_refusing))
-        drive(app, method="GET", path="/v1/readyz")
+        app = gw.make_v1_app(self.server, self.cfg(blob_connection_factory=_refusing))
+        self.drive(app, method="GET", path="/v1/readyz")
         got = [l for l in self.gwm.METRICS.prometheus_lines()
                if l.startswith("matrixark_gateway_datanode_reachable")]
         self.assertEqual(["matrixark_gateway_datanode_reachable 0"], got,

--- a/tools/test_matrixark_readiness_reports_what_it_found.py
+++ b/tools/test_matrixark_readiness_reports_what_it_found.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Readiness reports what the probe found.
+
+`/v1/readyz` probed the datanode, learned it could not serve, and answered
+`200 {"ready": true}` regardless. Orchestrators route on the status code, so a gateway whose
+backend was unreachable stayed in rotation and kept being handed requests it could not fulfil --
+the one thing a readiness probe exists to prevent.
+
+The same fix has already been made twice elsewhere in this system: a drained proxy fails its
+readiness probe, and a metaserver that cannot serve fails its readiness probe. The gateway's own
+was missed.
+
+The two failure labels were also the wrong way round, which is why reading the body did not give it
+away. The probe returned None when the connection failed -- nothing listening at all -- and that
+was reported as `"unknown"`; it returned False when the datanode answered with a 5xx, and that was
+reported as `"unreachable"`. The reassuring word described the worse state.
+
+The only test here before was the happy path, which is exactly why none of this was caught.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import (  # noqa: E402
+    _cfg, _factory_for, _FakeResponse, _FakeServer, drive,
+)
+
+
+def _refusing(_cfg_unused):
+    raise OSError("connection refused")
+
+
+class ReadinessReportsWhatItFoundTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.server = _FakeServer()
+
+    def _readyz(self, factory):
+        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=factory))
+        status, _headers, body = drive(app, method="GET", path="/v1/readyz")
+        return status, json.loads(body)
+
+    def test_a_healthy_datanode_is_ready(self) -> None:
+        status, body = self._readyz(_factory_for(_FakeResponse(200)))
+        self.assertEqual(200, status)
+        self.assertTrue(body["ready"])
+        self.assertEqual("ok", body["datanode"])
+
+    def test_a_datanode_answering_5xx_is_not_ready(self) -> None:
+        status, body = self._readyz(_factory_for(_FakeResponse(503)))
+        self.assertEqual(503, status,
+                         "the probe found a datanode that cannot serve and the gateway still "
+                         "reported itself routable")
+        self.assertFalse(body["ready"])
+        self.assertEqual("erroring", body["datanode"])
+
+    def test_a_datanode_that_cannot_be_reached_is_not_ready(self) -> None:
+        status, body = self._readyz(_refusing)
+        self.assertEqual(503, status)
+        self.assertFalse(body["ready"])
+        self.assertEqual("unreachable", body["datanode"],
+                         "a refused connection is the least ambiguous failure there is, and it "
+                         "used to be the one reported as 'unknown'")
+
+    def test_the_status_code_and_the_body_agree(self) -> None:
+        """A load balancer reads the code and a human reads the body; they must say one thing."""
+        for factory in (_factory_for(_FakeResponse(200)), _factory_for(_FakeResponse(500)),
+                        _refusing):
+            status, body = self._readyz(factory)
+            self.assertEqual(status == 200, body["ready"],
+                             "HTTP %s with ready=%r" % (status, body["ready"]))
+
+    def test_the_datanode_state_is_one_of_the_named_ones(self) -> None:
+        for factory in (_factory_for(_FakeResponse(200)), _factory_for(_FakeResponse(500)),
+                        _refusing):
+            _status, body = self._readyz(factory)
+            self.assertIn(body["datanode"], {"ok", "erroring", "unreachable"})
+
+
+class LivenessIsNotReadinessTest(unittest.TestCase):
+    """`/v1/healthz` must keep answering 200 while the process is alive.
+
+    A liveness probe that fails on a dependency gets the container killed and restarted, which
+    fixes nothing -- the datanode is still down -- and throws away whatever the process was doing.
+    Readiness takes it out of rotation; liveness decides whether it should exist at all.
+    """
+
+    def setUp(self) -> None:
+        self.server = _FakeServer()
+
+    def test_liveness_survives_a_datanode_that_is_gone(self) -> None:
+        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=_refusing))
+        status, _headers, body = drive(app, method="GET", path="/v1/healthz")
+        self.assertEqual(200, status,
+                         "liveness failed because a dependency is down, so the orchestrator will "
+                         "restart a process that has nothing wrong with it")
+        self.assertEqual("ok", json.loads(body)["status"])
+
+    def test_readiness_and_liveness_disagree_when_they_should(self) -> None:
+        """The whole point of having two: same process, different questions, different answers."""
+        app = gw.make_v1_app(self.server, _cfg(blob_connection_factory=_refusing))
+        live, _h1, _b1 = drive(app, method="GET", path="/v1/healthz")
+        ready, _h2, _b2 = drive(app, method="GET", path="/v1/readyz")
+        self.assertEqual(200, live)
+        self.assertEqual(503, ready)
+
+
+class TheProbeNamesItsStatesTest(unittest.TestCase):
+
+    def test_it_returns_a_name_rather_than_a_tri_state_bool(self) -> None:
+        """None/False/True read fine at the call site and were reported under swapped names."""
+        self.assertEqual("ok", gw._probe_datanode(_cfg(
+            blob_connection_factory=_factory_for(_FakeResponse(204)))))
+        self.assertEqual("erroring", gw._probe_datanode(_cfg(
+            blob_connection_factory=_factory_for(_FakeResponse(500)))))
+        self.assertEqual("unreachable", gw._probe_datanode(_cfg(
+            blob_connection_factory=_refusing)))
+
+    def test_a_4xx_from_the_datanode_is_still_serving(self) -> None:
+        """The datanode answered. A 404 on /health is a wrong path, not a dead backend."""
+        self.assertEqual("ok", gw._probe_datanode(_cfg(
+            blob_connection_factory=_factory_for(_FakeResponse(404)))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_readiness_reports_what_it_found.py
+++ b/tools/test_matrixark_readiness_reports_what_it_found.py
@@ -129,5 +129,62 @@ class TheProbeNamesItsStatesTest(unittest.TestCase):
             blob_connection_factory=_factory_for(_FakeResponse(404)))))
 
 
+class MonitoringCanSeeItTooTest(unittest.TestCase):
+    """The orchestrator acts on the status code. Nobody else could see the probe at all.
+
+    Without a series, a deployment cannot alert on "the backend has been unreachable for two
+    minutes" -- only notice later that instances were being cycled.
+    """
+
+    def setUp(self) -> None:
+        import matrixark_gateway_metrics as gwm
+        self.gwm = gwm
+        self.metrics = gwm.GatewayMetrics()
+
+    def _series(self, name):
+        return [l for l in self.metrics.prometheus_lines()
+                if l.startswith(name) and not l.startswith("#")]
+
+    def test_the_family_is_declared_before_anything_has_looked(self) -> None:
+        """An alert on a series nothing declares is an alert that can never fire."""
+        declared = [l for l in self.metrics.prometheus_lines()
+                    if l.startswith("# TYPE matrixark_gateway_datanode")]
+        self.assertEqual(2, len(declared), declared)
+
+    def test_there_is_no_sample_before_anything_has_looked(self) -> None:
+        """A 0 would say the datanode is down when the truth is that nobody has asked."""
+        self.assertEqual([], self._series("matrixark_gateway_datanode_reachable"))
+
+    def test_a_healthy_probe_reads_one(self) -> None:
+        self.metrics.note_datanode("ok")
+        self.assertEqual(["matrixark_gateway_datanode_reachable 1"],
+                         self._series("matrixark_gateway_datanode_reachable"))
+
+    def test_either_failure_reads_zero(self) -> None:
+        for state in ("erroring", "unreachable"):
+            metrics = self.gwm.GatewayMetrics()
+            metrics.note_datanode(state)
+            got = [l for l in metrics.prometheus_lines()
+                   if l.startswith("matrixark_gateway_datanode_reachable")]
+            self.assertEqual(["matrixark_gateway_datanode_reachable 0"], got, state)
+
+    def test_the_answer_comes_with_its_age(self) -> None:
+        """A gauge with no age reads as current, and a stale 1 says fine for ever."""
+        self.metrics.note_datanode("ok")
+        age = self._series("matrixark_gateway_datanode_probe_age_seconds")
+        self.assertEqual(1, len(age), age)
+        self.assertLess(float(age[0].split()[-1]), 5.0)
+
+    def test_calling_readiness_records_it(self) -> None:
+        """The route is what writes the gauge; if it does not, the series never moves."""
+        self.gwm.METRICS.note_datanode("ok")
+        app = gw.make_v1_app(_FakeServer(), _cfg(blob_connection_factory=_refusing))
+        drive(app, method="GET", path="/v1/readyz")
+        got = [l for l in self.gwm.METRICS.prometheus_lines()
+               if l.startswith("matrixark_gateway_datanode_reachable")]
+        self.assertEqual(["matrixark_gateway_datanode_reachable 0"], got,
+                         "readiness found an unreachable datanode and the gauge still says 1")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`/v1/readyz` probed the datanode, learned it could not serve, and answered `200 {"ready": true}` anyway. Orchestrators route on the status code, so a gateway whose backend was unreachable **stayed in rotation** and kept being handed requests it could not fulfil — the one thing a readiness probe exists to prevent.

The same fix has been made twice already in this system — [#289](https://github.com/matrixarkai/TemporalStore/pull/289) (a drained proxy fails its readiness probe) and [#335](https://github.com/matrixarkai/TemporalStore/pull/335) (a metaserver that cannot serve fails its readiness probe). The gateway's own was missed.

**The labels were also backwards**, which is why reading the body didn't give it away: the probe returned `None` when the *connection failed* — nothing listening — and reported that as `"unknown"`; it returned `False` when the datanode *answered with a 5xx*, reported as `"unreachable"`. The reassuring word described the worse state. States are named now: `ok`, `erroring`, `unreachable`.

`/v1/healthz` is deliberately unchanged and still answers 200 while the process is up. A liveness probe that fails on a dependency gets the container restarted, which doesn't fix the datanode and discards whatever it was doing. There's a test that the two disagree when they should.

The only test on this route was the happy path — which is exactly why none of this was caught. Five mutations fail the new ones.

**One existing test needed a decision, not an edit.** The sweep that runs every documented example and requires 2xx now sees readyz answer 503, because its harness has no datanode. Excluding the route would have asserted that a readiness probe cannot report unready; instead the sweep gives it a datanode that answers, so the documented example is exercised rather than skipped.