### PR TITLE
Point the pages that demand a key at the one that explains keys

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -160,7 +160,7 @@
     <!-- A deployment enforcing keys has none until somebody mints one, and this page cannot mint
          the first: minting is an admin call and needs a key already. Without this, the first thing
          a new customer meets is a page asking for something they have no way to obtain. -->
-    <details class="firstkey">
+    <details class="firstkey" id="firstkey">
       <summary>No key yet?</summary>
       <p class="hint">This page cannot mint the first one — creating a key is itself an
         admin-scoped call. Run this wherever the gateway reads its keystore, then paste what it
@@ -1120,6 +1120,41 @@
   });
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
+}());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
 }());
 </script>
 </body>

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -955,6 +955,41 @@
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
 }());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
 </script>
 </body>
 </html>

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -504,6 +504,41 @@ NAV_JS = r'''<script>
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
 }());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
 </script>
 '''
 
@@ -654,6 +689,8 @@ SETUP_BODY = """
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
+      — no page can mint it; it takes one command where the gateway runs.</p>
     <div class="hint">Reading this page needs nothing; every action calls an admin-gated endpoint, so
       the page is inert without a key. “Remember” keeps it in this tab only and forgets it when the
       tab closes — it is never written to disk or sent anywhere but this gateway.</div>
@@ -2904,6 +2941,8 @@ OVERVIEW_BODY = """
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
+      — no page can mint it; it takes one command where the gateway runs.</p>
     <div class="hint">Reading this page needs nothing; the checklist needs an admin-scoped key.</div>
   </section>
 

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1073,6 +1073,41 @@
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
 }());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
 </script>
 </body>
 </html>

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -2032,6 +2032,41 @@
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
 }());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
+}());
 </script>
 </body>
 </html>

