### PR TITLE
Rotating a key asks first, because it stops the key working

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -623,6 +623,11 @@
 
   function rotateKey(id) {
     if (!id) return;
+    /* Revoke asks and this did not, though it revokes the key too -- and it is the button that
+       looks safer of the two, sitting next to it in the same row. */
+    if (!window.confirm("Rotate " + id + "? A replacement is issued and this key stops working "
+                        + "immediately, so anything still using it will be rejected until you "
+                        + "update it.")) { return; }
     apiFetch(mgmtBase(), "/api/admin/rotate_api_key", "POST", { api_key_id: id })
       .then(function (data) {
         var r = unwrap(data);

--- a/tools/portal/key_copy_harness.js
+++ b/tools/portal/key_copy_harness.js
@@ -52,6 +52,8 @@ function boot(clipboard) {
   const els = new Map();
   const created = [];
   const timers = [];
+  const asked = [];              // every window.confirm message, in order
+  let answer = true;             // what the person clicks in the dialog
 
   function makeEl(id) {
     return {
@@ -121,6 +123,7 @@ function boot(clipboard) {
     setTimeout(fn) { timers.push(fn); return timers.length; },
     setInterval: () => 0, clearInterval() {}, clearTimeout() {},
     wireTabs() {}, requestAnimationFrame: () => 0,
+    confirm(message) { asked.push(String(message)); return answer; },
     Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
     encodeURIComponent, decodeURIComponent, parseInt, parseFloat, console,
     TextDecoder: function () { this.decode = () => ""; },
@@ -154,7 +157,8 @@ function boot(clipboard) {
   });
 
   return {
-    el, created, timers,
+    el, created, timers, asked,
+    answerDialogs(value) { answer = value; },
     setCreateResponse(v) { createResponse = v; },
     create() {
       /* Both are required, and createKey returns quietly without either -- which would leave the
@@ -273,6 +277,38 @@ async function quiet() { for (let i = 0; i < 60; i += 1) { await settle(); } }
     ok("E it copies the NEW key, not the one it replaced",
        cb.seen.length === before + 1 && cb.seen[cb.seen.length - 1] === ROTATED_KEY,
        JSON.stringify(cb.seen));
+  }
+
+  /* ---- G. rotation asks before it stops the key working -------------------------------------- */
+  {
+    const cb = clipboardThat("resolve");
+    const page = boot(cb.api);
+    page.create();
+    await quiet();
+
+    const rotate = () => page.created.filter((c) => c.textContent === "Rotate")[0];
+
+    /* Declining must leave the key alone. A dialog that is shown and ignored is the same button
+       it was before, with an extra click. */
+    page.answerDialogs(false);
+    const before = page.el("createKeyOut").innerHTML;
+    rotate().onclick({});
+    await quiet();
+    ok("G rotating asks first", page.asked.some((m) => /Rotate/.test(m)),
+       JSON.stringify(page.asked));
+    ok("G the question says the key stops working, not just the word rotate",
+       page.asked.some((m) => /stops working/.test(m)), JSON.stringify(page.asked));
+    ok("G answering no rotates nothing",
+       page.el("createKeyOut").innerHTML === before,
+       JSON.stringify(page.el("createKeyOut").innerHTML).slice(0, 160));
+
+    /* And answering yes still rotates. */
+    page.answerDialogs(true);
+    rotate().onclick({});
+    await quiet();
+    ok("G answering yes still rotates",
+       page.el("createKeyOut").innerHTML.indexOf(ROTATED_KEY) >= 0,
+       JSON.stringify(page.el("createKeyOut").innerHTML).slice(0, 200));
   }
 
   /* ---- F. the curl button shares the honest copier ------------------------------------------ */

--- a/tools/test_matrixark_rotating_a_key_asks_first.py
+++ b/tools/test_matrixark_rotating_a_key_asks_first.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Both destructive actions on the key portal ask first.
+
+Revoke always asked: *"Revoke <id>? Requests using it will be rejected."* Rotate sat directly
+beside it in the same table row and asked nothing -- while doing the same thing to the key you
+were using, plus issuing a replacement. Worse, of the two it is the one that looks safe: Revoke
+carries `mini danger`, Rotate `mini secondary`, so the unguarded button is the calmer-looking one.
+
+There is no undo. The old secret is stored as a hash and the new one is shown once, so a
+mis-click means every client holding that key starts failing and the replacement is on screen
+exactly once.
+
+The wording says what happens rather than naming the operation, because "rotate" is precisely the
+word whose consequences the person clicking has not thought through.
+
+Two of these can only be seen by running the page: that the dialog appears at all, and that
+answering *no* leaves the key alone. A guard that asks and then proceeds regardless is the same
+button it was before with an extra click, and it reads identically in source.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+HARNESS = os.path.join(PORTAL, "key_copy_harness.js")
+
+# Everything on this page that cannot be undone. Adding a third without a confirmation should
+# fail here rather than in somebody's deployment.
+DESTRUCTIVE = ("revokeKey", "rotateKey")
+
+
+def page_source() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def body_of(source: str, function: str) -> str:
+    """The text of one top-level function, up to the next one at the same indent."""
+    start = source.index("function %s(" % function)
+    following = re.search(r"\n  function \w+\(", source[start + 1:])
+    end = start + 1 + following.start() if following else len(source)
+    return source[start:end]
+
+
+class BothDestructiveActionsAskTest(unittest.TestCase):
+
+    def test_each_one_confirms_before_it_acts(self) -> None:
+        source = page_source()
+        for function in DESTRUCTIVE:
+            body = body_of(source, function)
+            self.assertIn("window.confirm(", body,
+                          "%s cannot be undone and does not ask" % function)
+
+    def test_the_question_says_what_happens_not_just_the_verb(self) -> None:
+        """"Rotate this key?" is the question somebody clicks through. What it costs is that the
+        key they are using stops working."""
+        body = body_of(page_source(), "rotateKey")
+        self.assertIn("stops working", body, body[:200])
+
+    def test_the_guard_runs_before_the_request(self) -> None:
+        """A confirmation after the call is decoration."""
+        body = body_of(page_source(), "rotateKey")
+        self.assertLess(body.index("window.confirm("), body.index("apiFetch("),
+                        "the request is issued before the question is asked")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheDialogIsObeyedTest(unittest.TestCase):
+    """Runs the page. Whether a dialog is obeyed is behaviour, not text."""
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=180)
+
+    def test_the_page_runs_clean(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_rotating_asks(self) -> None:
+        self.assertIn("ok   G rotating asks first", self._run().stdout)
+
+    def test_declining_rotates_nothing(self) -> None:
+        self.assertIn("ok   G answering no rotates nothing", self._run().stdout)
+
+    def test_accepting_still_rotates(self) -> None:
+        """Otherwise a rotate button that never worked would satisfy the check above."""
+        self.assertIn("ok   G answering yes still rotates", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Revoke has always asked — *"Revoke &lt;id&gt;? Requests using it will be rejected."* Rotate sits
directly beside it in the same table row and asked nothing, while doing the same thing to the key
you are using and issuing a replacement as well.

Of the two, **it is the one that looks safe**: Revoke carries `mini danger`, Rotate `mini
secondary`. The unguarded button is the calmer-looking one, an inch from the guarded one.

There is no undo. The old secret is stored as a hash and the replacement is shown exactly once, so
a mis-click means every client holding that key starts failing, and the new key is on screen only
until the page changes.

The question says what happens rather than naming the operation:

> Rotate `key_…`? A replacement is issued and this key stops working immediately, so anything still
> using it will be rejected until you update it.

"Rotate this key?" is the question somebody clicks straight through; what it costs is the sentence
after it.

### Tests

Two properties can only be seen by running the page — that the dialog appears at all, and that
answering **no** leaves the key alone. A guard that asks and then proceeds regardless is the same
button with an extra click, and it reads identically in source. The harness that already drives
Rotate now answers both ways, and the accepting case is there so a Rotate button that had simply
stopped working could not satisfy the declining one.

The source checks assert that **both** destructive actions confirm — named in a list, so a third
one added later fails here rather than in somebody's deployment — and that the question is asked
before the request is issued rather than after it.

Verified red first: the three new harness cases fail on the page as it stands.
