### PR TITLE
The setup checklist asks whether the backend is there

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2472,6 +2472,8 @@ _CHECK_SOURCES: Json = {
     "fail_closed": "configuration",
     "config_warnings": "configuration",
     "ingestion_root": "configuration",
+    # Counted a real connection to the backend, not a setting that says where it should be.
+    "datanode": "measured",
     "content": "measured",
     # Counts of what is actually there, and traffic actually observed -- these survive a
     # deployment being misconfigured, which is the whole reason the distinction is printed.
@@ -2487,7 +2489,8 @@ _CHECK_SOURCES: Json = {
 
 def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
                       request_total: float = 0.0,
-                      imports: Optional[Json] = None) -> List[Json]:
+                      imports: Optional[Json] = None,
+                      datanode: Optional[str] = None) -> List[Json]:
     """The deployment's setup state as an ordered checklist.
 
     A customer standing up MatrixArk has to get several independent things right, and every one of
@@ -2522,6 +2525,30 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
                        "href": href, "action": action,
                        "source": source, "source_label": _CHECK_SOURCE_LABELS[source],
                        "how": list(how or []) if status != "ok" else []})
+
+    # First, because if the backend is unreachable the rest of the list is moot -- a reader who
+    # sees this at the top stops working through checks about models and keys.
+    #
+    # Absent means nothing probed, which is not the same as unreachable, so the row says so rather
+    # than guessing either way.
+    if datanode == "ok":
+        add("datanode", "Datanode", "ok",
+            "The gateway reached the datanode on its last probe.",
+            "/v1/admin/setup", "Deployment")
+    elif datanode in ("erroring", "unreachable"):
+        add("datanode", "Datanode", "warn",
+            ("The datanode answered with an error." if datanode == "erroring"
+             else "The gateway could not connect to the datanode.")
+            + " Reads and writes cannot be served, and /v1/readyz is answering 503, so this worker "
+              "should already be out of rotation.",
+            "/v1/admin/setup", "Deployment",
+            ["Check the datanode process is running and listening.",
+             "Check MATRIXARK_DATANODE_BLOB_URL points at it.",
+             "Nothing below this line can work until it does."])
+    elif datanode is not None:
+        add("datanode", "Datanode", "warn",
+            "The datanode reported a state this gateway does not recognise: %r." % datanode,
+            "/v1/admin/setup", "Deployment")
 
     model_on = str(extraction.get("provider", "")).lower() not in deterministic
     add("extraction", "Extraction model", "ok" if model_on else "todo",
@@ -3888,8 +3915,11 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 config_snapshot = dict(config_snapshot)
                 config_snapshot["live_storage_backend"] = live.get("backend")
                 config_snapshot["live_storage_reason"] = live.get("reason") or ""
+            # From the frame's shared cache, so this endpoint adds no probing of its own.
+            datanode_state = await _datanode_for_frame(cfg)
             checks = _readiness_checks(config_snapshot, counts, cfg,
-                                       float(traffic.get("total_requests") or 0), imports)
+                                       float(traffic.get("total_requests") or 0), imports,
+                                       datanode=datanode_state)
             done = sum(1 for c in checks if c["status"] == "ok")
             return await _json(send, 200, {
                 "status": "ok",

--- a/tools/test_matrixark_checklist_asks_about_the_backend.py
+++ b/tools/test_matrixark_checklist_asks_about_the_backend.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The setup checklist asks whether the gateway can reach its backend.
+
+Thirteen checks covered extraction, embedding, auth, content, memory, metrics and imports. None
+asked the most basic question: is the datanode there. A deployment whose backend was unreachable
+satisfied every one of those and still could not serve a request -- which is the exact failure mode
+the checklist exists for, since it says of its other rows that each one "fails quietly".
+
+The row goes first. If the backend is unreachable the rest of the list is moot, and a reader who
+sees it at the top stops working through checks about models and keys.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+SNAP = {"extraction": {}, "embedding": {}, "warnings": []}
+
+
+def _rows(datanode):
+    return gw._readiness_checks(SNAP, {}, gw.GatewayConfig(), datanode=datanode)
+
+
+def _datanode_row(rows):
+    found = [r for r in rows if r["id"] == "datanode"]
+    return found[0] if found else None
+
+
+class TheChecklistAsksIfTheBackendIsThereTest(unittest.TestCase):
+
+    def test_a_reachable_backend_is_ok(self) -> None:
+        row = _datanode_row(_rows("ok"))
+        self.assertIsNotNone(row)
+        self.assertEqual("ok", row["status"])
+
+    def test_an_unreachable_backend_is_flagged(self) -> None:
+        row = _datanode_row(_rows("unreachable"))
+        self.assertEqual("warn", row["status"])
+        self.assertIn("could not connect", row["detail"])
+
+    def test_an_erroring_backend_is_flagged_differently(self) -> None:
+        """A backend answering 5xx and one that is not listening want different things looked at."""
+        row = _datanode_row(_rows("erroring"))
+        self.assertEqual("warn", row["status"])
+        self.assertIn("answered with an error", row["detail"])
+        self.assertNotEqual(row["detail"], _datanode_row(_rows("unreachable"))["detail"])
+
+    def test_it_says_the_worker_should_be_out_of_rotation(self) -> None:
+        """Ties the row to what the orchestrator is already doing, so the two are not read apart."""
+        self.assertIn("readyz", _datanode_row(_rows("unreachable"))["detail"])
+
+    def test_nothing_probed_claims_nothing(self) -> None:
+        """Absent is not unreachable. A row either way would be inventing an answer."""
+        self.assertIsNone(_datanode_row(_rows(None)))
+
+    def test_an_unrecognised_state_is_not_waved_through(self) -> None:
+        """A state this gateway does not know is a warning, not a silent pass."""
+        row = _datanode_row(_rows("something_new"))
+        self.assertIsNotNone(row, "an unknown state produced no row at all")
+        self.assertEqual("warn", row["status"])
+
+    def test_it_comes_first(self) -> None:
+        for state in ("ok", "unreachable", "erroring"):
+            self.assertEqual("datanode", _rows(state)[0]["id"],
+                             "with the backend %s, the reader works through other checks first"
+                             % state)
+
+    def test_the_other_checks_are_still_there(self) -> None:
+        """Adding a row must not displace the list it was added to."""
+        ids = {r["id"] for r in _rows("ok")}
+        for expected in ("extraction", "embedding", "auth", "content", "memory", "metrics"):
+            self.assertIn(expected, ids)
+
+    def test_it_declares_what_kind_of_claim_it_makes(self) -> None:
+        """The guard in `add` requires this, and 'measured' is the honest word: it counted a real
+        connection, unlike a row reporting that a setting is set."""
+        self.assertEqual("measured", gw._CHECK_SOURCES.get("datanode"))
+
+
+class TheEndpointSuppliesIt(unittest.TestCase):
+
+    def test_the_overview_route_passes_what_the_probe_found(self) -> None:
+        import inspect
+        source = inspect.getsource(gw)
+        self.assertIn("datanode=datanode_state", source,
+                      "the checklist takes a datanode state and the route never passes one, so "
+                      "the row can never appear in the served answer")
+
+    def test_it_reuses_the_shared_probe_rather_than_making_its_own(self) -> None:
+        """The frame already probes on a slow shared cadence; a second prober would double it."""
+        import inspect
+        source = inspect.getsource(gw)
+        self.assertIn("datanode_state = await _datanode_for_frame(cfg)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Thirteen checks covered extraction, embedding, auth, content, memory, metrics and imports. **None asked whether the datanode was there.** A deployment whose backend was unreachable satisfied every one of them and still could not serve a request — precisely the failure mode this list exists for. Its own docstring says each other row "fails quietly"; this was the quietest, because it was never asked.

**The row goes first.** If the backend is unreachable the rest is moot, and a reader who sees it at the top stops working through checks about models and keys. It also says the worker should already be out of rotation, tying it to the 503 from readiness rather than leaving someone to connect the two.

Three states, three answers — and the fourth is the one worth naming: **nothing having probed is not unreachable**, so it produces no row rather than inventing a verdict. An erroring backend and an unreachable one read differently too: one wants the datanode's logs, the other wants the process and the URL checked.

The probe comes from the frame's shared cache, so this endpoint adds no probing of its own.

Declared `measured` rather than `configuration`, which the guard in `add` requires: a row that read a setting and a row that counted a real connection both print as ok, and only one survives a deployment misconfigured in a way that still answers 200. Five mutations fail the tests, including that relabelling.