### PR TITLE
Let an embedded proxy run the storage-manager cycle

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -3587,6 +3587,46 @@ fn execute_record_log_request(
             }
             json_output(serde_json::Value::Object(map), root)?
         }
+        // Run the engine's own storage-manager cycle: dump the catalog, mint the durable WAL
+        // anchor, and let reclaim use it. This proxy never ran it, so the anchor was never
+        // produced and the log could never be reclaimed -- every start replayed everything.
+        // Exposed as an op, not a background thread: it rewrites durable structures, so it runs
+        // when asked. `shard_size` carries the dump budget so no new request field is needed.
+        "storage_manager_cycle" => {
+            // Only an embedded engine has a cycle to run; a remote table is served elsewhere.
+            let RecordStore::Local(local) = &engine else {
+                return Err("the storage-manager cycle needs a local engine".to_string());
+            };
+            // `shard_size` carries the dump budget: the request shape has no field for it, and
+            // adding one would change a wire format for a maintenance call.
+            let budget = request.shard_size.unwrap_or(4).clamp(1, 1024) as usize;
+            let report = local.run_storage_manager_cycle(
+                temporalstore_rust::engine::reports::StorageManagerCycleRequest {
+                    shard_id: DEFAULT_SHARD_ID,
+                    max_dump_buckets_per_round: budget,
+                    warm_cache: false,
+                    ..Default::default()
+                },
+            );
+            // Report the reclaim outcome, not just that the cycle ended: a cycle that frees
+            // nothing looks identical to one that freed plenty unless it says which.
+            let reclaim = report
+                .wal_reclaim_report
+                .as_ref()
+                .map(|r| serde_json::to_value(r).unwrap_or(serde_json::Value::Null))
+                .unwrap_or(serde_json::Value::Null);
+            json_output(
+                serde_json::json!({
+                    "completed": report.completed,
+                    "shard_id": DEFAULT_SHARD_ID,
+                    "max_dump_buckets_per_round": budget,
+                    "duration_ms": report.duration_ms,
+                    "stages": report.native_stage_order,
+                    "wal_reclaim_report": reclaim,
+                }),
+                root,
+            )?
+        }
         "matrixark_scan_candidates" => {
             json_output(scan_matrixark_candidates(&engine, &request)?, root)?
         }
@@ -3753,7 +3793,7 @@ fn validate_request(request: &RecordLogRequest) -> Result<(), String> {
             }
         }
         // Read-only counter dump: no key, no field, nothing to validate.
-        "durability_barriers" => Ok(()),
+        "durability_barriers" | "storage_manager_cycle" => Ok(()),
         "hset" | "hget" | "hdel" => {
             require_non_empty("key", &request.key)?;
             require_non_empty("field", &request.field)


### PR DESCRIPTION
An embedded proxy has no way to ask the engine to run a storage-manager cycle, so on a box that
runs `matrixark_rust_proxy` the cycle never runs at all. `run_storage_manager_cycle` is a public
engine method, driven from `bin/server.rs`, `data_node/worker.rs` and
`data_node/runtime_storage.rs` — every path except this one.

What that costs, measured on a 460 MB hook store:

* the index catalog is never dumped, so the base index never reflects state;
* with no durable anchor, a start that trusts it serves **84,108 bytes where a full load serves
  21,162,060** — every records shard empty, `record_count` still answering correctly;
* so every start must replay the entire log, and the log can only grow.

Running the cycle fixes the first two. A store that has had one loads **complete** without any
anchor rewind:

| first load, fresh process, no rewind | ran first | ran second |
|---|---|---|
| after a cycle | 21,912 ms complete | 15,571 ms complete |
| without one | 54,070 ms complete | 55,604 ms **8/8 shards empty** |

It wins from either position, which matters because on that machine the second run is otherwise
always faster — the bias runs against this result.

## What this adds

One op, `storage_manager_cycle`. Not a background thread: the cycle rewrites durable structures,
so it should run when an operator asks, on a cadence they choose. `shard_size` carries the dump
budget rather than adding a field to the request shape for a maintenance call.

It returns the `wal_reclaim_report`, not just a status. That was not cosmetic — `completed: true`
cannot distinguish a cycle that freed plenty from one that freed nothing, and the report
immediately named why the WAL on that store is not reclaimable:

```
applied=false  blockers=["slot_generation_without_durable_dump"]
frontier_wal=0  current_wal=24840  missing=1691  covered_slot_count=0
```

Unchanged across five cycles at the maximum dump budget. That is a separate problem — no bucket
has a matching dump manifest — and this change does not claim to fix it. It makes it visible.

## Verified

* `cargo test -p temporalstore-rust --lib -- --test-threads=1` — full suite, on this branch.
* The op runs against a real 460 MB store: cycle completes, data intact (23,705,186 B served
  after, 23,692,014 before — the difference is live writes), and the store then loads complete
  with no rewind.
* A remote table returns an error rather than pretending: the cycle needs a local engine.
