### PR TITLE
Say what the absent postings depend on

### DIFF
--- a/tools/test_codex_pipeline_part4.py
+++ b/tools/test_codex_pipeline_part4.py
@@ -1568,6 +1568,11 @@ class _CodexPipelinePart4:
         self.assertEqual("warning", output["status"])
         self.assertIn("timed out", output["error"])
 
+    # Pinned for the same reason as the sibling backfill test: a posting is only dropped
+    # when the record it points at carries a vector, so with embeddings off nothing is
+    # dropped and the names asserted absent below are written after all. The suite shares
+    # one process and other tests move this policy.
+    @mock.patch.dict(os.environ, {"MATRIXARK_GENERATE_EMBEDDINGS": "1"})
     def test_user_prompt_cli_idle_preflushes_previous_assistant_rollout(self) -> None:
         repo = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1828,6 +1833,13 @@ class _CodexPipelinePart4:
             self.assertTrue(any("cross_session" in record.get("source_session_continuities", []) for record in profile_summaries))
             self.assertTrue(any("assistant_decision" in record.get("source_entity_types", []) for record in profile_summaries))
 
+    # The absence checks below depend on embeddings being ON. A posting is only dropped when the
+    # record it points at carries a vector -- that is the condition drop_owner_derivable_postings
+    # is gated on -- so with embeddings off nothing is dropped and every one of those names is
+    # written after all. The suite shares one process and other tests move this policy, which is
+    # why this passed alone and failed under discovery. Pin it rather than depend on whoever ran
+    # first.
+    @mock.patch.dict(os.environ, {"MATRIXARK_GENERATE_EMBEDDINGS": "1"})
     def test_user_prompt_fast_async_still_backfills_previous_assistant_rollout(self) -> None:
         repo = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1977,6 +1989,11 @@ class _CodexPipelinePart4:
             memory_budget = pack["recall_policy"]["memory_layer_budget"]
             self.assertGreaterEqual(memory_budget["source_message_counts_by_role"].get("assistant", 0), 1)
 
+    # Pinned for the same reason as the sibling backfill test: a posting is only dropped
+    # when the record it points at carries a vector, so with embeddings off nothing is
+    # dropped and the names asserted absent below are written after all. The suite shares
+    # one process and other tests move this policy.
+    @mock.patch.dict(os.environ, {"MATRIXARK_GENERATE_EMBEDDINGS": "1"})
     def test_user_prompt_fast_async_threshold_commits_previous_tool_rollout(self) -> None:
         repo = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2828,6 +2845,11 @@ class _CodexPipelinePart4:
             self.assertIsInstance(pack.get("retrieval_metrics"), dict)
             self.assertTrue(result["summary_refresh"]["profile_dirty_hashes"])
 
+    # Pinned for the same reason as the sibling backfill test: a posting is only dropped
+    # when the record it points at carries a vector, so with embeddings off nothing is
+    # dropped and the names asserted absent below are written after all. The suite shares
+    # one process and other tests move this policy.
+    @mock.patch.dict(os.environ, {"MATRIXARK_GENERATE_EMBEDDINGS": "1"})
     def test_batch_extract_assigns_role_specific_event_types(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             adapter = MatrixArkLocalAdapter(Path(tmp_dir) / "matrixark-role-event-types.jsonl")

--- a/tools/test_codex_pipeline_part5.py
+++ b/tools/test_codex_pipeline_part5.py
@@ -1857,6 +1857,11 @@ class _CodexPipelinePart5:
                 )
             )
 
+    # Pinned for the same reason as the sibling backfill test: a posting is only dropped
+    # when the record it points at carries a vector, so with embeddings off nothing is
+    # dropped and the names asserted absent below are written after all. The suite shares
+    # one process and other tests move this policy.
+    @mock.patch.dict(os.environ, {"MATRIXARK_GENERATE_EMBEDDINGS": "1"})
     def test_batch_extract_normalizes_llm_response_aliases_to_assistant_profile_memory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             adapter = MatrixArkLocalAdapter(Path(tmp_dir) / "matrixark-profile-llm-aliases.jsonl")


### PR DESCRIPTION
Five tests assert that certain posting names are **not** written, because the record they would
point at derives the term itself. That only holds when the record carries a vector — the
condition `drop_owner_derivable_postings` is gated on. With embeddings off, nothing is dropped
and every one of those names is written after all.

None of them said so.

| | embeddings on | embeddings off |
| --- | --- | --- |
| before | 5 of 5 pass | **4 of 5 fail** |
| after | 5 of 5 pass | 5 of 5 pass |

That policy is one this suite moves at runtime, in a shared process. An absence assertion that
quietly depends on ambient state is the kind that passes for the wrong reason — or fails
pointing at the wrong thing, since the message names a posting rather than the policy that
produced it. Each test now pins the knob for its own duration and says why.

## Not fixed by this, and not claimed

`test_user_prompt_fast_async_still_backfills_previous_assistant_rollout` still fails under full
`unittest discover` while passing on its own. The pin is applied and active there — the
traceback runs through mock's wrapper — and the failure is unchanged, so whatever moves that
behaviour under discovery is **not** this knob.

Ruled out so far, each running before it in one process and each passing:

- `test_tenant_policy` (sets and clears tenant policies)
- `test_matrixark_owner_derivable_postings`
- `test_matrixark_owner_derivable_postings_choke_point`

The last two set `MATRIXARK_INDEX_SKIP_OWNER_DERIVABLE_TERMS=0` and restore it in `finally`,
which made them the obvious suspects. Filed separately rather than guessed at; finding it needs
a bisect over the discovery order.

## Sweep

105 failing names before, 106 after. The difference is `test_the_three_listings_run_together`,
a timing assertion — 232 ms against a 150 ms ceiling — on a box running several suites at once.
Not a behaviour change, and load-sensitive by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)