### PR TITLE
A list push re-indexed every page of the list

### DIFF
--- a/crates/temporalstore-rust/src/engine.rs
+++ b/crates/temporalstore-rust/src/engine.rs
@@ -709,7 +709,7 @@ impl TemporalEngine {
             // Capture this write's touched keys for the O(delta) index-log append below
             // (the command is moved into the WAL append before we reach that point).
             let delta_command_keys = object_keys.clone();
-            let upsert_components = command_upsert_components(&command);
+            let upsert_components = command_upsert_components(&command, shard);
             if object_keys.is_empty() {
                 rebuild_bucket_page_ownership(
                     request.shard_id,
@@ -2112,6 +2112,7 @@ pub(super) fn decode_index_bytes(bytes: &[u8]) -> Result<ShardState, String> {
 /// rewrites), and the caller must fall back to the whole-object snapshot record.
 fn command_upsert_components(
     command: &Command,
+    shard: &ShardState,
 ) -> Option<Vec<(&'static str, String, Option<String>)>> {
     match command {
         Command::HashSet { key, field, .. } => {
@@ -2140,6 +2141,24 @@ fn command_upsert_components(
         )]),
         Command::SetAdd { key, member } => {
             Some(vec![("set", key.clone(), Some(hex::encode(member)))])
+        }
+        // A push files its page under its sequence number, which is only knowable once the
+        // write has landed: post-apply the pushed element is the list's FIRST entry for a left
+        // push and its LAST for a right one. That is why this needs shard state and the other
+        // arms do not.
+        Command::ListPush { key, left, .. } => {
+            let seq = shard.lists.get(key).and_then(|list| {
+                if *left {
+                    list.keys().next().copied()
+                } else {
+                    list.keys().next_back().copied()
+                }
+            })?;
+            Some(vec![(
+                "list",
+                key.clone(),
+                Some(format!("{:016x}", (seq as u64).wrapping_sub(i64::MIN as u64))),
+            )])
         }
         _ => None,
     }
@@ -2179,6 +2198,18 @@ fn collect_upsert_index_items(
                 }),
             // `hex::encode(member)` is the component a set add files its page under, so
             // the member the map is keyed by is recoverable from the component itself.
+            // `{biased:016x}` of the entry's sequence, so the key the list map is keyed by
+            // is recoverable from the component it was filed under.
+            ("list", Some(component)) => u64::from_str_radix(component, 16)
+                .ok()
+                .map(|biased| biased.wrapping_add(i64::MIN as u64) as i64)
+                .and_then(|seq| {
+                    shard
+                        .lists
+                        .get(object_key)
+                        .and_then(|entries| entries.get(&seq))
+                        .cloned()
+                }),
             ("set", Some(component)) => hex::decode(component)
                 .ok()
                 .and_then(|member| {

--- a/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
+++ b/crates/temporalstore-rust/src/engine/stream_batch_methods.rs
@@ -344,7 +344,7 @@ impl TemporalEngine {
                 delta_command_keys.extend(object_keys.iter().cloned());
                 match (
                     &mut batch_upsert_components,
-                    command_upsert_components(&command_for_post_write),
+                    command_upsert_components(&command_for_post_write, shard),
                 ) {
                     (Some(collected), Some(components)) => collected.extend(components),
                     (state, _) => *state = None,

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14699,3 +14699,175 @@ fn a_set_survives_a_restart_with_its_members_and_removals() {
         "a duplicate add must not add a second copy, and nothing may appear that was not written"
     );
 }
+
+/// A list must come back from a restart with its ORDER intact, pushes from both ends included.
+///
+/// `ListPush` now declares its index component, and that component is its sequence number --
+/// read from the list AFTER the write lands, because a push's position is not knowable from the
+/// command alone.
+///
+/// This is a GUARD on the restart path, not a check of the component: a clean `unload_shard`
+/// writes a full base snapshot that recovery reads wholesale, so inverting the end the component
+/// is taken from leaves this test green. The component itself is asserted directly by
+/// `a_list_push_files_its_index_item_under_the_pushed_entry`, which reads the delta record.
+#[test]
+fn a_list_survives_a_restart_with_its_order_across_both_ends() {
+    let dir = tempfile::tempdir().unwrap();
+    let page_dir = dir.path().join("pages");
+    let index_dir = dir.path().join("indexes");
+
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache-a"),
+        &page_dir,
+        &index_dir,
+    );
+    engine.load_shard(1);
+
+    // Right pushes build r-0000..r-0031 left-to-right; left pushes then prepend l-0000, l-0001,
+    // so the head ends up l-0001, l-0000 -- an order no single-ended push could produce.
+    for index in 0..32 {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ListPush {
+                key: "queue".to_string(),
+                member: format!("r-{index:04}").into_bytes(),
+                left: false,
+            },
+        });
+        assert!(out.status.ok, "right push {index}: {:?}", out.status);
+    }
+    for index in 0..2 {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ListPush {
+                key: "queue".to_string(),
+                member: format!("l-{index:04}").into_bytes(),
+                left: true,
+            },
+        });
+        assert!(out.status.ok, "left push {index}: {:?}", out.status);
+    }
+
+    let expected: Vec<String> = std::iter::once("l-0001".to_string())
+        .chain(std::iter::once("l-0000".to_string()))
+        .chain((0..32).map(|index| format!("r-{index:04}")))
+        .collect();
+
+    let read_all = |engine: &TemporalEngine| -> Vec<String> {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ListRange {
+                key: "queue".to_string(),
+                start: 0,
+                stop: -1,
+            },
+        });
+        assert!(out.status.ok, "ListRange refused: {:?}", out.status);
+        match out.response {
+            CommandResponse::Members { members } => members
+                .into_iter()
+                .map(|m| String::from_utf8(m).expect("member is utf8"))
+                .collect(),
+            other => panic!("expected list members, got {other:?}"),
+        }
+    };
+
+    // Before the restart, so a mismatch after it is attributable to the RESTART and not to the
+    // pushes having been wrong all along.
+    assert_eq!(read_all(&engine), expected, "the order is wrong before any restart");
+
+    engine.unload_shard(1);
+
+    let restarted = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache-b"),
+        &page_dir,
+        &index_dir,
+    );
+    restarted.load_shard(1);
+
+    let after = read_all(&restarted);
+    assert!(
+        !after.is_empty(),
+        "the list read back EMPTY after the restart: its entries no longer resolve"
+    );
+    assert_eq!(
+        after, expected,
+        "the list came back in a different order than it went in"
+    );
+}
+
+/// A push must file its index item under the entry it actually pushed.
+///
+/// The restart tests cannot see this: a clean unload writes a full base snapshot, so recovery
+/// never consults the incremental item. This reads the delta record itself, which is the only
+/// place the component appears, and so is the only test that fails if the component is computed
+/// from the wrong end of the list.
+#[test]
+fn a_list_push_files_its_index_item_under_the_pushed_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = TemporalEngine::with_local_dirs(
+        16 * 1024 * 1024,
+        dir.path().join("cache"),
+        dir.path().join("pages"),
+        dir.path().join("indexes"),
+    );
+    engine.load_shard(1);
+
+    for index in 0..4 {
+        let out = engine.execute(ExecuteRequest {
+            shard_id: 1,
+            command: Command::ListPush {
+                key: "queue".to_string(),
+                member: format!("r-{index:04}").into_bytes(),
+                left: false,
+            },
+        });
+        assert!(out.status.ok, "right push: {:?}", out.status);
+    }
+    // The last write is a LEFT push, so the entry it created is the list's FIRST key. If the
+    // component were taken from the other end it would name the last right push instead.
+    let out = engine.execute(ExecuteRequest {
+        shard_id: 1,
+        command: Command::ListPush {
+            key: "queue".to_string(),
+            member: b"l-0000".to_vec(),
+            left: true,
+        },
+    });
+    assert!(out.status.ok, "left push: {:?}", out.status);
+
+    let (head_seq, tail_seq) = {
+        let shards = engine.shards.read().expect("shards lock poisoned");
+        let shard = shards.get(&1).expect("shard 1 loaded");
+        let list = shard.lists.get("queue").expect("the list exists");
+        (
+            *list.keys().next().expect("a head"),
+            *list.keys().next_back().expect("a tail"),
+        )
+    };
+    assert_ne!(head_seq, tail_seq, "the list must have both ends to tell them apart");
+
+    let records = engine
+        .index_log_store
+        .read_delta_records(1, 0)
+        .expect("delta records readable");
+    // The newest record carrying a component for this list is the left push's.
+    let component = records
+        .iter()
+        .rev()
+        .flat_map(|record| record.items.iter())
+        .find(|item| item.object_key == "queue" && item.component.is_some())
+        .and_then(|item| item.component.clone())
+        .expect("the push wrote an index item with a component");
+
+    let biased = u64::from_str_radix(&component, 16).expect("the component is 16 hex digits");
+    let seq = biased.wrapping_add(i64::MIN as u64) as i64;
+
+    assert_eq!(
+        seq, head_seq,
+        "a LEFT push must file its item under the list's head ({head_seq}), not its tail \
+         ({tail_seq}); the component named {seq}"
+    );
+}


