### PR TITLE
Persist the configuration before applying it

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1092,26 +1092,28 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
             coerced[key] = ""
         else:
             coerced[key] = _coerce(SETTINGS_BY_KEY[key], raw)
+            # The one thing that makes assignment into the environment raise. Refused here, with
+            # the other value checks, so that neither half of the write can fail once it starts.
+            if "\x00" in coerced[key]:
+                raise InvalidValue("%s must not contain a NUL byte" % key)
     # The *.api_key_env settings decide where the secrets land, so fold the whole patch in before
     # resolving any target name -- otherwise a single call that sets both the key and its variable
     # name would write the key to the OLD variable.
     values.update(coerced)
 
     applied: List[Json] = []
+    # What the environment would become, worked out but not yet done. The write to disk happens
+    # first: if it fails, the running process must not already be carrying settings the operator
+    # has just been told were not saved.
+    env_ops: List[Tuple[str, Optional[str]]] = []
     for key in sorted(coerced):
         setting = SETTINGS_BY_KEY[key]
         value = coerced[key]
         name = _env_name(setting, values)
         if name:
-            if value == "":
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
+            env_ops.append((name, None if value == "" else value))
         if key == "extraction.provider":
-            if value:
-                os.environ["MATRIXARK_EXTRACTION_PROVIDER"] = value
-            else:
-                os.environ.pop("MATRIXARK_EXTRACTION_PROVIDER", None)
+            env_ops.append(("MATRIXARK_EXTRACTION_PROVIDER", value or None))
         # A value the engine will raise is reported back with what it will really be. The
         # write is still accepted -- the engine takes it and raises it, and refusing here would be
         # this file inventing a stricter rule than the thing it configures.
@@ -1165,6 +1167,14 @@ def update(patch: Json, actor: Optional[str] = None) -> Json:
     document["updated_at"] = time.time()
     document["updated_by"] = actor or "portal"
     _store(document)
