### PR TITLE
Name the stored settings this build no longer has

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -1042,6 +1042,11 @@ def snapshot(include_catalog: bool = True) -> Json:
         # whoever looks next.
         "pending_restart": sorted(entry["key"] for group in groups.values() for entry in group
                                   if entry.get("pending_restart")),
+        # In the file and not in this build: renamed or dropped since it was written, still
+        # sitting there, doing nothing. Reported rather than removed -- deleting a customer's
+        # stored values because this build does not recognise them is the wrong answer to a
+        # downgrade or a partial rollout.
+        "unknown_stored": sorted(set(values) - set(SETTINGS_BY_KEY)),
         "config_file": config_path(),
         "updated_at": document.get("updated_at"),
         "updated_by": document.get("updated_by"),

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1008,9 +1008,22 @@ function liveStream(options) {
     $("summary").innerHTML = cards.map(function (c) {
       return '<div class="stat ' + c.c + '"><b>' + esc(c.n) + "</b><span>" + esc(c.l) + "</span></div>";
     }).join("");
+    /* Values in the file that this build has no setting for. They were set deliberately by
+       somebody who then upgraded, and they have quietly meant nothing since. The page cannot
+       remove them -- a write of an unknown key is refused, correctly -- so it says where they
+       are instead. */
+    var forgotten = ((d.settings || {}).unknown_stored) || [];
     $("warnings").innerHTML = (d.warnings || []).map(function (w) {
       return '<div class="note">' + esc(w) + "</div>";
-    }).join("");
+    }).join("") + (forgotten.length
+      ? '<div class="note">' + esc(forgotten.length) +
+        (forgotten.length === 1 ? " stored value is" : " stored values are") +
+        " not a setting this build has, so " +
+        (forgotten.length === 1 ? "it does" : "they do") + " nothing: " +
+        esc(forgotten.join(", ")) + ". Stored by an older build, in " +
+        esc((d.settings || {}).config_file || "the configuration file") + "." +
+        "</div>"
+      : "");
   }
 
   /* ---------- presets ---------- */

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -882,9 +882,22 @@ function liveStream(options) {
     $("summary").innerHTML = cards.map(function (c) {
       return '<div class="stat ' + c.c + '"><b>' + esc(c.n) + "</b><span>" + esc(c.l) + "</span></div>";
     }).join("");
+    /* Values in the file that this build has no setting for. They were set deliberately by
+       somebody who then upgraded, and they have quietly meant nothing since. The page cannot
+       remove them -- a write of an unknown key is refused, correctly -- so it says where they
+       are instead. */
+    var forgotten = ((d.settings || {}).unknown_stored) || [];
     $("warnings").innerHTML = (d.warnings || []).map(function (w) {
       return '<div class="note">' + esc(w) + "</div>";
-    }).join("");
+    }).join("") + (forgotten.length
+      ? '<div class="note">' + esc(forgotten.length) +
+        (forgotten.length === 1 ? " stored value is" : " stored values are") +
+        " not a setting this build has, so " +
+        (forgotten.length === 1 ? "it does" : "they do") + " nothing: " +
+        esc(forgotten.join(", ")) + ". Stored by an older build, in " +
+        esc((d.settings || {}).config_file || "the configuration file") + "." +
+        "</div>"
+      : "");
   }
 
   /* ---------- presets ---------- */

