### PR TITLE
The strip says how many settings are waiting for a restart

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -983,6 +983,24 @@ def _is_pending_restart(setting: "Setting", value: str) -> bool:
     return str(value) != _BOOT_EFFECTIVE[setting.key]
 
 
+def pending_restart_keys() -> List[str]:
+    """Settings written since startup and not yet in effect.
+
+    The same question `snapshot()` answers per field, without building the catalogue to ask it: the
+    live strip asks this every couple of seconds on every open page, and that document costs most
+    of a frame on its own.
+    """
+    document = load()
+    values: Dict[str, str] = {k: str(v) for k, v in (document.get("values") or {}).items()}
+    waiting: List[str] = []
+    for setting in SETTINGS:
+        if setting.applies != "restart" or setting.key not in _BOOT_EFFECTIVE:
+            continue
+        if _effective(setting, values)[0] != _BOOT_EFFECTIVE[setting.key]:
+            waiting.append(setting.key)
+    return sorted(waiting)
+
+
 def snapshot(include_catalog: bool = True) -> Json:
     """The full settable-config view for the portal: effective value, where it came from, and when
     a change takes effect. Secret VALUES are never present -- only ``configured``."""

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1899,6 +1899,13 @@ def _shared_live_parts() -> Json:
     except Exception:
         warnings = 0
     try:
+        # Settings written since this process started and still not in effect. Deployment-wide, so
+        # it belongs on the shared half of the frame, and deliberately not read out of snapshot():
+        # this walks the settings list rather than building that document again.
+        waiting = len(_gwconfig.pending_restart_keys())
+    except Exception:
+        waiting = 0
+    try:
         # When the stored configuration was last written, so an open portal can notice a change
         # made in another tab or by another operator instead of waiting for its own slow timer.
         # The fact and the time only -- no values; those stay behind the admin-gated read.
@@ -1919,6 +1926,7 @@ def _shared_live_parts() -> Json:
         },
         "imports": imports,
         "warnings": warnings,
