### PR TITLE
Drop the buckets a write emptied by name, not by walking every bucket

### DIFF
--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1667,11 +1667,32 @@ pub(super) fn sync_bucket_index_object_pages(
         }
     }
 
-    if removed_any || dirty {
-        shard
-            .bucket_index
-            .bucket_map
-            .retain(|_, bucket| !bucket.page_index.is_empty() || !bucket.object_index.is_empty());
+    // Drop buckets this call emptied -- BY NAME, not by walking the map.
+    //
+    // This was `bucket_map.retain(..)`, which is O(buckets) and ran on every write because
+    // `dirty` is true for one. At the default routing-slot range every key gets its own slot, so
+    // the map holds one bucket per record and the walk is O(corpus) per command: measured at
+    // 94.2% of the datanode's self time under a message-ingest profile, and an 8-hour run
+    // degraded from 7 ms to 105 ms per message as `corpus^0.96` -- linear per write, quadratic
+    // overall.
+    //
+    // Only a bucket whose `page_index` actually shrank above can have newly become empty, and
+    // that set is `touched_buckets`. Buckets the publish loop inserted into gained a page, and
+    // buckets this call never opened are unchanged. So the same buckets are removed, without
+    // reading the ones that cannot have changed.
+    if removed_any {
+        for routing_bucket in &touched_buckets {
+            let now_empty = shard
+                .bucket_index
+                .bucket_map
+                .get(routing_bucket)
+                .is_some_and(|bucket| {
+                    bucket.page_index.is_empty() && bucket.object_index.is_empty()
+                });
+            if now_empty {
+                shard.bucket_index.bucket_map.remove(routing_bucket);
+            }
+        }
     }
     if lookup_needs_establishing {
         shard.bucket_index.rebuild_object_page_lookup();

--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -7924,3 +7924,132 @@ fn what_a_thousand_records_hides() {
 
     assert!(rows.iter().all(|r| r.1 > 0.0), "measured nothing");
 }
+
+/// Dropping emptied buckets must not walk every bucket.
+///
+/// `sync_bucket_index_object_pages` ended with `bucket_map.retain(..)` to drop buckets it had
+/// emptied. `dirty` is true for a write, so that ran on every one, and at the default routing-slot
+/// range the map holds a bucket per record -- O(corpus) per command. Profiling a degraded node put
+/// 94.2% of self time in that one retain, and an 8-hour run went 7 ms -> 105 ms per message.
+///
+/// Two properties, and the test needs BOTH: the cost must not grow with the store, and the
+/// emptied buckets must still be gone. Either alone is satisfiable by a wrong change -- never
+/// dropping anything is flat, and walking everything is correct.
+///
+///   cargo test -p temporalstore-rust --lib emptied_buckets_are_dropped_without_walking_the_map -- --nocapture
+#[test]
+fn emptied_buckets_are_dropped_without_walking_the_map() {
+    use crate::types::ContextNode;
+
+    fn node(nid: u64) -> Box<ContextNode> {
+        Box::new(ContextNode {
+            node_hash: nid, parent_hash: 0, kind: 1,
+            canonical_name: format!("session/turn/{nid}"),
+            l0: "body".to_string(), status: 0,
+            last_event_time_ms: 1_780_000_000_000,
+            l1_ref: String::new(), raw_metadata_ref: String::new(),
+            vector: Vec::new(), embedding_model_hash: 0, embedding_updated_at_ms: 0,
+            summary_vector: Vec::new(), summary_vector_valid_from_ms: 0,
+            summary_vector_model_hash: 0,
+        })
+    }
+
+    // --- correctness: a bucket emptied by a delete must not survive -----------------------
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        4 * 1024 * 1024, dir.path().join("cache"),
+        dir.path().join("pages"), dir.path().join("indexes"));
+    engine.load_shard(1);
+    for index in 0..200u64 {
+        let r = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::StringSet { key: format!("drop-{index}"), value: vec![b'v'; 64] },
+        });
+        assert!(r.status.ok, "write: {:?}", r.status);
+    }
+    let before = {
+        let shards = engine.shards.read().expect("lock");
+        shards.get(&1).expect("shard").bucket_index.bucket_map.len()
+    };
+    for index in 0..200u64 {
+        let r = engine.execute(ExecuteRequest {
+            shard_id: 1, command: Command::StringDelete { key: format!("drop-{index}") } });
+        assert!(r.status.ok, "delete: {:?}", r.status);
+    }
+    let (after, empties) = {
+        let shards = engine.shards.read().expect("lock");
+        let map = &shards.get(&1).expect("shard").bucket_index.bucket_map;
+        let empties = map
+            .values()
+            .filter(|b| b.page_index.is_empty() && b.object_index.is_empty())
+            .count();
+        (map.len(), empties)
+    };
+    println!();
+    println!("  buckets after 200 writes: {before}, after deleting all: {after} ({empties} empty)");
+    assert!(before > 0, "the writes should have created buckets");
+    assert_eq!(
+        empties, 0,
+        "an emptied bucket survived in bucket_map: {empties} of {after} hold nothing"
+    );
+
+    // --- the shape: per-write cost must not grow with the store --------------------------
+    // The batch a real message sends. An upsert ALONE does not reproduce this -- the first
+    // version of this test used one, passed on the unfixed code, and guarded nothing. The
+    // removals that reach the whole-map walk come from the event and index-ref writes.
+    let per_write_us = |corpus: u64| -> f64 {
+        use crate::types::{ContextEvent, ContextIndexRef};
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            4 * 1024 * 1024, dir.path().join("cache"),
+            dir.path().join("pages"), dir.path().join("indexes"));
+        engine.load_shard(1);
+        let msg = |nid: u64| vec![
+            Command::ContextUpsertNode { tenant_hash: 7, node: node(nid) },
+            Command::ContextWriteEvent {
+                tenant_hash: 7, node_hash: nid, first_write_only: true, cold_storage: false,
+                event: Box::new(ContextEvent {
+                    event_id_hash: nid, event_time_ms: 1_780_000_000_000,
+                    ingestion_time_ms: 1_780_000_000_000, kind: 1, event_type: 1,
+                    actor_hash: 42, status: 1, valid_until_ms: 0, confidence: 1.0,
+                    importance: 1.0, text: "body".to_string(),
+                    source_ref: format!("msg-{nid}"), related_node_hashes: Vec::new(),
+                    compact_attrs: Vec::new(), vector: Vec::new(),
+                }),
+            },
+            Command::ContextWriteIndexRef {
+                tenant_hash: 7, index_name: "source".to_string(),
+                index_value_hash: nid % 100_000, scope_hash: 0,
+                event_time_ms: 1_780_000_000_000,
+                index_ref: ContextIndexRef {
+                    primary_node_hash: nid, primary_event_time_ms: 1_780_000_000_000,
+                    event_id_hash: nid,
+                },
+            },
+        ];
+        let mut nid = 5_000_000u64;
+        for _ in 0..corpus {
+            nid += 1;
+            engine.batch_execute(crate::types::BatchExecuteRequest {
+                shard_id: 1, commands: msg(nid) });
+        }
+        const N: u64 = 300;
+        let t0 = std::time::Instant::now();
+        for _ in 0..N {
+            nid += 1;
+            engine.batch_execute(crate::types::BatchExecuteRequest {
+                shard_id: 1, commands: msg(nid) });
+        }
+        t0.elapsed().as_micros() as f64 / N as f64
+    };
+    let small = per_write_us(2_000);
+    let large = per_write_us(20_000);
+    let growth = large / small;
+    println!("  per-write: {small:.0} us at 2k -> {large:.0} us at 20k  ({growth:.2}x)");
+    // Generous: the defect measured 2.97x over this range and 15x over a real run. Anything
+    // under 2x is not the walk coming back; timing on a shared machine is not tighter than this.
+    assert!(
+        growth < 2.0,
+        "per-write cost grew {growth:.2}x from a 2k to a 20k corpus -- the whole-map walk is back"
+    );
+}


