### PR TITLE
Ask a tool result for the projection it keeps, not the raw blob it does not

### DIFF
--- a/tools/test_codex_hook_output_part3.py
+++ b/tools/test_codex_hook_output_part3.py
@@ -902,18 +902,21 @@ class _CodexHookOutputPart3:
             original_text="verbose stdout\nExit code: 0\nRan 9 tests\nOK",
         )
 
+        # Keeping the raw tool blob is OPT-IN: HOOK_TOOL_RESULT_RAW has defaulted off since it
+        # was introduced, and its fields were once even named tool_result_raw_opt_in_env. What
+        # a tool result leaves behind by default is the selected serving projection, which is
+        # what this test is named for. The opt-in itself is covered by
+        # test_fast_async_tool_result_raw_override_keeps_raw_only.
         self.assertEqual("accepted", result["status"])
-        self.assertEqual("accepted", result["raw_ingestion_status"])
+        self.assertEqual("skipped_tool_result_raw_capture", result["raw_ingestion_status"])
         self.assertEqual("accepted", result["serving_projection_status"])
         self.assertEqual("pending", result["async_pipeline_status"])
-        self.assertEqual(1, len(server.adapter.raw_records))
+        self.assertEqual([], server.adapter.raw_records)
         self.assertGreaterEqual(len(server.adapter.serving_records), 1)
-        raw = server.adapter.raw_records[0]
         serving = next(record for record in server.adapter.serving_records if record["record_type"] == "context_event")
-        self.assertEqual("tool", raw["role"])
         self.assertEqual("tool", serving["role"])
-        self.assertEqual("serving", raw["metadata"]["serving_projection"]["visibility"])
         self.assertEqual("serving", serving["metadata"]["serving_projection"]["visibility"])
+        # The projection is the SELECTED text, not the raw stdout it was taken from.
         self.assertIn("Ran 9 tests", serving["text"])
         self.assertNotIn("verbose stdout", serving["text"])
 
@@ -1023,7 +1026,9 @@ class _CodexHookOutputPart3:
             hook.HOOK_TOOL_RESULT_SERVING = original
 
         self.assertEqual("accepted", result["status"])
-        self.assertEqual(1, len(server.adapter.raw_records))
+        # Only HOOK_TOOL_RESULT_SERVING is pinned above; the raw opt-in is untouched, so no raw
+        # record is kept. This test is about the serving projection being promoted.
+        self.assertEqual([], server.adapter.raw_records)
         self.assertGreaterEqual(len(server.adapter.serving_records), 1)
         serving = next(record for record in server.adapter.serving_records if record["record_type"] == "context_event")
         self.assertEqual("tool", serving["role"])


### PR DESCRIPTION
Two tests asserted that a tool result leaves a raw record behind by default. It does not, and
never has.

`HOOK_TOOL_RESULT_RAW` has defaulted **off** since it was introduced — the first spelling read
the environment and treated anything unset as false — and the fields that report it were
originally named `raw_opt_in_env` and `tool_result_raw_opt_in_env`. Keeping the raw blob is
opt-in. What a tool result leaves by default is the selected serving projection, which is what
the first test is *named* for.

So both were asserting a default that never existed in this knob's lifetime; they predate the
opt-in.

| | asserted | actual |
| --- | --- | --- |
| `raw_ingestion_status` | `accepted` | `skipped_tool_result_raw_capture` |
| raw records kept | 1 | 0 |

They now assert what happens, and keep every check that was doing work: the serving projection
is written, carries `role: tool` and `visibility: serving`, and holds the **selected** text
(`Ran 9 tests`) rather than the stdout it came from (`verbose stdout` stays out). The second
test pins only `HOOK_TOOL_RESULT_SERVING`, so its raw expectation was incidental to what it is
about.

The opt-in itself stays covered by `test_fast_async_tool_result_raw_override_keeps_raw_only`,
which pins the knob on and passes today.

**Mutation-tested** by flipping the default on:

| | result |
| --- | --- |
| `..._defaults_to_serving_memory` | killed |
| `..._serving_override_promotes_context_event` | killed |
| `..._raw_override_keeps_raw_only` | survives — correctly; it pins the knob itself |

**No fallout.** Full `unittest discover` before and after: 108 failing names → 106, nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)