### PR TITLE
Two constants cost a whole dict size step

### DIFF
--- a/tools/matrixark_local_adapter_ingest.py
+++ b/tools/matrixark_local_adapter_ingest.py
@@ -1460,8 +1460,14 @@ class _LocalAdapterIngestMixin:
                     "index_write_count": index_write_count,
                     "index_dropped_by_cap_count": index_dropped_by_cap_count,
                     **secondary_index_budget_summary(secondary_index_budget),
-                    "index_cap_per_chunk": MAX_INDEX_TERMS_PER_RESOURCE_CHUNK,
-                    "index_cap_per_fact": MAX_INDEX_TERMS_PER_RESOURCE_FACT,
+                    # The two caps live in `metrics` below, byte-identical, and nothing reads
+                    # either copy at the top level. They are also process constants, so the copy
+                    # said the same thing on every row.
+                    #
+                    # Removing them is worth far more than their two values: CPython sizes a dict
+                    # by KEY COUNT in steps, and this record sat at 44 keys with the next step
+                    # down at 43. At 42 the container costs 1,176 B instead of 2,272 -- 1,096 B
+                    # per row, 48%, for two keys holding "10" and "10".
                     "summary_dirty_hashes": resource_dirty_hashes,
                     "progress": {"stage": "completed", "percent": 100},
                     "metrics": resource_import_metrics,

--- a/tools/matrixark_mcp_ingest_resource_runtime.py
+++ b/tools/matrixark_mcp_ingest_resource_runtime.py
@@ -559,8 +559,10 @@ def ingest_resource_or_skill_if_needed(
                     "index_write_count": index_write_count,
                     "index_dropped_by_cap_count": index_dropped_by_cap_count,
                     **secondary_index_budget_summary(secondary_index_budget),
-                    "index_cap_per_chunk": MAX_INDEX_TERMS_PER_RESOURCE_CHUNK,
-                    "index_cap_per_fact": MAX_INDEX_TERMS_PER_RESOURCE_FACT,
+                    # Same two caps the local writer drops: already in `metrics` on this record,
+                    # byte-identical, read by nothing at the top level, and process constants. At
+                    # 44 keys the record sat one over CPython's 43-key dict step, so the two of
+                    # them cost 1,096 B per row. See matrixark_local_adapter_ingest.
                     "summary_dirty_hashes": resource_dirty_hashes,
                     "metrics": resource_import_metrics,
                 },

