### PR TITLE
Every page says which scope a refusal wanted

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -894,6 +894,22 @@
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -749,6 +749,22 @@
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -298,6 +298,22 @@ NAV_JS = r'''<script>
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -1608,7 +1624,7 @@ function liveStream(options) {
       .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
       .then(function (res) {
         if (!res.ok) {
-          say($("polMsg"), res.body.detail || res.body.error || "Save failed.", "err");
+          say($("polMsg"), window.__matrixarkWhy(res.body, "Save failed."), "err");
           return;
         }
         policyView = res.body;
@@ -1796,7 +1812,7 @@ function liveStream(options) {
       .then(function (res) {
         $("save").disabled = false;
         if (!res.ok) {
-          say($("saveMsg"), res.body.detail || res.body.error || "Save failed.", "err");
+          say($("saveMsg"), window.__matrixarkWhy(res.body, "Save failed."), "err");
           return;
         }
         var restart = res.body.restart_required || [];
@@ -2216,7 +2232,7 @@ function liveStream(options) {
       .then(function (res) {
         $("importCfg").disabled = false;
         if (!res.ok) {
-          say($("importMsg"), res.b.detail || res.b.error || failure(res.s), "err");
+          say($("importMsg"), window.__matrixarkWhy(res.b, failure(res.s)), "err");
           return;
         }
         var n = Object.keys(settings).length;
@@ -2617,7 +2633,7 @@ CATALOG_JS = r"""
         if (!res.ok) {
           say($("listMsg"), res.status === 403
             ? "This key cannot change skills. It needs skill:manage."
-            : (res.body.detail || res.body.error || "Could not update the skill."), "err");
+            : window.__matrixarkWhy(res.body, "Could not update the skill."), "err");
           return;
         }
         /* load() clears the message area, so refresh first and confirm after -- otherwise the

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -667,7 +667,7 @@
         if (!res.ok) {
           say($("listMsg"), res.status === 403
             ? "This key cannot change skills. It needs skill:manage."
-            : (res.body.detail || res.body.error || "Could not update the skill."), "err");
+            : window.__matrixarkWhy(res.body, "Could not update the skill."), "err");
           return;
         }
         /* load() clears the message area, so refresh first and confirm after -- otherwise the
@@ -867,6 +867,22 @@
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -1826,6 +1826,22 @@
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -390,7 +390,7 @@
       })
       .then(function (res) {
         if (!res.ok) {
-          say($("startMsg"), res.body.detail || res.body.error || failure(res.status), "err");
+          say($("startMsg"), window.__matrixarkWhy(res.body, failure(res.status)), "err");
           return;
         }
         say($("startMsg"), "Retrying " + res.body.total + " document" +
@@ -720,6 +720,22 @@
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -912,6 +912,22 @@ function liveStream(options) {
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/refusal_message_harness.js
+++ b/tools/portal/refusal_message_harness.js
@@ -1,0 +1,82 @@
+/* Run the shared "why was this refused" helper against the shapes the edge actually answers with.
+ *
+ * The interesting cases are not readable from the source: which half wins when both `detail` and
+ * `error` are present, and whether the scope list is appended to that or quietly replaces it. The
+ * edge sends `detail` for a rejected value ("extraction.provider must be one of ...") and
+ * `required` for a refused scope, and a message that shows one and drops the other is how an
+ * operator ends up guessing at something the response already answered.
+ *
+ * Usage: node refusal_message_harness.js <page.html> [more pages...]
+ */
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* Read out of a built page rather than the generator: this is the copy a browser runs. */
+function helperFrom(file) {
+  const page = fs.readFileSync(file, "utf8");
+  const marker = "window.__matrixarkWhy = function (body, fallback) {";
+  const start = page.indexOf(marker);
+  if (start < 0) { return null; }
+  const end = page.indexOf("\n  };", start);
+  const win = { window: null };
+  win.window = win;
+  new Function("window", page.slice(start, end + 5))(win);
+  return win.__matrixarkWhy;
+}
+
+const pages = process.argv.slice(2);
+ok("pages were given", pages.length > 0, "none");
+
+let carried = 0;
+for (const file of pages) {
+  const name = path.basename(file);
+  const why = helperFrom(file);
+  if (why === null) {
+    console.log("FAIL " + name + " does not carry the shared refusal helper");
+    failures += 1;
+    continue;
+  }
+  carried += 1;
+
+  ok(name + ": a scope refusal names the scope",
+     /admin:api_key/.test(why({ error: "insufficient_scope", required: ["admin:api_key"] }, "no")),
+     why({ error: "insufficient_scope", required: ["admin:api_key"] }, "no"));
+
+  ok(name + ": and still says what was refused",
+     /insufficient_scope/.test(why({ error: "insufficient_scope", required: ["admin:api_key"] },
+                                   "no")));
+
+  /* A rejected VALUE carries detail and no required: the detail is the whole answer. */
+  const value = why({ error: "invalid_value", detail: "extraction.provider must be one of x, y" },
+                    "Save failed.");
+  ok(name + ": a rejected value shows the reason, not the code",
+     /must be one of/.test(value) && !/^invalid_value/.test(value), value);
+
+  /* Both halves present: neither may swallow the other. */
+  const both = why({ error: "insufficient_scope", detail: "writing settings needs a write scope",
+                     required: ["admin:api_key"] }, "no");
+  ok(name + ": detail and scope both survive",
+     /write scope/.test(both) && /admin:api_key/.test(both), both);
+
+  ok(name + ": more than one acceptable scope is listed",
+     /admin:api_key or admin:audit/.test(
+       why({ error: "insufficient_scope", required: ["admin:api_key", "admin:audit"] }, "no")));
+
+  ok(name + ": an empty body falls back", why({}, "Save failed.") === "Save failed.");
+  ok(name + ": a missing body falls back", why(null, "Save failed.") === "Save failed.");
+  ok(name + ": nothing is appended when nothing was required",
+     why({ error: "boom" }, "no") === "boom");
+}
+
+ok("every page given carries the helper", carried === pages.length,
+   carried + " of " + pages.length);
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1498,7 +1498,7 @@ function liveStream(options) {
       .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
       .then(function (res) {
         if (!res.ok) {
-          say($("polMsg"), res.body.detail || res.body.error || "Save failed.", "err");
+          say($("polMsg"), window.__matrixarkWhy(res.body, "Save failed."), "err");
           return;
         }
         policyView = res.body;
@@ -1686,7 +1686,7 @@ function liveStream(options) {
       .then(function (res) {
         $("save").disabled = false;
         if (!res.ok) {
-          say($("saveMsg"), res.body.detail || res.body.error || "Save failed.", "err");
+          say($("saveMsg"), window.__matrixarkWhy(res.body, "Save failed."), "err");
           return;
         }
         var restart = res.body.restart_required || [];
@@ -2106,7 +2106,7 @@ function liveStream(options) {
       .then(function (res) {
         $("importCfg").disabled = false;
         if (!res.ok) {
-          say($("importMsg"), res.b.detail || res.b.error || failure(res.s), "err");
+          say($("importMsg"), window.__matrixarkWhy(res.b, failure(res.s)), "err");
           return;
         }
         var n = Object.keys(settings).length;
@@ -2336,6 +2336,22 @@ function liveStream(options) {
    a copier defined after that line would not exist on those pages. */
 (function () {
   "use strict";
+  /* Why a request was refused, in the words the edge used. A scope refusal answers
+     {"error": "insufficient_scope", "required": ["admin:api_key"]}, and showing the code alone
+     leaves the operator guessing at the one thing the answer already contained -- and the scope
+     name is exactly the string to tick when issuing the key.
+
+     `detail` still wins where there is one: it names the setting and the reason. The scope is
+     appended to that rather than replacing it. */
+  window.__matrixarkWhy = function (body, fallback) {
+    body = body || {};
+    var text = body.detail || body.error || fallback;
+    if (body.required && body.required.length) {
+      text += " — this needs " + [].concat(body.required).join(" or ");
+    }
+    return text;
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/test_matrixark_every_page_says_which_scope_a_refusal_wanted.py
+++ b/tools/test_matrixark_every_page_says_which_scope_a_refusal_wanted.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every page says which scope a refusal wanted, not just that it was refused.
+
+The key portal was fixed for this. Four other places answered the same way and dropped the same
+field: the policy save, the settings save, the settings import and the skill update all reduced a
+failure to ``detail || error`` and threw away the ``required`` list beside it.
+
+The edge answers a scope refusal as ``{"error": "insufficient_scope", "required":
+["admin:api_key"]}`` and the operator read *insufficient_scope*. That became a likelier answer
+rather than a rarer one when configuration writes stopped accepting ``admin:audit`` — the settings
+save and the policy save are exactly the calls a read-scoped key now loses.
+
+One helper in the shared nav script rather than four copies, because four copies of a sentence is
+how three of them come to say something slightly different.
+
+Two things here are not readable from the source, and both are about which half survives:
+``detail`` names the setting and the reason and must win over the bare code, and the scope list is
+*appended* to that rather than replacing it. A message that shows one and drops the other is the
+same defect wearing different words.
+"""
+from __future__ import annotations
+
+import glob
+import io
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "refusal_message_harness.js")
+
+# Every portal page carries the shared nav script, so every one of them carries this.
+MIN_PAGES = 7
+
+
+def pages() -> list:
+    return sorted(glob.glob(os.path.join(PORTAL, "*.html")))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheHelperAnswersWithBothHalvesTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS] + pages(),
+                              capture_output=True, text=True, timeout=180)
+
+    def test_every_page_carries_it(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+        self.assertIn("ok   every page given carries the helper", proc.stdout)
+
+    def test_a_scope_refusal_names_the_scope(self) -> None:
+        self.assertIn("a scope refusal names the scope", self._run().stdout)
+
+    def test_a_rejected_value_shows_the_reason_not_the_code(self) -> None:
+        self.assertIn("a rejected value shows the reason, not the code", self._run().stdout)
+
+    def test_neither_half_swallows_the_other(self) -> None:
+        self.assertIn("detail and scope both survive", self._run().stdout)
+
+
+class NoCallerStillDropsTheFieldTest(unittest.TestCase):
+    """The helper is only worth having if the callers use it; a page keeping its own
+    `detail || error` would go on dropping the scope while this file reports success."""
+
+    GENERATOR = os.path.join(PORTAL, "build_portal_pages.py")
+
+    def test_the_scan_covers_the_pages_it_claims_to(self) -> None:
+        self.assertGreaterEqual(len(pages()), MIN_PAGES,
+                                "found %d portal pages" % len(pages()))
+
+    def test_no_page_reduces_a_failure_to_detail_or_error(self) -> None:
+        stale = []
+        for path in pages() + [self.GENERATOR]:
+            with io.open(path, encoding="utf-8") as handle:
+                source = handle.read()
+            for pattern in ("res.body.detail || res.body.error",
+                            "res.b.detail || res.b.error"):
+                if pattern in source:
+                    stale.append("%s: %s" % (os.path.basename(path), pattern))
+        self.assertEqual([], stale,
+                         "these still drop the scope the edge named: %r" % stale)
+
+    def test_the_helper_is_defined_where_the_callers_can_reach_it(self) -> None:
+        """It lives in the shared nav script, which is emitted after each page's own — so a caller
+        reaching for it at load time would throw, and inside a handler will not."""
+        for path in pages():
+            with io.open(path, encoding="utf-8") as handle:
+                source = handle.read()
+            if "__matrixarkWhy(" not in source:
+                continue
+            self.assertIn("window.__matrixarkWhy = function", source,
+                          "%s calls the helper but does not carry it" % os.path.basename(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The key portal was fixed for this in #799. **Five** other places answered the same way and dropped
the same field:

| where | what it did |
|---|---|
| policy save | `res.body.detail \|\| res.body.error` |
| settings save | `res.body.detail \|\| res.body.error` |
| settings import | `res.b.detail \|\| res.b.error` |
| skill update | `res.body.detail \|\| res.body.error` |
| ingestion start | `res.body.detail \|\| res.body.error` |

The edge answers a scope refusal as `{"error": "insufficient_scope", "required":
["admin:api_key"]}` and the operator read *insufficient_scope*. That became a **likelier** answer
rather than a rarer one when configuration writes stopped accepting `admin:audit` (#791, #800) —
the settings save and the policy save are exactly the calls a read-scoped key now loses.

One helper in the shared nav script rather than five copies, because five copies of a sentence is
how four of them come to say something slightly different. `detail` still wins where the edge sends
one — it names the setting and the reason — and the scope is **appended** to it rather than
replacing it.

### The fifth site was found by the guard, not by the sweep

I grepped the generator and found four. `ingestion_portal.html` is hand-maintained rather than
generated, so that sweep could never have reached it. The check scans the built pages *and* the
generator, and named it on the first run — which is the whole reason it exists rather than a test
that just re-asserts the four I already knew about.

### On the tests

Both halves surviving is what cannot be read off the source, so the harness asserts them
separately: a rejected value shows its reason rather than the bare code, and a refusal carrying
both a `detail` and a `required` keeps both. Verified red first — the harness fails on the page as
it stands, because no page carries the helper yet.

Suites green: portal_pages (4), copy_button (6), live_strip (38), dashboards (20), portal_tabs (19),
key-portal scope message (5), plus 7 new.
