### PR TITLE
Tell a test that was fixed from one that stopped running

### DIFF
--- a/tools/run_python_suite_ratchet.py
+++ b/tools/run_python_suite_ratchet.py
@@ -32,21 +32,47 @@ from pathlib import Path
 
 BASELINE = Path(__file__).with_name("python_suite_baseline.json")
 NAME = re.compile(r"^(?:FAIL|ERROR): (\S+)")
+# Verbose output names each test before its outcome. With a docstring the outcome lands on the
+# NEXT line ("name (Class)" / "the docstring ... skipped"), so the name is remembered rather than
+# read off the outcome line.
+STARTED = re.compile(r"^(\S+) \(")
 
 
-def failing_names() -> set[str]:
+def suite_result() -> tuple[set[str], set[str]]:
+    """(failing names, skipped names) from one full run.
+
+    Skipped names are collected because a test that stops RUNNING also stops being reported as
+    failing. Without them `baseline - failing` cannot tell "someone fixed it" from "it no longer
+    runs here", and the difference matters: banking the second kind removes a test from the gate
+    permanently while it sits unexercised. Eleven names read as fixed on 2026-09-03 and every one
+    was a skip -- five on a module absent from the repo, six on a native proxy binary CI does not
+    build.
+    """
     result = subprocess.run(
-        [sys.executable, "-m", "unittest", "discover", "-s", ".", "-p", "test_*.py"],
+        [sys.executable, "-m", "unittest", "discover", "-v", "-s", ".", "-p", "test_*.py"],
         cwd=str(Path(__file__).parent),
         capture_output=True,
         text=True,
     )
-    names = set()
+    failing: set[str] = set()
+    skipped: set[str] = set()
+    started = ""
     for line in (result.stderr + result.stdout).splitlines():
-        found = NAME.match(line.strip())
+        stripped = line.strip()
+        found = NAME.match(stripped)
         if found:
-            names.add(found.group(1))
-    return names
+            failing.add(found.group(1))
+            continue
+        begun = STARTED.match(stripped)
+        if begun:
+            started = begun.group(1)
+        if " ... skipped" in stripped and started:
+            skipped.add(started)
+    return failing, skipped
+
+
+def failing_names() -> set[str]:
+    return suite_result()[0]
 
 
 def main() -> int:
@@ -54,7 +80,7 @@ def main() -> int:
     parser.add_argument("--record", action="store_true", help="rewrite the baseline")
     args = parser.parse_args()
 
-    current = failing_names()
+    current, skipped = suite_result()
 
     if args.record:
         BASELINE.write_text(
@@ -82,14 +108,23 @@ def main() -> int:
         # actually showed up.
         print("\n%d new failure(s); confirming on a second run..." % len(added))
         added = sorted(set(added) & failing_names())
-    fixed = sorted(known - current)
+    # A name can leave the failing set two ways, and only one of them is good news.
+    gone = known - current
+    stopped = sorted(gone & skipped)
+    fixed = sorted(gone - skipped)
 
-    print("failing now: %d   baseline: %d" % (len(current), len(known)))
+    print("failing now: %d   baseline: %d   skipped: %d" % (len(current), len(known), len(skipped)))
     if fixed:
         print("\nfixed since the baseline (%d):" % len(fixed))
         for name in fixed[:20]:
             print("   %s" % name)
         print("\n   ...rerun with --record to bank these.")
+    if stopped:
+        print("\nno longer FAILING because they no longer RUN (%d):" % len(stopped))
+        for name in stopped[:20]:
+            print("   %s" % name)
+        print("\n   These are skipped, not fixed. Banking them drops them from the gate while")
+        print("   they sit unexercised -- make them run, or leave them in the baseline.")
     if added:
         print("\nNEW failures (%d):" % len(added))
         for name in added:


### PR DESCRIPTION
The ratchet lists names that left the failing set as **"fixed since the baseline"** and
invites you to bank them with `--record`. A name leaves that set two ways, and only one of
them is good news: someone fixed it, or it stopped running. `failing_names()` reads only
`FAIL:`/`ERROR:` lines, so a test that is skipped, deleted or renamed simply vanishes from
the current set and is reported as a fix.

**On main today, all eleven of those names are skips.**

| how many | why they stopped running |
| --- | --- |
| 5 | a module raises `SkipTest` at import because a report module is absent from this repository; the four that import it inherit the skip |
| 6 | they drive an agent hook end to end against a native proxy binary — and this job runs `actions/setup-python` and the suite, never a build, so **these have never run in CI at all** |

Banking them would have removed eleven tests from the gate while they sit unexercised,
which is the opposite of what that line is for. I nearly did it, following the script's own
suggestion — which is the argument for the change.

## What it does now

```
failing now: 115   baseline: 121   skipped: 14

fixed since the baseline (3):
   ...rerun with --record to bank these.

no longer FAILING because they no longer RUN (11):
   ...
   These are skipped, not fixed. Banking them drops them from the gate while
   they sit unexercised -- make them run, or leave them in the baseline.
```

Verbose output is needed to see skips at all. The test name is remembered from the line that
announces the test rather than read off the outcome line, because when a test has a docstring
unittest puts the outcome on the *following* line.

## Checked against unittest's own accounting, not by eye

The run reports `skipped: 14` for a suite whose unittest summary independently reports
`skipped=14` — so the parser is neither inventing nor missing skips. The eleven move from the
fixed list to the new one, while three genuinely fixed names stay where they were. (Those
three are local-only: this box has torch installed.)

## Deliberately not done here

Making those eleven actually run. Building the proxy would put a Rust build in front of every
python run, and the absent module is a question about what this repository carries. Both are
worth answering; neither should be answered by quietly dropping the tests from the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)