### PR TITLE
Measure the append, not the caller building the command

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -4963,18 +4963,20 @@ mod tests {
                 )
                 .unwrap();
 
+            // Built BEFORE the probe starts. Constructing the command is the caller's cost, not
+            // the append's, and a `format!` plus a `clone` inside the window put two allocations a
+            // write on the append's account that it never paid.
             let runs = 200usize;
+            let commands = (0..runs)
+                .map(|index| Command::StringSet {
+                    key: format!("k{index:06}"),
+                    value: value.clone(),
+                })
+                .collect::<Vec<_>>();
+
             let probe = crate::alloc_probe::Probe::start();
-            for index in 0..runs {
-                store
-                    .append(
-                        1,
-                        Command::StringSet {
-                            key: format!("k{index:06}"),
-                            value: value.clone(),
-                        },
-                    )
-                    .unwrap();
+            for command in commands {
+                store.append(1, command).unwrap();
             }
             let counts = probe.stop();
 


### PR DESCRIPTION
`what_one_append_allocates` built the command INSIDE the measured window:

```rust
Command::StringSet { key: format!("k{index:06}"), value: value.clone() }
```

That `format!`, that `clone` and the growth behind them are the caller's cost. Charging them to the
append put **three allocations a write** on its account that it never paid. The commands are built
before the probe starts now.

| | reported | actual |
|---|---|---|
| allocations an append | 16.0 | **13.0** |
| bytes at a 4 KiB value | 20,808 | **16,704** |

### What this does and does not change

Every figure this probe has reported was three high, including the baseline it was compared against.
The improvement those readings measured is unaffected -- the overhead was the same constant in every
one -- but the absolute numbers were not the append's.

Stated properly, the recent WAL work takes an append from about **31 allocations to 13**, and at a
four-kilobyte value from about 25,300 bytes to 16,704.

### Why it went unnoticed

The number was plausible and moved the right way after every change, which is exactly the shape a
wrong measurement takes when it is wrong by a constant. It survived four rounds of being quoted.