### PR TITLE
The strip says when the backend is down

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1801,6 +1801,15 @@ EVENT_STREAM_MAX_S = 600.0
 # Everything in a frame used to be built inside each connection's own loop, so a second browser tab
 # cost a second copy of all of it, exactly linear to sixteen viewers when measured. What a frame
 # carries is one deployment's state; the number of people looking at it is not part of the answer.
+# How often the frame re-probes the datanode. Slower than the tick on purpose: this is the one
+# part of a frame that costs an outbound connection, and a backend that just went down is worth
+# knowing about within half a minute rather than within two seconds.
+DATANODE_REFRESH_S = 30.0
+
+_LIVE_DATANODE: Optional[tuple] = None
+# (event loop, task) while a probe is running; everyone else waits on it.
+_LIVE_DATANODE_INFLIGHT: Optional[tuple] = None
+
 _LIVE_SHARED: Optional[Json] = None
 _LIVE_SHARED_AT = 0.0
 _LIVE_EMBEDDING: dict = {}
@@ -1813,6 +1822,9 @@ def _reset_live_cache() -> None:
     global _LIVE_SHARED, _LIVE_SHARED_AT
     _LIVE_SHARED = None
     _LIVE_SHARED_AT = 0.0
+    global _LIVE_DATANODE, _LIVE_DATANODE_INFLIGHT
+    _LIVE_DATANODE = None
+    _LIVE_DATANODE_INFLIGHT = None
     _LIVE_EMBEDDING.clear()
     _LIVE_EMBEDDING_INFLIGHT.clear()
     _LIVE_SIGNATURE.clear()
@@ -1885,6 +1897,51 @@ def _frame_signature(identity: tuple, frame: Json) -> bytes:
     return signature
 
 
+async def _datanode_for_frame(cfg: GatewayConfig) -> Optional[str]:
+    """The datanode's state for the frame: shared by every viewer, refreshed slowly.
+
+    Deployment-wide, so it is cached globally rather than per identity -- whether the backend is up
+    is the same answer for everyone, and it carries nothing about who asked.
+
+    Not read from the readiness route's recorded value: that only moves when something calls
+    /v1/readyz, so a deployment nobody probes would show a stale answer or none at all, and the
+    strip should not depend on somebody else's health check being configured.
+    """
+    global _LIVE_DATANODE, _LIVE_DATANODE_INFLIGHT
+    if _LIVE_DATANODE is not None and (time.time() - _LIVE_DATANODE[1]) < DATANODE_REFRESH_S:
+        return _LIVE_DATANODE[0]
+
+    # One probe in flight for the whole deployment. Caching the result alone leaves the cold start
+    # uncollapsed -- viewers arrive together, find nothing cached, and each opens its own
+    # connection to the same backend. That is the same stampede the embedding read has, and it is
+    # worse here because this one is a network probe rather than a local read.
+    loop = asyncio.get_event_loop()
+    pending = _LIVE_DATANODE_INFLIGHT
+    if pending is not None and pending[0] is loop and not pending[1].done():
+        return await asyncio.shield(pending[1])
+
+    async def _probe_and_cache() -> Optional[str]:
+        global _LIVE_DATANODE
+        try:
+            state = await asyncio.to_thread(_probe_datanode, cfg)
+        except Exception:
+            # The frame is not the place to fail. Absent reads as "not known", which is true.
+            return None if _LIVE_DATANODE is None else _LIVE_DATANODE[0]
+        _LIVE_DATANODE = (state, time.time())
+        # Keeps the gauge fresh too, so the series does not depend on an orchestrator polling
+        # readiness.
+        _gwmetrics.METRICS.note_datanode(state)
+        return state
+
+    task = loop.create_task(_probe_and_cache())
+    _LIVE_DATANODE_INFLIGHT = (loop, task)
+    try:
+        return await asyncio.shield(task)
+    finally:
+        if _LIVE_DATANODE_INFLIGHT is not None and _LIVE_DATANODE_INFLIGHT[1] is task                 and task.done():
+            _LIVE_DATANODE_INFLIGHT = None
+
+
 async def _embedding_for(server: Any, cfg: GatewayConfig, key: Optional[str],
                          tenant: Optional[str], account: Optional[str]) -> Optional[Json]:
     """The embedding backlog for ONE identity, reused by that identity's other viewers.
@@ -1929,7 +1986,8 @@ async def _embedding_for(server: Any, cfg: GatewayConfig, key: Optional[str],
 
 async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
                        tenant: Optional[str], account: Optional[str],
-                       embedding: Optional[Json]) -> Json:
+                       embedding: Optional[Json],
+                       datanode: Optional[str] = None) -> Json:
     """One frame of live state.
 
     The deployment-wide parts come from `_shared_live_parts`, which builds them once per tick for