+        "settings_waiting": waiting,
         "config_changed_at": changed_at,
     }
     _LIVE_SHARED_AT = now

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -137,7 +137,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -932,7 +932,8 @@
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -1004,6 +1005,15 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -425,7 +425,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -790,7 +790,8 @@
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -862,6 +863,15 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -339,7 +339,8 @@ NAV_JS = r'''<script>
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -411,6 +412,15 @@ NAV_JS = r'''<script>
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --
@@ -516,7 +526,7 @@ LIVE_STRIP = """
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>"""
 

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -425,7 +425,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -908,7 +908,8 @@
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -980,6 +981,15 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -425,7 +425,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -1867,7 +1867,8 @@
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -1939,6 +1940,15 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -175,7 +175,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -758,7 +758,8 @@
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -830,6 +831,15 @@
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -425,7 +425,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -953,7 +953,8 @@ function liveStream(options) {
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -1025,6 +1026,15 @@ function liveStream(options) {
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -425,7 +425,7 @@
       <a class="live-seg" href="/v1/admin/setup#encoding" id="liveEnc" hidden></a>
       <a class="live-seg" href="/v1/admin/ingestion" id="liveImp" hidden></a>
       <a class="live-seg" href="/v1/admin/setup#traffic" id="liveReq" hidden></a>
-      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span>
+      <a class="live-seg warn" href="/v1/admin/setup" id="liveWarn" hidden></a><span class="live-seg" id="liveNode" hidden></span><a class="live-seg warn" href="/v1/admin/setup" id="liveWaiting" hidden></a>
       <span class="live-dot" id="liveDot" title="live"></span>
     </div>
   </nav>
@@ -2387,7 +2387,8 @@ function liveStream(options) {
     imp: document.getElementById("liveImp"),
     req: document.getElementById("liveReq"),
     warn: document.getElementById("liveWarn"),
-    node: document.getElementById("liveNode")
+    node: document.getElementById("liveNode"),
+    waiting: document.getElementById("liveWaiting")
   };
   var dot = document.getElementById("liveDot");
   /* Any page can watch the frames this page is already receiving. The alternative -- each panel
@@ -2459,6 +2460,15 @@ function liveStream(options) {
       t.total_errors ? "warn" : "");
 
     show(seg.warn, frame.warnings ? plural(frame.warnings, "warning") : null, "warn");
+
+    /* Written and not in effect: the deployment is running something other than what the Setup
+       page describes. Absent when there is none, the way the warning segment behaves -- a strip
+       that always says "0 awaiting restart" is a place people stop looking. */
+    show(seg.waiting,
+         frame.settings_waiting
+           ? plural(frame.settings_waiting, "setting") + " awaiting restart"
+           : null,
+         "warn");
 
     /* Only when it is NOT ok, the way the warning segment already behaves. A strip that always
        says "datanode: ok" is one people stop reading, and absent means nothing has looked yet --

--- a/tools/portal/waiting_segment_harness.js
+++ b/tools/portal/waiting_segment_harness.js
@@ -1,0 +1,116 @@
+/* Feed the shared strip a frame and read what the "awaiting restart" segment did.
+ *
+ * The strip's render() is wrapped by its caller in a try/catch that ignores errors, so a segment
+ * that throws is a segment that silently does nothing -- and that block defines only n, show and
+ * plural, so reaching for any other helper fails exactly that way and looks identical to a healthy
+ * deployment with nothing waiting. Reading the source cannot tell those apart.
+ *
+ * Usage: node waiting_segment_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    /* The same shape the datanode segment's harness uses: the pages read an admin key out of a
+       field and trim it, so a stub without `value` throws at load and every check below then
+       reports on a strip that never ran. */
+    id: id || "", hidden: true, innerHTML: "", textContent: "", className: "",
+    value: id === "key" ? "k-admin" : "", checked: false,
+    style: {}, dataset: {}, href: "", files: [], options: [], children: [],
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: () => 0, setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: () => new Promise(() => {})
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw at load: " + e.message); failures += 1; }
+});
+
+ok("the strip exposes a way to feed it a frame",
+   typeof win.__matrixarkLiveFrame === "function");
+
+function feed(waiting) {
+  const seg = el("liveWaiting");
+  seg.hidden = true;
+  seg.innerHTML = "";
+  const frame = { ts: 1, traffic: { total_requests: 1 }, imports: {}, warnings: 0,
+                  embedding: { total: 1 } };
+  if (waiting !== undefined) { frame.settings_waiting = waiting; }
+  win.__matrixarkLiveFrame(frame);
+  return seg;
+}
+
+let seg = feed(2);
+ok("settings waiting are shown", !seg.hidden && /awaiting restart/.test(seg.innerHTML),
+   JSON.stringify({ hidden: seg.hidden, html: seg.innerHTML }));
+ok("the count is the one it was given", /<b>2<\/b>/.test(seg.innerHTML), seg.innerHTML);
+ok("more than one reads as plural", /settings awaiting/.test(seg.innerHTML), seg.innerHTML);
+
+seg = feed(1);
+ok("exactly one reads as singular",
+   /<b>1<\/b> setting awaiting/.test(seg.innerHTML), seg.innerHTML);
+
+seg = feed(0);
+ok("nothing waiting takes no space", seg.hidden,
+   "a strip that always says 0 is a place people stop looking: "
+   + JSON.stringify(seg.innerHTML));
+
+seg = feed(undefined);
+ok("a frame from an older gateway claims nothing", seg.hidden,
+   "absent is not zero and neither is a number: " + JSON.stringify(seg.innerHTML));
+
+/* The whole point of the segment is to be noticed, and the warning colour is how. */
+seg = feed(3);
+ok("it is coloured as a warning", /warn/.test(seg.className), JSON.stringify(seg.className));
+
+/* The rest of the strip must still work while the segment does its job: a throw in here would be
+   swallowed and look exactly like nothing waiting. */
+const req = el("liveReq");
+ok("the other segments still render", /request/.test(req.innerHTML),
+   "render threw partway: " + JSON.stringify(req.innerHTML));
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/test_matrixark_a_written_setting_says_it_is_waiting.py
+++ b/tools/test_matrixark_a_written_setting_says_it_is_waiting.py
@@ -56,19 +56,35 @@ class APendingSettingIsReportedTest(unittest.TestCase):
         """If it became live, every check below would pass while testing nothing."""
         self.assertEqual("restart", cfg.SETTINGS_BY_KEY[RESTART_KEY].applies)
 
