### PR TITLE
A refusal at the tenant boundary leaves a trace

### DIFF
--- a/tools/matrixark_access.py
+++ b/tools/matrixark_access.py
@@ -1176,16 +1176,30 @@ class MatrixArkAccessManager(_AccessPortalMixin, _AccessSsoMixin, _AccessApiKeyM
             }
         )
 
-    def ensure_identity_can_manage(self, identity: Json, account_id: str, tenant_id: str) -> None:
+    def ensure_identity_can_manage(self, identity: Json, account_id: str, tenant_id: str,
+                                   *, action: str = "admin.operation") -> None:
         if identity.get("mode") == "dev":
             return
         if identity.get("account_id") != account_id or identity.get("tenant_id") != tenant_id:
+            # Authentication passed and so did the scope check: this is a valid admin key reaching
+            # for a tenant it does not hold, which is the most interesting denial this system can
+            # produce -- and it used to write nothing at all. append_audit rather than
+            # append_denied_audit because the identity IS known here; the record names the caller
+            # and the details name what they asked for instead.
+            self.append_audit(action, identity, status="denied",
+                              details={"requested_account_id": account_id,
+                                       "requested_tenant_id": tenant_id})
             raise MatrixArkError("admin operation account/tenant does not match API key")
 
-    def ensure_identity_can_read_scope(self, identity: Json, account_id: str, tenant_id: str, scope: Json | None = None) -> None:
+    def ensure_identity_can_read_scope(self, identity: Json, account_id: str, tenant_id: str, scope: Json | None = None,
+                                       *, action: str = "portal.read") -> None:
         if identity.get("mode") == "dev":
             return
         if identity.get("account_id") != account_id or identity.get("tenant_id") != tenant_id:
+            # The read side of the same boundary, and it was equally silent.
+            self.append_audit(action, identity, status="denied",
+                              details={"requested_account_id": account_id,
+                                       "requested_tenant_id": tenant_id})
             raise MatrixArkError("portal scope account/tenant does not match API key")
         self.ensure_account_tenant_active(account_id, tenant_id)
         scope = scope or {}

--- a/tools/matrixark_access_apikey.py
+++ b/tools/matrixark_access_apikey.py
@@ -14,7 +14,8 @@ class _AccessApiKeyMixin:
         scope = optional_object(args, "scope")
         account_id = canonical_account_id(optional_string(args, "account_id") or str(scope.get("account_id") or identity["account_id"]))
         tenant_id = canonical_tenant_id(optional_string(args, "tenant_id") or str(scope.get("tenant_id") or identity["tenant_id"]))
-        self.ensure_identity_can_manage(identity, account_id, tenant_id)
+        self.ensure_identity_can_manage(identity, account_id, tenant_id,
+                                        action="admin.create_api_key")
         scopes = optional_string_list(args, "scopes", ["context:ingest", "context:retrieve", "context:feedback", "context:replay"])
         if not scopes:
             raise MatrixArkError("scopes must not be empty")
@@ -112,7 +113,8 @@ class _AccessApiKeyMixin:
         tenant_id = canonical_tenant_id(optional_string(args, "tenant_id") or str(defaults["tenant_id"]))
         user_id = optional_string(args, "user_id") or str(scope.get("user_id") or defaults["user_id"])
         agent_name = safe_identifier(optional_string(args, "agent_name") or str(defaults["agent_name"]), default="local_agent")
-        self.ensure_identity_can_manage(identity, account_id, tenant_id)
+        self.ensure_identity_can_manage(identity, account_id, tenant_id,
+                                        action="admin.apply_api_key")
 
         created_records: list[str] = []
         if self.latest_account_record(account_id) is None:
@@ -310,7 +312,8 @@ class _AccessApiKeyMixin:
         # Creating a key checks this; revoking one did not, so an admin key for one tenant could
         # revoke another tenant's key given its id. Authorization must not rest on an identifier
         # being hard to guess.
