### PR TITLE
Count an index posting in a layer, and ask the postings the question that is now theirs

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -275,7 +275,16 @@ def retrieval_memory_inventory(records: list[Json], retrieval_scope: Json) -> Js
                 and session_continuity == "cross_session"
             )
         )
-        is_session = memory_scope in {"session", "session_memory"} or session_continuity == "same_session"
+        # An index posting carries neither a memory scope nor a session continuity -- it is a
+        # derived row pointing at one -- so on those two tests alone it belonged to no layer and
+        # was skipped: twenty postings on a log, context_indexes 0 in all three layers. The
+        # profile clause above already reads data_model for exactly this reason; the session
+        # layer needs the same, for the models the session's own postings are attributed to.
+        is_session = (
+            memory_scope in {"session", "session_memory"}
+            or session_continuity == "same_session"
+            or data_model in {"context_event", "context_batch_commit", "context_segment"}
+        )
 
         if is_shared:
             # A folded owner counts as the embedding it carries -- the separate record it

--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -2889,6 +2889,14 @@ class _CodexPipelinePart4:
             self.assertTrue(all("source_role_counts" not in record for record in event_embeddings))
             self.assertGreaterEqual(result["event_indexes_written"], 3)
 
+            # Every term this used to look for -- the event types and the roles -- is one the
+            # context_event row it points at carries itself, and #562 stops writing a posting
+            # whose owner carries a vector and can derive the term. All twenty-one are dropped on
+            # the way to the log, so this set is empty rather than differently spelled.
+            #
+            # Asserting emptiness proves nothing on its own, so the batch's own postings are
+            # asserted present alongside it: those point at the commit, which derives nothing, and
+            # they are still written.
             event_index_names = {
                 record.get("index_name")
                 for record in records
@@ -2896,12 +2904,15 @@ class _CodexPipelinePart4:
                 and record.get("data_model") == "context_event"
                 and record.get("batch_id_hash") == result["batch_id_hash"]
             }
