### PR TITLE
A refusal for want of a scope says which scope

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -465,6 +465,12 @@
         try { data = txt ? JSON.parse(txt) : {}; } catch (e) { data = { raw: txt }; }
         if (!resp.ok) {
           var detail = data.error || data.detail || ("HTTP " + resp.status);
+          /* A refusal for want of a scope names the scope, and that name is exactly what has to
+             be ticked in the Scopes box. Dropping it left "insufficient_scope" on screen and the
+             operator guessing at the one thing the answer already contained. */
+          if (typeof detail === "string" && data.required && data.required.length) {
+            detail += " — this needs " + [].concat(data.required).join(" or ");
+          }
           var err = new Error(typeof detail === "string" ? detail : JSON.stringify(detail));
           err.status = resp.status; err.data = data;
           throw err;

--- a/tools/portal/key_copy_harness.js
+++ b/tools/portal/key_copy_harness.js
@@ -96,6 +96,7 @@ function boot(clipboard) {
   }
 
   let createResponse = { api_key_id: "ak_new", api_key: CREATED_KEY };
+  let createStatus = 200;
   const rotateResponse = { api_key_id: "ak_rotated", api_key: ROTATED_KEY };
 
   const store = { mtx_admin_key: "admin-key-for-the-harness" };
@@ -132,7 +133,16 @@ function boot(clipboard) {
     URL: { createObjectURL: () => "", revokeObjectURL() {} },
     fetch: (url) => {
       const u = String(url);
-      if (u.indexOf("create_api_key") >= 0) { return reply({ result: createResponse }); }
+      if (u.indexOf("create_api_key") >= 0) {
+        if (createStatus !== 200) {
+          const body = JSON.stringify(createResponse);
+          return Promise.resolve({
+            ok: false, status: createStatus,
+            text: () => Promise.resolve(body), json: () => Promise.resolve(createResponse)
+          });
+        }
+        return reply({ result: createResponse });
+      }
       if (u.indexOf("rotate_api_key") >= 0) { return reply({ result: rotateResponse }); }
       if (u.indexOf("list_api_keys") >= 0) {
         /* The field names are the served ones: the list reads `api_keys`, and only a row whose
@@ -160,6 +170,7 @@ function boot(clipboard) {
     el, created, timers, asked,
     answerDialogs(value) { answer = value; },
     setCreateResponse(v) { createResponse = v; },
+    setCreateStatus(v) { createStatus = v; },
     create() {
       /* Both are required, and createKey returns quietly without either -- which would leave the
          output empty and let an "is no button offered?" check pass having rendered nothing. */
@@ -309,6 +320,21 @@ async function quiet() { for (let i = 0; i < 60; i += 1) { await settle(); } }
     ok("G answering yes still rotates",
        page.el("createKeyOut").innerHTML.indexOf(ROTATED_KEY) >= 0,
        JSON.stringify(page.el("createKeyOut").innerHTML).slice(0, 200));
+  }
+
+  /* ---- H. a refusal names the scope it wanted ------------------------------------------------ */
+  {
+    const cb = clipboardThat("resolve");
+    const page = boot(cb.api);
+    page.setCreateStatus(403);
+    page.setCreateResponse({ error: "insufficient_scope", required: ["admin:api_key"] });
+    page.create();
+    await quiet();
+
+    const message = page.el("createMsg").textContent;
+    ok("H the refusal is reported", /insufficient_scope/.test(message), JSON.stringify(message));
+    ok("H it names the scope that was wanted", /admin:api_key/.test(message),
+       JSON.stringify(message));
   }
 
   /* ---- F. the curl button shares the honest copier ------------------------------------------ */

--- a/tools/test_matrixark_an_error_says_which_scope_is_missing.py
+++ b/tools/test_matrixark_an_error_says_which_scope_is_missing.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A refusal for want of a scope says which scope.
+
+`apiFetch` reduced every failure to ``data.error || data.detail || "HTTP <status>"``. For the one
+failure an operator is most likely to meet -- a key without the scope for what they just clicked --
+the edge answers:
+
+    403 {"error": "insufficient_scope", "required": ["admin:api_key"]}
+
+and the page rendered *"Usage failed: insufficient_scope"*. The `required` list was carried on the
+error object and never shown, leaving the operator to guess at the one thing the response had
+already answered. It arrives on the Usage tab through `/v1/admin/api_key_usage`, and every other
+call on this page goes through the same helper.
+
+The scope names are shown verbatim, because they are the strings to tick in the Scopes box above.
+
+The two halves are asserted separately: that the refusal is reported at all, and that it carries
+the scope. Removing the change reddens only the second, which is how the pair earns its place --
+a single check covering both would pass on a page that says nothing useful.
+"""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+HARNESS = os.path.join(PORTAL, "key_copy_harness.js")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ARefusalNamesTheScopeTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=180)
+
+    def test_the_page_runs_clean(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_refusal_is_reported(self) -> None:
+        self.assertIn("ok   H the refusal is reported", self._run().stdout)
+
+    def test_the_message_names_the_scope(self) -> None:
+        self.assertIn("ok   H it names the scope that was wanted", self._run().stdout)
+
+
+class TheHelperReadsTheFieldTheEdgeSendsTest(unittest.TestCase):
+    """`required` is the field name the gateway uses; reading a different one would leave the
+    behaviour above passing only because the harness invented the same mistake."""
+
+    def test_the_page_reads_required(self) -> None:
+        with io.open(PAGE, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("data.required", source)
+
+    def test_the_edge_still_sends_that_field(self) -> None:
+        gateway = os.path.join(TOOLS, "matrixark_v1_gateway.py")
+        with io.open(gateway, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('"required": sorted(', source,
+                      "the edge no longer sends `required`, so the page has nothing to show")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`apiFetch` reduced every failure to `data.error || data.detail || "HTTP <status>"`. For the one
failure an operator is most likely to meet — a key without the scope for what they just clicked —
the edge answers:

```
403 {"error": "insufficient_scope", "required": ["admin:api_key"]}
```

and the page rendered:

> Usage failed: insufficient_scope

The `required` list was attached to the error object and never shown, leaving the operator to guess
at the one thing the response had already answered. It arrives on the **Usage** tab through
`/v1/admin/api_key_usage`, and every other call on this page goes through the same helper, so this
fixes the class rather than the instance. Now:

> Usage failed: insufficient_scope — this needs admin:api_key

The scope names go in verbatim rather than being prettified: they are the strings to tick in the
Scopes box above, so what is on screen should be what to look for.

The two halves are asserted separately — that the refusal is reported at all, and that it carries
the scope — because a single check covering both would pass on a page that says nothing useful.
Removing the change reddens only the second.

One test also asserts the **edge still sends `required`**, so the page reading a field nobody sends
would fail here rather than silently going back to the bare message.