--- a/tools/test_matrixark_a_record_stays_under_its_dict_step.py
+++ b/tools/test_matrixark_a_record_stays_under_its_dict_step.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""CPython sizes a dict by KEY COUNT in steps, so a record's container cost is a cliff, not a slope.
+
+Measured on the read cache, the record dicts themselves are 46.8% of live heap -- more than any
+value they hold. A record sitting one key over a step pays the whole next one: `resource_import_task`
+was at 44 keys with the step at 43, so two keys holding the constants 10 and 10 cost 1,096 B per row.
+
+These tests pin the record types that sit closest to a boundary, so the next field added to one of
+them fails here instead of silently costing ~50-85% more container memory per row.
+
+The step boundaries are MEASURED from the running interpreter rather than tabulated, so the guard
+stays true if CPython changes its growth policy.
+"""
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:  # package path
+    from tools.matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+except ImportError:
+    from matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def dict_bytes(key_count: int) -> int:
+    """What this interpreter charges for a dict of ``key_count`` keys."""
+    probe = {}
+    for index in range(key_count):
+        probe["k%06d" % index] = index
+    return sys.getsizeof(probe)
+
+
+def step_ceiling(key_count: int) -> int:
+    """The largest key count that costs the same as ``key_count`` -- the room left before a jump."""
+    size = dict_bytes(key_count)
+    ceiling = key_count
+    while dict_bytes(ceiling + 1) == size:
+        ceiling += 1
+    return ceiling
+
+
+def skill_text(index: int) -> str:
+    lines = ["# Runbook %d" % index, "", "Draining a stuck queue for case %d." % index, ""]
+    for step in range(12):
+        lines += ["## Step %d" % step, "",
+                  "Check the queue depth for case %d step %d and drain it." % (index, step), ""]
+    return "\n".join(lines)
+
+
+class RecordStaysUnderItsDictStepTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = Path(tempfile.mkdtemp(prefix="dict_step_"))
+        log = cls.root / "events.jsonl"
+        writer = MatrixArkLocalAdapter(log)
+        for index in range(3):
+            writer.ingest({
+                "kind": "skill", "scope": SCOPE, "text": skill_text(index),
+                "metadata": {"raw_uri": "file:///s/r-%d.md" % index, "title": "r-%d" % index},
+            })
+        writer.close(timeout_s=600)
+        cls.records = MatrixArkLocalAdapter(log).read_all()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def rows(self, record_type: str) -> list:
+        found = [r for r in self.records if str(r.get("record_type") or "") == record_type]
+        # An upper bound on key count passes hardest when there are no rows at all, so require the
+        # type to be present before believing anything the bound says about it.
+        self.assertGreater(len(found), 0, "no %s rows: the bound below would pass vacuously"
+                           % record_type)
+        return found
+
+    def test_the_step_helper_actually_sees_steps(self):
+        # Control for the helpers themselves: if dict sizing were linear, every assertion built on
+        # step_ceiling would be meaningless.
+        self.assertGreater(step_ceiling(11), 11, "no headroom found at 11 keys -- helper is wrong")
+        self.assertLess(dict_bytes(step_ceiling(11)), dict_bytes(step_ceiling(11) + 1),
+                        "crossing a ceiling did not cost more, so there is no step to guard")
+
+    def test_the_import_task_stays_below_its_step(self):
+        rows = self.rows("resource_import_task")
+        widest = max(len(r) for r in rows)
+        ceiling = step_ceiling(widest)
+        self.assertLessEqual(
+            widest, ceiling,
+            "resource_import_task has %d keys; %d is the last that costs %d B, and one more costs "
+            "%d B per row" % (widest, ceiling, dict_bytes(ceiling), dict_bytes(ceiling + 1)))
+        # It sat at 44 against a step at 43. Pin that it is back under, naming the number, so a
+        # regression says what it cost rather than just that a count changed.
+        self.assertLessEqual(widest, 42,
+                             "resource_import_task is back over CPython's 43-key step: %d keys "
+                             "costs %d B per row against %d at 42"
+                             % (widest, dict_bytes(widest), dict_bytes(42)))
+
+    def test_nothing_was_lost_when_the_caps_moved_out(self):
+        # The two removed keys are still on the record, inside its own metrics dict. Dropping data
+        # would be a different change from dropping a duplicate.
+        for row in self.rows("resource_import_task"):
+            metrics = row.get("metrics")
+            self.assertIsInstance(metrics, dict, "the task lost its metrics dict")
+            for field in ("index_cap_per_chunk", "index_cap_per_fact"):
+                self.assertIn(field, metrics,
+                              "%s is not in metrics, so removing the top-level copy lost it"
+                              % field)
+            self.assertNotIn("index_cap_per_chunk", row,
+                             "the top-level duplicate is back")
+
+    def test_the_two_most_numerous_types_have_headroom(self):
+        # skill_section and resource_chunk are the bulk of any corpus and sit at 21 keys, which is
+        # the LAST slot before the next step. One added field costs them ~84% more container each.
+        for record_type in ("skill_section", "resource_chunk"):
+            rows = self.rows(record_type)
+            widest = max(len(r) for r in rows)
+            ceiling = step_ceiling(widest)
+            self.assertLessEqual(
+                widest, ceiling,
+                "%s has %d keys, over the %d that cost %d B; the next step is %d B per row"
+                % (record_type, widest, ceiling, dict_bytes(ceiling), dict_bytes(ceiling + 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CPython sizes a dict by **key count, in steps** — measured on this interpreter, not tabulated:

| keys | container |
|---|---|
| 11–21 | 640 B |
| 22–42 | 1,176 B |
| 43–85 | 2,272 B |

That matters more than it looks, because a live-heap walk of the read cache says the record dicts
**themselves** are 46.8% of it — 1,075 B per record before any value. More than the vectors, more
than the text. So a record sitting one key over a step pays the whole next one, and no per-field
byte census can see it: the field that pushes it over may hold two bytes.

Every record type sits on or near a boundary:

| record_type | rows | keys | container |
|---|---|---|---|
| `skill_section` | 192 | **21** | 640 B — the last slot before 1,176 |
| `resource_chunk` | 192 | **21** | 640 B — same |
| `resource_import_task` | 48 | **44** | **2,272 B — one key over the 43 step** |
| `context_index` | 112 | 17 | 640 B |

## The change

`resource_import_task` carried `index_cap_per_chunk` and `index_cap_per_fact` at the top level.
Both are process constants (`MAX_INDEX_TERMS_PER_RESOURCE_CHUNK` / `_FACT`), both are
byte-identical copies of entries already inside the record's own `metrics` dict, and neither is read
at the top level anywhere in `tools/` or `crates/`.

**Nineteen of the record's 44 keys duplicate its `metrics` that way.** These two are simply the two
that no reader depends on, which is why they are the ones that move.

Dropping them takes the record to 42 keys: **2,272 B → 1,176 B per row, −48%**, with both values
still present in `metrics`, so nothing is lost. Dropping the other seventeen would save nothing
further — 25 keys and 42 keys are the same step — so this is the whole available win, not a first
instalment.

## Tests

`test_matrixark_a_record_stays_under_its_dict_step.py` is the durable half of the change. It pins
the record types nearest a boundary — `resource_import_task`, and `skill_section` / `resource_chunk`,
which are the bulk of any corpus and sit at exactly 21 keys — so the next field added to one of them
fails here rather than silently costing 50–85% more container memory on every row.

Three things it does deliberately:

- The step boundaries are **measured from the running interpreter**, so the guard stays true if
  CPython changes its growth policy rather than encoding today's table as a constant.
- Every bound is preceded by an assertion that the record type **exists**, because an upper bound on
  key count passes hardest when there are no rows at all.
- One test checks the two caps are still present **inside `metrics`**, so a future change that
  removed the data rather than the duplicate would fail.

Verified against `main`: the two behaviour-pinning tests fail there — `44 not less than or equal to
42` and `the top-level duplicate is back` — and pass here. Container bytes measured 2,272 → 1,176
per task row.

Both arms of the full python suite were built with `git archive` and diffed by failing test name.