--- a/tools/portal/stale_settings_harness.js
+++ b/tools/portal/stale_settings_harness.js
@@ -1,0 +1,123 @@
+/* Load the setup page against a deployment whose config file holds settings this build dropped.
+ *
+ * Whether the note appears, and whether it appears when there is nothing to say, is behaviour: the
+ * warnings area is shared with the model-configuration warnings, and an addition that swallowed
+ * those or that drew an empty note every time would read the same in the source.
+ *
+ * Usage: node stale_settings_harness.js <setup_portal.html> [--none]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const none = process.argv.indexOf("--none") >= 0;
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = new Map();
+function makeEl(id) {
+  return {
+    id: id || "", hidden: true, innerHTML: "", textContent: "", className: "",
+    value: id === "key" ? "k-admin" : "", checked: false, disabled: false,
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener() {}, removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+const STALE = none ? [] : ["embedding.old_name", "extraction.retired_knob"];
+
+function snapshot() {
+  return {
+    status: "ok",
+    /* A real warning alongside, so an addition that swallowed the existing ones would show. */
+    warnings: ["extraction is falling back to rules"],
+    extraction: { provider: "deterministic" }, embedding: { provider: "deterministic" },
+    settings: {
+      status: "ok",
+      groups: { Extraction: [
+        { key: "extraction.model", kind: "str", label: "Model", help: "", value: "m",
+          env: "MATRIXARK_EXTRACTION_MODEL", applies: "live", source: "config", essential: false,
+          default: "", overridable_by: [], boot_pinned: false, pending_restart: false }
+      ] },
+      group_meta: {}, presets: [], history: [], inventory: {}, essential_keys: [],
+      config_file: "/etc/matrixark/runtime_config.json",
+      pending_restart: [], unknown_stored: STALE
+    }
+  };
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: (fn) => { if (typeof fn === "function") { fn(); } return 0; },
+  setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url) => {
+    if (String(url).indexOf("/v1/admin/config") >= 0) {
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(snapshot()),
+                               text: () => Promise.resolve("{}") });
+    }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw at load: " + e.message); failures += 1; }
+});
+
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+
+(async function () {
+  for (let i = 0; i < 60; i += 1) { await settle(); }
+  const shown = el("warnings").innerHTML;
+
+  ok("the model warning still renders", /falling back to rules/.test(shown), shown.slice(0, 200));
+
+  if (none) {
+    ok("nothing is said when nothing is stale", !/does nothing|do nothing/.test(shown),
+       "a note appeared with nothing to report: " + shown.slice(0, 240));
+  } else {
+    ok("the stale values are named",
+       /extraction\.retired_knob/.test(shown) && /embedding\.old_name/.test(shown),
+       shown.slice(0, 300));
+    ok("it says they do nothing", /do nothing/.test(shown), shown.slice(0, 300));
+    ok("it says where they are", /runtime_config\.json/.test(shown), shown.slice(0, 300));
+    ok("it counts them", /2 stored values are/.test(shown), shown.slice(0, 300));
+  }
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}().catch(function (err) {
+  console.log("FAILED harness threw: " + err.message);
+  process.exit(1);
+}));

