### PR TITLE
An import says which secrets it could not bring

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1113,6 +1113,14 @@ function liveStream(options) {
       controlHtml(f) + '<div class="helptext' + longCls + '">' + help + "</div></div>";
   }
 
+  function unsetSecrets() {
+    /* The snapshot never carries a secret VALUE -- it reports `kind: "secret"` and a
+       `configured` boolean -- so this asks the only question there is to ask. */
+    return Object.keys(fields)
+      .filter(function (k) { return fields[k].kind === "secret" && !fields[k].configured; })
+      .sort();
+  }
+
   function renderGroups(settings) {
     var groups = (settings || {}).groups || {};
     var meta = (settings || {}).group_meta || {};
@@ -1780,7 +1788,9 @@ function liveStream(options) {
 
   /* ---------- load ---------- */
   function load() {
-    fetch("/v1/admin/config", { headers: auth() })
+    /* Returned so a caller can act on the reloaded settings. The import needs to say what this
+       deployment is still missing, and that is only knowable once the answer has come back. */
+    return fetch("/v1/admin/config", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
       .then(function (d) {
         conn("live", "connected");
@@ -2250,14 +2260,24 @@ function liveStream(options) {
         }
         var n = Object.keys(settings).length;
         var restart = res.b.restart_required || [];
-        say($("importMsg"), "Applied " + n + " setting" + (n === 1 ? "" : "s") + "." +
+        var applied = "Applied " + n + " setting" + (n === 1 ? "" : "s") + "." +
           (restart.length
             ? " " + restart.length + (restart.length === 1 ? " of them needs" : " of them need") +
               " a gateway restart."
-            : ""),
-          restart.length ? "info" : "ok");
+            : "");
+        say($("importMsg"), applied, restart.length ? "info" : "ok");
         $("importText").value = "";
-        load();
+        load().then(function () {
+          /* An export never carries secret values, because blanking them at the target would
+             clear a working key. The person who made the file was told that; the person applying
+             it here was not, and an absent key looks exactly like a present one until an ingest
+             quietly falls back. */
+          var missing = unsetSecrets();
+          if (!missing.length) { return; }
+          say($("importMsg"), applied + " " + missing.length +
+            (missing.length === 1 ? " secret is" : " secrets are") + " not set on this " +
+            "deployment: " + missing.join(", ") + ". An export never carries them.", "info");
+        });
       })
       .catch(function () {
         $("importCfg").disabled = false;

--- a/tools/portal/import_secrets_harness.js
+++ b/tools/portal/import_secrets_harness.js
@@ -1,0 +1,136 @@
+/* Apply a pasted configuration and read what the page said afterwards.
+ *
+ * An export omits secret values on purpose -- blanking them at the target would clear a working
+ * key -- and the export button says so to the person exporting. The file does not carry that note,
+ * so the person applying it somewhere else is told "Applied 47 settings." and nothing more. Whether
+ * the missing credentials are mentioned depends on a reload finishing and a second message
+ * replacing the first, which is behaviour a reader of the source cannot confirm.
+ *
+ * Usage: node import_secrets_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = new Map();
+const listeners = {};
+function makeEl(id) {
+  return {
+    id: id || "", hidden: true, innerHTML: "", textContent: "", className: "",
+    value: id === "key" ? "k-admin" : "", checked: false, disabled: false,
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(type, fn) { listeners[(id || "") + ":" + type] = fn; },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+/* One secret configured, one not: the message must name the second and only the second. */
+function snapshot() {
+  return {
+    status: "ok",
+    settings: {
+      status: "ok", groups: { Extraction: [
+        { key: "extraction.model", kind: "str", label: "Model", help: "", value: "m",
+          env: "MATRIXARK_EXTRACTION_MODEL", applies: "live", source: "config",
+          essential: false, default: "", overridable_by: [], boot_pinned: false,
+          pending_restart: false },
+        { key: "extraction.api_key", kind: "secret", label: "API key", help: "", value: null,
+          configured: false, env: "MATRIXARK_EXTRACTION_API_KEY", applies: "restart",
+          source: "default", essential: false, default: "", overridable_by: [],
+          boot_pinned: false, pending_restart: false },
+        { key: "embedding.api_key", kind: "secret", label: "Embedding key", help: "", value: null,
+          configured: true, env: "MATRIXARK_EMBEDDING_API_KEY", applies: "restart",
+          source: "config", essential: false, default: "", overridable_by: [],
+          boot_pinned: false, pending_restart: false }
+      ] },
+      group_meta: {}, presets: [], history: [], inventory: {}, essential_keys: [],
+      config_file: "/tmp/runtime.json", pending_restart: []
+    },
+    warnings: []
+  };
+}
+
+function reply(body) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body),
+                           text: () => Promise.resolve(JSON.stringify(body)) });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: (fn) => { if (typeof fn === "function") { fn(); } return 0; },
+  setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url, opts) => {
+    const method = ((opts || {}).method || "GET").toUpperCase();
+    if (String(url).indexOf("/v1/admin/config") >= 0 && method === "POST") {
+      return reply({ status: "ok", applied: [], restart_required: ["extraction.provider"] });
+    }
+    if (String(url).indexOf("/v1/admin/config") >= 0) { return reply(snapshot()); }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw at load: " + e.message); failures += 1; }
+});
+
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+async function quiet() { for (let i = 0; i < 60; i += 1) { await settle(); } }
+
+(async function () {
+  ok("the import control is wired", typeof listeners["importCfg:click"] === "function");
+
+  el("importText").value = JSON.stringify({ settings: { "extraction.model": "deepseek-chat" } });
+  listeners["importCfg:click"]({});
+  await quiet();
+
+  const said = el("importMsg").innerHTML + " " + el("importMsg").textContent;
+  ok("it still reports what it applied", /Applied 1 setting/.test(said), said);
+  ok("it says the restart is needed", /restart/.test(said), said);
+  ok("it names the secret this deployment does not have",
+     /extraction\.api_key/.test(said), said);
+  ok("it does not name the one that is set",
+     !/embedding\.api_key/.test(said), said);
+  ok("it says why the file could not carry it",
+     /never carries/.test(said), said);
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}().catch(function (err) {
+  console.log("FAILED harness threw: " + err.message);
+  process.exit(1);
+}));

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -987,6 +987,14 @@ function liveStream(options) {
       controlHtml(f) + '<div class="helptext' + longCls + '">' + help + "</div></div>";
   }
 
