### PR TITLE
Every field on the key portal is announced by its own label

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -148,25 +148,25 @@
     <p class="hint">The admin key is held in <code>sessionStorage</code> for this tab only and is sent as
       <code>Authorization: Bearer &lt;key&gt;</code>. It is never written into the page source or persisted to disk.
       It must carry the <code>admin:api_key</code> scope (usage reads also accept <code>admin:audit</code>).</p>
-    <label>Admin API key <span class="opt">(bearer — held in sessionStorage)</span></label>
+    <label for="adminKey">Admin API key <span class="opt">(bearer — held in sessionStorage)</span></label>
     <input id="adminKey" type="password" placeholder="sk_live_… / mk_… admin-scoped key" autocomplete="off">
     <div class="row">
       <div>
-        <label>Key-management API base <span class="opt">(serves <code>/api/admin/*</code>; blank = same origin)</span></label>
+        <label for="mgmtBase">Key-management API base <span class="opt">(serves <code>/api/admin/*</code>; blank = same origin)</span></label>
         <input id="mgmtBase" type="text" placeholder="https://portal-host:8080" autocomplete="off">
       </div>
       <div>
-        <label>Gateway base <span class="opt">(serves <code>/v1/admin/api_key_usage</code>; blank = same origin)</span></label>
+        <label for="gwBase">Gateway base <span class="opt">(serves <code>/v1/admin/api_key_usage</code>; blank = same origin)</span></label>
         <input id="gwBase" type="text" placeholder="https://gateway-host:8080" autocomplete="off">
       </div>
     </div>
     <div class="row">
       <div>
-        <label>Account ID <span class="opt">(scopes the list/create views)</span></label>
+        <label for="ctxAccount">Account ID <span class="opt">(scopes the list/create views)</span></label>
         <input id="ctxAccount" type="text" placeholder="acct_local" autocomplete="off">
       </div>
       <div>
-        <label>Tenant ID <span class="opt">(scopes the list/create views)</span></label>
+        <label for="ctxTenant">Tenant ID <span class="opt">(scopes the list/create views)</span></label>
         <input id="ctxTenant" type="text" placeholder="tenantA" autocomplete="off">
       </div>
     </div>
@@ -196,44 +196,44 @@
       MatrixArk stores only its hash.</p>
     <div class="row">
       <div>
-        <label>Tenant ID <span class="opt">(defaults to the connection tenant)</span></label>
+        <label for="ckTenant">Tenant ID <span class="opt">(defaults to the connection tenant)</span></label>
         <input id="ckTenant" type="text" placeholder="tenantA">
       </div>
       <div>
-        <label>Account ID <span class="opt">(defaults to the connection account)</span></label>
+        <label for="ckAccount">Account ID <span class="opt">(defaults to the connection account)</span></label>
         <input id="ckAccount" type="text" placeholder="acct_local">
       </div>
     </div>
-    <label>What is this key for?</label>
-    <div id="scopePresets" class="scope-presets"><span class="hint">Connect above to load the
+    <label id="scopePresetsLabel">What is this key for?</label>
+    <div id="scopePresets" role="group" aria-labelledby="scopePresetsLabel" class="scope-presets"><span class="hint">Connect above to load the
       scope catalogue.</span></div>
-    <label style="margin-top:14px">Scopes <span class="opt">(tick what this key may do)</span></label>
-    <div id="scopeList" class="scope-list"></div>
-    <label style="margin-top:10px">Scopes, as sent <span class="opt">(editable)</span></label>
+    <label id="scopeListLabel" style="margin-top:14px">Scopes <span class="opt">(tick what this key may do)</span></label>
+    <div id="scopeList" role="group" aria-labelledby="scopeListLabel" class="scope-list"></div>
+    <label for="ckScopes" style="margin-top:10px">Scopes, as sent <span class="opt">(editable)</span></label>
     <input id="ckScopes" type="text" value="context:ingest,context:retrieve,context:feedback,resource:read,skill:read">
     <div class="row3">
       <div>
-        <label>Role <span class="opt"></span></label>
+        <label for="ckRole">Role <span class="opt"></span></label>
         <input id="ckRole" type="text" value="service">
       </div>
       <div>
-        <label>Display name <span class="opt"></span></label>
+        <label for="ckDisplay">Display name <span class="opt"></span></label>
         <input id="ckDisplay" type="text" placeholder="team ingest key">
       </div>
       <div>
-        <label>Key prefix <span class="opt"></span></label>
+        <label for="ckPrefix">Key prefix <span class="opt"></span></label>
         <input id="ckPrefix" type="text" value="sk_live">
       </div>
     </div>
-    <label>Allowed user IDs <span class="opt">(comma-separated; blank = no per-user restriction)</span></label>
+    <label for="ckUsers">Allowed user IDs <span class="opt">(comma-separated; blank = no per-user restriction)</span></label>
     <input id="ckUsers" type="text" placeholder="alice,bob">
     <div class="row">
       <div>
-        <label>Request quota <span class="opt">(max requests per window; blank/0 = unlimited)</span></label>
+        <label for="ckQuota">Request quota <span class="opt">(max requests per window; blank/0 = unlimited)</span></label>
         <input id="ckQuota" type="number" min="0" placeholder="unlimited">
       </div>
       <div>
-        <label>Quota window seconds <span class="opt">(blank = per-process lifetime window)</span></label>
+        <label for="ckWindow">Quota window seconds <span class="opt">(blank = per-process lifetime window)</span></label>
         <input id="ckWindow" type="number" min="0" step="1" placeholder="e.g. 60">
       </div>
     </div>

--- a/tools/test_matrixark_every_field_on_the_key_portal_is_named.py
+++ b/tools/test_matrixark_every_field_on_the_key_portal_is_named.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every field on the key portal is announced by its own label.
+
+The page carried seventeen labels in its markup and not one of them was attached to a control --
+the only portal page where that was true, while the others bind most of theirs.
+
+Read off the page's own accessibility tree, that meant the admin key field announced itself as
+"sk_live_... / mk_... admin-scoped key". With no label attached the browser falls back to the
+placeholder, so the field that takes a credential was described by an example of one. Worse, this
+page names two fields "Tenant ID" and two "Account ID" -- one pair for the connection, one for the
+key being created -- so unbound they were four controls carrying two names between them with
+nothing to tell them apart. And clicking a label focused nothing, which costs more here than
+elsewhere because these labels carry the explanatory text and so are wide, obviously clickable
+targets.
+
+Three ways a control can be named, all accepted here:
+
+  * a label with `for` naming it,
+  * a label that wraps it, which associates it without an attribute,
+  * for a set of controls rather than one, `role="group"` with `aria-labelledby` -- `for` takes a
+    single id, so the preset buttons and the scope checkboxes are named that way.
+
+The count of controls checked is asserted, because a selector that stopped matching would leave
+every check below quantified over nothing and passing.
+"""
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from html.parser import HTMLParser
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PAGE = os.path.join(TOOLS, "portal", "api_key_portal.html")
+
+CONTROLS = {"input", "select", "textarea"}
+# Static controls carrying an id today. A floor, so an empty match cannot pass as success.
+CONTROL_COUNT = 15
+
+
+class Markup(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.depth = 0
+        self.label_depth = None
+        self.labels = []          # (for, id, wrapped-control-ids)
+        self.controls = {}        # id -> tag
+        self.labelled_by = set()  # ids named in an aria-labelledby
+        self._wrapped = []
+
+    def handle_starttag(self, tag, attrs) -> None:
+        d = dict(attrs)
+        if d.get("aria-labelledby"):
+            self.labelled_by.update(d["aria-labelledby"].split())
+        if tag in CONTROLS:
+            if d.get("id"):
+                self.controls[d["id"]] = tag
+            if self.label_depth is not None and d.get("id"):
+                self._wrapped.append(d["id"])
+        if tag == "label":
+            self.label_depth = self.depth
+            self._wrapped = []
+            self._for = d.get("for")
+            self._id = d.get("id")
+        if tag not in {"input", "br", "img", "meta", "link", "hr"}:
+            self.depth += 1
+
+    def handle_endtag(self, tag) -> None:
+        if tag not in {"input", "br", "img", "meta", "link", "hr"}:
+            self.depth -= 1
+        if tag == "label" and self.label_depth is not None:
+            self.labels.append((self._for, self._id, list(self._wrapped)))
+            self.label_depth = None
+
+
+def markup() -> Markup:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        body = handle.read().split("<script>")[0]
+    parsed = Markup()
+    parsed.feed(body)
+    return parsed
+
+
+class EveryFieldIsNamedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.page = markup()
+
+    def test_the_page_still_has_the_fields_these_checks_are_about(self) -> None:
+        self.assertGreaterEqual(len(self.page.controls), CONTROL_COUNT,
+                                "expected at least %d controls with ids, found %r"
+                                % (CONTROL_COUNT, sorted(self.page.controls)))
+
+    def test_every_control_is_named_by_a_label(self) -> None:
+        named = set()
+        for target, _, wrapped in self.page.labels:
+            if target:
+                named.add(target)
+            named.update(wrapped)
+        unnamed = sorted(set(self.page.controls) - named - self.page.labelled_by)
+        self.assertEqual([], unnamed,
+                         "these fields have no label attached, so a screen reader falls back to "
+                         "the placeholder and clicking the label focuses nothing: %r" % unnamed)
+
+    def test_no_label_points_at_a_field_that_does_not_exist(self) -> None:
+        missing = sorted(t for t, _, _ in self.page.labels
+                         if t and t not in self.page.controls)
+        self.assertEqual([], missing, "labels naming absent controls: %r" % missing)
+
+    def test_no_two_labels_claim_the_same_field(self) -> None:
+        targets = [t for t, _, _ in self.page.labels if t]
+        duplicates = sorted({t for t in targets if targets.count(t) > 1})
+        self.assertEqual([], duplicates, "more than one label claims: %r" % duplicates)
+
+    def test_every_label_does_a_job(self) -> None:
+        """A label attached to nothing is decoration that announces itself as a label."""
+        idle = [(t, i) for t, i, wrapped in self.page.labels
+                if not t and not wrapped and (i is None or i not in self.page.labelled_by)]
+        self.assertEqual([], idle, "labels attached to nothing: %r" % idle)
+
+    def test_the_two_repeated_names_are_told_apart(self) -> None:
+        """Tenant ID and Account ID each appear twice; each pair must reach different fields."""
+        for pair in (("ctxTenant", "ckTenant"), ("ctxAccount", "ckAccount")):
+            targets = [t for t, _, _ in self.page.labels if t in pair]
+            self.assertEqual(sorted(pair), sorted(targets),
+                             "%r are not separately labelled, so they announce identically" % (pair,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Seventeen labels in the markup, **none** attached to a control — the only portal page where that
was true. Explore binds 16 of its 19, catalog 7 of 9.

Read off the page's own accessibility tree, the admin key field announced itself as
`sk_live_… / mk_… admin-scoped key`. With no label attached the browser falls back to the
placeholder, so **the field that takes a credential was described by an example of one**.

This page also names two fields "Tenant ID" and two "Account ID" — one pair for the connection, one
for the key being created — so unbound they were four controls carrying two names between them with
nothing to distinguish them. And clicking a label focused nothing, which costs more here than
elsewhere: these labels carry the explanatory text, so they are wide targets that look clickable.

- 14 labels now name their field with `for`.
- 2 name a *set* rather than a single control — the preset buttons and the scope checkboxes — so
  they get `role="group"` and `aria-labelledby`, since `for` takes one id.
- The 17th already wraps its checkbox, and the scope list's generated labels wrap theirs, both of
  which associate without an attribute.

Confirmed in a browser rather than inferred — `label.control` resolves to the right element for
every field, and the repeated names now differ by the hint each carries:

```
ctxTenant -> "Tenant ID (scopes the list/create views)"
ckTenant  -> "Tenant ID (defaults to the connection tenant)"
```

`tools/test_matrixark_every_field_on_the_key_portal_is_named.py` accepts all three ways a control
can be named, asserts how many controls it found so it cannot pass over an empty match, and fails
three ways with the `for` attributes stripped. The page diff is attributes only — 18 lines changed,
no content moved.

Other pages are untouched; setup binds 7 of 19 and would need its own pass.
