### PR TITLE
Keep the payload on the record that exists to carry it

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4633,7 +4633,17 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if LOCAL_JSONL_INCLUDE_BULKY_FIELDS:
             return record
         sanitized = dict(record)
-        dropped = sorted(field for field in LOCAL_JSONL_BULKY_FIELDS if field in sanitized)
+        bulky = LOCAL_JSONL_BULKY_FIELDS
+        if sanitized.get("record_type") == "context_debug_record":
+            # On this record type debug_payload is the entire content, not incidental bulk riding
+            # on a larger row. The writer refuses to emit the record at all without a payload
+            # (materialize_serving_record returns early), and the record only exists when the
+            # caller opts in via MATRIXARK_CONTEXT_DEBUG_RECORDS. Stripping the payload here left
+            # a husk that costs bytes and tells every reader nothing -- so the opt-in bought no
+            # diagnostics unless the caller also knew to set the unrelated bulky-fields flag.
+            # Every other record type keeps the default treatment.
+            bulky = bulky - {"debug_payload"}
+        dropped = sorted(field for field in bulky if field in sanitized)
         for field in dropped:
             sanitized.pop(field, None)
         if dropped:

--- a/tools/test_matrixark_python_module_boundaries.py
+++ b/tools/test_matrixark_python_module_boundaries.py
@@ -968,6 +968,52 @@ class MatrixArkMcpProtocolHardeningTest(unittest.TestCase):
         self.assertFalse(any(record.get("record_type") == "context_pack_audit" for record in records))
         self.assertFalse(any(record.get("record_type") == "context_pack_telemetry" for record in records))
 
+    def test_context_debug_record_keeps_its_payload_through_the_local_log(self) -> None:
+        # debug_payload is on the local-JSONL bulky strip list, which is correct for rows where it
+        # is incidental. On context_debug_record it is the entire record -- the writer refuses to
+        # emit one without a payload -- so stripping it stored a husk, and opting in via
+        # MATRIXARK_CONTEXT_DEBUG_RECORDS bought no diagnostics at all. The exemption is limited
+        # to that record type and to that one field; this test pins both edges.
+        server = self._server()
+        adapter = server.adapter
+        # Read the flag off the live method's globals rather than by module name: discovery keeps
+        # several generations of the adapter module alive, so importing it by name can return a
+        # different object than the one defining the class in use here.
+        live_globals = type(adapter)._sanitize_jsonl_record.__globals__
+        self.assertFalse(
+            live_globals["LOCAL_JSONL_INCLUDE_BULKY_FIELDS"],
+            "this test is only meaningful against the default, stripping configuration")
+
+        adapter.append_many(
+            [
+                {
+                    "record_type": "context_debug_record",
+                    "debug_type": "event_extraction_detail",
+                    "ref_type": "event",
+                    "ref_hash": 7,
+                    "debug_payload": {"kept": True},
+                    "raw_payload": {"stripped": True},
+                    "updated_at_ms": 1780000000000,
+                },
+                {
+                    "record_type": "agent_message",
+                    "role": "tool",
+                    "text": "summary",
+                    "debug_payload": {"stripped": True},
+                    "updated_at_ms": 1780000000001,
+                },
+            ]
+        )
+        records = adapter.read_all()
+        debug = next(record for record in records if record.get("record_type") == "context_debug_record")
+        message = next(record for record in records if record.get("record_type") == "agent_message")
+
+        self.assertEqual({"kept": True}, debug["debug_payload"])
+        # Only the defining field is exempt -- other bulky fields still go.
+        self.assertNotIn("raw_payload", debug)
+        # And no other record type is affected by the exemption.
+        self.assertNotIn("debug_payload", message)
+
     def test_storage_options_are_validated_stored_and_audited(self) -> None:
         core_modules = []
         for module_name in ("matrixark_mcp_core", "tools.matrixark_mcp_core"):


### PR DESCRIPTION
`test_storage_options_are_validated_stored_and_audited` died on `KeyError:
'debug_payload'`. The record it reads is a context_debug_record, whose entire
content is that one field: materialize_serving_record computes the payload and
returns early rather than emit a record without one.

But debug_payload is a member of LOCAL_JSONL_BULKY_FIELDS, and
LOCAL_JSONL_INCLUDE_BULKY_FIELDS defaults to False, so the local write path
stripped exactly the field the writer had insisted on, and stored the husk the
writer declined to write. Measured by appending one record and reading it back:
present before append_many, absent after read_all and absent on the raw log;
present at every stage with MATRIXARK_LOCAL_JSONL_INCLUDE_BULKY_FIELDS=1, which
is the positive control.

The records are themselves opt-in behind MATRIXARK_CONTEXT_DEBUG_RECORDS, which
defaults to "0". So switching the diagnostic on bought no diagnostics at all
unless the caller also knew to set a second, unrelated flag. At least six readers
do record.get("debug_payload", {}) and cannot tell a stripped payload from
nothing to report: matrixark_mcp_dashboard.py:54,
matrixark_local_adapter_dashboard.py:114,
matrixark_local_adapter_summaries.py:340,
matrixark_mcp_time_compression_runtime.py:202 and :360,
matrixark_local_adapter_ingest.py:3830.

Stripping stays the default everywhere else, including debug_payload on rows
where it really is incidental bulk. The exemption is one field on one record
type.

I fixed this in the test first, by pinning the bulky-fields flag, and the sweep
showed that was wrong: it passed standalone and changed nothing under discovery,
because discovery keeps several generations of the adapter module alive and
patching by module name need not reach the one defining the class in use. The
test was right and the write path was wrong.

The new test reads the flag off the live method's __globals__ for that reason,
and pins both edges: raw_payload still goes from a debug record, and
debug_payload still goes from an agent_message.

Mutation-tested: reverting the adapter change fails the new test on
KeyError: 'debug_payload'.

Full `unittest discover`: 102 failing names to 101, the one name being the
target. No name appeared.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
