### PR TITLE
Leave the folded row identity out of the meta it leaves behind

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -1247,6 +1247,21 @@ _EMBEDDING_META_SKIP = (
     "ref_type",
     "ref_hash",
     "vector",
+    # The retired row's OWN identity, which describes a row that no longer exists once the
+    # embedding is folded onto its owner. 36.7% of embedding_meta's bytes over 100,105 records,
+    # and the only unique field in a dict whose other members hold one distinct value each -- so
+    # it is also what keeps the dict from being shared: 99,371 objects for 99,371 values.
+    #
+    # Checked for readers the way the rest of this tuple was: no reader in any Python module
+    # outside this one, and inside it only the TOP-LEVEL row_key is used; no occurrence anywhere
+    # in the Rust crates; and a runtime probe over read_all + retrieve never saw it asked for,
+    # while `model` was asked for 99,324 times.
+    #
+    # It is also wrong to carry. `record_with_embedding_defaults` fills every meta key onto an
+    # owner whose value is empty, with no exclusion list, so an owner without a top-level row_key
+    # -- 99,280 of 100,122 records -- inherits the RETIRED row's identity, and
+    # `latest_value_record_key` prefers a stamped key over deriving one.
+    "row_key",
     "storage_route",
     "storage_options",
     # The placement/storage half of the same routing blob, inherited the same way and read by

--- a/tools/test_matrixark_meta_drops_the_retired_row_key.py
+++ b/tools/test_matrixark_meta_drops_the_retired_row_key.py
@@ -1,0 +1,99 @@
+"""The meta a folded embedding leaves behind must not carry that row's own identity.
+
+`embedding_meta` is 12.3% of the durable log, and 36.7% of its bytes were `row_key` -- the identity
+of the context_embedding row that no longer exists once it is folded onto its owner. Every other
+member of that dict holds one distinct value across a store, so this single unique field was what
+kept the whole dict from being shared: 164 rows, 164 objects, 164 distinct values.
+
+Two reasons it goes, and the second is the one that matters:
+
+  it is unread -- no reader in any Python module outside the adapter, none in the Rust crates, and
+  a runtime probe over read_all + retrieve never saw it asked for while `model` was asked for
+  99,324 times;
+
+  and it is wrong to carry. `record_with_embedding_defaults` copies every meta key onto an owner
+  whose value is empty, with no exclusion list, so an owner without a top-level row_key inherits
+  the RETIRED row's identity -- and `latest_value_record_key` prefers a stamped key over deriving
+  one.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrixark_mcp_local_adapter as adapter_module
+
+
+SECTIONS = 12
+
+
+def _skill_text(i):
+    out = ["# Runbook %d" % i, "", "A procedure for case %d." % i, ""]
+    for s in range(SECTIONS):
+        out += ["## Step %d" % s, "",
+                "Check the queue depth for case %d step %d and drain it in order. Record the "
+                "outcome against the case identifier." % (i, s), ""]
+    return "\n".join(out)
+
+
+class MetaDropsTheRetiredRowKey(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        store = Path(tempfile.mkdtemp())
+        adapter = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl")
+        scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+        for i in range(3):
+            adapter.ingest({"kind": "skill", "scope": scope, "text": _skill_text(i),
+                            "metadata": {"raw_uri": "file:///s/r-%d.md" % i, "title": "r-%d" % i}})
+        adapter.close(timeout_s=300)
+        cls.records = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl").read_all()
+        cls.metas = [r["embedding_meta"] for r in cls.records
+                     if isinstance(r.get("embedding_meta"), dict)]
+
+    def test_there_is_meta_to_examine(self):
+        """Non-vacuity: with no embedding_meta anywhere, every assertion below passes emptily."""
+        self.assertGreater(len(self.metas), 10,
+                           "the fixture produced almost no embedding_meta")
+
+    def test_the_meta_still_carries_the_model_identity(self):
+        """A positive control, and a real requirement: the model guard reads these."""
+        for field in ("model", "model_ref"):
+            carrying = [m for m in self.metas if m.get(field)]
+            self.assertTrue(
+                carrying,
+                "%s vanished from embedding_meta; the model-identity guard reads it" % field,
+            )
+
+    def test_no_meta_carries_the_retired_row_key(self):
+        offenders = [m for m in self.metas if "row_key" in m]
+        self.assertEqual(
+            [], offenders[:3],
+            "%d of %d embedding_meta values still carry the folded row's own identity"
+            % (len(offenders), len(self.metas)),
+        )
+
+    def test_the_meta_is_shared_rather_than_one_object_per_row(self):
+        """The point of removing it: one unique field kept the whole dict unshareable."""
+        objects = {id(m) for m in self.metas}
+        self.assertLess(
+            len(objects), len(self.metas),
+            "%d meta values are held as %d separate objects; nothing is shared"
+            % (len(self.metas), len(objects)),
+        )
+
+    def test_no_owner_inherits_an_identity_from_its_embedding(self):
+        """The reason this is a correctness fix and not only a size one."""
+        for record in self.records:
+            meta = record.get("embedding_meta")
+            if isinstance(meta, dict) and meta.get("row_key"):
+                stamped = record.get(adapter_module.ROW_KEY_FIELD)
+                self.assertEqual(
+                    stamped, meta["row_key"],
+                    "a record carries a meta row_key that is not its own; self-repair would "
+                    "hand it that identity",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A folded embedding leaves its own row identity behind, and that one field keeps the whole dict from
being shared.

## What it costs

`embedding_meta` is **12.3% of the durable log** and effectively unique per record. Broken down over
6,000 sampled values:

| sub-field | share of embedding_meta | distinct values |
|---|---|---|
| **row_key** | **36.7%** | **5,999 (unique)** |
| node_path | 22.5% | 1 |
| model_ref | 20.9% | 1 |
| model | 15.8% | 1 |
| dim | 3.6% | 1 |

Every other member holds ONE distinct value across the store. So the unique one is not just the
largest — it is what stops the dict being shared at all.

Measured on an 8-skill store, before and after:

| | log | read cache | embedding_meta objects | distinct values |
|---|---|---|---|---|
| before | 1.32 MB | 0.75 MB | 164 | 164 |
| after | 1.29 MB | **0.67 MB** | **5** | **5** |

**-10.7% of the read cache for -2.3% on disk.** The cache falls 4.6x further because 164 rows now
share 5 objects instead of holding 164. Retrieval is byte-identical: the same 32 refs, the same
16 skill_section and 16 resource_chunk.

## Why it is safe to drop

`row_key` here is the identity of the `context_embedding` row that was folded onto its owner and no
longer exists. Checked for readers the way the entries already in `_EMBEDDING_META_SKIP` were:

- no reader in any Python module outside the adapter, and inside it only the **top-level**
  `row_key` is used (`ROW_KEY_FIELD` / `canonical_row_key` / `stamp_row_keys`);
- no occurrence of `row_key` anywhere in the Rust crates;
- a runtime probe wrapping every `embedding_meta` in a recording dict across `read_all` +
  `retrieve`: `model` was asked for **99,324** times; `row_key`, `node_path`, `dim` and
  `embedding_type` were **never** asked for, and `model_ref` only by the probe's own positive
  control.

`model` and `model_ref` stay, deliberately — the same reason the existing comment gives for keeping
them despite scanning clean.

## It is also wrong to carry

`record_with_embedding_defaults` copies **every** key of the meta onto an owner whose value is
empty, with no exclusion list. An owner without a top-level `row_key` — 99,280 of 100,122 records —
therefore inherits the retired row's identity, and `latest_value_record_key` prefers a stamped key
over deriving one.

The test shows it on `main` rather than arguing it:

```
'["context_node",5689206235060161283]'
  != '["context_embedding","context_node","node",5689206235060161283]'
```

That is a record's own identity against the one its meta hands it.

## Tests

Five, three of which fail on `main` on their own claims. Two are there to stop this being a
size-only change: a **positive control** asserting `model`/`model_ref` are still present, so a
future trim cannot quietly take the model identity the guard depends on; and a non-vacuity case
asserting there is any `embedding_meta` to examine at all.

Validation: every test module naming `embedding_meta` or the recovery helper — 13 of 13 ran on both
trees, 5 failing names each, **0 unique**.
