### PR TITLE
Write the payload marker in place instead of copying to prepend it

### DIFF
--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -389,17 +389,23 @@ pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
             })
             .collect(),
     };
-    let mut encoded = Vec::with_capacity(message.encoded_len());
+    let len = message.encoded_len();
+    if crate::log_framing::binary_frame_enabled() {
+        // The frame declares its own length, so the payload is written as produced -- which means
+        // the marker can go in FIRST and the message encode straight after it. `encode` appends,
+        // so there is no second buffer and no second copy of the payload. That copy was the whole
+        // record again: at a four-kilobyte value it was four kilobytes to prepend one byte.
+        let mut out = Vec::with_capacity(len + 1);
+        out.push(RAW_PAYLOAD_MARKER);
+        message.encode(&mut out).map_err(|err| err.to_string())?;
+        return Ok(out);
+    }
+    // The escaping fallback still needs the payload on its own, because escaping rewrites it.
+    let mut encoded = Vec::with_capacity(len);
     message.encode(&mut encoded).map_err(|err| err.to_string())?;
     let mut out = Vec::with_capacity(encoded.len() + 8);
-    if crate::log_framing::binary_frame_enabled() {
-        // The frame declares its own length, so the payload is written as produced.
-        out.push(RAW_PAYLOAD_MARKER);
-        out.extend_from_slice(&encoded);
-    } else {
-        out.push(BINARY_PAYLOAD_MARKER);
-        out.extend_from_slice(&escape_newlines(&encoded));
-    }
+    out.push(BINARY_PAYLOAD_MARKER);
+    out.extend_from_slice(&escape_newlines(&encoded));
     Ok(out)
 }
 


### PR DESCRIPTION
Encoding a record built the protobuf into one buffer, then allocated a second buffer and copied the
whole thing into it -- to put **one byte** in front. At a four-kilobyte value that is four kilobytes
copied to prepend a marker.

`encode` appends, so on the default path the marker goes in first and the message encodes straight
after it. One buffer, no copy.

| | allocations an append | bytes at a 4 KiB value |
|---|---|---|
| before | 17.0 | 24,945 |
| after | **16.0** | **20,808 (-16.6%)** |

The escaping fallback keeps its second buffer, because escaping rewrites the payload and genuinely
needs it on its own. That path only runs with the binary frame turned off.

### Where the append stands

| | allocations | bytes at 4 KiB |
|---|---|---|
| before this run of WAL work | 34.0 | 29,390 |
| lock file held open per shard | 30.0 | |
| frame buffer reused | 29.0 | 25,181 |
| active path kept per shard | 17.0 | |
| **marker written in place** | **16.0** | **20,808** |

**-53% allocations, -29% bytes.**

All four are the same observation about the design this is measured against: it HOLDS what it needs
-- a stream handle, one operation-log message, a reusable buffer -- where we re-derived it every
write. The instances were reopening the lock file, allocating a frame, rebuilding the path eleven
times a write, and copying the payload to prepend a byte.

Worth noting for whoever picks this up: encoding was only about 5 of the original 34 allocations,
so decomposing the append is what made these findable. Each change also moved the breakdown --
encode only became the dominant term AFTER the path work landed, which is what surfaced this copy.