### PR TITLE
Give the manifest preview a previews size

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -13,6 +13,13 @@ import warnings as _warnings
 _PROFILE_SCOPE_WARNED: set = set()
 
 
+
+#: How much of a skill's text its manifest carries as a preview.
+#:
+#: Not MAX_CONTEXT_REF_CHARS (4096): that is what a served context ref may reach, and a manifest
+#: preview is not a ref. 260 is what the codex hook's own text_preview uses.
+SKILL_PREVIEW_CHARS = 260
+
 def _segments_enabled(scope) -> bool:
     """Whether this tenant materialises context_segment rows (default OFF).
 
@@ -822,7 +829,21 @@ class _LocalAdapterIngestMixin:
                             "outputs": parsed_skill.metadata.get("outputs", []),
                             "access_scope": access_scope,
                             "deployment_scope": deployment_scope,
-                            "text_preview": clip_context_text(parsed_skill.text),
+                            # A preview, at a preview's size. clip_context_text defaults to
+                            # MAX_CONTEXT_REF_CHARS (4096) -- what a served context REF may reach,
+                            # because a ref carries content. This is not a ref. At the default it
+                            # was 29% of the ~11 KB per document the index costs, and the index
+                            # cost is FLAT in document size, so on small skills that is ~10% of
+                            # everything stored at production embedding width.
+                            #
+                            # Nothing that serves skills reads it: list_skills emits 24 manifest
+                            # fields without it, the index-term path reads name/triggers/tools, and
+                            # a runtime probe over list_skills + retrieve saw it asked for zero
+                            # times. It stays because matrixark_http falls back to it for display,
+                            # which is what a preview is for -- and 260 chars is the size the
+                            # codex hook's own text_preview uses.
+                            "text_preview": clip_context_text(
+                                parsed_skill.text, max_chars=SKILL_PREVIEW_CHARS),
                             "token_estimate": parsed_skill.token_estimate,
                             "metadata": skill_serving_metadata,
                             "scope": resource_record_scope,

--- a/tools/test_matrixark_manifest_preview_is_preview_sized.py
+++ b/tools/test_matrixark_manifest_preview_is_preview_sized.py
@@ -1,0 +1,98 @@
+"""A skill manifest's preview must be a preview, not a copy of the skill.
+
+`clip_context_text` defaults to MAX_CONTEXT_REF_CHARS (4096) -- the size a served context REF may
+reach, because a ref carries content. A manifest preview is not a ref, and at that default it was
+3,096 characters per skill.
+
+Why it matters more than it looks: the index costs a FLAT ~11 KB per document whatever the
+document's size (measured at 8 KB, 40 KB, 200 KB and 806 KB per document -- 0.05 MB of index in
+every case), and this field was 29% of it. On small skills that is around 10% of everything stored
+at production embedding width; on 1 MB documents it disappears into the denominator.
+
+It is trimmed rather than removed because matrixark_http falls back to it for display.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# The adapter first: importing the ingest mixin on its own trips the cycle between them
+# (matrixark_local_adapter_ingest imports tools.matrixark_mcp_local_adapter, which imports the
+# mixin back), and the failure reads as a missing 'tools' package rather than as an ordering bug.
+import matrixark_mcp_local_adapter as adapter_module
+import matrixark_local_adapter_ingest as ingest_module
+
+
+def _skill_text(i, sections=60):
+    out = ["# Runbook %d" % i, "", "A procedure for case %d." % i, ""]
+    for s in range(sections):
+        out += ["## Step %d" % s, "",
+                "Check the queue depth for case %d step %d and drain it in order. Record the "
+                "outcome against the case identifier." % (i, s), ""]
+    return "\n".join(out)
+
+
+class ManifestPreviewIsPreviewSized(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        store = Path(tempfile.mkdtemp())
+        adapter = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl")
+        scope = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+        cls.source = {}
+        for i in range(3):
+            text = _skill_text(i)
+            cls.source[i] = text
+            adapter.ingest({"kind": "skill", "scope": scope, "text": text,
+                            "metadata": {"raw_uri": "file:///s/r-%d.md" % i, "title": "r-%d" % i}})
+        adapter.close(timeout_s=300)
+        records = adapter_module.MatrixArkLocalAdapter(store / "events.jsonl").read_all()
+        cls.manifests = [r for r in records
+                         if str(r.get("record_type") or "") == "skill_manifest"]
+
+    def test_there_are_manifests_to_examine(self):
+        """Non-vacuity: with no manifest, every assertion below passes emptily."""
+        self.assertGreaterEqual(len(self.manifests), 3)
+
+    #: Read with a default so this file also runs against a build that has no such constant --
+    #: the bound below then fails on its own claim, which is the only way to know it discriminates.
+    LIMIT = getattr(ingest_module, "SKILL_PREVIEW_CHARS", 260)
+
+    def test_the_source_is_long_enough_to_be_clipped(self):
+        """Also non-vacuity: a short skill would satisfy the bound without anything being clipped."""
+        longest = max(len(t) for t in self.source.values())
+        self.assertGreater(
+            longest, self.LIMIT * 4,
+            "the fixture's skills are too short to show a clip happening",
+        )
+
+    def test_the_preview_is_bounded(self):
+        limit = self.LIMIT
+        for manifest in self.manifests:
+            preview = manifest.get("text_preview") or ""
+            self.assertLessEqual(
+                len(preview), limit + 32,          # room for the truncation marker
+                "a manifest preview is %d chars against a %d-char budget; it is carrying the "
+                "skill, not a preview of it" % (len(preview), limit),
+            )
+
+    def test_the_preview_is_still_there(self):
+        """It is trimmed, not removed -- matrixark_http falls back to it for display."""
+        carrying = [m for m in self.manifests if (m.get("text_preview") or "").strip()]
+        self.assertEqual(
+            len(carrying), len(self.manifests),
+            "a manifest lost its preview entirely; the display fallback reads this field",
+        )
+
+    def test_the_preview_still_starts_the_skill(self):
+        """A preview that no longer previews the thing would be worse than a long one."""
+        for manifest in self.manifests:
+            preview = (manifest.get("text_preview") or "").strip()
+            self.assertTrue(
+                preview.startswith("# Runbook"),
+                "the preview does not begin with the skill's own opening: %r" % preview[:40],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A skill manifest's "preview" is 3,096 characters of the skill.

## The measurement that makes this worth doing

The index costs a **flat ~11 KB per document**, whatever the document's size. Four documents, same
count, swept across a 100x size range on one build:

| document size | index bytes | index share (32-dim) | at 384 dims |
|---|---|---|---|
| 8 KB | 0.05 MB | 17.3% | 9.7% |
| 40 KB | 0.05 MB | 6.6% | 3.1% |
| 200 KB | 0.05 MB | 1.6% | 0.7% |
| 806 KB | 0.05 MB | 0.4% | 0.2% |

The bytes do not move; only the denominator does. So "the index is negligible" is a statement about
large documents, not about the index — on a box holding many small skills it is around **10% of
everything stored** at production embedding width.

Broken down, `skill_manifest.text_preview` is **29% of that fixed cost**, the single largest item,
ahead of `context_index.ref_hashes` at 9.3%.

## Why it is that big

`clip_context_text` defaults to `MAX_CONTEXT_REF_CHARS` — **4096** — which is the size a served
context *ref* may reach, because a ref carries content. A manifest preview is not a ref. The codex
hook's own `text_preview` uses 260 characters; this one inherited the ref budget by default.

## What changes

The manifest preview is clipped at 260 characters.

| | manifest preview | log | read cache |
|---|---|---|---|
| before | 3,096 chars | 0.447 MB | 0.277 MB |
| after | **275 chars** | 0.426 MB | 0.266 MB |

**-4.7% of the log and -4.0% of the cache** on a four-skill store, and the saving is per document,
so it grows with the number of skills rather than washing out.

## Trimmed, not removed

Nothing that serves skills reads this field: `list_skills` emits 24 manifest fields and it is not
among them, and the index-term path reads `skill_hash` / `node_hash` / `name` / `triggers` /
`allowed_tools`. A runtime probe wrapping every manifest in a recording dict across `list_skills` +
`retrieve` recorded it asked for **zero** times, while 14 other manifest fields were read 4-44
times — with a positive control proving the probe records at all.

It stays anyway, because `matrixark_http` falls back to it for display. That is what a preview is
for; it just has to be one.

## Tests

Five, and the bound fails on `main` on its own claim — *"a manifest preview is 4111 chars against a
260-char budget"* — rather than erroring on a missing constant, so it is known to discriminate.
Two exist to stop the change being hollow: that the fixture's skills are long enough for a clip to
actually happen, and that the preview still **starts the skill it previews** rather than merely
being short.
