### PR TITLE
An open portal notices a configuration change made somewhere else

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1858,6 +1858,15 @@ def _shared_live_parts() -> Json:
         warnings = len(_model_config_snapshot().get("warnings") or [])
     except Exception:
         warnings = 0
+    try:
+        # When the stored configuration was last written, so an open portal can notice a change
+        # made in another tab or by another operator instead of waiting for its own slow timer.
+        # The fact and the time only -- no values; those stay behind the admin-gated read.
+        changed_at = float(_gwconfig.load().get("updated_at") or 0.0)
+    except Exception:
+        # Absent rather than 0: never written and could not tell are different, and a page that
+        # treated "could not tell" as a change would re-read on every tick.
+        changed_at = None
     _LIVE_SHARED = {
         "traffic": {
             "total_requests": traffic.get("total_requests", 0),
@@ -1870,6 +1879,7 @@ def _shared_live_parts() -> Json:
         },
         "imports": imports,
         "warnings": warnings,
+        "config_changed_at": changed_at,
     }
     _LIVE_SHARED_AT = now
     return _LIVE_SHARED
@@ -2000,6 +2010,7 @@ async def _event_frame(server: Any, cfg: GatewayConfig, key: Optional[str],
         "traffic": shared["traffic"],
         "imports": shared["imports"],
         "warnings": shared["warnings"],
+        "config_changed_at": shared.get("config_changed_at"),
         "embedding": embedding,
         # Absent when nothing has looked yet. "not known" and "unreachable" are different answers
         # and the strip renders them differently.

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2986,6 +2986,7 @@ function liveStream(options) {
 
   /* ---------- diagnostics ---------- */
   var lastReport = null;
+  var lastConfigChangedAt = null;
   var lastFrame = null;
 
   function compactConfig(config) {
@@ -3108,6 +3109,25 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* A configuration write in another tab, or by another operator, used to take up to a full
+           minute to show here -- the checklist rows that exist to say what is misconfigured were the
+           ones going stale. The frame carries when the stored configuration was last written, so a
+           change is picked up on the next tick instead.
+
+           The first frame only records the value: on load the checklist has just been read, and
+           treating the first sighting as a change would re-read it immediately for nothing.
+
+           The slow timer stays. This list counts records and requests as well as reading settings,
+           and those move without anyone writing configuration. */
+        var seen = frame.config_changed_at;
+        if (seen != null) {
+          if (lastConfigChangedAt !== null && seen !== lastConfigChangedAt) {
+            lastConfigChangedAt = seen;
+            if (!document.hidden && $("key").value.trim()) { load(); }
+          } else {
+            lastConfigChangedAt = seen;
+          }
+        }
         /* Kept for the diagnostics bundle. The failure timeline exists only on the frame, and
            it answers "when did this start" -- which is the question a bundle is sent to
            answer. */

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -921,6 +921,7 @@ function liveStream(options) {
   var loaded = null;      /* last GET /v1/admin/config payload */
   var fields = {};        /* setting key -> field descriptor from the server */
   var edits = {};         /* setting key -> value typed/reset since the last load */
+  var lastConfigAt = null;
   var timer = null;
 
   function auth() {
@@ -2295,6 +2296,32 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* Somebody else changed this configuration.
+
+           This page is the one holding an editable form, so reloading is not automatically the
+           kind thing to do: it would discard whatever the person here has typed and not saved.
+           Two operators on the same deployment is exactly when that happens.
+
+           With nothing unsaved, take their change -- the form is showing stale values and there
+           is nothing to lose. With unsaved edits, say so and leave the edits alone. Saving from
+           here would overwrite what they just set, and the person deserves to know that before
+           they press the button rather than after. */
+        var configAt = frame.config_changed_at;
+        if (configAt != null) {
+          if (lastConfigAt !== null && configAt !== lastConfigAt) {
+            lastConfigAt = configAt;
+            if (Object.keys(pendingPatch()).length) {
+              say($("saveMsg"),
+                "Someone changed this configuration elsewhere. Your unsaved edits are still here, "
+                + "and saving now will overwrite theirs. Discard changes to see what they set.",
+                "warn");
+            } else if (!document.hidden && $("key").value.trim()) {
+              load();
+            }
+          } else {
+            lastConfigAt = configAt;
+          }
+        }
         renderLiveTraffic(frame.traffic);
         renderFailures((frame.traffic || {}).recent_failures);
         if (frame.embedding) { renderEncoding(frame.embedding); }

--- a/tools/portal/config_change_harness.js
+++ b/tools/portal/config_change_harness.js
@@ -1,0 +1,156 @@
+/* Does an open overview page re-read when the configuration changes, and only then?
+ *
+ * Re-reading costs three listings on the backend, so "reacts to a change" and "reacts to every
+ * frame" are very different behaviours that look nearly identical in source. The page's own stream
+ * delivers a sequence of frames here and the harness counts what it fetched.
+ *
+ * Usage: node config_change_harness.js <overview_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function frame(changedAt) {
+  const f = { ts: Date.now() / 1000, traffic: { total_requests: 1 }, imports: {}, warnings: 0,
+              embedding: { total: 1 } };
+  if (changedAt !== undefined) { f.config_changed_at = changedAt; }
+  return "event: status\ndata: " + JSON.stringify(f) + "\n\n";
+}
+
+
+const overviewReads = [];
+const seenFetches = [];
+const els = new Map();
+const hidden = { value: false };
+
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, innerHTML: "", textContent: "",
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+function json(body) {
+  return Promise.resolve({ ok: true, status: 200,
+                           json: () => Promise.resolve(body),
+                           text: () => Promise.resolve(JSON.stringify(body)) });
+}
+
+/* Frames are released one at a time by the harness, not on a timer. Two attempts at timing this
+   produced two different wrong answers -- first "0 re-reads for one change" about a page that had
+   re-read correctly, then the re-read attributed to the wrong phase. Whether a frame has been
+   PROCESSED is the thing being waited on, and a clock only approximates it. */
+let release = null;
+function streaming() {
+  return Promise.resolve({
+    ok: true, status: 200,
+    body: { getReader: () => ({ read: () => new Promise((r) => { release = r; }) }) },
+    json: () => Promise.resolve({}), text: () => Promise.resolve("")
+  });
+}
+
+function settle() {
+  return new Promise((r) => setImmediate(() => setImmediate(r)));
+}
+
+async function deliver(text) {
+  while (!release) { await settle(); }
+  const r = release;
+  release = null;
+  r({ done: false, value: Buffer.from(text, "utf8") });
+  await settle();
+  await settle();
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(),
+    get hidden() { return hidden.value; }
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    seenFetches.push(u.slice(0, 40));
+    if (u.indexOf("/v1/admin/events") >= 0) { return streaming(); }
+    if (u.indexOf("/v1/admin/overview") >= 0) {
+      overviewReads.push(Date.now());
+      return json({ checks: [], counts: {} });
+    }
+    if (u.indexOf("/v1/metrics") >= 0) {
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("") });
+    }
+    return json({ settings: {} });
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+(async function () {
+  await settle();
+  await settle();
+  ok("the page read its checklist on load", overviewReads.length >= 1,
+     "reads: " + overviewReads.length);
+  const afterLoad = overviewReads.length;
+
+  await deliver(frame(1000));          // first sighting: records, does not re-read
+  await deliver(frame(1000));          // same value again: still nothing to do
+  ok("an unchanged configuration does not cause a re-read",
+     overviewReads.length === afterLoad,
+     "re-read " + (overviewReads.length - afterLoad) + " time(s) with nothing changed");
+
+  await deliver(frame(2000));          // changed
+  ok("a changed configuration causes exactly one re-read",
+     overviewReads.length === afterLoad + 1,
+     "re-read " + (overviewReads.length - afterLoad) + " time(s) for one change");
+
+  await deliver(frame(2000));          // and does not keep re-reading afterwards
+  ok("it does not re-read again while the value stays put",
+     overviewReads.length === afterLoad + 1,
+     "re-read " + (overviewReads.length - afterLoad) + " time(s) in total");
+
+  await deliver(frame(undefined));     // a frame with no timestamp at all
+  ok("a frame without the field changes nothing",
+     overviewReads.length === afterLoad + 1,
+     "re-read " + (overviewReads.length - afterLoad) + " time(s) in total");
+
+  console.log("     fetches: " + JSON.stringify(seenFetches));
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}());

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -691,6 +691,7 @@ function liveStream(options) {
 
   /* ---------- diagnostics ---------- */
   var lastReport = null;
+  var lastConfigChangedAt = null;
   var lastFrame = null;
 
   function compactConfig(config) {
@@ -813,6 +814,25 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* A configuration write in another tab, or by another operator, used to take up to a full
+           minute to show here -- the checklist rows that exist to say what is misconfigured were the
+           ones going stale. The frame carries when the stored configuration was last written, so a
+           change is picked up on the next tick instead.
+
+           The first frame only records the value: on load the checklist has just been read, and
+           treating the first sighting as a change would re-read it immediately for nothing.
+
+           The slow timer stays. This list counts records and requests as well as reading settings,
+           and those move without anyone writing configuration. */
+        var seen = frame.config_changed_at;
+        if (seen != null) {
+          if (lastConfigChangedAt !== null && seen !== lastConfigChangedAt) {
+            lastConfigChangedAt = seen;
+            if (!document.hidden && $("key").value.trim()) { load(); }
+          } else {
+            lastConfigChangedAt = seen;
+          }
+        }
         /* Kept for the diagnostics bundle. The failure timeline exists only on the frame, and
            it answers "when did this start" -- which is the question a bundle is sent to
            answer. */

--- a/tools/portal/setup_config_harness.js
+++ b/tools/portal/setup_config_harness.js
@@ -1,0 +1,179 @@
+/* When someone else changes the configuration, what does the Setup page do?
+ *
+ * Two answers, and picking the wrong one loses work. With nothing unsaved, taking their change is
+ * right -- the form is showing stale values. With unsaved edits, reloading would discard what the
+ * person here has typed, so it must say something instead and leave the edits alone.
+ *
+ * Both paths run through the same handler and differ only by a condition, which is exactly the
+ * kind of thing that reads correct and behaves wrong. Frames are released on demand rather than on
+ * a timer, because what is being waited on is a frame having been PROCESSED.
+ *
+ * Usage: node setup_config_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+process.on("unhandledRejection", (e) => {
+  console.log("  unhandled rejection: " + String(e && e.message ? e.message : e));
+});
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const FIELD = { key: "extraction.provider", value: "deterministic", kind: "text",
+                label: "Extraction provider",
+                /* The page does `f.help.length` unguarded, so a field without help throws and the
+                   error surfaces as "Could not reach the gateway". The server always sends it. */
+                help: "Which provider extracts memories.", env: "MATRIXARK_EXTRACTION_PROVIDER",
+                applies: "live", group: "models" };
+const CONFIG = { settings: { groups: { models: [FIELD] },
+                             group_meta: { models: { title: "Models", order: 1 } },
+                             updated_at: 1000, config_file: "/tmp/runtime.json" } };
+
+function frame(changedAt) {
+  const f = { ts: Date.now() / 1000, traffic: { routes: {} }, imports: {}, warnings: 0,
+              embedding: { total: 1, encoded: 1, pending: 0, encoder: {} } };
+  if (changedAt !== undefined) { f.config_changed_at = changedAt; }
+  return "event: status\ndata: " + JSON.stringify(f) + "\n\n";
+}
+
+const configReads = [];
+const seenUrls = [];
+const listeners = {};
+const els = new Map();
+
+function makeEl(id) {
+  const el = {
+    id: id || "", hidden: false, textContent: "", _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = String(v); },
+    value: id === "key" ? "k-admin" : "", checked: true, className: "",
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(type, fn) { (listeners[(id || "") + ":" + type] = fn); },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+  return el;
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+let release = null;
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+async function deliver(text) {
+  /* Bounded. An unbounded wait for a stream that never opened is a harness that hangs instead of
+     failing, which is worse than a wrong answer: it tells you nothing and costs the whole timeout. */
+  let spins = 0;
+  while (!release) {
+    if (spins++ > 2000) {
+      console.log("FAIL the page never opened its live stream, so no frame could be delivered");
+      console.log("FAILED 1");
+      process.exit(1);
+    }
+    await settle();
+  }
+  const r = release;
+  release = null;
+  r({ done: false, value: Buffer.from(text, "utf8") });
+  await settle();
+  await settle();
+}
+
+function json(body) {
+  return Promise.resolve({ ok: true, status: 200,
+                           json: () => Promise.resolve(body),
+                           text: () => Promise.resolve(JSON.stringify(body)) });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = (v) => Buffer.from(v || []).toString("utf8"); },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    seenUrls.push(u.slice(0, 32));
+    if (u.indexOf("/v1/admin/events") >= 0) {
+      return Promise.resolve({
+        ok: true, status: 200,
+        body: { getReader: () => ({ read: () => new Promise((r) => { release = r; }) }) },
+        json: () => Promise.resolve({}), text: () => Promise.resolve("")
+      });
+    }
+    if (u.indexOf("/v1/admin/config") >= 0) { configReads.push(u); return json(CONFIG); }
+    if (u.indexOf("/v1/metrics") >= 0) {
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("") });
+    }
+    return json({});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+(async function () {
+  await settle(); await settle();
+  ok("the page loaded its configuration", configReads.length >= 1,
+     "config reads: " + configReads.length);
+  const afterLoad = configReads.length;
+
+  // ---- nothing unsaved: taking their change is the right answer ----
+  await deliver(frame(1000));
+  await deliver(frame(2000));
+  ok("with nothing unsaved, a change elsewhere is taken",
+     configReads.length === afterLoad + 1,
+     "re-read " + (configReads.length - afterLoad) + " time(s)");
+  const afterReload = configReads.length;
+
+  // ---- now type something and leave it unsaved ----
+  const onInput = listeners["groups:input"];
+  ok("the settings form records edits", typeof onInput === "function",
+     "no input handler was registered, so the next check would prove nothing");
+  if (typeof onInput === "function") {
+    onInput({ target: { dataset: { key: FIELD.key }, value: "openai" } });
+  }
+  el("saveMsg").innerHTML = "";
+
+  await deliver(frame(3000));
+  ok("with unsaved edits, the page does NOT reload over them",
+     configReads.length === afterReload,
+     "it re-read " + (configReads.length - afterReload) + " time(s) and discarded the edits");
+  const said = el("saveMsg").innerHTML;
+  ok("it says someone else changed it", /changed this configuration elsewhere/.test(said),
+     JSON.stringify(said).slice(0, 160));
+  ok("it warns that saving would overwrite theirs", /overwrite/.test(said),
+     JSON.stringify(said).slice(0, 160));
+  ok("the notice is a warning, not an aside", /class="msg warn"/.test(said),
+     JSON.stringify(said).slice(0, 160));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}());

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -834,6 +834,7 @@ function liveStream(options) {
   var loaded = null;      /* last GET /v1/admin/config payload */
   var fields = {};        /* setting key -> field descriptor from the server */
   var edits = {};         /* setting key -> value typed/reset since the last load */
+  var lastConfigAt = null;
   var timer = null;
 
   function auth() {
@@ -2208,6 +2209,32 @@ function liveStream(options) {
         }
       },
       onFrame: function (frame) {
+        /* Somebody else changed this configuration.
+
+           This page is the one holding an editable form, so reloading is not automatically the
+           kind thing to do: it would discard whatever the person here has typed and not saved.
+           Two operators on the same deployment is exactly when that happens.
+
+           With nothing unsaved, take their change -- the form is showing stale values and there
+           is nothing to lose. With unsaved edits, say so and leave the edits alone. Saving from
+           here would overwrite what they just set, and the person deserves to know that before
+           they press the button rather than after. */
+        var configAt = frame.config_changed_at;
+        if (configAt != null) {
+          if (lastConfigAt !== null && configAt !== lastConfigAt) {
+            lastConfigAt = configAt;
+            if (Object.keys(pendingPatch()).length) {
+              say($("saveMsg"),
+                "Someone changed this configuration elsewhere. Your unsaved edits are still here, "
+                + "and saving now will overwrite theirs. Discard changes to see what they set.",
+                "warn");
+            } else if (!document.hidden && $("key").value.trim()) {
+              load();
+            }
+          } else {
+            lastConfigAt = configAt;
+          }
+        }
         renderLiveTraffic(frame.traffic);
         renderFailures((frame.traffic || {}).recent_failures);
         if (frame.embedding) { renderEncoding(frame.embedding); }

--- a/tools/test_matrixark_portal_notices_a_config_change.py
+++ b/tools/test_matrixark_portal_notices_a_config_change.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""An open portal notices a configuration change made somewhere else.
+
+The overview page re-read its checklist on a blind sixty-second timer. Someone changing a setting
+in another tab -- or a colleague changing one from another machine -- left every other open portal
+telling people the old answer for up to a minute, including the rows that exist precisely to say
+what is misconfigured.
+
+The stored configuration already recorded when it was last written, and the metrics endpoint
+published it. The frame did not carry it, so the page had nothing to react to and no choice but to
+poll.
+
+Two halves that fail differently. Whether the GATEWAY puts the timestamp on the frame is Python.
+Whether the PAGE re-reads on a change, and only on a change, can only be seen by running it -- a
+page that re-read on every frame would look almost identical in source and would cost three backend
+listings every two seconds.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+
+def _helpers():
+    """Deferred: importing a test module from a test module reorders `unittest discover`."""
+    from test_matrixark_v1_gateway import _cfg, _FakeServer
+    return _cfg, _FakeServer
+
+
+class TheFrameCarriesWhenConfigChangedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.cfg, self.FakeServer = _helpers()
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def _frame(self):
+        return asyncio.run(gw._event_frame(self.FakeServer(), self.cfg(),
+                                           "k", "acme", None, None))
+
+    def test_the_field_is_on_the_frame(self) -> None:
+        self.assertIn("config_changed_at", self._frame())
+
+    def test_it_reports_what_the_stored_configuration_says(self) -> None:
+        """Isolated, and the isolation is asserted: this box has a real config file with real
+        deployment keys in it, and a test that wrote there once already cost an afternoon."""
+        import matrixark_gateway_config as cfgmod
+        directory = tempfile.mkdtemp()
+        before = os.environ.get("MATRIXARK_RUNTIME_CONFIG_FILE")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(directory, "runtime.json")
+        self.addCleanup(shutil.rmtree, directory, True)
+        if before is None:
+            self.addCleanup(os.environ.pop, "MATRIXARK_RUNTIME_CONFIG_FILE", None)
+        else:
+            self.addCleanup(os.environ.__setitem__, "MATRIXARK_RUNTIME_CONFIG_FILE", before)
+
+        self.assertEqual(os.path.join(directory, "runtime.json"), cfgmod.config_path(),
+                         "the config path did not move, so this test would write the real one")
+        with open(cfgmod.config_path(), "w", encoding="utf-8") as handle:
+            json.dump({"updated_at": 1730000000.5, "values": {}}, handle)
+        gw._reset_live_cache()
+        self.assertEqual(1730000000.5, self._frame()["config_changed_at"])
+
+    def test_it_is_shared_rather_than_built_per_viewer(self) -> None:
+        """Deployment-wide: one write, the same answer for everyone watching."""
+        gw._reset_live_cache()
+        parts = gw._shared_live_parts()
+        self.assertIn("config_changed_at", parts)
+
+    def test_it_carries_no_values(self) -> None:
+        """The fact and the time. The settings stay behind the admin-gated read."""
+        value = self._frame()["config_changed_at"]
+        self.assertTrue(value is None or isinstance(value, float), repr(value))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePageReactsOnlyToAChangeTest(unittest.TestCase):
+    """Re-reading costs three backend listings, so "reacts to a change" and "reacts to every
+    frame" are very different behaviours that look nearly identical in source."""
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "config_change_harness.js"),
+             os.path.join(PORTAL, "overview_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_it_re_reads_when_the_configuration_changes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_an_unchanged_configuration_costs_nothing(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   an unchanged configuration does not cause a re-read", out, out)
+
+    def test_the_first_frame_is_not_treated_as_a_change(self) -> None:
+        """On load the checklist has just been read; reacting to the first sighting re-reads it
+        immediately for nothing."""
+        out = self._run().stdout
+        self.assertIn("ok   an unchanged configuration does not cause a re-read", out, out)
+        self.assertIn("ok   the page read its checklist on load", out, out)
+
+    def test_a_frame_without_the_field_changes_nothing(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a frame without the field changes nothing", out, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_portal_notices_a_config_change.py
+++ b/tools/test_matrixark_portal_notices_a_config_change.py
@@ -118,5 +118,47 @@ class ThePageReactsOnlyToAChangeTest(unittest.TestCase):
         self.assertIn("ok   a frame without the field changes nothing", out, out)
 
 
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheSetupPageDoesNotClobberEditsTest(unittest.TestCase):
+    """The Setup page holds an editable form, so reacting to someone else's change is not simply
+    "reload".
+
+    With nothing unsaved, taking their change is right -- the form is showing stale values and
+    there is nothing to lose. With unsaved edits, reloading would discard what the person here has
+    typed, which is the case two operators on one deployment actually hit. Both paths run through
+    the same handler and differ by one condition, which is the kind of thing that reads correct and
+    behaves wrong.
+    """
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "setup_config_harness.js"),
+             os.path.join(PORTAL, "setup_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_both_paths_behave(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_with_nothing_unsaved_it_takes_the_change(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   with nothing unsaved, a change elsewhere is taken", out, out)
+
+    def test_with_unsaved_edits_it_does_not_reload_over_them(self) -> None:
+        """The one that loses work if it goes wrong."""
+        out = self._run().stdout
+        self.assertIn("ok   with unsaved edits, the page does NOT reload over them", out, out)
+
+    def test_it_warns_that_saving_would_overwrite_the_other_change(self) -> None:
+        """Knowing after you pressed save is not knowing."""
+        out = self._run().stdout
+        self.assertIn("ok   it warns that saving would overwrite theirs", out, out)
+
+    def test_the_edit_path_is_actually_exercised(self) -> None:
+        """If the form never recorded an edit, the check above would pass with nothing unsaved."""
+        out = self._run().stdout
+        self.assertIn("ok   the settings form records edits", out, out)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The overview page re-read its checklist on a blind 60-second timer. Someone changing a setting in another tab — or a colleague from another machine — left every other open portal telling people the old answer for up to a minute, **including the rows that exist to say what is misconfigured**.

The stored configuration already recorded when it was last written and `/v1/metrics` publishes it. The frame did not carry it, so the page had nothing to react to and no choice but to poll.

It rides the **shared** part of the frame: one deployment-wide fact, built once per tick, the same for every viewer. The fact and the time only — no values; settings stay behind the admin-gated read.

**Re-reads on a change, not on every frame.** A re-read costs three backend listings; doing that every two seconds per viewer would be worse than the timer it replaces. The first sighting only records, since on load the checklist has just been read. The slow timer stays, because the list also counts records and requests, which move without anyone writing configuration.

Absent rather than 0 when the document cannot be read — never-written and could-not-tell are different, and treating the latter as a change would re-read every tick.

**The harness delivers frames on demand rather than on a timer.** Two attempts at timing gave two different wrong answers: first "0 re-reads for one change" about a page that had re-read correctly, then the re-read attributed to the wrong phase. What is being waited on is a frame having been *processed*, which a clock only approximates. Four mutations fail it, plus one on the gateway side that the page harness cannot see.