### PR TITLE
Authorize revocation, and mint the replacement before revoking

### DIFF
--- a/tools/matrixark_access_apikey.py
+++ b/tools/matrixark_access_apikey.py
@@ -56,6 +56,10 @@ class _AccessApiKeyMixin:
             "allowed_session_ids": allowed_session_ids,
             "expires_at_ms": expires_at_ms,
             "status": "active",
+            # Stored so rotation can mint the replacement with the same prefix. Without it rotate
+            # has nothing to carry and falls back to its default, turning an sk_live key into an
+            # mk_test one.
+            "key_prefix": key_prefix,
             "created_by_api_key_id": identity.get("api_key_id", ""),
             "created_at_ms": now_ms(),
         }
@@ -303,6 +307,10 @@ class _AccessApiKeyMixin:
         record = self.latest_api_key_record(api_key_id)
         if not record or record.get("status") != "active":
             raise MatrixArkError("active api_key_id not found")
+        # Creating a key checks this; revoking one did not, so an admin key for one tenant could
+        # revoke another tenant's key given its id. Authorization must not rest on an identifier
+        # being hard to guess.
+        self.ensure_identity_can_manage(identity, record["account_id"], record["tenant_id"])
         revoked = {
             **record,
             "record_type": "matrixark_api_key",
@@ -319,7 +327,13 @@ class _AccessApiKeyMixin:
         old_record = self.latest_api_key_record(old_api_key_id)
         if old_record is None or old_record.get("status") != "active":
             raise MatrixArkError("active api_key_id not found")
-        self.revoke_api_key({"api_key_id": old_api_key_id}, identity, action="admin.rotate_api_key.revoke_old")
+        # Before either half runs. This used to be reached only inside the create below, by
+        # which point the old key had already been revoked -- so a refused rotation destroyed the
+        # key it was refused permission to touch.
+        self.ensure_identity_can_manage(identity, old_record["account_id"], old_record["tenant_id"])
+        # Mint first, revoke second. Whatever the create rejects -- a scope retired since the key
+        # was made, a role that no longer carries it -- the caller keeps a working key. The old
+        # order left them with none, and returned an error that read like nothing had happened.
         created = self.create_api_key(
             {
                 "account_id": old_record["account_id"],
@@ -332,12 +346,28 @@ class _AccessApiKeyMixin:
                 "expires_at_ms": old_record.get("expires_at_ms"),
                 "request_quota": old_record.get("request_quota"),
                 "quota_window": old_record.get("quota_window"),
-                "key_prefix": optional_string(args, "key_prefix", "mk_test"),
+                # The replacement keeps the prefix of the key it replaces. Records written
+                # before the prefix was stored have nothing to carry, so they keep the old default.
+                "key_prefix": optional_string(args, "key_prefix",
+                                              old_record.get("key_prefix") or "mk_test"),
             },
             identity,
         )
+        try:
+            self.revoke_api_key({"api_key_id": old_api_key_id}, identity,
+                                action="admin.rotate_api_key.revoke_old")
+        except MatrixArkError as exc:
+            # The replacement exists and works. Say so rather than letting a bare failure suggest
+            # the rotation did nothing -- the caller needs to know the new key is live and the old
+            # one still is too.
+            raise MatrixArkError(
+                "rotation minted %s but could not revoke %s (%s); the new key is active and the "
+                "old one is still active" % (created["api_key_id"], old_api_key_id, exc)
+            ) from exc
         self.append_audit("admin.rotate_api_key", identity, status="ok", details={"old_api_key_id": old_api_key_id, "new_api_key_id": created["api_key_id"]})
-        return {"status": "rotated", "old_api_key_id": old_api_key_id, **created}
+        # `**created` last would overwrite the status with the "created" that create_api_key
+        # returns, so every rotation reported itself as a creation.
+        return {**created, "status": "rotated", "old_api_key_id": old_api_key_id}
 
     def list_api_keys(self, args: Json, identity: Json) -> Json:
         limit = args.get("limit", 100)

--- a/tools/test_matrixark_revoking_a_key_is_authorized.py
+++ b/tools/test_matrixark_revoking_a_key_is_authorized.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Revoking a key is authorized, and rotating one cannot destroy it.
+
+Three faults in the two endpoints behind the key portal's Rotate and Revoke buttons, each
+reproduced against a server in enforced mode before the fix.
+
+**Revocation was not authorized.** Creating a key calls `ensure_identity_can_manage`, which
+requires the caller's account and tenant to match. Revoking one did not: it found the record by id,
+saw it was active, and revoked it. An admin key for one tenant could revoke another tenant's key.
+Listing is fenced, so the id must come from elsewhere -- an audit line, a screenshot, a support
+ticket -- but authorization cannot rest on an identifier being awkward to obtain.
+
+**A refused rotation destroyed the key anyway.** Rotation revoked first and only met an
+authorization check inside the create half, so rotating another tenant's key raised "account/tenant
+does not match" *after* the revocation had landed. The caller was told no; the key was gone. The
+replacement is now minted first, so no failure in either half can leave the caller with no key.
+
+**Rotation changed the key's prefix.** The prefix was never stored, so rotation fell back to its
+"mk_test" default and a key created as `sk_live_...` came back as `mk_test_...`.
+
+Every check that expects a refusal is paired with the same caller doing the same thing to its own
+tenant, because a test that only ever sees "refused" passes just as well when the setup is broken.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer, MatrixArkError
+
+ADMIN_SCOPES = ["admin:account", "admin:user", "admin:api_key", "admin:audit", "portal:read"]
+A = {"account_id": "acct_a", "tenant_id": "tenant_a"}
+B = {"account_id": "acct_b", "tenant_id": "tenant_b"}
+
+
+class KeyManagementIsFencedByTenantTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.log = Path(tmp.name) / "events.jsonl"
+
+        # Enforced mode has no way to mint the first key, so the fixtures are made in dev mode and
+        # the log is reopened enforced.
+        dev = self._server("dev")
+        self.admin_a = dev.call_tool("matrixark_admin_create_api_key",
+                                     {"scope": A, **A, "role": "owner", "scopes": ADMIN_SCOPES})
+        self.own_a = self._service(dev, A)
+        self.victim_b = self._service(dev, B)
+        dev.close(timeout_s=10.0)
+
+        self.server = self._server("enforced")
+
+    def _server(self, mode: str) -> MatrixArkMcpServer:
+        server = MatrixArkMcpServer(MatrixArkLocalAdapter(self.log), line_json=True,
+                                    access_mode=mode)
+        self.addCleanup(server.close, timeout_s=10.0)
+        return server
+
+    @staticmethod
+    def _service(server, scope, prefix="sk_live"):
+        return server.call_tool("matrixark_admin_create_api_key",
+                                {"scope": scope, **scope, "role": "service",
+                                 "key_prefix": prefix, "scopes": ["context:ingest"]})
+
+    def _as_admin_a(self, tool, args):
+        return self.server.call_tool(tool, dict(args, api_key=self.admin_a["api_key"]))
+
+    def _status(self, api_key_id: str) -> str:
+        record = self._server("dev").access.latest_api_key_record(api_key_id)
+        return (record or {}).get("status", "absent")
+
+    # ---- revoke ---------------------------------------------------------------------------
+
+    def test_an_admin_may_revoke_a_key_in_its_own_tenant(self) -> None:
+        """The control. Without it, the refusal below could mean the setup was simply wrong."""
+        result = self._as_admin_a("matrixark_admin_revoke_api_key",
+                                  {"api_key_id": self.own_a["api_key_id"]})
+        self.assertEqual("revoked", result["status"])
+        self.assertEqual("revoked", self._status(self.own_a["api_key_id"]))
+
+    def test_an_admin_may_not_revoke_another_tenants_key(self) -> None:
+        with self.assertRaises(MatrixArkError):
+            self._as_admin_a("matrixark_admin_revoke_api_key",
+                             {"api_key_id": self.victim_b["api_key_id"]})
+        self.assertEqual("active", self._status(self.victim_b["api_key_id"]),
+                         "the key was revoked by an admin with no authority over its tenant")
+
+    # ---- rotate ---------------------------------------------------------------------------
+
+    def test_an_admin_may_rotate_a_key_in_its_own_tenant(self) -> None:
+        rotated = self._as_admin_a("matrixark_admin_rotate_api_key",
+                                   {"api_key_id": self.own_a["api_key_id"]})
+        self.assertEqual("rotated", rotated["status"])
+        self.assertTrue(rotated.get("api_key"))
+        self.assertEqual("revoked", self._status(self.own_a["api_key_id"]))
+        self.assertEqual("active", self._status(rotated["api_key_id"]))
+
+    def test_a_refused_rotation_leaves_the_key_alone(self) -> None:
+        """The old order revoked first, so this raised and destroyed the key at the same time."""
+        with self.assertRaises(MatrixArkError):
+            self._as_admin_a("matrixark_admin_rotate_api_key",
+                             {"api_key_id": self.victim_b["api_key_id"]})
+        self.assertEqual("active", self._status(self.victim_b["api_key_id"]),
+                         "a rotation that was refused still revoked the key it could not touch")
+
+
+class RotationKeepsTheKeysPrefixTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.server = MatrixArkMcpServer(
+            MatrixArkLocalAdapter(Path(tmp.name) / "events.jsonl"),
+            line_json=True, access_mode="dev")
+        self.addCleanup(self.server.close, timeout_s=10.0)
+        self.scope = {"account_id": "acct_p", "tenant_id": "tenant_p"}
+
+    def _create(self, prefix):
+        return self.server.call_tool(
+            "matrixark_admin_create_api_key",
+            {"scope": self.scope, **self.scope, "role": "service", "key_prefix": prefix,
+             "scopes": ["context:ingest"]})
+
+    def test_the_replacement_carries_the_same_prefix(self) -> None:
+        for prefix in ("sk_live", "mk_test", "sk_staging"):
+            made = self._create(prefix)
+            self.assertTrue(made["api_key"].startswith(prefix + "_"), made["api_key"][:12])
+            rotated = self.server.call_tool("matrixark_admin_rotate_api_key",
+                                            {"api_key_id": made["api_key_id"]})
+            self.assertTrue(rotated["api_key"].startswith(prefix + "_"),
+                            "%s rotated into %s..." % (prefix, rotated["api_key"][:14]))
+
+    def test_an_explicit_prefix_still_wins(self) -> None:
+        made = self._create("sk_live")
+        rotated = self.server.call_tool(
+            "matrixark_admin_rotate_api_key",
+            {"api_key_id": made["api_key_id"], "key_prefix": "sk_next"})
+        self.assertTrue(rotated["api_key"].startswith("sk_next_"), rotated["api_key"][:14])
+
+    def test_a_record_written_before_the_prefix_was_stored_still_rotates(self) -> None:
+        """Older records have no prefix to carry, so they keep the previous default."""
+        made = self._create("sk_live")
+        record = self.server.access.latest_api_key_record(made["api_key_id"])
+        legacy = {key: value for key, value in record.items() if key != "key_prefix"}
+        self.server.access.metadata.append(legacy)
+        self.assertNotIn("key_prefix",
+                         self.server.access.latest_api_key_record(made["api_key_id"]))
+
+        rotated = self.server.call_tool("matrixark_admin_rotate_api_key",
+                                        {"api_key_id": made["api_key_id"]})
+        self.assertTrue(rotated["api_key"].startswith("mk_test_"), rotated["api_key"][:14])
+
+    def test_the_prefix_is_recorded_in_the_first_place(self) -> None:
+        made = self._create("sk_live")
+        record = self.server.access.latest_api_key_record(made["api_key_id"])
+        self.assertEqual("sk_live", record.get("key_prefix"))
+
+    def test_the_record_still_holds_no_plaintext_key(self) -> None:
+        """Storing the prefix must not have widened what a key record keeps."""
+        made = self._create("sk_live")
+        record = self.server.access.latest_api_key_record(made["api_key_id"])
+        self.assertIn("api_key_hash", record)
+        self.assertNotIn("api_key", record)
+        self.assertNotIn(made["api_key"], str(record))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three faults in the two endpoints behind the key portal's **Rotate** and **Revoke** buttons. Each
was reproduced against a server running in enforced mode before the fix, and each is now covered.

**Revoking a key was not authorized.** Creating one calls `ensure_identity_can_manage`, which
requires the caller's account and tenant to match the ones being operated on. Revoking one never
called it — it found the record by id, saw it was active, and revoked it. An admin key for one
tenant could revoke another tenant's key. Listing *is* fenced, so the id has to come from somewhere
else, but authorization cannot rest on an identifier being awkward to obtain.

**A refused rotation destroyed the key anyway.** Rotation revoked first and only met an
authorization check inside the create half, so rotating another tenant's key raised
`account/tenant does not match` *after* the revocation had landed. The caller was told no; the key
was gone, irreversibly. The check now runs before either half, and — independently of
authorization — the replacement is minted **before** the old key is revoked, so nothing that fails
in either half can leave a caller with no key at all. If the revoke half fails, the error names
both keys and says both are active, rather than reading like the rotation did nothing.

**Rotation changed the key's prefix.** `key_prefix` was never stored on the record, so rotation had
nothing to carry and fell back to its `mk_test` default: a key created as `sk_live_…` came back as
`mk_test_…`. It is stored now. Records written before this keep the old fallback, since there is
nothing to recover the prefix from — covered by its own test.

**A rotation reported itself as a creation.** `{"status": "rotated", …, **created}` put the spread
last, so `created`'s own `"status": "created"` overwrote it. Nothing in the tree read either value.

Nine tests in `tools/test_matrixark_revoking_a_key_is_authorized.py`. Every check that expects a
refusal is paired with the same caller doing the same thing to its own tenant, because a test that
only ever sees "refused" passes just as well when the setup is broken. The module fails five ways
on the code it replaces.

Two suites (`access_governance`, `monitoring_ui_context_ops`) are red with identical failure names
on a tree without this change.
