### PR TITLE
Say what a list slice reads, and what it still walks

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1240,7 +1240,15 @@ pub(crate) fn execute_on_shard(
                 Vec::new()
             } else {
                 // A BTreeMap iterates in key order, which is the list's order -- the same order the
-                // materialised Vec had. Only the requested span is visited.
+                // materialised Vec had. Only the requested span is READ: `read_page_bytes` runs
+                // `wanted` times, not `length` times, which is what stopped a ten-entry page of a
+                // four-thousand-entry list from touching four thousand pages.
+                //
+                // `skip(from)` still ADVANCES the iterator `from` times, so reaching a late offset
+                // walks the nodes before it -- cheap per step and allocating nothing, but not
+                // free. A read near the head is O(wanted); one near the tail is O(from + wanted).
+                // An allocation probe cannot see that difference, so it is stated here rather
+                // than left for a flat byte measurement to imply otherwise.
                 let wanted = (to - from + 1) as usize;
                 list.map(|list| {
                     list.values()


### PR DESCRIPTION
The comment over the `ListRange` slice said *"Only the requested span is visited"*. The iterator **visits** `from + wanted` entries; only `wanted` are **read**.

```rust
list.values().skip(from as usize).take(wanted)
    .filter_map(|address| read_page_bytes(..))
```

`read_page_bytes` runs `wanted` times rather than `length` times — the saving that stopped a ten-entry page of a four-thousand-entry list from touching four thousand pages. But `skip(from)` still advances the iterator `from` times, so a read near the head is O(wanted) and one near the tail is O(from + wanted): cheap per step, allocating nothing, and not free.

An allocation probe cannot see that — a walk that allocates nothing costs the same bytes whether it steps 10 nodes or 3,200 — so a byte measurement of this command reads flat at any offset. Anyone pairing that flat result with "only the requested span is visited" would conclude a late-offset read is O(1). It is not.

Comment only; no behaviour changes. The claim was mine.