### PR TITLE
"Saved and live now" is true in one worker out of four

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -2795,24 +2795,16 @@ def _readiness_checks(config_snapshot: Json, counts: Json, cfg: Any,
     return checks
 
 
-def _single_writer_warning(
-    argv: Optional[list] = None, env: Optional[dict] = None
-) -> Optional[str]:
-    """Warn when the worker count would silently split a tenant's memory across separate stores.
+def _worker_count(argv: Optional[list] = None, env: Optional[dict] = None) -> int:
+    """How many workers this deployment was started with; 1 when nothing says otherwise.
 
-    With the spawning MCP backend each uvicorn worker starts its OWN `--serve` proxy child over a
-    pipe (see matrixark_mcp_rust_proxy_process.ensure_lane_process -- there is no code path that
-    dials an existing proxy), and that child owns an embedded store. So `--workers 4` is four
-    independent stores: a memory written through one worker is invisible to the other three, with no
-    error at any layer.
-
-    A worker count above one is only safe when the workers share a store: a real TS_META_ADDR
-    (distributed routing) or an explicit TS_STORAGE_BACKEND. Returns the warning text, or None when
-    the configuration is safe -- returning it rather than printing keeps this unit-testable.
+    Read from the command line, then WEB_CONCURRENCY. Lifted out of the split-store warning so
+    there is one answer to the question: that warning is about workers not sharing a STORE, and a
+    configuration write has its own reason to care -- a live setting is applied to the environment
+    of whichever worker served the request, and no other.
     """
     argv = list(sys.argv if argv is None else argv)
     env = dict(os.environ if env is None else env)
-
     workers = 0
     for index, token in enumerate(argv):
         if token == "--workers" and index + 1 < len(argv):
@@ -2830,6 +2822,26 @@ def _single_writer_warning(
             workers = int(str(env.get("WEB_CONCURRENCY", "")).strip() or "0")
         except ValueError:
             workers = 0
+    return workers if workers > 0 else 1
+
+
+def _single_writer_warning(
+    argv: Optional[list] = None, env: Optional[dict] = None
+) -> Optional[str]:
+    """Warn when the worker count would silently split a tenant's memory across separate stores.
+
+    With the spawning MCP backend each uvicorn worker starts its OWN `--serve` proxy child over a
+    pipe (see matrixark_mcp_rust_proxy_process.ensure_lane_process -- there is no code path that
+    dials an existing proxy), and that child owns an embedded store. So `--workers 4` is four
+    independent stores: a memory written through one worker is invisible to the other three, with no
+    error at any layer.
+
+    A worker count above one is only safe when the workers share a store: a real TS_META_ADDR
+    (distributed routing) or an explicit TS_STORAGE_BACKEND. Returns the warning text, or None when
+    the configuration is safe -- returning it rather than printing keeps this unit-testable.
+    """
+    env = dict(os.environ if env is None else env)
+    workers = _worker_count(argv, env)
     if workers <= 1:
         return None
 
@@ -3857,6 +3869,11 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             except OSError as exc:
                 return await _json(send, 500, {"error": "config_write_failed", "detail": str(exc)})
             result["config"] = _model_config_snapshot()
+            # A live setting is applied to the environment of THIS worker, and read per call from
+            # the environment of whichever worker serves the next request. With more than one, the
+            # write is in effect for a fraction of traffic until they are all restarted -- so the
+            # answer says how many there are rather than letting the page claim "live now".
+            result["workers"] = _worker_count()
             return await _json(send, 200, result)
 
         # ---- apply a provider preset (auth + admin scope) -------------------------------------

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1863,12 +1863,20 @@ function liveStream(options) {
         }
         var restart = res.body.restart_required || [];
         var one = restart.length === 1;
+        /* "live now" is true of the worker that served this request. A live setting is read from
+           the environment per call, and only this process's environment was written, so with
+           several workers the rest keep the old value until they restart. */
+        var workers = res.body.workers || 1;
+        var elsewhere = workers > 1
+          ? " This worker has it now; the other " + (workers - 1) +
+            (workers === 2 ? " picks it up" : " pick it up") + " when they restart."
+          : "";
         say($("saveMsg"), restart.length
           ? "Saved. " + restart.length + " setting" + (one ? "" : "s") + " (" +
             restart.join(", ") + ") " + (one ? "is" : "are") + " read once at startup — restart " +
             "the gateway for " + (one ? "it" : "them") + " to take effect. Everything else is " +
-            "live now."
-          : "Saved and live now.", restart.length ? "info" : "ok");
+            "live now." + elsewhere
+          : "Saved and live now." + elsewhere, restart.length || workers > 1 ? "info" : "ok");
         load();
       })
       .catch(function () {

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1727,12 +1727,20 @@ function liveStream(options) {
         }
         var restart = res.body.restart_required || [];
         var one = restart.length === 1;
+        /* "live now" is true of the worker that served this request. A live setting is read from
+           the environment per call, and only this process's environment was written, so with
+           several workers the rest keep the old value until they restart. */
+        var workers = res.body.workers || 1;
+        var elsewhere = workers > 1
+          ? " This worker has it now; the other " + (workers - 1) +
+            (workers === 2 ? " picks it up" : " pick it up") + " when they restart."
+          : "";
         say($("saveMsg"), restart.length
           ? "Saved. " + restart.length + " setting" + (one ? "" : "s") + " (" +
             restart.join(", ") + ") " + (one ? "is" : "are") + " read once at startup — restart " +
             "the gateway for " + (one ? "it" : "them") + " to take effect. Everything else is " +
-            "live now."
-          : "Saved and live now.", restart.length ? "info" : "ok");
+            "live now." + elsewhere
+          : "Saved and live now." + elsewhere, restart.length || workers > 1 ? "info" : "ok");
         load();
       })
       .catch(function () {

--- a/tools/portal/worker_reach_harness.js
+++ b/tools/portal/worker_reach_harness.js
@@ -1,0 +1,136 @@
+/* Save a setting and read how far the page says the write reached.
+ *
+ * A live setting is read from the environment per call, and a write touches the environment of the
+ * one worker that served it. With several workers the others keep the old value until they
+ * restart, so "Saved and live now" is true of a fraction of the traffic. Whether the page says so
+ * depends on what comes back from the write, which is behaviour rather than text.
+ *
+ * Usage: node worker_reach_harness.js <setup_portal.html> [workers]
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const WORKERS = process.argv[3] === undefined ? 4 : Number(process.argv[3]);
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+const els = new Map();
+const listeners = {};
+function makeEl(id) {
+  return {
+    id: id || "", hidden: true, innerHTML: "", textContent: "", className: "",
+    value: id === "key" ? "k-admin" : "", checked: false, disabled: false,
+    style: {}, dataset: {}, files: [], options: [], children: [],
+    addEventListener(type, fn) { listeners[(id || "") + ":" + type] = fn; },
+    removeEventListener() {}, appendChild() {}, removeChild() {},
+    setAttribute() {}, getAttribute() { return null; }, closest() { return null; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    scrollIntoView() {}, focus() {}, click() {},
+    classList: { add() {}, remove() {}, toggle() {} }
+  };
+}
+function el(id) {
+  if (!els.has(id)) { els.set(id, makeEl(id)); }
+  return els.get(id);
+}
+
+function snapshot() {
+  return {
+    status: "ok", warnings: [],
+    extraction: { provider: "deterministic" }, embedding: { provider: "deterministic" },
+    settings: {
+      status: "ok",
+      groups: { Extraction: [
+        { key: "extraction.model", kind: "str", label: "Model", help: "", value: "before",
+          env: "MATRIXARK_EXTRACTION_MODEL", applies: "live", source: "config", essential: false,
+          default: "", overridable_by: [], boot_pinned: false, pending_restart: false }
+      ] },
+      group_meta: {}, presets: [], history: [], inventory: {}, essential_keys: [],
+      config_file: "/tmp/runtime.json", pending_restart: [], unknown_stored: []
+    }
+  };
+}
+
+function reply(body) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body),
+                           text: () => Promise.resolve(JSON.stringify(body)) });
+}
+
+const win = {
+  document: {
+    getElementById: (id) => el(id),
+    querySelector: () => makeEl(), querySelectorAll: () => [],
+    createElement: () => makeEl(), addEventListener() {}, body: makeEl(), hidden: false
+  },
+  addEventListener() {},
+  location: { origin: "http://localhost", href: "http://localhost", reload() {} },
+  sessionStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  localStorage: { getItem: () => "", setItem() {}, removeItem() {} },
+  navigator: {},
+  setTimeout: (fn) => { if (typeof fn === "function") { fn(); } return 0; },
+  setInterval: () => 0, clearInterval() {},
+  Number, JSON, String, Math, Date, Object, Array, Promise, RegExp, Error, isNaN,
+  encodeURIComponent, decodeURIComponent, parseInt, parseFloat,
+  TextDecoder: function () { this.decode = () => ""; },
+  AbortController: function () { this.abort = () => {}; this.signal = {}; },
+  FileReader: function () {}, Blob: function () {},
+  URL: { createObjectURL: () => "", revokeObjectURL() {} },
+  fetch: (url, opts) => {
+    const method = ((opts || {}).method || "GET").toUpperCase();
+    if (String(url).indexOf("/v1/admin/config") >= 0 && method === "POST") {
+      const body = { status: "ok", applied: [], restart_required: [] };
+      if (WORKERS) { body.workers = WORKERS; }
+      return reply(body);
+    }
+    if (String(url).indexOf("/v1/admin/config") >= 0) { return reply(snapshot()); }
+    return new Promise(() => {});
+  }
+};
+win.window = win;
+
+const names = Object.keys(win);
+const values = names.map((k) => win[k]);
+scripts.forEach((body, index) => {
+  try { new Function(...names, body)(...values); }
+  catch (e) { console.log("FAIL script " + index + " threw at load: " + e.message); failures += 1; }
+});
+
+function settle() { return new Promise((r) => setImmediate(() => setImmediate(r))); }
+async function quiet() { for (let i = 0; i < 60; i += 1) { await settle(); } }
+
+(async function () {
+  await quiet();
+  ok("the settings form is wired", typeof listeners["settingsForm:submit"] === "function");
+  ok("an edit can be made", typeof listeners["groups:input"] === "function");
+
+  /* Edit a field, the way typing into it does, then submit. Without an edit the form reports
+     "Nothing changed" and never asks the gateway anything. */
+  listeners["groups:input"]({ target: { dataset: { key: "extraction.model" }, value: "after" } });
+  listeners["settingsForm:submit"]({ preventDefault() {} });
+  await quiet();
+
+  const said = el("saveMsg").innerHTML + " " + el("saveMsg").textContent;
+  ok("it says the write was saved", /Saved/.test(said), said);
+
+  if (WORKERS > 1) {
+    ok("it says this worker has it", /This worker has it now/.test(said), said);
+    ok("it counts the others", new RegExp("other " + (WORKERS - 1)).test(said), said);
+    ok("it says what makes them agree", /restart/.test(said), said);
+  } else {
+    ok("a single worker is not told about other workers",
+       !/This worker has it now/.test(said),
+       "a one-worker deployment was given a caveat about workers it does not have: " + said);
+  }
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+}().catch(function (err) {
+  console.log("FAILED harness threw: " + err.message);
+  process.exit(1);
+}));

--- a/tools/test_matrixark_a_live_setting_is_live_in_one_worker.py
+++ b/tools/test_matrixark_a_live_setting_is_live_in_one_worker.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A live setting is live in the worker that was written to, and no other.
+
+``applies: live`` means the value is read from ``os.environ`` inside the function that needs it,
+per call::
+
+    matrixark_mcp_embeddings.py:151  provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", ...)
+
+``update()`` writes ``os.environ`` and persists the file, so the worker that served the POST is
+correct at once. The gateway documents ``--workers 4`` and supports it wherever the workers share a
+store — and those other workers never see the write. They read their own environment, which still
+holds what ``apply_boot`` gave them at startup, until they are restarted.
+
+So a customer changes their embedding provider and one request in four uses it. Retrieval quality
+diverges by worker with nothing in any log saying why, and the page said *"Saved and live now."*
+
+This does not make the other workers pick it up — that wants a deliberate refresh path and its own
+review. It stops the page claiming something true of one process out of several.
+
+The worker count is lifted out of the split-store warning, which already reads it from the command
+line and ``WEB_CONCURRENCY``, so there is one answer to the question rather than two that can
+drift. That warning's own behaviour is asserted here too, because the refactor could have changed
+it silently.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+
+import matrixark_v1_gateway as gw
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "worker_reach_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+
+class TheWorkerCountIsReadOnceTest(unittest.TestCase):
+
+    def test_nothing_said_means_one(self) -> None:
+        """The default has to be 1, not 0 or unknown: every caveat below hangs off "more than
+        one", and a zero would either silence it everywhere or fire it everywhere."""
+        self.assertEqual(1, gw._worker_count([], {}))
+
+    def test_the_command_line_forms(self) -> None:
+        self.assertEqual(4, gw._worker_count(["--workers", "4"], {}))
+        self.assertEqual(3, gw._worker_count(["--workers=3"], {}))
+
+    def test_the_environment_form(self) -> None:
+        self.assertEqual(2, gw._worker_count([], {"WEB_CONCURRENCY": "2"}))
+
+    def test_the_command_line_wins(self) -> None:
+        self.assertEqual(4, gw._worker_count(["--workers", "4"], {"WEB_CONCURRENCY": "9"}))
+
+    def test_nonsense_is_one_rather_than_a_crash(self) -> None:
+        self.assertEqual(1, gw._worker_count(["--workers", "many"], {}))
+        self.assertEqual(1, gw._worker_count([], {"WEB_CONCURRENCY": "lots"}))
+
+
+class TheSplitStoreWarningStillBehavesTest(unittest.TestCase):
+    """It gave up its own copy of the counting; it must not have given up anything else."""
+
+    def test_it_fires_on_several_workers_with_an_embedded_store(self) -> None:
+        self.assertIsNotNone(gw._single_writer_warning(["--workers", "4"], {}))
+
+    def test_it_stays_quiet_on_one_worker(self) -> None:
+        self.assertIsNone(gw._single_writer_warning(["--workers", "1"], {}))
+
+    def test_it_stays_quiet_when_the_workers_share_a_store(self) -> None:
+        self.assertIsNone(
+            gw._single_writer_warning(["--workers", "4"], {"TS_STORAGE_BACKEND": "shared"}))
+
+    def test_it_still_names_the_count(self) -> None:
+        self.assertIn("--workers 4", gw._single_writer_warning(["--workers", "4"], {}))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePageSaysHowFarTheWriteReachedTest(unittest.TestCase):
+
+    def _run(self, workers):
+        return subprocess.run(["node", HARNESS, PAGE, str(workers)],
+                              capture_output=True, text=True, timeout=180)
+
+    def test_a_save_still_reports_itself(self) -> None:
+        proc = self._run(4)
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+        self.assertIn("ok   it says the write was saved", proc.stdout)
+
+    def test_several_workers_are_described(self) -> None:
+        out = self._run(4).stdout
+        self.assertIn("ok   it says this worker has it", out)
+        self.assertIn("ok   it counts the others", out)
+        self.assertIn("ok   it says what makes them agree", out)
+
+    def test_one_worker_hears_nothing_about_workers(self) -> None:
+        """A deployment with a single worker has no caveat, and inventing one teaches the reader
+        to skip the sentence on the deployments that do."""
+        self.assertIn("ok   a single worker is not told about other workers",
+                      self._run(1).stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_gateway_portal.py
+++ b/tools/test_matrixark_gateway_portal.py
@@ -644,5 +644,28 @@ class AdminWritesNeedAScopeThatMayWriteTest(_PortalTest):
         self.assertNotEqual(403, status)
 
 
+class TheWriteSaysHowManyWorkersTest(_PortalTest):
+    """A live setting is applied to the environment of the worker that served the write, and read
+    per call from the environment of whichever worker serves the next request. The answer carries
+    the count so the page can say how far the write reached instead of claiming "live now"."""
+
+    def test_the_response_carries_the_worker_count(self) -> None:
+        status, _, body = drive(
+            self.app, method="POST", path="/v1/admin/config", headers=ADMIN,
+            body={"settings": {"extraction.model": "deepseek-chat"}})
+        self.assertEqual(200, status)
+        self.assertIn("workers", json.loads(body))
+
+    def test_it_is_a_number_and_never_zero(self) -> None:
+        """The page branches on "more than one"; a zero would read as a single worker on a
+        deployment running eight."""
+        _s, _h, body = drive(
+            self.app, method="POST", path="/v1/admin/config", headers=ADMIN,
+            body={"settings": {"extraction.model": "deepseek-chat"}})
+        workers = json.loads(body)["workers"]
+        self.assertIsInstance(workers, int)
+        self.assertGreaterEqual(workers, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A setting whose `applies` is `live` is read from `os.environ` **inside the function that needs it,
per call** — that is what live means here:

```python
matrixark_mcp_embeddings.py:151  provider = os.environ.get("MATRIXARK_EMBEDDING_PROVIDER", ...)
```

`update()` writes `os.environ` and persists the file, so the worker that served the POST is correct
at once. The gateway documents `--workers 4` and supports it wherever the workers share a store —
and **those other workers never see the write**. They read their own environment, which still holds
what `apply_boot` gave them at startup, until they are restarted.

So a customer changes their embedding provider and one request in four uses it. Retrieval quality
diverges by worker, with nothing in any log saying why, and the page said:

> Saved and live now.

Now:

> Saved and live now. This worker has it now; the other 3 pick it up when they restart.

### What this deliberately does not do

It does not make the other workers pick it up. That wants a refresh path — a worker noticing the
file changed and re-applying — with its own design and review, and inventing one here would be a
larger change than the fault justifies. This stops the page claiming something true of one process
out of several.

### One answer to "how many workers is this"

The count is lifted out of the split-store warning, which already read it from the command line and
`WEB_CONCURRENCY`. That warning's own behaviour is asserted here too — fires on `--workers 4` with
an embedded store, quiet on one worker, quiet when they share a store, still names the count —
because the refactor could have changed it silently.

A **single-worker deployment is told nothing about workers**. Inventing a caveat for a deployment
that cannot have the problem teaches the reader to skip the sentence on the ones that can, so that
has its own test.

Verified red against main: the harness fails exactly the three multi-worker checks there and passes
the one about the save being reported, so it is exercising the page rather than failing to load it.

Suites green: gateway_portal (60), gateway_admin_config (11), v1_gateway (97), portal_pages (4),
dashboards (20), plus 12 new.
