### PR TITLE
Carry the two largest constants in the intern bundle

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -462,6 +462,23 @@ INTERN_METADATA_FIELDS = (
     # identity fields (model_kind, model_ref, model_name, model_hash, provider, execution_mode --
     # _seed_model_registry_seen_locked reads them off the unexpanded log), and the bundle's own
     # token key, which cannot be part of what it names.
+    # Measured on a corpus of 1 MB documents: `access_scope` is 9.6% of the durable log and
+    # `deployment_scope` a further 1.2%, and BOTH carry exactly one distinct value across the
+    # whole store -- 5,940 rows, one value each. They are the two largest constants on the wire.
+    #
+    # They are safe here on the criterion this list already uses. The exclusions above are fields
+    # some path reads off the UNEXPANDED log, where an interned value is invisible. Every raw
+    # reader was checked: of the six functions that iterate log lines, three expand first
+    # (`_load_durable_read_cache`, `_read_all_compacted`, `_read_raw_records`) and the three that
+    # do not -- `_seed_intern_tokens_locked`, `_seed_model_registry_seen_locked` and
+    # `purge_tombstones` -- read only record_type, scope_key and the model identity fields, which
+    # is exactly why those are excluded and these are not.
+    #
+    # They also cost nothing in sidecars, which is the number to watch: fields share ONE bundle,
+    # so a field that varies multiplies the tokens instead of removing bytes. At one distinct
+    # value each these add no combinations at all -- the bundle count stays where it was.
+    "access_scope",
+    "deployment_scope",
     "storage_record_kind",
     "storage_part",
     "dirty_reason",

--- a/tools/test_matrixark_intern_the_scope_constants.py
+++ b/tools/test_matrixark_intern_the_scope_constants.py
@@ -1,0 +1,110 @@
+"""The two largest constants on the wire must ride in the intern bundle, and survive the trip.
+
+`access_scope` was 9.6% of the durable log and `deployment_scope` a further 1.2%, each carrying
+exactly ONE distinct value across the store. Interning them removes both from every data line and
+keeps one copy per distinct value.
+
+The number to watch is the SIDECAR count, not the byte count: fields share one bundle, so a field
+that varies multiplies tokens rather than removing bytes. A constant adds no combinations, and the
+last test here pins that.
+"""
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_mcp_local_adapter as adapter_module
+
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def _rows(count):
+    return [
+        {"record_type": "skill_section",
+         "node_id": "n-%d" % i,
+         "text": "section %d" % i,
+         "access_scope": {"tenant_hash": 11, "user_hash": 22, "scope_key": "t=11|u=22|s=1|"},
+         "deployment_scope": "global",
+         "storage_route": "local",
+         "storage_options": {"durable": True}}
+        for i in range(count)
+    ]
+
+
+class TheTwoLargestConstantsAreInterned(unittest.TestCase):
+    def _encode(self, rows):
+        emitted = set()
+        return adapter_module.encode_interned_records(rows, emitted)
+
+    def test_the_fields_are_in_the_intern_list(self):
+        for field in ("access_scope", "deployment_scope"):
+            self.assertIn(
+                field, adapter_module.INTERN_METADATA_FIELDS,
+                "%s is the largest constant on the wire and is still written on every row" % field,
+            )
+
+    def test_they_leave_the_data_line(self):
+        encoded = self._encode(_rows(20))
+        data = [r for r in encoded
+                if str(r.get("record_type") or "") != adapter_module.INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(len(data), 20)
+        for record in data:
+            self.assertNotIn("access_scope", record)
+            self.assertNotIn("deployment_scope", record)
+            self.assertIn(adapter_module.INTERN_BUNDLE_TOKEN_KEY, record)
+
+    def test_a_read_expands_them_back_unchanged(self):
+        """The whole contract: interning must be invisible above the log."""
+        rows = _rows(20)
+        originals = [(r["access_scope"], r["deployment_scope"]) for r in rows]
+        expanded = adapter_module.expand_interned_records(self._encode(rows))
+        data = [r for r in expanded
+                if str(r.get("record_type") or "") != adapter_module.INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(len(data), len(originals))
+        for (scope, deployment), record in zip(originals, data):
+            self.assertEqual(record["access_scope"], scope)
+            self.assertEqual(record["deployment_scope"], deployment)
+
+    def test_a_constant_adds_no_sidecars(self):
+        """A field that varies would multiply the bundles. These do not vary."""
+        encoded = self._encode(_rows(200))
+        sidecars = [r for r in encoded
+                    if str(r.get("record_type") or "") == adapter_module.INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(
+            len(sidecars), 1,
+            "200 rows carrying one distinct scope produced %d sidecars; a field that varies has "
+            "been added to the bundle" % len(sidecars),
+        )
+
+    def test_it_survives_a_real_write_and_read(self):
+        """End to end through the adapter, not just the codec."""
+        store = Path(tempfile.mkdtemp())
+        adapter = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl")
+        adapter.ingest({"kind": "skill", "scope": SCOPE, "text": "a runbook section",
+                        "metadata": {"raw_uri": "file:///s/r.md", "title": "r"}})
+        adapter.close(timeout_s=120)
+
+        raw = [json.loads(line) for line in
+               (store / "events.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+        data = [r for r in raw
+                if str(r.get("record_type") or "") != adapter_module.INTERN_DICT_RECORD_TYPE]
+        self.assertTrue(data, "nothing was written, so the assertions below would pass emptily")
+        inline = [r for r in data if "access_scope" in r]
+        self.assertEqual(
+            inline, [],
+            "%d rows still carry access_scope inline on the durable log" % len(inline),
+        )
+
+        served = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl").read_all()
+        with_scope = [r for r in served if isinstance(r.get("access_scope"), dict)]
+        self.assertTrue(
+            with_scope,
+            "no served record carries access_scope, so interning it lost the field",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two fields are ~11% of the durable log and each carries exactly one distinct value.

## What was on the wire

`INTERN_METADATA_FIELDS` moves a repeated `{field: value}` set into a sidecar written once per
distinct token, leaving a short hash on the row. It covers 45 fields. It did not cover the two
biggest constants.

Sampled over 6,000 data rows of a 1 MB-per-document corpus:

| field | share of the wire | rows | distinct values | interned |
|---|---|---|---|---|
| text | 39.1% | 5,936 | 2,969 | no |
| embedding_meta | 12.3% | 5,941 | 5,940 | no |
| vector | 12.0% | 5,944 | 2,594 | no |
| **access_scope** | **9.6%** | 5,940 | **1** | **no** |
| **deployment_scope** | **1.2%** | 5,940 | **1** | **no** |

`access_scope` is 216 B on 99% of rows. At ~1,949 records per 1 MB document that is roughly 400 KB
of one repeated value per document.

## Why these two are safe

The exclusions in that list are not stylistic — `scope_key`, `record_type` and the model-registry
identity fields are named there because some path reads them off the **unexpanded** log, where an
interned value is invisible. Eliding `scope_key` would make scope-level tombstones miss a purge.

Every raw reader was checked. Six functions iterate log lines; three expand first
(`_load_durable_read_cache`, `_read_all_compacted`, `_read_raw_records`) and the three that do not
— `_seed_intern_tokens_locked`, `_seed_model_registry_seen_locked`, `purge_tombstones` — read only
record_type, scope_key and the model identity fields. Neither field here is read by any unexpanded
path. The Rust side reads `access_scope` (`scope_scoring.rs`) but no Rust file reads
`events.jsonl`; it arrives through the API, past expansion.

They also cost nothing in sidecars, which is the number to watch: fields share ONE bundle, so a
field that varies multiplies tokens instead of removing bytes. At one distinct value each these add
no combinations at all.

## Measured

Ingesting 8 documents of 1 MB, same corpus, same records:

| | append log |
|---|---|
| main | 38.0 MB |
| with this change | **34.3 MB** |

**-9.7%**, against the 10.8% the sample predicted. The append log is deterministic here — main
produced 38.0 MB on repeated runs.

## Tests

Five, including one end to end through the adapter rather than the codec alone: it asserts that no
row carries `access_scope` inline on the durable log **and** that a served read still carries it,
which is the whole contract. One more pins the sidecar count at 1 for 200 rows, so a future field
that varies cannot be added here without the test noticing.
