### PR TITLE
Tabs for the API surface, one per feature area

### DIFF
--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -437,9 +437,81 @@
       scope column is what a key must carry.</div>
   </section>
 
+  <!-- Empty until the catalogue arrives. It carries role="tablist" in the static body because
+       the builder injects the shared tab switcher only into pages that declare one, and a strip
+       built after a fetch would not be there to see. -->
+  <div class="tabs" role="tablist" aria-label="API groups" id="routeTabs"></div>
+  <div id="crossGroup"></div>
   <div id="routes"><div class="empty">Loading…</div></div>
 
 </div>
+<script>
+/* Tabs, for every portal page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
 <script>
 (function () {
   "use strict";
@@ -531,6 +603,21 @@
   (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
     function (frame) { paintTraffic((frame || {}).traffic); });
 
+  /* Which group is showing. Kept across re-renders: the list is rebuilt on every keystroke in
+     the filter, and losing the open tab each time would make the strip unusable. */
+  var activeGroup = "";
+
+  function paneId(group) {
+    /* A pane id the switcher can find. Group names have spaces ("Portal pages"), and the switcher
+       matches on `pane-` + the button's data-pane, so both sides use the same slug. */
+    return String(group).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  }
+
+  function matches(route, query) {
+    return !query || (route.method + " " + route.path + " " + (route.scope || "") + " " +
+      route.summary).toLowerCase().indexOf(query) >= 0;
+  }
+
   function render() {
     var query = $("filter").value.trim().toLowerCase();
     var groups = {};
@@ -538,19 +625,83 @@
       (groups[route.group] = groups[route.group] || []).push([route, index]);
     });
     var order = Object.keys(groups);
