### PR TITLE
close() waits for the audit writes it started

### DIFF
--- a/tools/matrixark_mcp_audit_queue.py
+++ b/tools/matrixark_mcp_audit_queue.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The pool async audit writes run on, and the bounded drain close() needs.
+
+Kept beside the server rather than inside it: this is background-worker plumbing, and the
+entrypoint carries a size budget that test_mcp_entrypoint_stays_small enforces.
+"""
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, wait as wait_for_futures
+from typing import Any, Callable, Set
+
+
+class AuditWriteQueue:
+    """An audit write pool that can be drained within a deadline.
+
+    The executor's own shutdown(wait=False) neither cancels queued writes nor waits for
+    in-flight ones, so a closed server could still be appending audit records -- into a
+    directory its caller has already started removing. shutdown(wait=True) is not the answer
+    either: it takes no timeout, so a single wedged write would hang shutdown forever. Track
+    what was submitted and wait for exactly that, bounded.
+    """
+
+    def __init__(self, max_workers: int) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max(1, max_workers))
+        self._pending: Set[Any] = set()
+        self._lock = threading.Lock()
+
+    @property
+    def pending(self) -> Set[Any]:
+        with self._lock:
+            return set(self._pending)
+
+    def submit(self, write: Callable[[], Any]) -> Any:
+        future = self._executor.submit(write)
+        with self._lock:
+            self._pending.add(future)
+        future.add_done_callback(self._forget)
+        return future
+
+    def _forget(self, future: Any) -> None:
+        with self._lock:
+            self._pending.discard(future)
+
+    def drain(self, timeout_s: float) -> None:
+        with self._lock:
+            pending = list(self._pending)
+        if pending:
+            wait_for_futures(pending, timeout=max(0.0, timeout_s))
+        self._executor.shutdown(wait=False, cancel_futures=False)

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -16,7 +16,6 @@ storage adapters for compatibility with existing scripts.
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import sys
@@ -288,7 +287,8 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         # read-heavy workload grows the store without bound. MATRIXARK_AUDIT_MODE=async restores
         # the off-request-path auditing; full/sync restore per-call durability.
         self._audit_mode_default = os.environ.get("MATRIXARK_AUDIT_MODE", "off").strip().lower() or "off"
-        self._audit_executor = ThreadPoolExecutor(max_workers=max(1, int(os.environ.get("MATRIXARK_AUDIT_WORKERS", "2"))))
+        from matrixark_mcp_audit_queue import AuditWriteQueue  # sibling; keeps this module small
+        self._audit_queue = AuditWriteQueue(int(os.environ.get("MATRIXARK_AUDIT_WORKERS", "2")))
         self._operation_limiters = {
             group: threading.BoundedSemaphore(max(1, int(capacity)))
             for group, capacity in self.DEFAULT_OPERATION_CONCURRENCY.items()
@@ -409,7 +409,7 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         adapter_close = getattr(self.adapter, "close", None)
         if callable(adapter_close):
             adapter_close(timeout_s=timeout_s)
-        self._audit_executor.shutdown(wait=False, cancel_futures=False)
+        self._audit_queue.drain(timeout_s)
 
     def append_audit_policy(self, action: str, identity: Json, *, status: str, details: Json | None = None, args: Json | None = None, hot_path: bool = False) -> None:
         mode = str((args or {}).get("audit_mode") or self._audit_mode_default).strip().lower()
@@ -423,7 +423,7 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
                     setattr(self.adapter, "_audit_flush_failures", int(getattr(self.adapter, "_audit_flush_failures", 0) or 0) + 1)
                     _mcp_debug_log(f"async audit write failed action={action}: {exc}")
 
-            self._audit_executor.submit(write_audit)
+            self._audit_queue.submit(write_audit)
             return
         self.access.append_audit(action, identity, status=status, details=details)
 

--- a/tools/test_matrixark_access_governance.py
+++ b/tools/test_matrixark_access_governance.py
@@ -482,6 +482,40 @@ class MatrixArkAccessGovernanceTest(unittest.TestCase):
         self.assertNotIn(secret_password, str(server.adapter.read_all()))
 
 
+    def test_close_waits_for_an_audit_write_it_started(self) -> None:
+        # Auditing is async here, so an audited hot-path call hands its write to a pool thread.
+        # close() stops every other background worker it owns and waits for it; if it does not do
+        # the same for these, it returns while writes are still landing in the event log -- and a
+        # caller that closes usually removes that directory next.
+        #
+        # The write is made slow on purpose. With a fast one this test passes whether or not
+        # close() waits, which is what a first version of it did. The count assertion matters for
+        # the same reason: "no outstanding writes" is trivially true of a set nothing was ever
+        # added to, so the write has to be shown to exist before its absence means anything.
+        import threading
+        import time as _time
+
+        server = self.make_server()
+        started = threading.Event()
+        original = server.access.append_audit
+
+        def slow_append(*args, **kwargs):
+            started.set()
+            _time.sleep(1.5)
+            return original(*args, **kwargs)
+
+        server.access.append_audit = slow_append
+        server.call_tool(
+            "matrixark_list_users",
+            {"scope": {"account_id": "acct_gov", "tenant_id": "tenant_gov"}},
+        )
+        self.assertTrue(started.wait(5.0), "no async audit write was ever submitted")
+        self.assertTrue(server._audit_queue.pending, "the audit write was not tracked as pending")
+
+        server.close(timeout_s=10.0)
+        outstanding = [future for future in server._audit_queue.pending if not future.done()]
+        self.assertEqual([], outstanding, "close() returned while an audit write was still running")
+
     def test_http_json_portal_facade_calls_live_mcp_admin_routes(self) -> None:
         server = self.make_server()
         handler = make_matrixark_http_handler(


### PR DESCRIPTION
close() waits for the audit writes it started

MatrixArkMcpServer.close() stops every background worker it owns and waits for it -- the summary
thread, the stream materialize thread, the adapter -- each bounded by timeout_s. Then it ended
with:

    self._audit_executor.shutdown(wait=False, cancel_futures=False)

which neither cancels queued audit writes nor waits for in-flight ones. With auditing async, an
audited hot-path call hands its write to a pool thread, so close() could return while writes were
still landing in the event log. A caller that closes usually removes that directory next, which
is how this surfaced: the governance fixture is the one place that turns auditing on, and its
temporary directory was being torn down under a live writer.

The pool and its drain now live in tools/matrixark_mcp_audit_queue.py. That is where the
reasoning belongs, and it keeps the entrypoint at its size budget, which
test_mcp_entrypoint_stays_small pins at 750 lines with no headroom -- main sits exactly on it, so
any new top-level import trips it. Only __init__ names the class; close() and the audit path go
through the instance. The budget is left alone: raising a guard in the change it blocks is how
guards stop meaning anything.

Waiting is bounded by the same timeout_s as the joins above, not shutdown(wait=True), which takes
no timeout and would let one wedged write hang shutdown forever.

The test makes the audit write slow on purpose. A first version used a fast one and passed
whether or not close() waited -- removing the drain did not turn it red, so it proved nothing. It
also asserts the write was submitted before asserting none is outstanding, because "nothing still
running" is trivially true of a set nothing was ever added to.

Checked by removing the drain and keeping the tracking: 10 of 10 red without it, 10 of 10 green
with it.
