### PR TITLE
A copy button reports what happened

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -871,6 +871,29 @@
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -714,9 +714,14 @@
     var route = button.closest(".route");
     var open = route.classList.toggle("open");
     button.textContent = open ? "hide curl" : "show curl";
-    if (open && navigator.clipboard) {
-      navigator.clipboard.writeText(curlFor(ROUTES[parseInt(button.dataset.curl, 10)]));
-      button.textContent = "hide curl — copied";
+    if (open) {
+      window.__matrixarkCopyText(curlFor(ROUTES[parseInt(button.dataset.curl, 10)]))
+        .then(function (ok) {
+          /* Only while the route is still open: the reader may have closed it again, and
+             relabelling a closed toggle "copied" describes something not on screen. */
+          if (!route.classList.contains("open")) { return; }
+          button.textContent = ok ? "hide curl — copied" : "hide curl — copy failed";
+        });
     }
   });
   $("filter").addEventListener("input", render);
@@ -732,6 +737,29 @@
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -286,6 +286,29 @@ EXTRA_CSS = """
 # hand-maintained ones through `_with_nav_js`. It is deliberately self-contained -- no helper from
 # any page's own script -- because it has to run identically on pages that share nothing else.
 NAV_JS = r'''<script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {
@@ -2017,16 +2040,18 @@ function liveStream(options) {
 
   $("copyUserData").addEventListener("click", function () {
     var text = $("depUserData").textContent;
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyUserData").textContent = "copied";
-    setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyUserData").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
+    });
   });
 
   $("copyEnv").addEventListener("click", function () {
     var text = $("depEnv").textContent;
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyEnv").textContent = "copied";
-    setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyEnv").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+    });
   });
 
   /* Set once the config lands. Until then only the gateway job is knowable, and printing a
@@ -2160,9 +2185,10 @@ function liveStream(options) {
         "  -H \"Authorization: Bearer $MATRIXARK_ADMIN_KEY\" \\\n" +
         "  -H 'Content-Type: application/json' \\\n  -d '" +
         JSON.stringify({ settings: d.settings }) + "'\n";
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      $("copyCfgCurl").textContent = "copied";
-      setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
+      window.__matrixarkCopyText(text).then(function (ok) {
+        $("copyCfgCurl").textContent = ok ? "copied" : "copy failed";
+        setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
+      });
     }).catch(function (e) {
       say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
           "err");
@@ -2263,9 +2289,10 @@ function liveStream(options) {
 
   $("copyScrape").addEventListener("click", function () {
     var text = scrapeConfig();
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyScrape").textContent = "copied";
-    setTimeout(function () { $("copyScrape").textContent = "copy scrape config"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyScrape").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyScrape").textContent = "copy scrape config"; }, 1400);
+    });
   });
   /* Traffic and encoding arrive on the stream; the checkbox now pauses the stream rather than a
      timer, which is the same promise to the reader and one connection instead of two pollers. */
@@ -3220,8 +3247,12 @@ function liveStream(options) {
 
   $("copyDiag").addEventListener("click", function () {
     withBundle(function (text) {
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      say($("diagMsg"), "Copied " + text.length + " characters to the clipboard.", "ok");
+      window.__matrixarkCopyText(text).then(function (ok) {
+        say($("diagMsg"),
+            ok ? "Copied " + text.length + " characters to the clipboard."
+               : "Could not copy. Use Download instead, or select the bundle and copy it by hand.",
+            ok ? "ok" : "err");
+      });
     });
   });
   $("downloadDiag").addEventListener("click", function () {
@@ -4153,9 +4184,13 @@ EXPLORE_JS = r"""
       }
       /* The key is named, never pasted: this goes on a clipboard and often into a ticket. */
       var text = lines.join(" \\\n");
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      say($("opMsg"), "Copied. It reads $MATRIXARK_API_KEY from your environment rather than " +
-        "carrying your key.", "ok");
+      window.__matrixarkCopyText(text).then(function (ok) {
+        say($("opMsg"),
+            ok ? "Copied. It reads $MATRIXARK_API_KEY from your environment rather than "
+                 + "carrying your key."
+               : "Could not copy. The command is shown above; select it and copy it by hand.",
+            ok ? "ok" : "err");
+      });
       return;
     }
     if (ev.target.id === "opRun") { runOp(); }
