### PR TITLE
The snapshot stored what the log compressed

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -149,7 +149,11 @@ def _snapshot_prefix_fingerprint(record: "Json") -> str:
         ).hexdigest()[:32]
     except (TypeError, ValueError):
         return ""
-LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION = 1
+# Version 2 stores the base snapshot in the same interned form the durable log uses, so the two
+# files no longer disagree about how the same records are written. The bump is what protects an
+# older reader: it would otherwise serve tokenised records with the interned fields missing, so a
+# version it does not recognise has to send it back to the log, which it already does.
+LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION = 2
 PRE_RETRIEVAL_SUMMARY_REFRESH = os.environ.get("MATRIXARK_PRE_RETRIEVAL_SUMMARY_REFRESH", "0").strip().lower() in {"1", "true", "yes"}
 
 QUALITY_FIRST_UNDERFILL_DROP_KEYS = {
@@ -4742,6 +4746,12 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if not isinstance(records, list):
             return None
         records = [record for record in records if isinstance(record, dict)]
+        # Undo the interning the writer applied, dropping the sidecars, so what comes back is the
+        # record set the caller stored -- the same inverse the log path applies at its own read.
+        # Called unconditionally rather than behind the intern flag, because the flag can differ
+        # between the process that wrote the file and the one reading it; with nothing interned
+        # this takes the no-op path. It runs before the count check, which counts data records.
+        records = expand_interned_records(records)
         if len(records) != head.get("record_count"):
             return None
         delta_count = head.get("delta_count") or 0
@@ -4927,7 +4937,21 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             "cache_key": self._cache_key_str(),
             "signature": signature,
             "record_count": len(records),
-            "records": records,
+            # Store what the log stores. The log writes each record with its interned metadata
+            # replaced by a bundle token and one sidecar per distinct bundle; the snapshot was
+            # writing the same records fully expanded, so the largest file in the store was the
+            # one copy of the data that had opted out of the compression.
+            #
+            # What it is worth depends on how much of a record is metadata rather than body, so
+            # the range matters more than any single figure. Re-encoding snapshots two real runs
+            # left behind: 13.4 MB -> 4.3 MB (67.8%) on a store of 3,022 small records, and
+            # 207.2 MB -> 186.3 MB (10.1%) on 100,105 records whose text and vectors dominate.
+            # The sidecar count barely moves with the corpus -- 22 for 99,919 tokened records --
+            # so this is the whole per-record cost of these fields, not a ratio that decays.
+            #
+            # `record_count` above counts data records, which is what the load path recovers
+            # after expansion; the encoded list is longer by the sidecars it carries.
+            "records": encode_interned_records(records, set()),
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/test_incremental_read_cache.py
+++ b/tools/test_incremental_read_cache.py
@@ -190,7 +190,16 @@ class IncrementalReadCacheCase(unittest.TestCase):
         base = json.loads(adapter._durable_read_cache_path().read_text(encoding="utf-8"))
         tail = [l for l in adapter._durable_read_cache_delta_path().read_text(
             encoding="utf-8").splitlines() if l.strip()]
-        self.assertEqual(head["record_count"], len(base["records"]))
+        # `record_count` counts DATA records, which is what the load path recovers and compares
+        # after expansion. The stored array is longer by the intern sidecars it carries, so count
+        # what the head is actually describing rather than the raw array length.
+        stored = [r for r in base["records"]
+                  if str(r.get("record_type") or "") != A.INTERN_DICT_RECORD_TYPE]
+        self.assertEqual(head["record_count"], len(stored))
+        # Stronger than the length check it replaces: expanding the array has to yield exactly the
+        # count the head claims, which a stray sidecar or a dropped record would break.
+        self.assertEqual(head["record_count"],
+                         len(A.expand_interned_records(list(base["records"]))))
         self.assertEqual(head["delta_count"], len(tail))
         self.assertEqual(self.SEED + 6, head["record_count"] + head["delta_count"])
 

--- a/tools/test_matrixark_snapshot_stores_what_the_log_compresses.py
+++ b/tools/test_matrixark_snapshot_stores_what_the_log_compresses.py
@@ -1,0 +1,132 @@
+"""The durable snapshot and the durable log hold the same records; they must hold them the same way.
+
+The log replaces each record's interned metadata with a bundle token and writes one sidecar per
+distinct bundle. The snapshot was writing those same records fully expanded, which made the largest
+file in the store the one copy of the data that had opted out of the compression -- measured at
+3,849 KB against 2,185 KB for 1,225 records.
+
+What these tests pin, in order: the snapshot really is written interned; a reader gets back exactly
+what a reader of the log gets, values included; the saving is real rather than a rounding artifact;
+and a reader that predates the format is sent to the log instead of being handed tokens it cannot
+expand.
+"""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_mcp_local_adapter as adapter_module
+from matrixark_mcp_local_adapter import (
+    INTERN_BUNDLE_TOKEN_KEY,
+    INTERN_DICT_RECORD_TYPE,
+    LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,
+    MatrixArkLocalAdapter,
+)
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def skill_text(index: int, sections: int = 12) -> str:
+    lines = ["# Runbook %d" % index, "", "A procedure for case %d." % index, ""]
+    for step in range(sections):
+        lines += ["## Step %d" % step, "",
+                  "Check the queue depth for case %d step %d and drain it." % (index, step), ""]
+    return "\n".join(lines)
+
+
+class SnapshotStoresWhatTheLogCompressesTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="snapshot_interned_"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.log = self.root / "events.jsonl"
+        writer = MatrixArkLocalAdapter(self.log)
+        for index in range(3):
+            writer.ingest({
+                "kind": "skill", "scope": SCOPE, "text": skill_text(index),
+                "metadata": {"raw_uri": "file:///s/r-%d.md" % index, "title": "r-%d" % index},
+            })
+        writer.close(timeout_s=600)
+        # A read is what materialises the snapshot, so take one and keep what it returned.
+        self.from_log = MatrixArkLocalAdapter(self.log).read_all()
+        self.base = self.root / "events.jsonl.read-cache.json"
+        self.assertTrue(self.base.exists(), "no base snapshot was written, so nothing is under test")
+
+    def _snapshot_records(self) -> list:
+        payload = json.loads(self.base.read_text(encoding="utf-8"))
+        records = payload.get("records")
+        self.assertIsInstance(records, list)
+        return records
+
+    def test_the_snapshot_is_written_interned(self) -> None:
+        records = self._snapshot_records()
+        sidecars = [r for r in records
+                    if str(r.get("record_type") or "") == INTERN_DICT_RECORD_TYPE]
+        tokened = [r for r in records if INTERN_BUNDLE_TOKEN_KEY in r]
+        # Positive control first: a corpus with nothing to intern would satisfy every other
+        # assertion here vacuously, so require that interning had something to do.
+        self.assertGreater(len(tokened), 0, "no record was interned, so the format is untested")
+        self.assertGreater(len(sidecars), 0, "records carry tokens with no sidecar to expand them")
+        # And the compression has to be real: far fewer sidecars than the records citing them.
+        self.assertLess(len(sidecars), len(tokened),
+                        "one sidecar per tokened record stores no less than storing the values")
+
+    def test_a_reader_gets_back_what_the_log_gives(self) -> None:
+        from_snapshot = MatrixArkLocalAdapter(self.log).read_all()
+        self.assertEqual(len(from_snapshot), len(self.from_log))
+        # Compare the records themselves, not their count: expanding to the wrong values, or
+        # dropping an interned field, keeps the count exactly right.
+        self.assertEqual(
+            json.dumps(from_snapshot, sort_keys=True, default=str),
+            json.dumps(self.from_log, sort_keys=True, default=str),
+        )
+        # The interned fields are the ones at risk, so name one and require it present.
+        with_route = [r for r in from_snapshot if r.get("storage_route")]
+        self.assertGreater(len(with_route), 0,
+                           "storage_route survived on no record, so expansion dropped it")
+        self.assertNotIn(INTERN_BUNDLE_TOKEN_KEY, from_snapshot[0],
+                         "a token reached a caller, which should only ever see expanded records")
+
+    def test_the_snapshot_is_smaller_than_the_expanded_form(self) -> None:
+        records = self._snapshot_records()
+        interned = len(json.dumps(records, separators=(",", ":"), default=str))
+        expanded = len(json.dumps(self.from_log, separators=(",", ":"), default=str))
+        self.assertLess(interned, expanded,
+                        "the interned snapshot is no smaller than the expanded records")
+        # A 1% win would be within noise of the sidecars it adds; require the saving to be worth
+        # the format change. Measured at 40-43% across corpus sizes.
+        self.assertLess(interned, expanded * 0.85,
+                        "saving is %.1f%%, too small to justify the stored format"
+                        % (100.0 * (expanded - interned) / expanded))
+
+    def test_an_older_reader_is_sent_back_to_the_log(self) -> None:
+        head_path = self.root / ".events.jsonl.read-cache-head.json"
+        head = json.loads(head_path.read_text(encoding="utf-8"))
+        self.assertEqual(head.get("schema_version"), LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION)
+        # Stamp the head with the version that predates interning, which is what an older writer
+        # would have left, and confirm the loader declines it rather than expanding nothing.
+        head["schema_version"] = LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION - 1
+        head_path.write_text(json.dumps(head, separators=(",", ":")) + "\n", encoding="utf-8")
+        reader = MatrixArkLocalAdapter(self.log)
+        loaded = reader._load_durable_read_cache({"total_size": os.path.getsize(self.log)})
+        self.assertIsNone(loaded, "a snapshot from an unknown format version was accepted")
+        # The store still serves, because declining the snapshot falls back to the log.
+        self.assertEqual(
+            json.dumps(reader.read_all(), sort_keys=True, default=str),
+            json.dumps(self.from_log, sort_keys=True, default=str),
+        )
+
+    def test_the_expansion_shares_one_object_per_value(self) -> None:
+        records = MatrixArkLocalAdapter(self.log).read_all()
+        holders = [r for r in records if isinstance(r.get("storage_route"), (dict, list, str))]
+        self.assertGreater(len(holders), 4, "too few records carry the field to show sharing")
+        objects = {id(r["storage_route"]) for r in holders}
+        self.assertLess(len(objects), len(holders),
+                        "%d records hold %d separate copies of storage_route"
+                        % (len(holders), len(objects)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The durable read-cache snapshot and the durable log hold the same records. The log writes each one
with its interned metadata replaced by a bundle token, plus one sidecar per distinct bundle. The
snapshot was writing `"records": records` verbatim — fully expanded — so the largest file in a
store was the one copy of the data that had opted out of the compression.

Nothing in the code relates the two files, which is why this held: the writer that compresses and
the writer that does not are two hundred lines apart and neither mentions the other.

## The snapshot is the file that matters

Across 14 stores real runs left behind, the base snapshot is consistently larger than the log —
1.4x typically, and 9.7x on the largest (207 MB of snapshot against 22 MB of log, because the log
compacts and the snapshot holds everything).

The delta tail was **0 bytes on all 14**, so the base is the whole cache and fixing the base covers
all of it.

## What it saves

The saving is the per-record cost of the interned fields, so it tracks how much of a record is
metadata rather than body:

| store | as written | interned | saving |
|---|---|---|---|
| 3,022 small records | 13.4 MB | 4.3 MB | **67.8%** |
| 100,105 records, text and vectors dominant | 207.2 MB | 186.3 MB | **10.1%** |

Sidecars stay flat as the corpus grows — 22 for 99,919 tokened records, and 17 whether the store
holds 105 records or 1,225 — so this is the whole per-record cost of those fields rather than a
ratio that decays with corpus size.

Fewer bytes on disk is also fewer bytes to parse on a cold load, since the snapshot is read with a
single `json.load`.

## The change

- `_write_durable_read_cache` encodes through `encode_interned_records`, the same encoder the log
  uses. `record_count` still counts data records; the encoded list is longer by its sidecars.
- `_load_durable_read_cache` calls `expand_interned_records` before the count check. It is called
  unconditionally rather than behind the intern flag, because the flag can differ between the
  process that wrote the file and the one reading it; with nothing interned it takes the no-op path,
  so an existing snapshot loads unchanged.
- `LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION` 1 → 2. This is the safety: an older reader would
  otherwise serve tokenised records with the interned fields silently missing. An unrecognised
  version sends it back to the log, which is the same fallback a missing snapshot already takes.

## Tests

`test_matrixark_snapshot_stores_what_the_log_compresses.py`, five tests: the snapshot really is
written interned (with a positive control, since a corpus with nothing to intern would satisfy
every other assertion vacuously); a reader gets back exactly what a reader of the log gets, values
compared rather than counted; the saving is large enough to be worth the stored format; an older
reader is sent back to the log and the store still serves; and the expansion yields one shared
object per distinct value rather than a copy per record.

Two of the five fail on `main` and three pass there — the three are invariants that should hold
either way. Both arms built with `git archive`, so neither carries anything from a working tree.

Full python suite run on both arms and diffed by failing test NAME: no failure on this branch that
`main` does not already have.
