### PR TITLE
Serve the audit log the scope catalogue already promises

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -73,6 +73,7 @@ _EXACT_ROUTES = frozenset({
     # other unmatched path.
     "/v1/admin/deployment", "/v1/admin/deployment/plan",
     "/v1/admin/api_key_usage", "/v1/admin/ingestion/jobs",
+    "/v1/admin/audit",
 })
 
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -787,6 +787,39 @@ def _usage_rows_visible_to(record: Optional[Json], rows: list, tenant: Optional[
             if row.get("tenant_id") == tenant and row.get("account_id") == account]
 
 
+_AUDIT_READ_SCOPES = {"admin:audit"}
+
+
+def _audit_read_denied(record: Optional[Json]) -> Optional[Json]:
+    """403 payload when the key may not read the audit log, else ``None``.
+
+    Narrower than ``_usage_read_denied`` on purpose. That gate admits ``admin:api_key`` as well,
+    which is right for usage counters -- a key manager needs to see what their keys are doing. The
+    audit log is the record of who reached for what and was refused, the catalogue publishes
+    ``admin:audit`` as "Read the audit log", and a scope that names one thing should be the thing
+    that opens it. Same dev/legacy posture as its neighbours.
+    """
+    if record is None:
+        return None
+    scopes = record.get("scopes")
+    if scopes is None:
+        return None
+    if _AUDIT_READ_SCOPES.intersection(set(scopes)):
+        return None
+    return {"error": "insufficient_scope", "required": sorted(_AUDIT_READ_SCOPES)}
+
+
+def _audit_recording_mode() -> str:
+    """What this worker is doing with audit records right now.
+
+    Reported, not acted on: an empty log means "nothing happened" or "nothing is kept", and only
+    this tells them apart. The value is frozen for the MCP server at its construction, so what this
+    reports is the mode a change would take effect under after a restart -- which is what the
+    setting's own help says.
+    """
+    return (os.environ.get("MATRIXARK_AUDIT_MODE", "off").strip().lower() or "off")
+
+
 _ADMIN_WRITE_SCOPES = {"admin:api_key"}
 
 
@@ -1739,6 +1772,11 @@ ROUTE_DOCS: List[Json] = [
      "query": "user_id=alice"},
     {"group": "Administration", "method": "GET", "path": "/v1/admin/scopes", "scope": "admin",
      "summary": "What each scope permits, plus four ready-made key shapes."},
+    {"group": "Administration", "method": "GET", "path": "/v1/admin/audit", "scope": "admin",
+     "summary": "Recent audit records for this tenant, newest first, with the recording mode "
+                "beside them. Requires a key carrying admin:audit. An empty list with recording "
+                "\"off\" means nothing is being kept, not that nothing happened.",
+     "query": "limit (1-500, default 100)"},
     {"group": "Administration", "method": "GET", "path": "/v1/admin/api_key_usage",
      "scope": "admin", "summary": "Per-key edge counters: totals, ingest/retrieve split, bytes, "
                                   "first and last use."},
@@ -3728,6 +3766,49 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 return await _json(send, 403, denied)
             usage = _usage_rows_visible_to(key_record, meter.snapshot(), tenant, account)
             return await _json(send, 200, {"status": "ok", "usage": usage, "count": len(usage)})
+
+        # ---- the audit log (auth + admin:audit) ------------------------------------------------
+        # The scope catalogue publishes admin:audit as "Read the audit log" and nothing served one.
+        # The records existed and the tool that reads them back existed; no route reached it, so the
+        # trail was write-only and the scope opened nothing the usage scope did not.
+        #
+        # The tenant check lives in the tool (ensure_identity_can_manage), and the identity it
+        # checks is the one injected here -- the caller's own, never anything they sent.
+        if method == "GET" and path == "/v1/admin/audit":
+            allowed, key, tenant, account, key_record = _authorize(scope.get("headers", []), cfg)
+            if not allowed:
+                return await _json(send, 401, {"error": "unauthorized"})
+            denied = _audit_read_denied(key_record)
+            if denied is not None:
+                return await _json(send, 403, denied)
+            params = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+            try:
+                limit = int((params.get("limit") or ["100"])[0])
+            except Exception:
+                limit = 100
+            # The tool reads the whole record log and filters, so the ceiling is on what comes
+            # back, not on what it costs to get it. This is a page a person opens, not one that
+            # polls.
+            limit = min(max(limit, 1), 500)
+            args: Json = {"scope": {}, "limit": limit}
+            _apply_identity(args, key, tenant, account)
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(server.call_tool, "matrixark_admin_audit", args),
+                    cfg.backend_timeout)
+            except Exception as exc:
+                return await _json(send, 502,
+                                   {"error": "backend_unavailable", "detail": str(exc)})
+            rows = (result or {}).get("audit_logs") if isinstance(result, dict) else None
+            rows = rows if isinstance(rows, list) else []
+            return await _json(send, 200, {
+                "status": "ok",
+                "audit_logs": rows,
+                "count": len(rows),
+                # Without this an empty list reads as "nothing to worry about". Off means every
+                # record -- including every refusal -- was discarded before it reached storage.
+                "recording": _audit_recording_mode(),
+            })
 
         # ---- effective model configuration (auth + admin scope) ------------------------------
         # Which extraction/embedding endpoints this deployment actually talks to, plus the skill

