### PR TITLE
Measure what the flat item shape would cost the record

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4780,6 +4780,32 @@ mod tests {
         assert!(whole > 0);
     }
 
+    /// What their item SHAPE costs us, since we already have the type.
+    ///
+    /// `WalItem` mirrors their operation-log item field for field -- the field numbers match
+    /// one-for-one and a test pins that. It is one flat message with optional fields, where
+    /// `Command` is a 99-variant sum type as wide as its widest arm. That difference, not any
+    /// individual field, is why our record is bigger than theirs.
+    ///
+    /// If the record carried the flat item the way theirs does, this is what it would occupy.
+    #[test]
+    #[ignore]
+    fn what_their_item_shape_would_cost() {
+        use std::mem::size_of;
+        let wal_item = size_of::<crate::wal_record::WalItem>();
+        let command = size_of::<Option<Command>>();
+        let record = size_of::<WriteAheadLogRecord>();
+        println!("  SHAPE WalItem (their item, our type)  {wal_item:>4} B");
+        println!("  SHAPE Option<Command> (a sum type)    {command:>4} B");
+        println!("  SHAPE record as it stands             {record:>4} B");
+        println!(
+            "  SHAPE record with the flat item instead {:>4} B  (record - command + item)",
+            record - command + wal_item
+        );
+        println!("  their item is ~20 B of scalars plus the message, held by value");
+        assert!(wal_item > 0);
+    }
+
     /// What one append allocates, and how much of it is the value it carries.
     ///
     /// Allocation count is latency and allocation bytes are memory; both are deterministic, unlike


### PR DESCRIPTION
`WalItem` mirrors the operation-log item field for field -- the field numbers match one-for-one and
`field_numbers_match_the_on_disk_log_item_layout` pins it. It is **one flat message with optional
fields**, where `Command` is a **99-variant sum type as wide as its widest arm**. Those are
genuinely different shapes, so it is worth knowing what the difference is worth.

| | bytes |
|---|---|
| `WalItem` (the flat item) | **144** |
| `Option<Command>` (the sum type) | **152** |
| record as it stands | 288 |
| record carrying the flat item instead | **280** |

**Eight bytes.** The payload representation is already at parity; carrying the flat item instead of
the enum would change almost nothing.

### What actually makes the record bigger

Not the width of its types -- what it CARRIES. `metadata` at 72, `staged_pages` at 24 and
`outcomes` at 24: 120 bytes with no counterpart on their item. Staged pages travel in the record on
purpose, so one durability barrier covers the record and the pages it produced; their logger stages
pages separately and commits them with the log. That is a durability decision, not a type choice.

### Why this is a test and not a comment

Because the number is the point, and two earlier readings of this comparison were wrong. Their item
was quoted at "~20 B" while the message it holds **by value** was left out -- which made a 2x
difference look like 7-8x and drove work aimed at a gap that was not there.

Sits alongside `every_command_variant_payload_size`, which prices each variant, and
`what_one_append_allocates`, which measures the metric that does track real memory.