### PR TITLE
Every series write costs the length of its series

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -15087,3 +15087,102 @@ fn what_a_feature_write_costs_against_its_series() {
         "the flat control reported {flat:.2}x -- the probe invents amplification"
     );
 }
+
+/// The four commands that hand a WHOLE address list to `sync_bucket_index_object_pages`
+/// (execute_on_shard lines ~1334, ~1402, ~1566, ~1727) -- do they all cost their series?
+///
+/// FeatureAppend is carried as a KNOWN-amplifying control (15.20x, mx#793) and SetAdd as the
+/// flat one. Source agreement is not evidence: the same survey shape has twice reported a
+/// command as cheap when its work had merely moved somewhere the grep could not see.
+#[test]
+#[cfg(feature = "alloc-probe")]
+fn which_series_writers_cost_their_series() {
+    const REPS: usize = 20;
+    let cost = |family: &str, fill: usize| -> u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = TemporalEngine::with_local_dirs(
+            1024 * 1024,
+            dir.path().join("cache"),
+            dir.path().join("pages"),
+            dir.path().join("indexes"),
+        );
+        engine.load_shard(1);
+        let make = |i: usize| -> Command {
+            let ts = 1_000 + i as u64;
+            match family {
+                "SetAdd" => Command::SetAdd {
+                    key: "s".to_string(),
+                    member: format!("m{i:06}").into_bytes(),
+                },
+                "FeatureAppend" => Command::FeatureAppend {
+                    key: "f".to_string(),
+                    points: vec![FeaturePoint { timestamp_ms: ts, value: vec![b'v'; 8] }],
+                },
+                "FeatureAppendWithPolicy" => Command::FeatureAppendWithPolicy {
+                    key: "fp".to_string(),
+                    points: vec![FeaturePoint { timestamp_ms: ts, value: vec![b'v'; 8] }],
+                    policy: FeatureWritePolicy::Upsert,
+                },
+                "FeatureReplace" => Command::FeatureReplace {
+                    key: "fr".to_string(),
+                    start_ms: ts,
+                    end_ms: ts,
+                    points: vec![FeaturePoint { timestamp_ms: ts, value: vec![b'v'; 8] }],
+                },
+                "SequenceAdd" => Command::SequenceAdd {
+                    key: "sq".to_string(),
+                    rows: vec![SequenceFeatureRow {
+                        timestamp_ms: ts,
+                        gid: i as u64,
+                        action_type: 1,
+                        duration: 2,
+                        author_id: 3,
+                    }],
+                },
+                other => panic!("unknown family {other}"),
+            }
+        };
+        for i in 0..fill {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: make(i) });
+            assert!(out.status.ok, "{family} fill refused: {:?}", out.status);
+        }
+        let probe = crate::alloc_probe::Probe::start();
+        for i in 0..REPS {
+            let out = engine.execute(ExecuteRequest { shard_id: 1, command: make(fill + i) });
+            assert!(out.status.ok, "{family} probe refused: {:?}", out.status);
+        }
+        probe.stop().alloc_bytes / REPS as u64
+    };
+
+    println!("  family                    bytes/write @200     @3200      ratio");
+    let mut amplifying = 0.0f64;
+    let mut flat = 0.0f64;
+    for family in [
+        "SetAdd",
+        "FeatureAppend",
+        "FeatureAppendWithPolicy",
+        "FeatureReplace",
+        "SequenceAdd",
+    ] {
+        let small = cost(family, 200);
+        let large = cost(family, 3200);
+        assert!(small > 0, "{family}: measured zero bytes, the probe never reached the path");
+        let ratio = large as f64 / small as f64;
+        match family {
+            "FeatureAppend" => amplifying = ratio,
+            "SetAdd" => flat = ratio,
+            _ => {}
+        }
+        println!("  {family:24}  {small:10}  {large:10}   {ratio:8.2}x");
+    }
+    assert!(
+        amplifying > 3.0,
+        "FeatureAppend is known to cost its series (15.20x); it reported {amplifying:.2}x, so \
+         this probe cannot see amplification and no row above means anything"
+    );
+    assert!(
+        flat < 1.5,
+        "SetAdd declares its component and must stay flat; it reported {flat:.2}x, so this probe \
+         reports amplification where there is none"
+    );
+}


### PR DESCRIPTION
Four commands, two families, **one shared code path** — and each costs ~**4.07 MB per write** on a
3 200-point series.

| command | @200 | @3 200 | ratio |
|---|---|---|---|
| `SetAdd` *(flat control)* | 3 586 | 3 645 | 1.02x |
| `FeatureAppend` *(amplifying control, #793)* | 267 697 | 4 070 106 | 15.20x |
| `FeatureAppendWithPolicy` | 266 965 | 4 073 651 | 15.26x |
| `FeatureReplace` | 266 158 | 4 071 759 | 15.30x |
| **`SequenceAdd`** | 268 403 | **4 084 193** | **15.22x** |

## The convergence is the finding

Four commands landing within **0.4 %** of each other, at ratios of 15.20–15.30, is not four
coincidental defects. It is one mechanism measured four times. `SequenceAdd` matching the feature
commands to three significant figures is the part that matters: it is a *different family*, so the
cost cannot be a property of features — it belongs to what they share.

What they share is the call every one of them makes:

```rust
let live_addresses = series.values().cloned().collect::<Vec<_>>();
sync_bucket_index_object_pages(shard, shard_id, kind, &key, live_addresses, mutated);
```

`execute_on_shard` lines ~1334, ~1402, ~1566 and ~1727. Two further call sites in `lifecycle.rs`
pass a whole list the same way.

## The optimisation already exists and every caller defeats it

`sync_bucket_index_object_pages` is written to be incremental. It narrows target buckets through
`object_page_refs`, and it tracks `removed_components` so that — in its own words — "the lookup can
be corrected for exactly those instead of being rebuilt from every page in the shard".

Callers hand it the entire address list, so none of that narrowing helps. The fix may be much
smaller than the number suggests: it is a question of callers naming their delta, not of rewriting
the sync.

## Why this is not fixed here

The cure used for `SetAdd` (#777) and `ListPush` (#778) — declare the component you touched — does
not transfer. Feature and sequence pages are created with
`stable_page_object_id(shard_id, kind, key, None)`, carrying **no component**, so they cannot be
addressed individually the way a hash field or a set member can. Making these incremental changes
what a series page is addressed by, which is a storage-format decision rather than a performance
edit.

## Controls

Two-sided, and both asserted:

* `FeatureAppend` is known from #793 to cost 15.20x and must report **> 3x**.
* `SetAdd` has declared its component since #777 and must report **< 1.5x**.

A probe that cannot see amplification — or that invents it — fails instead of returning five
plausible rows. This matters here because the rows agree so closely that a broken probe would look
like a clean result.

## Verification

* Built and run **with the `alloc-probe` feature enabled**; `cargo check --all-targets` does not
  compile feature-gated code.
* Test-only; no engine code is touched.
