### PR TITLE
A linked fragment can be answered by a fold instead of a tab

### DIFF
--- a/tools/portal/deep_link_harness.js
+++ b/tools/portal/deep_link_harness.js
@@ -182,12 +182,22 @@ const checks = wanted.length ? wanted : (derived.length ? ["#" + derived[0]] : [
 ok("there is a fragment to follow", checks.length > 0,
    "no id lives inside a pane other than the default one");
 
+const handled = [];
 checks.forEach((fragment) => {
   const name = fragment.replace(/^#/, "");
   const holder = paneHolding(name);
-  ok("the page has somewhere to send " + fragment, !!holder,
-     ids.has(name) ? "the id exists but is not inside any pane" : "no element has that id");
-  if (!holder) { return; }
+  if (!holder) {
+    /* Not every link into a page names something a tab holds. The key portal answers "where does
+       the first key come from" in a <details> above the tablist, and the strip helper unfolds it
+       -- a different mechanism, checked by folded_answer_harness. Failing here would report a
+       working link as broken; the check that the target EXISTS lives in the Python test, which
+       covers every link on every page rather than only the ones this file was handed. */
+    console.log("skip " + fragment + " is not inside a tab pane" +
+                (ids.has(name) ? "" : " (and no element has that id)"));
+    return;
+  }
+  handled.push(fragment);
+  ok("the page has somewhere to send " + fragment, true);
 
   const run = build(fragment);
   const want = "tab-" + holder.id.replace(/^pane-/, "");
@@ -203,8 +213,8 @@ checks.forEach((fragment) => {
 /* ---------- the same page, no navigation ---------- */
 /* The strip is on the setup page too. Clicking a segment that points into this page loads nothing:
    the URL gains a fragment and that is the entire event. */
-if (checks.length) {
-  const name = checks[0].replace(/^#/, "");
+if (handled.length) {
+  const name = handled[0].replace(/^#/, "");
   const holder = paneHolding(name);
   if (holder) {
     const run = build("");

--- a/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
+++ b/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
@@ -40,6 +40,7 @@ import unittest
 TOOLS = os.path.dirname(os.path.abspath(__file__))
 PORTAL = os.path.join(TOOLS, "portal")
 HARNESS = os.path.join(PORTAL, "deep_link_harness.js")
+FOLD_HARNESS = os.path.join(PORTAL, "folded_answer_harness.js")
 GATEWAY = os.path.join(TOOLS, "matrixark_v1_gateway.py")
 
 
@@ -136,32 +137,64 @@ class TheTabOpensTest(unittest.TestCase):
                 grouped.setdefault(target, []).append(anchor)
         return grouped
 
+    def _by_mechanism(self, page_name, anchors):
+        """Which anchors a tab answers, and which something else does.
+
+        Not every link into a page names something a tab holds: the key portal answers "where does
+        the first key come from" in a <details> above its tablist. The harness reports those rather
+        than failing them, and they are checked below through the helper that actually opens them.
+        """
+        out = self._run(page_name, anchors).stdout
+        folds = {a for a in set(anchors) if ("skip #%s is not inside a tab pane" % a) in out}
+        return out, sorted(set(anchors) - folds), sorted(folds)
+
     def test_the_pages_that_are_linked_into_open_the_right_tab(self) -> None:
         grouped = self._targets()
         self.assertTrue(grouped, "nothing is linked into; this check is vacuous")
+        opened = 0
         for page_name, anchors in sorted(grouped.items()):
             with self.subTest(page=page_name):
                 proc = self._run(page_name, anchors)
                 self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
-                for anchor in sorted(set(anchors)):
+                _out, tabbed, _folds = self._by_mechanism(page_name, anchors)
+                for anchor in tabbed:
                     self.assertIn("ok   arriving at #%s opens the tab that holds it" % anchor,
                                   proc.stdout)
+                opened += len(tabbed)
+        self.assertGreater(opened, 0, "no link opens a tab; this check is quantified over nothing")
 
     def test_the_reader_is_taken_to_the_target_not_just_the_pane(self) -> None:
         """The pane can be metres long. Opening it and leaving them at the top is most of the way
         to the original problem: they are looking at a page that does not obviously concern them."""
         for page_name, anchors in sorted(self._targets().items()):
-            out = self._run(page_name, anchors).stdout
-            for anchor in sorted(set(anchors)):
+            out, tabbed, _folds = self._by_mechanism(page_name, anchors)
+            for anchor in tabbed:
                 self.assertIn("ok   arriving at #%s scrolls to it once the pane is showing" % anchor,
                               out)
 
     def test_the_same_page_case_is_handled(self) -> None:
         """The strip is on the setup page too, so its own segments load no document at all."""
         for page_name, anchors in sorted(self._targets().items()):
-            out = self._run(page_name, anchors).stdout
+            out, tabbed, _folds = self._by_mechanism(page_name, anchors)
+            if not tabbed:
+                continue
             self.assertIn("ok   the page listens for the fragment changing under it", out)
             self.assertIn("ok   changing the fragment without reloading still opens the tab", out)
+
+    def test_a_link_no_tab_answers_is_answered_by_a_fold(self) -> None:
+        """The other half of the split, so "not my business" cannot become "nobody's business"."""
+        checked = 0
+        for page_name, anchors in sorted(self._targets().items()):
+            _out, _tabbed, folds = self._by_mechanism(page_name, anchors)
+            for anchor in folds:
+                proc = subprocess.run(["node", FOLD_HARNESS, os.path.join(PORTAL, page_name)],
+                                      capture_output=True, text=True, timeout=300)
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                self.assertIn("ok   arriving at #%s unfolds it" % anchor, proc.stdout,
+                              "no tab holds it and no fold opens it either")
+                checked += 1
+        self.assertGreater(checked, 0,
+                           "no link is answered by a fold; this check is quantified over nothing")
 
     def test_a_fragment_that_means_nothing_here_changes_nothing(self) -> None:
         for page_name, anchors in sorted(self._targets().items()):


### PR DESCRIPTION
**main is red** — three failures in `test_matrixark_a_badge_that_names_a_tab_opens_it`.

Two changes went in green and are red together:

- #820 made a fragment open the tab pane that holds it, and its harness requires every linked
  fragment to be inside a pane.
- #824 added a link to `/v1/admin/portal#firstkey`, which names a `<details>` in the Connection
  panel — **above** the tablist, inside no pane at all.

Each was tested against a base that did not contain the other, so neither CI run ever had both.

```
FAIL the page has somewhere to send #firstkey
     the id exists but is not inside any pane
```

### Both mechanisms are right

The tab helper opens the pane holding a target; the strip helper unfolds a `<details>` holding one.
What was wrong is the assumption underneath the first: that every fragment a page links to lives in
a pane.

`deep_link_harness.js` now reports a fragment outside every pane as not its business rather than
failing it, and the same-page check runs against an anchor the tabs actually answer instead of
whatever came first. The Python test splits anchors by which mechanism reported them and checks each
through the harness that runs it — so **"not my business" cannot become nobody's business**: a link
no tab answers has to be one a fold opens.

### The split is floored on both sides

A split like this fails by emptying one side, so each half asserts it covered something:

```
no link opens a tab; this check is quantified over nothing
no link is answered by a fold; this check is quantified over nothing
```

Mutations:

```
make the fold never unfold -> FAIL test_a_link_no_tab_answers_is_answered_by_a_fold
rename a linked target     -> FAIL test_every_anchor_exists_on_the_page_it_points_at
                              FAIL test_a_link_no_tab_answers_is_answered_by_a_fold
```

9 tests green on this branch; 3 failures on main without it.
