### PR TITLE
Assert the idempotence this test is named for

### DIFF
--- a/tools/test_matrixark_debug_trace_compaction.py
+++ b/tools/test_matrixark_debug_trace_compaction.py
@@ -55,9 +55,23 @@ class MatrixArkDebugTraceCompactionTest(unittest.TestCase):
         }
 
         compact = core.compact_context_pack_for_serving(grouped_pack)
+        again = core.compact_context_pack_for_serving(compact)
 
-        self.assertEqual(compact["groups"], grouped_pack["groups"])
+        # Idempotence is f(f(x)) == f(x), which is what the entrypoint needs: it may compact a
+        # pack an adapter already returned in serving shape, and the second pass must not erase
+        # anything. Asserting f(x) == x instead asked compaction to be the identity on a
+        # hand-built pack, and this one carries a per-item `tokens` that the serving shape does
+        # not have -- nothing builds it, only the pack-level token summary exists -- so the
+        # first pass drops it and the test failed on a projection doing its job.
+        self.assertEqual(again["groups"], compact["groups"])
+        self.assertEqual(again["tokens"], compact["tokens"])
+        # The pack-level summary is carried through, and the evidence survives -- without this
+        # the equality above would hold just as well on a pack compacted down to nothing.
         self.assertEqual(compact["tokens"], grouped_pack["tokens"])
+        self.assertEqual(
+            [item["text"] for group in compact["groups"] for item in group["items"]],
+            ["Alice approved Project Aurora."],
+        )
 
     def test_trace_export_drops_raw_scope_and_replay_payloads(self) -> None:
         trace = {


### PR DESCRIPTION
The test compacted a pack once and asserted the result equalled its **input**. Compaction is a
projection, so that asks it to be the identity — and the hand-built fixture carried a per-item
`tokens` that the serving shape does not have. Nothing builds one; only the pack-level token
summary exists. The first pass dropped it and the test failed on a projection doing its job.

| property | holds? |
| --- | --- |
| `f(f(x)) == f(x)` — idempotence, the name of the test | **yes** |
| `f(x) == x` — what it asserted | no |

The property the entrypoint actually needs is the first one: an adapter may already return the
serving shape, and a second compaction must not erase anything.
`compact_context_pack_for_serving` has a branch for exactly that, commented *"Preserve it so a
second compaction pass in the MCP entrypoint does not erase refs."*

So it now compacts twice and compares those, keeps the pack-level token assertion that was
already correct, and adds the evidence text as a **positive control** — without it the equality
would hold just as well on a pack compacted down to nothing.

## One name moved the other way, and it is not this change

`test_background_worker_refreshes_dirty_nodes_and_embeddings` appears in my after-sweep and not
the before. It is not caused by this:

- it lives in a different module (`test_matrixark_summary_worker`), which this does not touch
- it is absent from the baseline
- it fails in roughly **one standalone run in three**, with the failure count varying between
  identical runs

It races the asynchronous summary worker: `assertIn("node_l1", embedding_types)` against
`{'event_text', 'session_l0', 'node_l0', None}` — the L1 node summary has not been written yet
when the assertion runs. Filed separately rather than folded in here.

Full `unittest discover`: 105 failing names before and after, with the target test moving to
passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)