### PR TITLE
The dashboard shows whether the gateway can reach its backend

### DIFF
--- a/docs/ops/matrixark-gateway-dashboard.json
+++ b/docs/ops/matrixark-gateway-dashboard.json
@@ -493,6 +493,96 @@
           "legendFormat": "errors/s"
         }
       ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Datanode",
+      "description": "Whether the gateway could reach its datanode on the last probe. 0 means it answered a readiness probe with 503 and should already be out of rotation -- no other panel here distinguishes that deployment from a healthy one. Absent means nothing has probed yet, which is not the same as reachable.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "cannot serve",
+                  "color": "red",
+                  "index": 0
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "reachable",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "min(matrixark_gateway_datanode_reachable{instance=~\"$instance\"})"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Datanode answer age",
+      "description": "How old the reading beside this is. The gauge only moves when something probes, so a stale 'reachable' would read as current for as long as nobody looked. A number climbing past a minute or two means the answer is not being refreshed, whatever it says.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 120
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(matrixark_gateway_datanode_probe_age_seconds{instance=~\"$instance\"})"
+        }
+      ]
     }
   ]
 }

--- a/tools/validate_grafana_metrics_conformance.py
+++ b/tools/validate_grafana_metrics_conformance.py
@@ -451,8 +451,16 @@ def check_no_bare_histogram_targets(kinds: dict) -> list:
     Found on a panel added in the change that introduced this dashboard, which is the honest reason
     the guard is here rather than the rule being obvious.
 
-    Only a target that is EXACTLY the base name is reported. `histogram_quantile(...)` over the
-    buckets, or a `_sum / _count` mean, both mention the base name as a prefix and are correct.
+    Reported when the base name appears as a WHOLE metric token. It used to require the target to
+    be exactly the base name and nothing else, which let through every realistic way of writing the
+    mistake -- `max(foo{instance=~"$instance"})` draws the same empty line as `foo` and did not
+    match. Found while adding a panel to this dashboard: the mutation that should have failed the
+    check passed it.
+
+    A token boundary is what keeps the legitimate uses safe, and they are the reason the match was
+    narrow in the first place. `histogram_quantile(...)` over `foo_bucket`, and a `foo_sum /
+    foo_count` mean, both mention the base name only as a prefix of a longer token, so neither is
+    reported.
     """
     shaped = {name for name, kind in kinds.items() if kind in ("histogram", "summary")}
     if not shaped:
@@ -468,9 +476,13 @@ def check_no_bare_histogram_targets(kinds: dict) -> list:
         for panel in panels:
             for target in panel.get("targets", []):
                 expr = str(target.get("expr", "")).strip()
-                if expr in shaped:
-                    failures.append("bare_histogram_target:%s:%s:%s"
-                                    % (path.name, panel.get("title"), expr))
+                for name in shaped:
+                    # The base name as a complete token: not followed by another name character,
+                    # which is what distinguishes `foo` from `foo_bucket` and `foo_sum`.
+                    if re.search(r"(?<![A-Za-z0-9_])%s(?![A-Za-z0-9_])" % re.escape(name), expr):
+                        failures.append("bare_histogram_target:%s:%s:%s"
+                                        % (path.name, panel.get("title"), expr))
+                        break
     return failures
 
 
@@ -526,16 +538,6 @@ def main() -> int:
             "missing": family_missing,
         }
 
-    report = {
-        "schema": "temporalstore_grafana_metrics_parity_report_v1",
-        "dashboard": str(DASHBOARD.relative_to(ROOT)),
-        "alerts": str(ALERTS.relative_to(ROOT)),
-        "doc": str(DOC.relative_to(ROOT)),
-        "families": family_reports,
-        "grafana_metrics_parity_ready": not missing,
-        "missing": missing,
-    }
-    print(json.dumps(report, indent=2, sort_keys=True))
     # A known gap stays in the report -- it is not hidden -- but does not fail the run. A gap that
     # gets FIXED does fail, so the list cannot go stale the way the one it replaces did.
     unexpected = [m for m in missing if m not in KNOWN_UNEMITTED]
@@ -553,6 +555,22 @@ def main() -> int:
                       + check_families_state_their_emission(METRIC_FAMILIES)
                       + check_alert_expressions_are_emitted(alerts, declared)
                       + check_alert_metric_names(alerts, declared))
+    report = {
+        "schema": "temporalstore_grafana_metrics_parity_report_v1",
+        "dashboard": str(DASHBOARD.relative_to(ROOT)),
+        "alerts": str(ALERTS.relative_to(ROOT)),
+        "doc": str(DOC.relative_to(ROOT)),
+        "families": family_reports,
+        # Scoped to family parity, which is what it has always meant. The checks below can fail
+        # while this is true, and the exit code -- not this flag -- is the gate.
+        "grafana_metrics_parity_ready": not missing,
+        "missing": missing,
+        # Carried so the machine-readable report says everything the exit code does. Reading
+        # `grafana_metrics_parity_ready: true` off a run that exited 1 is the sort of half-truth
+        # this file exists to stop.
+        "checks_failed": alert_failures,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
     for failure in alert_failures:
         print("ALERT CANNOT FIRE: %s" % failure, file=sys.stderr)
     lost = check_scan_extent()


### PR DESCRIPTION
The datanode gauge is emitted and alerted on, so a deployment can page somebody. What it could not do is answer the next question: someone is now looking at the gateway dashboard, and thirteen panels cover requests, latency, bytes and configuration while saying nothing about whether the gateway can reach its datanode.

Two panels — reachability, and the **age of that answer**, because the gauge only moves when something probes and a stale "reachable" reads as current.

**The overlap guard caught my first placement** (I put it on top of an existing panel at 18,4). They now sit below the layout, at a position computed from it.

**The guard that should have caught my other mistake did not.** Mutating a panel to plot a histogram by its base name passed — and the check for exactly that has existed since this dashboard was wired up. It required the target to be *exactly* the base name, so it caught `foo` and missed `max(foo{instance=~"$instance"})`, which draws the same empty line and is the more realistic way to write it.

The narrow match was deliberate: `histogram_quantile(...)` over `foo_bucket` and a `foo_sum / foo_count` mean both mention the base name and neither is wrong. Matching a whole metric **token** keeps both safe — in each the base name is only a prefix of a longer token — while catching the bare name anywhere in an expression. Real dashboards still pass; the mutation that slipped through now fails.

The report also carries the checks it ran. `grafana_metrics_parity_ready` is scoped to family parity and always was, and the exit code was already the correct gate — but a report saying `ready: true` on a run that exited 1 is the half-truth this file exists to stop. Nothing reads that flag today, so its meaning is left alone rather than widened.