### PR TITLE
Box the field that decided how wide every command is

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -2615,7 +2615,9 @@ pub(crate) fn execute_on_shard(
             // never fed the time index, so every extracted event was invisible to time-ranged
             // queries while its write reported success.
             if !(first_write_only && event_series.contains_key(&event_id_hash)) {
-                let value = context_bytes(&event);
+                // `event` is boxed on this variant; the wire encoder takes the value.
+                let event_value = &*event;
+                let value = context_bytes(event_value);
                 let routing_bucket = page_routing_bucket(
                     &event_object_key,
                     start_routing_bucket,

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -389,7 +389,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         command: Command::ContextWriteExtractedEvent {
             tenant_hash: 11,
             node_hash: 42,
-            event: extracted_event.clone(),
+            event: Box::new(extracted_event.clone()),
             indexes: ContextExtractedEventIndexes {
                 scope_hash: 3001,
                 entity_hashes: vec![501, 502],
@@ -450,7 +450,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
         command: Command::ContextWriteExtractedEvent {
             tenant_hash: 11,
             node_hash: 43,
-            event: ContextEvent {
+            event: Box::new(ContextEvent {
                 event_id_hash: 446,
                 event_time_ms: 1_781_500_000_010,
                 ingestion_time_ms: 1_781_500_000_010,
@@ -466,7 +466,7 @@ fn context_models_match_keys_timeline_pages_and_filters() {
                 related_node_hashes: vec![43],
                 compact_attrs: Vec::new(),
                 vector: Vec::new(),
-            },
+            }),
             indexes: ContextExtractedEventIndexes {
                 scope_hash: 3001,
                 entity_hashes: Vec::new(),

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -8159,7 +8159,7 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
         Command::ContextWriteExtractedEvent {
             tenant_hash: 41,
             node_hash: 42,
-            event: crate::types::ContextEvent {
+            event: Box::new(crate::types::ContextEvent {
                 event_id_hash: 445,
                 event_time_ms: 1_787_270_075_000,
                 ingestion_time_ms: 1_787_270_075_000,
@@ -8175,7 +8175,7 @@ fn a_shard_rebuilt_from_outcomes_equals_one_rebuilt_from_commands() {
                 related_node_hashes: vec![42],
                 compact_attrs: Vec::new(),
                 vector: Vec::new(),
-            },
+            }),
             indexes: crate::types::ContextExtractedEventIndexes {
                 scope_hash: 3001,
                 entity_hashes: vec![501],
@@ -9570,7 +9570,7 @@ fn a_numeric_component_travels_as_a_number_and_returns_intact() {
         Command::ContextWriteExtractedEvent {
             tenant_hash: 41,
             node_hash: 42,
-            event: crate::types::ContextEvent {
+            event: Box::new(crate::types::ContextEvent {
                 event_id_hash: 445,
                 event_time_ms: 1_787_270_075_000,
                 ingestion_time_ms: 1_787_270_075_000,
@@ -9586,7 +9586,7 @@ fn a_numeric_component_travels_as_a_number_and_returns_intact() {
                 related_node_hashes: vec![42],
                 compact_attrs: Vec::new(),
                 vector: Vec::new(),
-            },
+            }),
             indexes: crate::types::ContextExtractedEventIndexes {
                 scope_hash: 3001,
                 entity_hashes: vec![501],

--- a/crates/temporalstore-rust/src/types.rs
+++ b/crates/temporalstore-rust/src/types.rs
@@ -1746,7 +1746,15 @@ pub enum Command {
     ContextWriteExtractedEvent {
         tenant_hash: u64,
         node_hash: u64,
-        event: ContextEvent,
+        /// Boxed because this field decides how wide EVERY command is.
+        ///
+        /// `Command` is as wide as its widest variant, and this variant was the widest at 288
+        /// bytes -- 184 of them this field. Every command everywhere paid for it, including a
+        /// `StringSet` carrying eight bytes. Behind a box the variant is about 112 and the enum
+        /// drops to 216, which is the next widest (`ContextUpsertNode`).
+        ///
+        /// `Box<T>` serialises exactly as `T`, so nothing on disk or on the wire changes.
+        event: Box<ContextEvent>,
         #[serde(default)]
         indexes: ContextExtractedEventIndexes,
         #[serde(default)]

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4652,6 +4652,134 @@ mod tests {
         assert_eq!(scanned.len(), 2, "both records must be readable: {scanned:?}");
     }
 
+    /// Every `Command` variant's payload, sized by the compiler rather than by eye.
+    ///
+    /// `large_enum_variant` stays silent when the top variants are all wide -- it compares the
+    /// largest against the SECOND largest, so a family of equally fat variants reads as no problem.
+    /// That is a different question from "would boxing a few of them collapse the enum", which is
+    /// what this answers.
+    #[test]
+    #[ignore]
+    fn every_command_variant_payload_size() {
+        // Glob so every field type resolves without guessing which need qualifying.
+        #[allow(unused_imports)]
+        use crate::types::*;
+        let mut rows: Vec<(&str, usize)> = vec![
+        ("CommonDelete", std::mem::size_of::<(String)>()),
+        ("CommonExpire", std::mem::size_of::<(String, u64)>()),
+        ("CommonTtl", std::mem::size_of::<(String)>()),
+        ("CommonPersist", std::mem::size_of::<(String)>()),
+        ("CommonExists", std::mem::size_of::<(String)>()),
+        ("StringSet", std::mem::size_of::<(String, Vec<u8>)>()),
+        ("StringSetEx", std::mem::size_of::<(String, Vec<u8>, u64)>()),
+        ("StringSetConditional", std::mem::size_of::<(String, Vec<u8>, Option<u64>, StringSetCondition, bool)>()),
+        ("StringGet", std::mem::size_of::<(String)>()),
+        ("StringDelete", std::mem::size_of::<(String)>()),
+        ("HashSet", std::mem::size_of::<(String, String, Vec<u8>)>()),
+        ("HashGet", std::mem::size_of::<(String, String)>()),
+        ("HashMultiGet", std::mem::size_of::<(String, Vec<String>)>()),
+        ("HashMultiSet", std::mem::size_of::<(String, Vec<(String, Vec<u8>)>)>()),
+        ("HashIncrBy", std::mem::size_of::<(String, String, i64)>()),
+        ("HashGetAll", std::mem::size_of::<(String)>()),
+        ("HashLen", std::mem::size_of::<(String)>()),
+        ("HashDelete", std::mem::size_of::<(String, String)>()),
+        ("SetAdd", std::mem::size_of::<(String, Vec<u8>)>()),
+        ("ZSetAdd", std::mem::size_of::<(String, Vec<u8>, f64)>()),
+        ("ZSetScore", std::mem::size_of::<(String, Vec<u8>)>()),
+        ("ZSetRemove", std::mem::size_of::<(String, Vec<u8>)>()),
+        ("ZSetCard", std::mem::size_of::<(String)>()),
+        ("ZSetRange", std::mem::size_of::<(String, i64, i64, bool)>()),
+        ("ZSetRangeByScore", std::mem::size_of::<(String, f64, f64, bool, bool, bool)>()),
+        ("SeenCheck", std::mem::size_of::<(String, Vec<u8>, u64)>()),
+        ("SeenCard", std::mem::size_of::<(String)>()),
+        ("BucketTake", std::mem::size_of::<(String, f64, f64, f64)>()),
+        ("BucketPeek", std::mem::size_of::<(String, f64, f64, f64)>()),
+        ("ZSetIncrBy", std::mem::size_of::<(String, Vec<u8>, f64)>()),
+        ("ZSetPop", std::mem::size_of::<(String, bool, u64)>()),
+        ("ZSetRank", std::mem::size_of::<(String, Vec<u8>, bool)>()),
+        ("ListPush", std::mem::size_of::<(String, Vec<u8>, bool)>()),
+        ("ListPop", std::mem::size_of::<(String, bool)>()),
+        ("ListRange", std::mem::size_of::<(String, i64, i64)>()),
+        ("ListLen", std::mem::size_of::<(String)>()),
+        ("SetMembers", std::mem::size_of::<(String)>()),
+        ("SetRemove", std::mem::size_of::<(String, Vec<u8>)>()),
+        ("FeatureAppend", std::mem::size_of::<(String, Vec<FeaturePoint>)>()),
+        ("FeatureAppendWithPolicy", std::mem::size_of::<(String, Vec<FeaturePoint>, FeatureWritePolicy)>()),
+        ("FeatureQuery", std::mem::size_of::<(String, u64, u64, Option<usize>)>()),
+        ("FeatureQueryFiltered", std::mem::size_of::<(String, u64, u64, Option<usize>, Vec<FeatureFilter>)>()),
+        ("FeatureReplace", std::mem::size_of::<(String, u64, u64, Vec<FeaturePoint>)>()),
+        ("FeatureDelete", std::mem::size_of::<(String)>()),
+        ("FeatureAggQuery", std::mem::size_of::<(String, u64, u64, String, Option<usize>)>()),
+        ("SequenceAdd", std::mem::size_of::<(String, Vec<SequenceFeatureRow>)>()),
+        ("SequenceQuery", std::mem::size_of::<(String, u64, u64, usize, Vec<FeatureFilter>)>()),
+        ("SequenceBatchQuery", std::mem::size_of::<(Vec<SequenceQuerySpec>)>()),
+        ("ControlStateIncrement", std::mem::size_of::<(String, u64, i64)>()),
+        ("ControlStateIncrementWithOptions", std::mem::size_of::<(String, u64, i64, Option<u64>, Option<u64>)>()),
+        ("ControlStateChangeAdd", std::mem::size_of::<(String, u64, Vec<u8>, Option<u64>, Option<u64>)>()),
+        ("ControlStateCount", std::mem::size_of::<(String, u64, u64)>()),
+        ("ControlStateQuery", std::mem::size_of::<(String, u64, u64, String)>()),
+        ("ControlStateDetail", std::mem::size_of::<(String, u64, u64, Option<usize>)>()),
+        ("ControlStateSet", std::mem::size_of::<(ControlStateFamily, String, u64, i64)>()),
+        ("ControlStateSetAndGet", std::mem::size_of::<(ControlStateFamily, String, u64, i64, u64, u64, String)>()),
+        ("ControlStateSetAndGetWithOptions", std::mem::size_of::<(ControlStateFamily, String, u64, i64, u64, u64, String, Option<u64>, Option<u64>, Option<String>)>()),
+        ("ControlStateFamilyQuery", std::mem::size_of::<(ControlStateFamily, String, u64, u64, String)>()),
+        ("ControlStateSelectionSet", std::mem::size_of::<(String, Vec<u8>, u64, u64, ControlStateSelectionType)>()),
+        ("ControlStateSelectionQuery", std::mem::size_of::<(String)>()),
+        ("ControlStateManager", std::mem::size_of::<(String, Option<String>, Vec<(String, String)>, String, String, bool)>()),
+        ("ControlStateDebug", std::mem::size_of::<(String, u64, u64)>()),
+        ("ContextQueryNodeEmbeddings", std::mem::size_of::<(u64, Vec<u64>)>()),
+        ("ContextResourceBlobBegin", std::mem::size_of::<(u64)>()),
+        ("ContextResourceBlobAppend", std::mem::size_of::<(u64, String, String)>()),
+        ("ContextResourceBlobCommit", std::mem::size_of::<(u64, String)>()),
+        ("ContextResourceBlobPut", std::mem::size_of::<(u64, String)>()),
+        ("ContextResourceBlobFetch", std::mem::size_of::<(String, u64, u64)>()),
+        ("ContextResourceBlobSweep", std::mem::size_of::<(u64, Vec<u64>, u64)>()),
+        ("ContextSetNodeEmbedding", std::mem::size_of::<(u64, u64, u64, Vec<f32>, u64)>()),
+        ("ContextUpsertNode", std::mem::size_of::<(u64, ContextNode)>()),
+        ("ContextGetNode", std::mem::size_of::<(u64, u64)>()),
+        ("ContextGetNodes", std::mem::size_of::<(u64, Vec<u64>)>()),
+        ("ContextWriteEvent", std::mem::size_of::<(u64, u64, ContextEvent, bool, bool)>()),
+        ("ContextWriteExtractedEvent", std::mem::size_of::<(u64, u64, Box<ContextEvent>, ContextExtractedEventIndexes, bool, bool)>()),
+        ("ContextQueryEvents", std::mem::size_of::<(u64, u64, u64, u64, Option<usize>, Option<usize>, bool, u64, Vec<u32>, Vec<u32>, f32, f32)>()),
+        ("ContextWriteIndexRef", std::mem::size_of::<(u64, String, u64, u64, u64, ContextIndexRef)>()),
+        ("ContextQueryIndex", std::mem::size_of::<(u64, String, u64, u64, u64, u64, Option<usize>)>()),
+        ("ContextQueryIndexIntersection", std::mem::size_of::<(u64, Vec<ContextIndexLookup>, Option<usize>)>()),
+        ("ContextWritePackAudit", std::mem::size_of::<(u64, ContextPackAudit)>()),
+        ("ContextQueryPackAudit", std::mem::size_of::<(u64, u64, u64, u64, Option<usize>)>()),
+        ("ContextMarkSummaryDirty", std::mem::size_of::<(u64, u64, u64, u32, u32)>()),
+        ("ContextQuerySummaryDirty", std::mem::size_of::<(u64, u64, u64, u64, Option<usize>)>()),
+        ("ContextMarkEmbeddingDirty", std::mem::size_of::<(u64, u64, u64, u32, u32, bool)>()),
+        ("ContextQueryEmbeddingDirty", std::mem::size_of::<(u64, u64, u64, u64, Option<usize>)>()),
+        ("ContextUpsertEntity", std::mem::size_of::<(u64, ContextEntity)>()),
+        ("ContextGetEntity", std::mem::size_of::<(u64, u64, u64)>()),
+        ("ContextQueryEntities", std::mem::size_of::<(u64, u64, Vec<u64>, Option<usize>)>()),
+        ("ContextUpsertChildRef", std::mem::size_of::<(u64, ContextChildRef)>()),
+        ("ContextQueryChildren", std::mem::size_of::<(u64, u64, Option<usize>)>()),
+        ("ContextTraverseTree", std::mem::size_of::<(u64, u64, Vec<f32>, Option<u32>, Option<usize>, Option<usize>, Option<usize>, bool)>()),
+        ("ContextUpsertSummary", std::mem::size_of::<(u64, ContextSummary)>()),
+        ("ContextQuerySummaries", std::mem::size_of::<(u64, u64, u32, u64, Option<usize>)>()),
+        ("ContextQuerySummaryVectors", std::mem::size_of::<(u64, Vec<u64>, u32, u64)>()),
+        ("ContextWriteCompressionEvent", std::mem::size_of::<(u64, ContextCompressionEvent)>()),
+        ("ContextQueryCompressionEvents", std::mem::size_of::<(u64, Vec<u64>, u64, u64, Option<usize>)>()),
+        ("ContextCompressEvents", std::mem::size_of::<(u64, u64, u64, u64, u64, Option<usize>, f32, f32)>()),
+        ("ContextQueryNodeContext", std::mem::size_of::<(u64, u64, Option<u32>, u64, u64, u64, Option<usize>)>()),
+        ];
+        rows.sort_by(|a, b| b.1.cmp(&a.1));
+        let whole = std::mem::size_of::<Command>();
+        println!("  Command is {whole} B");
+        println!("  FIELD ContextEvent                    {:>4} B", std::mem::size_of::<ContextEvent>());
+        println!("  FIELD ContextExtractedEventIndexes    {:>4} B", std::mem::size_of::<ContextExtractedEventIndexes>());
+        println!("  FIELD Box<ContextEvent>               {:>4} B", std::mem::size_of::<Box<ContextEvent>>());
+        let mut cumulative = 0usize;
+        for (index, (name, size)) in rows.iter().enumerate().take(12) {
+            cumulative += size;
+            println!("    VARIANT {:>2}. {:<36} {:>4} B", index + 1, name, size);
+        }
+        let _ = cumulative;
+        println!("  boxing the top N drops the enum to the (N+1)th plus a discriminant");
+        assert!(whole > 0);
+    }
+
     /// What one append allocates, and how much of it is the value it carries.
     ///
     /// Allocation count is latency and allocation bytes are memory; both are deterministic, unlike

--- a/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
+++ b/crates/temporalstore-rust/tests/cold_raw_ingestion.rs
@@ -70,7 +70,7 @@ fn cold_raw_ingestion_writes_wal_and_avoids_cache_promotion() {
         command: Command::ContextWriteExtractedEvent {
             tenant_hash: TENANT,
             node_hash: NODE,
-            event: cold_event(9001, START + 30, "cold extracted"),
+            event: Box::new(cold_event(9001, START + 30, "cold extracted")),
             indexes: ContextExtractedEventIndexes {
                 scope_hash: 77,
                 entity_hashes: vec![901, 902],


### PR DESCRIPTION
`Command` is as wide as its widest variant, and every command everywhere paid for it -- a
`StringSet` carrying eight bytes of value occupied 288.

### Sized by the compiler, not by eye

Two rounds of estimating variant widths by hand were wrong, so this asks `size_of`:

| variant | bytes |
|---|---|
| `ContextWriteExtractedEvent` | **288** <- set the width |
| `ContextUpsertNode` | 216 |
| `ContextWriteEvent` | 208 |
| `ControlStateSetAndGetWithOptions` | 144 |

184 of that 288 is a single field, `event: ContextEvent`. Behind a box the variant is about 112 and
the enum drops to the next widest:

**`Command`: 288 B -> 216 B (-25%)**

`Box<T>` serialises exactly as `T`, so nothing on disk or on the wire changes. Allocations an append
are unchanged at 29.0 -- only this variant allocates, and it is not the common path. Ten call
sites, six outside tests.

### Why this was nearly missed

`clippy::large_enum_variant` does not fire on `Command`, and I read that as "no single variant is
the problem". It compares the largest against the **second** largest and wants a 200-byte gap;
here it is 288 against 216. The silence meant "gap below threshold", not "no outlier".

The lint also only answers under `--force-warn`: crate-level allows override a plain `-W`, and a
positive control (`too_many_arguments`, visibly `#[allow]`ed in the source) returning zero is what
revealed the tool had not been observing at all. Under `--force-warn` that control fires 31 times.

`every_command_variant_payload_size` ships with the change so the next person gets the numbers
rather than the inference.

### Note

`Command` is `pub`, so this is a breaking change for an outside caller constructing this variant.
The crate is pre-1.0 and the on-disk and wire encodings are untouched.