### PR TITLE
Read the commit that landed, not the one that was already there

### DIFF
--- a/tools/matrixark_codex_hook.py
+++ b/tools/matrixark_codex_hook.py
@@ -2969,6 +2969,15 @@ def pushed_main_commit_from_text(text: str) -> str:
     match = re.search(r"\bpushed commit\s+([0-9a-f]{7,40})\b", compact, re.IGNORECASE)
     if match:
         return match.group(1)
+    # A `old..new` range names both ends, and the pushed commit is always the SECOND. Ask it
+    # before the looser forms below: those capture the first hash they meet after the word
+    # "push", which in a range is the commit that was ALREADY there. Git's own output does not
+    # contain the word, so it reached the range pattern and read correctly, while a sentence
+    # about the same push ("git push output was b223ca8c..4eafaf9c HEAD -> main") reported the
+    # old head as the thing that landed.
+    match = re.search(r"\b[0-9a-f]{7,40}\.\.([0-9a-f]{7,40})\s+(?:HEAD|[^\s]+)\s*->\s*(?:main|origin/main)\b", compact, re.IGNORECASE)
+    if match:
+        return match.group(1)
     match = re.search(
         r"\b(?:git\s+push|push|published|publish|pushed)\s+(?:accepted|succeeded|completed|done|sent|landed)?\b.{0,80}?\b(?:main|origin/main)\b.{0,40}?\b(?:at|as|commit)?\s*([0-9a-f]{7,40})\b",
         compact,
@@ -2984,9 +2993,6 @@ def pushed_main_commit_from_text(text: str) -> str:
     if match:
         return match.group(1)
     match = re.search(r"\b([0-9a-f]{7,40})\s+(?:refs/heads/main|origin/main)\b", compact, re.IGNORECASE)
-    if match:
-        return match.group(1)
-    match = re.search(r"\b[0-9a-f]{7,40}\.\.([0-9a-f]{7,40})\s+(?:HEAD|[^\s]+)\s*->\s*(?:main|origin/main)\b", compact, re.IGNORECASE)
     if match:
         return match.group(1)
     match = re.search(r"\b([0-9a-f]{7,40})\s+(?:HEAD|[^\s]+)\s*->\s*(?:main|origin/main)\b", compact, re.IGNORECASE)

--- a/tools/test_codex_hook_output_part2.py
+++ b/tools/test_codex_hook_output_part2.py
@@ -1129,6 +1129,32 @@ class _CodexHookOutputPart2:
         self.assertIn("Outcome: pushed commit 4eafaf9c to origin/main", assistant_memory)
         self.assertIn("Validation: tests passed", assistant_memory)
 
+    def test_pushed_commit_is_the_new_head_however_the_push_is_described(self) -> None:
+        """A range names both ends, and the commit that landed is the SECOND one.
+
+        The looser patterns take the first hash they meet after the word "push", which in a
+        range is the commit that was already there. Git's own output never says "push", so it
+        reached the range pattern and read correctly while a sentence about the same push
+        reported the old head. Both spellings are asserted here so the order cannot drift back.
+        """
+        old, new = "b223ca8c", "4eafaf9c"
+        for description in (
+            "   %s..%s  HEAD -> main" % (old, new),
+            "To https://github.com/matrixarkai/TemporalStore.git\n   %s..%s  HEAD -> main" % (old, new),
+            "Done. Git push output was %s..%s  HEAD -> main after validation passed." % (old, new),
+            "git push succeeded: %s..%s HEAD -> main" % (old, new),
+            "pushed %s..%s HEAD -> origin/main" % (old, new),
+        ):
+            self.assertEqual(
+                new, hook.pushed_main_commit_from_text(description),
+                "read the wrong end of the range in: %r" % description,
+            )
+        # Without a range there is only one commit to name, and it is still found.
+        self.assertEqual(
+            new, hook.pushed_main_commit_from_text("pushed commit %s to origin/main" % new)
+        )
+        self.assertEqual("", hook.pushed_main_commit_from_text("nothing was pushed here"))
+
     def test_selected_assistant_memory_filters_large_response(self) -> None:
         raw = "\n".join(
             [f"background explanation line {index}" for index in range(40)]


### PR DESCRIPTION
A push range names both ends — `b223ca8c..4eafaf9c` — and the commit that landed is the
**second**. `pushed_main_commit_from_text` tried the range pattern fifth, after two looser
ones that take the first hash they meet following the word "push". In a range, that hash is
the old head.

Git's own output never contains the word "push", so it fell through to the range pattern and
read correctly. A sentence describing the same push did not:

| input | before | after |
| --- | --- | --- |
| `   b223ca8c..4eafaf9c  HEAD -> main` (git output) | `4eafaf9c` ✓ | `4eafaf9c` |
| `Done. Git push output was b223ca8c..4eafaf9c  HEAD -> main after validation passed.` | **`b223ca8c`** ✗ | `4eafaf9c` |

So the tool path and the assistant path disagreed about the same push — and the assistant one,
which is the text a person reads back later, was the wrong one. It reported a commit that was
already on the branch as the thing that had just landed.

## The fix

Ask the range pattern first, after only the explicit `pushed commit X` form. A range is
unambiguous where the looser patterns are guessing, so it belongs ahead of them.

**Confirmed by instrumenting which pattern fires**, rather than inferred: before, the git text
matched the range pattern and the sentence matched the loose one; after, both take the range.

## It had no test of its own

`pushed_main_commit_from_text` was covered only incidentally, through a single phrasing. It has
a direct test now, over five spellings of the same push plus the no-range and no-push cases.

**Mutation-tested:** moving the range pattern back where it was fails both the new test and the
existing one. (The first harness I wrote restored the file after each case, so the second case
silently ran against the fixed code and reported a meaningless pass — re-run with the mutation
applied per case.)

## No fallout

Full `unittest discover` before and after: the only baseline name that changes state is
`test_selected_tool_and_assistant_memory_capture_git_push_head_range`, which now passes.
Nothing else moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)