### PR TITLE
A chunk pays for the branches it never takes

### DIFF
--- a/tools/matrixark_mcp_core_packing.py
+++ b/tools/matrixark_mcp_core_packing.py
@@ -615,6 +615,19 @@ def candidate_memory_layer_name(candidate: Json) -> str:
     elif not ref_type and record_type == "context_segment":
         ref_type = "segment"
     context_class = str(candidate.get("context_class") or metadata.get("context_class") or ref_type)
+    # These four answers need nothing beyond context_class and ref_type, and they are almost all
+    # of the traffic: over one retrieve, 84,841 of 88,340 calls (96%) end here -- 63,328
+    # skill_section and 21,513 resource_chunk. Deciding them before the block below, rather than
+    # after it, is what keeps a chunk from paying for three set comprehensions and a dozen lookups
+    # it never reads. Measured at 27.8% of a retrieve spent in this function.
+    if context_class == "resource_entity_fact":
+        return "resource_entity_fact"
+    if context_class == "resource_fact":
+        return "resource_fact"
+    if ref_type == "resource_chunk":
+        return "resource_chunk"
+    if ref_type == "skill_section":
+        return "skill_section"
     memory_scope = str(candidate.get("memory_scope") or metadata.get("memory_scope") or "")
     session_continuity = str(candidate.get("session_continuity") or metadata.get("session_continuity") or "")
     profile_memory_class = str(candidate.get("profile_memory_class") or metadata.get("profile_memory_class") or "").strip().lower()
@@ -667,14 +680,6 @@ def candidate_memory_layer_name(candidate: Json) -> str:
         or any("memory_feature" in layer for layer in source_memory_layers)
         or event_type == "memory_feature"
     )
-    if context_class == "resource_entity_fact":
-        return "resource_entity_fact"
-    if context_class == "resource_fact":
-        return "resource_fact"
-    if ref_type == "resource_chunk":
-        return "resource_chunk"
-    if ref_type == "skill_section":
-        return "skill_section"
     if ref_type == "compression" or context_class == "compression":
         if memory_scope == "user_profile" and session_continuity == "cross_session":
             if is_codex_outcome_memory:

