### PR TITLE
A copy button for the key you are shown once

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -477,6 +477,36 @@
     return (s || "").split(",").map(function (x) { return x.trim(); }).filter(Boolean);
   }
 
+  /* One copier for the three things worth copying, reporting what actually happened. The inline
+     version this replaces said "Copied" whether or not a clipboard existed, and never looked at
+     the promise writeText returns -- so a rejected write (an insecure origin, an unfocused
+     document, a denied permission) also read as "Copied". That is a small annoyance for a curl
+     command and the entire loss for a key shown once.
+
+     It says so on the button rather than in the message area, because that area carries the
+     reason a key was not created and overwriting it would hide one failure with another. */
+  function copyText(text, buttonId, done) {
+    var button = $(buttonId);
+    if (!button) { return; }
+    var restore = button.textContent;
+    function settled(ok) {
+      button.textContent = ok ? done : "Copy failed";
+      window.setTimeout(function () { button.textContent = restore; }, 1400);
+    }
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () { settled(true); },
+                                                 function () { settled(false); });
+        return;
+      }
+    } catch (e) { /* falls through to the failure path below */ }
+    /* No clipboard API at all -- an http:// origin, which a self-hosted portal often is. The text
+       is on the page either way, so saying the copy failed beats a button that does nothing. */
+    settled(false);
+  }
+  /* The scope catalogue runs in a later script block with its own scope. */
+  window.__matrixarkCopy = copyText;
+
   // ---- create ----------------------------------------------------------------------------------
   function createKey() {
     hideMsg("createMsg");
@@ -503,9 +533,22 @@
       .then(function (data) {
         var r = unwrap(data);
         out.className = "keyout show";
+        /* Offered only when there is a key to copy. The server can answer without one, and this
+           page renders "(not returned)" for that -- a button there would put that string on the
+           clipboard and look like it had worked. */
+        var secret = r.api_key || "";
         out.innerHTML = "<div>api_key_id: <strong>" + escapeHtml(r.api_key_id || "") + "</strong></div>" +
-          "<div style='margin-top:6px'>api_key: " + escapeHtml(r.api_key || "(not returned)") + "</div>" +
+          "<div style='margin-top:6px'>api_key: " + escapeHtml(secret || "(not returned)") +
+          (secret ? " <button type='button' class='mini' id='copyNewKey'>Copy key</button>" : "") +
+          "</div>" +
           "<div class='warn-line'>Copy this key now — it is shown only once. MatrixArk stores only its hash.</div>";
+        if (secret) {
+          /* The secret alone: sweeping up the id or the warning gives a clipboard that fails when
+             pasted into a config file, later and somewhere else. */
+          $("copyNewKey").addEventListener("click", function () {
+            copyText(secret, "copyNewKey", "Copied");
+          });
+        }
         showMsg("createMsg", "ok", "Created " + (r.api_key_id || "key") + ".");
         listKeys();
       })
@@ -582,9 +625,18 @@
         var r = unwrap(data);
         var out = $("createKeyOut");
         out.className = "keyout show";
+        /* Rotation shows a secret on the same terms as creation, so it gets the same button. */
+        var rotated = r.api_key || "";
         out.innerHTML = "<div>Rotated " + escapeHtml(id) + " → <strong>" + escapeHtml(r.api_key_id || "") + "</strong></div>" +
-          "<div style='margin-top:6px'>new api_key: " + escapeHtml(r.api_key || "(not returned)") + "</div>" +
+          "<div style='margin-top:6px'>new api_key: " + escapeHtml(rotated || "(not returned)") +
+          (rotated ? " <button type='button' class='mini' id='copyRotatedKey'>Copy key</button>" : "") +
+          "</div>" +
           "<div class='warn-line'>Copy the new key now — shown only once.</div>";
+        if (rotated) {
+          $("copyRotatedKey").addEventListener("click", function () {
+            copyText(rotated, "copyRotatedKey", "Copied");
+          });
+        }
         showMsg("listMsg", "ok", "Rotated " + id + ".");
         listKeys();
       })
