### PR TITLE
Say where the first key comes from

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -32,6 +32,13 @@
   .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:18px 0}
   .card > h2 + .hint{margin-top:.25em}
   .hint{color:var(--muted);font-size:13.5px;margin:.2em 0 .8em}
+  /* Shut by default: it answers a question you have once, and every later visit is spent by
+     somebody who already holds a key. */
+  .firstkey{margin:-.4em 0 .9em}
+  .firstkey summary{cursor:pointer;color:var(--accent);font-size:13.5px}
+  .firstkey-cmd{background:var(--code-bg);color:var(--code-fg);padding:11px 13px;border-radius:9px;
+                font-family:var(--mono);font-size:12.5px;line-height:1.55;overflow-x:auto;
+                white-space:pre;margin:.4em 0 .6em}
   label{display:block;font-size:13px;font-weight:650;margin:10px 0 4px;color:var(--fg)}
   label .opt{font-weight:400;color:var(--muted)}
   input,select,textarea{width:100%;font-family:var(--sans);font-size:14px;padding:8px 10px;border:1px solid var(--line);
@@ -150,6 +157,23 @@
       It must carry the <code>admin:api_key</code> scope (usage reads also accept <code>admin:audit</code>).</p>
     <label for="adminKey">Admin API key <span class="opt">(bearer — held in sessionStorage)</span></label>
     <input id="adminKey" type="password" placeholder="sk_live_… / mk_… admin-scoped key" autocomplete="off">
+    <!-- A deployment enforcing keys has none until somebody mints one, and this page cannot mint
+         the first: minting is an admin call and needs a key already. Without this, the first thing
+         a new customer meets is a page asking for something they have no way to obtain. -->
+    <details class="firstkey">
+      <summary>No key yet?</summary>
+      <p class="hint">This page cannot mint the first one — creating a key is itself an
+        admin-scoped call. Run this wherever the gateway reads its keystore, then paste what it
+        prints:</p>
+      <pre class="firstkey-cmd">python3 tools/matrixark_provision_api_key.py \
+  --tenant-id tenantA --account-id acct_local \
+  --scopes admin:api_key,admin:audit,portal:read \
+  --store "$MATRIXARK_API_KEYS_HASHED_FILE"</pre>
+      <p class="hint">The key is printed once and only its hash is stored, so copy it before the
+        terminal scrolls. <code>--scopes</code> is not optional in practice: left off, the tool
+        mints the four <code>context:*</code> scopes, and a key carrying those is refused by this
+        page with no hint as to why.</p>
+    </details>
     <div class="row">
       <div>
         <label for="mgmtBase">Key-management API base <span class="opt">(serves <code>/api/admin/*</code>; blank = same origin)</span></label>

--- a/tools/test_matrixark_the_first_key_instructions_are_real.py
+++ b/tools/test_matrixark_the_first_key_instructions_are_real.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The instructions for getting a first key describe a command that exists.
+
+Every portal page asks for an admin key and is inert without one. A deployment enforcing keys
+starts with none, and the key page cannot mint the first: minting is itself an admin-scoped call.
+So the first thing a new customer met was a page demanding something they had no way to obtain.
+
+The Connection panel now says where the first one comes from. Instructions on a page are the kind
+of thing that goes quietly wrong -- a flag is renamed, a scope is retired, the tool moves -- and
+nobody notices until somebody following them gets an error the page cannot explain. So every part
+of the printed command is checked against the thing it describes:
+
+  * the tool is at the path the page prints,
+  * every ``--flag`` shown is a flag that tool accepts,
+  * every scope named is a scope the gateway knows.
+
+The scopes matter most. Left off, the provisioning tool mints the four ``context:*`` scopes, and a
+key carrying those is refused by this page -- so the obvious command produces a key that looks
+right and does not work. The page says so, and the flag it tells you to pass has to keep existing.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PAGE = os.path.join(TOOLS, "portal", "api_key_portal.html")
+TOOL = os.path.join(TOOLS, "matrixark_provision_api_key.py")
+
+
+def page() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def panel() -> str:
+    """The block itself, not the stylesheet.
+
+    Both carry the word `firstkey`, and the stylesheet comes first in the file -- so searching for
+    the name and slicing forward reads CSS and finds none of the prose.
+    """
+    source = page()
+    start = source.index('<details class="firstkey">')
+    return source[start:source.index("</details>", start)]
+
+
+def command() -> str:
+    """The command the page prints, and nothing else."""
+    block = panel()
+    start = block.index('<pre class="firstkey-cmd">')
+    return block[start:block.index("</pre>", start)]
+
+
+class ThePageAnswersTheQuestionTest(unittest.TestCase):
+
+    def test_the_connection_panel_says_where_a_first_key_comes_from(self) -> None:
+        self.assertIn("No key yet?", page())
+
+    def test_it_says_the_page_cannot_mint_it(self) -> None:
+        """The reason is the part that stops somebody hunting for a button that is not there."""
+        self.assertIn("cannot mint the first", page())
+
+    def test_it_warns_that_the_key_is_shown_once(self) -> None:
+        self.assertIn("printed once", panel())
+
+
+class TheCommandIsRealTest(unittest.TestCase):
+
+    def test_the_tool_it_names_exists(self) -> None:
+        self.assertIn("matrixark_provision_api_key.py", command())
+        self.assertTrue(os.path.exists(TOOL),
+                        "the page tells people to run a tool that is not in the tree")
+
+    def test_every_flag_shown_is_one_the_tool_accepts(self) -> None:
+        with io.open(TOOL, encoding="utf-8") as handle:
+            tool = handle.read()
+        shown = sorted(set(re.findall(r"--[a-z][a-z-]+", command())))
+        self.assertTrue(shown, "no flags found in the command; this check is vacuous")
+        unknown = [flag for flag in shown if ('"%s"' % flag) not in tool]
+        self.assertEqual([], unknown,
+                         "the page prints flags this tool does not accept: %r" % unknown)
+
+    def test_every_scope_named_is_one_the_gateway_knows(self) -> None:
+        """A retired scope in printed instructions mints a key that is refused, and the customer
+        has no way to tell the instructions were stale."""
+        import matrixark_v1_gateway as gw
+
+        known = {entry["scope"] for entry in gw.SCOPE_CATALOG}
+        shown = sorted(set(re.findall(r"[a-z]+:[a-z_]+", command())))
+        self.assertTrue(shown, "no scopes found in the command; this check is vacuous")
+        unknown = [scope for scope in shown if scope not in known]
+        self.assertEqual([], unknown,
+                         "the page names scopes this deployment does not have: %r" % unknown)
+
+    def test_the_scopes_shown_can_actually_use_this_page(self) -> None:
+        """The whole reason the flag is spelled out: the tool's default scopes cannot."""
+        self.assertIn("admin:api_key", command(),
+                      "the command omits the one scope this page requires")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every portal page asks for an admin key and is inert without one:

> Paste an admin API key in the Connection panel first.
> Enter an admin key to load the scope catalogue.
> Enter an admin key above to see how this is configured.

A deployment enforcing keys starts with **none**, and this page cannot mint the first — minting is
itself an admin-scoped call, which needs a key already. So the first thing a new customer meets is
a page demanding something they have no way to obtain, with nothing anywhere saying how to get it.

The answer exists: `matrixark_provision_api_key.py` writes a hashed record into the store the
gateway reads. It lives in the repository, which is not where somebody looking at a web page is
looking.

The Connection panel now answers it — shut by default, because it is a question you have once and
every later visit is made by somebody who already holds a key.

### Why `--scopes` is spelled out

Leaving it off is the trap. The tool then mints the four `context:*` scopes, and a key carrying
those is refused by this page with no hint as to why — so the obvious command produces a key that
*looks* right and does not work. The panel says so in as many words.

### Instructions that cannot rot silently

A flag renamed, a scope retired, the tool moved — nobody notices until somebody following the
instructions hits an error the page cannot explain. So the printed command is checked against what
it describes:

- the tool exists at the path printed,
- every `--flag` shown is one that tool accepts,
- every scope named is one the gateway's own `SCOPE_CATALOG` carries.

Verified by renaming a flag on the page, which reddens it:
`the page prints flags this tool does not accept: ['--scope-list']`.

Key-portal suites all green: copy (13), field labels (6), tab panes (7), rotate confirm (7),
portal_pages (4).