@@ -1943,6 +2001,9 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
         "imports": shared["imports"],
         "warnings": shared["warnings"],
         "embedding": embedding,
+        # Absent when nothing has looked yet. "not known" and "unreachable" are different answers
+        # and the strip renders them differently.
+        "datanode": datanode,
     }
 
 
@@ -2020,7 +2081,9 @@ async def _event_stream(server: Any, cfg: GatewayConfig, scope: Json, receive: C
             # Per identity rather than per connection: two tabs open on the same key asked the
             # backend the same question twice on every refresh.
             embedding = await _embedding_for(server, cfg, key, tenant, account)
-            frame = await _event_frame(server, cfg, key, tenant, account, embedding)
+            datanode = await _datanode_for_frame(cfg)
+            frame = await _event_frame(server, cfg, key, tenant, account, embedding,
+                                       datanode=datanode)
             signature = _frame_signature((key, tenant, account), frame)
             if signature == last_signature:
                 # Nothing has changed since the last frame, so there is nothing to say. The comment

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -137,7 +137,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -828,7 +828,8 @@
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -900,6 +901,20 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -422,7 +422,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -591,7 +591,8 @@
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -663,6 +664,20 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2986,6 +2986,7 @@ function liveStream(options) {
 
   /* ---------- diagnostics ---------- */
   var lastReport = null;
+  var lastFrame = null;
 
   function compactConfig(config) {
     if (!config) { return null; }
@@ -3018,14 +3019,26 @@ function liveStream(options) {
       fetch("/v1/admin/config", { headers: auth() })
         .then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
       fetch("/v1/metrics").then(function (r) { return r.ok ? r.text() : ""; })
-        .catch(function () { return ""; })
+        .catch(function () { return ""; }),
+      /* Readiness answers 503 when the backend cannot serve, so a non-2xx here is the answer rather
+         than a failure to collect -- the status is recorded next to the body. */
+      fetch("/v1/readyz").then(function (r) {
+        return r.json().then(function (body) { return { status: r.status, body: body }; });
+      }).catch(function () { return null; })
     ]).then(function (parts) {
+      var traffic = (lastFrame || {}).traffic || {};
       return JSON.stringify({
         collected_at: new Date().toISOString(),
         origin: location.origin,
         overview: lastReport,
         config: compactConfig(parts[0]),
-        metrics: parts[1]
+        metrics: parts[1],
+        readiness: parts[2],
+        /* The counters in `metrics` say how many requests failed. This says WHEN, which is the
+           difference between an incident and a footnote -- and it exists only on the live frame, so
+           a bundle assembled from endpoints alone cannot carry it. */
+        recent_failures: traffic.recent_failures || null,
+        datanode: (lastFrame || {}).datanode || null
       }, null, 2);
     });
   }
@@ -3095,6 +3108,10 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* Kept for the diagnostics bundle. The failure timeline exists only on the frame, and
+           it answers "when did this start" -- which is the question a bundle is sent to
+           answer. */
+        lastFrame = frame;
         if (window.__matrixarkLiveFrame) { window.__matrixarkLiveFrame(frame); }
         renderImports(frame.imports);
         if (frame.embedding) { renderEncoding(frame.embedding); }

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -296,7 +296,8 @@ NAV_JS = r'''<script>
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -368,6 +369,20 @@ NAV_JS = r'''<script>
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */
@@ -459,7 +474,7 @@ LIVE_STRIP = """
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>"""
 

--- a/tools/portal/bundle_harness.js
+++ b/tools/portal/bundle_harness.js
@@ -1,0 +1,159 @@
+/* Run the overview page, give it a frame, press copy, and read the bundle it assembled.
+ *
+ * The bundle is built in a closure from a live frame plus three fetches. Whether a field reaches
+ * it cannot be read off the source: the frame half only arrives if the page's own stream delivers,
+ * and a field referencing something the page never stored would come out null while the source
+ * looks correct.
+ *
+ * Usage: node bundle_harness.js <overview_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const FRAME = {
+  ts: 1, warnings: 0, imports: {}, embedding: { total: 3 },
+  datanode: "unreachable",
+  traffic: {
+    total_requests: 5, total_errors: 2, in_flight: 0,
+    routes: { "/v1/retrieve": { requests: 5, errors: 2, avg_ms: 9, p95_ms: 25,
+                                statuses: { "200": 3, "503": 2 } } },
+    recent_failures: [
+      { at: 1730000000, route: "/v1/retrieve", method: "POST", status: 503 },
+      { at: 1729999990, route: "/v1/retrieve", method: "POST", status: 503 }
+    ]
+  }
+};
+const SSE = "event: status\ndata: " + JSON.stringify(FRAME) + "\n\n";
+
+const clicks = {};
+let copied = null;
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, innerHTML: "", textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(type, fn) { if (type === "click" && id) { clicks[id] = fn; } },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+function json(body, status) {
+  return Promise.resolve({
+    ok: (status || 200) < 400, status: status || 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  });
+}
+
+function streaming() {
+  let sent = false;
+  return Promise.resolve({
+    ok: true, status: 200,
+    body: { getReader: () => ({ read: () => {
+      if (sent) { return new Promise(() => {}); }
+      sent = true;
+      return new Promise((r) => setTimeout(
+        () => r({ done: false, value: Buffer.from(SSE, "utf8") }), 5));
+    } }) },
+    json: () => Promise.resolve({}), text: () => Promise.resolve("")
+  });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: { clipboard: { writeText(text) { copied = text; } } },
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/admin/events") >= 0) { return streaming(); }
+    if (u.indexOf("/v1/readyz") >= 0) {
+      return json({ ready: false, datanode: "unreachable" }, 503);
+    }
+    if (u.indexOf("/v1/metrics") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               text: () => Promise.resolve("# HELP x\nx 1\n"),
+                               json: () => Promise.resolve({}) });
+    }
+    if (u.indexOf("/v1/admin/overview") >= 0) { return json({ checks: [], counts: {} }); }
+    if (u.indexOf("/v1/admin/config") >= 0) { return json({ settings: {} }); }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+setTimeout(function () {
+  ok("the copy button is wired", typeof clicks.copyDiag === "function");
+  if (typeof clicks.copyDiag !== "function") {
+    console.log("FAILED " + failures); process.exit(1);
+  }
+  clicks.copyDiag();
+
+  setTimeout(function () {
+    ok("a bundle was produced", typeof copied === "string" && copied.length > 0,
+       "nothing reached the clipboard; the bundle refused to assemble");
+    let parsed = null;
+    try { parsed = JSON.parse(copied); } catch (e) { /* reported below */ }
+    ok("it is valid JSON", parsed !== null, String(copied).slice(0, 120));
+    if (!parsed) { console.log("FAILED " + failures); process.exit(1); }
+
+    ok("it still carries what it always did",
+       "overview" in parsed && "config" in parsed && "metrics" in parsed,
+       Object.keys(parsed).join(", "));
+    ok("it carries the readiness verdict", parsed.readiness && parsed.readiness.status === 503,
+       JSON.stringify(parsed.readiness));
+    ok("a 503 from readiness is recorded, not dropped as a failed collection",
+       parsed.readiness && parsed.readiness.body && parsed.readiness.body.ready === false,
+       JSON.stringify(parsed.readiness));
+    ok("it carries the failure timeline",
+       Array.isArray(parsed.recent_failures) && parsed.recent_failures.length === 2,
+       JSON.stringify(parsed.recent_failures));
+    ok("the timeline says when, not just how many",
+       Array.isArray(parsed.recent_failures) && parsed.recent_failures[0].at > 0,
+       JSON.stringify(parsed.recent_failures && parsed.recent_failures[0]));
+    ok("it carries the backend state", parsed.datanode === "unreachable",
+       JSON.stringify(parsed.datanode));
+
+    console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+    process.exit(failures === 0 ? 0 : 1);
+  }, 40);
+}, 60);

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -422,7 +422,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -758,7 +758,8 @@
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -830,6 +831,20 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/datanode_segment_harness.js
+++ b/tools/portal/datanode_segment_harness.js
@@ -1,0 +1,111 @@
+/* Feed the shared strip a frame and read what the datanode segment did.
+ *
+ * The strip's render() is wrapped by its caller in a try/catch that ignores errors, so a segment
+ * that throws is a segment that silently does nothing -- and the block defines only n, show and
+ * plural, so reaching for any other helper fails exactly that way. Reading the source cannot tell
+ * a working segment from one that throws on the first frame.
+ *
+ * Usage: node datanode_segment_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: true, innerHTML: "", textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: false, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: () => new Promise(() => {})
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw at load: " + e.message); failures += 1; }
+});
+
+ok("the strip exposes a way to feed it a frame",
+   typeof win.__matrixarkLiveFrame === "function");
+
+function feed(datanode) {
+  const node = el("liveNode");
+  node.hidden = true;
+  node.innerHTML = "";
+  const frame = { ts: 1, traffic: { total_requests: 1 }, imports: {}, warnings: 0,
+                  embedding: { total: 1 } };
+  if (datanode !== undefined) { frame.datanode = datanode; }
+  win.__matrixarkLiveFrame(frame);
+  return node;
+}
+
+let seg = feed("unreachable");
+ok("an unreachable datanode is shown", !seg.hidden && /unreachable/.test(seg.innerHTML),
+   JSON.stringify({ hidden: seg.hidden, html: seg.innerHTML }));
+
+seg = feed("erroring");
+ok("an erroring datanode is shown", !seg.hidden && /erroring/.test(seg.innerHTML),
+   JSON.stringify({ hidden: seg.hidden, html: seg.innerHTML }));
+
+seg = feed("ok");
+ok("a healthy datanode takes no space", seg.hidden,
+   JSON.stringify({ hidden: seg.hidden, html: seg.innerHTML }));
+
+seg = feed(undefined);
+ok("nothing is claimed before anything has looked", seg.hidden,
+   "absent is not the same as reachable: " + JSON.stringify(seg.innerHTML));
+
+seg = feed("<img src=x onerror=alert(1)>");
+ok("an unexpected value renders nothing at all",
+   seg.hidden && seg.innerHTML.indexOf("<img") < 0,
+   "a value outside the known states reached the page: " + JSON.stringify(seg.innerHTML));
+
+/* The rest of the strip must still work while the segment does its job. */
+seg = feed("unreachable");
+const req = el("liveReq");
+ok("the other segments still render", /request/.test(req.innerHTML),
+   "render threw partway: " + JSON.stringify(req.innerHTML));
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -422,7 +422,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -1820,7 +1820,8 @@
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -1892,6 +1893,20 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -175,7 +175,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -718,7 +718,8 @@
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -790,6 +791,20 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -422,7 +422,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -869,7 +869,8 @@ function liveStream(options) {
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -941,6 +942,20 @@ function liveStream(options) {
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -691,6 +691,7 @@ function liveStream(options) {
 
   /* ---------- diagnostics ---------- */
   var lastReport = null;
+  var lastFrame = null;
 
   function compactConfig(config) {
     if (!config) { return null; }
@@ -723,14 +724,26 @@ function liveStream(options) {
       fetch("/v1/admin/config", { headers: auth() })
         .then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
       fetch("/v1/metrics").then(function (r) { return r.ok ? r.text() : ""; })
-        .catch(function () { return ""; })
+        .catch(function () { return ""; }),
+      /* Readiness answers 503 when the backend cannot serve, so a non-2xx here is the answer rather
+         than a failure to collect -- the status is recorded next to the body. */
+      fetch("/v1/readyz").then(function (r) {
+        return r.json().then(function (body) { return { status: r.status, body: body }; });
+      }).catch(function () { return null; })
     ]).then(function (parts) {
+      var traffic = (lastFrame || {}).traffic || {};
       return JSON.stringify({
         collected_at: new Date().toISOString(),
         origin: location.origin,
         overview: lastReport,
         config: compactConfig(parts[0]),
-        metrics: parts[1]
+        metrics: parts[1],
+        readiness: parts[2],
+        /* The counters in `metrics` say how many requests failed. This says WHEN, which is the
+           difference between an incident and a footnote -- and it exists only on the live frame, so
+           a bundle assembled from endpoints alone cannot carry it. */
+        recent_failures: traffic.recent_failures || null,
+        datanode: (lastFrame || {}).datanode || null
       }, null, 2);
     });
   }
@@ -800,6 +813,10 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* Kept for the diagnostics bundle. The failure timeline exists only on the frame, and
+           it answers "when did this start" -- which is the question a bundle is sent to
+           answer. */
+        lastFrame = frame;
         if (window.__matrixarkLiveFrame) { window.__matrixarkLiveFrame(frame); }
         renderImports(frame.imports);
         if (frame.embedding) { renderEncoding(frame.embedding); }

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -422,7 +422,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -2303,7 +2303,8 @@ function liveStream(options) {
     enc: document.getElementById("liveEnc"),
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
-    warn: document.getElementById("liveWarn")
+    warn: document.getElementById("liveWarn"),
+    node: document.getElementById("liveNode")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -2375,6 +2376,20 @@ function liveStream(options) {
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
+       says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
+       which is not the same as reachable, so that shows nothing either.
+
+       Matched against the two states rather than escaped and interpolated: this block has no esc()
+       (it defines n, show and plural and nothing else), so calling one would have thrown inside
+       render, which the caller wraps in a catch that ignores -- failing in total silence. A closed
+       set of expected values is also stricter than escaping: a server sending something
+       unexpected renders nothing rather than rendering it safely. */
+    show(seg.node,
+      frame.datanode === "unreachable" ? "datanode <b>unreachable</b>"
+        : (frame.datanode === "erroring" ? "datanode <b>erroring</b>" : null),
+      "warn");
 
     watchers.forEach(function (callback) {
       /* One panel throwing must not stop the others, or the strip, from updating. */

--- a/tools/test_matrixark_strip_says_when_the_backend_is_down.py
+++ b/tools/test_matrixark_strip_says_when_the_backend_is_down.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The strip says when the backend is down.
+
+Readiness answers 503 when the datanode cannot serve, and there is a metric for it. Both are for
+machines. Someone looking at the portal -- the surface a customer opens when something seems wrong
+-- had no way to see it: the strip showed requests, imports, encoding and warnings, and stayed
+reassuring while every write was failing.
+
+Two halves, and they need different tests. Whether the GATEWAY puts the state on the frame is
+Python; whether the STRIP draws it is JavaScript, and the strip's caller wraps render() in a catch
+that ignores, so a segment that throws does nothing at all and looks fine in a diff.
+
+The probe is deliberately not the one readiness records. That value only moves when something calls
+/v1/readyz, so a deployment nobody probes would show a stale answer or none -- the strip should not
+depend on somebody else's health check being configured.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+
+def _helpers():
+    """Imported per test, not at module import: importing a test module from a test module
+    reorders `unittest discover` and can fail tests it has nothing to do with."""
+    from test_matrixark_v1_gateway import _cfg, _factory_for, _FakeResponse, _FakeServer
+    return _cfg, _factory_for, _FakeResponse, _FakeServer
+
+
+def _refusing(_cfg_unused):
+    raise OSError("connection refused")
+
+
+class TheFrameCarriesTheDatanodeStateTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.cfg, self.factory_for, self.FakeResponse, self.FakeServer = _helpers()
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def _frame_for(self, factory):
+        cfg = self.cfg(blob_connection_factory=factory)
+        state = asyncio.run(gw._datanode_for_frame(cfg))
+        return asyncio.run(gw._event_frame(self.FakeServer(), cfg, "k", "acme", None, None,
+                                           datanode=state))
+
+    def test_a_healthy_datanode_is_reported_as_ok(self) -> None:
+        self.assertEqual("ok", self._frame_for(self.factory_for(self.FakeResponse(200)))["datanode"])
+
+    def test_an_erroring_datanode_is_reported(self) -> None:
+        frame = self._frame_for(self.factory_for(self.FakeResponse(503)))
+        self.assertEqual("erroring", frame["datanode"])
+
+    def test_an_unreachable_datanode_is_reported(self) -> None:
+        self.assertEqual("unreachable", self._frame_for(_refusing)["datanode"])
+
+    def test_the_field_is_actually_on_the_frame(self) -> None:
+        """The harness feeds frames directly, so only this can catch the field being dropped."""
+        frame = self._frame_for(self.factory_for(self.FakeResponse(200)))
+        self.assertIn("datanode", frame)
+
+    def test_it_is_probed_once_and_shared(self) -> None:
+        """Deployment-wide state, so eight open tabs must not mean eight probes per tick."""
+        calls = {"n": 0}
+        real = gw._probe_datanode
+
+        def counted(cfg):
+            calls["n"] += 1
+            return real(cfg)
+
+        gw._probe_datanode = counted
+        self.addCleanup(setattr, gw, "_probe_datanode", real)
+        gw._reset_live_cache()
+        cfg = self.cfg(blob_connection_factory=self.factory_for(self.FakeResponse(200)))
+
+        async def eight_viewers():
+            return await asyncio.gather(*[gw._datanode_for_frame(cfg) for _ in range(8)])
+
+        asyncio.run(eight_viewers())
+        self.assertEqual(1, calls["n"],
+                         "eight viewers caused %d probes of one deployment's backend" % calls["n"])
+
+    def test_the_refresh_is_slower_than_the_tick(self) -> None:
+        """It is the one part of a frame that costs an outbound connection."""
+        self.assertGreater(gw.DATANODE_REFRESH_S, gw.EVENT_TICK_S * 5)
+
+    def test_probing_keeps_the_metric_fresh(self) -> None:
+        """So the series does not depend on an orchestrator polling readiness."""
+        import matrixark_gateway_metrics as gwm
+        before = getattr(gwm.METRICS, "_datanode", None)
+        self.addCleanup(setattr, gwm.METRICS, "_datanode", before)
+        gw._reset_live_cache()
+        asyncio.run(gw._datanode_for_frame(self.cfg(blob_connection_factory=_refusing)))
+        got = [l for l in gwm.METRICS.prometheus_lines()
+               if l.startswith("matrixark_gateway_datanode_reachable")]
+        self.assertEqual(["matrixark_gateway_datanode_reachable 0"], got)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the strip JS cannot be run")
+class TheStripDrawsItTest(unittest.TestCase):
+    """render() is wrapped by its caller in a catch that ignores, so a throwing segment is silent."""
+
+    def _run(self, page):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "datanode_segment_harness.js"),
+             os.path.join(PORTAL, page)],
+            capture_output=True, text=True, timeout=180)
+
+    def test_the_segment_works_on_a_generated_page(self) -> None:
+        proc = self._run("overview_portal.html")
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_segment_works_on_a_hand_kept_page(self) -> None:
+        """The strip is shared, so a change to it has to land on both kinds of page."""
+        proc = self._run("api_key_portal.html")
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_healthy_backend_takes_no_space(self) -> None:
+        out = self._run("overview_portal.html").stdout
+        self.assertIn("ok   a healthy datanode takes no space", out, out)
+
+    def test_an_unexpected_value_is_not_rendered(self) -> None:
+        """A closed set of known states, not escaping: this block has no esc() to reach for."""
+        out = self._run("overview_portal.html").stdout
+        self.assertIn("ok   an unexpected value renders nothing at all", out, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_strip_says_when_the_backend_is_down.py
+++ b/tools/test_matrixark_strip_says_when_the_backend_is_down.py
@@ -137,5 +137,47 @@ class TheStripDrawsItTest(unittest.TestCase):
         self.assertIn("ok   an unexpected value renders nothing at all", out, out)
 
 
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheDiagnosticsBundleCarriesItTest(unittest.TestCase):
+    """What a customer sends to support should include what was wrong.
+
+    The bundle already carried the overview, the config and the whole /v1/metrics text, so the
+    counters were in it -- how many requests failed. It could not say WHEN, because the failure
+    timeline exists only on the live frame and a bundle assembled from endpoints alone cannot
+    reach it. Nor did it record the readiness verdict, which is the single clearest statement of
+    whether the deployment could serve at all.
+
+    Run rather than read: the bundle is built in a closure from a frame plus three fetches, and a
+    field referencing something the page never stored comes out null while the source looks right.
+    """
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "bundle_harness.js"),
+             os.path.join(PORTAL, "overview_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_the_bundle_assembles_and_carries_the_new_evidence(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_it_still_carries_what_it_always_did(self) -> None:
+        """Adding to a support bundle must not quietly drop what was already in it."""
+        out = self._run().stdout
+        self.assertIn("ok   it still carries what it always did", out, out)
+
+    def test_a_failing_readiness_is_recorded_rather_than_dropped(self) -> None:
+        """Readiness answers 503 when the backend is down -- that is the answer, not a failure
+        to collect. A bundle that omits the one thing that was wrong is worse than one that says
+        it could not look."""
+        out = self._run().stdout
+        self.assertIn("ok   a 503 from readiness is recorded, not dropped as a failed collection",
+                      out, out)
+
+    def test_the_timeline_says_when(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the timeline says when, not just how many", out, out)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Readiness answers 503 when the datanode cannot serve, and there is a metric for it. Both are for machines. Someone looking at the **portal** — the surface a customer opens when something seems wrong — had no way to see it: the strip showed requests, imports, encoding and warnings and stayed reassuring while every write was failing.

The probe rides the live frame on a 30s cadence rather than the 2s tick, because it is the one part of a frame that costs an outbound connection. It is shared across viewers and **single-flighted**: caching the result alone left the cold start uncollapsed, so eight tabs opening together each opened their own connection to the same backend. A test drives eight concurrent viewers and requires exactly one probe — **it failed when written**, which is how the stampede was found.

It deliberately does not reuse the value readiness records: that only moves when something calls `/v1/readyz`, so a deployment nobody probes would show a stale answer or none. Probing here keeps the gauge fresh for the same reason.

The segment appears only when the datanode is **not** ok, as the warnings segment already behaves. Absent shows nothing either — nothing having looked yet is not the same as reachable.

**The state is matched against known values rather than escaped.** This block defines `n`, `show` and `plural` and no `esc`, so calling one would have thrown inside `render` — which the caller wraps in a catch that ignores, failing in total silence. I nearly shipped exactly that; checking which helpers the block defines is what stopped it.

Two harnesses, because the halves fail differently: whether the gateway puts the state on the frame is Python; whether the strip draws it can only be seen by running it — against a generated page *and* a hand-maintained one, since the strip is shared.