-    var html = order.map(function (group) {
-      var rows = groups[group].filter(function (pair) {
-        return !query || (pair[0].method + " " + pair[0].path + " " + (pair[0].scope || "") + " " +
-          pair[0].summary).toLowerCase().indexOf(query) >= 0;
-      });
-      if (!rows.length) { return ""; }
-      return "<section><h2>" + esc(group) + " <span class='aux'>" + rows.length + " route" +
-        (rows.length === 1 ? "" : "s") + "</span></h2>" +
-        rows.map(function (pair) { return routeHtml(pair[0], pair[1]); }).join("") + "</section>";
+    if (!order.length) {
+      $("routeTabs").innerHTML = "";
+      $("crossGroup").innerHTML = "";
+      $("routes").innerHTML = '<section><div class="empty">No routes to show.</div></section>';
+      return;
+    }
+    if (order.indexOf(activeGroup) < 0) { activeGroup = order[0]; }
+
+    /* Matches per group under the CURRENT query, so the counts on the tabs describe what a click
+       would actually show rather than the size of the group. */
+    var hits = {};
+    var total = 0;
+    order.forEach(function (group) {
+      hits[group] = groups[group].filter(function (pair) { return matches(pair[0], query); });
+      total += hits[group].length;
+    });
+
+    $("routeTabs").innerHTML = order.map(function (group) {
+      var n = hits[group].length;
+      return '<button type="button" role="tab" id="tab-' + esc(paneId(group)) +
+        '" aria-controls="pane-' + esc(paneId(group)) + '" data-pane="' + esc(paneId(group)) +
+        '" aria-selected="' + (group === activeGroup ? "true" : "false") + '"' +
+        (group === activeGroup ? "" : ' tabindex="-1"') + '>' + esc(group) +
+        "<span class='aux'> " + n + "</span></button>";
     }).join("");
-    $("routes").innerHTML = html ||
-      '<section><div class="empty">Nothing matches that.</div></section>';
+
+    $("routes").innerHTML = order.map(function (group) {
+      var rows = hits[group];
+      var body = rows.length
+        ? rows.map(function (pair) { return routeHtml(pair[0], pair[1]); }).join("")
+        : '<div class="empty">' + (query ? "Nothing in this group matches that."
+                                         : "No routes in this group.") + "</div>";
+      return '<section class="pane" role="tabpanel" aria-labelledby="tab-' + esc(paneId(group)) +
+        '" id="pane-' + esc(paneId(group)) + '"' + (group === activeGroup ? "" : " hidden") + ">" +
+        body + "</section>";
+    }).join("");
+
+    /* The filter searches every group. Restricting it to the open tab would hide matches in the
+       other five and read as "nothing matches that", which is the worst answer to give somebody
+       searching a reference -- so when the open tab has none and others do, say where they are. */
+    var elsewhere = total - hits[activeGroup].length;
+    if (query && !hits[activeGroup].length && elsewhere > 0) {
+      var first = order.filter(function (g) { return hits[g].length; })[0];
+      $("crossGroup").innerHTML = '<div class="msg info">' + elsewhere + " match" +
+        (elsewhere === 1 ? "" : "es") + " in other groups. " +
+        '<button type="button" class="link" data-goto="' + esc(paneId(first)) + '">Show ' +
+        esc(first) + "</button></div>";
+    } else {
+      $("crossGroup").innerHTML = "";
+    }
+
+    /* Called after every render: the buttons are new elements each time, so the listeners the
+       switcher attached to the old ones went with them. */
+    if (window.wireTabs) {
+      window.wireTabs(function (pane) {
+        /* The switcher calls this once while wiring, for the tab that is already selected. Without
+           this guard that call re-renders, which re-wires, which calls it again -- the page died
+           of a stack overflow on load. Only an actual change to another group redraws. */
+        var next = null;
+        for (var i = 0; i < order.length; i++) {
+          if (paneId(order[i]) === pane) { next = order[i]; break; }
+        }
+        if (next === null || next === activeGroup) { return; }
+        activeGroup = next;
+        render();
+      });
+    }
   }
+
+  $("crossGroup").addEventListener("click", function (ev) {
+    var button = ev.target.closest ? ev.target.closest("[data-goto]") : null;
+    if (!button) { return; }
+    for (var i = 0; i < ROUTES.length; i++) {
+      if (paneId(ROUTES[i].group) === button.dataset.goto) { activeGroup = ROUTES[i].group; break; }
+    }
+    render();
+  });
 
   /* A re-render replaces every cell, so the counters have to go back on. Without this, filtering
      blanks them until the next frame. */

--- a/tools/portal/api_tabs_harness.js
+++ b/tools/portal/api_tabs_harness.js
@@ -1,0 +1,185 @@
+/* Run the API page's group tabs and read what they did.
+ *
+ * Two things here cannot be seen in source. The list is rebuilt on every keystroke, so whether the
+ * open tab survives a re-render is behaviour. And the text filter searches every group while only
+ * one pane is visible -- if it quietly searched the open tab alone, a reference page would answer
+ * "nothing matches that" while holding the match one tab away.
+ *
+ * Usage: node api_tabs_harness.js <api_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const ROUTES = [
+  { group: "Memory", method: "POST", path: "/v1/ingest", summary: "Store a memory.",
+    scope: "write", metric: "/v1/ingest" },
+  { group: "Memory", method: "POST", path: "/v1/retrieve", summary: "Recall memories.",
+    scope: "read", metric: "/v1/retrieve" },
+  { group: "Administration", method: "GET", path: "/v1/admin/config",
+    summary: "Read the configuration blueprint.", scope: "admin",
+    metric: "/v1/admin/config" },
+  { group: "Blobs", method: "PUT", path: "/v1/blob/{key}",
+    summary: "Upload a zeppelin blueprint.", scope: "write", metric: "/v1/blob/{key}" },
+];
+
+let tabCells = [];
+let panes = [];
+const listeners = {};
+const els = new Map();
+
+function attr(tag, name) {
+  const m = tag.match(new RegExp(name + '="([^"]*)"'));
+  return m ? m[1] : null;
+}
+
+function parseTabs(html) {
+  tabCells = [...String(html || "").matchAll(/<button[^>]*role="tab"[^>]*>[\s\S]*?<\/button>/g)]
+    .map((m) => {
+      const tag = m[0];
+      const el = {
+        id: attr(tag, "id"), text: tag.replace(/<[^>]*>/g, ""),
+        dataset: { pane: attr(tag, "data-pane") },
+        tabIndex: 0, focused: false,
+        _attrs: { "aria-selected": attr(tag, "aria-selected") || "false" },
+        _listeners: {},
+        addEventListener(t, fn) { (this._listeners[t] = this._listeners[t] || []).push(fn); },
+        dispatch(t, ev) { (this._listeners[t] || []).forEach((fn) => fn(ev || {})); },
+        setAttribute(k, v) { this._attrs[k] = String(v); },
+        getAttribute(k) { return k in this._attrs ? this._attrs[k] : null; },
+        focus() { this.focused = true; }, click() { this.dispatch("click"); }
+      };
+      return el;
+    });
+}
+
+function parsePanes(html) {
+  panes = [...String(html || "").matchAll(/<section[^>]*class="pane"[^>]*>/g)].map((m) => ({
+    id: attr(m[0], "id"), hidden: /\shidden[\s>]/.test(m[0])
+  }));
+}
+
+function makeEl(id) {
+  const el = {
+    id: id || "", hidden: false, textContent: "", value: "", className: "",
+    style: {}, dataset: {}, children: [], _html: "",
+    get innerHTML() { return this._html; },
+    set innerHTML(v) {
+      this._html = String(v);
+      if (this.id === "routeTabs") { parseTabs(v); }
+      if (this.id === "routes") { parsePanes(v); }
+    },
+    addEventListener(type, fn) { listeners[(id || "") + ":" + type] = fn; },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+  return el;
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(),
+    querySelectorAll: (sel) => (sel === ".tabs button" ? tabCells
+                                : (sel === ".pane" ? panes : [])),
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: { clipboard: { writeText() {} } },
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    if (String(url).indexOf("/v1/admin/routes") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               json: () => Promise.resolve({ status: "ok", routes: ROUTES }) });
+    }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+function visible() { return panes.filter((p) => !p.hidden).map((p) => p.id); }
+function selected() {
+  return tabCells.filter((t) => t.getAttribute("aria-selected") === "true").map((t) => t.id);
+}
+function type(text) {
+  el("filter").value = text;
+  listeners["filter:input"]({});
+}
+
+setTimeout(function () {
+  ok("a tab per group", tabCells.length === 3,
+     tabCells.map((t) => t.text).join(" | "));
+  ok("each tab carries its count",
+     tabCells.some((t) => /Memory\s*2/.test(t.text)),
+     tabCells.map((t) => t.text).join(" | "));
+  ok("exactly one pane is visible", visible().length === 1, visible().join(", "));
+  ok("exactly one tab is selected", selected().length === 1, selected().join(", "));
+
+  /* Switch to Blobs. */
+  const blobs = tabCells.filter((t) => /Blob/.test(t.text))[0];
+  ok("there is a Blobs tab", !!blobs, tabCells.map((t) => t.text).join(" | "));
+  blobs.dispatch("click");
+  ok("clicking a tab shows that group", visible().join() === "pane-blobs", visible().join(", "));
+
+  /* A term that appears only in Memory, while Blobs is open. */
+  type("recall");
+  ok("the open tab survives a keystroke",
+     selected().join().indexOf("blobs") >= 0, selected().join(", "));
+  ok("the filter searched every group, not just the open one",
+     tabCells.some((t) => /Memory\s*1/.test(t.text)),
+     "tab counts: " + tabCells.map((t) => t.text).join(" | "));
+  const notice = el("crossGroup").innerHTML;
+  ok("it says the matches are in another group", /match/.test(notice) && /Memory/.test(notice),
+     JSON.stringify(notice).slice(0, 140));
+
+  /* A term that matches nothing anywhere. */
+  type("zeppelin-that-does-not-exist");
+  ok("a term matching nothing says so without pointing elsewhere",
+     el("crossGroup").innerHTML === "",
+     JSON.stringify(el("crossGroup").innerHTML).slice(0, 140));
+
+  /* A term that matches the OPEN group and another one. The notice is for the case where the open
+     tab has nothing -- announcing "matches elsewhere" while the visible list is full of matches is
+     noise, and only a term hitting both tells those two behaviours apart. */
+  type("blueprint");
+  ok("the shared term really does match two groups",
+     tabCells.filter(function (t) { return /\s1$/.test(t.text.trim()); }).length >= 2,
+     "tab counts: " + tabCells.map(function (t) { return t.text; }).join(" | "));
+  ok("a match in the open group is not announced as elsewhere",
+     el("crossGroup").innerHTML === "",
+     JSON.stringify(el("crossGroup").innerHTML).slice(0, 140));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}, 40);

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -4516,6 +4516,11 @@ API_BODY = """
       scope column is what a key must carry.</div>
   </section>
 
+  <!-- Empty until the catalogue arrives. It carries role="tablist" in the static body because
+       the builder injects the shared tab switcher only into pages that declare one, and a strip
+       built after a fetch would not be there to see. -->
+  <div class="tabs" role="tablist" aria-label="API groups" id="routeTabs"></div>
+  <div id="crossGroup"></div>
   <div id="routes"><div class="empty">Loading…</div></div>
 """
 