-            self.assertIn("event_type:user_prompt", event_index_names)
-            self.assertIn("event_type:assistant_response", event_index_names)
-            self.assertIn("event_type:tool_evidence", event_index_names)
-            self.assertIn("source_role:user", event_index_names)
-            self.assertIn("source_role:assistant", event_index_names)
-            self.assertIn("source_role:tool", event_index_names)
+            batch_index_names = {
+                record.get("index_name")
+                for record in records
+                if record.get("record_type") == "context_index"
+                and record.get("data_model") == "context_batch_commit"
+                and record.get("batch_id_hash") == result["batch_id_hash"]
+            }
+            self.assertEqual(set(), event_index_names, batch_index_names)
+            self.assertIn("classification:batch_memory", batch_index_names)
 
             prefiltered = adapter.retrieval_records(
                 scope={
@@ -2915,7 +2926,16 @@ class _CodexPipelinePart4:
                 secondary_index_groups=[{"event_type:tool_evidence"}],
             )
             self.assertTrue(prefiltered["scan_stats"]["secondary_index_prefilter_enabled"], prefiltered)
-            self.assertGreaterEqual(prefiltered["scan_stats"]["index_postings_read"], 1)
+            # index_postings_read is 0 because no posting was stored to read. The match now comes
+            # from the owner branch -- the same branch dropping those postings is gated on -- and
+            # that is the count that carries it.
+            stats = prefiltered["scan_stats"]
+            self.assertEqual(0, stats["index_postings_read"], stats)
+            self.assertGreaterEqual(stats["secondary_embedding_matched_posting_count"], 1, stats)
+            # And it NARROWED. Falling back to a broad scan would return these same records while
+            # proving nothing about the prefilter, so the answer below needs this next to it.
+            self.assertFalse(stats["broad_scan_used"], stats)
+            self.assertLess(stats["returned_records"], stats["scanned_records"], stats)
             self.assertTrue(
                 any(
                     record.get("record_type") == "context_event"
@@ -3013,7 +3033,13 @@ class _CodexPipelinePart4:
             self.assertGreaterEqual(inventory["session"]["context_segments"], 1)
             self.assertGreaterEqual(inventory["profile"]["context_entities"], 1)
             self.assertGreaterEqual(inventory["profile"]["context_embeddings"], 1)
-            self.assertGreaterEqual(inventory["profile"]["context_indexes"], 1)
+            # The postings this used to find under "profile" are attributed to the batch commit
+            # that wrote them, not to the profile entity they point at, so the profile layer has
+            # none and the session layer holds them. Counting them at all is what was fixed
+            # alongside this: a posting carries neither a memory scope nor a session continuity,
+            # so before, every layer reported 0 while twenty postings sat on the log.
+            self.assertEqual(0, inventory["profile"]["context_indexes"], inventory["profile"])
+            self.assertGreaterEqual(inventory["session"]["context_indexes"], 1, inventory["session"])
             self.assertGreaterEqual(inventory["shared"]["resource_chunks"], 1)
             self.assertEqual("prefer", inventory["query_scope"]["session_scope"])
             self.assertNotIn("source_event_ids", json.dumps(inventory, sort_keys=True))


### PR DESCRIPTION
The last two NEW failures the ratchet reports. Both are the same story: postings moved,
and the tests still ask where they used to be. One of them turned out to be a real hole.

## The inventory counted postings in no layer at all

`retrieval_memory_inventory` reported `context_indexes: 0` in **all three** layers while
twenty postings sat on the log. A posting carries neither `memory_scope` nor
`session_continuity` — it is a derived row pointing at one that does — so `is_profile`,
`is_session` and `is_shared` were all false and it was skipped entirely. The field was dead
everywhere, not just under `profile`.

The profile clause already reads `data_model` for exactly this reason
(`data_model == "context_profile_entity"`). The session layer now does the same for the
models its own postings are attributed to. On the test's log: **0 → 12**.

The profile layer still reports 0, and that is the honest answer — postings for a profile
entity are attributed to the batch commit that wrote them, not to the entity they point at.
The test asserts that now, instead of the number it used to see.

## The other test asked for postings that are no longer written

`drop_owner_derivable_postings` drops a posting whose owner carries a vector and can derive
the term — all twenty-one event-type and role postings in that batch. Its docstring says the
owner-carries-a-vector condition is *"the condition the retrieve prefilter's owner branch is
gated on"*, and that is exactly what happens:

| | |
| --- | --- |
| `index_postings_read` | 0 — nothing was stored to read |
| `secondary_embedding_matched_posting_count` | 1 — the owner branch matched |
| `broad_scan_used` | False |
| scanned → returned | 37 → 3 |
| the `tool_evidence` event asked for | returned |

So the prefilter still narrows and still answers; only the counter moved. The test now
asserts the answer and the narrowing rather than a counter measuring a mechanism that is no
longer used. I had this recorded as a genuine retrieval regression — it is not.

## Both keep a positive control

Each absence assertion sits next to a presence one — the batch's own postings, which derive
nothing and are still written — so neither can pass on an empty set.

**Mutation-tested**, every flip fails:

| mutation | result |
| --- | --- |
| `assertEqual(set(), event_index_names)` → `assertNotEqual` | killed |
| positive control `assertIn` → `assertNotIn` | killed |
| `index_postings_read == 0` → `!= 0` | killed |
| owner-branch match `>= 1` → `>= 99` | killed |
| `broad_scan_used` False → True | killed |
| narrowed (`returned < scanned`) → reversed | killed |
| profile `== 0` → `!= 0` | killed |
| session `>= 1` → `>= 99` | killed |
| **the classifier change reverted** | killed |

## Noticed, not changed here

`event_indexes_written` counts postings as they are built, before
`drop_owner_derivable_postings` removes them — it reported 21 for a batch that wrote none.
Left alone: it is a separate call about what that number should mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
