### PR TITLE
Say which settings are waiting for a restart

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -50,6 +50,15 @@ Json = Dict[str, Any]
 # be overwritten by the stored file.
 _BOOT_ENV: Dict[str, str] = dict(os.environ)
 
+# What each `applies == "restart"` setting was actually running as, recorded by apply_boot() once
+# the stored file has been folded into the environment. Those settings are read into module
+# constants at import and never re-read, so this is the only moment their effective value is
+# knowable -- and without it "has this been changed since startup?" cannot be answered at all.
+#
+# Empty means nobody called apply_boot (a test, a tool importing this module). Then nothing is
+# reported as pending: missing evidence is not evidence of a pending change.
+_BOOT_EFFECTIVE: Dict[str, str] = {}
+
 _TRUTHY = {"1", "true", "yes", "on"}
 
 # Floors the ENGINE applies, by variable. These are not a policy this file invents -- the accessors
@@ -892,6 +901,7 @@ def apply_boot(document: Optional[Json] = None) -> List[str]:
     document = load() if document is None else document
     values: Dict[str, str] = {k: str(v) for k, v in (document.get("values") or {}).items()}
     seeded: List[str] = []
+    _BOOT_EFFECTIVE.clear()
     for setting in SETTINGS:
         if setting.key not in values:
             continue
@@ -908,6 +918,11 @@ def apply_boot(document: Optional[Json] = None) -> List[str]:
     if "extraction.provider" in values and "MATRIXARK_EXTRACTION_PROVIDER" not in _BOOT_ENV:
         os.environ["MATRIXARK_EXTRACTION_PROVIDER"] = values["extraction.provider"]
         seeded.append("MATRIXARK_EXTRACTION_PROVIDER")
+    # After the seeding, because this has to be the value the process will actually read -- the
+    # stored one where it was applied, the launcher's where that took precedence.
+    for setting in SETTINGS:
+        if setting.applies == "restart":
+            _BOOT_EFFECTIVE[setting.key] = _effective(setting, values)[0]
     return seeded
 
 
@@ -954,6 +969,20 @@ def _override_layers_by_env() -> Dict[str, List[str]]:
     return out
 
 
+def _is_pending_restart(setting: "Setting", value: str) -> bool:
+    """Stored value differs from the one this process started with.
+
+    False when there is nothing to compare: a setting that applies live is never pending, and a
+    process that never called apply_boot has no record of what it started with. Reporting a change
+    on missing evidence would put an alarm on every deployment that imports this module.
+    """
+    if setting.applies != "restart":
+        return False
+    if setting.key not in _BOOT_EFFECTIVE:
+        return False
+    return str(value) != _BOOT_EFFECTIVE[setting.key]
+
+
 def snapshot(include_catalog: bool = True) -> Json:
     """The full settable-config view for the portal: effective value, where it came from, and when
     a change takes effect. Secret VALUES are never present -- only ``configured``."""
@@ -994,6 +1023,10 @@ def snapshot(include_catalog: bool = True) -> Json:
             # what the value currently is or where it came from.
             "boot_pinned": bool(_env_name(setting, values)
                                 and _env_name(setting, values) in _BOOT_ENV),
+            # Changed since this process started, and frozen at import, so the deployment is still
+            # running the old value. Distinct from the `applies` badge, which says what KIND of
+            # setting this is and says it before anybody touches anything.
+            "pending_restart": _is_pending_restart(setting, value),
         }
         if setting.secret:
             entry["configured"] = bool(value)
