### PR TITLE
A filtered sequence query returns fewer rows than match

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14273,3 +14273,108 @@ fn a_no_page_command_leaves_the_index_matching_a_rebuild() {
          `command_writes_no_page` is no longer safe for it"
     );
 }
+
+
+/// What `SequenceQuery`'s single bound costs a filtered caller.
+///
+/// `ContextQueryEvents` has TWO bounds -- `max_scan` for work, `limit` for results after filtering --
+/// and its regression test records the harm that shape was introduced to stop: taking the limit off
+/// the raw timeline first "silently dropped" matching events beyond it, so low-value rows hid the
+/// high-value ones on the retrieval path.
+///
+/// `SequenceQuery` has one knob, `count`, doing both jobs, so it still behaves the way QueryEvents
+/// did before that fix. This test does not change that -- it makes the cost visible. It passes
+/// against current behaviour; if `SequenceQuery` ever gains a `max_scan`, it will fail and should be
+/// updated to assert the fixed behaviour.
+#[test]
+fn a_filtered_sequence_query_returns_fewer_rows_than_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    // 500 rows that do NOT match the filter, then 500 that do -- the shape the QueryEvents comment
+    // describes, where the interesting rows sit behind a wall of uninteresting ones.
+    const NON_MATCHING: usize = 500;
+    const MATCHING: usize = 500;
+    for index in 0..(NON_MATCHING + MATCHING) {
+        let action_type = if index < NON_MATCHING { 1 } else { 9 };
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::SequenceAdd {
+                key: "events".to_string(),
+                rows: vec![SequenceFeatureRow {
+                    timestamp_ms: 1_000 + index as u64,
+                    gid: index as u64,
+                    action_type,
+                    duration: 10,
+                    author_id: 1,
+                }],
+            },
+        });
+        assert!(out.status.ok, "add {index}: {:?}", out.status);
+    }
+
+    // Ask for 10 rows where action_type == 9. Five hundred match.
+    let response = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::SequenceQuery {
+            key: "events".to_string(),
+            start_ms: 0,
+            end_ms: 1_000_000,
+            count: 10,
+            filters: vec![FeatureFilter {
+                field: "action_type".to_string(),
+                op: FeatureFilterOp::Equal,
+                value: 9,
+            }],
+        },
+    });
+    assert!(response.status.ok, "{:?}", response.status);
+    let rows = match response.response {
+        CommandResponse::SequenceRows { rows } => rows,
+        other => panic!("expected sequence rows, got {other:?}"),
+    };
+
+    // Current behaviour: `count` caps the SCAN, so the first 10 rows are read, none match the
+    // filter, and the caller is told nothing.
+    assert_eq!(
+        rows.len(),
+        0,
+        "current behaviour: `count` bounds the scan, so a caller asking for 10 of 500 matching rows \
+         receives {} -- with no field in the reply saying the answer was cut short. If this now \
+         returns 10, SequenceQuery has gained a separate scan bound and this test should assert the \
+         fixed behaviour instead.",
+        rows.len()
+    );
+
+    // The rows really are there: the same query without the filter reaches them, and a scan wide
+    // enough finds them. This is not an empty store.
+    let wide = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::SequenceQuery {
+            key: "events".to_string(),
+            start_ms: 0,
+            end_ms: 1_000_000,
+            count: NON_MATCHING + MATCHING,
+            filters: vec![FeatureFilter {
+                field: "action_type".to_string(),
+                op: FeatureFilterOp::Equal,
+                value: 9,
+            }],
+        },
+    });
+    let wide_rows = match wide.response {
+        CommandResponse::SequenceRows { rows } => rows,
+        other => panic!("expected sequence rows, got {other:?}"),
+    };
+    assert_eq!(
+        wide_rows.len(),
+        MATCHING,
+        "the matching rows exist -- a scan wide enough returns all {MATCHING} of them"
+    );
+}


### PR DESCRIPTION
A caller asking `SequenceQuery` for **10 rows matching a filter** receives **zero**, while 500 rows
match — and nothing in the reply says the answer was cut short.

This change does not alter that behaviour. It demonstrates it, so the decision to keep or change it is
made on evidence.

## What the test shows

500 rows that do not match the filter, then 500 that do — the shape where the interesting rows sit
behind a wall of uninteresting ones. A query for `count: 10` with `action_type == 9` returns **0 rows**.
The same query with a wide enough `count` returns all 500, so the rows are demonstrably there.

## Why it happens

`sequence_rows_in_range` reads:

```rust
series.range(bounds)
    .take(count)                            // the cap
    .filter_map(read_sequence_row)
    .filter(|row| filters.iter().all(..))   // the filter, AFTER the cap
```

`count` bounds the **scan**, not the **result**. Ten rows are read, none match, and the caller is told
nothing.

## The sibling already fixed this

`ContextQueryEvents` carries **two** bounds — `max_scan` for work, `limit` for results — and applies
the limit after filtering. Its regression test records why:

> Rust previously took `limit` off the raw timeline first, so matching events beyond the first `limit`
> timeline entries were silently dropped — e.g. many earlier low-confidence events hid the
> high-confidence matches on the live retrieval path.

That is this defect, in the sibling command, judged harmful enough to fix and pinned by a test.
`SequenceQuery` still has one knob doing both jobs:

| command | bounds |
|---|---|
| `ContextQueryEvents` | `limit: Option<usize>` **and** `max_scan: Option<usize>` |
| `SequenceQuery` | `count: usize` |

That difference is the whole reason they behave differently. `QueryEvents` can filter before limiting
*because* a separate bound caps the work; `SequenceQuery` cannot, so its single `count` has to cap the
scan.

## Why this change does not fix it

Two reasons, and both are decisions rather than obstacles:

* **A 20-seed test pins the current ordering.** `long_sequence_query_keeps_timestamp_order_and_applies_random_filters`
  computes its expected value as range → `take(count)` → filter, across 20 seeds. The behaviour is
  deliberate, not accidental.
* **Changing it changes results for existing callers.** Giving `SequenceQuery` a `max_scan` and moving
  the filter ahead of the limit alters what `count` means. That is a product decision about the
  contract, not a performance edit.

The fix shape is known and already proven in this codebase, so the choice is informed either way. What
was missing was a concrete demonstration of the cost, and that is what this adds.

## The test is written to fail when the behaviour changes

It asserts the current answer (`0`) with a message naming what a non-zero result would mean, so if
`SequenceQuery` ever gains a scan bound the test fails and gets updated to assert the fixed behaviour.
It also asserts the matching rows exist, so it cannot pass against an empty store — the failure mode
that would make it worthless.

## Verification

* The new test passes on current main.
* `long_sequence_query_keeps_timestamp_order_and_applies_random_filters` still passes.
* Test-only change; no engine code is touched.