### PR DESCRIPTION
One `ListPush` onto a 3,200-element list allocated **2.4 MB**. It now allocates **3.5 KB** — a
687x reduction.

This is the other half of the defect fixed for `SetAdd` in #777: a write that does not declare
its index component falls back to `collect_command_index_items`, which re-indexes **every page
of the object**.

| command | declares component | @200 | @3,200 | ratio |
|---|---|---|---|---|
| `HashSet` | yes | 3,425 | 3,450 | 1.01x |
| `ZSetAdd` | yes | 3,842 | 3,721 | 0.97x |
| `SetAdd` | yes (#777) | 3,570 | 3,660 | 1.03x |
| `ListPush` **(before)** | no | 155,492 | 2,432,825 | **15.65x** |
| `ListPush` **(after)** | yes | 3,493 | 3,542 | **1.01x** |

`ControlStateIncrement` rides along as a positive control and reports 7.57x before and after, so
the probe is still able to see amplification when it is there.

## Why this one needed a signature change

`SetAdd`'s component is `hex::encode(member)` — it comes from the command. A push's component is
its **sequence number**, which is only knowable once the write has landed: post-apply, the
pushed entry is the list's first key for a left push and its last for a right one. So
`command_upsert_components` now takes `&ShardState`.

Both of its call sites already run post-apply, inside `if outcome.mutated`, with the shard in
scope:

* `engine.rs` — the single-command path.
* `engine/stream_batch_methods.rs` — the batch path, inside the per-command loop, so each push
  reads the list as it stood after that push.

## Testing the component, not a round trip

`a_list_push_files_its_index_item_under_the_pushed_entry` reads the delta record and asserts the
component names the entry the push created. Inverting the end it is taken from fails it:

```
a LEFT push must file its item under the list's head (-1), not its tail (3); the component named 3
```

This test exists because the obvious one does not work. A restart test **cannot** check a
component: `unload_shard` writes a full base snapshot and a reload recovers from it wholesale,
so the incremental item is never consulted. Both restart tests here stayed green under the same
mutation, and their comments now say so rather than implying coverage they do not provide. The
restart tests are still worth having — nothing covered plain-list order across a restart — but
as guards, which is what they are labelled.

## Verification

* Full library suite green.
* `cargo check --all-targets` clean.
* The component test fails under mutation and passes without it.
