### PR TITLE
Offer the settings that decide what the store keeps

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -473,6 +473,31 @@ SETTINGS: List[Setting] = [
             "Drainer interval (ms)", "int", "", "restart",
             "How often the drainer wakes to encode what ingest left behind."),
 
+    # ---- what the local store keeps -------------------------------------------------------------
+    # These two together are the deployment's disk ceiling and, less obviously, its ingest cost:
+    # the retained window is what a read has to hold and what compaction has to walk, so per
+    # document ingest time rises with it until rotation starts discarding. Measured on 1 MB
+    # documents, ingest cost per document climbed 2.68 s -> 4.83 s -> 7.35 s at 15, 30 and 60
+    # documents and then flattened, and it flattened because rotation had begun. An operator
+    # sizing a box needs to see both numbers, and until now neither was offered.
+    Setting("ingestion.local_log_max_bytes", "ingestion", "MATRIXARK_LOCAL_JSONL_MAX_BYTES",
+            "Event log shard size (bytes)", "int", "67108864", "restart",
+            "How large one event-log shard grows before the store rotates to a new one. This "
+            "times the retained count below is the disk the event log will occupy."),
+    Setting("ingestion.local_log_retention_count", "ingestion",
+            "MATRIXARK_LOCAL_JSONL_RETENTION_COUNT",
+            "Event log shards retained", "int", "4", "restart",
+            "How many rotated shards are kept behind the live one. Records in a dropped shard are "
+            "gone from the store, so this is a retention policy and not only a disk setting: at "
+            "the defaults the store keeps roughly 336 MB and discards the oldest records past it."),
+    Setting("ingestion.durable_read_cache", "ingestion",
+            "MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED",
+            "Durable read snapshot", "bool", "1", "restart",
+            "Keep a snapshot of the compacted read view beside the event log so a restart serves "
+            "reads without replaying it. Turning it off makes the first read after a restart "
+            "much slower and saves the disk the snapshot occupies, which is comparable to the "
+            "event log itself."),
+
     # ---- edge limits ---------------------------------------------------------------------------
     Setting("limits.ingest_rps", "limits", "MATRIXARK_RL_INGEST_RPS",
             "Ingest rate limit (req/s)", "float", "5000", "restart",

--- a/tools/test_matrixark_portal_shows_what_the_store_keeps.py
+++ b/tools/test_matrixark_portal_shows_what_the_store_keeps.py
@@ -1,0 +1,81 @@
+"""An operator sizing a deployment must be able to see what the store keeps.
+
+The event log rotates into fixed-size shards and keeps a bounded number of them, so those two
+numbers are the disk ceiling AND a retention policy: records in a dropped shard are gone. They are
+also what bounds ingest cost, because the retained window is what a read holds and compaction
+walks — measured on 1 MB documents, per-document ingest climbed 2.68 s, 4.83 s, 7.35 s at 15, 30
+and 60 documents and then flattened, and it flattened because rotation had begun.
+
+Neither was offered on the portal, so neither could be seen or tuned.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_gateway_config as config_module
+import matrixark_mcp_local_adapter as adapter_module
+
+
+OFFERED = {
+    "ingestion.local_log_max_bytes": "MATRIXARK_LOCAL_JSONL_MAX_BYTES",
+    "ingestion.local_log_retention_count": "MATRIXARK_LOCAL_JSONL_RETENTION_COUNT",
+    "ingestion.durable_read_cache": "MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED",
+}
+
+
+class ThePortalShowsWhatTheStoreKeeps(unittest.TestCase):
+    def setUp(self):
+        self.by_key = {s.key: s for s in config_module.SETTINGS}
+
+    def test_the_retention_knobs_are_offered(self):
+        for key, env in sorted(OFFERED.items()):
+            # assertTrue, not assertIn: assertIn renders the whole registry into the failure and
+            # buries the one name that matters.
+            self.assertTrue(
+                key in self.by_key,
+                "%s decides how much the store keeps and is not offered anywhere on the portal"
+                % env,
+            )
+            self.assertEqual(self.by_key[key].env, env)
+
+    def test_they_are_in_a_group_the_page_renders(self):
+        for key in OFFERED:
+            group = self.by_key[key].group
+            self.assertIn(
+                group, config_module.GROUPS,
+                "%s is in group %r, which has no metadata, so the page cannot render it"
+                % (key, group),
+            )
+
+    def test_the_defaults_match_what_the_store_actually_uses(self):
+        """A portal that shows a default the code does not use is worse than showing nothing."""
+        self.assertEqual(
+            int(self.by_key["ingestion.local_log_max_bytes"].default),
+            adapter_module.LOCAL_JSONL_MAX_BYTES,
+        )
+        self.assertEqual(
+            int(self.by_key["ingestion.local_log_retention_count"].default),
+            adapter_module.LOCAL_JSONL_RETENTION_COUNT,
+        )
+
+    def test_they_are_labelled_restart_because_they_are_read_at_import(self):
+        """Claiming a change is live when it cannot be is the direction that misleads a customer."""
+        for key in OFFERED:
+            self.assertEqual(
+                self.by_key[key].applies, "restart",
+                "%s is read once at import, so offering it as a live change would be a lie" % key,
+            )
+
+    def test_each_one_says_what_it_costs(self):
+        for key in OFFERED:
+            note = self.by_key[key].help or ""
+            self.assertGreater(
+                len(note), 40,
+                "%s is offered with no help text; a knob that bounds retention needs to say so"
+                % key,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal offers 80-odd settings and none of them says how much the store keeps.

## What is missing

The local event log rotates into fixed-size shards and retains a bounded number of them. Those two
numbers are the deployment's disk ceiling — and, less obviously, a **retention policy**: records in
a dropped shard are gone from the store. At the defaults, 64 MB per shard and 4 retained behind the
live one, that is roughly **336 MB kept and the oldest records discarded past it**.

Neither number was offered anywhere on the portal, so an operator could neither see the ceiling nor
raise it.

They also bound ingest cost, which is the part that is easy to miss. The retained window is what a
read holds and what compaction walks, so per-document ingest time rises with it until rotation
begins. Measured on 1 MB documents, drained, fresh store each time:

| documents | s/document |
|---|---|
| 15 | 2.684 |
| 30 | 4.833 |
| 60 | 7.346 |

The curve flattens after that, and it flattens because rotation has started discarding — so the
retention setting is also, in effect, the throughput setting. An operator who cannot see it cannot
reason about either.

## The change

Three settings added to the `ingestion` group, which the setup page already renders:

| key | variable |
|---|---|
| `ingestion.local_log_max_bytes` | `MATRIXARK_LOCAL_JSONL_MAX_BYTES` |
| `ingestion.local_log_retention_count` | `MATRIXARK_LOCAL_JSONL_RETENTION_COUNT` |
| `ingestion.durable_read_cache` | `MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED` |

All three are labelled `restart`, which the existing config audit independently confirms is
correct: its source scan finds each one read exactly once, at import, in
`matrixark_mcp_local_adapter.py`. That matters in both directions — the audit also fails a setting
labelled `restart` that has no import-time reader, so the label is checked, not merely asserted.

They go in `ingestion` rather than `storage_engine` deliberately: every setting in that group is a
`TS_*` engine knob, guarded by a test that each is actually read by the engine. These are Python
knobs and belong beside the other `MATRIXARK_*` ingestion settings.

## Tests

Five, all failing on `main` because the settings do not exist. Beyond presence they pin the things
that make an offered setting trustworthy rather than decorative: that the group has metadata so the
page can render it, that each carries help text, that the label is `restart`, and that the default
shown **equals the value the store actually uses** — a portal that displays a default the code does
not use is worse than showing nothing.
