### PR TITLE
Skills and Resources become tabs on the catalogue

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2462,20 +2462,29 @@ CATALOG_BODY = """
     <div id="listMsg" role="status" aria-live="polite"></div>
   </section>
 
-  <section>
-    <h2>Skills</h2>
+  <div class="tabs" role="tablist" aria-label="Catalogue">
+    <button type="button" role="tab" id="tab-skills" aria-controls="pane-skills"
+            data-pane="skills" aria-selected="true">Skills<span class="aux"
+            id="skillsCount"></span></button>
+    <button type="button" role="tab" id="tab-resources" aria-controls="pane-resources"
+            data-pane="resources" aria-selected="false" tabindex="-1">Resources<span class="aux"
+            id="resourcesCount"></span></button>
+  </div>
+  <div id="crossList"></div>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-skills" id="pane-skills">
     <div id="skills"><div class="empty">Not loaded.</div></div>
   </section>
 
-  <section>
-    <h2>Resources</h2>
+  <section class="pane" role="tabpanel" aria-labelledby="tab-resources" id="pane-resources"
+           hidden>
     <div id="resources"><div class="empty">Not loaded.</div></div>
   </section>
 
   <section>
     <h2>Stored text <span class="aux" id="contentTitle"></span></h2>
-    <p class="hint" style="margin-top:0">Select a row above to read what was actually stored — the
-      chunks retrieval will draw from, not the source file on disk.</p>
+    <p class="hint" style="margin-top:0">Select a row in either list to read what was
+      actually stored — the chunks retrieval will draw from, not the source file on disk.</p>
     <pre id="content">Nothing selected.</pre>
   </section>
 """
@@ -2485,6 +2494,16 @@ CATALOG_JS = r"""
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
+
+  /* Wired once: these buttons live in the static markup, so unlike the API page they are
+     not replaced on every render and their listeners survive. */
+  if (window.wireTabs) { window.wireTabs(); }
+
+  document.getElementById("crossList").addEventListener("click", function (ev) {
+    var button = ev.target.closest ? ev.target.closest("[data-goto]") : null;
+    if (!button) { return; }
+    if (window.showTab) { window.showTab(button.dataset.goto); }
+  });
 
   function auth() {
     var k = $("key").value.trim();
@@ -2623,6 +2642,27 @@ CATALOG_JS = r"""
       renderSummary(skills, resources);
       $("skills").innerHTML = skillsHtml(skills);
       $("resources").innerHTML = resourcesHtml(resources);
