### PR TITLE
A key that may read the audit log should not rewrite the deployment

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -787,6 +787,27 @@ def _usage_rows_visible_to(record: Optional[Json], rows: list, tenant: Optional[
             if row.get("tenant_id") == tenant and row.get("account_id") == account]
 
 
+_ADMIN_WRITE_SCOPES = {"admin:api_key"}
+
+
+def _admin_write_denied(record: Optional[Json]) -> Optional[Json]:
+    """403 payload when the key may not CHANGE anything, else ``None``.
+
+    Same shape and the same dev/legacy posture as ``_usage_read_denied``, over a narrower set. The
+    scope catalogue this gateway serves calls ``admin:audit`` "Read the audit log", and it was
+    authorising configuration writes and ingestion. A scope presented as read-only has to be
+    read-only, or the label is the lie.
+    """
+    if record is None:
+        return None
+    scopes = record.get("scopes")
+    if scopes is None:  # legacy/unrestricted key
+        return None
+    if _ADMIN_WRITE_SCOPES.intersection(scopes):
+        return None
+    return {"error": "insufficient_scope", "required": sorted(_ADMIN_WRITE_SCOPES)}
+
+
 def _usage_read_denied(record: Optional[Json]) -> Optional[Json]:
     """403 payload when the key may not read usage, else ``None``.
 
@@ -1404,7 +1425,8 @@ SCOPE_CATALOG: List[Json] = [
      "detail": "Create, rotate and revoke API keys, and read per-key usage. This is the scope the "
                "portal's own admin actions need."},
     {"scope": "admin:audit", "label": "Read the audit log",
-     "detail": "Read admin activity, and per-key usage."},
+     "detail": "Read admin activity, and per-key usage. Reading only: changing configuration or "
+               "starting an import needs admin:api_key."},
 ]
 
 # Four shapes that cover almost every key anyone actually issues. Named for the job rather than the
@@ -3804,7 +3826,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
             if not allowed:
                 return await _json(send, 401, {"error": "unauthorized"})
-            denied = _usage_read_denied(key_record)
+            denied = _admin_write_denied(key_record)
             if denied is not None:
                 return await _json(send, 403, denied)
             raw, too_big = await _read_body_capped(receive, 1 << 18)
@@ -3837,7 +3859,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
             if not allowed:
                 return await _json(send, 401, {"error": "unauthorized"})
-            denied = _usage_read_denied(key_record)
+            denied = _admin_write_denied(key_record)
             if denied is not None:
                 return await _json(send, 403, denied)
             raw, too_big = await _read_body_capped(receive, 1 << 16)
@@ -4250,7 +4272,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
             if not allowed:
                 return await _json(send, 401, {"error": "unauthorized"})
-            denied = _usage_read_denied(key_record)
+            denied = _admin_write_denied(key_record)
             if denied is not None:
                 return await _json(send, 403, denied)
             raw, too_big = await _read_body_capped(receive, 1 << 20)
@@ -4303,7 +4325,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
             if not allowed:
                 return await _json(send, 401, {"error": "unauthorized"})
-            denied = _usage_read_denied(key_record)
+            denied = _admin_write_denied(key_record)
             if denied is not None:
                 return await _json(send, 403, denied)
             raw, too_big = await _read_body_capped(receive, MAX_BATCH_RECORDS_BYTES)

--- a/tools/test_matrixark_gateway_portal.py
+++ b/tools/test_matrixark_gateway_portal.py
@@ -554,5 +554,95 @@ class MetricsRouteTest(_PortalTest):
         self.assertIn('route="other"', text)
 
 
+class AdminWritesNeedAScopeThatMayWriteTest(_PortalTest):
+    """`admin:audit` is "Read the audit log" in the catalogue this gateway serves, and it was
+    authorising configuration writes and ingestion.
+
+    Every refusal below is paired with the same key doing something it is entitled to do, because
+    a key that is refused everything would satisfy the refusals on its own.
+    """
+
+    AUDIT = "testkey_audit_only"        # "Read the audit log", and nothing else
+    MANAGE = "testkey_manages_keys"     # admin:api_key -- what the portal's own actions carry
+    LEGACY = "testkey_legacy_plain"     # no scopes at all: unrestricted, by documented design
+
+    def setUp(self) -> None:
+        super().setUp()
+        hashed = {
+            gw._secret_hash(self.AUDIT): {
+                "tenant_id": "t", "account_id": "acct", "scopes": ["admin:audit"]},
+            gw._secret_hash(self.MANAGE): {
+                "tenant_id": "t", "account_id": "acct", "scopes": ["admin:api_key"]},
+            gw._secret_hash(self.LEGACY): {"tenant_id": "t", "account_id": "acct"},
+        }
+        self.app = gw.make_v1_app(
+            self.server, gw.GatewayConfig.from_env({"enforced": True, "hashed_api_keys": hashed}))
+
+    def _as(self, key):
+        return {"Authorization": "Bearer " + key}
+
+    def _post(self, key, path, body):
+        return drive(self.app, method="POST", path=path, headers=self._as(key), body=body)
+
+    SETTINGS = {"settings": {"extraction.model": "deepseek-chat"}}
+
+    # ---- the control: the reading key is a working key ---------------------------------------
+
+    def test_an_audit_key_still_reads_what_it_is_for(self) -> None:
+        status, _, _ = drive(self.app, method="GET", path="/v1/admin/api_key_usage",
+                             headers=self._as(self.AUDIT))
+        self.assertEqual(200, status)
+
+    # ---- what it must not do ------------------------------------------------------------------
+
+    def test_an_audit_key_cannot_rewrite_the_configuration(self) -> None:
+        status, _, body = self._post(self.AUDIT, "/v1/admin/config", self.SETTINGS)
+        self.assertEqual(403, status)
+        payload = json.loads(body)
+        self.assertEqual("insufficient_scope", payload["error"])
+        self.assertEqual(["admin:api_key"], payload["required"])
+        self.assertNotIn("MATRIXARK_EXTRACTION_MODEL", os.environ)
+
+    def test_an_audit_key_cannot_apply_a_preset(self) -> None:
+        status, _, _ = self._post(self.AUDIT, "/v1/admin/config/preset", {"preset": "deepseek"})
+        self.assertEqual(403, status)
+
+    def test_an_audit_key_cannot_start_an_import(self) -> None:
+        status, _, _ = self._post(self.AUDIT, "/v1/admin/ingestion/jobs", {"paths": ["."]})
+        self.assertEqual(403, status)
+
+    def test_an_audit_key_cannot_submit_records(self) -> None:
+        status, _, _ = self._post(self.AUDIT, "/v1/admin/ingestion/records",
+                                  {"records": [{"text": "hello"}]})
+        self.assertEqual(403, status)
+
+    # ---- what a managing key may still do -----------------------------------------------------
+
+    def test_a_managing_key_may_rewrite_the_configuration(self) -> None:
+        """Otherwise the checks above would pass just as well with the route bricked."""
+        status, _, _ = self._post(self.MANAGE, "/v1/admin/config", self.SETTINGS)
+        self.assertNotEqual(403, status)
+
+    # ---- the two POSTs that change nothing ----------------------------------------------------
+
+    def test_a_reading_key_may_still_ask_what_a_plan_would_do(self) -> None:
+        """It composes a plan without touching this process; needing a write scope to look would
+        be its own mistake."""
+        status, _, _ = self._post(self.AUDIT, "/v1/admin/deployment/plan", {})
+        self.assertNotEqual(403, status)
+
+    def test_a_reading_key_may_still_probe_the_configured_endpoints(self) -> None:
+        status, _, _ = self._post(self.AUDIT, "/v1/admin/config/test", {})
+        self.assertNotEqual(403, status)
+
+    # ---- the posture that is deliberately unchanged --------------------------------------------
+
+    def test_a_legacy_unrestricted_key_is_unaffected(self) -> None:
+        """A key with no scopes is unrestricted everywhere else at this edge, and narrowing it
+        here would change what those deployments can do without anybody asking."""
+        status, _, _ = self._post(self.LEGACY, "/v1/admin/config", self.SETTINGS)
+        self.assertNotEqual(403, status)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Sixteen admin routes share one gate, which accepts `admin:api_key` **or** `admin:audit`. Ten are
reads, and the gate is named for the read it was written for. Four of the remaining six change
something:

| route | what it does |
|---|---|
| `POST /v1/admin/config` | rewrites the settings registry |
| `POST /v1/admin/config/preset` | writes a provider preset into it |
| `POST /v1/admin/ingestion/jobs` | starts a background import |
| `POST /v1/admin/ingestion/records` | ingests a batch from the request body |

The scope catalogue **this same gateway serves** describes `admin:audit` as:

> **Read the audit log** — Read admin activity, and per-key usage.

and `admin:api_key` as "the scope the portal's own admin actions need". So a scope the portal
presents as read-only was authorising configuration writes and data ingestion.

No preset issues an audit-only key — the `admin` preset carries both scopes. But the portal's scope
picker offers them individually, with those labels beside them, which is exactly how somebody
issues `admin:audit` alone to a compliance dashboard believing it can only read.

Those four now require a scope that may write, and the catalogue entry says so: a label that
overstates what a scope withholds is how the key gets issued in the first place.

**The two POSTs that change nothing keep the read gate**, deliberately.
`/v1/admin/deployment/plan` composes a plan "without touching this process", and
`/v1/admin/config/test` probes the endpoints already configured. Requiring a write scope to *look*
would be its own mistake; both have a test saying so, which also stops the split being widened by
accident.

Dev keys and legacy keys with no scopes are unchanged — the posture the read gate already
documents for them, with its own test.

Every refusal is paired with the same key doing something it *is* entitled to do, and with a
managing key doing the thing that was refused, because a route that simply stopped working would
satisfy the refusals on its own. Pointing the four back at the read gate reddens exactly those four
and leaves the five controls green.

Suites green: gateway_portal (58), v1_gateway (97), deployment_routes (23), dashboards (20),
api_traffic (15), readiness_sources (13), gateway_metrics (11).
