### PR TITLE
Removing one entry costs the size of the collection

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -14871,3 +14871,137 @@ fn a_list_push_files_its_index_item_under_the_pushed_entry() {
          ({tail_seq}); the component named {seq}"
     );
 }
+
+/// Does REMOVING one entry cost the size of the collection it leaves?
+///
+/// `capture_key_states` runs when membership shrinks, and its own comment says it "serializes
+/// every entry the per-key maps hold for the key". Adds were measured by
+/// `which_write_paths_cost_their_collection`; this is the other axis.
+///
+/// Two-sided control: ControlStateIncrement is known to amplify (7.57x) and SetAdd is known flat
+/// (1.03x since the component declaration). A probe that cannot show BOTH states is not
+/// measuring anything, so both are asserted.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn which_removals_cost_their_collection() {
+    const REPS: usize = 20;
+    let fill = |engine: &TemporalEngine, family: &str, n: usize| {
+        for i in 0..n {
+            let command = match family {
+                "SetRemove" | "SetAdd" => Command::SetAdd {
+                    key: "k".to_string(),
+                    member: format!("m{i:06}").into_bytes(),
+                },
+                "ListPop" => Command::ListPush {
+                    key: "k".to_string(),
+                    member: format!("m{i:06}").into_bytes(),
+                    left: false,
+                },
+                "ZSetRemove" => Command::ZSetAdd {
+                    key: "k".to_string(),
+                    member: format!("m{i:06}").into_bytes(),
+                    score: i as f64,
+                },
+                "HashDelete" => Command::HashSet {
+                    key: "k".to_string(),
+                    field: format!("f{i:06}"),
+                    value: vec![b'v'; 32],
+                },
+                "ControlStateIncrement" => Command::ControlStateIncrement {
+                    key: "k".to_string(),
+                    timestamp_ms: 1_000 + i as u64,
+                    amount: 1,
+                },
+                other => panic!("unknown family {other}"),
+            };
+            engine.execute(ExecuteRequest { shard_id: 1, command });
+        }
+    };
+    let probed = |family: &str, i: usize, fill_n: usize| -> Command {
+        match family {
+            "SetRemove" => Command::SetRemove {
+                key: "k".to_string(),
+                member: format!("m{i:06}").into_bytes(),
+            },
+            "ListPop" => Command::ListPop {
+                key: "k".to_string(),
+                left: false,
+            },
+            "ZSetRemove" => Command::ZSetRemove {
+                key: "k".to_string(),
+                member: format!("m{i:06}").into_bytes(),
+            },
+            "HashDelete" => Command::HashDelete {
+                key: "k".to_string(),
+                field: format!("f{i:06}"),
+            },
+            // The two controls keep ADDING -- their known behaviour is on the add path.
+            "SetAdd" => Command::SetAdd {
+                key: "k".to_string(),
+                member: format!("m{:06}", fill_n + i).into_bytes(),
+            },
+            "ControlStateIncrement" => Command::ControlStateIncrement {
+                key: "k".to_string(),
+                timestamp_ms: 900_000 + i as u64,
+                amount: 1,
+            },
+            other => panic!("unknown family {other}"),
+        }
+    };
+
+    let cost = |family: &str, n: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        fill(&engine, family, n);
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..REPS {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: probed(family, i, n),
+            });
+            assert!(out.status.ok, "{family} probe write refused: {:?}", out.status);
+        }
+        probe.stop().alloc_bytes / REPS as u64
+    };
+
+    println!("  family                  bytes/op @200   @3200      ratio");
+    let mut amplifying_control = 0.0f64;
+    let mut flat_control = 0.0f64;
+    for family in [
+        "ControlStateIncrement",
+        "SetAdd",
+        "SetRemove",
+        "ListPop",
+        "ZSetRemove",
+        "HashDelete",
+    ] {
+        let small = cost(family, 200);
+        let large = cost(family, 3200);
+        assert!(small > 0, "{family}: measured zero bytes, the probe never reached the path");
+        let ratio = large as f64 / small as f64;
+        match family {
+            "ControlStateIncrement" => amplifying_control = ratio,
+            "SetAdd" => flat_control = ratio,
+            _ => {}
+        }
+        println!("  {family:22}  {small:10}  {large:10}   {ratio:8.2}x");
+    }
+    assert!(
+        amplifying_control > 3.0,
+        "the amplifying control reported {amplifying_control:.2}x -- the probe cannot see \
+         amplification, so no row above means anything"
+    );
+    assert!(
+        flat_control < 1.5,
+        "the flat control reported {flat_control:.2}x -- the probe reports amplification where \
+         there is none, so no row above means anything"
+    );
+    println!("  Ratio near 1 => the removal is incremental. Ratio rising with the collection");
+    println!("  => removing one entry costs the size of what remains.");
+}


### PR DESCRIPTION
Removing one entry from a 3 200-member collection allocates **~2.5 MB**. Every removal command
in the engine does it, and none had been measured.

This change measures it. It does not fix it.

## Measured

Bytes allocated per operation, one collection filled to 200 and to 3 200 members:

| command | @200 | @3 200 | ratio |
|---|---|---|---|
| `ControlStateIncrement` *(amplifying control)* | 9 116 | 68 760 | 7.54x |
| `SetAdd` *(flat control)* | 3 570 | 3 660 | 1.03x |
| **`SetRemove`** | 154 941 | 2 553 695 | **16.48x** |
| **`ListPop`** | 160 238 | 2 582 843 | **16.12x** |
| **`ZSetRemove`** | 164 464 | 2 713 222 | **16.50x** |
| **`HashDelete`** | 151 528 | 2 496 920 | **16.48x** |

Ratios of 16.1–16.5 over a 16x range are linear: removing one entry costs the size of what
remains.

The sharpest row is `HashDelete`. `HashSet` measures 1.01x — hash *writes* have always taken the
declared-component fast path — so hashes were only ever cheap on the add side. The same holds for
sets and lists, whose adds were made cheap in #777 and #778 while their removals were not.

## Two-sided control

A survey that can only show amplification cannot be trusted when it shows none, and one that can
only show flatness cannot be trusted when it shows amplification. This asserts both:

* `ControlStateIncrement` is known to rewrite its whole series and must report **> 3x**.
* `SetAdd` has declared its component since #777 and must report **< 1.5x**.

If either control moves, the test fails rather than returning four clean-looking rows.

## Where the cost is

`collect_command_index_items` walks every page in the routing bucket and, for each page belonging
to the key, builds an `IndexItem` with four `to_string()` allocations. For a 3 200-member
collection that is 3 200 items per removal — the same per-object shape fixed for adds in #777 and
#778, on the path those fixes did not touch.

## Why it is not fixed here

A removal cannot simply declare its component the way an add does. The entry is gone from the
in-memory map, so the address lookup finds nothing, and an index item that fails to record the
deletion would let a replay resurrect a removed entry. `capture_key_states` exists to prevent
exactly that.

The shape of a fix is visible — `SetRemove` marks the page deleted rather than dropping it, the
component is derivable from the command, and `IndexItem` already carries a `deleted` flag, so a
tombstone could name what was removed instead of re-snapshotting the key. But that is a change to
the path that keeps deleted data deleted, and it needs its own test and its own change. What was
missing first was the measurement.

## Verification

* The probe was built and run **with the `alloc-probe` feature enabled**. `cargo check
  --all-targets` does not compile feature-gated code, so a probe that failed to build would
  otherwise pass CI green.
* Test-only; no engine code is touched.
