### PR TITLE
Let the summary worker finish before reading what it wrote

### DIFF
--- a/tools/test_matrixark_summary_worker.py
+++ b/tools/test_matrixark_summary_worker.py
@@ -259,14 +259,22 @@ class MatrixArkSummaryWorkerTest(unittest.TestCase):
                     "metadata": {"node_path": ["tenant:summary", "user:worker", "session:worker"]},
                 },
             )
-        deadline = time.time() + 3.0
+        # The loop leaves as soon as the worker has produced everything, so a longer ceiling
+        # costs nothing when it is quick and stops the test failing on a busy machine. Three
+        # seconds was not enough: on a loaded box this failed about one standalone run in
+        # three, always on node_l1 -- the L1 refresh is the last step, so it is the one a short
+        # deadline cuts off.
+        settle_seconds = 30.0
+        deadline = time.time() + settle_seconds
         records = []
+        settled = False
         while time.time() < deadline:
             records = adapter.read_all()
             summary_types = {r.get("summary_type") for r in records if r.get("record_type") == "context_summary"}
             embedding_types = {(r.get("embedding_meta") or {}).get("embedding_type")
                                for r in records if r.get("vector")}
             if {"node_l0", "node_l1"}.issubset(summary_types) and {"node_l0", "node_l1"}.issubset(embedding_types):
+                settled = True
                 break
             time.sleep(0.05)
         summary_types = {r.get("summary_type") for r in records if r.get("record_type") == "context_summary"}
@@ -274,6 +282,15 @@ class MatrixArkSummaryWorkerTest(unittest.TestCase):
         # survives under embedding_meta.
         embedding_types = {(r.get("embedding_meta") or {}).get("embedding_type")
                            for r in records if r.get("vector")}
+        # Say that the worker ran out of time, rather than asserting against a half-finished
+        # store and reporting a missing summary type as though the worker had produced a wrong
+        # answer. The checks below still name exactly what has to be there.
+        self.assertTrue(
+            settled,
+            "the summary worker did not settle within %.0fs: summary_types=%r embedding_types=%r"
+            % (settle_seconds, sorted(str(value) for value in summary_types),
+               sorted(str(value) for value in embedding_types)),
+        )
         self.assertIn("node_l0", summary_types)
         self.assertIn("node_l1", summary_types)
         self.assertIn("node_l0", embedding_types)


### PR DESCRIPTION
`test_background_worker_refreshes_dirty_nodes_and_embeddings` failed about **one standalone run
in three**, always on `node_l1`. It is not in the baseline, so every flake counted as a NEW
failure and could turn the merge gate red for whoever happened to be merging.

It already polled — but with a **three second** ceiling, and the L1 refresh is the last thing
the worker does, so a busy machine is exactly what that cut off. Forcing the timeout shows the
shape precisely:

```
summary_types=['node_l0', 'node_l1', 'session_l0']
embedding_types=['None', 'event_text', 'node_l0', 'session_l0']
```

The node_l1 **summary** is already there; its **embedding** is not. That last write is what a
short deadline loses.

## Two changes

**The ceiling is now 30s**, which costs nothing — the loop leaves as soon as the worker is
done, and the test still finishes in about **1.3 seconds**.

**Running out of time now says so.** Before, the loop fell through and asserted against a
half-written store, so a timeout reported a missing summary type as though the worker had
produced a wrong answer:

```
the summary worker did not settle within 30s: summary_types=[...] embedding_types=[...]
```

## Verified

- five standalone runs pass, where it previously failed roughly one in three
- it passes under full `unittest discover`, where it had been failing
- the timeout path is exercised by making the wait condition unsatisfiable, and reports the new
  message rather than the old confusing one

## Unrelated, and not from this change

A different name — `test_user_prompt_fast_async_still_backfills_previous_assistant_rollout` —
failed in the same discovery sweep and passes three times out of three on its own. This suite
has more than one order-dependent test; that one is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)