### PR TITLE
A daemon whose engine is restarting is not a dead daemon

### DIFF
--- a/tools/matrixark_rust_proxy_daemon.py
+++ b/tools/matrixark_rust_proxy_daemon.py
@@ -113,6 +113,21 @@ class RustProxyDaemon:
                 proc.kill()
         self._write_log({"event": "proxy_stopped", "returncode": proc.returncode})
 
+    def _health_ok(self) -> bool:
+        """Whether this socket can serve the next request.
+
+        Deliberately lock-free. Taking the daemon lock here would queue the health check
+        behind an in-flight request, and a cold load takes tens of seconds -- long enough
+        that every ping times out and reads as a dead daemon, which is the very thing this
+        answer exists to prevent. A live engine is healthy; no engine is still healthy,
+        because `_ensure_proxy` starts one on the next request. The condition worth
+        reporting is an engine that cannot be started at all.
+        """
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            return True
+        return os.access(str(self.proxy_path), os.X_OK)
+
     def _ensure_proxy(self) -> None:
         proc = self._proc
         if proc is not None and proc.poll() is None:
@@ -236,13 +251,19 @@ class RustProxyDaemon:
                 self._send(file, {"ok": False, "error": f"invalid json: {exc}"})
                 return
             if request.get("op") == "__daemon_health":
-                proc = self._proc
                 self._send(
                     file,
                     {
-                        "ok": bool(proc is not None and proc.poll() is None),
+                        # Health is about whether this socket will serve the next request,
+                        # not about whether an engine happens to be running right now. The
+                        # engine is restarted on demand by `_ensure_proxy`, and callers read
+                        # an unhealthy answer as "no daemon" and start their OWN -- which
+                        # unlinks this socket on bind and leaves them reloading the store per
+                        # invocation. Reporting "dead" while the engine restarts is what
+                        # turns a one-second gap into a spawn storm.
+                        "ok": self._health_ok(),
                         "mode": "rust_proxy_daemon",
-                        "proxy_pid": None if proc is None else proc.pid,
+                        "proxy_pid": None if self._proc is None else self._proc.pid,
                         "socket": str(self.socket_path),
                     },
                 )

--- a/tools/test_matrixark_rust_proxy_socket_deadline.py
+++ b/tools/test_matrixark_rust_proxy_socket_deadline.py
@@ -177,6 +177,36 @@ class DaemonPingTimeoutTest(unittest.TestCase):
         self.assertTrue(answer.get("ok"))
         self.assertGreaterEqual(elapsed_s, 3.0)
 
+    def test_health_survives_an_engine_restart(self) -> None:
+        """A daemon whose engine is momentarily gone can still serve the next request.
+
+        `_ensure_proxy` starts one on demand, so answering "dead" here is what makes every
+        caller start its own proxy -- and a second daemon unlinks this one's socket on bind,
+        leaving the losers reloading the store per call.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            daemon = proxy_daemon.RustProxyDaemon(
+                proxy_path=Path("/bin/cat"),  # executable; never driven in this test
+                socket_path=Path(os.path.join(tmp, "health.sock")),
+                log_path=Path(os.path.join(tmp, "daemon.log")),
+            )
+            daemon._proc = None
+            self.assertTrue(daemon._health_ok(), "no engine yet is still a serving socket")
+
+            # A held lock stands in for a request in flight. Health must not queue behind
+            # it: a cold load takes tens of seconds, and a ping that waits that long is
+            # indistinguishable from a dead daemon.
+            daemon._lock.acquire()
+            try:
+                started = time.monotonic()
+                self.assertTrue(daemon._health_ok())
+                self.assertLess(time.monotonic() - started, 1.0)
+            finally:
+                daemon._lock.release()
+
+            daemon.proxy_path = Path(os.path.join(tmp, "not-a-binary"))
+            self.assertFalse(daemon._health_ok(), "an engine that cannot start is not healthy")
+
     def test_ping_timeout_is_configurable_and_bounded(self) -> None:
         previous = os.environ.get("MATRIXARK_RUST_PROXY_PING_TIMEOUT_MS")
         self.addCleanup(


### PR DESCRIPTION
The daemon answered `__daemon_health` with `ok: false` whenever its engine was momentarily
gone. But the engine is restarted on demand — `_ensure_proxy` starts one on the next request —
so that answer is about a transient, while callers read it as "there is no daemon here" and
respond by starting their own. A second daemon unlinks this one's socket on bind, so the loser
falls back to spawning an engine per invocation and reloading the whole store each time.

Measured on a box where that was happening: two daemons, each holding a full copy of the store,
**669 MB of resident memory where one engine costs 343 MB**.

## What changed

- Health now reports whether this socket will serve the next request. A live engine is healthy;
  no engine is still healthy, because one is started on demand. The condition worth reporting is
  an engine that cannot be started at all, so the fallback is an executable check on the proxy
  path.
- It is deliberately **lock-free**. Taking the daemon lock made the health check queue behind an
  in-flight request, and a cold load takes tens of seconds — long enough that every ping timed
  out and read as a dead daemon, which is the exact failure this answer exists to prevent. The
  first attempt at this fix had that bug; a ping measured 53 ms after it was removed, with no
  engine running.

## Tests

`tools/test_matrixark_rust_proxy_socket_deadline.py` gains one case covering all three states:
no engine yet is healthy; health returns in under a second while the daemon lock is held by a
stand-in for an in-flight request; and an engine that cannot be started is not healthy.

It fails against this branch's base, and the file's other five cases still pass (6/6).