@@ -4814,9 +4849,14 @@ API_JS = r"""
     var route = button.closest(".route");
     var open = route.classList.toggle("open");
     button.textContent = open ? "hide curl" : "show curl";
-    if (open && navigator.clipboard) {
-      navigator.clipboard.writeText(curlFor(ROUTES[parseInt(button.dataset.curl, 10)]));
-      button.textContent = "hide curl — copied";
+    if (open) {
+      window.__matrixarkCopyText(curlFor(ROUTES[parseInt(button.dataset.curl, 10)]))
+        .then(function (ok) {
+          /* Only while the route is still open: the reader may have closed it again, and
+             relabelling a closed toggle "copied" describes something not on screen. */
+          if (!route.classList.contains("open")) { return; }
+          button.textContent = ok ? "hide curl — copied" : "hide curl — copy failed";
+        });
     }
   });
   $("filter").addEventListener("input", render);
@@ -4879,7 +4919,8 @@ def _with_nav_js(text):
     that stacks would open one stream per build.
     """
     if NAV_JS_MARKER in text:
-        start = text.index("<script>", text.index(NAV_JS_MARKER) - 200)
+        marker = text.index(NAV_JS_MARKER)
+        start = text.rindex("<script>", 0, marker)
         end = text.index("</script>", start) + len("</script>")
         return text[:start] + NAV_JS.strip() + text[end:]
     if "</body>" not in text:
@@ -4927,7 +4968,8 @@ def inject(filename, anchor, active):
         if not count:
             print("nav present but unrecognised in %s" % filename)
             sys.exit(1)
-        io.open(path, "w", encoding="utf-8", newline="\n").write(_with_tabs_js(_with_nav_js(replaced)))
+        rendered = _with_tabs_js(_with_nav_js(replaced))
+        io.open(path, "w", encoding="utf-8", newline="\n").write(rendered)
         print("nav refreshed in %s" % filename)
         return
     if anchor not in text:

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -855,6 +855,29 @@
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/copy_helper_harness.js
+++ b/tools/portal/copy_helper_harness.js
@@ -1,0 +1,92 @@
+/* Run the shared copy helper, and one page's copy button, under a clipboard that misbehaves.
+ *
+ * The three outcomes cannot be told apart by reading: a resolved write, a rejected one (a denied
+ * permission, an unfocused document), and no clipboard API at all -- which is what an http://
+ * origin gives you, and what a self-hosted portal often is. Every caller used to announce success
+ * for all three.
+ *
+ * Usage: node copy_helper_harness.js <page.html> [more pages...]
+ */
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* The helper is injected into every page by the builder, so it is read back out of a built page
+   rather than out of the generator -- that is the copy a browser actually runs. */
+function helperFrom(file) {
+  const page = fs.readFileSync(file, "utf8");
+  const marker = "window.__matrixarkCopyText = function (text) {";
+  const start = page.indexOf(marker);
+  if (start < 0) { return null; }
+  const end = page.indexOf("\n  };", start);
+  return page.slice(start, end + 5);
+}
+
+function build(clipboard) {
+  const win = { navigator: clipboard === null ? {} : { clipboard: clipboard }, Promise: Promise };
+  win.window = win;
+  return win;
+}
+
+function load(file, clipboard) {
+  const body = helperFrom(file);
+  if (body === null) { return null; }
+  const win = build(clipboard);
+  new Function("window", "navigator", "Promise", body)(win, win.navigator, Promise);
+  return win.__matrixarkCopyText;
+}
+
+const seen = [];
+const resolving = { writeText(t) { seen.push(t); return Promise.resolve(); } };
+const rejecting = { writeText(t) { seen.push(t); return Promise.reject(new Error("denied")); } };
+const throwing = { get writeText() { throw new Error("blocked by policy"); } };
+
+(async function () {
+  const pages = process.argv.slice(2);
+  ok("pages were given", pages.length > 0, "none");
+
+  let carried = 0;
+  for (const file of pages) {
+    const name = path.basename(file);
+    const copy = load(file, resolving);
+    if (copy === null) {
+      console.log("FAIL " + name + " does not carry the shared copy helper");
+      failures += 1;
+      continue;
+    }
+    carried += 1;
+
+    ok(name + ": a clipboard that accepts resolves true", (await copy("hello")) === true);
+    ok(name + ": the text reaches the clipboard unchanged",
+       seen[seen.length - 1] === "hello", JSON.stringify(seen.slice(-1)));
+
+    const rejects = load(file, rejecting);
+    ok(name + ": a clipboard that refuses resolves FALSE, it does not throw",
+       (await rejects("hello")) === false);
+
+    const absent = load(file, null);
+    ok(name + ": no clipboard API at all resolves FALSE rather than throwing",
+       (await absent("hello")) === false);
+
+    /* An http:// origin can also make the property access itself throw. Resolving false is the
+       only answer that lets a caller report something truthful. */
+    const blocked = load(file, throwing);
+    ok(name + ": a clipboard that throws on access resolves FALSE",
+       (await blocked("hello")) === false);
+  }
+
+  ok("every page given carries the helper", carried === pages.length,
+     carried + " of " + pages.length);
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}().catch(function (err) {
+  console.log("FAILED harness threw: " + err.message);
+  process.exit(1);
+}));

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -1379,9 +1379,13 @@
       }
       /* The key is named, never pasted: this goes on a clipboard and often into a ticket. */
       var text = lines.join(" \\\n");
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      say($("opMsg"), "Copied. It reads $MATRIXARK_API_KEY from your environment rather than " +
-        "carrying your key.", "ok");
+      window.__matrixarkCopyText(text).then(function (ok) {
+        say($("opMsg"),
+            ok ? "Copied. It reads $MATRIXARK_API_KEY from your environment rather than "
+                 + "carrying your key."
+               : "Could not copy. The command is shown above; select it and copy it by hand.",
+            ok ? "ok" : "err");
+      });
       return;
     }
     if (ev.target.id === "opRun") { runOp(); }