+  function unsetSecrets() {
+    /* The snapshot never carries a secret VALUE -- it reports `kind: "secret"` and a
+       `configured` boolean -- so this asks the only question there is to ask. */
+    return Object.keys(fields)
+      .filter(function (k) { return fields[k].kind === "secret" && !fields[k].configured; })
+      .sort();
+  }
+
   function renderGroups(settings) {
     var groups = (settings || {}).groups || {};
     var meta = (settings || {}).group_meta || {};
@@ -1654,7 +1662,9 @@ function liveStream(options) {
 
   /* ---------- load ---------- */
   function load() {
-    fetch("/v1/admin/config", { headers: auth() })
+    /* Returned so a caller can act on the reloaded settings. The import needs to say what this
+       deployment is still missing, and that is only knowable once the answer has come back. */
+    return fetch("/v1/admin/config", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
       .then(function (d) {
         conn("live", "connected");
@@ -2124,14 +2134,24 @@ function liveStream(options) {
         }
         var n = Object.keys(settings).length;
         var restart = res.b.restart_required || [];
-        say($("importMsg"), "Applied " + n + " setting" + (n === 1 ? "" : "s") + "." +
+        var applied = "Applied " + n + " setting" + (n === 1 ? "" : "s") + "." +
           (restart.length
             ? " " + restart.length + (restart.length === 1 ? " of them needs" : " of them need") +
               " a gateway restart."
-            : ""),
-          restart.length ? "info" : "ok");
+            : "");
+        say($("importMsg"), applied, restart.length ? "info" : "ok");
         $("importText").value = "";
-        load();
+        load().then(function () {
+          /* An export never carries secret values, because blanking them at the target would
+             clear a working key. The person who made the file was told that; the person applying
+             it here was not, and an absent key looks exactly like a present one until an ingest
+             quietly falls back. */
+          var missing = unsetSecrets();
+          if (!missing.length) { return; }
+          say($("importMsg"), applied + " " + missing.length +
+            (missing.length === 1 ? " secret is" : " secrets are") + " not set on this " +
+            "deployment: " + missing.join(", ") + ". An export never carries them.", "info");
+        });
       })
       .catch(function () {
         $("importCfg").disabled = false;

--- a/tools/test_matrixark_an_import_says_what_it_could_not_bring.py
+++ b/tools/test_matrixark_an_import_says_what_it_could_not_bring.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""An import names the secrets it could not bring.
+
+``export_settings`` omits secret values on purpose, and says why: a blank would be a *write* that
+clears the target's working key, so an export that "just applied everything" would break the
+deployment it was meant to configure. It returns ``secrets_omitted``, and the export button shows
+that list.
+
+To the person exporting. The downloaded file does not carry it — the export writes
+``JSON.stringify({settings: d.settings})`` and drops the rest — and the import answered *"Applied
+47 settings."* and stopped there. So whoever configures the target, who is usually not whoever made
+the file, is told the configuration transferred.
+
+It did, apart from the credentials. An absent key looks exactly like a present-but-rejected one:
+both fall back to the deterministic path at ingest time with no error the caller ever sees.
+
+The import now names the secrets unset **on this deployment**, rather than echoing whatever the
+file declared. That is the question the operator has to act on, and it answers for a hand-written
+file too. The snapshot never carries a secret value — it reports ``kind: "secret"`` and a
+``configured`` boolean — so that is what is read.
+
+The message depends on a reload finishing and a second message replacing the first, which is
+behaviour rather than text: the harness applies a configuration against a deployment with one
+secret set and one not, and reads what the page ended up saying.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+HARNESS = os.path.join(PORTAL, "import_secrets_harness.js")
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class AnImportSaysWhatItCouldNotBringTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=180)
+
+    def test_the_import_path_runs_clean(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_it_still_reports_what_it_applied(self) -> None:
+        """The new sentence must not cost the old one: how many settings landed, and whether any
+        of them wait on a restart, is still the first thing an operator needs."""
+        out = self._run().stdout
+        self.assertIn("ok   it still reports what it applied", out)
+        self.assertIn("ok   it says the restart is needed", out)
+
+    def test_it_names_a_secret_this_deployment_lacks(self) -> None:
+        self.assertIn("ok   it names the secret this deployment does not have", self._run().stdout)
+
+    def test_it_does_not_name_one_that_is_already_set(self) -> None:
+        """Otherwise it is a fixed warning rather than a report, and the reader learns to skip it."""
+        self.assertIn("ok   it does not name the one that is set", self._run().stdout)
+
+    def test_it_says_why_the_file_could_not_carry_it(self) -> None:
+        """"extraction.api_key is not set" reads like something went wrong. It did not: an export
+        never carries secret values, and saying so is the difference between a fault and a step."""
+        self.assertIn("ok   it says why the file could not carry it", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`export_settings` omits secret values on purpose, and its docstring says why: a blank would be a
**write** that clears the target's working key, so an export that "just applied everything" would
break the deployment it was meant to configure. It returns `secrets_omitted`, and the export button
shows that list.

**To the person exporting.** The downloaded file does not carry it — the export writes
`JSON.stringify({settings: d.settings})` and drops the rest — and the import answered:

> Applied 47 settings.

and stopped there. So whoever configures the target, who is usually **not** whoever made the file,
is told the configuration transferred.

It did, apart from the credentials. And an absent key looks exactly like a present-but-rejected
one: both fall back to the deterministic path at ingest time with no error the caller ever sees.

Now:

> Applied 47 settings. 1 of them needs a gateway restart. 1 secret is not set on this deployment:
> extraction.api_key. An export never carries them.

It names the secrets unset **on this deployment** rather than echoing whatever the file declared —
that is the question the operator has to act on, and it answers for a hand-written file too. The
snapshot never carries a secret value (it reports `kind: "secret"` and a `configured` boolean), so
that is what is read, and `load()` now hands its promise back so the answer can be waited for.

The message says *why*, not just *what*. "extraction.api_key is not set" reads like something went
wrong, and nothing did.

**The downloaded file is deliberately unchanged**: `{"settings": {...}}` is directly POSTable, and
that is worth more than making the file self-describing.

### On the test

Whether this appears depends on a reload finishing and a second message replacing the first, which
is behaviour rather than text. The harness applies a configuration against a deployment with one
secret set and one not, then reads what the page ended up saying — including that it does **not**
name the one already set, since a fixed warning is one people learn to skip.

Against the page as it stands it fails exactly the two secret cases and passes the two about what
was applied.