-        self.ensure_identity_can_manage(identity, record["account_id"], record["tenant_id"])
+        self.ensure_identity_can_manage(identity, record["account_id"], record["tenant_id"],
+                                        action=action)
         revoked = {
             **record,
             "record_type": "matrixark_api_key",
@@ -330,7 +333,8 @@ class _AccessApiKeyMixin:
         # Before either half runs. This used to be reached only inside the create below, by
         # which point the old key had already been revoked -- so a refused rotation destroyed the
         # key it was refused permission to touch.
-        self.ensure_identity_can_manage(identity, old_record["account_id"], old_record["tenant_id"])
+        self.ensure_identity_can_manage(identity, old_record["account_id"], old_record["tenant_id"],
+                                        action="admin.rotate_api_key")
         # Mint first, revoke second. Whatever the create rejects -- a scope retired since the key
         # was made, a role that no longer carries it -- the caller keeps a working key. The old
         # order left them with none, and returned an error that read like nothing had happened.
@@ -376,7 +380,8 @@ class _AccessApiKeyMixin:
         scope = optional_object(args, "scope")
         account_id = canonical_account_id(optional_string(args, "account_id") or str(scope.get("account_id") or identity["account_id"]))
         tenant_id = canonical_tenant_id(optional_string(args, "tenant_id") or str(scope.get("tenant_id") or identity["tenant_id"]))
-        self.ensure_identity_can_manage(identity, account_id, tenant_id)
+        self.ensure_identity_can_manage(identity, account_id, tenant_id,
+                                        action="admin.list_api_keys")
         include_revoked = bool(args.get("include_revoked", False))
         metadata_records = self.metadata.read_all()
         usage_by_key: dict[str, Json] = {}

--- a/tools/test_matrixark_a_refused_admin_operation_leaves_a_trace.py
+++ b/tools/test_matrixark_a_refused_admin_operation_leaves_a_trace.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A refusal at the tenant boundary is recorded.
+
+The audit trail covered two kinds of denial and not the third. `append_denied_audit` handles the
+ones that happen before an identity is known -- an unknown key, a missing scope, a failed login --
+and records `api_key_id: "unknown"` because at that point there is nothing better to say.
+
+The tenant boundary is the interesting one and it wrote nothing. Authentication has passed, the
+scope check has passed, and what is being refused is a valid admin key reaching for a tenant it
+does not hold. An operator saw their own successful revocations and saw nothing at all when
+somebody else's admin key tried the same against theirs.
+
+The record now goes through `append_audit`, because here the identity is known: it carries the
+caller's own api_key_id, role, account and tenant, and the details carry what they asked for
+instead. Both halves are needed -- who, and against whom.
+
+Auditing is off by default and stays that way. A deployment recording nothing today records
+nothing after this; the hole is filled for the deployments that do record.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer, MatrixArkError
+
+ADMIN_SCOPES = ["admin:account", "admin:user", "admin:api_key", "admin:audit", "portal:read"]
+A = {"account_id": "acct_a", "tenant_id": "tenant_a"}
+B = {"account_id": "acct_b", "tenant_id": "tenant_b"}
+
+
+class ARefusedAdminOperationIsRecordedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.log = Path(tmp.name) / "events.jsonl"
+
+        # Process-global, so it is restored however this test ends.
+        previous = os.environ.get("MATRIXARK_AUDIT_MODE")
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_AUDIT_MODE", None)
+            else:
+                os.environ["MATRIXARK_AUDIT_MODE"] = previous
+
+        self.addCleanup(restore)
+
+        dev = self._server("dev")
+        self.admin_a = dev.call_tool("matrixark_admin_create_api_key",
+                                     {"scope": A, **A, "role": "owner", "scopes": ADMIN_SCOPES})
+        self.own_a = self._service(dev, A)
+        self.victim_b = self._service(dev, B)
+        dev.close(timeout_s=10.0)
+
+    def _server(self, mode: str) -> MatrixArkMcpServer:
+        return MatrixArkMcpServer(MatrixArkLocalAdapter(self.log), line_json=True,
+                                  access_mode=mode)
+
+    @staticmethod
+    def _service(server, scope):
+        return server.call_tool("matrixark_admin_create_api_key",
+                                {"scope": scope, **scope, "role": "service",
+                                 "key_prefix": "sk_live", "scopes": ["context:ingest"]})
+
+    def _attempt(self, tool, args, expect_refusal: bool) -> list:
+        """Run one call as tenant A's admin, then read the audit records it produced.
+
+        The server is closed before reading: audit writes are buffered, and a test that reads
+        through the same handle can see an empty log and call it a missing record.
+        """
+        server = self._server("enforced")
+        try:
+            if expect_refusal:
+                with self.assertRaises(MatrixArkError):
+                    server.call_tool(tool, dict(args, api_key=self.admin_a["api_key"]))
+            else:
+                server.call_tool(tool, dict(args, api_key=self.admin_a["api_key"]))
+        finally:
+            server.close(timeout_s=10.0)
+
+        reader = MatrixArkLocalAdapter(self.log)
+        return [r for r in reader.read_all() if r.get("record_type") == "matrixark_audit_log"]
+
+    # ---- the refusal ------------------------------------------------------------------------
+
+    def test_a_cross_tenant_revocation_is_recorded_as_denied(self) -> None:
+        audits = self._attempt("matrixark_admin_revoke_api_key",
+                               {"api_key_id": self.victim_b["api_key_id"]}, True)
+        denied = [r for r in audits if r.get("status") == "denied"]
+        self.assertEqual(1, len(denied), "expected exactly one denial, got %r"
+                         % [(r.get("action"), r.get("status")) for r in audits])
+        record = denied[0]
+        self.assertEqual("admin.revoke_api_key", record["action"])
+
+    def test_the_record_says_who_asked_and_against_whom(self) -> None:
+        """Either half alone is useless: the caller without the target, or the target without the
+        caller, does not describe what happened."""
+        audits = self._attempt("matrixark_admin_revoke_api_key",
+                               {"api_key_id": self.victim_b["api_key_id"]}, True)
+        record = [r for r in audits if r.get("status") == "denied"][0]
+        self.assertEqual(self.admin_a["api_key_id"], record["api_key_id"])
+        self.assertEqual("tenant_a", record["tenant_id"])
+        self.assertEqual("tenant_b", record["details"]["requested_tenant_id"])
+        self.assertEqual("acct_b", record["details"]["requested_account_id"])
+
+    def test_a_refused_rotation_is_attributed_to_the_rotation(self) -> None:
+        """Rotation refuses through the same guard. Recording it as a bare revoke would describe
+        an operation nobody attempted."""
+        audits = self._attempt("matrixark_admin_rotate_api_key",
+                               {"api_key_id": self.victim_b["api_key_id"]}, True)
+        denied = [r for r in audits if r.get("status") == "denied"]
+        self.assertEqual(["admin.rotate_api_key"], [r["action"] for r in denied])
+
+    def test_no_plaintext_key_reaches_the_record(self) -> None:
+        audits = self._attempt("matrixark_admin_revoke_api_key",
+                               {"api_key_id": self.victim_b["api_key_id"]}, True)
+        blob = str(audits)
+        self.assertNotIn(self.admin_a["api_key"], blob)
+        self.assertNotIn(self.victim_b["api_key"], blob)
+
+    # ---- the controls -----------------------------------------------------------------------
+
+    def test_an_allowed_revocation_is_not_recorded_as_denied(self) -> None:
+        """Without this, a change that marked everything denied would pass the checks above."""
+        audits = self._attempt("matrixark_admin_revoke_api_key",
+                               {"api_key_id": self.own_a["api_key_id"]}, False)
+        self.assertEqual([], [r for r in audits if r.get("status") == "denied"])
+        self.assertIn("admin.revoke_api_key",
+                      [r.get("action") for r in audits if r.get("status") == "ok"])
+
+    def test_auditing_stays_off_by_default(self) -> None:
+        """The default posture is unchanged: a deployment that records nothing still records
+        nothing, denials included."""
+        os.environ["MATRIXARK_AUDIT_MODE"] = "off"
+        audits = self._attempt("matrixark_admin_revoke_api_key",
+                               {"api_key_id": self.victim_b["api_key_id"]}, True)
+        # setUp built its fixtures with auditing on, so its records are in the log and this is
+        # reading the right one -- which is what stops the check below passing over an empty file.
+        self.assertTrue([r for r in audits if r.get("status") == "ok"],
+                        "no records at all; this is not reading the log it thinks it is")
+        self.assertEqual([], [r for r in audits if r.get("status") == "denied"],
+                         "auditing is off, yet the refusal was recorded anyway")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The audit trail covered two kinds of denial and not the third.

`append_denied_audit` handles the ones that happen before an identity is known — an unknown key, a
missing scope, a failed login — and records `api_key_id: "unknown"`, because at that point there is
nothing better to say.

**The tenant boundary wrote nothing at all.** Authentication has passed, the scope check has
passed, and what is being refused is a *valid admin key reaching for a tenant it does not hold*.
An operator saw their own successful revocations, and saw nothing whatever when somebody else's
admin key tried the same against theirs — which is exactly the event worth recording, and exactly
the one being generated if anybody is probing key ids across tenants.

The record now goes through `append_audit`, because here the identity **is** known. It carries the
caller's own `api_key_id`, role, account and tenant; the details carry what they asked for instead:

```
action=admin.revoke_api_key  status=denied
api_key_id=<tenant A's admin>  tenant_id=tenant_a
details={requested_account_id: acct_b, requested_tenant_id: tenant_b}
```

Either half alone describes nothing — the caller without the target, or the target without the
caller.

The key lifecycle names its own operation, so a refused **rotation** is recorded as a rotation
rather than as the bare revocation it runs internally, which nobody attempted. The read side of
the same boundary (`ensure_identity_can_read_scope`) was equally silent and is covered too.

**Auditing is off by default and stays off.** A deployment that records nothing today records
nothing after this, denials included; that has its own test, with a control asserting the test is
reading a log that has records in it rather than passing over an empty file.

Removing the record reddens the three checks that assert it and leaves the three controls green.