@@ -4611,6 +4616,21 @@ API_JS = r"""
   (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
     function (frame) { paintTraffic((frame || {}).traffic); });
 
+  /* Which group is showing. Kept across re-renders: the list is rebuilt on every keystroke in
+     the filter, and losing the open tab each time would make the strip unusable. */
+  var activeGroup = "";
+
+  function paneId(group) {
+    /* A pane id the switcher can find. Group names have spaces ("Portal pages"), and the switcher
+       matches on `pane-` + the button's data-pane, so both sides use the same slug. */
+    return String(group).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  }
+
+  function matches(route, query) {
+    return !query || (route.method + " " + route.path + " " + (route.scope || "") + " " +
+      route.summary).toLowerCase().indexOf(query) >= 0;
+  }
+
   function render() {
     var query = $("filter").value.trim().toLowerCase();
     var groups = {};
@@ -4618,19 +4638,83 @@ API_JS = r"""
       (groups[route.group] = groups[route.group] || []).push([route, index]);
     });
     var order = Object.keys(groups);
-    var html = order.map(function (group) {
-      var rows = groups[group].filter(function (pair) {
-        return !query || (pair[0].method + " " + pair[0].path + " " + (pair[0].scope || "") + " " +
-          pair[0].summary).toLowerCase().indexOf(query) >= 0;
-      });
-      if (!rows.length) { return ""; }
-      return "<section><h2>" + esc(group) + " <span class='aux'>" + rows.length + " route" +
-        (rows.length === 1 ? "" : "s") + "</span></h2>" +
-        rows.map(function (pair) { return routeHtml(pair[0], pair[1]); }).join("") + "</section>";
+    if (!order.length) {
+      $("routeTabs").innerHTML = "";
+      $("crossGroup").innerHTML = "";
+      $("routes").innerHTML = '<section><div class="empty">No routes to show.</div></section>';
+      return;
+    }
+    if (order.indexOf(activeGroup) < 0) { activeGroup = order[0]; }
+
+    /* Matches per group under the CURRENT query, so the counts on the tabs describe what a click
+       would actually show rather than the size of the group. */
+    var hits = {};
+    var total = 0;
+    order.forEach(function (group) {
+      hits[group] = groups[group].filter(function (pair) { return matches(pair[0], query); });
+      total += hits[group].length;
+    });
+
+    $("routeTabs").innerHTML = order.map(function (group) {
+      var n = hits[group].length;
+      return '<button type="button" role="tab" id="tab-' + esc(paneId(group)) +
+        '" aria-controls="pane-' + esc(paneId(group)) + '" data-pane="' + esc(paneId(group)) +
+        '" aria-selected="' + (group === activeGroup ? "true" : "false") + '"' +
+        (group === activeGroup ? "" : ' tabindex="-1"') + '>' + esc(group) +
+        "<span class='aux'> " + n + "</span></button>";
     }).join("");
-    $("routes").innerHTML = html ||
-      '<section><div class="empty">Nothing matches that.</div></section>';
+
+    $("routes").innerHTML = order.map(function (group) {
+      var rows = hits[group];
+      var body = rows.length
+        ? rows.map(function (pair) { return routeHtml(pair[0], pair[1]); }).join("")
+        : '<div class="empty">' + (query ? "Nothing in this group matches that."
+                                         : "No routes in this group.") + "</div>";
+      return '<section class="pane" role="tabpanel" aria-labelledby="tab-' + esc(paneId(group)) +
+        '" id="pane-' + esc(paneId(group)) + '"' + (group === activeGroup ? "" : " hidden") + ">" +
+        body + "</section>";
+    }).join("");
+
+    /* The filter searches every group. Restricting it to the open tab would hide matches in the
+       other five and read as "nothing matches that", which is the worst answer to give somebody
+       searching a reference -- so when the open tab has none and others do, say where they are. */
+    var elsewhere = total - hits[activeGroup].length;
+    if (query && !hits[activeGroup].length && elsewhere > 0) {
+      var first = order.filter(function (g) { return hits[g].length; })[0];
+      $("crossGroup").innerHTML = '<div class="msg info">' + elsewhere + " match" +
+        (elsewhere === 1 ? "" : "es") + " in other groups. " +
+        '<button type="button" class="link" data-goto="' + esc(paneId(first)) + '">Show ' +
+        esc(first) + "</button></div>";
+    } else {
+      $("crossGroup").innerHTML = "";
+    }
+
+    /* Called after every render: the buttons are new elements each time, so the listeners the
+       switcher attached to the old ones went with them. */
+    if (window.wireTabs) {
+      window.wireTabs(function (pane) {
+        /* The switcher calls this once while wiring, for the tab that is already selected. Without
+           this guard that call re-renders, which re-wires, which calls it again -- the page died
+           of a stack overflow on load. Only an actual change to another group redraws. */
+        var next = null;
+        for (var i = 0; i < order.length; i++) {
+          if (paneId(order[i]) === pane) { next = order[i]; break; }
+        }
+        if (next === null || next === activeGroup) { return; }
+        activeGroup = next;
+        render();
+      });
+    }
   }
+
+  $("crossGroup").addEventListener("click", function (ev) {
+    var button = ev.target.closest ? ev.target.closest("[data-goto]") : null;
+    if (!button) { return; }
+    for (var i = 0; i < ROUTES.length; i++) {
+      if (paneId(ROUTES[i].group) === button.dataset.goto) { activeGroup = ROUTES[i].group; break; }
+    }
+    render();
+  });
 
   /* A re-render replaces every cell, so the counters have to go back on. Without this, filtering
      blanks them until the next frame. */

--- a/tools/test_matrixark_api_traffic.py
+++ b/tools/test_matrixark_api_traffic.py
@@ -137,5 +137,46 @@ class EveryPageThatAsksForFramesGetsThemTest(unittest.TestCase):
         self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
 
 
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheApiSurfaceIsGroupedIntoTabsTest(unittest.TestCase):
+    """55 routes in six groups arrived as one column; Administration alone is 21 of them.
+
+    Two behaviours here cannot be read off the source. The list is rebuilt on every keystroke, so
+    whether the open tab survives a re-render is behaviour. And the text filter searches every
+    group while one pane is visible -- a filter quietly restricted to the open tab would answer
+    "nothing matches that" while holding the match one tab away, which is the worst answer a
+    reference page can give.
+    """
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "api_tabs_harness.js"),
+             os.path.join(PORTAL, "api_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_the_tabs_work(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_filter_searches_every_group(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the filter searched every group, not just the open one", out, out)
+
+    def test_the_open_tab_survives_a_keystroke(self) -> None:
+        """The list is rebuilt on every keystroke; losing the tab each time makes it unusable."""
+        out = self._run().stdout
+        self.assertIn("ok   the open tab survives a keystroke", out, out)
+
+    def test_matches_in_another_group_are_pointed_at(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   it says the matches are in another group", out, out)
+
+    def test_the_notice_is_not_shown_when_the_open_group_has_matches(self) -> None:
+        """Announcing "matches elsewhere" over a list full of matches is noise."""
+        out = self._run().stdout
+        self.assertIn("ok   the shared term really does match two groups", out, out)
+        self.assertIn("ok   a match in the open group is not announced as elsewhere", out, out)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fifty-five routes arrived as one long column — Administration alone is 21 of them, so finding the blob routes meant scrolling past the lot. They become tabs: Memory, Administration, Catalogue, Blobs, Health, Portal pages, each carrying its route count.

**The filter is the part that had to be right.** Narrowing it to the open tab would hide matches in the other five and answer *"nothing matches that"* — the worst thing a reference page can say to someone searching it. So it searches everything: tab counts are matches under the **current query**, not group sizes, and when the open tab has none while others do, the page says how many are elsewhere and offers to go there. When the open tab has matches it says nothing, because announcing "matches elsewhere" over a list full of matches is noise.

Real tabs with real panes, not filter chips dressed as tabs — `role="tablist"` promises a screen reader that these switch panels, and these do.

**The harness caught a stack overflow on page load.** The shared switcher calls its `onShow` callback once while wiring, for the already-selected tab — and that callback re-rendered, which re-wired, which called it again. Only an actual change of group redraws now.

Five mutations fail the tests, including removing that guard. One of my own checks was also passing for the wrong reason: *"a match in the open group is not announced as elsewhere"* used a term matching only the open group, so nothing was elsewhere either way. The fixture now shares a term across two groups — and asserts that it does.