@@ -808,9 +860,7 @@
         "  -H \"Authorization: Bearer $MATRIXARK_ADMIN_KEY\" \\\n" +
         "  -H 'Content-Type: application/json' \\\n  -d '" +
         JSON.stringify(payload) + "'\n";
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      copy.textContent = "Copied";
-      setTimeout(function () { copy.textContent = "Copy as curl"; }, 1400);
+      window.__matrixarkCopy(text, "copyCurl", "Copied");
     });
   }
 

--- a/tools/portal/key_copy_harness.js
+++ b/tools/portal/key_copy_harness.js
@@ -1,0 +1,296 @@
+/* Run the key portal's copy paths and read what they actually did.
+ *
+ * Three things here cannot be seen by reading the source. Whether a copy button is offered when
+ * the server answers without a key. What lands on the clipboard when it is clicked -- the secret
+ * alone, or the secret with the id and the warning swept up around it. And what the button says
+ * when the clipboard REFUSES, which is the case the previous code got wrong: it reported "Copied"
+ * unconditionally, and for a key shown exactly once that is the difference between a copied key
+ * and a lost one.
+ *
+ * Usage: node key_copy_harness.js <api_key_portal.html> [mutation]
+ *   mutation = nogate   -- offer the button even with no key  (case B must go red)
+ *   mutation = oldcopy  -- report "Copied" unconditionally     (cases C, D, F must go red)
+ */
+"use strict";
+const fs = require("fs");
+
+const PATH = process.argv[2];
+const MUTATION = process.argv[3] || "";
+/* Deliberately unlike a real key: low-entropy, no live-looking prefix, and named for what it
+   is. A fixture shaped like a credential trains the secret scanner's readers to wave findings
+   through, and the alternative -- allowlisting this file by path -- would hide a real one later. */
+const CREATED_KEY = "created-key-placeholder-not-a-real-key";
+const ROTATED_KEY = "rotated-key-placeholder-not-a-real-key";
+
+const GATE = "(secret ? \" <button type='button' class='mini' id='copyNewKey'>Copy key</button>\" : \"\") +";
+const UNGATED = "\" <button type='button' class='mini' id='copyNewKey'>Copy key</button>\" +";
+const HONEST = "      button.textContent = ok ? done : \"Copy failed\";";
+const ALWAYS = "      button.textContent = done;";
+
+let source = fs.readFileSync(PATH, "utf8");
+if (MUTATION) {
+  const before = source;
+  if (MUTATION === "nogate") { source = source.replace(GATE, UNGATED); }
+  else if (MUTATION === "oldcopy") { source = source.replace(HONEST, ALWAYS); }
+  else { console.log("FAIL unknown mutation " + MUTATION); process.exit(1); }
+  if (source === before) {
+    console.log("FAIL mutation '" + MUTATION + "' matched nothing -- it tests neither code nor test");
+    process.exit(1);
+  }
+}
+
+const scripts = [...source.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* ---- one page, with a clipboard that behaves as the case requires ---------------------------- */
+function boot(clipboard) {
+  const els = new Map();
+  const created = [];
+  const timers = [];
+
+  function makeEl(id) {
+    return {
+      id: id || "", hidden: false, innerHTML: "", textContent: "", value: "", className: "",
+      disabled: false, checked: false, onclick: null, style: {}, dataset: {}, children: [],
+      _listeners: {},
+      addEventListener(t, fn) { (this._listeners[t] = this._listeners[t] || []).push(fn); },
+      dispatch(t, ev) { (this._listeners[t] || []).forEach((fn) => fn(ev || {})); },
+      removeEventListener() {},
+      appendChild(child) { this.children.push(child); }, removeChild() {}, remove() {},
+      setAttribute() {}, getAttribute() { return null; },
+      closest() { return null; },
+      /* The key table's renderer reaches for a tbody and then for the row's last cell, and both
+         have to be real objects or the rows -- and the Rotate button on them -- never exist. */
+      querySelector(sel) {
+        this._found = this._found || {};
+        if (!this._found[sel]) { this._found[sel] = makeEl((id || "") + " " + sel); }
+        return this._found[sel];
+      },
+      get lastChild() {
+        if (!this._last) { this._last = makeEl((id || "") + ":last"); }
+        return this._last;
+      },
+      querySelectorAll() { return []; },
+      scrollIntoView() {}, focus() {}, click() { if (this.onclick) { this.onclick({}); } },
+      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } }
+    };
+  }
+  function el(id) {
+    if (!els.has(id)) { els.set(id, makeEl(id)); }
+    return els.get(id);
+  }
+
+  function reply(body) {
+    return Promise.resolve({
+      ok: true, status: 200,
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body)
+    });
+  }
+
+  let createResponse = { api_key_id: "ak_new", api_key: CREATED_KEY };
+  const rotateResponse = { api_key_id: "ak_rotated", api_key: ROTATED_KEY };
+
+  const store = { mtx_admin_key: "admin-key-for-the-harness" };
+  const storage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem(k, v) { store[k] = String(v); },
+    removeItem(k) { delete store[k]; }
+  };
+
+  const win = {
+    document: {
+      getElementById: (id) => el(id),
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      createElement() { const e = makeEl(); created.push(e); return e; },
+      createTextNode() { return makeEl(); },
+      addEventListener() {}, body: makeEl(), hidden: false
+    },
+    addEventListener() {},
+    location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+    localStorage: storage, sessionStorage: storage,
+    navigator: clipboard === null ? {} : { clipboard: clipboard },
+    /* Recorded, never fired: the label restores after 1.4s, and firing that would erase the very
+       thing each case asserts. That the restore was scheduled is checked on its own. */
+    setTimeout(fn) { timers.push(fn); return timers.length; },
+    setInterval: () => 0, clearInterval() {}, clearTimeout() {},
+    wireTabs() {}, requestAnimationFrame: () => 0,
+    Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+    encodeURIComponent, decodeURIComponent, parseInt, parseFloat, console,
+    TextDecoder: function () { this.decode = () => ""; },
+    AbortController: function () { this.abort = () => {}; this.signal = {}; },
+    FileReader: function () {}, Blob: function () {},
+    URL: { createObjectURL: () => "", revokeObjectURL() {} },
+    fetch: (url) => {
+      const u = String(url);
+      if (u.indexOf("create_api_key") >= 0) { return reply({ result: createResponse }); }
+      if (u.indexOf("rotate_api_key") >= 0) { return reply({ result: rotateResponse }); }
+      if (u.indexOf("list_api_keys") >= 0) {
+        /* The field names are the served ones: the list reads `api_keys`, and only a row whose
+           status is exactly "active" gets a Rotate button built for it. A fixture shaped to a
+           guess would render nothing and let the rotate case pass having tested nothing. */
+        return reply({ result: { api_keys: [{
+          api_key_id: "ak_new", tenant_id: "t1", account_id: "a1", role: "service",
+          scopes: ["read", "write"], status: "active", request_quota: 0, quota_window: 0,
+          created_at_ms: 1756000000000, last_used_at_ms: 1756000090000, usage_count: 3
+        }] } });
+      }
+      return new Promise(() => {});
+    }
+  };
+  win.window = win;
+
+  const names = Object.keys(win);
+  const values = names.map((k) => win[k]);
+  scripts.forEach((body, index) => {
+    try { new Function(...names, body)(...values); }
+    catch (e) { console.log("FAIL script " + index + " threw: " + e.message); failures += 1; }
+  });
+
+  return {
+    el, created, timers,
+    setCreateResponse(v) { createResponse = v; },
+    create() {
+      /* Both are required, and createKey returns quietly without either -- which would leave the
+         output empty and let an "is no button offered?" check pass having rendered nothing. */
+      el("ckScopes").value = "read";
+      el("ckTenant").value = "t1";
+      const btn = el("createBtn");
+      if (!btn.onclick) { throw new Error("createBtn has no handler"); }
+      btn.onclick({});
+    },
+    rotate() {
+      const b = created.filter((c) => c.textContent === "Rotate")[0];
+      if (!b) { throw new Error("no Rotate button was built"); }
+      b.onclick({});
+    }
+  };
+}
+
+function clipboardThat(behaviour) {
+  const seen = [];
+  return {
+    seen,
+    api: {
+      writeText(text) {
+        seen.push(text);
+        return behaviour === "resolve" ? Promise.resolve() : Promise.reject(new Error("denied"));
+      }
+    }
+  };
+}
+
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+async function quiet() { for (let i = 0; i < 60; i += 1) { await settle(); } }
+
+(async function () {
+  /* ---- A. a key comes back: the button is offered, and copies the secret alone -------------- */
+  {
+    const cb = clipboardThat("resolve");
+    const page = boot(cb.api);
+    page.create();
+    await quiet();
+    const out = page.el("createKeyOut").innerHTML;
+    ok("A the created key is shown", out.indexOf(CREATED_KEY) >= 0, JSON.stringify(out).slice(0, 200));
+    ok("A a copy button is offered", out.indexOf("id='copyNewKey'") >= 0,
+       JSON.stringify(out).slice(0, 240));
+    page.el("copyNewKey").dispatch("click");
+    await quiet();
+    ok("A clicking it copies the secret and nothing else",
+       cb.seen.length === 1 && cb.seen[0] === CREATED_KEY, JSON.stringify(cb.seen));
+    ok("A the button confirms the copy", page.el("copyNewKey").textContent === "Copied",
+       JSON.stringify(page.el("copyNewKey").textContent));
+    ok("A the label is scheduled to restore", page.timers.length > 0,
+       "timers: " + page.timers.length);
+  }
+
+  /* ---- B. no key came back: nothing to copy, so nothing is offered -------------------------- */
+  {
+    const cb = clipboardThat("resolve");
+    const page = boot(cb.api);
+    page.setCreateResponse({ api_key_id: "ak_new" });
+    page.create();
+    await quiet();
+    const out = page.el("createKeyOut").innerHTML;
+    ok("B the page says the key was not returned", out.indexOf("(not returned)") >= 0,
+       JSON.stringify(out).slice(0, 240));
+    /* Requires the output to exist: "no button in an empty string" is true of a page that
+       rendered nothing at all, and would pass while proving nothing. */
+    ok("B no copy button is offered when there is no key",
+       out.length > 0 && out.indexOf("copyNewKey") < 0, JSON.stringify(out).slice(0, 280));
+  }
+
+  /* ---- C. the clipboard refuses: the button must NOT claim a copy --------------------------- */
+  {
+    const cb = clipboardThat("reject");
+    const page = boot(cb.api);
+    page.create();
+    await quiet();
+    page.el("copyNewKey").dispatch("click");
+    await quiet();
+    ok("C a refused copy is reported as failed, not as copied",
+       page.el("copyNewKey").textContent === "Copy failed",
+       JSON.stringify(page.el("copyNewKey").textContent));
+  }
+
+  /* ---- D. no clipboard API at all -- an http:// origin, which a self-hosted portal often is -- */
+  {
+    const page = boot(null);
+    page.create();
+    await quiet();
+    page.el("copyNewKey").dispatch("click");
+    await quiet();
+    ok("D with no clipboard API the button says so rather than quietly doing nothing",
+       page.el("copyNewKey").textContent === "Copy failed",
+       JSON.stringify(page.el("copyNewKey").textContent));
+  }
+
+  /* ---- E. rotation shows a secret on the same terms ----------------------------------------- */
+  {
+    const cb = clipboardThat("resolve");
+    const page = boot(cb.api);
+    page.create();
+    await quiet();
+    /* Rotation is reached the way a customer reaches it: the button the key list built. */
+    const built = page.created.filter((c) => c.textContent === "Rotate")[0];
+    ok("E the key list built a Rotate button", !!built,
+       "elements created: " + page.created.length);
+    if (built) { built.onclick({}); }
+    await quiet();
+    const out = page.el("createKeyOut").innerHTML;
+    ok("E the rotated key is shown", out.indexOf(ROTATED_KEY) >= 0, JSON.stringify(out).slice(0, 240));
+    ok("E the rotated key gets a copy button too", out.indexOf("id='copyRotatedKey'") >= 0,
+       JSON.stringify(out).slice(0, 280));
+    const before = cb.seen.length;
+    page.el("copyRotatedKey").dispatch("click");
+    await quiet();
+    ok("E it copies the NEW key, not the one it replaced",
+       cb.seen.length === before + 1 && cb.seen[cb.seen.length - 1] === ROTATED_KEY,
+       JSON.stringify(cb.seen));
+  }
+
+  /* ---- F. the curl button shares the honest copier ------------------------------------------ */
+  {
+    const cb = clipboardThat("reject");
+    const page = boot(cb.api);
+    page.el("copyCurl").dispatch("click");
+    await quiet();
+    ok("F a refused curl copy is reported as failed too",
+       page.el("copyCurl").textContent === "Copy failed",
+       JSON.stringify(page.el("copyCurl").textContent));
+  }
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}().catch(function (err) {
+  /* A throw inside the async body would otherwise surface as an unhandled rejection and a zero
+     exit status -- a harness that ran nothing reporting success. */
+  console.log("FAILED harness threw: " + err.message);
+  process.exit(1);
+}));