--- a/tools/test_matrixark_a_stored_setting_this_build_forgot.py
+++ b/tools/test_matrixark_a_stored_setting_this_build_forgot.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A stored value this build has no setting for is named.
+
+The configuration file outlives the process that wrote it -- that is its purpose -- and it outlives
+the build too. When a setting is renamed or dropped, the value stays in the file and stops meaning
+anything, and until now nothing said so:
+
+    the stale key is mentioned anywhere in the snapshot: False
+    apply_boot seeded:                                   ['MATRIXARK_EXTRACTION_MODEL']
+    export carries it:                                   False
+    writing it is refused: unknown setting(s): extraction.retired_knob
+
+So an operator who set it, upgraded, and came back to the page saw a deployment configured the way
+they remembered, running the default for that behaviour instead. The single place it surfaced was a
+write attempt, which nobody makes for a setting they have already set.
+
+Reported, never removed. Deleting a customer's stored values because this build does not recognise
+them is the wrong answer to a downgrade, a partial rollout, or a key this build reads under another
+name -- so the page says what they are and where they live, and leaves them alone.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import matrixark_gateway_config as cfg
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "stale_settings_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+class TheSnapshotNamesThemTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._saved = dict(os.environ)
+        self.addCleanup(lambda: (os.environ.clear(), os.environ.update(self._saved)))
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.path = os.path.join(tmp.name, "runtime.json")
+        os.environ["MATRIXARK_RUNTIME_CONFIG_FILE"] = self.path
+
+    def _store(self, values) -> None:
+        with io.open(self.path, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({"values": values, "updated_at": 1}))
+
+    def test_a_key_this_build_does_not_have_is_reported(self) -> None:
+        self._store({"extraction.model": "m", "extraction.retired_knob": "set-long-ago"})
+        self.assertEqual(["extraction.retired_knob"], cfg.snapshot()["unknown_stored"])
+
+    def test_a_file_of_known_keys_reports_nothing(self) -> None:
+        """Otherwise it is a permanent notice, and a permanent notice is one people stop reading."""
+        self._store({"extraction.model": "m"})
+        self.assertEqual([], cfg.snapshot()["unknown_stored"])
+
+    def test_the_known_key_is_still_a_setting(self) -> None:
+        """If extraction.model ever stopped being one, the check above would pass by accident."""
+        self.assertIn("extraction.model", cfg.SETTINGS_BY_KEY)
+
+    def test_writing_one_is_still_refused(self) -> None:
+        """Naming them is not permitting them: an unknown key is still not writable."""
+        self._store({"extraction.retired_knob": "set-long-ago"})
+        with self.assertRaises(cfg.UnknownSetting):
+            cfg.update({"extraction.retired_knob": "x"})
+
+    def test_they_are_left_in_the_file(self) -> None:
+        """A build that does not recognise a value has not established that it is rubbish."""
+        self._store({"extraction.model": "m", "extraction.retired_knob": "set-long-ago"})
+        cfg.update({"extraction.model": "changed"})
+        with io.open(self.path, encoding="utf-8") as handle:
+            self.assertIn("extraction.retired_knob", json.load(handle)["values"])
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePageSaysSoTest(unittest.TestCase):
+
+    def _run(self, *extra):
+        return subprocess.run(["node", HARNESS, PAGE] + list(extra),
+                              capture_output=True, text=True, timeout=180)
+
+    def test_the_page_renders_them(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_it_says_they_do_nothing_and_where_they_are(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   it says they do nothing", out)
+        self.assertIn("ok   it says where they are", out)
+
+    def test_it_is_silent_when_there_is_nothing_to_say(self) -> None:
+        self.assertIn("ok   nothing is said when nothing is stale", self._run("--none").stdout)
+
+    def test_the_existing_warnings_survive_it(self) -> None:
+        """It shares the warnings area, so an addition could have replaced what was there."""
+        self.assertIn("ok   the model warning still renders", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The configuration file outlives the process that wrote it — that is its purpose — and it outlives
the **build** too. When a setting is renamed or dropped, the value stays in the file and stops
meaning anything. Nothing said so:

```
the stale key is mentioned anywhere in the snapshot: False
apply_boot seeded:                                   ['MATRIXARK_EXTRACTION_MODEL']
export carries it:                                   False
writing it is refused: unknown setting(s): extraction.retired_knob
```

So an operator who set it, upgraded, and came back to the page saw a deployment configured the way
they remembered — running the default for that behaviour instead. The single place it surfaced was
a *write* attempt, which nobody makes for a setting they have already set.

The snapshot now names what is in the file and not in this build, and the page says it in the
warnings area it already has: how many, which, that they do nothing, and which file they are in.

### Reported, never removed

Deleting a customer's stored values because *this* build does not recognise them is the wrong
answer to a downgrade, a partial rollout, or a key this build reads under another name. They stay
in the file, and a test says so. Naming them is not permitting them, either — writing an unknown
key is still refused, with its own test.

### Silent when there is nothing to say

A permanent notice is one people stop reading, so the note appears only when the list is non-empty.
And because it shares the warnings area, an addition could have replaced what was already there —
the harness renders a real model-configuration warning alongside and asserts it survives.

Verified red against main's page: exactly the four stale cases fail there, while "the model warning
still renders" passes, so the harness is exercising the page rather than failing to load it.

Suites green: gateway_config (28), gateway_portal (58), portal_pages (4), dashboards (20), plus 9
new.
