### PR TITLE
Count an execute without taking the client's stats lock

### DIFF
--- a/crates/temporalstore-rust/src/client.rs
+++ b/crates/temporalstore-rust/src/client.rs
@@ -648,6 +648,13 @@ struct ClientInner {
     /// is atomic. It writes only when a route is fetched, replaced by a topology sync, or
     /// cleared.
     routes: RwLock<HashMap<ShardId, CachedRoute>>,
+    /// Executes and batch executes, counted outside `stats`.
+    ///
+    /// Both are bumped once per call on the path that succeeds, and taking the stats mutex for
+    /// that serialised every execute against every other. Folded into `ClientStats` on read, so
+    /// callers -- including the proxy, which takes deltas -- see the same monotonic numbers.
+    execute_requests: AtomicU64,
+    batch_execute_requests: AtomicU64,
     /// Cached-route hits, counted outside `stats`.
     ///
     /// Every request that finds its route cached lands here, and taking the stats mutex to add one
@@ -824,6 +831,8 @@ impl TemporalStoreClient {
             inner: Arc::new(ClientInner {
                 options,
                 routes: RwLock::default(),
+                execute_requests: AtomicU64::new(0),
+                batch_execute_requests: AtomicU64::new(0),
                 route_cache_hits: AtomicU64::new(0),
                 backend_failures: Mutex::default(),
                 backend_failure_entries: AtomicUsize::new(0),
@@ -1405,10 +1414,8 @@ impl TemporalStoreTable {
     pub fn execute(&self, command: Command) -> Result<ExecuteResponse, ClientError> {
         self.client
             .inner
-            .stats
-            .lock()
-            .expect("client stats lock poisoned")
-            .execute_requests += 1;
+            .execute_requests
+            .fetch_add(1, Ordering::Relaxed);
         let write = is_write(&command);
         if write {
             self.refresh_table_topology_before_write_if_due()?;
@@ -1470,10 +1477,8 @@ impl TemporalStoreTable {
     ) -> Result<BatchExecuteResponse, ClientError> {
         self.client
             .inner
-            .stats
-            .lock()
-            .expect("client stats lock poisoned")
-            .batch_execute_requests += 1;
+            .batch_execute_requests
+            .fetch_add(1, Ordering::Relaxed);
         let write = commands.iter().any(is_write);
         if write {
             self.refresh_table_topology_before_write_if_due()?;

--- a/crates/temporalstore-rust/src/client/client_meta_sync.rs
+++ b/crates/temporalstore-rust/src/client/client_meta_sync.rs
@@ -568,6 +568,14 @@ impl TemporalStoreClient {
             .inner
             .route_cache_hits
             .load(std::sync::atomic::Ordering::Relaxed);
+        stats.execute_requests += self
+            .inner
+            .execute_requests
+            .load(std::sync::atomic::Ordering::Relaxed);
+        stats.batch_execute_requests += self
+            .inner
+            .batch_execute_requests
+            .load(std::sync::atomic::Ordering::Relaxed);
         stats
     }
 

--- a/crates/temporalstore-rust/src/client/tests/part1.rs
+++ b/crates/temporalstore-rust/src/client/tests/part1.rs
@@ -702,6 +702,46 @@ fn table_write_refreshes_topology_after_meta_changed_without_write_retry_budget(
 }
 
 #[test]
+fn the_execute_counters_survive_the_move_off_the_stats_lock() {
+    // These are counted in atomics and added back when the stats are read. Nothing else checks
+    // that the adding-back happens, and if it stopped they would read zero forever -- the counter
+    // still incrementing, the report still answering, and the number simply always 0.
+    let client = TemporalStoreClient::new("127.0.0.1:1");
+    let table = client.open_table("ns", "tbl", TableOptions::default());
+
+    assert_eq!(client.stats().execute_requests, 0, "nothing executed yet");
+    assert_eq!(client.stats().batch_execute_requests, 0);
+
+    // There is no backend, so these fail -- but the count is taken before the attempt, which is
+    // what makes a failing execute countable at all.
+    let _ = table.execute(Command::StringGet {
+        key: "k".to_string(),
+    });
+    let _ = table.execute(Command::StringGet {
+        key: "k2".to_string(),
+    });
+    assert_eq!(
+        client.stats().execute_requests,
+        2,
+        "two executes must be reported -- zero here means the atomic is no longer folded into          the stats the report reads"
+    );
+
+    let _ = table.batch_execute(vec![Command::StringGet {
+        key: "k".to_string(),
+    }]);
+    assert_eq!(
+        client.stats().batch_execute_requests,
+        1,
+        "batch executes are counted separately and must be folded in too"
+    );
+    assert_eq!(
+        client.stats().execute_requests,
+        2,
+        "a batch must not be counted as a plain execute as well"
+    );
+}
+
+#[test]
 fn a_split_table_routes_keys_over_its_new_shard_count() {
     // `shard_id_for_key` reads the table's options through the per-thread snapshot. A table that
     // is re-synced after a split has more shards, and a handle taken before that must pick the


### PR DESCRIPTION
Every execute and batch execute took the client's stats mutex to add one to a counter -- the last lock on the path that *succeeds*. The other three the routing code takes are on error and retry branches, so on a healthy deployment this serialised exactly the calls with no other reason to wait.

Both counters move to atomics, folded into `ClientStats` on read so every reader (including the proxy's deltas) sees the same monotonic numbers.

**Not separately measured**: the identical substitution measured ~8% on the route lookup, and this path cannot be timed here without a backend -- a failing execute spends its time in the connection refusal, which would swamp it either way.

A test executes twice against no backend and requires the reported count to be two, since the count is taken before the attempt. With the fold removed it reads zero -- counter incrementing, report answering, number always zero.

`client::` 41/0 (42 with the new test), `proxy::` 80/0, `table` 66/0, `context` 76/0.