@@ -1810,6 +1814,29 @@
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -646,12 +646,12 @@
   $("copyScrape").addEventListener("click", function () {
     var cfg = "scrape_configs:\n  - job_name: matrixark_gateway\n    metrics_path: /v1/metrics\n" +
               "    static_configs:\n      - targets: [\"" + location.host + "\"]\n";
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(cfg).then(function () {
-        $("copyScrape").textContent = "copied";
-        setTimeout(function () { $("copyScrape").textContent = "copy Prometheus scrape config"; }, 1800);
-      });
-    }
+    window.__matrixarkCopyText(cfg).then(function (ok) {
+      $("copyScrape").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () {
+        $("copyScrape").textContent = "copy Prometheus scrape config";
+      }, 1800);
+    });
   });
 
   /* invalidate a stale preview when the selection changes */
@@ -708,6 +708,29 @@
 })();
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -858,8 +858,12 @@ function liveStream(options) {
 
   $("copyDiag").addEventListener("click", function () {
     withBundle(function (text) {
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      say($("diagMsg"), "Copied " + text.length + " characters to the clipboard.", "ok");
+      window.__matrixarkCopyText(text).then(function (ok) {
+        say($("diagMsg"),
+            ok ? "Copied " + text.length + " characters to the clipboard."
+               : "Could not copy. Use Download instead, or select the bundle and copy it by hand.",
+            ok ? "ok" : "err");
+      });
     });
   });
   $("downloadDiag").addEventListener("click", function () {
@@ -896,6 +900,29 @@ function liveStream(options) {
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1930,16 +1930,18 @@ function liveStream(options) {
 
   $("copyUserData").addEventListener("click", function () {
     var text = $("depUserData").textContent;
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyUserData").textContent = "copied";
-    setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyUserData").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyUserData").textContent = "copy user-data"; }, 1400);
+    });
   });
 
   $("copyEnv").addEventListener("click", function () {
     var text = $("depEnv").textContent;
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyEnv").textContent = "copied";
-    setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyEnv").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyEnv").textContent = "copy env file"; }, 1400);
+    });
   });
 
   /* Set once the config lands. Until then only the gateway job is knowable, and printing a
@@ -2073,9 +2075,10 @@ function liveStream(options) {
         "  -H \"Authorization: Bearer $MATRIXARK_ADMIN_KEY\" \\\n" +
         "  -H 'Content-Type: application/json' \\\n  -d '" +
         JSON.stringify({ settings: d.settings }) + "'\n";
-      if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-      $("copyCfgCurl").textContent = "copied";
-      setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
+      window.__matrixarkCopyText(text).then(function (ok) {
+        $("copyCfgCurl").textContent = ok ? "copied" : "copy failed";
+        setTimeout(function () { $("copyCfgCurl").textContent = "copy as curl"; }, 1400);
+      });
     }).catch(function (e) {
       say($("importMsg"), typeof e === "number" ? failure(e) : "Could not reach the gateway.",
           "err");
@@ -2176,9 +2179,10 @@ function liveStream(options) {
 
   $("copyScrape").addEventListener("click", function () {
     var text = scrapeConfig();
-    if (navigator.clipboard) { navigator.clipboard.writeText(text); }
-    $("copyScrape").textContent = "copied";
-    setTimeout(function () { $("copyScrape").textContent = "copy scrape config"; }, 1400);
+    window.__matrixarkCopyText(text).then(function (ok) {
+      $("copyScrape").textContent = ok ? "copied" : "copy failed";
+      setTimeout(function () { $("copyScrape").textContent = "copy scrape config"; }, 1400);
+    });
   });
   /* Traffic and encoding arrive on the stream; the checkbox now pauses the stream rather than a
      timer, which is the same promise to the reader and one connection instead of two pollers. */