--- a/tools/test_matrixark_layer_name_decides_early.py
+++ b/tools/test_matrixark_layer_name_decides_early.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`candidate_memory_layer_name` answers `resource_chunk` or `skill_section` for 96% of its calls,
+and used to compute a dozen lookups and three set comprehensions before getting there. Deciding
+those four answers first is pure code motion -- none of them reads anything from the block they now
+precede -- but "pure" is a claim, so these tests pin it.
+
+The risk in moving a return EARLIER is that it shadows a later branch. That can only happen for a
+candidate matching both, so the tests below build exactly those candidates: a chunk that also
+carries every field the compression, summary, segment, event and entity branches key on. If the
+move changed anything, one of them answers with a later branch's name.
+"""
+import unittest
+
+# Importing matrixark_mcp_core_packing directly trips a cycle through matrixark_mcp_core, so go in
+# through core, which is the order the rest of the suite uses. Package path first, bare as the
+# fallback, because the suite is run both ways.
+try:  # package path
+    from tools.matrixark_mcp_core import candidate_memory_layer_name
+except ImportError:
+    from matrixark_mcp_core import candidate_memory_layer_name
+
+# Every field the block below the moved returns reads, set to values that would drive a later
+# branch. A candidate carrying all of these must STILL answer from the early return.
+LATER_BRANCH_FIELDS = {
+    "memory_scope": "user_profile",
+    "session_continuity": "cross_session",
+    "profile_memory_class": "memory_feature",
+    "profile_memory_kind": "codex_outcome",
+    "source_profile_memory_classes": ["memory_feature"],
+    "source_profile_memory_kinds": ["codex_outcome"],
+    "source_memory_layers": ["cross_session_memory_feature_compression"],
+    "event_type": "assistant_response",
+}
+
+
+class LayerNameDecidesEarlyTest(unittest.TestCase):
+
+    def test_this_is_the_copy_the_retrieve_path_calls(self):
+        # The name exists on several modules and the suite loads some of them twice, bare and
+        # package-prefixed. Reaching a dead copy would make every test below pass while pinning
+        # nothing, so assert the function under test is the one DEFINED in the packing module.
+        source = getattr(candidate_memory_layer_name, "__module__", "")
+        self.assertTrue(source.endswith("matrixark_mcp_core_packing"),
+                        "testing a copy defined in %r, not the packing module" % source)
+
+    def test_the_four_early_answers(self):
+        self.assertEqual(candidate_memory_layer_name({"ref_type": "resource_chunk"}),
+                         "resource_chunk")
+        self.assertEqual(candidate_memory_layer_name({"ref_type": "skill_section"}),
+                         "skill_section")
+        self.assertEqual(candidate_memory_layer_name({"context_class": "resource_fact"}),
+                         "resource_fact")
+        self.assertEqual(candidate_memory_layer_name({"context_class": "resource_entity_fact"}),
+                         "resource_entity_fact")
+
+    def test_a_later_branch_cannot_be_shadowed_by_the_move(self):
+        # The shadowing case: a candidate that satisfies an early return AND carries everything a
+        # later branch keys on. The early answer must win, exactly as it did when the returns sat
+        # below the block -- they were always ahead of these branches in source order.
+        for ref_type, expected in (("resource_chunk", "resource_chunk"),
+                                   ("skill_section", "skill_section")):
+            candidate = dict(LATER_BRANCH_FIELDS, ref_type=ref_type)
+            self.assertEqual(candidate_memory_layer_name(candidate), expected,
+                             "a later branch shadowed the early answer for %s" % ref_type)
+
+    def test_the_later_branches_still_answer(self):
+        # Positive control: if the move had swallowed the rest of the function, these would fall
+        # through to the early returns or to the "unknown" tail instead of naming their branch.
+        cases = [
+            ({"ref_type": "compression", "session_continuity": "same_session"},
+             "same_session_compression"),
+            ({"ref_type": "summary", "session_continuity": "cross_session"},
+             "cross_session_summary"),
+            ({"ref_type": "segment", "session_continuity": "same_session"},
+             "same_session_segment"),
+            ({"ref_type": "event", "session_continuity": "cross_session"},
+             "cross_session_event"),
+            ({"ref_type": "entity", "memory_scope": "user_profile"}, "profile_entity"),
+        ]
+        for candidate, expected in cases:
+            self.assertEqual(candidate_memory_layer_name(candidate), expected, repr(candidate))
+
+    def test_an_explicit_layer_still_wins_over_everything(self):
+        # The explicit-layer return sits ABOVE the moved block and must keep winning, including for
+        # a candidate whose ref_type would otherwise take one of the early returns.
+        self.assertEqual(
+            candidate_memory_layer_name({"memory_layer": "chosen", "ref_type": "resource_chunk"}),
+            "chosen")
+
+    def test_metadata_is_consulted_for_the_early_answers(self):
+        # ref_type and context_class are read from the record OR its metadata; the move must not
+        # have dropped the metadata half of that.
+        self.assertEqual(
+            candidate_memory_layer_name({"metadata": {"ref_type": "skill_section"}}),
+            "skill_section")
+        self.assertEqual(
+            candidate_memory_layer_name({"metadata": {"context_class": "resource_fact"}}),
+            "resource_fact")
+
+    def test_the_derived_ref_types_still_derive(self):
+        # ref_type is derived from record_type when absent, above the moved returns, so the later
+        # branches keyed on it must still be reachable through that derivation.
+        self.assertEqual(
+            candidate_memory_layer_name({"record_type": "context_event",
+                                         "session_continuity": "same_session"}),
+            "same_session_event")
+        self.assertEqual(
+            candidate_memory_layer_name({"record_type": "context_summary",
+                                         "session_continuity": "cross_session"}),
+            "cross_session_summary")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`candidate_memory_layer_name` answers `resource_chunk` or `skill_section` for almost everything it
is asked about, and computed a dozen lookups and three set comprehensions before getting there.

Over one retrieve on a 2,346-record store: **88,340 calls, of which 84,841 (96%) end at one of four
early answers** — 63,328 `skill_section`, 21,513 `resource_chunk`. Those four need nothing but
`context_class` and `ref_type`, both already computed. Everything between them and the top of the
function — `memory_scope`, `session_continuity`, the profile class and kind, three set
comprehensions over source lists, `event_type`, and the two `is_*` flags built from all of it — is
read by none of them.

So a chunk paid for the compression, summary, segment, event and entity branches on every call.
The function was **27.8% of a retrieve**.

## The change

Move the four returns above that block. Nothing else moves, and their order relative to each other
and to every later branch is unchanged, so this is code motion: none of the four reads a value the
block produces, and the block has no side effects.

## What it is worth

Interleaved A/B, both orderings, 10 rounds per arm, each arm on its own store:

| arm | median | best | worst | refs selected |
|---|---|---|---|---|
| main | 1498.8 ms | 1177.2 | 2119.2 | 64 |
| this branch | **1043.8 ms** | 982.1 | 1389.8 | 64 |

**−30.4% on the median**, and the branch wins on best and worst as well, in both orderings. Both
arms select the same 64 refs, so it is like-for-like rather than two different amounts of work.

Reversing the order matters here: this box has repeatedly shown whichever arm runs second winning
on work that was identical, so a single ordering proves nothing.

## Tests

`test_matrixark_layer_name_decides_early.py`, seven tests. Because this is a performance change the
tests pin *behaviour preservation* rather than the change — they pass on `main` too, by design, and
the measurement above is what carries the win.

The risk in moving a return earlier is that it shadows a later branch, which can only happen for a
candidate matching both. So the tests build exactly those: a chunk carrying every field the
compression, summary, segment, event and entity branches key on, which must still answer
`resource_chunk`. Plus a positive control that each later branch still answers (if the move had
swallowed the rest of the function, they would fall through), that an explicit `memory_layer` still
wins, that the metadata half of each lookup still applies, and that `ref_type` derived from
`record_type` still reaches the later branches.

One test asserts the function under test is the copy defined in the packing module — the name is
re-exported by several modules and the suite loads some of them twice, so a test could otherwise
pin a copy nothing calls.

Full python suite run on both arms and diffed by failing test name: no failure on this branch that
`main` does not already have.
