### PR TITLE
A test that reads the raw record has to ask for the raw record

### DIFF
--- a/tools/test_codex_hook_output_part3.py
+++ b/tools/test_codex_hook_output_part3.py
@@ -3,6 +3,8 @@
 """_CodexHookOutputPart3 methods split from test_matrixark_codex_hook_output.MatrixArkCodexHookOutputTest (mixin)."""
 from __future__ import annotations
 
+from unittest import mock
+
 try:  # package path
     from tools.matrixark_mcp_core import *  # noqa: F401,F403
 except ImportError:
@@ -224,6 +226,12 @@ class _CodexHookOutputPart3:
         self.assertNotIn("--user-id \"${MATRIXARK_HOOK_USER_ID:-local_user}\"", source)
 
 
+    # Keeping the raw tool blob is opt-in and this test reads raw_records[0] to assert the
+    # RAW record shape, so without it the test dies on an empty list rather than on
+    # anything it is about. The switch is read into a module constant at import, so the
+    # environment cannot reach it from here -- patch the constant. Default behaviour is
+    # covered by test_fast_async_tool_result_defaults_to_serving_memory.
+    @mock.patch.object(hook, "HOOK_TOOL_RESULT_RAW", True)
     def test_fast_async_hook_ingest_marks_tool_evidence_lifecycle(self) -> None:
         class Adapter:
             def __init__(self) -> None:
@@ -350,6 +358,12 @@ class _CodexHookOutputPart3:
         self.assertEqual(["after_llm"], serving_event["source_hook_types"])
         self.assertIn("assistant: Final assistant answer", serving_event["text"])
 
+    # Keeping the raw tool blob is opt-in and this test reads raw_records[0] to assert the
+    # RAW record shape, so without it the test dies on an empty list rather than on
+    # anything it is about. The switch is read into a module constant at import, so the
+    # environment cannot reach it from here -- patch the constant. Default behaviour is
+    # covered by test_fast_async_tool_result_defaults_to_serving_memory.
+    @mock.patch.object(hook, "HOOK_TOOL_RESULT_RAW", True)
     def test_fast_async_hook_ingest_threshold_commits_tool_evidence(self) -> None:
         original_auto_batch = hook.HOOK_AUTO_BATCH_EXTRACT
         hook.HOOK_AUTO_BATCH_EXTRACT = True


### PR DESCRIPTION
Two tests died on `IndexError: list index out of range` at `server.adapter.raw_records[0]`.

Keeping the raw tool blob is opt-in — `HOOK_TOOL_RESULT_RAW` has defaulted off since it was
introduced — so for a tool-role event there is no raw record, and both tests failed on an empty
list rather than on anything they are about. Their assertions are entirely about the RAW
record's shape: `source_role`, `role`, `codex_api_event`, and that `hook_type` is absent from it.

Each now pins the switch for its own duration. The default stays covered by
`test_fast_async_tool_result_defaults_to_serving_memory`, which asserts that no raw record is
kept.

## Pinned as the module attribute, not the environment

The switch is read into a module constant at import, so `mock.patch.dict(os.environ, ...)`
cannot reach it. I wrote that version first and it changed nothing — worth recording, because
setting the variable on the command line **does** work (the constant is evaluated before the
test runs) and that makes the environment look like the right lever when it isn't.

**Mutation-tested:** pinning it `False` instead fails both.

## Sweep

105 failing names → **102**.

One name appeared — `test_user_prompt_fast_async_threshold_commits_previous_tool_rollout` — and
it is not this change:

- it passes **three times out of three** standalone
- it fails in the sweep with `'source_role:tool' unexpectedly found`

That is the discovery-only behaviour already under investigation for its sibling: absence
assertions hold only when the owner record carries a vector, and something about
`unittest discover` specifically changes that. Running the identical modules in the identical
order from a script does not reproduce it, so it is the import mechanism rather than test order.
This is now the second test of that family to show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)