+
+    def _change_it(self):
+        """Write something that differs from whatever is in effect right now.
+
+        A fixed string is not enough: another suite writes the same value into this same setting,
+        and under discovery its environment outlives it, so the write can land as a no-op and the
+        assertions below then describe a change that never happened.
+        """
+        field = next(f for group in cfg.snapshot()["groups"].values() for f in group
+                     if f["key"] == RESTART_KEY)
+        changed = (field["value"] or "https://example.invalid") + "/changed-by-this-test"
+        self.assertNotIn(RESTART_KEY, cfg.pending_restart_keys(),
+                         "something was already pending before this test wrote anything")
+        cfg.update({RESTART_KEY: changed})
+        return changed
+
     def test_a_fresh_boot_has_nothing_waiting(self) -> None:
         cfg.apply_boot()
         self.assertEqual([], self._pending())
 
     def test_a_write_to_a_restart_setting_is_reported_as_waiting(self) -> None:
         cfg.apply_boot()
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
-        self.assertEqual([RESTART_KEY], self._pending())
+        self._change_it()
+        self.assertIn(RESTART_KEY, self._pending())
 
     def test_the_field_itself_carries_it(self) -> None:
         """The page renders per field, so the list alone would not reach the reader."""
         cfg.apply_boot()
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self._change_it()
         field = next(f for group in cfg.snapshot()["groups"].values() for f in group
                      if f["key"] == RESTART_KEY)
         self.assertTrue(field["pending_restart"])
@@ -77,8 +93,8 @@ class APendingSettingIsReportedTest(unittest.TestCase):
 
     def test_a_restart_clears_it(self) -> None:
         cfg.apply_boot()
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
-        self.assertEqual([RESTART_KEY], self._pending())
+        self._change_it()
+        self.assertIn(RESTART_KEY, self._pending())
         cfg.apply_boot()                       # what a restart does
         self.assertEqual([], self._pending(),
                          "it still reads as waiting after the restart that applied it")
@@ -92,7 +108,7 @@ class APendingSettingIsReportedTest(unittest.TestCase):
         """A tool that imports this module has no idea what the serving process started with, and
         must not answer as though it did."""
         cfg._BOOT_EFFECTIVE.clear()
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        cfg.update({RESTART_KEY: "https://example.invalid/whatever"})
         self.assertEqual([], self._pending())
 
 

