### PR TITLE
Compact means without the debug lineage, not without the fields the store reads

### DIFF
--- a/tools/test_matrixark_summary_worker.py
+++ b/tools/test_matrixark_summary_worker.py
@@ -186,11 +186,19 @@ class MatrixArkSummaryWorkerTest(unittest.TestCase):
             dirty_markers = [r for r in adapter.read_all() if r.get("record_type") == "context_summary_dirty"]
             self.assertTrue(dirty_markers)
             for marker in dirty_markers:
-                self.assertNotIn("dirty_reason", marker)
-                self.assertNotIn("source_ref_type", marker)
-                self.assertNotIn("source_event_hash", marker)
+                # What "compact" leaves out is the DEBUG lineage, which is what the flag gates.
                 self.assertNotIn("changed_ref_count", marker)
+                self.assertNotIn("propagate_depth", marker)
+                self.assertNotIn("source_role_counts", marker)
+                self.assertNotIn("source_codex_events", marker)
                 self.assertNotIn("empty_summary_seen", marker)
+                # What it keeps is the part the store itself reads. Recovery branches on
+                # dirty_reason (profile_entity_promoted), and both dashboards and the summary
+                # runtime read all three of these, so a marker without them is not compact --
+                # it is broken. Asserting their absence asked for that.
+                self.assertEqual("new_event", marker.get("dirty_reason"))
+                self.assertEqual("event", marker.get("source_ref_type"))
+                self.assertIn("source_event_hash", marker)
 
     def test_summary_dirty_debug_fields_are_opt_in(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -220,10 +228,14 @@ class MatrixArkSummaryWorkerTest(unittest.TestCase):
             dirty_markers = [r for r in adapter.read_all() if r.get("record_type") == "context_summary_dirty"]
             self.assertTrue(dirty_markers)
             for marker in dirty_markers:
+                # These three are written either way -- see the compact test above -- so they
+                # document the shape rather than guard the flag. The gated ones below are what
+                # turning it on actually adds.
                 self.assertEqual("new_event", marker.get("dirty_reason"))
                 self.assertEqual("event", marker.get("source_ref_type"))
                 self.assertIn("source_event_hash", marker)
                 self.assertEqual(1, marker.get("changed_ref_count"))
+                self.assertIn("propagate_depth", marker)
 
     def test_background_worker_refreshes_dirty_nodes_and_embeddings(self) -> None:
         mcp.SUMMARY_REFRESH_INTERVAL_MS = 100


### PR DESCRIPTION
`test_summary_dirty_markers_are_compact_by_default` asserted that a summary-dirty marker
carries no `dirty_reason`, no `source_ref_type` and no `source_event_hash`.

All three are written unconditionally, and they should be:

| field | read by |
| --- | --- |
| `dirty_reason` | `matrixark_mcp_recovery.py:705` branches on it (`profile_entity_promoted`), plus both dashboards and the summary runtime |
| `source_ref_type` | both dashboards, summary runtime |
| `source_event_hash` | both dashboards, `matrixark_mcp_local_adapter.py:4023` |

A marker without them is not compact — it is missing the parts that make it usable.

What the flag actually gates is the **lineage**: `changed_ref_count`, `depth`,
`propagate_depth` and the `source_role` / `source_codex_event` counts. The test now asserts
those are absent by default *and* that the functional three are present, so it fails in both
directions instead of asking for a marker nothing could use.

## The opt-in sibling had the mirror problem

`test_summary_dirty_debug_fields_are_opt_in` asserted four things; three of them
(`dirty_reason`, `source_ref_type`, `source_event_hash`) are written either way, so they could
not tell the flag from its absence. Only `changed_ref_count` was doing work. It now also
asserts `propagate_depth`, which appears only when the flag is on.

## One field deliberately not asserted

`depth` is `len(prefix)`, which is `0` for the marker this test produces, and a falsy value is
dropped on write. Asserting its presence fails with the flag on; asserting its absence proves
nothing with the flag off. So it is left out rather than used as evidence either way — I tried
asserting it first and it failed, which is how I found this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)