--- a/tools/test_matrixark_the_audit_log_can_be_read.py
+++ b/tools/test_matrixark_the_audit_log_can_be_read.py
@@ -30,7 +30,6 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import matrixark_v1_gateway as gw  # noqa: E402
-from test_matrixark_v1_gateway import drive  # noqa: E402
 
 AUDIT = "k-audit"
 KEYMGR = "k-keys"
@@ -64,6 +63,18 @@ class _Server:
         return {"jsonrpc": "2.0", "id": body.get("id"), "result": {}}
 
 
+def _drive(*args, **kwargs):
+    """The gateway suite's request driver, imported when it is called rather than at import time.
+
+    Under `unittest discover` a test module is reachable as both `tools.X` and bare `X`, so one
+    test module importing another at module level pulls a second copy into the run and shifts what
+    every later module sees. That has cost an afternoon before, showing up as CI failures in tests
+    the branch never touched -- see test_matrixark_no_cross_test_imports.
+    """
+    from test_matrixark_v1_gateway import drive
+    return drive(*args, **kwargs)
+
+
 def _app(server=None):
     hashed = {
         gw._secret_hash(AUDIT): {"tenant_id": "t", "account_id": "acct",
@@ -81,13 +92,13 @@ def _as(key):
 
 
 def _get(app, path, key=AUDIT):
-    return drive(app, method="GET", path=path, headers=_as(key))
+    return _drive(app, method="GET", path=path, headers=_as(key))
 
 
 class ItIsReachableAtAllTest(unittest.TestCase):
 
     def test_it_needs_a_key(self) -> None:
-        status, _h, _b = drive(_app(), method="GET", path="/v1/admin/audit")
+        status, _h, _b = _drive(_app(), method="GET", path="/v1/admin/audit")
         self.assertEqual(401, status)
 
     def test_an_audit_key_reads_it(self) -> None:

--- a/tools/test_matrixark_the_audit_log_can_be_read.py
+++ b/tools/test_matrixark_the_audit_log_can_be_read.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The scope published as "Read the audit log" reads the audit log.
+
+``admin:audit`` is in the catalogue this gateway serves, described in those words, and offered in
+the admin preset. The records existed. A tool that reads them back with a tenant check on it
+existed. No route reached it -- so the trail was write-only, and a key carrying that scope opened
+nothing the usage scope did not already open.
+
+Two things are asserted beyond "it answers 200".
+
+The gate is narrower than its neighbour on purpose. ``_usage_read_denied`` admits ``admin:api_key``
+too, which is right for usage counters: a key manager needs to see what their keys are doing. The
+audit log is the record of who reached for what and was refused, and a scope that names one thing
+should be the thing that opens it. The refusal is checked against a key that is otherwise perfectly
+good -- it reads usage in the same test -- so the 403 is about this route and not a broken key.
+
+And the response carries the recording mode. An empty list means two entirely different things:
+nothing happened, or nothing was kept. ``MATRIXARK_AUDIT_MODE`` defaults to off, so on most
+deployments it means the second, and a reader who cannot tell them apart is reassured by silence
+that was never evidence of anything.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+from test_matrixark_v1_gateway import drive  # noqa: E402
+
+AUDIT = "k-audit"
+KEYMGR = "k-keys"
+LEGACY = "k-legacy"
+
+ROWS = [
+    {"action": "admin.revoke_api_key", "status": "denied", "api_key_id": "ak_1",
+     "tenant_id": "t", "created_at_ms": 2},
+    {"action": "admin.create_api_key", "status": "ok", "api_key_id": "ak_1",
+     "tenant_id": "t", "created_at_ms": 1},
+]
+
+
+class _Server:
+    """Answers the audit tool and remembers what it was asked."""
+
+    def __init__(self, rows=None, boom=False):
+        self.calls = []
+        self.rows = ROWS if rows is None else rows
+        self.boom = boom
+
+    def call_tool(self, name, args):
+        self.calls.append((name, dict(args)))
+        if self.boom:
+            raise RuntimeError("the metadata store is unreachable")
+        if name == "matrixark_admin_audit":
+            return {"status": "ok", "audit_logs": list(self.rows), "count": len(self.rows)}
+        return {"ok": name}
+
+    def handle(self, body):
+        return {"jsonrpc": "2.0", "id": body.get("id"), "result": {}}
+
+
+def _app(server=None):
+    hashed = {
+        gw._secret_hash(AUDIT): {"tenant_id": "t", "account_id": "acct",
+                                 "scopes": ["admin:audit"]},
+        gw._secret_hash(KEYMGR): {"tenant_id": "t", "account_id": "acct",
+                                  "scopes": ["admin:api_key"]},
+        gw._secret_hash(LEGACY): {"tenant_id": "t", "account_id": "acct"},
+    }
+    return gw.make_v1_app(server or _Server(),
+                          gw.GatewayConfig.from_env({"enforced": True, "hashed_api_keys": hashed}))
+
+
+def _as(key):
+    return {"Authorization": "Bearer " + key}
+
+
+def _get(app, path, key=AUDIT):
+    return drive(app, method="GET", path=path, headers=_as(key))
+
+
+class ItIsReachableAtAllTest(unittest.TestCase):
+
+    def test_it_needs_a_key(self) -> None:
+        status, _h, _b = drive(_app(), method="GET", path="/v1/admin/audit")
+        self.assertEqual(401, status)
+
+    def test_an_audit_key_reads_it(self) -> None:
+        status, _h, body = _get(_app(), "/v1/admin/audit")
+        self.assertEqual(200, status)
+        payload = json.loads(body)
+        self.assertEqual(2, payload["count"])
+        self.assertEqual("admin.revoke_api_key", payload["audit_logs"][0]["action"])
+
+    def test_it_is_in_the_published_contract(self) -> None:
+        """The API page is generated from this list, so a route missing from it is a route a
+        customer has no way to discover."""
+        paths = {(r["method"], r["path"]) for r in gw.ROUTE_DOCS}
+        self.assertIn(("GET", "/v1/admin/audit"), paths)
+
+    def test_the_contract_warns_that_empty_may_mean_off(self) -> None:
+        doc = [r for r in gw.ROUTE_DOCS if r["path"] == "/v1/admin/audit"][0]
+        self.assertIn("off", doc["summary"])
+
+
+class TheGateIsTheScopeThatNamesItTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.app = _app()
+
+    def test_a_key_manager_key_is_refused(self) -> None:
+        status, _h, body = _get(self.app, "/v1/admin/audit", KEYMGR)
+        self.assertEqual(403, status)
+        payload = json.loads(body)
+        self.assertEqual("insufficient_scope", payload["error"])
+        self.assertEqual(["admin:audit"], payload["required"])
+
+    def test_the_control_that_key_is_otherwise_fine(self) -> None:
+        """Without this the refusal above could be a broken key rather than a narrow gate."""
+        status, _h, _b = _get(self.app, "/v1/admin/api_key_usage", KEYMGR)
+        self.assertEqual(200, status)
+
+    def test_an_unrestricted_key_is_allowed(self) -> None:
+        """Same posture as every neighbouring route: a key with no scope list is legacy, not
+        forbidden. Changing that here and nowhere else would be its own surprise."""
+        status, _h, _b = _get(self.app, "/v1/admin/audit", LEGACY)
+        self.assertEqual(200, status)
+
+
+class TheCallerCannotAskForSomebodyElsesRecordsTest(unittest.TestCase):
+
+    def test_the_identity_sent_to_the_tool_is_the_callers_own(self) -> None:
+        server = _Server()
+        _st, _h, _b = _get(_app(server), "/v1/admin/audit")
+        name, args = server.calls[-1]
+        self.assertEqual("matrixark_admin_audit", name)
+        self.assertEqual("t", args["scope"]["tenant_id"])
+        self.assertEqual("acct", args["scope"]["account_id"])
+
+    def test_a_tenant_in_the_query_string_changes_nothing(self) -> None:
+        """The tool fences on the identity it is handed. Whatever the caller writes in the URL has
+        to lose to the key they authenticated with."""
+        server = _Server()
+        _st, _h, _b = _get(_app(server), "/v1/admin/audit?tenant_id=someone_else&account_id=other")
+        _name, args = server.calls[-1]
+        self.assertEqual("t", args["scope"]["tenant_id"])
+        self.assertEqual("acct", args["scope"]["account_id"])
+
+
+class TheLimitIsBoundedTest(unittest.TestCase):
+
+    def _limit(self, query):
+        server = _Server()
+        _st, _h, _b = _get(_app(server), "/v1/admin/audit" + query)
+        return server.calls[-1][1]["limit"]
+
+    def test_the_default(self) -> None:
+        self.assertEqual(100, self._limit(""))
+
+    def test_a_huge_request_is_capped(self) -> None:
+        """The tool walks the whole record log to answer, so an unbounded limit is an unbounded
+        response on top of a walk that already costs."""
+        self.assertEqual(500, self._limit("?limit=9999"))
+
+    def test_zero_and_negatives_become_one(self) -> None:
+        self.assertEqual(1, self._limit("?limit=0"))
+        self.assertEqual(1, self._limit("?limit=-5"))
+
+    def test_nonsense_falls_back_rather_than_failing(self) -> None:
+        self.assertEqual(100, self._limit("?limit=lots"))
+
+
+class AnEmptyListSaysWhichKindOfEmptyTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        previous = os.environ.get("MATRIXARK_AUDIT_MODE")
+
+        def restore() -> None:
+            if previous is None:
+                os.environ.pop("MATRIXARK_AUDIT_MODE", None)
+            else:
+                os.environ["MATRIXARK_AUDIT_MODE"] = previous
+
+        self.addCleanup(restore)
+
+    def _payload(self, rows):
+        _st, _h, body = _get(_app(_Server(rows=rows)), "/v1/admin/audit")
+        return json.loads(body)
+
+    def test_nothing_kept_is_reported_as_nothing_kept(self) -> None:
+        os.environ["MATRIXARK_AUDIT_MODE"] = "off"
+        payload = self._payload([])
+        self.assertEqual([], payload["audit_logs"])
+        self.assertEqual("off", payload["recording"],
+                         "an empty log with nothing to explain it reads as 'all quiet'")
+
+    def test_nothing_happened_is_a_different_answer(self) -> None:
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+        payload = self._payload([])
+        self.assertEqual([], payload["audit_logs"])
+        self.assertEqual("async", payload["recording"])
+
+    def test_the_mode_travels_with_records_too(self) -> None:
+        os.environ["MATRIXARK_AUDIT_MODE"] = "async"
+        self.assertEqual("async", self._payload(ROWS)["recording"])
+
+    def test_an_unset_variable_reports_off_not_blank(self) -> None:
+        """Blank would render as an empty cell, which is the ambiguity this field exists to end."""
+        os.environ.pop("MATRIXARK_AUDIT_MODE", None)
+        self.assertEqual("off", self._payload([])["recording"])
+
+
+class ABackendThatCannotAnswerSaysSoTest(unittest.TestCase):
+
+    def test_it_is_not_reported_as_an_empty_log(self) -> None:
+        """The failure that matters: a store that cannot be read returning 200 with no rows is
+        indistinguishable from a clean audit trail."""
+        status, _h, body = _get(_app(_Server(boom=True)), "/v1/admin/audit")
+        self.assertEqual(502, status)
+        self.assertEqual("backend_unavailable", json.loads(body)["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The catalogue this gateway publishes describes `admin:audit` in these words:

> Read the audit log

and the admin preset issues keys carrying it. The records existed. A tool that reads them back —
fenced by `ensure_identity_can_manage` — existed. **Nothing connected the two.** No route reached
the tool, so the trail was write-only and that scope opened nothing `admin:api_key` did not already
open.

`GET /v1/admin/audit` reaches it. The identity handed to the tool is the caller's own, injected at
the edge and never taken from the request, so `?tenant_id=someone_else` loses to the key that
authenticated.

### The gate is narrower than its neighbour, on purpose

`_usage_read_denied` admits `admin:api_key` too, which is right for usage counters — a key manager
needs to see what their own keys are doing. The audit log is the record of who reached for what and
was refused, so the scope that names it is the one that opens it.

The refusal is checked against a key that is otherwise perfectly good: **the same key reads
`/v1/admin/api_key_usage` in the same test**, so the 403 is about this route and not a broken key.

### An empty list says which kind of empty

`MATRIXARK_AUDIT_MODE` defaults to `off`, so on most deployments an empty audit log means *nothing
was kept*, not *nothing happened*. The response carries `recording` beside the rows. Unset reports
`"off"` rather than blank — a blank cell is the same ambiguity wearing different clothes.

A store that cannot be read answers **502**. Returning 200 with no rows would be indistinguishable
from a clean trail, which is the worst available answer for this endpoint specifically.

`limit` is capped at 500: the tool walks the whole record log to answer, so this is a page a person
opens, not one that polls.

### Mutations

```
widen the gate to the usage scopes -> FAIL test_a_key_manager_key_is_refused
drop the recording field           -> ERROR x4 in AnEmptyListSaysWhichKindOfEmptyTest
swallow the backend failure as []  -> FAIL test_it_is_not_reported_as_an_empty_log
```

18 tests here. Neighbours: v1_gateway 97, gateway_portal 60, tenant-fence sweep 11, deployment
routes 23.

The portal pane that reads this comes next, once the two portal changes already in flight land — it
adds a tab to `api_key_portal.html`, which those are editing.
