### PR TITLE
Offer the sharing knob, with the trade it makes

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -490,6 +490,20 @@ SETTINGS: List[Setting] = [
             "How many rotated shards are kept behind the live one. Records in a dropped shard are "
             "gone from the store, so this is a retention policy and not only a disk setting: at "
             "the defaults the store keeps roughly 336 MB and discards the oldest records past it."),
+    # The sharpest memory/latency trade in the local store, and it was not offered at all.
+    # Measured on a 100,105-record store, warm read, three alternating runs each:
+    #   sharing on : 8.00 s, 2,305 B/record, 761 MB resident
+    #   sharing off: 4.58 s, 4,173 B/record, 1,041 MB resident
+    # So it costs ~3.4 s on the read that loads the cache and returns ~45% of the cache. Which way
+    # that should go depends on the deployment, which is exactly why it belongs on the page.
+    Setting("ingestion.share_repeated_values", "ingestion",
+            "MATRIXARK_SHARE_REPEATED_VALUES",
+            "Share repeated values in the read cache", "bool", "1", "restart",
+            "Give every record carrying the same value one shared object instead of a private "
+            "copy. On a 100,105-record store this held the cache at 2,305 bytes per record "
+            "instead of 4,173, and resident memory at 761 MB instead of 1,041 MB, for about 3.4 "
+            "seconds more on the read that loads the cache. Turn it off if that load latency "
+            "matters more than the memory."),
     Setting("ingestion.durable_read_cache", "ingestion",
             "MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED",
             "Durable read snapshot", "bool", "1", "restart",

--- a/tools/test_matrixark_portal_shows_what_the_store_keeps.py
+++ b/tools/test_matrixark_portal_shows_what_the_store_keeps.py
@@ -21,6 +21,7 @@ OFFERED = {
     "ingestion.local_log_max_bytes": "MATRIXARK_LOCAL_JSONL_MAX_BYTES",
     "ingestion.local_log_retention_count": "MATRIXARK_LOCAL_JSONL_RETENTION_COUNT",
     "ingestion.durable_read_cache": "MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED",
+    "ingestion.share_repeated_values": "MATRIXARK_SHARE_REPEATED_VALUES",
 }
 
 
@@ -75,6 +76,25 @@ class ThePortalShowsWhatTheStoreKeeps(unittest.TestCase):
                 "%s is offered with no help text; a knob that bounds retention needs to say so"
                 % key,
             )
+
+
+    def test_the_sharing_knob_says_what_it_trades(self):
+        """It is the sharpest memory/latency trade in the store, so the help must carry both sides.
+
+        Measured on a 100,105-record store, warm read: sharing on gives 8.00 s, 2,305 B/record and
+        761 MB resident; off gives 4.58 s, 4,173 B/record and 1,041 MB. A knob offered without
+        both numbers invites the operator to guess.
+        """
+        help_text = self.by_key["ingestion.share_repeated_values"].help
+        for token in ("2,305", "4,173"):
+            self.assertIn(
+                token, help_text,
+                "the help does not give the memory it buys, so the trade cannot be judged",
+            )
+        self.assertRegex(
+            help_text, r"second",
+            "the help does not give the latency it costs, so it reads as free",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The sharpest memory-for-latency trade in the local store, and it was not offered at all.

## The trade

Value sharing gives every record carrying the same value one shared object instead of a private
copy. Measured on the 100,105-record store, warm read, three alternating runs per arm on separate
store copies:

| | warm read | B/record | resident |
|---|---|---|---|
| sharing on | 8.00 s | 2,305 | 761 MB |
| sharing off | 4.58 s | 4,173 | 1,041 MB |

So it returns **~45% of the read cache and 280 MB of resident memory** for about **3.4 seconds** on
the read that loads the cache. Which way that should go is a property of the deployment — a
long-lived server pays the seconds once and keeps the memory; a short-lived process may prefer the
opposite — and there is no way to choose it from the portal today, though the variable has always
existed.

Worth noting what is *not* the cost: interning keys and values during the decode is free. Measured
on the same store, the current code with sharing off reads in 4.58 s against 5.26 s for the build
before any of today's changes, so the decode path got slightly faster. The 3.4 s is entirely the
container sharing, which is what makes it a real choice rather than a regression to hide.

## The change

One setting, in the `ingestion` group beside the other local-store knobs added recently:

| key | variable |
|---|---|
| `ingestion.share_repeated_values` | `MATRIXARK_SHARE_REPEATED_VALUES` |

Labelled `restart`, which the existing config audit confirms independently: its source scan finds
the variable read once, at import, in `matrixark_mcp_local_adapter.py`.

## Tests

The existing portal-settings test grows to cover it, and one new case asserts the help text carries
**both** sides of the trade — the memory it buys and the seconds it costs. A knob offered with only
one half invites the operator to guess, and this is the knob where guessing is most expensive.