--- a/tools/test_matrixark_a_key_shown_once_can_be_copied.py
+++ b/tools/test_matrixark_a_key_shown_once_can_be_copied.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The key you are shown once can be copied, and a copy that failed says so.
+
+A new API key is returned exactly once and stored only as a hash. The page said so plainly and
+then left the customer to select twenty-four characters of base62 out of a dark code block by
+hand -- while offering a copy button for the curl command, which they could rebuild from the form
+above it in ten seconds. Rotation mints a replacement on the same terms and had the same gap. Miss
+the selection, or navigate away, and the only recovery is to rotate again and update whatever was
+going to use it.
+
+The copy button that did exist reported success unconditionally. It wrote "Copied" whether or not
+`navigator.clipboard` was there -- it is absent on an http:// origin, which a self-hosted portal
+often is -- and it never looked at the promise `writeText` returns, so a rejected write also read
+as "Copied". For a curl command that is a small annoyance. For a key shown once it is the entire
+loss, and it is silent: the customer has been told the copy worked.
+
+So one copier, used by all three sites, that reports what actually happened.
+
+Two properties are worth pinning because neither is visible in the source.
+
+**Nothing is offered when there is no key.** The server can answer without one, and the page
+renders "(not returned)" for that. A copy button there would put that string on the clipboard and
+look like it had worked.
+
+**The secret is copied alone.** It is rendered beside the key id and above the warning; a copier
+that swept up its surroundings would produce a clipboard that fails when pasted into a config
+file, later and somewhere else.
+
+The mutations below turn each guard off in the page source and require the harness to notice. A
+guard whose removal changes no output is not being tested by anything.
+"""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+HARNESS = os.path.join(PORTAL, "key_copy_harness.js")
+
+
+def page_source() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheKeyShownOnceCanBeCopiedTest(unittest.TestCase):
+    """Runs the page's own JS. Reading the source cannot tell these cases apart."""
+
+    def _run(self, *mutation):
+        return subprocess.run(["node", HARNESS, PAGE] + list(mutation),
+                              capture_output=True, text=True, timeout=180)
+
+    def test_every_copy_path_behaves(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+        self.assertIn("PASS", proc.stdout, proc.stdout)
+
+    def test_the_created_key_is_offered_a_copy_button(self) -> None:
+        self.assertIn("ok   A a copy button is offered", self._run().stdout)
+
+    def test_the_secret_reaches_the_clipboard_alone(self) -> None:
+        self.assertIn("ok   A clicking it copies the secret and nothing else", self._run().stdout)
+
+    def test_nothing_is_offered_when_no_key_came_back(self) -> None:
+        self.assertIn("ok   B no copy button is offered when there is no key", self._run().stdout)
+
+    def test_a_refused_copy_is_not_reported_as_a_copy(self) -> None:
+        self.assertIn("ok   C a refused copy is reported as failed, not as copied",
+                      self._run().stdout)
+
+    def test_an_absent_clipboard_api_is_reported_rather_than_ignored(self) -> None:
+        self.assertIn("ok   D with no clipboard API the button says so rather than quietly "
+                      "doing nothing", self._run().stdout)
+
+    def test_rotation_copies_the_replacement_not_the_key_it_replaced(self) -> None:
+        self.assertIn("ok   E it copies the NEW key, not the one it replaced", self._run().stdout)
+
+    def test_the_curl_button_shares_the_honest_copier(self) -> None:
+        self.assertIn("ok   F a refused curl copy is reported as failed too", self._run().stdout)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheGuardsAreLoadBearingTest(unittest.TestCase):
+    """Turn each guard off and require the harness to go red, and to go red in the right place.
+
+    A mutation that changes nothing means the guard is inert; a mutation that reddens everything
+    means the harness is asserting something coarser than the guard.
+    """
+
+    def _run(self, mutation):
+        proc = subprocess.run(["node", HARNESS, PAGE, mutation],
+                              capture_output=True, text=True, timeout=180)
+        self.assertNotEqual(0, proc.returncode,
+                            "the mutation changed no observable behaviour:\n" + proc.stdout)
+        return proc.stdout
+
+    def test_offering_a_button_with_no_key_is_caught(self) -> None:
+        out = self._run("nogate")
+        self.assertIn("FAIL B no copy button is offered when there is no key", out, out)
+        self.assertNotIn("FAIL A", out, "the no-key gate should not affect the happy path:\n" + out)
+
+    def test_claiming_a_copy_that_failed_is_caught(self) -> None:
+        out = self._run("oldcopy")
+        for case in ("FAIL C a refused copy", "FAIL D with no clipboard API",
+                     "FAIL F a refused curl copy"):
+            self.assertIn(case, out, out)
+        self.assertNotIn("FAIL A", out,
+                         "a successful copy should still be reported as one:\n" + out)
+
+
+class EveryClipboardWriteGoesThroughTheOneCopierTest(unittest.TestCase):
+    """A second copier would be free to lie again, so there is only allowed to be one.
+
+    This scans source, so it states its own extent: the assertion is over the whole page, and it
+    names the count it found rather than checking that some particular line still exists.
+    """
+
+    def test_the_page_writes_to_the_clipboard_in_exactly_one_place(self) -> None:
+        source = page_source()
+        self.assertEqual(1, source.count("clipboard.writeText("),
+                         "every copy on this page must go through copyText, which reports what "
+                         "happened; a second write site is free to claim a copy it did not make")
+
+    def test_that_one_place_is_inside_the_copier(self) -> None:
+        source = page_source()
+        start = source.index("function copyText(")
+        end = source.index("// ---- create", start)
+        write = source.index("clipboard.writeText(")
+        self.assertTrue(start < write < end,
+                        "the only clipboard write is outside copyText, so its result is not "
+                        "reported to anyone")
+
+    def test_the_copier_reports_both_outcomes(self) -> None:
+        """The failure branch is the one that was missing; assert it is present and distinct."""
+        source = page_source()
+        start = source.index("function copyText(")
+        end = source.index("// ---- create", start)
+        body = source[start:end]
+        self.assertIn("Copy failed", body)
+        self.assertIn("settled(false)", body,
+                      "nothing drives the failure branch, so it cannot be reached")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A new API key is returned once and stored only as a hash. The page says so, then leaves the
customer to select it out of a dark code block by hand -- while offering a copy button for the
curl command, which they could rebuild from the form above it in ten seconds. Rotation mints a
replacement on the same terms and had the same omission.

**The copy button that did exist reported success unconditionally.** It wrote "Copied" whether or
not `navigator.clipboard` was there -- it is absent on an `http://` origin, which a self-hosted
portal often is -- and it never looked at the promise `writeText` returns, so a rejected write
also read as "Copied". For a curl command that is a small annoyance. For a key shown once it is
the entire loss, and it is silent: the customer has been told the copy worked.

One copier now serves all three sites and says what actually happened, on the button rather than
in the message area -- that area carries the reason a key was not created, and overwriting it
would hide one failure with another.

Two properties are pinned because neither is visible in the source:

- **Nothing is offered when there is no key.** The server can answer without one, and the page
  renders `(not returned)` for that. A button there would put that string on the clipboard and
  look like it had worked.
- **The secret is copied alone.** It sits beside the key id and above the warning; a copier that
  swept up its surroundings yields a clipboard that fails when pasted into a config file, later
  and somewhere else.

`tools/portal/key_copy_harness.js` runs the page's own JS across six cases: a key returned, no key
returned, a clipboard that refuses, no clipboard API at all, rotation, and the curl button. Both
guards are mutation-tested in CI -- turning either off in the page source reddens the harness, and
reddens only the cases it should. Thirteen tests in
`tools/test_matrixark_a_key_shown_once_can_be_copied.py`.
