### PR TITLE
Open the tab a status badge points into

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -373,10 +373,47 @@
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -492,10 +492,47 @@
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -584,10 +584,47 @@ TABS_JS = r"""
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -547,10 +547,47 @@
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/portal/deep_link_harness.js
+++ b/tools/portal/deep_link_harness.js
@@ -1,0 +1,236 @@
+/* Follow a link that names a place inside a tab, the way the status strip does.
+ *
+ * The live strip on every portal page links to "/v1/admin/setup#encoding" and
+ * "/v1/admin/setup#traffic". Both name a div inside a tab pane, and every pane but the first loads
+ * hidden -- so the browser's one attempt to scroll to the fragment finds nothing on screen, the
+ * default tab comes up, and the badge that was reporting a problem has quietly delivered the reader
+ * somewhere else. A link cannot report that it failed; it went to the page it named.
+ *
+ * Whether that now works is a question about NESTING -- which pane contains the target -- and a
+ * flat stub of a DOM cannot answer it. It would happily agree with any answer, including the wrong
+ * one, which is how three panes on the key portal shipped spliced into the wrong parents with every
+ * harness green. So containment here is read out of the page's own markup by matching <section>
+ * against </section>, and the extents that come out are checked for sanity before anything is built
+ * on them.
+ *
+ * Usage: node deep_link_harness.js <page.html> [#fragment ...]
+ */
+"use strict";
+const fs = require("fs");
+
+const path = process.argv[2];
+const wanted = process.argv.slice(3).map((f) => (f.charAt(0) === "#" ? f : "#" + f));
+const page = fs.readFileSync(path, "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* ---------- containment, read from the markup ---------- */
+/* Script blocks build markup out of strings -- "<section>" appears in them with no closing tag in
+   sight -- and an unbalanced tag inside one would run the depth count off the end of the document.
+   Blanked rather than removed so every index below still points into the real file. */
+const markup = page.replace(/<script[\s\S]*?<\/script>/g, (m) => " ".repeat(m.length));
+
+function extentFrom(start) {
+  const scan = /<section\b|<\/section>/g;
+  scan.lastIndex = start;
+  let depth = 0;
+  let match;
+  while ((match = scan.exec(markup)) !== null) {
+    depth += match[0] === "</section>" ? -1 : 1;
+    if (depth === 0) { return match.index + match[0].length; }
+  }
+  return -1;
+}
+
+const panes = [];
+const paneOpen = /<section[^>]*class="pane"[^>]*>/g;
+let open;
+while ((open = paneOpen.exec(markup)) !== null) {
+  const id = (open[0].match(/\sid="([^"]*)"/) || [])[1] || null;
+  panes.push({ id, start: open.index, end: extentFrom(open.index),
+               hidden: /\shidden[\s>]/.test(open[0]) });
+}
+
+if (!panes.length) { console.log("FAIL the page declares no panes"); process.exit(1); }
+
+/* ---------- the extents have to be worth trusting ---------- */
+/* A scan that silently matched nothing, or ran to the end of the file, would make every
+   containment answer below come out "no" -- and every assertion that a link does NOT go somewhere
+   would pass. So the extents are checked before they are used. */
+ok("every pane's extent was found", panes.every((p) => p.end > p.start),
+   panes.map((p) => p.id + ":" + p.start + ".." + p.end).join(" "));
+ok("every pane is named", panes.every((p) => p.id));
+ok("the panes do not overlap and are in order",
+   panes.every((p, i) => i === 0 || panes[i - 1].end <= p.start),
+   panes.map((p) => p.id + ":" + p.start + ".." + p.end).join(" "));
+ok("no pane's extent swallows the rest of the document",
+   panes[panes.length - 1].end <= markup.length);
+
+const ids = new Map();
+const idAttr = /\sid="([^"]+)"/g;
+let found;
+while ((found = idAttr.exec(markup)) !== null) {
+  if (!ids.has(found[1])) { ids.set(found[1], found.index); }
+}
+
+function paneHolding(id) {
+  if (!ids.has(id)) { return null; }
+  const at = ids.get(id);
+  return panes.find((p) => at > p.start && at < p.end) || null;
+}
+
+const inside = [...ids.keys()].filter((id) => {
+  const holder = paneHolding(id);
+  return holder && holder.id !== id;
+});
+ok("some element is nested inside a pane", inside.length > 0,
+   "nothing is contained by anything; the containment test would be vacuous");
+
+/* ---------- a DOM that knows what contains what ---------- */
+function makeEl(spec) {
+  return Object.assign({
+    id: spec.id,
+    hidden: !!spec.hidden,
+    tabIndex: 0,
+    scrolled: 0,
+    dataset: Object.assign({}, spec.dataset),
+    attrs: Object.assign({}, spec.attrs),
+    addEventListener() {},
+    setAttribute(k, v) { this.attrs[k] = String(v); },
+    getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; },
+    focus() {},
+    click() {},
+    scrollIntoView() { this.scrolled += 1; },
+    closest() { return null; },
+  });
+}
+
+const tabTags = [...markup.matchAll(/<button[^>]*role="tab"[\s\S]*?>/g)].map((m) => m[0]);
+if (!tabTags.length) { console.log("FAIL the page declares no tabs"); process.exit(1); }
+
+function build(hash) {
+  const tabs = tabTags.map((tag) => makeEl({
+    id: (tag.match(/\sid="([^"]*)"/) || [])[1],
+    dataset: { pane: (tag.match(/data-pane="([^"]*)"/) || [])[1] },
+    attrs: { "aria-selected": (tag.match(/aria-selected="([^"]*)"/) || [])[1] || "false" },
+  }));
+  const paneEls = panes.map((p) => makeEl({ id: p.id, hidden: p.hidden }));
+  const byId = new Map();
+  tabs.concat(paneEls).forEach((el) => byId.set(el.id, el));
+
+  const doc = {
+    querySelectorAll(selector) {
+      if (selector === ".tabs button") { return tabs; }
+      if (selector === ".pane") { return paneEls; }
+      return [];
+    },
+    getElementById(id) {
+      if (byId.has(id)) { return byId.get(id); }
+      if (!ids.has(id)) { return null; }
+      const holder = paneHolding(id);
+      const el = makeEl({ id });
+      /* The whole point: the real ancestor, taken from the real markup. */
+      el.closest = (selector) =>
+        (selector === ".pane" && holder) ? byId.get(holder.id) || null : null;
+      byId.set(id, el);
+      return el;
+    },
+  };
+
+  const listeners = {};
+  const win = {
+    location: { hash: hash || "" },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+  };
+  const src = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+    .map((m) => m[1]).find((s) => s.includes("window.wireTabs = function"));
+  if (!src) { console.log("FAIL the page carries no tab helper"); process.exit(1); }
+  new Function("window", "document", src)(win, doc);
+  win.wireTabs();
+
+  return {
+    doc,
+    selected: () => tabs.filter((t) => t.getAttribute("aria-selected") === "true").map((t) => t.id),
+    visible: () => paneEls.filter((p) => !p.hidden).map((p) => p.id),
+    go(next) {
+      win.location.hash = next;
+      (listeners.hashchange || []).forEach((fn) => fn({}));
+    },
+    listens: (type) => (listeners[type] || []).length > 0,
+  };
+}
+
+/* ---------- what a fresh page with no fragment does ---------- */
+const plain = build("");
+const fallback = plain.selected().join();
+ok("with no fragment the page opens on its own default tab", plain.selected().length === 1,
+   plain.selected().join(", "));
+ok("with no fragment exactly one pane is visible", plain.visible().length === 1);
+
+/* ---------- the fragments the strip actually links to ---------- */
+/* Derived, not listed: whichever ids the caller names, plus one taken from a pane that is not the
+   default, so this file still has something to check on a page nobody passed fragments for. */
+const derived = inside.filter((id) => {
+  const holder = paneHolding(id);
+  return holder && "tab-" + holder.id.replace(/^pane-/, "") !== fallback;
+});
+const checks = wanted.length ? wanted : (derived.length ? ["#" + derived[0]] : []);
+ok("there is a fragment to follow", checks.length > 0,
+   "no id lives inside a pane other than the default one");
+
+checks.forEach((fragment) => {
+  const name = fragment.replace(/^#/, "");
+  const holder = paneHolding(name);
+  ok("the page has somewhere to send " + fragment, !!holder,
+     ids.has(name) ? "the id exists but is not inside any pane" : "no element has that id");
+  if (!holder) { return; }
+
+  const run = build(fragment);
+  const want = "tab-" + holder.id.replace(/^pane-/, "");
+  ok("arriving at " + fragment + " opens the tab that holds it",
+     run.selected().join() === want, run.selected().join(", ") + " (wanted " + want + ")");
+  ok("arriving at " + fragment + " leaves exactly one pane visible",
+     run.visible().join() === holder.id, run.visible().join(", "));
+  ok("arriving at " + fragment + " scrolls to it once the pane is showing",
+     run.doc.getElementById(name).scrolled > 0,
+     "the pane opened but the reader is left at the top of it");
+});
+
+/* ---------- the same page, no navigation ---------- */
+/* The strip is on the setup page too. Clicking a segment that points into this page loads nothing:
+   the URL gains a fragment and that is the entire event. */
+if (checks.length) {
+  const name = checks[0].replace(/^#/, "");
+  const holder = paneHolding(name);
+  if (holder) {
+    const run = build("");
+    ok("the page listens for the fragment changing under it", run.listens("hashchange"));
+    run.go(checks[0]);
+    ok("changing the fragment without reloading still opens the tab",
+       run.selected().join() === "tab-" + holder.id.replace(/^pane-/, ""),
+       run.selected().join(", "));
+  }
+}
+
+/* ---------- fragments that mean nothing here ---------- */
+const unknown = build("#no-such-anchor-exists");
+ok("a fragment naming nothing leaves the default tab up", unknown.selected().join() === fallback,
+   unknown.selected().join(", "));
+
+const outside = [...ids.keys()].find((id) => !paneHolding(id));
+if (outside) {
+  const run = build("#" + outside);
+  ok("a fragment outside the tabs (#" + outside + ") leaves the default tab up",
+     run.selected().join() === fallback, run.selected().join(", "));
+}
+
+const weird = build("#%E0%A4%A");
+ok("a fragment that is not valid escaping is survivable", weird.selected().join() === fallback,
+   weird.selected().join(", "));
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -634,10 +634,47 @@
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -726,10 +726,47 @@
       });
     });
 
+    /* A fragment can name something inside a pane that is not showing.
+     *
+     * The live strip does exactly that from every page: "/v1/admin/setup#encoding" is a div inside
+     * the Settings pane, "#traffic" one inside Checks, and both panes load hidden. The browser
+     * scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to -- so the
+     * badge arrived at the page, the default tab came up, and the state it was reporting on was not
+     * on screen. Nothing said so; the link worked in the only sense a link can be said to work.
+     *
+     * Which pane holds the target is the page's business, not this helper's, so it is read off the
+     * element rather than listed here: any fragment naming anything inside any pane opens it. */
+    function fromHash(hash) {
+      var name;
+      try { name = decodeURIComponent((hash || "").replace(/^#/, "")); }
+      catch (error) { name = (hash || "").replace(/^#/, ""); }
+      if (!name) { return false; }
+      var target = document.getElementById(name);
+      var pane = target && target.closest ? target.closest(".pane") : null;
+      if (!pane) { return false; }
+      var button = document.getElementById("tab-" + pane.id.replace(/^pane-/, ""));
+      if (!button) { return false; }
+      show(button);
+      /* The pane was hidden when the browser did its own scrolling, so it did not scroll. */
+      if (target.scrollIntoView) { target.scrollIntoView(); }
+      return true;
+    }
+
+    /* Clicking "#traffic" while already on this page changes no document, so nothing reloads and
+       the only signal is this event. That is the strip's own page -- the case most likely to be
+       reached and the one where doing nothing looks most like a dead control. */
+    if (window.addEventListener) {
+      window.addEventListener("hashchange", function () {
+        fromHash(window.location && window.location.hash);
+      });
+    }
+
     var already = tabs.filter(function (b) {
       return b.getAttribute("aria-selected") === "true";
     });
-    show(already[0] || tabs[0]);
+    if (!fromHash(window.location && window.location.hash)) {
+      show(already[0] || tabs[0]);
+    }
   };
 
   /* Show a pane from code. Needed whenever one pane's control writes into another's: without

--- a/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
+++ b/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A link that names a place inside a tab has to open that tab.
+
+The status strip runs across the top of every portal page, and two of its segments are links:
+``/v1/admin/setup#encoding`` when the deployment is retrieving on hash vectors, and
+``/v1/admin/setup#traffic`` when requests are being refused. Both name a div that lives inside a tab
+pane, and every pane but the first loads ``hidden``.
+
+A browser scrolls to a fragment once, at load. There is nothing to scroll to -- the element is
+inside a hidden section -- so it doesn't, the Access tab comes up, and the reader is looking at the
+key input instead of the thing the badge was warning them about. On the setup page itself it is
+worse: no document changes, so nothing at all happens, and the badge is indistinguishable from a
+dead control.
+
+``location.hash`` appeared nowhere in the portal. The helper now resolves the fragment to whichever
+pane contains it, opens that tab, and scrolls -- and handles ``hashchange``, which is the same-page
+case.
+
+Two things are checked, because they fail differently:
+
+* every fragment any page links to names an element that exists on the page it points at -- a
+  cheap check that catches a target being renamed out from under the link;
+* the tab helper, run against the real markup, actually opens the pane holding it.
+
+The second needs to know what contains what, and a flat DOM stub cannot answer that -- it agrees
+with whatever it is told, which is how three panes once shipped spliced into the wrong parents with
+every harness green. So the harness reads containment out of the page by matching ``<section>``
+against ``</section>``, and asserts those extents are sane before trusting them.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "deep_link_harness.js")
+GATEWAY = os.path.join(TOOLS, "matrixark_v1_gateway.py")
+
+
+def read(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def pages() -> dict:
+    return {name: read(os.path.join(PORTAL, name))
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+def markup(text: str) -> str:
+    """The page without its scripts.
+
+    Script blocks build markup out of strings, so ``class="pane"`` appears in a page that declares
+    no pane at all -- the API page assembles its tabs from the route catalogue after a fetch, and
+    reading its source for panes finds the template rather than the page.
+    """
+    return re.sub(r"<script[\s\S]*?</script>", "", text)
+
+
+def routes_to_pages() -> dict:
+    """Which file a portal route serves, taken from the gateway rather than assumed.
+
+    The names do not follow from each other -- ``/v1/admin/portal`` serves the key page and
+    ``/v1/admin`` serves the overview -- so guessing the mapping would check the wrong file and
+    pass.
+    """
+    source = read(GATEWAY)
+    served = re.findall(
+        r'path (?:==|in) \(?"(/v1/admin[^"]*)"[^\n]*\n\s*return await _html\(send, 200, (\w+)\(\)\)',
+        source)
+    files = {}
+    for helper in {name for _, name in served}:
+        body = source[source.index("def %s(" % helper):]
+        match = re.search(r'"([a-z_]+_portal\.html)"', body[:2000])
+        if match:
+            files[helper] = match.group(1)
+    return {route: files[helper] for route, helper in served if helper in files}
+
+
+def fragment_links() -> list:
+    """Every ``/v1/admin/...#anchor`` any portal page links to, with the page it is written on."""
+    found = []
+    for name, text in pages().items():
+        for route, anchor in re.findall(r'href="(/v1/admin[a-z/]*)#([^"]+)"', text):
+            found.append((name, route, anchor))
+    return found
+
+
+class TheLinksPointAtSomethingTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.links = fragment_links()
+        self.routes = routes_to_pages()
+
+    def test_there_are_links_to_check(self) -> None:
+        """Without this the two tests below pass on an empty list and say nothing."""
+        self.assertTrue(self.links, "no page links to a fragment; these checks are vacuous")
+
+    def test_every_route_linked_to_is_one_the_gateway_serves(self) -> None:
+        unserved = sorted({route for _, route, _ in self.links if route not in self.routes})
+        self.assertEqual([], unserved,
+                         "pages link to routes that serve no page: %r" % unserved)
+
+    def test_every_anchor_exists_on_the_page_it_points_at(self) -> None:
+        """A renamed div leaves the link pointing nowhere, and it still navigates."""
+        broken = []
+        for source_page, route, anchor in self.links:
+            target = self.routes.get(route)
+            if not target:
+                continue
+            if ('id="%s"' % anchor) not in read(os.path.join(PORTAL, target)):
+                broken.append("%s -> %s#%s" % (source_page, target, anchor))
+        self.assertEqual([], broken, "links whose target does not exist: %r" % broken)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheTabOpensTest(unittest.TestCase):
+
+    def _run(self, page_name, anchors):
+        return subprocess.run(
+            ["node", HARNESS, os.path.join(PORTAL, page_name)] + sorted(set(anchors)),
+            capture_output=True, text=True, timeout=300)
+
+    def _targets(self):
+        routes = routes_to_pages()
+        grouped = {}
+        for _, route, anchor in fragment_links():
+            target = routes.get(route)
+            if target:
+                grouped.setdefault(target, []).append(anchor)
+        return grouped
+
+    def test_the_pages_that_are_linked_into_open_the_right_tab(self) -> None:
+        grouped = self._targets()
+        self.assertTrue(grouped, "nothing is linked into; this check is vacuous")
+        for page_name, anchors in sorted(grouped.items()):
+            with self.subTest(page=page_name):
+                proc = self._run(page_name, anchors)
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                for anchor in sorted(set(anchors)):
+                    self.assertIn("ok   arriving at #%s opens the tab that holds it" % anchor,
+                                  proc.stdout)
+
+    def test_the_reader_is_taken_to_the_target_not_just_the_pane(self) -> None:
+        """The pane can be metres long. Opening it and leaving them at the top is most of the way
+        to the original problem: they are looking at a page that does not obviously concern them."""
+        for page_name, anchors in sorted(self._targets().items()):
+            out = self._run(page_name, anchors).stdout
+            for anchor in sorted(set(anchors)):
+                self.assertIn("ok   arriving at #%s scrolls to it once the pane is showing" % anchor,
+                              out)
+
+    def test_the_same_page_case_is_handled(self) -> None:
+        """The strip is on the setup page too, so its own segments load no document at all."""
+        for page_name, anchors in sorted(self._targets().items()):
+            out = self._run(page_name, anchors).stdout
+            self.assertIn("ok   the page listens for the fragment changing under it", out)
+            self.assertIn("ok   changing the fragment without reloading still opens the tab", out)
+
+    def test_a_fragment_that_means_nothing_here_changes_nothing(self) -> None:
+        for page_name, anchors in sorted(self._targets().items()):
+            out = self._run(page_name, anchors).stdout
+            self.assertIn("ok   a fragment naming nothing leaves the default tab up", out)
+            self.assertIn("ok   a fragment that is not valid escaping is survivable", out)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class EveryTabbedPageAnswersAFragmentTest(unittest.TestCase):
+    """Not only the pages something links into today.
+
+    The helper is shared, so a page growing tabs gets this behaviour without anyone deciding it
+    should. Running every tabbed page through the harness -- with the fragment derived from its own
+    markup rather than supplied -- is what keeps that true.
+    """
+
+    def test_every_page_with_tabs_and_panes(self) -> None:
+        """Pages whose tabs are in the markup. The API page's are built from the route catalogue
+        after a fetch, and it calls the helper once they exist, so a fragment naming one of them is
+        resolved then -- there is just nothing in the file for a source scan to check."""
+        tabbed = [name for name, text in pages().items()
+                  if 'role="tab"' in markup(text) and 'class="pane"' in markup(text)]
+        self.assertGreaterEqual(len(tabbed), 4, tabbed)
+        for name in tabbed:
+            with self.subTest(page=name):
+                proc = subprocess.run(["node", HARNESS, os.path.join(PORTAL, name)],
+                                      capture_output=True, text=True, timeout=300)
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                self.assertIn("ok   there is a fragment to follow", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The live strip on every portal page turns two of its segments into links — `/v1/admin/setup#encoding`
when the deployment is retrieving on hash vectors, `/v1/admin/setup#traffic` when requests are being
refused. Both name a div inside a tab pane:

- `#encoding` → `pane-settings`, `hidden` at load
- `#traffic` → `pane-health`, `hidden` at load
- default tab: `access`

A browser scrolls to a fragment once, at load, and a hidden element is nowhere to scroll to. **So the
badge navigated, the Access tab came up, and the state it was warning about was not on screen.** From
the setup page itself nothing happened at all — no document changes, so no load — and the badge was
indistinguishable from a dead control. `location.hash` appeared nowhere in the portal.

`wireTabs` now resolves a fragment to whichever pane contains it, shows that tab, scrolls the target
into view (the browser's own attempt already ran and found nothing), and listens for `hashchange`.
Containment is read off the element rather than listed in the helper, so this holds for any fragment
naming anything inside any pane, on all five tabbed pages.

### Checked two ways

**The link points at something.** Every fragment any page links to must name an element that exists
on the page that route serves. The route→file map is read out of the gateway, not assumed:
`/v1/admin/portal` serves the key page and `/v1/admin` the overview, so guessing would check the
wrong file and pass.

**The tab opens.** That is a question about *nesting*, and a flat DOM stub cannot answer it — it
agrees with whatever it is told, which is how three panes once shipped spliced into the wrong
parents with every harness green. So `deep_link_harness.js` reads containment out of the page by
matching `<section>` against `</section>`, with script blocks blanked (the API page builds its tabs
from strings), and checks the extents before trusting them — a scan that matched nothing would make
every "does not go there" assertion pass.

Run against the page as it ships today, the harness fails eight assertions:

```
FAIL arriving at #encoding opens the tab that holds it
FAIL arriving at #encoding scrolls to it once the pane is showing
FAIL arriving at #traffic opens the tab that holds it
FAIL the page listens for the fragment changing under it
FAIL changing the fragment without reloading still opens the tab
FAILED 8
```

Green after: 21 harness assertions on setup, and the derived-fragment sweep passes on setup,
explore, catalog and the key portal. The API page assembles its tabs from the route catalogue after
a fetch and calls the helper once they exist, so its fragments resolve then — there is simply
nothing static for a source scan to check, and it is excluded by masking scripts before looking.

Neighbouring suites: portal_tabs (19), api_traffic (15), tab panes (7), portal_pages (4).
