### PR TITLE
Remove eight switches and the paths they kept alive

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -43,23 +43,6 @@ def _context_debug_records_enabled() -> bool:
     except Exception:  # pragma: no cover - policy module absent
         return False
     return bool(context_debug_records_enabled())
-
-
-def _segment_access_scope_enabled() -> bool:
-    """Gate: write context_segment records WITH a tenant/user/session access_scope so a
-    scored segment passes access_scope_matches_before_scoring instead of being dropped
-    scope-less. Default ON; set MATRIXARK_SEGMENT_ACCESS_SCOPE=0 to restore prior behavior."""
-    return str(_os.environ.get("MATRIXARK_SEGMENT_ACCESS_SCOPE", "1")).strip().lower() not in {"0", "false", "no", "off"}
-
-
-def _value_entity_capture_enabled() -> bool:
-    """Gate: mint a scoped, embedded fact entity for any assistant message stating an exact
-    value (number+unit, count, hex hash, ALL_CAPS/dotted flag) that the topic segmenter and
-    entity extractor skipped, with its state text NOT truncated before the value token.
-    Default ON; set MATRIXARK_VALUE_ENTITY_CAPTURE=0 to restore prior behavior."""
-    return str(_os.environ.get("MATRIXARK_VALUE_ENTITY_CAPTURE", "1")).strip().lower() not in {"0", "false", "no", "off"}
-
-
 _VALUE_TOKEN_RE = _re.compile(
     r"(?:\b0x[0-9a-fA-F]{6,}\b)"
     r"|(?:\b[0-9a-f]{7,40}\b)"
@@ -3267,88 +3250,87 @@ class _LocalAdapterIngestMixin:
         # value (number+unit, count, hex hash, ALL_CAPS/dotted flag) that the topic segmenter
         # and entity extractor skipped, so the value token stays a selectable retrieval
         # candidate and its state text is NOT truncated before the value. Mirrors
-        # session_entity_record; gated by MATRIXARK_VALUE_ENTITY_CAPTURE (default on).
-        if _value_entity_capture_enabled():
-            _seen_value_texts: set = set()
-            for _vindex, _vmessage, _vevent_text, _vevent_hash in event_rows:
-                if normalize_message_role(_vmessage.get("role")) != "assistant":
-                    continue
-                _vcontent = str(_vmessage.get("content") or "").strip()
-                if not _line_has_exact_value(_vcontent):
-                    continue
-                _vnorm = _vcontent.lower()
-                if _vnorm in _seen_value_texts:
-                    continue
-                # Mint a dedicated clean-state value entity even when the line is also folded
-                # into another (often non-surfacing / truncated) extraction entity: the point
-                # is to give exact-value facts their own selectable, untruncated candidate.
-                _seen_value_texts.add(_vnorm)
-                _value_state = f"assistant: {_vcontent}"
-                _value_entity_hash = stable_hash(f"{batch_id_hash}:value_entity:{_vindex}:{_vevent_text}")
-                _value_entity_record = {
-                    "record_type": "context_entity",
-                    "entity_hash": _value_entity_hash,
-                    "batch_id_hash": batch_id_hash,
+        # session_entity_record.
+        _seen_value_texts: set = set()
+        for _vindex, _vmessage, _vevent_text, _vevent_hash in event_rows:
+            if normalize_message_role(_vmessage.get("role")) != "assistant":
+                continue
+            _vcontent = str(_vmessage.get("content") or "").strip()
+            if not _line_has_exact_value(_vcontent):
+                continue
+            _vnorm = _vcontent.lower()
+            if _vnorm in _seen_value_texts:
+                continue
+            # Mint a dedicated clean-state value entity even when the line is also folded
+            # into another (often non-surfacing / truncated) extraction entity: the point
+            # is to give exact-value facts their own selectable, untruncated candidate.
+            _seen_value_texts.add(_vnorm)
+            _value_state = f"assistant: {_vcontent}"
+            _value_entity_hash = stable_hash(f"{batch_id_hash}:value_entity:{_vindex}:{_vevent_text}")
+            _value_entity_record = {
+                "record_type": "context_entity",
+                "entity_hash": _value_entity_hash,
+                "batch_id_hash": batch_id_hash,
+                "node_hash": node_hash,
+                "node_path": node_path,
+                "scope": envelope["scope"],
+                "access_scope": envelope["scope"],
+                "entity_type": "exact_value_fact",
+                "entity_name": _value_entity_name(_vcontent),
+                "state": _value_state,
+                "previous_state": "",
+                "confidence": 1.0,
+                "operator": "observed",
+                "source_refs": [],
+                "source_event_ids": [_vevent_hash],
+                "source_roles": ["assistant"],
+                "source_role_counts": {"assistant": 1},
+                "extraction_context_event_ids": extraction_context_event_ids,
+                "field_patches": [],
+                "patch_results": [],
+                "update_mode": "value_capture",
+                "memory_scope": "session",
+                "session_continuity": "same_session",
+                "extraction_phase": extraction_phase,
+                "final_session_boundary": final_session_boundary,
+                "updated_at_ms": envelope["ingestion_time_ms"],
+            }
+            records_to_append.append(_value_entity_record)
+            for _value_index_name in candidate_index_terms(_value_entity_record, {}, {}):
+                _value_index = context_index_posting_record(
+                    index_name=_value_index_name,
+                    data_model="context_entity",
+                    ref_type="entity",
+                    ref_hashes=[_value_entity_hash],
+                    batch_id_hash=batch_id_hash,
+                    node_hash=node_hash,
+                    scope=envelope["scope"],
+                    updated_at_ms=envelope["ingestion_time_ms"],
+                )
+                _value_index["access_scope"] = envelope["scope"]
+                _value_index["memory_scope"] = "session"
+                _value_index["session_continuity"] = "same_session"
+                _value_index.pop("index_hash", None)
+                records_to_append.append(_value_index)
+                entity_index_write_count += 1
+            _value_vector = embedding_for_text("exact_value_fact " + _value_state)
+            records_to_append.append(
+                compact_context_embedding_record({
+                    "record_type": "context_embedding",
+                    "embedding_type": "entity_state",
+                    "ref_type": "entity",
+                    "ref_hash": _value_entity_hash,
                     "node_hash": node_hash,
                     "node_path": node_path,
+                    "dim": len(_value_vector),
+                    "model": embedding_model_name(),
+                    "vector": _value_vector,
                     "scope": envelope["scope"],
-                    "access_scope": envelope["scope"],
-                    "entity_type": "exact_value_fact",
-                    "entity_name": _value_entity_name(_vcontent),
-                    "state": _value_state,
-                    "previous_state": "",
-                    "confidence": 1.0,
-                    "operator": "observed",
-                    "source_refs": [],
                     "source_event_ids": [_vevent_hash],
                     "source_roles": ["assistant"],
                     "source_role_counts": {"assistant": 1},
-                    "extraction_context_event_ids": extraction_context_event_ids,
-                    "field_patches": [],
-                    "patch_results": [],
-                    "update_mode": "value_capture",
-                    "memory_scope": "session",
-                    "session_continuity": "same_session",
-                    "extraction_phase": extraction_phase,
-                    "final_session_boundary": final_session_boundary,
-                    "updated_at_ms": envelope["ingestion_time_ms"],
-                }
-                records_to_append.append(_value_entity_record)
-                for _value_index_name in candidate_index_terms(_value_entity_record, {}, {}):
-                    _value_index = context_index_posting_record(
-                        index_name=_value_index_name,
-                        data_model="context_entity",
-                        ref_type="entity",
-                        ref_hashes=[_value_entity_hash],
-                        batch_id_hash=batch_id_hash,
-                        node_hash=node_hash,
-                        scope=envelope["scope"],
-                        updated_at_ms=envelope["ingestion_time_ms"],
-                    )
-                    _value_index["access_scope"] = envelope["scope"]
-                    _value_index["memory_scope"] = "session"
-                    _value_index["session_continuity"] = "same_session"
-                    _value_index.pop("index_hash", None)
-                    records_to_append.append(_value_index)
-                    entity_index_write_count += 1
-                _value_vector = embedding_for_text("exact_value_fact " + _value_state)
-                records_to_append.append(
-                    compact_context_embedding_record({
-                        "record_type": "context_embedding",
-                        "embedding_type": "entity_state",
-                        "ref_type": "entity",
-                        "ref_hash": _value_entity_hash,
-                        "node_hash": node_hash,
-                        "node_path": node_path,
-                        "dim": len(_value_vector),
-                        "model": embedding_model_name(),
-                        "vector": _value_vector,
-                        "scope": envelope["scope"],
-                        "source_event_ids": [_vevent_hash],
-                        "source_roles": ["assistant"],
-                        "source_role_counts": {"assistant": 1},
-                    })
-                )
+                })
+            )
 
         segment_hashes = []
         for segment in (extraction["segments"] if _segments_enabled(envelope.get("scope")) else []):
@@ -3386,7 +3368,7 @@ class _LocalAdapterIngestMixin:
                 "node_hash": node_hash,
                 "node_path": node_path,
                 "scope": envelope["scope"],
-                **({"access_scope": envelope["scope"]} if _segment_access_scope_enabled() else {}),
+                "access_scope": envelope["scope"],
                 "topic": segment["topic"],
                 "coordinate_tuples": segment["coordinate_tuples"],
                 "message_indexes": segment["message_indexes"],

--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -10,7 +10,7 @@ except ImportError:
     from matrixark_mcp_core import *  # noqa: F401,F403
 
 
-# --- Lexical exact-recall lane (gated by MATRIXARK_LEXICAL_EXACT_RECALL, default ON) -----------
+# --- Lexical exact-recall lane -----------------------------------------------------------------
 # Dense (MiniLM) similarity under-weights rare/exact tokens -- numbers, units, counts, version
 # strings, hex hashes, and capitalized proper names / acronyms. When a query names such a token,
 # the record carrying it can be pruned by tree/node placement before it is ever scored, so the
@@ -39,14 +39,6 @@ _EMBEDDING_OWNER_REFS = {
     "resource_chunk": ("resource_chunk", "chunk_hash"),
     "skill_section": ("skill_section", "section_hash"),
 }
-
-def lexical_exact_recall_enabled() -> bool:
-    """Feature gate. Default ON; set MATRIXARK_LEXICAL_EXACT_RECALL=0 to restore exact prior behavior."""
-    return str(_os.environ.get("MATRIXARK_LEXICAL_EXACT_RECALL", "1")).strip().lower() not in {
-        "0", "false", "no", "off", "",
-    }
-
-
 def lexical_exact_recall_query_tokens(query: object) -> set:
     """Rare/exact query tokens worth a lexical recall lane: numeric/version/hash tokens always, and
     capitalized proper-name/acronym tokens when not the leading word. Common words are excluded so
@@ -609,11 +601,7 @@ class _LocalAdapterRetrieveMixin:
         query_terms = {term for term in tokens(retrieval_query) if len(term) > 2}
         # Lexical exact-recall lane: rare/exact tokens the dense encoder under-weights. Empty for
         # ordinary phrasings, so this is a no-op unless the query actually names an exact token.
-        lexical_exact_tokens = (
-            lexical_exact_recall_query_tokens(retrieval_query)
-            if lexical_exact_recall_enabled()
-            else set()
-        )
+        lexical_exact_tokens = lexical_exact_recall_query_tokens(retrieval_query)
         raw_reference_time_ms = args.get("reference_time_ms", now_ms())
         if not isinstance(raw_reference_time_ms, int):
             raise MatrixArkError("reference_time_ms must be an integer")

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -533,14 +533,16 @@ INTERN_METADATA_FIELDS = (
 INTERN_DICT_RECORD_TYPE = "matrixark_intern_dict"
 INTERN_TOKEN_KEY = "_im"  # legacy per-record map {field_name: token} (Phase-1 format)
 
-# Phase-2 -- bundle interning. The per-field ``_im`` map repeats the field NAMES on every interned
-# record (measured ~8% of on-disk memory just for the token map). Because the whole eligible-field
-# bundle is near-constant per store, we hash the WHOLE {field: value} bundle to a single token and
-# carry only that token (``_imb``) on the data line; the sidecar dict stores the full bundle once per
-# distinct token. This subsumes the per-field format (which is still read for backward compatibility)
-# and collapses the token-map overhead to a single short hash per record. Gated independently so it can
-# be turned off to fall back to the Phase-1 per-field format.
-INTERN_METADATA_BUNDLE = bool_env("MATRIXARK_INTERN_METADATA_BUNDLE", True)
+# Bundle interning. The per-field ``_im`` map repeated the field NAMES on every interned record
+# (measured ~8% of on-disk memory just for the token map). Because the whole eligible-field bundle
+# is near-constant per store, the WHOLE {field: value} bundle hashes to a single token and only
+# that token (``_imb``) rides on the data line; the sidecar dict stores the bundle once per distinct
+# token.
+#
+# The per-field format is still READ -- an old log expands unchanged, which is what backward
+# compatibility requires. It is no longer WRITTEN. The switch that fell back to it kept a second
+# durable encoding alive on the write side, and nothing chose it: no test set it, the portal never
+# offered it, and the format it produced is one this reader already understands.
 INTERN_BUNDLE_TOKEN_KEY = "_imb"  # bundle token -> sidecar {im_token, im_bundle: {field: value}}
 INTERN_BUNDLE_EMIT_KEY = "__bundle__"  # emitted-token namespace for bundle sidecars
 
@@ -598,11 +600,6 @@ def _model_registry_identity(record: Json) -> tuple[Any, ...]:
     )
 
 
-def _intern_token_for_value(value: Any) -> str:
-    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"))
-    return _hashlib.blake2b(canonical.encode("utf-8"), digest_size=6).hexdigest()
-
-
 def _intern_token_for_bundle(bundle: dict[str, Any]) -> str:
     canonical = json.dumps(bundle, sort_keys=True, separators=(",", ":"))
     return _hashlib.blake2b(canonical.encode("utf-8"), digest_size=6).hexdigest()
@@ -629,42 +626,19 @@ def encode_interned_records(records: list[Json], emitted_tokens: set[tuple[str, 
         if not present:
             encoded_records.append(record)
             continue
-        if INTERN_METADATA_BUNDLE:
-            token = _intern_token_for_bundle(present)
-            key = (INTERN_BUNDLE_EMIT_KEY, token)
-            if key not in emitted_tokens:
-                emitted_tokens.add(key)
-                dict_records.append({
-                    "record_type": INTERN_DICT_RECORD_TYPE,
-                    "im_token": token,
-                    "im_bundle": present,
-                })
-            encoded = dict(record)
-            for field in present:
-                encoded.pop(field, None)
-            encoded[INTERN_BUNDLE_TOKEN_KEY] = token
-            encoded_records.append(encoded)
-            continue
-        # Legacy Phase-1 per-field format (bundle flag OFF).
-        token_map: dict[str, str] = {}
+        token = _intern_token_for_bundle(present)
+        key = (INTERN_BUNDLE_EMIT_KEY, token)
+        if key not in emitted_tokens:
+            emitted_tokens.add(key)
+            dict_records.append({
+                "record_type": INTERN_DICT_RECORD_TYPE,
+                "im_token": token,
+                "im_bundle": present,
+            })
         encoded = dict(record)
-        for field, value in present.items():
-            token = _intern_token_for_value(value)
-            token_map[field] = token
-            key = (field, token)
-            if key not in emitted_tokens:
-                emitted_tokens.add(key)
-                dict_records.append({
-                    "record_type": INTERN_DICT_RECORD_TYPE,
-                    "im_field": field,
-                    "im_token": token,
-                    "im_value": value,
-                })
+        for field in present:
             encoded.pop(field, None)
-        existing = encoded.get(INTERN_TOKEN_KEY)
-        merged = dict(existing) if isinstance(existing, dict) else {}
-        merged.update(token_map)
-        encoded[INTERN_TOKEN_KEY] = merged
+        encoded[INTERN_BUNDLE_TOKEN_KEY] = token
         encoded_records.append(encoded)
     return dict_records + encoded_records
 

--- a/tools/matrixark_mcp_server.py
+++ b/tools/matrixark_mcp_server.py
@@ -244,11 +244,11 @@ class MatrixArkMcpServer(MatrixArkServerRequestPolicyMixin):
         # set (thousands of records) before scoring, which routinely exceeds the old
         # 5000ms ceiling and made the server discard the real ContextPack for an empty
         # deadline_fallback_pack (silent recall collapse: refs computed but dropped).
-        # Raised to match the ingest deadline (30000ms); still fully overridable via
-        # MATRIXARK_RETRIEVE_TIMEOUT_MS / MATRIXARK_RETRIEVAL_TIMEOUT_MS (set to 5000 to
-        # restore prior behavior). Actual warm/cold retrieve latency stays well under
-        # this ceiling; this only prevents premature abort of an in-flight retrieve.
-        "matrixark_retrieve": int(os.environ.get("MATRIXARK_RETRIEVE_TIMEOUT_MS", os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS", "30000"))),
+        # Raised to match the ingest deadline (30000ms); overridable via
+        # MATRIXARK_RETRIEVAL_TIMEOUT_MS, the one spelling every caller in the tree uses. Actual
+        # warm/cold retrieve latency stays well under this ceiling; this only prevents premature
+        # abort of an in-flight retrieve.
+        "matrixark_retrieve": int(os.environ.get("MATRIXARK_RETRIEVAL_TIMEOUT_MS", "30000")),
         "matrixark_feedback": int(os.environ.get("MATRIXARK_FEEDBACK_TIMEOUT_MS", "15000")),
         "matrixark_replay": int(os.environ.get("MATRIXARK_REPLAY_TIMEOUT_MS", "10000")),
         "matrixark_admin": int(os.environ.get("MATRIXARK_ADMIN_TIMEOUT_MS", "10000")),

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -2538,8 +2538,9 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # land in the store and become retrievable on later turns. The pure-local
         # JSONL adapter is unaffected (it keeps _local_jsonl_enabled and is not
         # this class); the fast direct-ingest path calls _append_many_materialized
-        # itself (never append), so there is no double write. Disable with
-        # MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND=0 as an escape hatch.
+        # itself (never append), so there is no double write. There is no switch off: what the
+        # off position restored is the state described below, where an ingest carrying a
+        # ttl_seconds stored a record nothing would ever expire.
         #
         # Per-ingestion stamping runs HERE, in the same order as
         # MatrixArkLocalAdapter.append_many, because it was being skipped entirely on every
@@ -2569,10 +2570,6 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         route_to_backend = (
             callable(append_backend)
             and not getattr(self, "_local_jsonl_enabled", False)
-            and os.environ.get(
-                "MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND", "1"
-            ).strip().lower()
-            not in {"0", "false", "no"}
         )
         if route_to_backend:
             append_backend(materialized, allow_queue=False)

--- a/tools/matrixark_mcp_temporal_append.py
+++ b/tools/matrixark_mcp_temporal_append.py
@@ -29,15 +29,6 @@ _ROUTE_KEYS_WORTH_STORING = (
 # one add, they cost 25 index postings x ~280 bytes -- about 7 KB per add to say the same thing
 # three more times. The one place that reads them consults `placement_key` first and falls through
 # to `routing_key` / `partition_key` only when it is absent, which it is not.
-
-
-def _drop_derivable_route_enabled() -> bool:
-    """ON by default; MATRIXARK_DROP_DERIVABLE_ROUTE=0 keeps the old persisted route."""
-    return os.environ.get("MATRIXARK_DROP_DERIVABLE_ROUTE", "1").strip().lower() not in {
-        "0", "false", "no", "off",
-    }
-
-
 def _placement_is_derivable(record: Json) -> bool:
     """Can this record's placement be rebuilt from what it already carries?
 
@@ -199,7 +190,7 @@ def slim_persisted_storage_route(record: Json) -> Json:
     #
     # Measured over 300 ingests by walking the page segments, `storage_route` cost 1.76 KB per add
     # across records, and 161 bytes on every one of the ~10 index postings an add writes.
-    if _drop_derivable_route_enabled() and _placement_is_derivable(record):
+    if _placement_is_derivable(record):
         slim = dict(record)
         slim.pop("storage_route", None)
         slim.pop("posting_policy", None)

--- a/tools/matrixark_temporal_location_codec.py
+++ b/tools/matrixark_temporal_location_codec.py
@@ -24,8 +24,9 @@ Two decisions are load-bearing:
 * **A location whose base is not the reader's own record log stays a dict.** Readers already skip
   foreign bases; compacting one would assert something the form cannot express.
 
-Decoding accepts both shapes, so a store written before this reads unchanged, and
-``MATRIXARK_COMPACT_LOCATIONS=0`` returns the writer to the long form without touching readers.
+Decoding accepts both shapes, so a store written before this reads unchanged. The writer has
+no switch back: the long form is what the compact form replaced, and a way to re-emit it kept
+a second encoding alive that no reader treated differently.
 """
 
 from __future__ import annotations
@@ -35,22 +36,10 @@ from typing import Any
 
 SHARD_DIGITS = 6
 FIELD_DIGITS = 20
-
-
-def compact_locations_enabled() -> bool:
-    """ON by default; ``MATRIXARK_COMPACT_LOCATIONS=0`` is the escape hatch."""
-    return os.environ.get("MATRIXARK_COMPACT_LOCATIONS", "1").strip().lower() not in {
-        "0",
-        "false",
-        "no",
-        "off",
-    }
-
-
 def compact_location(key: str, field: str, base: str) -> Any:
     """``(key, field)`` as ``"shard:offset"`` when it belongs to ``base``, else the dict as-is."""
     original = {"key": key, "field": field}
-    if not compact_locations_enabled() or not base:
+    if not base:
         return original
     if not key.startswith(base + ":"):
         return original

--- a/tools/test_intern_record_metadata.py
+++ b/tools/test_intern_record_metadata.py
@@ -166,9 +166,10 @@ class InterningCase(_FlagGuard):
             self._ingest_turns(server, 40)
             original = adapter._read_raw_records()
         encoded = A.encode_interned_records(original, set())
-        # the encoded form is genuinely interned: dict records exist and some data record hides a field
-        # behind either the legacy per-field token map (_im) or the bundle token (_imb).
-        token_key = A.INTERN_BUNDLE_TOKEN_KEY if A.INTERN_METADATA_BUNDLE else A.INTERN_TOKEN_KEY
+        # the encoded form is genuinely interned: dict records exist and some data record hides a
+        # field behind the bundle token (_imb). The per-field map (_im) is still READ, so the
+        # round-trip below still asserts it is absent after expansion, but it is no longer written.
+        token_key = A.INTERN_BUNDLE_TOKEN_KEY
         self.assertTrue(any(r.get("record_type") == A.INTERN_DICT_RECORD_TYPE for r in encoded))
         self.assertTrue(any(token_key in r for r in encoded if isinstance(r, dict)))
         self.assertTrue(any("storage_route" not in r for r in encoded
@@ -207,25 +208,23 @@ class InterningCase(_FlagGuard):
             raw_lines = [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
         self.assertTrue(any(r.get("record_type") == A.INTERN_DICT_RECORD_TYPE for r in raw_lines),
                         "expected durable intern-dict records on disk")
-        if A.INTERN_METADATA_BUNDLE:
-            # Bundle format: the data line carries a single bundle token (_imb) and every bundled field
-            # is elided from the line; the full bundle lives once in the sidecar dict record.
-            bundles = {r.get("im_token"): r.get("im_bundle") for r in raw_lines
-                       if isinstance(r, dict) and r.get("record_type") == A.INTERN_DICT_RECORD_TYPE
-                       and isinstance(r.get("im_bundle"), dict)}
-            interned_data = [r for r in raw_lines if isinstance(r, dict) and A.INTERN_BUNDLE_TOKEN_KEY in r]
-            self.assertTrue(interned_data, "expected bundle-interned data records on disk")
-            for r in interned_data:
-                bundle = bundles.get(r[A.INTERN_BUNDLE_TOKEN_KEY])
-                self.assertIsInstance(bundle, dict, "bundle token must resolve to a sidecar bundle")
-                for field in bundle:  # every bundled field is elided from the data line
-                    self.assertNotIn(field, r)
-        else:
-            interned_data = [r for r in raw_lines if isinstance(r, dict) and A.INTERN_TOKEN_KEY in r]
-            self.assertTrue(interned_data, "expected interned data records on disk")
-            for r in interned_data:  # the interned field is elided from the data line
-                for field in r[A.INTERN_TOKEN_KEY]:
-                    self.assertNotIn(field, r)
+        # The data line carries a single bundle token (_imb) and every bundled field is elided
+        # from the line; the full bundle lives once in the sidecar dict record.
+        bundles = {r.get("im_token"): r.get("im_bundle") for r in raw_lines
+                   if isinstance(r, dict) and r.get("record_type") == A.INTERN_DICT_RECORD_TYPE
+                   and isinstance(r.get("im_bundle"), dict)}
+        interned_data = [r for r in raw_lines if isinstance(r, dict) and A.INTERN_BUNDLE_TOKEN_KEY in r]
+        self.assertTrue(interned_data, "expected bundle-interned data records on disk")
+        for r in interned_data:
+            bundle = bundles.get(r[A.INTERN_BUNDLE_TOKEN_KEY])
+            self.assertIsInstance(bundle, dict, "bundle token must resolve to a sidecar bundle")
+            for field in bundle:  # every bundled field is elided from the data line
+                self.assertNotIn(field, r)
+        # Nothing writes the per-field map any more.
+        self.assertEqual(
+            [], [r for r in raw_lines if isinstance(r, dict) and A.INTERN_TOKEN_KEY in r],
+            "the per-field intern map is a read-only format now and must not be written",
+        )
 
     def test_flag_off_is_byte_identical_to_today(self):
         """With interning OFF, no dict records and no token key are ever written."""


### PR DESCRIPTION
Eight switches removed, and with them the paths they kept alive.

## How they were chosen

Not by reading names. Each of these flags is read through a small gate function whose docstring
says what the alternate position does, and the useful ones say the same thing:

- *"Default ON; set `MATRIXARK_VALUE_ENTITY_CAPTURE=0` to restore prior behavior"*
- *"`MATRIXARK_DROP_DERIVABLE_ROUTE=0` keeps the old persisted route"*
- *"`MATRIXARK_COMPACT_LOCATIONS=0` ... the escape hatch"*

So the classifier is over that prose, and it matches a **verb** — *restores the prior*, *keeps the
old*, *returns the writer to the long form*, *escape hatch* — rather than a mood. Matching words
like "before" or "previously" flags anything that mentions its own history; requiring a phrase that
says the off position **restores** something gives a list you can act on. That found 9 flags. Three
survive, for reasons below.

Every one removed here clears the same bar: default ON, **exactly one branch site**, **no test sets
it**, and **not offered on the portal**.

## What went

| flag | what its off position restored |
|---|---|
| `MATRIXARK_VALUE_ENTITY_CAPTURE` | not minting a fact entity for an exact value the segmenter skipped |
| `MATRIXARK_SEGMENT_ACCESS_SCOPE` | writing `context_segment` rows with no access scope |
| `MATRIXARK_LEXICAL_EXACT_RECALL` | dropping the exact-recall lane |
| `MATRIXARK_DROP_DERIVABLE_ROUTE` | persisting a route that is derivable |
| `MATRIXARK_COMPACT_LOCATIONS` | emitting locations in the long form |
| `MATRIXARK_INTERN_METADATA_BUNDLE` | writing the Phase-1 per-field intern map |
| `MATRIXARK_DIRECT_SERVING_APPEND_TO_BACKEND` | skipping the append that stamps `expires_at_ms` |
| `MATRIXARK_RETRIEVE_TIMEOUT_MS` | nothing — a second spelling of one knob |

Two are worth a note.

**The intern bundle** is the only one that touches a durable format, and only the **write** side
goes. The per-field map is still read, so an old log expands exactly as before — that is what
backward compatibility requires. Writing two formats is not. Its per-value tokeniser had one
caller, the arm just deleted, and goes with it.

**The retrieve deadline** had two env names for one value, and the tidier-looking one was the wrong
one to keep. `MATRIXARK_RETRIEVE_TIMEOUT_MS` matches the shape of every sibling
(`MATRIXARK_<OP>_TIMEOUT_MS`) and appears in exactly one place in the tree: the lookup that
preferred it. `MATRIXARK_RETRIEVAL_TIMEOUT_MS` is what the server launch script, the agent config,
the scale test and both retrieve deadline reads actually use. Consistency would have removed the
one in use.

## What stayed, and why

`MATRIXARK_ALLOW_SHARED_OSS_MODEL_DRIFT` matches the classifier — its help calls it an escape
hatch — and is **kept**. It is a `--allow-shared-oss-model-drift` CLI switch on the benchmark
runner that enforces a baseline comparison using the same reader, embedding and budgets. That is a
fairness guard on a measurement, not a legacy code path, and removing it would remove the ability
to say a comparison was unfair.

The two `*_TIMEOUT_MS` entries the classifier flagged are values, not path selectors; one of them
is the consolidation above.

## Effect

- boolean feature flags: **69 → 63**
- flags whose alternate path restores what came before: **9 → 3**, and none of the three is a
  second code path
- **-75 lines**, most of it an 81-line block that no longer needs to be indented under a condition
  that was always true

## Tests

The whole suite was run on two full archive trees — main, and main with exactly these files
overlaid — and name-diffed. These gates were default ON and the ON path is what survives, so the
expectation is that nothing moves at all.

`test_intern_record_metadata` changed rather than being deleted: two of its cases branched on the
bundle flag to decide what to assert. With one write format there is one thing to assert, and it
now also asserts the per-field map is **never written**, which is the property the removal creates.

## What this leaves for a second pass

The same scan finds ten more knobs read under two names, of the shape
`os.environ.get(A, os.environ.get(B, default))`. They are NOT all duplicates, and the difference
decides whether consolidating them is a cleanup or a regression:

- a genuine **alias** is two spellings of one concept, like the deadline above;
- a **hierarchy** is a specific override falling back to a shared default, and
  `MATRIXARK_CLAUDE_HOOK_STORE_BASE` falling back to `MATRIXARK_SHARED_HOOK_STORE_BASE` is exactly
  that: the Claude and Codex hooks deliberately share one store base and differ elsewhere.
  Collapsing it would merge two agents' stores.

Several of the ten also have the property that caught me above — the name being *preferred* has
fewer uses than the one it falls back to. `MATRIXARK_SUMMARY_PROVIDER` is read first and used in 4
places; `MATRIXARK_UNDERSTANDING_PROVIDER`, its fallback, is used in 12.

So that pass needs the same per-knob evidence this one used, not a sweep. It is left out here
rather than bundled in.