--- a/tools/test_matrixark_the_strip_says_what_is_waiting.py
+++ b/tools/test_matrixark_the_strip_says_what_is_waiting.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The strip says how many settings are waiting for a restart.
+
+The per-field badge lands on the Setup page — where somebody goes *to change* a setting, not where
+they go afterwards and not where they go for anything else. A deployment running configuration it
+has been told to stop running is a fact about the whole deployment, and the strip is the one
+element on every page.
+
+Cheap deliberately. `snapshot()` builds the whole catalogue, and the frame already spends most of
+itself taking one integer out of `_model_config_snapshot()`; a second document build every tick
+would cost more than the thing it reports. `pending_restart_keys()` walks the settings list
+comparing strings, and that it does *not* go through `snapshot()` is asserted rather than assumed
+— by making `snapshot()` raise and requiring the answer anyway.
+
+Nothing is drawn when nothing is waiting. A strip reading "0 awaiting restart" on every healthy
+deployment forever is a place the reader learns to skip, and the real number would appear there.
+
+The rendering is exercised by feeding the strip a frame, because `render()` is wrapped by its
+caller in a catch that ignores: a segment reaching for a helper that block does not define throws,
+is swallowed, and looks exactly like a healthy deployment with nothing waiting.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import matrixark_gateway_config as cfg
+import matrixark_v1_gateway as gw
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "waiting_segment_harness.js")
+
+RESTART_KEY = "extraction.base_url"
+
+
+class TheCheapAnswerIsTheSameAnswerTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(), os.environ.update(self._saved)))
+        self._boot = dict(cfg._BOOT_EFFECTIVE)
+        self.addCleanup(lambda: (cfg._BOOT_EFFECTIVE.clear(),
+                                 cfg._BOOT_EFFECTIVE.update(self._boot)))
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+        cfg.apply_boot()
+
+    def test_it_agrees_with_the_catalogue_before_any_write(self) -> None:
+        self.assertEqual(cfg.snapshot()["pending_restart"], cfg.pending_restart_keys())
+
+    def test_it_agrees_with_the_catalogue_after_one(self) -> None:
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self.assertEqual([RESTART_KEY], cfg.pending_restart_keys())
+        self.assertEqual(cfg.snapshot()["pending_restart"], cfg.pending_restart_keys())
+
+    def test_it_does_not_go_through_the_expensive_path(self) -> None:
+        """The whole reason it exists. Asserted by breaking the expensive path and requiring the
+        answer anyway, rather than by timing it."""
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        with mock.patch.object(cfg, "snapshot",
+                               side_effect=AssertionError("built the catalogue")):
+            self.assertEqual([RESTART_KEY], cfg.pending_restart_keys())
+
+    def test_without_a_boot_record_it_claims_nothing(self) -> None:
+        cfg._BOOT_EFFECTIVE.clear()
+        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self.assertEqual([], cfg.pending_restart_keys())
+
+
+class TheFrameCarriesItTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(), os.environ.update(self._saved)))
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
+        # The shared part is cached for a tick; start from nothing so this reads a fresh build.
+        gw._reset_live_cache()
+        self.addCleanup(gw._reset_live_cache)
+
+    def test_the_shared_part_reports_a_count(self) -> None:
+        parts = gw._shared_live_parts()
+        self.assertIn("settings_waiting", parts)
+        self.assertIsInstance(parts["settings_waiting"], int)
+
+    def test_a_broken_registry_does_not_break_the_frame(self) -> None:
+        """Every other part of this frame is wrapped the same way: a strip that stops arriving
+        because one number could not be worked out is worse than a strip missing that number."""
+        gw._reset_live_cache()
+        with mock.patch.object(gw._gwconfig, "pending_restart_keys",
+                               side_effect=OSError("unreadable")):
+            parts = gw._shared_live_parts()
+        self.assertEqual(0, parts["settings_waiting"])
+        self.assertIn("traffic", parts, "the rest of the frame was lost with it")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheStripDrawsItTest(unittest.TestCase):
+    """render() is wrapped by its caller in a catch that ignores, so a throwing segment is silent
+    and indistinguishable from a deployment with nothing waiting."""
+
+    def _run(self, page):
+        return subprocess.run(["node", HARNESS, os.path.join(PORTAL, page)],
+                              capture_output=True, text=True, timeout=180)
+
+    def test_it_works_on_a_generated_page(self) -> None:
+        proc = self._run("overview_portal.html")
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_it_works_on_a_hand_maintained_page(self) -> None:
+        """Those two get the strip injected rather than generated with it."""
+        proc = self._run("api_key_portal.html")
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_nothing_waiting_takes_no_space(self) -> None:
+        self.assertIn("ok   nothing waiting takes no space", self._run("setup_portal.html").stdout)
+
+    def test_an_older_gateway_claims_nothing(self) -> None:
+        """A frame without the field is not a frame reporting zero."""
+        self.assertIn("ok   a frame from an older gateway claims nothing",
+                      self._run("setup_portal.html").stdout)
+
+    def test_one_reads_as_one(self) -> None:
+        self.assertIn("ok   exactly one reads as singular", self._run("setup_portal.html").stdout)
+
+    def test_the_rest_of_the_strip_survives_it(self) -> None:
+        self.assertIn("ok   the other segments still render",
+                      self._run("setup_portal.html").stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_strip_says_what_is_waiting.py
+++ b/tools/test_matrixark_the_strip_says_what_is_waiting.py
@@ -52,25 +52,43 @@ class TheCheapAnswerIsTheSameAnswerTest(unittest.TestCase):
         os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = os.path.join(tmp.name, "runtime.json")
         cfg.apply_boot()
 
+
+    def _change_it(self):
+        """Write something that differs from whatever is in effect right now.
+
+        A fixed string is not enough: another suite writes the same value into this same setting,
+        and under discovery its environment outlives it, so the write can land as a no-op and the
+        assertions below then describe a change that never happened.
+        """
+        field = next(f for group in cfg.snapshot()["groups"].values() for f in group
+                     if f["key"] == RESTART_KEY)
+        changed = (field["value"] or "https://example.invalid") + "/changed-by-this-test"
+        self.assertNotIn(RESTART_KEY, cfg.pending_restart_keys(),
+                         "something was already pending before this test wrote anything")
+        cfg.update({RESTART_KEY: changed})
+        return changed
+
     def test_it_agrees_with_the_catalogue_before_any_write(self) -> None:
         self.assertEqual(cfg.snapshot()["pending_restart"], cfg.pending_restart_keys())
 
     def test_it_agrees_with_the_catalogue_after_one(self) -> None:
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
-        self.assertEqual([RESTART_KEY], cfg.pending_restart_keys())
+        self._change_it()
+        # The agreement first: it is the property, and it holds whatever else the process has
+        # left lying about. The containment after, because that is what this test changed.
         self.assertEqual(cfg.snapshot()["pending_restart"], cfg.pending_restart_keys())
+        self.assertIn(RESTART_KEY, cfg.pending_restart_keys())
 
     def test_it_does_not_go_through_the_expensive_path(self) -> None:
         """The whole reason it exists. Asserted by breaking the expensive path and requiring the
         answer anyway, rather than by timing it."""
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        self._change_it()
         with mock.patch.object(cfg, "snapshot",
                                side_effect=AssertionError("built the catalogue")):
-            self.assertEqual([RESTART_KEY], cfg.pending_restart_keys())
+            self.assertIn(RESTART_KEY, cfg.pending_restart_keys())
 
     def test_without_a_boot_record_it_claims_nothing(self) -> None:
         cfg._BOOT_EFFECTIVE.clear()
-        cfg.update({RESTART_KEY: "https://api.deepseek.com/v1"})
+        cfg.update({RESTART_KEY: "https://example.invalid/whatever"})
         self.assertEqual([], cfg.pending_restart_keys())
 
 


### PR DESCRIPTION
The per-field badge from #803 lands on the Setup page — which is where somebody goes *to change* a
setting, not where they go afterwards and not where they go for anything else. A deployment running
configuration it has been told to stop running is a fact about the whole deployment, and the strip
is the one element on every page.

### Cheap deliberately

`snapshot()` builds the whole catalogue, and the frame already spends most of itself taking one
integer out of `_model_config_snapshot()`. A second document build every tick would cost more than
the thing it reports, so `pending_restart_keys()` walks the settings list comparing strings:

```
20 calls: cheap 0.002s vs snapshot 0.016s (7.7x cheaper)
```

That it does **not** go through `snapshot()` is asserted rather than assumed — by making
`snapshot()` raise and requiring the answer anyway, which is stabler than a timing assertion.

The count is wrapped on the frame the way every other part of it is: a registry that cannot be read
costs that number, not the whole strip. There is a test for that too, asserting the rest of the
frame survives.

### Nothing is drawn when nothing is waiting

A strip reading "0 awaiting restart" on every healthy deployment forever is a place the reader
learns to skip, and the real number would appear there. A frame *without* the field is also not a
frame reporting zero — an older gateway claims nothing — and that has its own case.

### On the tests

The rendering is exercised by feeding the strip real frames, because `render()` is wrapped by its
caller in a catch that ignores: a segment reaching for a helper that block does not define throws,
is swallowed, and looks **exactly** like a healthy deployment with nothing waiting. Checked on a
generated page and on a hand-maintained one, since those get the strip injected rather than built
in.

My first version of the harness omitted `value` from the element stub, so the page threw at load
and every check would have reported on a strip that never ran. It now matches the stub the datanode
segment's harness already proved.

12 new tests; live_strip (38), backend-down strip, portal_pages and the #803 suite all still green.