+
+    # Only now. _store is the half that can fail; assignment into the environment is the half that
+    # cannot be undone, and it has been checked for the one input that would make it raise.
+    for name, value in env_ops:
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
 
     restart_required = sorted({e["key"] for e in applied if not e["in_effect"]})
     return {

--- a/tools/test_matrixark_a_failed_configuration_write_changes_nothing.py
+++ b/tools/test_matrixark_a_failed_configuration_write_changes_nothing.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A configuration write that fails leaves the process as it was.
+
+`update()` used to put the new settings into `os.environ` and then persist them. When the persist
+failed -- a read-only mount, a full disk, a permission the container does not have -- the route
+answered 500 `config_write_failed` and the operator read that nothing had happened. The running
+process had in fact changed: the new extraction endpoint, the new embedding host, the new API key
+were all live. A restart then silently reverted them, so the deployment behaved one way until it
+next restarted and another way after, with nothing on record either way.
+
+The same shape as revoking a key before authorizing the revocation, and as rendering a page into a
+file already opened for writing: the step that cannot be undone ran before the step that can fail.
+
+Applying is the half that cannot fail, so it goes last. "The call failed" now means nothing
+changed, and "the call succeeded" means both halves did.
+
+The ordering is asserted from inside the persist step rather than from its outcome, because an
+outcome cannot tell "applied after" from "applied before and then rolled back" -- and only one of
+those is what the code does.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import matrixark_gateway_config as cfg
+
+KEY = "extraction.model"
+ENV = "MATRIXARK_EXTRACTION_MODEL"
+
+
+class AFailedWriteChangesNothingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # Both the environment and the config path are process-global, so both are restored
+        # however this test ends.
+        self._saved = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(), os.environ.update(self._saved)))
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+        os.environ.pop(ENV, None)
+
+    # ---- the control ----------------------------------------------------------------------------
+
+    def test_a_write_that_succeeds_applies_and_persists(self) -> None:
+        """Without this, a change that simply stopped writing anything would pass the rest."""
+        result = cfg.update({KEY: "deepseek-chat"})
+        self.assertEqual("ok", result["status"])
+        self.assertEqual("deepseek-chat", os.environ.get(ENV))
+        self.assertEqual("deepseek-chat", cfg.load()["values"][KEY])
+
+    # ---- the failure ------------------------------------------------------------------------------
+
+    def test_a_write_that_cannot_persist_leaves_the_process_alone(self) -> None:
+        os.environ[ENV] = "before"
+        with mock.patch.object(cfg, "_store", side_effect=OSError("read-only file system")):
+            with self.assertRaises(OSError):
+                cfg.update({KEY: "deepseek-chat"})
+        self.assertEqual("before", os.environ.get(ENV),
+                         "the write failed and the running process changed anyway")
+
+    def test_the_environment_is_untouched_at_the_moment_of_persisting(self) -> None:
+        """Asserted from inside `_store`, because an outcome cannot tell "applied afterwards" from
+        "applied first and then put back", and only one of those is what this does."""
+        os.environ[ENV] = "before"
+        seen = {}
+        real = cfg._store
+
+        def watching(document):
+            seen["env"] = os.environ.get(ENV)
+            return real(document)
+
+        with mock.patch.object(cfg, "_store", side_effect=watching):
+            cfg.update({KEY: "deepseek-chat"})
+
+        self.assertEqual("before", seen.get("env"),
+                         "the environment already carried the new value while the file was being "
+                         "written, so a failed write would leave the two disagreeing")
+        self.assertEqual("deepseek-chat", os.environ.get(ENV),
+                         "and it must be applied once the write has succeeded")
+
+    def test_what_was_persisted_is_what_takes_effect(self) -> None:
+        cfg.update({KEY: "deepseek-chat"})
+        self.assertEqual(cfg.load()["values"][KEY], os.environ.get(ENV))
+
+    # ---- the one input that would make applying fail ------------------------------------------------
+
+    def test_a_value_the_environment_cannot_hold_is_refused_before_either_half(self) -> None:
+        os.environ[ENV] = "before"
+        with self.assertRaises(cfg.InvalidValue):
+            cfg.update({KEY: "deep\x00seek"})
+        self.assertEqual("before", os.environ.get(ENV))
+        self.assertNotIn(KEY, cfg.load().get("values") or {},
+                         "a value that cannot be applied was written to the file anyway")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`update()` put the new settings into `os.environ` and then called `_store()` to persist them. When
that persist failed — a read-only mount, a full disk, a permission the container does not have —
the route answered `500 config_write_failed` and the operator read that nothing had happened.

**The running process had in fact changed.** The new extraction endpoint, the new embedding host,
the new API key were all live. A restart then silently reverted them, so the deployment behaved one
way until it next restarted and another way afterwards, with nothing on record either way — and the
only message anybody saw said the write had not gone through.

The same shape as revoking a key before authorizing the revocation (#781) and as rendering a page
into a file already opened for writing (#787): **the step that cannot be undone ran before the step
that can fail.**

The apply loop now works out what the environment *would* become rather than doing it; the document
is written; and only then is the environment changed. Applying is the half that cannot fail, so it
goes last — "the call failed" means nothing changed, and "the call succeeded" means both halves did.

Assignment into `os.environ` is not *quite* infallible — a NUL byte in a value raises — so that is
refused during coercion, beside the other value checks and before either half runs.

### On the test

The ordering is asserted **from inside the persist step**, by watching what the environment holds
at the moment `_store` is called:

```python
def watching(document):
    seen["env"] = os.environ.get(ENV)   # must still be the old value
    return real(document)
```

An outcome cannot distinguish "applied afterwards" from "applied first and then put back", and only
one of those is what this code does.

Restoring the old order reddens exactly the two ordering checks and leaves the three controls green
— including the one asserting a successful write still both applies and persists, so a change that
simply stopped writing anything could not pass.

Every settings suite green: gateway_config (28), config_audit (14), clamped_settings (8),
every_live_claim (4), engine_write (3), engine_settings (5), accessor_defaults (2), flag_inventory
(6), plus gateway_portal (58), v1_gateway (97), dashboards (20), deployment_routes (23).
