### PR TITLE
The usage read answers with your own rows

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -769,6 +769,24 @@ def _meter_and_check_quota(
 _USAGE_READ_SCOPES = {"admin:api_key", "admin:audit"}
 
 
+def _usage_rows_visible_to(record: Optional[Json], rows: list, tenant: Optional[str],
+                           account: Optional[str]) -> list:
+    """The usage rows this caller may see.
+
+    The meter's snapshot is deployment-wide -- every metered key's hash, tenant, account, request
+    counts and byte volume -- and the route returned it whole, so one tenant's admin key read how
+    much traffic every other tenant was doing.
+
+    A scoped enforced key sees its own account and tenant. A dev key (no record) or a legacy
+    unrestricted key (``scopes is None``) is unchanged, which is the same posture
+    ``_usage_read_denied`` takes for those keys.
+    """
+    if record is None or record.get("scopes") is None:
+        return rows
+    return [row for row in rows
+            if row.get("tenant_id") == tenant and row.get("account_id") == account]
+
+
 def _usage_read_denied(record: Optional[Json]) -> Optional[Json]:
     """403 payload when the key may not read usage, else ``None``.
 
@@ -3666,7 +3684,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             denied = _usage_read_denied(key_record)
             if denied is not None:
                 return await _json(send, 403, denied)
-            usage = meter.snapshot()
+            usage = _usage_rows_visible_to(key_record, meter.snapshot(), tenant, account)
             return await _json(send, 200, {"status": "ok", "usage": usage, "count": len(usage)})
 
         # ---- effective model configuration (auth + admin scope) ------------------------------

--- a/tools/test_matrixark_v1_gateway.py
+++ b/tools/test_matrixark_v1_gateway.py
@@ -1077,6 +1077,9 @@ class UsageMeterTest(unittest.TestCase):
 
     DATA_KEY = "testkey_usage_data"          # context scopes only, NO admin scope
     ADMIN_KEY = "testkey_usage_admin"        # carries admin:api_key -> may read usage
+    OTHER_KEY = "testkey_usage_other"        # a DIFFERENT tenant; no test below drives it except
+                                             # the cross-tenant one, so no other count changes
+    LEGACY_KEY = "testkey_usage_legacy"      # scopes=None -> unrestricted, by documented design
 
     _DATA_SCOPES = ["context:ingest", "context:retrieve"]
 
@@ -1087,6 +1090,11 @@ class UsageMeterTest(unittest.TestCase):
             gw._secret_hash(self.ADMIN_KEY): {
                 "tenant_id": "t", "account_id": "acct",
                 "scopes": ["admin:api_key", "context:retrieve"]},
+            gw._secret_hash(self.OTHER_KEY): {
+                "tenant_id": "other_t", "account_id": "other_acct",
+                "scopes": list(self._DATA_SCOPES)},
+            gw._secret_hash(self.LEGACY_KEY): {
+                "tenant_id": "t", "account_id": "acct"},        # no "scopes" -> unrestricted
         }
 
     def setUp(self):
@@ -1127,6 +1135,39 @@ class UsageMeterTest(unittest.TestCase):
         blob = json.dumps(payload)
         self.assertNotIn(self.DATA_KEY, blob)                          # never leak the plaintext key
         self.assertIn(gw._secret_hash(self.DATA_KEY), blob)
+
+    def test_usage_read_returns_only_the_callers_own_tenant(self):
+        """The snapshot is deployment-wide. Returning it whole told one tenant how much traffic
+        every other tenant was doing -- key hash, request counts and bytes."""
+        drive(self.app, path="/v1/ingest", body={"records": [1]}, headers=self._bearer(self.DATA_KEY))
+        for _ in range(4):
+            drive(self.app, path="/v1/ingest", body={"records": [1, 2, 3]},
+                  headers=self._bearer(self.OTHER_KEY))
+
+        st, payload = self._usage(self.ADMIN_KEY)
+        self.assertEqual(200, st)
+        # The control: the caller's OWN row must still be there, or a filter returning nothing at
+        # all would pass the check below without meaning anything.
+        own = [r for r in payload["usage"] if r["api_key_hash"] == gw._secret_hash(self.DATA_KEY)]
+        self.assertEqual(1, len(own), payload["usage"])
+        self.assertEqual(1, own[0]["total"])
+
+        foreign = [r for r in payload["usage"] if r["tenant_id"] != "t"]
+        self.assertEqual([], foreign,
+                         "another tenant's usage was returned to an admin of this one: %r" % foreign)
+        self.assertEqual(1, payload["count"])
+        blob = json.dumps(payload)
+        self.assertNotIn("other_t", blob)
+        self.assertNotIn(gw._secret_hash(self.OTHER_KEY), blob)
+
+    def test_a_legacy_unrestricted_key_still_reads_the_whole_snapshot(self):
+        """Unchanged on purpose: a key with no scopes is unrestricted everywhere else at this
+        edge, and narrowing it here would change what those deployments see."""
+        drive(self.app, path="/v1/ingest", body={"records": [1]}, headers=self._bearer(self.DATA_KEY))
+        drive(self.app, path="/v1/ingest", body={"records": [1]}, headers=self._bearer(self.OTHER_KEY))
+        st, payload = self._usage(self.LEGACY_KEY)
+        self.assertEqual(200, st)
+        self.assertEqual(2, payload["count"], payload["usage"])
 
     def test_non_admin_key_cannot_read_usage_403(self):
         st, payload = self._usage(self.DATA_KEY)


### PR DESCRIPTION
`GET /v1/admin/api_key_usage` returned the meter's snapshot **whole**. That snapshot is
deployment-wide — one row per metered key, carrying the key's hash, its tenant and account, its
request count split by category, and the bytes it moved. The route checked only that the caller's
key carries `admin:api_key` or `admin:audit`, so an admin key for one tenant read every other
tenant's traffic volumes directly off the portal's **Usage** tab.

Reproduced before the fix — two data keys in different tenants, one request from the first and four
from the second, read back with the first tenant's admin key:

```
read as tenant t_a's admin -> HTTP 200, 2 row(s)
   tenant=t_a   account=acct_a  total=1   bytes=16     own
   tenant=t_b   account=acct_b  total=4   bytes=88     <-- ANOTHER TENANT
```

A scoped enforced key now sees its own account and tenant only.

Dev keys (no record) and legacy keys with no scopes are **deliberately unchanged**. That is the
posture `_usage_read_denied` already documents for them, and narrowing it here would change what
those deployments see without anybody asking for it — so it has its own test asserting they still
read the full snapshot, which also stops the filter being tightened by accident.

The cross-tenant check carries a control: the caller's own row must still be present and still
report the right total, so a filter that returned nothing at all cannot pass it. Both tests sit in
the gateway's existing `UsageMeterTest` — the harness is already there, and a test module that
imports another test module reorders unittest discovery, which has broken this suite before.

Full gateway suite green (97), along with api_traffic, readiness_sources, dashboards and
live_strip.