--- a/tools/portal/folded_answer_harness.js
+++ b/tools/portal/folded_answer_harness.js
@@ -1,0 +1,123 @@
+/* Follow a link that names something folded away.
+ *
+ * The key portal answers "where does the first admin key come from" inside a <details>, shut by
+ * default because it is a question somebody has once. Three other pages link straight at it. A link
+ * to a closed <details> arrives with the answer still folded up -- the reader is on the right page,
+ * looking at a summary line, no worse informed than before -- and browsers disagree about whether
+ * they expand it, so leaving it to them means it works for some customers and not others.
+ *
+ * The page's own helper is executed here rather than read: whether a <details> ends up open is
+ * behaviour, and a page whose reveal helper is wired to nothing looks in source exactly like one
+ * whose works.
+ *
+ * Usage: node folded_answer_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const path = process.argv[2];
+const page = fs.readFileSync(path, "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* ---------- what the page actually declares ---------- */
+const markup = page.replace(/<script[\s\S]*?<\/script>/g, (m) => " ".repeat(m.length));
+const foldTags = [...markup.matchAll(/<details[^>]*>/g)].map((m) => m[0]);
+const named = foldTags
+  .map((tag) => ({ tag, id: (tag.match(/\sid="([^"]*)"/) || [])[1] }))
+  .filter((d) => d.id);
+
+ok("the page folds something away", foldTags.length > 0);
+ok("a link can name it", named.length > 0,
+   "no <details> carries an id, so nothing can be linked to");
+if (!named.length) { console.log("FAILED " + failures); process.exit(1); }
+
+named.forEach((fold) => {
+  ok("#" + fold.id + " starts shut", !/\sopen[\s>]/.test(fold.tag),
+     "it is open in the markup, so nothing below is testing anything");
+});
+
+/* ---------- a DOM with the one relationship that matters ---------- */
+function makeEl(spec) {
+  return {
+    id: spec.id || null,
+    tagName: spec.tagName,
+    open: false,
+    scrolled: 0,
+    parentNode: spec.parentNode || null,
+    scrollIntoView() { this.scrolled += 1; },
+  };
+}
+
+const src = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+  .map((m) => m[1]).find((s) => s.includes("function reveal()"));
+if (!src) { console.log("FAIL the page carries no reveal helper"); process.exit(1); }
+
+/* `nest` puts the named element INSIDE the fold rather than being it -- the walk has to climb, and
+   a helper that only ever looked at the element itself would pass every test that does not. */
+function build(hash, nest) {
+  const fold = makeEl({ tagName: "DETAILS", id: nest ? null : named[0].id });
+  const wrapper = makeEl({ tagName: "DIV", parentNode: fold });
+  const inner = makeEl({ tagName: "P", id: nest ? named[0].id : null, parentNode: wrapper });
+  const loose = makeEl({ tagName: "P", id: "not-folded-at-all" });
+
+  const byId = new Map();
+  [fold, inner, loose].forEach((el) => { if (el.id) { byId.set(el.id, el); } });
+
+  const listeners = {};
+  const win = {
+    location: { hash: hash || "" },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+  };
+  const doc = { getElementById: (id) => byId.get(id) || null };
+  new Function("window", "document", src)(win, doc);
+
+  return {
+    fold,
+    target: nest ? inner : fold,
+    listens: (type) => (listeners[type] || []).length > 0,
+    go(next) {
+      win.location.hash = next;
+      (listeners.hashchange || []).forEach((fn) => fn({}));
+    },
+  };
+}
+
+const anchor = "#" + named[0].id;
+
+/* ---------- the link works ---------- */
+const arrived = build(anchor, false);
+ok("arriving at " + anchor + " unfolds it", arrived.fold.open === true,
+   "the reader is on the right page looking at a folded summary");
+ok("arriving at " + anchor + " scrolls to it", arrived.target.scrolled > 0);
+
+const nested = build(anchor, true);
+ok("a fragment naming something inside the fold unfolds it too", nested.fold.open === true,
+   "the helper only looks at the element itself, not what encloses it");
+
+/* ---------- and does not fire when it should not ---------- */
+const plain = build("", false);
+ok("with no fragment it stays shut", plain.fold.open === false,
+   "opening it for everyone throws away the reason it is a <details>");
+
+const other = build("#no-such-anchor", false);
+ok("a fragment naming nothing leaves it shut", other.fold.open === false);
+
+const loose = build("#not-folded-at-all", false);
+ok("a fragment naming something outside any fold leaves it shut", loose.fold.open === false);
+
+const weird = build("#%E0%A4%A", false);
+ok("a fragment that is not valid escaping is survivable", weird.fold.open === false);
+
+/* ---------- the same-page case ---------- */
+const same = build("", false);
+ok("the page listens for the fragment changing under it", same.listens("hashchange"));
+same.go(anchor);
+ok("changing the fragment without reloading unfolds it", same.fold.open === true);
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -188,6 +188,8 @@
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
+      — no page can mint it; it takes one command where the gateway runs.</p>
     <div class="hint">Reading this page needs nothing; every action calls an admin-gated endpoint, so the
       page is inert without a key. “Remember” keeps it in this tab only and forgets it when the tab
       closes — it is never written to disk or sent anywhere but this gateway.</div>
@@ -922,6 +924,41 @@
   });
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
+}());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
 }());
 </script>
 </body>

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -439,6 +439,8 @@
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
+      — no page can mint it; it takes one command where the gateway runs.</p>
     <div class="hint">Reading this page needs nothing; the checklist needs an admin-scoped key.</div>
   </section>
 
@@ -1117,6 +1119,41 @@ function liveStream(options) {
   });
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
+}());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
 }());
 </script>
 </body>

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -452,6 +452,8 @@
     <h2>Access <span class="aux"><label class="check"><input type="checkbox" id="remember"> remember for this browser tab</label></span></h2>
     <label for="key">Admin API key</label>
     <input id="key" type="password" placeholder="Key carrying an admin scope" autocomplete="off" spellcheck="false">
+    <p class="hint">No key yet? <a href="/v1/admin/portal#firstkey">Where the first one comes from</a>
+      — no page can mint it; it takes one command where the gateway runs.</p>
     <div class="hint">Reading this page needs nothing; every action calls an admin-gated endpoint, so
       the page is inert without a key. “Remember” keeps it in this tab only and forgets it when the
       tab closes — it is never written to disk or sent anywhere but this gateway.</div>
@@ -2592,6 +2594,41 @@ function liveStream(options) {
   });
   window.addEventListener("pagehide", function () { if (controller) { controller.abort(); } });
   open();
