### PR TITLE
Budget a candidate by the roles it declares when it has no entity type

### DIFF
--- a/tools/matrixark_mcp_core_ref_selection.py
+++ b/tools/matrixark_mcp_core_ref_selection.py
@@ -652,7 +652,12 @@ def select_token_budgeted_refs(
                 role_names.update(normalize_message_role(role) for role in roles if normalize_message_role(role))
         metadata_entity_type = metadata.get("entity_type") if isinstance(metadata, dict) else ""
         entity_type = str(candidate.get("entity_type") or metadata_entity_type or "").strip().lower()
-        semantic_role = semantic_source_role_for_entity_type(entity_type, role_names)
+        # Only an entity type it actually HAS can speak for a candidate. An unknown one maps to
+        # "durable_profile", so an empty one used to answer "profile" and that answer replaced
+        # the roles the candidate declared. Summaries carry no entity type, so every summary
+        # budgeted as profile and a per-role budget could never reach one -- an assistant budget
+        # of one token let a twelve-token assistant summary through untouched.
+        semantic_role = semantic_source_role_for_entity_type(entity_type, role_names) if entity_type else ""
         if semantic_role == "profile":
             return {semantic_role}
         if semantic_role and semantic_role in role_names:
@@ -677,7 +682,9 @@ def select_token_budgeted_refs(
         metadata = candidate.get("metadata")
         metadata_entity_type = metadata.get("entity_type") if isinstance(metadata, dict) else ""
         entity_type = str(candidate.get("entity_type") or metadata_entity_type or "").strip().lower()
-        semantic_role = semantic_source_role_for_entity_type(entity_type, role_names)
+        # Same rule as candidate_source_role_names above, so the counts describe the roles the
+        # budget actually charged.
+        semantic_role = semantic_source_role_for_entity_type(entity_type, role_names) if entity_type else ""
         if semantic_role == "profile":
             return {semantic_role: 1}
         if semantic_role and semantic_role in role_names:


### PR DESCRIPTION
A per-source-role token budget never reached a summary. Asked to hold assistant context to
one token, the selector returned a twelve-token assistant summary and reported nothing
dropped.

```
source_role_budget_tokens={"assistant": 1}, max_context_tokens=8
candidate: summary, source_roles=["assistant"], 12 tokens

before:  selected 1   used_tokens 12   dropped[source_role_budget] 0
after:   selected 0   used_tokens  0   dropped[source_role_budget] 1
```

## Why

`profile_memory_kind_for_entity_type("")` answers `"durable_profile"` — an unknown entity is
durable profile memory, which is fine for classifying entities.
`semantic_source_role_for_entity_type` passes that through as the role `"profile"`, and
`candidate_source_role_names` returned `{"profile"}` early, **discarding the `source_roles` the
candidate declared**.

A summary carries no entity type, so every summary budgeted as profile and an assistant, tool
or user budget could not reach one. It is not about profile scope either — the same candidate
with `memory_scope` and `session_continuity` removed still budgeted as profile.

Only an entity type a candidate *has* can speak for it. With none, the roles it declares are
the evidence, and they are now what the budget charges.

## Verified this is the copy that serves

`select_token_budgeted_refs` is defined **twice** — `matrixark_mcp_budget_pack` and
`matrixark_mcp_core_ref_selection` — and they are different objects. Checked by identity, not
by grep: both the test and `matrixark_local_adapter_retrieve` resolve to the
`core_ref_selection` one, so this fixes the path that runs. The `budget_pack` copy has no
callers at all.

## Result

**Six baseline tests pass that did not, and none regress** — the four source-role-budget ones
plus `test_retrieve_source_role_budget_applies_to_raw_context_events` and
`test_fast_hook_idle_preflush_recovers_pending_buffer_after_restart`, which were failing for the
same reason and were not what I was aiming at. Full `unittest discover` before and after: 114
failing names → 108, nothing new.

**Mutation-tested:** removing the guard fails all four source-role-budget tests.

## Observed and not changed here

`matrixark_local_adapter_retrieve.py:3159` stamps `budget_source_roles` the same way on the
bridge-injection path, so it also says "profile" for a candidate with no entity type. That site
only reports, no test says what it should report instead, and guessing at it belongs in its own
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)