### PR TITLE
Serve a cached table request in three allocations instead of five

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -922,6 +922,30 @@ impl TemporalStoreClient {
         })
     }
 
+    /// The cached table, taking the names by value.
+    ///
+    /// A hit moves them into the table it returns; a miss hands them back so the caller can open
+    /// the table without having cloned them for a fallback that is almost never taken. The
+    /// caller used to clone both on every request to keep them for that case.
+    pub(crate) fn cached_table_or_names(
+        &self,
+        namespace: String,
+        table_name: String,
+    ) -> Result<TemporalStoreTable, (String, String)> {
+        let combined_name = table_combine_name(&namespace, &table_name);
+        let Some(options) = self.with_tables(|tables| tables.get(&combined_name).cloned()) else {
+            return Err((namespace, table_name));
+        };
+        Ok(TemporalStoreTable {
+            client: self.clone(),
+            namespace,
+            table_name,
+            shard_id: self.inner.options.default_shard_id,
+            options,
+            combined_name,
+        })
+    }
+
     pub fn cached_table(
         &self,
         namespace: impl Into<String>,
@@ -1833,7 +1857,13 @@ impl TemporalStorePipeline {
 }
 
 fn table_combine_name(namespace: &str, table_name: &str) -> String {
-    format!("{namespace}/{table_name}")
+    // Built by hand rather than with `format!`, which allocates twice. This runs on every
+    // namespaced request.
+    let mut combined = String::with_capacity(namespace.len() + 1 + table_name.len());
+    combined.push_str(namespace);
+    combined.push('/');
+    combined.push_str(table_name);
+    combined
 }
 
 fn client_partition_id_for_offset(options: &TableOptions, offset: u64) -> ShardId {

--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -1215,10 +1215,10 @@ impl ProxyService {
         table_name: String,
     ) -> Result<crate::client::TemporalStoreTable, crate::client::ClientError> {
         self.with_client(|client| {
-            client
-                .cached_table(namespace.clone(), table_name.clone())
-                .map(Ok)
-                .unwrap_or_else(|| client.open_table_from_meta(namespace, table_name))
+            match client.cached_table_or_names(namespace, table_name) {
+                Ok(table) => Ok(table),
+                Err((namespace, table_name)) => client.open_table_from_meta(namespace, table_name),
+            }
         })
     }
 
@@ -3368,6 +3368,135 @@ mod tests {
         println!(
             "BENCH shard_id_for_key threads={threads} ops={ops} ns_per_op={}",
             elapsed.as_nanos() / ops
+        );
+    }
+
+    /// A budget on what serving one namespaced request allocates.
+    ///
+    /// Only compiled with `alloc-probe`, because without the counting allocator every count reads
+    /// zero and an upper bound like this would pass while measuring nothing. The canary asserts
+    /// the allocator is really there before the budget is trusted.
+    #[cfg(feature = "alloc-probe")]
+    #[test]
+    fn serving_a_table_request_stays_within_its_allocation_budget() {
+        let canary = crate::alloc_probe::Probe::start();
+        let sink: Vec<u8> = Vec::with_capacity(8192);
+        assert!(
+            canary.stop().allocs > 0,
+            "counting allocator not installed despite the feature being on"
+        );
+        drop(sink);
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let _seeded = proxy
+            .client()
+            .open_table("ns", "tbl", crate::client::TableOptions::default());
+        // Warm the path: the first call fills caches, which is not per-request cost.
+        let _ = proxy.table_for_request("ns".to_string(), "tbl".to_string());
+
+        const ITERS: u64 = 200;
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let table = proxy.table_for_request("ns".to_string(), "tbl".to_string());
+            std::hint::black_box(&table);
+        }
+        let counts = probe.stop();
+        let per_call = counts.allocs / ITERS;
+
+        // The two the caller makes for the names, and one for the cache key. It was five: the
+        // names were cloned so a miss could still use them, and the key was built with `format!`,
+        // which allocates twice.
+        assert!(
+            per_call <= 3,
+            "serving a cached table request allocated {per_call} times, budget 3"
+        );
+        // Zero would mean the measurement stopped working, not that the path got free.
+        assert!(
+            per_call > 0,
+            "measured zero allocations, so this budget is not measuring anything"
+        );
+    }
+
+    /// What one proxy request allocates, by path.
+    ///
+    /// Latency work on these paths took the locks off them; this asks the other question, which
+    /// no benchmark here answered: how much a request allocates and where. Allocation is both
+    /// memory and time -- it is the remaining cost on the table path now the locks are gone.
+    ///
+    ///   cargo test --features alloc-probe --lib what_a_proxy_request_allocates -- --ignored --nocapture --test-threads=1
+    #[test]
+    #[ignore]
+    fn what_a_proxy_request_allocates() {
+        // Without the feature the allocator is not installed and every count reads zero, which
+        // would pass any budget. Fail loudly instead.
+        let canary = crate::alloc_probe::Probe::start();
+        let sink: Vec<u8> = Vec::with_capacity(8192);
+        assert!(
+            canary.stop().allocs > 0,
+            "counting allocator not installed -- rerun with `--features alloc-probe`"
+        );
+        drop(sink);
+
+        let proxy = scoped_proxy(ProxyOptions::default());
+        let _seeded = proxy
+            .client()
+            .open_table("ns", "tbl", crate::client::TableOptions::default());
+        proxy
+            .client()
+            .insert_cached_route_for_test(1, "127.0.0.1:1".to_string());
+        let scope = context_scope("acct", "t");
+
+        const ITERS: usize = 200;
+        let mut rows: Vec<(&str, u64, u64)> = Vec::new();
+
+        // Warm every path first: the first call through each fills caches, and counting that
+        // would report setup as if it were per-request cost.
+        let _ = proxy.admit(Some("ns"), &[Command::StringGet { key: "k".to_string() }]);
+        let _ = proxy.table_for_request("ns".to_string(), "tbl".to_string());
+        let _ = proxy.admit_context(&scope, false);
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let guard = proxy.admit(Some("ns"), &[Command::StringGet { key: "k".to_string() }]);
+            std::hint::black_box(&guard);
+        }
+        let counts = probe.stop();
+        rows.push(("admit, one command", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let table = proxy.table_for_request("ns".to_string(), "tbl".to_string());
+            std::hint::black_box(&table);
+        }
+        let counts = probe.stop();
+        rows.push(("table_for_request", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let guard = proxy.admit_context(&scope, false);
+            std::hint::black_box(&guard);
+        }
+        let counts = probe.stop();
+        rows.push(("admit_context", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
+
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let addr = proxy.client().shard_primary_addr(1, false);
+            std::hint::black_box(&addr);
+        }
+        let counts = probe.stop();
+        rows.push(("cached route lookup", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
+
+        println!();
+        println!("  path                    allocs/call   bytes/call");
+        for (name, allocs, bytes) in &rows {
+            println!("  {name:<22}  {allocs:>10}   {bytes:>10}");
+        }
+        println!();
+
+        assert!(
+            rows.iter().any(|(_, allocs, _)| *allocs > 0),
+            "every path reported zero allocations, which means this measured nothing"
         );
     }
 


### PR DESCRIPTION
Nothing measured allocation on these paths, so nothing said what a request costs in memory. A probe says: admission allocates once, the cached route lookup once, and serving a namespaced request **five times** -- the most on any path, and what remains on it now the locks are gone.

Two were avoidable: the names were cloned on every request so a *miss* could use them, though a miss happens once per table, not once per request. The lookup now takes them by value, moving them into the returned table on a hit and handing them back on a miss. The third was `format!` building the cache key -- two allocations where one reserved string does.

**Five to three; 18 to 11 bytes.**

The budget guarding it compiles only with `alloc-probe`: without the counting allocator every count reads zero and an upper bound would pass while measuring nothing. It also asserts the count is non-zero, and a canary asserts the allocator is installed first. Watched fail at five with the clones restored.

`client::` 41/0, `proxy::` 80/0, `table` 66/0, `context` 76/0.