+}());
+
+/* A fragment can name something that is folded away.
+ *
+ * The key portal answers "where does the first one come from" in a <details>, shut by default
+ * because it is a question somebody has once. The pages that ask for a key link straight at it --
+ * and a link to a closed <details> arrives with the answer still folded up, which is the dead end
+ * the block was written to remove, reached by a different road. Browsers disagree about expanding
+ * it; this does not depend on which one is reading.
+ */
+(function () {
+  "use strict";
+
+  function reveal() {
+    /* Every harness that runs this file stubs a window, and most have no location on it --
+       the same shape a page gets before navigation has settled. Nothing to reveal, not a crash. */
+    var hash = (window.location && window.location.hash) || "";
+    var name;
+    try { name = decodeURIComponent(hash.replace(/^#/, "")); }
+    catch (error) { name = hash.replace(/^#/, ""); }
+    if (!name) { return false; }
+    var target = document.getElementById(name);
+    if (!target) { return false; }
+    var opened = false;
+    /* From the target itself: the fragment usually names the <details>, not something inside it. */
+    for (var node = target; node; node = node.parentNode) {
+      if (node.tagName === "DETAILS" && !node.open) { node.open = true; opened = true; }
+    }
+    /* The browser scrolled before this ran, to a target that was folded up. */
+    if (opened && target.scrollIntoView) { target.scrollIntoView(); }
+    return opened;
+  }
+
+  reveal();
+  if (window.addEventListener) { window.addEventListener("hashchange", reveal); }
 }());
 </script>
 </body>

--- a/tools/test_matrixark_pages_that_need_a_key_say_where_to_get_one.py
+++ b/tools/test_matrixark_pages_that_need_a_key_say_where_to_get_one.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A page that demands a key says where the first one comes from.
+
+The key portal explains how an admin key is minted. It is the only page that does, and somebody who
+has no key is not on it -- they are on Setup, or Overview, or Ingestion, reading "Enter an admin
+key" with nothing beside it. So those three now link at the answer.
+
+Catalogue and Explore deliberately do not. They ask for ``skill:read``/``resource:read`` and
+``context:*``, and the command that block prints mints admin scopes -- pointing them there would
+hand them a key that looks right and is refused, which is the exact trap the block exists to warn
+about. Which pages get the link is therefore derived from what each one asks for, not from a list
+somebody has to remember to update.
+
+The link's destination is a ``<details>``, shut by default because it answers a question somebody
+has once. A link to a closed ``<details>`` arrives with the answer still folded up: right page,
+summary line, no better off. Browsers disagree about expanding it, so the shared strip helper does
+it, and that is behaviour -- a helper wired to nothing reads exactly like one that works, so it is
+run rather than grepped.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "folded_answer_harness.js")
+KEY_PAGE = os.path.join(PORTAL, "api_key_portal.html")
+POINTER = 'href="/v1/admin/portal#firstkey"'
+
+
+def read(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def pages() -> dict:
+    return {name: read(os.path.join(PORTAL, name))
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+def asks_for(text: str) -> list:
+    """What each key input on a page says it wants, taken from its own placeholder."""
+    return re.findall(r'<input id="key"[^>]*placeholder="([^"]*)"', text)
+
+
+class TheAdminPagesPointAtItTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.pages = pages()
+        self.admin = {name for name, text in self.pages.items()
+                      if any("admin scope" in ask for ask in asks_for(text))}
+        self.other = {name for name, text in self.pages.items()
+                      if asks_for(text) and name not in self.admin}
+
+    def test_there_are_pages_of_both_kinds(self) -> None:
+        """Both checks below are about a split; with everything on one side they say nothing."""
+        self.assertGreaterEqual(len(self.admin), 3, sorted(self.admin))
+        self.assertGreaterEqual(len(self.other), 1, sorted(self.other))
+
+    def test_every_page_asking_for_an_admin_key_says_where_to_get_one(self) -> None:
+        silent = sorted(name for name in self.admin
+                        if POINTER not in self.pages[name] and name != "api_key_portal.html")
+        self.assertEqual([], silent,
+                         "pages that demand an admin key and do not say how to get one: %r" % silent)
+
+    def test_the_pages_wanting_other_scopes_are_not_sent_there(self) -> None:
+        """The block prints a command minting admin scopes. A page whose work needs skill:read
+        would get a key that looks right and is refused -- the trap the block warns about."""
+        misdirected = sorted(name for name in self.other if POINTER in self.pages[name])
+        self.assertEqual([], misdirected,
+                         "pages sent to a command that mints the wrong scopes: %r" % misdirected)
+
+    def test_the_key_page_does_not_link_to_itself(self) -> None:
+        self.assertNotIn(POINTER, read(KEY_PAGE))
+
+
+class TheDestinationExistsTest(unittest.TestCase):
+
+    def test_the_anchor_is_on_the_key_page(self) -> None:
+        self.assertIn('id="firstkey"', read(KEY_PAGE))
+
+    def test_the_anchor_is_the_fold_itself(self) -> None:
+        """Naming something inside it would work too, but naming the fold is what makes the
+        summary line the thing the reader lands on."""
+        self.assertRegex(read(KEY_PAGE), r'<details[^>]*id="firstkey"')
+
+    def test_it_is_still_shut_by_default(self) -> None:
+        """If it ships open, every check that it gets opened passes without the helper."""
+        tag = re.search(r'<details[^>]*id="firstkey"[^>]*>', read(KEY_PAGE)).group(0)
+        self.assertNotRegex(tag, r"\sopen[\s>]")
+
+    def test_every_page_can_unfold_a_named_target(self) -> None:
+        """The helper rides the shared strip, so a link added from anywhere later already works."""
+        without = sorted(name for name, text in pages().items() if "function reveal()" not in text)
+        self.assertEqual([], without, "pages that would arrive with the answer folded up: %r" % without)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheLinkActuallyUnfoldsItTest(unittest.TestCase):
+
+    def _run(self):
+        proc = subprocess.run(["node", HARNESS, KEY_PAGE],
+                              capture_output=True, text=True, timeout=300)
+        return proc
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_arriving_at_the_anchor_opens_it(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   arriving at #firstkey unfolds it", out)
+        self.assertIn("ok   arriving at #firstkey scrolls to it", out)
+
+    def test_something_inside_it_opens_it_too(self) -> None:
+        self.assertIn("ok   a fragment naming something inside the fold unfolds it too",
+                      self._run().stdout)
+
+    def test_it_stays_shut_for_everybody_else(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   with no fragment it stays shut", out)
+        self.assertIn("ok   a fragment naming nothing leaves it shut", out)
+        self.assertIn("ok   a fragment naming something outside any fold leaves it shut", out)
+
+    def test_following_the_link_from_the_same_page_works(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the page listens for the fragment changing under it", out)
+        self.assertIn("ok   changing the fragment without reloading unfolds it", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_matrixark_the_first_key_instructions_are_real.py
+++ b/tools/test_matrixark_the_first_key_instructions_are_real.py
@@ -43,7 +43,9 @@ def panel() -> str:
     the name and slicing forward reads CSS and finds none of the prose.
     """
     source = page()
-    start = source.index('<details class="firstkey">')
+    # The opening tag, matched rather than spelled out: it has since gained an id so a link can
+    # name it, and a literal that pinned the whole tag broke on the attribute being added.
+    start = re.search(r'<details[^>]*class="firstkey"', source).start()
     return source[start:source.index("</details>", start)]
 
 


### PR DESCRIPTION
#818 gave the key portal an answer to "where does the first admin key come from". It is the only
page that has one — and somebody who has no key **is not on that page**. They are on Setup, or
Overview, or Ingestion, reading *"Enter an admin key"* with nothing beside it.

Those three now link at it.

### Catalogue and Explore deliberately do not

They ask for `skill:read`/`resource:read` and `context:*`. The command that block prints mints
**admin** scopes, so sending them there hands them a key that looks right and is refused — the exact
trap the block exists to warn about, reached from a different direction.

Which pages carry the link is derived from what each key input asks for, not from a list somebody
has to remember to update, and the test asserts the split in both directions: no admin page silent,
no non-admin page misdirected.

### A link to a closed `<details>` is its own dead end

The block is shut by default, because it answers a question somebody has once. Arriving with it
still folded up means the right page, a summary line, and no better off than before. Browsers
disagree about whether they expand a fragment target, so the shared strip helper does it: it climbs
from the target (naming something *inside* a fold works too), scrolls once it is open, and handles
`hashchange` for the same-page case. Every page carries it, so a link added from anywhere later
already works.

Whether a fold ends up open is behaviour — a helper wired to nothing reads exactly like one that
works — so `folded_answer_harness.js` runs the page's own code. Both mutations caught:

```
drop the climb           -> FAIL a fragment naming something inside the fold unfolds it too
open it unconditionally  -> FAIL with no fragment it stays shut
```

### Two things this broke on the way

The helper read `window.location.hash`, and every harness that runs the strip stubs a window with no
`location` on it — the same shape a page has before navigation settles. `test_matrixark_live_strip`
died in `setUpClass` with `Cannot read property 'hash' of undefined`. It treats a missing location
as nothing to reveal now, and that suite runs 38 green.

And giving the block an `id` broke the slice in its own test from #818, which pinned the opening tag
by literal text. It matches the tag rather than one spelling of it.

Suites: this one 13, live_strip 38, first-key instructions 7, backend-down strip 15, waiting strip
12, config-change 13, portal_tabs 19, gateway_portal 60.
