### PR TITLE
Share a value whose children are shared, not only a flat one

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -814,6 +814,9 @@ _SHARED_CONTAINERS_EARNED: set = set()
 _SHARED_CONTAINER_STATS: dict = {}
 #: Only a value whose every entry is one of these can be keyed by its contents.
 _SHAREABLE_SCALARS = frozenset({str, int, float, bool, type(None)})
+#: The two types :func:`_lookup_shared` hands back. An instance of either is canonical -- the one
+#: object the table holds for that value -- which is what makes its identity usable as a key.
+_SHARED_CONTAINER_TYPES = (_SharedInternedValue, _SharedInternedList)
 #: flat value -> the one object every record carrying it holds. Process-wide, so two adapters
 #: over the same store share as well.
 _SHARED_VALUE_TABLE: dict = {}
@@ -867,6 +870,29 @@ def _lookup_shared(field, key, value, table, shared_type):
     return entry
 
 
+def _shared_by_child_identity(field, value, table):
+    """Share a dict whose values are all scalars or already-shared containers.
+
+    Returns ``value`` untouched when some value is neither, which is the case that has to stay
+    cheap: it is one pass over the items with no hashing.
+    """
+    key_parts = []
+    for name, item in value.items():
+        if type(item) in _SHAREABLE_SCALARS:
+            key_parts.append((name, 0, item))
+        elif isinstance(item, _SHARED_CONTAINER_TYPES):
+            key_parts.append((name, 1, id(item)))
+        else:
+            return value
+    try:
+        # Keys are distinct within a dict, so sorting never compares past position 0 and the mixed
+        # types in position 2 are never ordered against each other.
+        return _lookup_shared(field, (field, tuple(sorted(key_parts))), value,
+                              table, _SharedInternedValue)
+    except TypeError:
+        return value        # keys of mixed type do not sort
+
+
 def _shared_container(field, value, table, depth):
     """Share ``value`` if it is a flat container, else rebuild it around whatever inside it is.
 
@@ -898,10 +924,26 @@ def _shared_container(field, value, table, depth):
                     replacements = {}
                 replacements[sub_field] = shared
         if replacements is None:
-            return value
-        rebuilt = dict(value)
-        rebuilt.update(replacements)
-        return rebuilt
+            rebuilt = value
+        else:
+            rebuilt = dict(value)
+            rebuilt.update(replacements)
+        # A dict holding a container could not be keyed by its contents, so it was returned
+        # unshared however often it repeated. Once its children have been shared it CAN be: a
+        # shared child is the one object held for its value, so the child's identity stands in for
+        # its contents and the parent gets a cheap, exact key.
+        #
+        # This is the whole of what was left. Measured on 100,105 records, every `metadata` value
+        # held exactly one container -- `heading_path`, a list -- and its repetition histogram was
+        # {2: 2000}: EVERY distinct value appeared exactly twice, once as a skill_section and once
+        # as a resource_chunk. 99,320 objects for 49,641 values, 13.4% of the read cache carried at
+        # double.
+        #
+        # Identity is safe as a key here only because the table holds its entries strongly and
+        # nothing evicts them, so a shared child outlives every key naming it. A child whose field
+        # was abandoned, or that arrived after the table hit its ceiling, is NOT one of these types
+        # and falls out of the check below -- which is what keeps the identity honest.
+        return _shared_by_child_identity(field, rebuilt, table)
     if kind is list:
         if not value:
             return value

--- a/tools/test_matrixark_metadata_shares_when_its_children_do.py
+++ b/tools/test_matrixark_metadata_shares_when_its_children_do.py
@@ -1,0 +1,113 @@
+"""A dict that holds a container must still be shared once that container is.
+
+Sharing keyed a dict by its contents, so a dict holding a list could not be keyed at all and was
+returned unshared however often it repeated. That covered every `metadata` value in the measured
+corpus: each one held exactly one container -- `heading_path` -- and each distinct value appeared
+exactly twice, once as a skill_section and once as a resource_chunk. 99,320 objects for 49,641
+values, 13.4% of the read cache carried at double.
+
+Once the child is shared it is canonical -- one object per distinct value -- so the child's
+identity keys the parent exactly.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_mcp_local_adapter as adapter_module
+
+
+DISTINCT = 900
+
+
+def _rows(distinct, copies=2):
+    """Records whose `metadata` holds a list, each distinct value repeated `copies` times."""
+    return [
+        {"record_type": "skill_section",
+         "node_id": "n-%d" % i,
+         "metadata": {"title": "r-%05d" % (i // copies),
+                      "heading_path": ["Runbook", "Section %d" % (i // copies)]}}
+        for i in range(distinct * copies)
+    ]
+
+
+class MetadataSharesWhenItsChildrenDo(unittest.TestCase):
+    _TABLES = ("_SHARED_VALUE_TABLE", "_SHARED_CONTAINERS_ABANDONED",
+               "_SHARED_CONTAINERS_EARNED", "_SHARED_CONTAINER_STATS")
+
+    def setUp(self):
+        self._saved = {}
+        for name in self._TABLES:
+            table = getattr(adapter_module, name, None)
+            if table is None:
+                continue
+            self._saved[name] = table.copy()
+            table.clear()
+
+    def tearDown(self):
+        for name, saved in self._saved.items():
+            table = getattr(adapter_module, name)
+            table.clear()
+            table.update(saved)
+
+    def test_the_nested_child_is_shared(self):
+        """Non-vacuity: the parent can only be keyed by a child that is itself canonical."""
+        shared = adapter_module.share_repeated_values(_rows(DISTINCT),
+                                                      adapter_module._SHARED_VALUE_TABLE)
+        children = {id(record["metadata"]["heading_path"]) for record in shared}
+        self.assertEqual(
+            len(children), DISTINCT,
+            "the nested list itself is not being shared, so nothing above it could be",
+        )
+
+    def test_the_parent_dict_is_shared_too(self):
+        shared = adapter_module.share_repeated_values(_rows(DISTINCT),
+                                                      adapter_module._SHARED_VALUE_TABLE)
+        parents = {id(record["metadata"]) for record in shared}
+        self.assertEqual(
+            len(parents), DISTINCT,
+            "%d rows over %d distinct metadata values held %d objects; a dict holding a list is "
+            "still being passed through unshared" % (len(shared), DISTINCT, len(parents)),
+        )
+
+    def test_the_content_is_unchanged(self):
+        rows = _rows(DISTINCT)
+        originals = [{"title": r["metadata"]["title"],
+                      "heading_path": list(r["metadata"]["heading_path"])} for r in rows]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+        self.assertEqual(len(shared), len(originals))
+        for original, record in zip(originals, shared):
+            self.assertEqual(record["metadata"]["title"], original["title"])
+            self.assertEqual(list(record["metadata"]["heading_path"]), original["heading_path"])
+
+    def test_two_values_differing_only_in_the_child_stay_apart(self):
+        """The identity key must distinguish, not just collapse."""
+        rows = [
+            {"record_type": "skill_section", "node_id": "a",
+             "metadata": {"title": "same", "heading_path": ["Runbook", "One"]}},
+            {"record_type": "skill_section", "node_id": "b",
+             "metadata": {"title": "same", "heading_path": ["Runbook", "Two"]}},
+        ]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+        self.assertNotEqual(
+            id(shared[0]["metadata"]), id(shared[1]["metadata"]),
+            "two metadata values differing only inside the nested list were given the same object",
+        )
+        self.assertEqual(list(shared[0]["metadata"]["heading_path"]), ["Runbook", "One"])
+        self.assertEqual(list(shared[1]["metadata"]["heading_path"]), ["Runbook", "Two"])
+
+    def test_a_dict_holding_an_unshareable_value_is_passed_through(self):
+        """A value that is neither a scalar nor a shared container must not be keyed by identity."""
+        rows = [
+            {"record_type": "skill_section", "node_id": "n-%d" % i,
+             "metadata": {"title": "same", "opaque": {"nested": {"deep": {"deeper": i}}}}}
+            for i in range(4)
+        ]
+        originals = [r["metadata"]["opaque"]["nested"]["deep"]["deeper"] for r in rows]
+        shared = adapter_module.share_repeated_values(rows, adapter_module._SHARED_VALUE_TABLE)
+        for original, record in zip(originals, shared):
+            self.assertEqual(record["metadata"]["opaque"]["nested"]["deep"]["deeper"], original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The last duplication in the read cache, and the reason it survived every previous pass.

## What was left

Sharing keys a container by its contents, so a dict holding a container could not be keyed at all
and was returned unshared however often it repeated. That covered `metadata` exactly:

- every one of its values holds a container — `heading_path`, a list — so none qualified;
- its repetition histogram is `{2: 2000}`: **every distinct value appears exactly twice**, once as
  a `skill_section` and once as a `resource_chunk`;
- 99,320 objects for 49,641 distinct values, **13.4% of the read cache carried at double**.

Measured over 4,000 sampled values, 4,000 of 4,000 would qualify under the change below.

## The change

Once a dict's children have been shared, the dict itself can be keyed: a shared child is the one
object the table holds for its value, so the child's **identity** stands in for its contents and
the parent gets a cheap, exact key.

Identity is only sound here because the table holds its entries strongly and nothing evicts them,
so a shared child outlives every key naming it. A child whose field was abandoned, or that arrived
after the table hit its ceiling, is not one of the shared types and falls out of the check — which
is what keeps the identity honest rather than merely convenient.

## Tests

Five, and the one that matters fails on the base branch at **1,800 objects for 900 distinct
values**. The other four are invariants that hold on both sides and are worth stating:

- the nested child is itself shared (non-vacuity — the parent can only be keyed by a canonical
  child);
- content is unchanged by sharing;
- two values differing **only inside the nested list** stay separate objects, so the identity key
  distinguishes rather than merely collapsing;
- a dict holding something that is neither a scalar nor a shared container is passed through
  untouched.

## Measured

100,105 records, one store copy per arm, cold and warm read each:

| | cache | B/record |
|---|---|---|
| main | 0.242 GB | 2,420 |
| with this change | 0.231 GB | 2,305 |

**-4.8%**, cold and warm identical. Less than the 6.7% a full collapse would give, because some
metadata values hold a child whose own field did not earn a place in the table and so is not
canonical -- those parents are correctly passed through rather than keyed by an identity that
would not be stable.