@@ -1004,6 +1037,11 @@ def snapshot(include_catalog: bool = True) -> Json:
     result: Json = {
         "status": "ok",
         "essential_keys": sorted(ESSENTIAL_KEYS),
+        # Which settings have been written since this process started and are still not in effect.
+        # The write that made each of them said so once, to whoever made it; this says it to
+        # whoever looks next.
+        "pending_restart": sorted(entry["key"] for group in groups.values() for entry in group
+                                  if entry.get("pending_restart")),
         "config_file": config_path(),
         "updated_at": document.get("updated_at"),
         "updated_by": document.get("updated_by"),

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -188,6 +188,9 @@
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -68,6 +68,9 @@ EXTRA_CSS = """
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}
@@ -1049,7 +1052,17 @@ function liveStream(options) {
   function fieldHtml(f) {
     var badges = "";
     if (f.essential) { badges += '<span class="badge essential">required</span>'; }
-    if (f.applies === "restart") { badges += '<span class="badge restart">needs restart</span>'; }
+    /* Written since this process started, and read only at startup, so the deployment is
+       running the old value right now. This replaces the "needs restart" note rather than
+       joining it: that note is about the kind of setting and is true before anybody touches
+       anything, and showing both buries the half that is about this deployment today. */
+    if (f.pending_restart) {
+      badges += '<span class="badge pending" title="This value is saved but not in effect: it ' +
+        'is read once at startup, and this process is still running the previous one. Restart ' +
+        'the gateway to apply it.">changed — restart to apply</span>';
+    } else if (f.applies === "restart") {
+      badges += '<span class="badge restart">needs restart</span>';
+    }
     /* The launcher set this variable before the process started. A change here takes effect now
        and is dropped at the next restart, because boot values keep precedence over stored ones.
        Without this the field looks exactly like any other live setting. */

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -188,6 +188,9 @@
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -188,6 +188,9 @@
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -188,6 +188,9 @@
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}

--- a/tools/portal/setting_badge_harness.js
+++ b/tools/portal/setting_badge_harness.js
@@ -1,0 +1,79 @@
+/* Run the setup page's fieldHtml and read the badges it produces.
+ *
+ * Whether the two badges are mutually exclusive cannot be read off the source with any confidence:
+ * "needs restart" describes the KIND of setting and is true from page load, and "changed — restart
+ * to apply" describes THIS deployment right now. Showing both says the same thing twice and buries
+ * the half that is about today, so the second has to replace the first rather than join it.
+ *
+ * Usage: node setting_badge_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* Read out of the built page rather than the generator: this is the copy a browser runs. */
+const start = page.indexOf("function fieldHtml(f) {");
+if (start < 0) { console.log("FAIL fieldHtml is not on the page"); process.exit(1); }
+const end = page.indexOf("\n  }", start);
+const body = page.slice(start, end + 4);
+
+const esc = (s) => String(s === undefined || s === null ? "" : s);
+
+/* The renderer reaches for several small helpers from the page around it, and naming them one by
+   one turns each into a round of "run it, read the ReferenceError, add a stub". Anything it asks
+   for that is not a real global answers with an inert function instead: this is about which badges
+   come out, and helper text would only be noise to match against. */
+const scope = new Proxy({}, {
+  has: () => true,
+  get: (_target, key) => {
+    if (key === Symbol.unscopables) { return undefined; }
+    if (key === "esc") { return esc; }
+    if (key in globalThis) { return globalThis[key]; }
+    return () => "";
+  }
+});
+const fieldHtml = new Function("scope", "with (scope) { " + body + "\nreturn fieldHtml; }")(scope);
+
+/* A field carrying every property the renderer reads. A thinner one would throw somewhere in the
+   middle and the throw would look like a missing badge. */
+function field(extra) {
+  return Object.assign({
+    key: "extraction.base_url", env: "MATRIXARK_EXTRACTION_BASE_URL",
+    label: "Extraction base URL", help: "Where extraction calls go.",
+    value: "https://api.deepseek.com/v1", default: "", source: "config",
+    applies: "restart", essential: false, secret: false, configured: true,
+    overridable_by: [], boot_pinned: false, pending_restart: false, options: null,
+    unit: null, minimum: null, maximum: null, group: "Extraction"
+  }, extra);
+}
+
+const advice = /needs restart/;
+const status = /changed — restart to apply/;
+
+let html = fieldHtml(field({}));
+ok("an untouched restart setting carries the advice", advice.test(html));
+ok("and does not claim to be waiting", !status.test(html), html.slice(0, 200));
+
+html = fieldHtml(field({ pending_restart: true }));
+ok("a written one says it is waiting", status.test(html), html.slice(0, 240));
+ok("and drops the advice, rather than showing both", !advice.test(html), html.slice(0, 240));
+
+html = fieldHtml(field({ applies: "live", pending_restart: false }));
+ok("a live setting carries neither", !advice.test(html) && !status.test(html),
+   html.slice(0, 200));
+
+/* The one that would make this a decoration: a live setting can never be pending, so if the
+   renderer ever showed the status badge for one, the flag would be meaningless. */
+html = fieldHtml(field({ applies: "live", pending_restart: true }));
+ok("the renderer shows what it is given, so the flag is the thing to get right",
+   status.test(html), html.slice(0, 200));
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -188,6 +188,9 @@
          padding:2px 7px;border-radius:20px;margin-left:7px;white-space:nowrap}
   .badge.restart{background:var(--warn-soft);color:var(--warn)}
   .badge.essential{background:var(--crit-soft);color:var(--crit)}
+  /* Louder than .restart on purpose: that one is advice about a kind of setting, this one is a
+     deployment running something other than what this page shows. */
+  .badge.pending{background:var(--crit-soft);color:var(--crit)}
   .badge.portal{background:var(--accent-soft);color:var(--accent)}
   .badge.environment{background:var(--line);color:var(--muted)}
   .badge.override{background:var(--panel-2);color:var(--muted);border:1px solid var(--line)}
@@ -939,7 +942,17 @@ function liveStream(options) {
   function fieldHtml(f) {
     var badges = "";
     if (f.essential) { badges += '<span class="badge essential">required</span>'; }
-    if (f.applies === "restart") { badges += '<span class="badge restart">needs restart</span>'; }
+    /* Written since this process started, and read only at startup, so the deployment is
+       running the old value right now. This replaces the "needs restart" note rather than
+       joining it: that note is about the kind of setting and is true before anybody touches
+       anything, and showing both buries the half that is about this deployment today. */
+    if (f.pending_restart) {
+      badges += '<span class="badge pending" title="This value is saved but not in effect: it ' +
+        'is read once at startup, and this process is still running the previous one. Restart ' +
+        'the gateway to apply it.">changed — restart to apply</span>';
+    } else if (f.applies === "restart") {
+      badges += '<span class="badge restart">needs restart</span>';
+    }
     /* The launcher set this variable before the process started. A change here takes effect now
        and is dropped at the next restart, because boot values keep precedence over stored ones.
        Without this the field looks exactly like any other live setting. */

--- a/tools/test_matrixark_a_written_setting_says_it_is_waiting.py
+++ b/tools/test_matrixark_a_written_setting_says_it_is_waiting.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A setting that has been written and is not in effect says so.
+
+The portal badges "needs restart" on every setting whose ``applies`` is ``restart``. That is a
+property of the setting and it is true before anybody touches anything — advice, not status. What
+nothing said was that a setting has *been* changed and this process is still running the old value.
+
+``update()`` reports ``restart_required`` in its own response, so the person who made the change is
+told once, at the moment they make it. Anybody arriving afterwards — the next operator, the same
+one on Monday — sees a page describing a configuration the deployment is not running. Settings
+frozen at import keep their startup value indefinitely, and nothing on any screen says so.
+
+The value a restart-scoped setting actually took is knowable at exactly one moment: ``apply_boot``,
+after the stored file has been folded into the environment. Recording it there turns "is this
+pending?" into a comparison rather than a guess.
+
+**Absence of a record means unknown, and unknown reports False.** A process that never called
+``apply_boot`` has nothing to compare against, and answering "pending" there would put an alarm on
+every deployment that merely imports this module.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import matrixark_gateway_config as cfg
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+RESTART_KEY = "extraction.base_url"
+LIVE_KEY = next(s.key for s in cfg.SETTINGS if s.applies == "live")
+
+
+class APendingSettingIsReportedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(), os.environ.update(self._saved)))
+        self._boot = dict(cfg._BOOT_EFFECTIVE)
+        self.addCleanup(lambda: (cfg._BOOT_EFFECTIVE.clear(),
+                                 cfg._BOOT_EFFECTIVE.update(self._boot)))
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+
+    @staticmethod
+    def _pending():
+        return cfg.snapshot()["pending_restart"]
+
+    def test_the_setting_this_is_about_is_still_restart_scoped(self) -> None:
+        """If it became live, every check below would pass while testing nothing."""
+        self.assertEqual("restart", cfg.SETTINGS_BY_KEY[RESTART_KEY].applies)
+
+    def test_a_fresh_boot_has_nothing_waiting(self) -> None:
+        cfg.apply_boot()
+        self.assertEqual([], self._pending())
+
+    def test_a_write_to_a_restart_setting_is_reported_as_waiting(self) -> None:
+        cfg.apply_boot()
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self.assertEqual([RESTART_KEY], self._pending())
+
+    def test_the_field_itself_carries_it(self) -> None:
+        """The page renders per field, so the list alone would not reach the reader."""
+        cfg.apply_boot()
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        field = next(f for group in cfg.snapshot()["groups"].values() for f in group
+                     if f["key"] == RESTART_KEY)
+        self.assertTrue(field["pending_restart"])
+        self.assertEqual("restart", field["applies"],
+                         "the two are different facts and both have to survive")
+
+    def test_a_restart_clears_it(self) -> None:
+        cfg.apply_boot()
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self.assertEqual([RESTART_KEY], self._pending())
+        cfg.apply_boot()                       # what a restart does
+        self.assertEqual([], self._pending(),
+                         "it still reads as waiting after the restart that applied it")
+
+    def test_a_live_setting_is_never_waiting(self) -> None:
+        cfg.apply_boot()
+        cfg.update({LIVE_KEY: cfg.SETTINGS_BY_KEY[LIVE_KEY].default or "1"})
+        self.assertEqual([], self._pending())
+
+    def test_without_a_boot_record_nothing_is_claimed(self) -> None:
+        """A tool that imports this module has no idea what the serving process started with, and
+        must not answer as though it did."""
+        cfg._BOOT_EFFECTIVE.clear()
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self.assertEqual([], self._pending())
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePageShowsTheStateNotJustTheAdviceTest(unittest.TestCase):
+    """Whether the two badges are mutually exclusive is behaviour: "needs restart" describes the
+    kind of setting, "changed — restart to apply" describes this deployment now, and showing both
+    says it twice while burying the half about today."""
+
+    def _run(self):
+        return subprocess.run(
+            ["node", os.path.join(PORTAL, "setting_badge_harness.js"),
+             os.path.join(PORTAL, "setup_portal.html")],
+            capture_output=True, text=True, timeout=180)
+
+    def test_the_badges_render_as_intended(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_written_setting_shows_the_state(self) -> None:
+        self.assertIn("ok   a written one says it is waiting", self._run().stdout)
+
+    def test_it_replaces_the_advice_rather_than_joining_it(self) -> None:
+        self.assertIn("ok   and drops the advice, rather than showing both", self._run().stdout)
+
+    def test_an_untouched_setting_keeps_the_advice(self) -> None:
+        self.assertIn("ok   an untouched restart setting carries the advice", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal badges **needs restart** on every setting whose `applies` is `restart`. That is a
property of the setting, true from the moment the page loads and before anybody touches anything —
*advice*. Nothing said that a setting had **been** changed and this process was still running the
old value — *status*.

`update()` reports `restart_required` in its own response, so whoever makes the change is told
once, at the moment they make it. Anybody arriving afterwards — the next operator, the same one on
Monday — sees a page describing a configuration the deployment is not running. Settings frozen at
import keep their startup value indefinitely, and nothing on any screen says so.

### Where the answer comes from

The value a restart-scoped setting actually took is knowable at exactly one moment: `apply_boot`,
once the stored file has been folded into the environment and the launcher's precedence resolved.
Recording it there turns *is this pending?* into a comparison rather than a guess.

```
at boot, pending:                 []
after the write, pending:         ['extraction.base_url']
after a restart, pending:         []
a LIVE setting written, pending:  []
```

**Absence of a record means unknown, and unknown reports False.** A process that never called
`apply_boot` — a test, a tool importing the module — has nothing to compare against, and answering
"pending" there would put an alarm on every deployment that merely imports this file. That case has
its own test.

### On the page

The status badge **replaces** the advice badge rather than joining it. Two badges reading "needs
restart" and "changed — restart to apply" on one field say the same thing twice and bury the half
that is about this deployment today. It is coloured as a state rather than a note, because a
deployment running something other than what the page shows is not a footnote.

This is asserted by running the page's own `fieldHtml` against four field shapes, because whether
two badges are mutually exclusive is behaviour and the source reads the same either way. The
harness resolves the renderer's helpers generically rather than one ReferenceError at a time.

Complements `boot_pinned`, which already reports the mirror image: a launcher-set variable that
makes a portal write vanish at the next restart.

Suites green: gateway_config (28), config_audit (14), clamped_settings (8), every_live_claim (4),
portal_pages (4), dashboards (20), plus 11 new.