@@ -2320,6 +2324,29 @@ function liveStream(options) {
 }());
 </script>
 <script>
+/* One copy helper for every page. It resolves true when the text reached the clipboard and false
+   when it did not: no clipboard API at all (an http:// origin, which a self-hosted portal often
+   is), a denied permission, a document that is not focused.
+
+   Callers must report what they are handed. Announcing "copied" without looking -- which every
+   caller here used to do -- is worse than saying nothing, because the reader stops trying and
+   walks away with an empty clipboard.
+
+   Its own IIFE, ahead of the strip's: the strip returns immediately on a page that has none, and
+   a copier defined after that line would not exist on those pages. */
+(function () {
+  "use strict";
+  window.__matrixarkCopyText = function (text) {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text).then(
+          function () { return true; }, function () { return false; });
+      }
+    } catch (e) { /* falls through to the failure below */ }
+    return Promise.resolve(false);
+  };
+}());
+
 /* The shared live strip. One stream per page: a page that runs its own (Setup, Overview) claims
    window.__matrixarkLive and calls window.__matrixarkLiveFrame instead of opening a second. */
 (function () {

--- a/tools/test_matrixark_a_copy_button_reports_what_happened.py
+++ b/tools/test_matrixark_a_copy_button_reports_what_happened.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A copy button says whether the copy happened.
+
+Seven call sites across four portal pages wrote to the clipboard and then announced success
+without looking:
+
+  * Setup's four buttons, and Explore's and Overview's message lines, ran
+    ``if (navigator.clipboard) { writeText(text); }`` and then said "copied" *unconditionally*. On
+    an http:// origin -- which a self-hosted portal often is -- ``navigator.clipboard`` does not
+    exist, so nothing was copied and the page said it was.
+  * The API page set "hide curl — copied" in the same tick as the write, before the promise it
+    ignored had settled.
+  * Ingestion alone waited for the promise, but had no rejection branch, so a refused copy left
+    the label untouched and said nothing at all.
+
+``writeText`` returns a promise that rejects on a denied permission or an unfocused document.
+Claiming a copy that did not happen is worse than saying nothing: the reader stops trying and
+leaves with an empty clipboard.
+
+One helper in the shared nav script now resolves true or false and each caller reports what it is
+handed. The behaviour is exercised by ``copy_helper_harness.js``, which runs the helper as a
+browser would across four clipboards: one that accepts, one that refuses, one that is absent, and
+one that throws on property access.
+
+The source checks below state their own extent -- how many pages were scanned and how many write
+sites were found -- because a pattern that stopped matching would otherwise report success over
+nothing.
+"""
+from __future__ import annotations
+
+import glob
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+# Every page carries the shared helper, so each contributes one write site; the key portal has its
+# own copier for the one-time secret as well. A floor, not an equality: adding a page is fine.
+MIN_PAGES = 7
+MIN_WRITE_SITES = 7
+
+WRITE = "navigator.clipboard.writeText("
+
+
+def pages() -> list:
+    return sorted(glob.glob(os.path.join(PORTAL, "*.html")))
+
+
+def text_of(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class TheCopyHelperBehavesTest(unittest.TestCase):
+
+    @unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+    def test_the_helper_reports_every_outcome_on_every_page(self) -> None:
+        proc = subprocess.run(
+            ["node", os.path.join(PORTAL, "copy_helper_harness.js")] + pages(),
+            capture_output=True, text=True, timeout=180)
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+        self.assertIn("every page given carries the helper", proc.stdout)
+
+
+class NoCopySiteClaimsWhatItDidNotDoTest(unittest.TestCase):
+
+    def test_the_scan_covers_the_pages_it_claims_to(self) -> None:
+        self.assertGreaterEqual(len(pages()), MIN_PAGES,
+                                "found %d portal pages, expected at least %d"
+                                % (len(pages()), MIN_PAGES))
+
+    def test_every_clipboard_write_looks_at_its_result(self) -> None:
+        """The fire-and-forget shape is exactly a write whose promise nobody reads."""
+        found = 0
+        for path in pages():
+            source = text_of(path)
+            for match in re.finditer(re.escape(WRITE), source):
+                found += 1
+                tail = source[match.end():match.end() + 240]
+                self.assertIn(".then(", tail,
+                              "%s: a clipboard write at offset %d ignores the promise it returns, "
+                              "so whatever it reports is a guess"
+                              % (os.path.basename(path), match.start()))
+        self.assertGreaterEqual(found, MIN_WRITE_SITES,
+                                "found only %d clipboard writes; the pattern has stopped matching "
+                                "and this check is passing over nothing" % found)
+
+    def test_no_page_still_carries_the_unconditional_shape(self) -> None:
+        """`if (navigator.clipboard) { writeText(x); }` followed by an unconditional claim."""
+        for path in pages():
+            self.assertNotIn("if (navigator.clipboard) { navigator.clipboard.writeText(",
+                             text_of(path),
+                             "%s writes to the clipboard without reading the result"
+                             % os.path.basename(path))
+
+    def test_every_caller_branches_on_the_answer(self) -> None:
+        """A caller that takes the boolean and ignores it is the same bug in a new shape."""
+        callers = 0
+        for path in pages():
+            source = text_of(path)
+            for match in re.finditer(r"__matrixarkCopyText\(", source):
+                # The definition itself is not a call site.
+                if source[max(0, match.start() - 30):match.start()].rstrip().endswith("="):
+                    continue
+                callers += 1
+                tail = source[match.end():match.end() + 400]
+                self.assertRegex(tail, r"\.then\(function \(ok\)",
+                                 "%s: a copy at offset %d does not take the outcome"
+                                 % (os.path.basename(path), match.start()))
+                self.assertIn("ok ?", tail,
+                              "%s: a copy at offset %d takes the outcome and never branches on it"
+                              % (os.path.basename(path), match.start()))
+        self.assertGreaterEqual(callers, MIN_WRITE_SITES,
+                                "found only %d callers of the shared copier" % callers)
+
+
+class TheHelperIsReachableFromEveryPageTest(unittest.TestCase):
+    """A page that calls the helper without carrying it throws inside a click handler, which is
+    invisible until somebody presses the button."""
+
+    def test_a_page_that_calls_the_copier_also_defines_it(self) -> None:
+        for path in pages():
+            source = text_of(path)
+            if "__matrixarkCopyText(" not in source:
+                continue
+            self.assertIn("window.__matrixarkCopyText = function", source,
+                          "%s calls the shared copier but the definition is not on the page"
+                          % os.path.basename(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_a_key_shown_once_can_be_copied.py
+++ b/tools/test_matrixark_a_key_shown_once_can_be_copied.py
@@ -122,20 +122,28 @@ class EveryClipboardWriteGoesThroughTheOneCopierTest(unittest.TestCase):
     names the count it found rather than checking that some particular line still exists.
     """
 
-    def test_the_page_writes_to_the_clipboard_in_exactly_one_place(self) -> None:
+    def test_no_write_on_this_page_ignores_its_result(self) -> None:
+        """Two copiers live here now -- this page's own, for the one-time secret, and the shared
+        one the nav script injects into every page. Both must read the promise they get; a write
+        that ignores it is free to claim a copy it did not make."""
         source = page_source()
-        self.assertEqual(1, source.count("clipboard.writeText("),
-                         "every copy on this page must go through copyText, which reports what "
-                         "happened; a second write site is free to claim a copy it did not make")
+        writes = [i for i in range(len(source))
+                  if source.startswith("clipboard.writeText(", i)]
+        self.assertGreaterEqual(len(writes), 1, "no clipboard write found; this check is vacuous")
+        for at in writes:
+            self.assertIn(".then(", source[at:at + 240],
+                          "a clipboard write at offset %d ignores the promise it returns" % at)
 
-    def test_that_one_place_is_inside_the_copier(self) -> None:
+    def test_the_secrets_own_copier_is_still_the_one_the_secret_uses(self) -> None:
+        """The shared helper takes only the text; this one also names the button it reports on,
+        which is what the one-time secret needs."""
         source = page_source()
         start = source.index("function copyText(")
         end = source.index("// ---- create", start)
-        write = source.index("clipboard.writeText(")
-        self.assertTrue(start < write < end,
-                        "the only clipboard write is outside copyText, so its result is not "
-                        "reported to anyone")
+        self.assertIn("clipboard.writeText(", source[start:end],
+                      "copyText no longer writes to the clipboard")
+        self.assertIn('copyText(secret, "copyNewKey", "Copied")', source,
+                      "the created key no longer goes through this page's own copier")
 
     def test_the_copier_reports_both_outcomes(self) -> None:
         """The failure branch is the one that was missing; assert it is present and distinct."""

--- a/tools/test_matrixark_portal_pages.py
+++ b/tools/test_matrixark_portal_pages.py
@@ -42,6 +42,53 @@ class GeneratedPagesTest(unittest.TestCase):
                              "hand-edited, or generated from an older script: %s. Change "
                              "%s and re-run it instead." % (", ".join(stale), GENERATOR))
 
+    def test_a_failure_while_rendering_leaves_the_page_intact(self) -> None:
+        """`io.open(path, "w").write(render())` truncates before render() runs, so a failure in
+        there destroyed the page rather than declining to update it. These two are hand-maintained
+        and not reproducible from the generator, so an empty one is lost work."""
+        with tempfile.TemporaryDirectory() as work:
+            copy = os.path.join(work, "portal")
+            shutil.copytree(PORTAL, copy)
+            generator = os.path.join(copy, GENERATOR)
+            with open(generator, encoding="utf-8") as handle:
+                text = handle.read()
+            broken = text.replace(
+                "def _with_nav_js(text):",
+                "def _with_nav_js(text):" + chr(10) + '    raise ValueError("rendering failed")',
+                1)
+            self.assertNotEqual(text, broken, "could not find the function to break")
+            with open(generator, "w", encoding="utf-8", newline=chr(10)) as handle:
+                handle.write(broken)
+
+            result = subprocess.run([sys.executable, generator],
+                                    capture_output=True, text=True, cwd=work)
+            self.assertNotEqual(0, result.returncode,
+                                "the generator was supposed to fail here:" + result.stdout)
+            for name in HAND_WRITTEN:
+                emitted = os.path.join(copy, name)
+                self.assertGreater(os.path.getsize(emitted), 0,
+                                   "%s was emptied by a build that failed" % name)
+                self.assertTrue(filecmp.cmp(os.path.join(PORTAL, name), emitted, shallow=False),
+                                "%s was modified by a build that failed" % name)
+
+    def test_running_the_generator_twice_changes_nothing(self) -> None:
+        """The nav and tab scripts are replaced in place on the hand-maintained pages, and finding
+        the block to replace used to depend on how long that block was."""
+        with tempfile.TemporaryDirectory() as work:
+            copy = os.path.join(work, "portal")
+            shutil.copytree(PORTAL, copy)
+            for run in (1, 2):
+                result = subprocess.run([sys.executable, os.path.join(copy, GENERATOR)],
+                                        capture_output=True, text=True, cwd=work)
+                self.assertEqual(0, result.returncode,
+                                 "build %d failed: %s%s" % (run, result.stdout, result.stderr))
+            drifted = [name for name in GENERATED + HAND_WRITTEN
+                       if not filecmp.cmp(os.path.join(PORTAL, name),
+                                          os.path.join(copy, name), shallow=False)]
+            self.assertEqual([], drifted,
+                             "a second build changed: %s -- the injected blocks are stacking or "
+                             "being placed differently each time" % ", ".join(drifted))
+
     def test_the_generator_writes_only_inside_its_own_directory(self) -> None:
         # It resolves its output from __file__, so a copy of the directory is a complete sandbox.
         # If that ever became an absolute path again, the test above would silently be checking the


### PR DESCRIPTION
Seven copy sites across four portal pages announced success without looking:

- **Setup** (×4), **Explore** and **Overview** ran `if (navigator.clipboard) { writeText(text); }`
  and then said "copied" **unconditionally**. On an `http://` origin — which a self-hosted portal
  often is — `navigator.clipboard` does not exist, so nothing was copied and the page said it was.
- **API** set `hide curl — copied` in the same tick as the write, before the promise it ignored
  had settled.
- **Ingestion** alone waited for the promise, but had no rejection branch, so a refused copy left
  the label untouched and said nothing at all.

`writeText` rejects on a denied permission or an unfocused document. Claiming a copy that did not
happen is worse than saying nothing: the reader stops trying and walks away with an empty
clipboard.

One helper now lives in the shared nav script that every page carries. It resolves true or false;
each caller reports what it is handed, in the idiom that page already uses — a button label or a
message line. It sits in its own IIFE ahead of the live strip's, because the strip's first act is
`if (!strip) { return; }` and a copier defined after that would not exist on pages without one.

### Two builder faults came out of doing this

**It found its own injected script by counting characters** — a fixed 200-byte lookback from a
marker comment. A longer script made it find the wrong tag. It now searches backwards for the
nearest opening tag.

**It rendered straight into an open file handle.** `io.open(path, "w").write(render())` truncates
before `render()` is evaluated, so *any* failure while rendering left the page on disk empty. That
is how the first fault emptied `ingestion_portal.html` outright rather than declining to update
it — and the next run then failed on a stylesheet it could no longer find, which reads like an
unrelated fault. These two pages are hand-maintained and not reproducible from the generator, so
an empty one is lost work. It renders first, then opens.

### Tests

`copy_helper_harness.js` runs the helper as a browser would, against four clipboards: one that
accepts, one that refuses, one that is absent, and one that throws on property access. The source
checks state their own extent — how many pages scanned, how many write sites found — so a pattern
that stopped matching cannot pass over nothing.

The generator gets two: one that breaks rendering on purpose and requires the hand-maintained
pages to survive it (verified red against the old writer, with the message
`ingestion_portal.html was emptied by a build that failed`), and one that builds twice and
requires the output to be identical.

The key portal keeps its own copier for the one-time secret — it names the button it reports on,
which the shared one does not — and its guard now asserts that no write on that page ignores its
result, rather than that there is exactly one.