+      /* Counts under the CURRENT query, not the size of each catalogue: they describe what
+         clicking would show. */
+      $("skillsCount").textContent = " " + skills.length;
+      $("resourcesCount").textContent = " " + resources.length;
+      /* One filter covers both lists, and only one is visible. With Skills open, a query matching
+         only Resources would empty the list and read as "nothing found" while the match sat one
+         tab away -- so when the open tab has none and the other has some, say where they are. */
+      var openPane = ($("tab-resources").getAttribute("aria-selected") === "true")
+        ? "resources" : "skills";
+      var here = openPane === "skills" ? skills.length : resources.length;
+      var other = openPane === "skills" ? resources.length : skills.length;
+      var otherName = openPane === "skills" ? "Resources" : "Skills";
+      if (text && !here && other) {
+        $("crossList").innerHTML = '<div class="msg info">' + other + " match" +
+          (other === 1 ? "" : "es") + " in " + otherName +
+          '. <button type="button" class="link" data-goto="' +
+          (openPane === "skills" ? "resources" : "skills") + '">Show ' + otherName +
+          "</button></div>";
+      } else {
+        $("crossList").innerHTML = "";
+      }
     }).catch(function (e) {
       if (e === 401 || e === 403) {
         conn("live", "connected");

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -473,28 +473,114 @@
     <div id="listMsg" role="status" aria-live="polite"></div>
   </section>
 
-  <section>
-    <h2>Skills</h2>
+  <div class="tabs" role="tablist" aria-label="Catalogue">
+    <button type="button" role="tab" id="tab-skills" aria-controls="pane-skills"
+            data-pane="skills" aria-selected="true">Skills<span class="aux"
+            id="skillsCount"></span></button>
+    <button type="button" role="tab" id="tab-resources" aria-controls="pane-resources"
+            data-pane="resources" aria-selected="false" tabindex="-1">Resources<span class="aux"
+            id="resourcesCount"></span></button>
+  </div>
+  <div id="crossList"></div>
+
+  <section class="pane" role="tabpanel" aria-labelledby="tab-skills" id="pane-skills">
     <div id="skills"><div class="empty">Not loaded.</div></div>
   </section>
 
-  <section>
-    <h2>Resources</h2>
+  <section class="pane" role="tabpanel" aria-labelledby="tab-resources" id="pane-resources"
+           hidden>
     <div id="resources"><div class="empty">Not loaded.</div></div>
   </section>
 
   <section>
     <h2>Stored text <span class="aux" id="contentTitle"></span></h2>
-    <p class="hint" style="margin-top:0">Select a row above to read what was actually stored — the
-      chunks retrieval will draw from, not the source file on disk.</p>
+    <p class="hint" style="margin-top:0">Select a row in either list to read what was
+      actually stored — the chunks retrieval will draw from, not the source file on disk.</p>
     <pre id="content">Nothing selected.</pre>
   </section>
 
 </div>
 <script>
+/* Tabs, for every portal page whose body declares a tablist.
+ *
+ * Shared rather than per page. The explore page had the only copy and this is the second caller;
+ * two copies of a behaviour that looks identical is how they stop being identical.
+ *
+ * Click alone is not enough for role="tablist". Someone arriving on the selected tab expects the
+ * arrow keys to move between them -- that is what the role announces -- and roving tabindex is
+ * what makes those arrows the way through rather than one more thing to tab past.
+ */
+(function () {
+  "use strict";
+
+  window.wireTabs = function (onShow) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tabs button"));
+    if (!tabs.length) { return; }
+
+    function show(button) {
+      tabs.forEach(function (b) {
+        var selected = b === button;
+        b.setAttribute("aria-selected", String(selected));
+        b.tabIndex = selected ? 0 : -1;
+      });
+      Array.prototype.forEach.call(document.querySelectorAll(".pane"), function (pane) {
+        pane.hidden = pane.id !== "pane-" + button.dataset.pane;
+      });
+      if (typeof onShow === "function") { onShow(button.dataset.pane); }
+    }
+
+    tabs.forEach(function (button, index) {
+      button.addEventListener("click", function () { show(button); });
+      button.addEventListener("keydown", function (event) {
+        var next = null;
+        if (event.key === "ArrowRight") { next = tabs[(index + 1) % tabs.length]; }
+        else if (event.key === "ArrowLeft") { next = tabs[(index - 1 + tabs.length) % tabs.length]; }
+        else if (event.key === "Home") { next = tabs[0]; }
+        else if (event.key === "End") { next = tabs[tabs.length - 1]; }
+        if (!next) { return; }
+        event.preventDefault();
+        show(next);
+        next.focus();
+      });
+    });
+
+    var already = tabs.filter(function (b) {
+      return b.getAttribute("aria-selected") === "true";
+    });
+    show(already[0] || tabs[0]);
+  };
+
+  /* Show a pane from code. Needed whenever one pane's control writes into another's: without
+     it the change lands somewhere the person cannot see, and any instruction about what to do
+     next refers to a part of the page that is not on screen. */
+  window.showTab = function (pane) {
+    var button = document.getElementById("tab-" + pane);
+    if (button) { button.click(); }
+  };
+
+  /* Put a count on a tab. A pane that is hidden cannot report anything itself, and the case that
+     matters is a form with unsaved changes in it. */
+  window.markTab = function (pane, badge) {
+    var button = document.getElementById("tab-" + pane);
+    if (!button) { return; }
+    button.setAttribute("data-badge", badge ? String(badge) : "");
+  };
+}());
+</script>
+<script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
+
+  /* Wired once: these buttons live in the static markup, so unlike the API page they are
+     not replaced on every render and their listeners survive. */
+  if (window.wireTabs) { window.wireTabs(); }
+
+  document.getElementById("crossList").addEventListener("click", function (ev) {
+    var button = ev.target.closest ? ev.target.closest("[data-goto]") : null;
+    if (!button) { return; }
+    if (window.showTab) { window.showTab(button.dataset.goto); }
+  });
 
   function auth() {
     var k = $("key").value.trim();
@@ -633,6 +719,27 @@
       renderSummary(skills, resources);
       $("skills").innerHTML = skillsHtml(skills);
       $("resources").innerHTML = resourcesHtml(resources);
+      /* Counts under the CURRENT query, not the size of each catalogue: they describe what
+         clicking would show. */
+      $("skillsCount").textContent = " " + skills.length;
+      $("resourcesCount").textContent = " " + resources.length;
+      /* One filter covers both lists, and only one is visible. With Skills open, a query matching
+         only Resources would empty the list and read as "nothing found" while the match sat one
+         tab away -- so when the open tab has none and the other has some, say where they are. */
+      var openPane = ($("tab-resources").getAttribute("aria-selected") === "true")
+        ? "resources" : "skills";
+      var here = openPane === "skills" ? skills.length : resources.length;
+      var other = openPane === "skills" ? resources.length : skills.length;
+      var otherName = openPane === "skills" ? "Resources" : "Skills";
+      if (text && !here && other) {
+        $("crossList").innerHTML = '<div class="msg info">' + other + " match" +
+          (other === 1 ? "" : "es") + " in " + otherName +
+          '. <button type="button" class="link" data-goto="' +
+          (openPane === "skills" ? "resources" : "skills") + '">Show ' + otherName +
+          "</button></div>";
+      } else {
+        $("crossList").innerHTML = "";
+      }
     }).catch(function (e) {
       if (e === 401 || e === 403) {
         conn("live", "connected");

--- a/tools/portal/catalog_tabs_harness.js
+++ b/tools/portal/catalog_tabs_harness.js
@@ -1,0 +1,177 @@
+/* Run the catalogue page's Skills/Resources tabs.
+ *
+ * One filter covers both lists while only one is visible, so the interesting behaviour is what
+ * happens when the query matches the tab you are NOT looking at. Reading the source cannot tell a
+ * page that says so from one that shows an empty list.
+ *
+ * Usage: node catalog_tabs_harness.js <catalog_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const SKILLS = { skills: [
+  { name: "deploy-runbook", description: "How to deploy the airship", updated_at: 1 },
+  { name: "oncall", description: "Who to wake", updated_at: 2 },
+] };
+const RESOURCES = { resources: [
+  { name: "hull-spec.md", description: "Airship hull specification", updated_at: 3 },
+] };
+
+const listeners = {};
+const els = new Map();
+
+function attr(tag, name) {
+  const m = tag.match(new RegExp(name + '="([^"]*)"'));
+  return m ? m[1] : null;
+}
+
+/* Tabs and panes come from the STATIC markup, so they are parsed from the page once. */
+const tabCells = [...page.matchAll(/<button[^>]*role="tab"[\s\S]*?<\/button>/g)].map((m) => {
+  const tag = m[0];
+  const el = {
+    id: attr(tag, "id"), dataset: { pane: attr(tag, "data-pane") },
+    tabIndex: 0, focused: false, _listeners: {},
+    _attrs: { "aria-selected": attr(tag, "aria-selected") || "false" },
+    addEventListener(t, fn) { (this._listeners[t] = this._listeners[t] || []).push(fn); },
+    dispatch(t, ev) { (this._listeners[t] || []).forEach((fn) => fn(ev || {})); },
+    setAttribute(k, v) { this._attrs[k] = String(v); },
+    getAttribute(k) { return k in this._attrs ? this._attrs[k] : null; },
+    focus() { this.focused = true; }, click() { this.dispatch("click"); }
+  };
+  return el;
+});
+const panes = [...page.matchAll(/<section[^>]*class="pane"[^>]*>/g)].map((m) => ({
+  id: attr(m[0], "id"), hidden: /\shidden[\s>]/.test(m[0])
+}));
+
+function makeEl(id) {
+  return {
+    id: id || "", hidden: false, innerHTML: "", textContent: "", value: "", className: "",
+    style: {}, dataset: {}, children: [],
+    addEventListener(type, fn) { listeners[(id || "") + ":" + type] = fn; },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  const fromMarkup = tabCells.filter((t) => t.id === id)[0];
+  if (fromMarkup) { return fromMarkup; }
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+function json(body) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body),
+                           text: () => Promise.resolve("{}") });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(),
+    querySelectorAll: (sel) => (sel === ".tabs button" ? tabCells
+                                : (sel === ".pane" ? panes : [])),
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    const u = String(url);
+    if (u.indexOf("/v1/skills") >= 0) { return json(SKILLS); }
+    if (u.indexOf("/v1/resources") >= 0) { return json(RESOURCES); }
+    if (u.indexOf("/v1/admin/events") >= 0) {
+      return Promise.resolve({ ok: true, status: 200,
+                               body: { getReader: () => ({ read: () => new Promise(() => {}) }) },
+                               json: () => Promise.resolve({}), text: () => Promise.resolve("") });
+    }
+    return json({});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+});
+
+function visible() { return panes.filter((p) => !p.hidden).map((p) => p.id); }
+function counts() {
+  return [el("skillsCount").textContent.trim(), el("resourcesCount").textContent.trim()];
+}
+function search(text) {
+  el("filter").value = text;
+  const fn = listeners["filter:input"];
+  if (fn) { fn({}); }
+}
+
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+
+(async function () {
+  for (let i = 0; i < 40; i += 1) { await settle(); }
+
+  ok("both tabs exist", tabCells.length === 2, tabCells.map((t) => t.id).join(", "));
+  ok("exactly one pane is visible", visible().length === 1, visible().join(", "));
+  ok("the tabs carry counts", counts()[0] === "2" && counts()[1] === "1", counts().join(" / "));
+
+  /* Clicking has to work, which means the page called the switcher. Without this check, removing
+     that call leaves every other assertion passing -- the counts and the notice are computed in
+     the render path and do not need the tabs to be wired at all. */
+  const resourcesTab = tabCells.filter((t) => t.dataset.pane === "resources")[0];
+  ok("there is a Resources tab", !!resourcesTab, tabCells.map((t) => t.id).join(", "));
+  resourcesTab.dispatch("click");
+  ok("clicking a tab switches the visible list", visible().join() === "pane-resources",
+     "visible: " + visible().join(", ") + " -- was the switcher wired?");
+  tabCells.filter((t) => t.dataset.pane === "skills")[0].dispatch("click");
+  ok("and switches back", visible().join() === "pane-skills", visible().join(", "));
+
+  /* A term only in Resources, while Skills is open. */
+  search("hull");
+  for (let i = 0; i < 40; i += 1) { await settle(); }
+  ok("the filter searched both lists", counts()[0] === "0" && counts()[1] === "1",
+     "counts: " + counts().join(" / "));
+  const notice = el("crossList").innerHTML;
+  ok("it says the match is in the other list",
+     /match/.test(notice) && /Resources/.test(notice), JSON.stringify(notice).slice(0, 140));
+
+  /* A term in BOTH lists: the open tab has matches, so nothing should be announced. */
+  search("airship");
+  for (let i = 0; i < 40; i += 1) { await settle(); }
+  ok("the shared term matches both lists", counts()[0] === "1" && counts()[1] === "1",
+     "counts: " + counts().join(" / "));
+  ok("a match in the open list is not announced as elsewhere",
+     el("crossList").innerHTML === "",
+     JSON.stringify(el("crossList").innerHTML).slice(0, 140));
+
+  /* Nothing anywhere. */
+  search("nothing-matches-this");
+  for (let i = 0; i < 40; i += 1) { await settle(); }
+  ok("a term matching nothing points nowhere", el("crossList").innerHTML === "",
+     JSON.stringify(el("crossList").innerHTML).slice(0, 140));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}());

--- a/tools/test_matrixark_portal_tabs.py
+++ b/tools/test_matrixark_portal_tabs.py
@@ -28,7 +28,8 @@ TOOLS = os.path.dirname(os.path.abspath(__file__))
 PORTAL = os.path.join(TOOLS, "portal")
 HARNESS = os.path.join(PORTAL, "tabs_harness.js")
 
-TABBED = ["setup_portal.html", "explore_portal.html", "api_key_portal.html"]
+TABBED = ["setup_portal.html", "explore_portal.html", "api_key_portal.html",
+          "catalog_portal.html"]
 
 # Every heading the setup page carried before it was grouped into panes.
 SETUP_HEADINGS = [
@@ -182,6 +183,44 @@ class TheHandMaintainedPagesGetTheHelperTest(unittest.TestCase):
         self.assertIn("Connection", above,
                       "the connection panel moved behind a tab, so the other tabs look broken "
                       "until you find it")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheCatalogueSplitsIntoTabsTest(unittest.TestCase):
+    """Skills and Resources were two full-width lists stacked one above the other.
+
+    One filter covers both while only one is visible, so the case that matters is a query matching
+    the tab you are NOT looking at: an empty list reads as "nothing found" while the match sits one
+    tab away. The counts are matches under the current query, and the page says where they are.
+    """
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "catalog_tabs_harness.js"),
+             os.path.join(PORTAL, "catalog_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_the_tabs_work(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_clicking_actually_switches(self) -> None:
+        """Without this the counts and the notice pass while the tabs are wired to nothing."""
+        out = self._run().stdout
+        self.assertIn("ok   clicking a tab switches the visible list", out, out)
+
+    def test_the_filter_covers_both_lists(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the filter searched both lists", out, out)
+
+    def test_a_match_in_the_other_list_is_pointed_at(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   it says the match is in the other list", out, out)
+
+    def test_it_stays_quiet_when_the_open_list_has_matches(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the shared term matches both lists", out, out)
+        self.assertIn("ok   a match in the open list is not announced as elsewhere", out, out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two independent full-width lists, stacked, and you read one at a time — so the second was mostly something to scroll past. They become tabs, each carrying its count.

**One filter covers both lists while only one is visible**, the same trap the API surface had: with Skills open, a query matching only Resources would empty the visible list and read as *"nothing found"* while the match sat one tab away. The counts are matches under the **current query** rather than catalogue sizes, and when the open tab has none while the other has some, the page says how many and offers to switch. When the open tab has matches it stays quiet.

Access and Scope stay above the tabs — both are needed before either list has anything in it, and a tab you must visit first every time is a step, not a tab. Stored text stays below both, since it is the detail view for whichever row was picked. Its wording changed with the layout: *"select a row above"* stopped being true once the rows went behind tabs.

**My first harness would have missed the wiring entirely.** Removing the call to the switcher left every assertion passing, because the counts and the notice are computed in the render path and never need a tab to be clicked. It clicks now, and that mutation fails — along with three others.