### PR TITLE
A feature append costs the length of its series

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -15005,3 +15005,85 @@ fn which_removals_cost_their_collection() {
     println!("  Ratio near 1 => the removal is incremental. Ratio rising with the collection");
     println!("  => removing one entry costs the size of what remains.");
 }
+
+/// Does a FEATURE write cost the length of the series it appends to?
+///
+/// Feature writes were made cheap in #716 by fixing the per-SHARD rebuild, measured in
+/// allocations. That is a different axis from the per-OBJECT one: a whole-series write is one
+/// big allocation, so a count cannot see it and only bytes can. This measures bytes against
+/// series length.
+///
+/// Two-sided control: ControlStateIncrement must amplify, SetAdd must not.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn what_a_feature_write_costs_against_its_series() {
+    const REPS: usize = 20;
+    let cost = |family: &str, fill: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let make = |i: usize| -> Command {
+            match family {
+                "FeatureAppend" => Command::FeatureAppend {
+                    key: "f".to_string(),
+                    points: vec![FeaturePoint {
+                        timestamp_ms: 1_000 + i as u64,
+                        value: vec![b'v'; 8],
+                    }],
+                },
+                "ControlStateIncrement" => Command::ControlStateIncrement {
+                    key: "c".to_string(),
+                    timestamp_ms: 1_000 + i as u64,
+                    amount: 1,
+                },
+                "SetAdd" => Command::SetAdd {
+                    key: "s".to_string(),
+                    member: format!("m{i:06}").into_bytes(),
+                },
+                other => panic!("unknown family {other}"),
+            }
+        };
+        for i in 0..fill {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: make(i) });
+            assert!(out.status.ok, "{family} fill refused: {:?}", out.status);
+        }
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..REPS {
+            let out = engine.execute(ExecuteRequest {
+                shard_id: 1,
+                command: make(fill + i),
+            });
+            assert!(out.status.ok, "{family} probe refused: {:?}", out.status);
+        }
+        probe.stop().alloc_bytes / REPS as u64
+    };
+
+    println!("  family                  bytes/write @200   @3200      ratio");
+    let mut amplifying = 0.0f64;
+    let mut flat = 0.0f64;
+    for family in ["ControlStateIncrement", "SetAdd", "FeatureAppend"] {
+        let small = cost(family, 200);
+        let large = cost(family, 3200);
+        assert!(small > 0, "{family}: measured zero bytes");
+        let ratio = large as f64 / small as f64;
+        match family {
+            "ControlStateIncrement" => amplifying = ratio,
+            "SetAdd" => flat = ratio,
+            _ => {}
+        }
+        println!("  {family:22}  {small:10}  {large:10}   {ratio:8.2}x");
+    }
+    assert!(
+        amplifying > 3.0,
+        "the amplifying control reported {amplifying:.2}x -- the probe cannot see amplification"
+    );
+    assert!(
+        flat < 1.5,
+        "the flat control reported {flat:.2}x -- the probe invents amplification"
+    );
+}


### PR DESCRIPTION
One single-point `FeatureAppend` onto a 3 200-point series allocates **4.07 MB**. At 200 points
it still allocates 267 697 bytes — **78x what a `HashSet` costs at the same size**.

This change measures it. It does not fix it.

## Measured

Bytes allocated per write, one series filled to 200 and to 3 200 points:

| command | @200 | @3 200 | ratio |
|---|---|---|---|
| `ControlStateIncrement` *(amplifying control)* | 9 072 | 68 711 | 7.57x |
| `SetAdd` *(flat control)* | 3 586 | 3 645 | 1.02x |
| **`FeatureAppend`** | **267 697** | **4 070 106** | **15.20x** |

15.20x over a 16x range is linear: appending one point costs the length of the series it joins.

## Where the cost is

The arm does it before any index-log work is reached:

```rust
let live_addresses = series.values().cloned().collect::<Vec<_>>();
sync_bucket_index_object_pages(shard, shard_id, "feature", &key, live_addresses, mutated);
```

Every append clones **every address in the series** and hands the whole list to a full re-sync.

`sync_bucket_index_object_pages` is itself written to be incremental — it narrows target buckets
through `object_page_refs` and tracks `removed_components` so that "the lookup can be corrected
for exactly those instead of being rebuilt from every page in the shard". The caller passes
everything, which defeats that.

Four call sites in `execute_on_shard` and two in `lifecycle.rs` pass a whole address list the
same way, so this shape is likely not unique to feature appends.

## This is a different axis from the earlier feature work

#716 removed a per-**shard** rebuild from this family and was measured in **allocations**
(12 717 → 102). That fix is real and still holds. This is the per-**object** cost in **bytes**,
which an allocation count cannot see: a whole-series clone and a bulk re-sync move megabytes
without moving the count much.

Two orthogonal axes. Fixing one says nothing about the other, which is why this was still here.

## Why it is not fixed here

The cure used for `SetAdd` (#777) and `ListPush` (#778) — declare the component you touched — does
not transfer. Feature pages are created with `stable_page_object_id(shard_id, kind, key, None)`,
so they carry **no component** and cannot be addressed individually the way a hash field or a set
member can. Making the sync incremental for this family means changing what a feature page is
addressed by, which is a storage-format decision rather than a performance edit.

## Verification

* Built and run **with the `alloc-probe` feature enabled**. `cargo check --all-targets` does not
  compile feature-gated code, so a probe that failed to build would otherwise pass CI green.
* Two-sided control: the amplifying control must report > 3x and the flat control < 1.5x, so a
  probe that cannot see amplification — or invents it — fails instead of returning a clean row.
* Test-only; no engine code is touched.
