### PR TITLE
Put the switch that decides whether anything is audited in the portal

### DIFF
--- a/tools/matrixark_gateway_config.py
+++ b/tools/matrixark_gateway_config.py
@@ -184,6 +184,14 @@ GROUPS: Dict[str, Json] = {
         "note": "The edge's own ceilings. All of these are read when the gateway process starts, "
                 "so a change here needs a restart.",
     },
+    "audit": {
+        "title": "Audit trail", "order": 65, "advanced": False,
+        "note": "Off by default, and off means discarded: the access layer writes a record every "
+                "time a key is used to manage another key or is refused, and drops it here. Audit "
+                "records live in the main record log, so a busy deployment with this on grows the "
+                "store without bound -- which is why the default is what it is, and why the "
+                "choice belongs somewhere a customer can see it.",
+    },
     "behaviour": {
         "title": "Retrieval behaviour", "order": 70, "advanced": True,
         "note": "Deployment-wide defaults. A tenant policy -- or, for the ones marked, one "
@@ -226,6 +234,23 @@ SETTINGS: List[Setting] = [
     Setting("extraction.max_tokens", "extraction", "MATRIXARK_EXTRACTION_MAX_TOKENS",
             "Extraction max tokens", "int", "1200", "restart",
             "Completion cap per extraction call."),
+
+    # ---- audit trail ---------------------------------------------------------------------------
+    # Two readers, and they disagree about when a change lands. matrixark_access reads os.environ
+    # inside _append_audit_record, so the records IT writes -- key management, and every refusal --
+    # start or stop on the next call. matrixark_mcp_server captures the value into
+    # self._audit_mode_default in its constructor, so the server's own auditing keeps whatever it
+    # was built with. `restart` is the only label true of both, and the help says which half moves
+    # first rather than leaving a customer to find out by not finding records.
+    Setting("audit.mode", "audit", "MATRIXARK_AUDIT_MODE",
+            "Audit records", "str", "off", "restart",
+            "off discards every audit record, including the one written each time a key is refused "
+            "-- nothing is kept and nothing says so. async writes them off the request path; full "
+            "and sync make each one durable before the call returns, at the cost of that write. "
+            "Records go into the main record log, so a read-heavy deployment with this on grows "
+            "without bound. Setting it starts the access layer's records at once; the server's own "
+            "auditing is fixed when the process starts, so restart to have all of it.",
+            ["off", "async", "full", "sync"]),
 
     # ---- embedding (the encoder that makes retrieval semantic) ---------------------------------
     Setting("embedding.provider", "embedding", "MATRIXARK_EMBEDDING_PROVIDER",

--- a/tools/test_matrixark_gateway_config_audit.py
+++ b/tools/test_matrixark_gateway_config_audit.py
@@ -80,6 +80,11 @@ _DISPLAY_ONLY = {
 # request handler nested inside it (`make_v1_app._serve`) runs per request and must not inherit the
 # factory's classification.
 _STARTUP_ONLY = {
+    # The MCP server is constructed once, by the gateway at startup. A read in its constructor is
+    # syntactically per call and behaviourally frozen for the life of the process -- the same shape
+    # as GatewayConfig.from_env below, and the reason MATRIXARK_AUDIT_MODE is labelled restart even
+    # though the access layer re-reads it on every call.
+    ("matrixark_mcp_server.py", "MatrixArkMcpServer.__init__"),
     ("matrixark_v1_gateway.py", "GatewayConfig.from_env"),
     ("matrixark_v1_gateway.py", "_coerce_config"),
     ("matrixark_v1_gateway.py", "make_v1_app"),

--- a/tools/test_matrixark_the_audit_switch_is_reachable.py
+++ b/tools/test_matrixark_the_audit_switch_is_reachable.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The switch that decides whether anything is audited is one a customer can reach.
+
+The portal's admin-key preset says the key it issues "Runs this portal: configuration, keys, usage
+and the audit log". There is a scope for it, ``admin:audit``, and a tool that reads the rows back
+with a tenant check on it. And ``MATRIXARK_AUDIT_MODE`` defaults to ``off``, so every record --
+including the one the access layer writes each time somebody is refused at the tenant boundary --
+is dropped before it reaches storage.
+
+That switch was in neither half of the portal's configuration. Not in ``SETTINGS``, so it could not
+be set; not in the read-only inventory either, so the deployment page did not report it. A customer
+who needed an audit trail had no way to learn from this product that they did not have one.
+
+Off is the right default -- audit records live in the main record log, so a read-heavy deployment
+with this on grows the store without bound -- which is a reason to make the choice visible, not a
+reason to hide it.
+
+The label is ``restart``, and the two readers are why. ``matrixark_access`` reads the variable
+inside ``_append_audit_record``, so the records it writes start on the next call. The MCP server
+captures it into ``_audit_mode_default`` in its constructor, so its own auditing keeps whatever the
+process was built with. Both halves are asserted here rather than argued: the AST audit in
+``test_matrixark_gateway_config_audit`` decides the label from where the reads sit, and it could
+only see the constructor once it was told a constructor runs once.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import matrixark_gateway_config as cfg
+from matrixark_mcp_server import MatrixArkLocalAdapter, MatrixArkMcpServer, MatrixArkError
+
+ADMIN_SCOPES = ["admin:account", "admin:user", "admin:api_key", "admin:audit", "portal:read"]
+A = {"account_id": "acct_a", "tenant_id": "tenant_a"}
+B = {"account_id": "acct_b", "tenant_id": "tenant_b"}
+
+
+class TheSwitchIsInTheRegistryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.setting = cfg.SETTINGS_BY_KEY.get("audit.mode")
+        self.assertIsNotNone(self.setting, "the audit switch is not a setting at all")
+
+    def test_it_drives_the_variable_the_code_reads(self) -> None:
+        """A setting whose env name matches nothing is a control that does nothing."""
+        self.assertEqual("MATRIXARK_AUDIT_MODE", self.setting.env)
+
+    def test_it_still_defaults_to_off(self) -> None:
+        """Making the choice visible must not make it for them: audit records go in the main
+        record log, and a deployment that turns this on unaware grows the store without bound."""
+        self.assertEqual("off", self.setting.default)
+
+    def test_it_offers_the_modes_the_code_understands(self) -> None:
+        self.assertEqual(["off", "async", "full", "sync"], list(self.setting.choices))
+
+    def test_it_says_a_restart_is_needed(self) -> None:
+        self.assertEqual("restart", self.setting.applies)
+
+    def test_the_help_says_what_off_costs(self) -> None:
+        """"off" reads like a neutral default. It means every refusal goes unrecorded."""
+        self.assertIn("discards", self.setting.help)
+
+    def test_a_customer_can_find_it(self) -> None:
+        """An access control folded behind "advanced" is one the people who need it do not see."""
+        group = cfg.GROUPS[self.setting.group]
+        self.assertFalse(group.get("advanced"), group)
+        self.assertTrue(group.get("title"))
+        self.assertTrue(group.get("note"))
+
+
+class WritingItThroughThePortalTakesEffectTest(unittest.TestCase):
+    """End to end: the portal write reaches the process, and the records follow.
+
+    A registry entry proves nothing on its own -- the point is whether setting it changes what is
+    kept.
+    """
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.log = Path(tmp.name) / "events.jsonl"
+
+        # Both of these are process-global and both are restored however this ends. The config
+        # file especially: a settings test that does not move it writes the real one.
+        self._keep("MATRIXARK_RUNTIME_CONFIG_FILE", str(Path(tmp.name) / "runtime.json"))
+        self._keep("MATRIXARK_AUDIT_MODE", "async")
+        self.assertTrue(cfg.config_path().startswith(tmp.name),
+                        "the config path did not move; this test would rewrite a live config")
+
+        dev = self._server()
+        self.admin_a = dev.call_tool("matrixark_admin_create_api_key",
+                                     {"scope": A, **A, "role": "owner", "scopes": ADMIN_SCOPES})
+        self.victim_b = dev.call_tool("matrixark_admin_create_api_key",
+                                      {"scope": B, **B, "role": "service",
+                                       "key_prefix": "sk_live", "scopes": ["context:ingest"]})
+        dev.close(timeout_s=10.0)
+
+    def _keep(self, name: str, value: str) -> None:
+        previous = os.environ.get(name)
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = previous
+
+        self.addCleanup(restore)
+        os.environ[name] = value
+
+    def _server(self, mode: str = "dev") -> MatrixArkMcpServer:
+        return MatrixArkMcpServer(MatrixArkLocalAdapter(self.log), line_json=True,
+                                  access_mode=mode)
+
+    def _refusal_records(self) -> list:
+        """One admin key reaching for another tenant, then whatever it left behind.
+
+        The server is closed before reading: audit writes are buffered, and reading through the
+        same handle can see an empty log and call it a missing record.
+        """
+        server = self._server("enforced")
+        try:
+            with self.assertRaises(MatrixArkError):
+                server.call_tool("matrixark_admin_revoke_api_key",
+                                 {"scope": A, **A, "api_key": self.admin_a["api_key"],
+                                  "api_key_id": self.victim_b["api_key_id"]})
+        finally:
+            server.close(timeout_s=10.0)
+        rows = []
+        for line in self.log.read_text(encoding="utf-8").splitlines():
+            if '"matrixark_audit_log"' in line:
+                rows.append(line)
+        return rows
+
+    def test_setting_it_through_the_portal_starts_the_records(self) -> None:
+        os.environ["MATRIXARK_AUDIT_MODE"] = "off"
+        cfg.update({"audit.mode": "async"}, actor="test")
+        self.assertEqual("async", os.environ["MATRIXARK_AUDIT_MODE"])
+        self.assertTrue([r for r in self._refusal_records() if '"denied"' in r],
+                        "the switch is on and the refusal was still not recorded")
+
+    def test_the_write_is_reported_as_waiting_on_a_restart(self) -> None:
+        """Half of it is live and half of it is not, so the honest report is the slower half."""
+        result = cfg.update({"audit.mode": "async"}, actor="test")
+        text = repr(result)
+        self.assertIn("restart", text, text[:400])
+
+    def test_turning_it_off_stops_them(self) -> None:
+        """The direction that matters for the store: off has to mean nothing is written."""
+        cfg.update({"audit.mode": "off"}, actor="test")
+        self.assertEqual("off", os.environ["MATRIXARK_AUDIT_MODE"])
+        self.assertEqual([], [r for r in self._refusal_records() if '"denied"' in r])
+
+    def test_the_positive_control(self) -> None:
+        """With it on, the very same call does leave a record -- so the check above is reading a
+        log it can actually see records in."""
+        cfg.update({"audit.mode": "async"}, actor="test")
+        self.assertTrue(self._refusal_records(), "no audit records at all, on or off")
+
+
+class WhyTheLabelSaysRestartTest(unittest.TestCase):
+    """The claim behind ``applies: restart``, asserted rather than argued."""
+
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.log = Path(tmp.name) / "events.jsonl"
+        previous = os.environ.get("MATRIXARK_AUDIT_MODE")
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_AUDIT_MODE", None)
+            else:
+                os.environ["MATRIXARK_AUDIT_MODE"] = previous
+
+        self.addCleanup(restore)
+
+    def _server(self) -> MatrixArkMcpServer:
+        return MatrixArkMcpServer(MatrixArkLocalAdapter(self.log), line_json=True,
+                                  access_mode="dev")
+
+    def test_the_server_takes_it_at_construction(self) -> None:
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+        server = self._server()
+        self.addCleanup(lambda: server.close(timeout_s=10.0))
+        self.assertEqual("async", server._audit_mode_default)
+
+    def test_and_never_looks_again(self) -> None:
+        """This is the whole reason the label is not "live": a running process keeps what it was
+        built with, so a portal write reaches the access layer and not this."""
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+        server = self._server()
+        self.addCleanup(lambda: server.close(timeout_s=10.0))
+        os.environ["MATRIXARK_AUDIT_MODE"] = "off"
+        self.assertEqual("async", server._audit_mode_default,
+                         "it re-read the variable, so the setting could be labelled live")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The admin-key preset this portal offers describes the key it issues as:

> Runs this portal: configuration, keys, usage and the audit log.

There is a scope for it (`admin:audit`), and a tool that reads the rows back with a tenant check on
it. And `MATRIXARK_AUDIT_MODE` defaults to `off`, so every record — including the one written each
time an admin key is refused at the tenant boundary — is dropped before it reaches storage.

**That switch was in neither half of the portal's configuration.** Not in `SETTINGS`, so it could
not be set. Not in the read-only inventory either, so the deployment page did not report it. A
customer who needed an audit trail had no way to learn from this product that they did not have one,
and no way to ask for one short of editing the environment of every process by hand.

`off` stays the default — audit records live in the main record log, so a read-heavy deployment with
this on grows the store without bound. That is a reason to make the choice visible, not a reason to
hide it. The help states what `off` costs in the same breath as what `on` costs, and the group is
not marked advanced: an access control folded away is one the people who need it never see.

### Why the label says `restart`

The two readers disagree, and that is worth stating rather than averaging:

| reader | when it takes the value |
|---|---|
| `matrixark_access.py:1098` — inside `_append_audit_record` | per call: key-management and refusal records start on the next call |
| `matrixark_mcp_server.py:289` — inside the constructor | once, at construction: the server's own auditing keeps what the process was built with |

`restart` is the only label true of both. Asserted behaviourally, not argued — a constructed server
keeps its mode when the variable changes underneath it.

### The audit that assigns these labels could not see a constructor

`test_matrixark_gateway_config_audit` walks the AST and classifies a read by whether it sits inside
a function. A constructor is a function, so asked about this variable it reported **both** readers as
per-call and would have required the label to say `live`:

```
audit.mode (MATRIXARK_AUDIT_MODE) is labelled restart but every reader is per-call:
  matrixark_access.py:1098, matrixark_mcp_server.py:289
```

A constructor the gateway calls once at startup is frozen for the life of the process — the same
shape as `GatewayConfig.from_env` already in that list. Naming it makes the audit reach the right
answer for its own stated reason. No existing setting changes label: a sweep of every env name read
in a constructor or `from_env` finds only `GatewayConfig.from_env`, whose nine settings are already
`restart`.

Both directions mutation-checked:

```
claim live            -> FAIL labelled live but captured at import in matrixark_mcp_server.py:289
hide the constructor  -> FAIL labelled restart but every reader is per-call
```

### End to end

Writing `audit.mode` through `update()` puts the value in the process environment and the refusal
records follow — with a positive control that the same call does leave a record when it is on, so
the "nothing recorded" assertion is reading a log it can see records in. The config path is moved to
a temp file and asserted moved first, because a settings test that skips that rewrites a live config.

Suites: this one 12, config audit 14, gateway_config 28, gateway_portal 60, config-change 13,
refusal-trace 6. `test_matrixark_access_governance` has one unrelated pre-existing error
(`test_http_agent_hook_accepts_remote_normalized_lifecycle_events`), red on branches without this
change.