### PR DESCRIPTION
`sync_bucket_index_object_pages` ended by walking the whole bucket map to drop the buckets it had
just emptied:

```rust
if removed_any || dirty {
    shard.bucket_index.bucket_map
        .retain(|_, b| !b.page_index.is_empty() || !b.object_index.is_empty());
}
```

`dirty` is true for a write, so that ran on **every** command. At the default routing-slot range
each key gets its own slot, so the map holds a bucket per record and the walk is O(corpus) per
write. The rest of the function is careful to touch only the affected buckets; this undid that.

## What it cost

An 8-hour one-box run of the real ingest shapes -- a message is four commands in one batch, a
skill file is ~30 chunks -- degraded from **7 ms to 105 ms per message**, fitting `corpus^0.96`:
linear per message, quadratic overall. Throughput fell to 13 of a targeted 40 msgs/s. Zero
failures throughout, so it degrades rather than breaks.

`perf` on a degraded node put **94.22% of self time** in that one retain. Nothing else exceeded
0.16%.

## The change

Only a bucket whose `page_index` actually shrank can have newly become empty, and the function
already tracks that set as `touched_buckets`. Buckets the publish loop inserted into gained a
page; buckets the call never opened are unchanged. So the same buckets are removed, by name.

```
                      corpus   us/msg   buckets   growth
  before 0..u32::MAX   40000   38,898   121,200    2.97x
  after  0..u32::MAX   40000    4,464   121,200    1.07x
  after  0..1023       40000    4,034     1,024    0.94x
```

**8.7x faster at 40k records with the same 121,200 buckets** -- the win is not reading them, not
having fewer. The bounded-range arm is unchanged, which is the control: at 1,024 buckets the walk
was always cheap.

Confirmed at scale on the same instance, identical 15-minute reproduction:

```
  before   5.96 -> 19.85 ms  (3.3x)  over ~74k records,  46.9 msgs/s
  after    5.38 ->  5.55 ms  (1.0x)  over ~92k records,  93.6 msgs/s
```

Flat at a larger corpus, with double the throughput.

## The test is mutation-tested

`emptied_buckets_are_dropped_without_walking_the_map` pins two properties, because each alone is
satisfiable by a wrong change -- never dropping anything is flat, and walking everything is
correct:

- emptied buckets must be gone after deleting every key
- per-write cost must not grow from a 2k to a 20k corpus

```
  with the fix     0.93x  PASS
  without the fix  3.41x  FAIL -- "the whole-map walk is back"
```

An earlier version drove `ContextUpsertNode` alone and passed on the unfixed code; upserts do not
reach the removal path. It drives the real three-command batch now.

## Why no existing test saw it

The narrow-routing-range tests run at 64 and 1023 slots, where the map holds ~1024 buckets and the
walk is cheap. They cannot observe default-range behaviour, and all three report `0.0` page
visits, which reads as proof of flatness and is not.

## Verification

- `cargo test -p temporalstore-rust --lib -- --test-threads=1`: **1610 passed, 0 failed**
- before/after on the same probe, same corpus, differing only in this change
- an 8-hour AWS run to find it, and a 15-minute reproduction on the same box to confirm the fix

Two files, no deletions.
