### PR TITLE
Install the one third-party import the python suite has

### DIFF
--- a/.github/workflows/python-suite-ratchet.yml
+++ b/.github/workflows/python-suite-ratchet.yml
@@ -29,5 +29,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+      # Nothing was installed here, so `import yaml` raised and the two ShippedStackTest cases
+      # that read the shipped prometheus.yml errored on every run -- the monitoring config went
+      # unchecked while the job that checks it reported the failure as pre-existing. It is the
+      # only third-party import in the suite; everything else runs on the standard library.
+      - name: Install what the suite imports
+        run: python3 -m pip install --disable-pip-version-check pyyaml==6.0.2
       - name: Run the suite against the recorded baseline
         run: python3 tools/run_python_suite_ratchet.py


### PR DESCRIPTION
The ratchet job runs `actions/setup-python` and then the suite, with no install step
in between. `tools/test_matrixark_dashboards.py` imports `yaml` to read the shipped
`tools/temporalstore-prometheus/prometheus.yml`, so on every CI run these two raised
`ModuleNotFoundError` before reaching a single assertion:

- `ShippedStackTest.test_the_engine_rules_have_a_job_that_feeds_them`
- `ShippedStackTest.test_the_engine_job_targets_the_service_ports`

Both pass locally, where PyYAML happens to be installed — which is why this read as a
pre-existing failure rather than a missing dependency. They are two of the five NEW
failures the ratchet currently reports.

Those two checks are *"a rule file has a job behind it"* and *"the job points at the
service ports"* — which makes this the exact failure their own class docstring names,
turned on the tests themselves:

> A rule file with no job behind it is permanent silence, and silence reads as health.

**Confirmed, not inferred.** Blocking `yaml` on `sys.meta_path` locally reproduces the CI
error on both tests; they pass again once it resolves.

**Blast radius is nil.** `yaml` is the only third-party import in the suite: exactly one
test file imports it, and no non-test module has a `try/except` fallback around it, so no
other test changes behaviour when it is present. Pinned to a 6.x wheel — the 5.4.1 I have
locally does not build on 3.10, and `safe_load` is identical across both.

Skipping the two tests when `yaml` is absent would also make the ratchet green, and this
file already skips when `node` is missing. I did not do that: it would keep the monitoring
config unchecked forever, which is the thing the tests exist to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
