### PR TITLE
Restore the guard that keeps a retired name out of the Rust surfaces

### DIFF
--- a/tools/test_rustraft_naming.py
+++ b/tools/test_rustraft_naming.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MatrixArkAI
+"""The retired raft name stays out of the Rust surfaces.
+
+This guard was added when those surfaces were renamed off an internal name, and its job is to
+keep that name from coming back. A later repository-wide rename of that name to `matrixraft`
+rewrote the string this guard *forbids* along with everything else, so the guard came to assert
+that `matrixraft` appears nowhere -- while the crate depends on MatrixRaft by exactly that name
+(`crates/temporalstore-rust/Cargo.toml` names it, and `src/raft/matrixraft.rs` is a module). It
+could not pass, and meanwhile nothing was checking for the retired name at all: the open-source
+readiness gate (`tools/validate_open_source_readiness.py`) covers licensing, private paths and
+the enterprise object store, not this.
+
+So the subject is restored, spelled in two pieces so that a guard naming what it forbids does not
+itself reintroduce it -- and so a repository-wide rename cannot silently retarget it a second
+time.
+"""
 from __future__ import annotations
 
 import unittest
@@ -9,26 +24,63 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Assembled at runtime: the literal must not appear in a tracked file, which is the whole point.
+RETIRED_NAME = "byte" + "raft"
+
+SCANNED_SUFFIXES = {".rs", ".md", ".py", ".toml", ".json"}
+
+CHECKED_ROOTS = (
+    ROOT / "crates" / "temporalstore-rust",
+    ROOT / "docs" / "rustraft_production_readiness.md",
+    ROOT / "docs" / "distributed_raft_readiness.md",
+    ROOT / "tools" / "validate_aws_validation_log.py",
+    ROOT / "tools" / "run_temporalstore_unified_tests.py",
+)
+
+# A floor on the scan, so a moved or renamed directory cannot leave this quantified over nothing
+# and reporting success. 267 files are in scope today.
+MIN_SCANNED_FILES = 200
+
+
+def offending_paths(documents: dict) -> list:
+    """Pure over {name: text} so the check can be run against deliberately broken input."""
+    return sorted(name for name, text in documents.items() if RETIRED_NAME in text.lower())
+
+
+def scanned_documents() -> dict:
+    documents = {}
+    for root in CHECKED_ROOTS:
+        if not root.exists():
+            continue
+        paths = [root] if root.is_file() else [path for path in root.rglob("*") if path.is_file()]
+        for path in paths:
+            if path.suffix not in SCANNED_SUFFIXES:
+                continue
+            documents[str(path.relative_to(ROOT))] = path.read_text(encoding="utf-8", errors="ignore")
+    return documents
+
 
 class RustRaftNamingTest(unittest.TestCase):
-    def test_rust_surfaces_do_not_expose_matrixraft_names(self) -> None:
-        checked_roots = [
-            ROOT / "crates" / "temporalstore-rust",
-            ROOT / "docs" / "rustraft_production_readiness.md",
-            ROOT / "docs" / "distributed_raft_readiness.md",
-            ROOT / "tools" / "validate_aws_validation_log.py",
-            ROOT / "tools" / "run_temporalstore_unified_tests.py",
-        ]
-        offenders: list[str] = []
-        for root in checked_roots:
-            paths = [root] if root.is_file() else [path for path in root.rglob("*") if path.is_file()]
-            for path in paths:
-                if path.suffix not in {".rs", ".md", ".py", ".toml", ".json"}:
-                    continue
-                text = path.read_text(encoding="utf-8", errors="ignore")
-                if "matrixraft" in text.lower():
-                    offenders.append(str(path.relative_to(ROOT)))
-        self.assertEqual(offenders, [])
+    def test_rust_surfaces_do_not_expose_the_retired_raft_name(self) -> None:
+        documents = scanned_documents()
+        missing = [str(root.relative_to(ROOT)) for root in CHECKED_ROOTS if not root.exists()]
+        self.assertEqual([], missing, "a checked path has moved, so it is no longer being scanned")
+        self.assertGreaterEqual(
+            len(documents), MIN_SCANNED_FILES,
+            "only %d files were scanned, expected at least %d -- the scan has lost its subject"
+            % (len(documents), MIN_SCANNED_FILES))
+        self.assertEqual([], offending_paths(documents))
+
+    def test_a_reintroduced_name_would_be_caught(self) -> None:
+        """The positive control. A checker that only ever sees clean input passes just as well
+        when it has stopped checking."""
+        planted = {
+            "crates/temporalstore-rust/src/lib.rs": "// migrated from " + RETIRED_NAME.upper(),
+            "crates/temporalstore-rust/README.md": "nothing to see here",
+        }
+        self.assertEqual(["crates/temporalstore-rust/src/lib.rs"], offending_paths(planted))
+        # And the current, legitimate dependency name is not what this guard is about.
+        self.assertEqual([], offending_paths({"Cargo.toml": 'matrixraft = { package = "matrixraft" }'}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`test_rust_surfaces_do_not_expose_matrixraft_names` has been failing with 24
offenders, and it could never have passed. The guard was added when those
surfaces were renamed off an internal name, to keep that name from coming back.
A later repository-wide rename of that name to `matrixraft` rewrote the string
the guard *forbids* along with every other occurrence, so the guard came to
assert that `matrixraft` appears nowhere -- while the crate depends on MatrixRaft
by exactly that name: `crates/temporalstore-rust/Cargo.toml` declares it and
`src/raft/matrixraft.rs` is a module.

The substitution is visible in the file's own history. Counting occurrences in
`tools/test_rustraft_naming.py` at each commit that touched it:

    3fe9662c1   retired name 2   matrixraft 0
    4bbb81c6e   retired name 2   matrixraft 0
    7758fe098   retired name 0   matrixraft 2

Two costs, not one. The visible cost is a permanently red test. The quiet cost is
that nothing has been checking for the retired name since: the open-source
readiness gate run in CI (`tools/validate_open_source_readiness.py`) covers cargo
licensing, the license file, tracked local config, private paths and the
enterprise object store, and does not mention it. The working tree is clean of it
today, so the restored guard passes rather than papering over anything.

The forbidden string is now assembled at runtime instead of stored, for two
reasons: a guard that names what it forbids should not itself reintroduce it, and
a future repository-wide rename cannot silently retarget it a second time.

Also added, because the guard had neither: a floor on the scan (267 files are in
scope; it now requires at least 200) and an explicit check that every configured
root still exists. Without those, moving or renaming a checked directory would
leave the scan quantified over nothing and still reporting success -- the same
shape of failure as the one above, where a check kept passing after it had
stopped checking.

A positive control feeds the checker a planted occurrence and requires a
complaint. Mutation-tested end to end as well: appending the name to a real
scanned file (`crates/temporalstore-rust/README.md`) fails the test and names
that file.

The old method name disappears from the failing set because the test is renamed
to describe what it actually checks, and both tests now pass. Two names appear,
neither failing.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
