### PR TITLE
A feature append publishes only the pages it wrote

### DIFF
--- a/crates/temporalstore-rust/src/engine/execute_on_shard.rs
+++ b/crates/temporalstore-rust/src/engine/execute_on_shard.rs
@@ -1317,6 +1317,8 @@ pub(crate) fn execute_on_shard(
             let routing_bucket =
                 page_routing_bucket(&key, start_routing_bucket, end_routing_bucket);
             let points = sorted_feature_points(points);
+            let mut published: Vec<BlockAddress> = Vec::new();
+            let mut replaced_any = false;
             // feature_append_chunks_and_persists_timestamped_kv_pages: append each
             // timestamped feature point through the page-backed KV layout, then
             // publish the resulting page addresses into the bucket index below.
@@ -1332,11 +1334,16 @@ pub(crate) fn execute_on_shard(
                 true,
             ) {
                 for (timestamp_ms, address) in addresses {
-                    series.insert(timestamp_ms, address);
+                    // A replaced timestamp supersedes a page, and a superseded page must be
+                    // dropped rather than joined -- so record it and take the restating path.
+                    if series.insert(timestamp_ms, address.clone()).is_some() {
+                        replaced_any = true;
+                    }
+                    published.push(address);
                     mutated = true;
                 }
             }
-            mutated |= trim_timestamped_series(
+            let trimmed = trim_timestamped_series(
                 shard_id,
                 "feature",
                 &key,
@@ -1344,15 +1351,32 @@ pub(crate) fn execute_on_shard(
                 series,
                 feature_max_size,
             );
-            let live_addresses = series.values().cloned().collect::<Vec<_>>();
-            sync_bucket_index_object_pages(
-                shard,
-                shard_id,
-                "feature",
-                &key,
-                live_addresses,
-                mutated,
-            );
+            mutated |= trimmed;
+            if replaced_any || trimmed {
+                // Something was superseded or evicted: the live set has to be restated in full.
+                let live_addresses = series.values().cloned().collect::<Vec<_>>();
+                sync_bucket_index_object_pages(
+                    shard,
+                    shard_id,
+                    "feature",
+                    &key,
+                    live_addresses,
+                    mutated,
+                );
+            } else {
+                // A pure append. Publishing only the new pages leaves the index in the same
+                // state, and stops an append costing the length of the series it joins:
+                // restating every address measured 4.07 MB for one point on a 3,200-point series.
+                sync_bucket_index_object_pages_with_mode(
+                    shard,
+                    shard_id,
+                    "feature",
+                    &key,
+                    published,
+                    mutated,
+                    false,
+                );
+            }
             let _ = cache.invalidate_record(shard_id, "feature", &key);
             CommandResponse::Empty
         }

--- a/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
+++ b/crates/temporalstore-rust/src/engine/storage_bucket_internals.rs
@@ -1511,6 +1511,35 @@ pub(super) fn sync_bucket_index_object_pages(
     addresses: Vec<BlockAddress>,
     dirty: bool,
 ) {
+    sync_bucket_index_object_pages_with_mode(shard, shard_id, kind, object_key, addresses, dirty, true)
+}
+
+/// Publish pages for an object into the bucket index.
+///
+/// `replace_existing` is the whole cost of this function. With it true the object's pages are
+/// dropped and rebuilt from `addresses`, which is the only way to express "the live set is
+/// exactly this" -- and it costs the object's whole page count on every call, however few pages
+/// the write actually touched.
+///
+/// A pure APPEND does not need that. Nothing was removed, and the pages already filed are still
+/// correct, so publishing only the new addresses leaves the index in the same state for a
+/// fraction of the work. Callers may pass false ONLY when both hold:
+///
+///   * nothing was evicted (a trim that dropped points must re-state the live set), and
+///   * no appended key REPLACED an existing one (a replacement must drop the superseded page,
+///     or the object would carry two entries for one key).
+///
+/// Both are decidable at the call site: `BTreeMap::insert` reports the value it displaced, and
+/// the trim reports whether it removed anything.
+pub(super) fn sync_bucket_index_object_pages_with_mode(
+    shard: &mut ShardState,
+    shard_id: ShardId,
+    kind: &str,
+    object_key: &str,
+    addresses: Vec<BlockAddress>,
+    dirty: bool,
+    replace_existing: bool,
+) {
     let mut touched_buckets = BTreeSet::new();
     let mut removed_any = false;
     // An empty lookup means "not established yet", which callers read as a signal to fall back to
@@ -1546,6 +1575,10 @@ pub(super) fn sync_bucket_index_object_pages(
             .unwrap_or_default()
     };
     for routing_bucket in target_buckets {
+        if !replace_existing {
+            // Additive publish: nothing is being superseded, so the pages already filed stay.
+            break;
+        }
         let Some(bucket) = shard.bucket_index.bucket_map.get_mut(&routing_bucket) else {
             continue;
         };


### PR DESCRIPTION
`FeatureAppend` on a 3,200-point series: **4,070,106 → 2,322,286 bytes per write, 43% less.**
Partial, not a cure — see below.

## What it stops doing

`sync_bucket_index_object_pages` exists to say *"the live set is exactly this list"*, so it drops
every page the object has and rebuilds them from the addresses passed: a component clone per
page, a `BTreeMap` keyed by a seven-tuple, and an entry construction per page — all for a write
that added one point.

A pure append does not need that. Nothing was removed, and the pages already filed are still
correct, so publishing only the new addresses leaves the index in the same state.
`sync_bucket_index_object_pages_with_mode` takes that as an explicit mode; the old entry point
delegates with `replace_existing = true`, so every other caller is byte-for-byte unchanged.

## Restating is still required in two cases

Both decided at the call site, not assumed:

* **A trim evicted points** — the live set really did change, so it must be restated in full.
* **An append replaced an existing timestamp** — the superseded page has to be dropped rather
  than joined, or the object carries two entries for one key. `BTreeMap::insert` reports the
  value it displaced, so this is detected.

## What this does not fix

The ratio is **unchanged at 15.44x over a 16x range**: the write is still linear in series
length. The remaining term is not in this arm. It is the post-command index-item collection,
which walks every page of the object because `FeatureAppend` declares no index component — and
feature pages are created with `component: None`, so they cannot be addressed individually.
Removing that means changing what a feature page is addressed by, which is a storage-format
decision. This change takes the half that does not require one.

## Scoped to one command on purpose

`FeatureAppendWithPolicy`, `FeatureReplace` and `SequenceAdd` share the same shape and are
measured **byte-identical to main** here — 266,965 / 266,158 / 268,403 at 200 points and ~4.07 MB
at 3,200 — so the win is attributable to this arm alone rather than to an edit that quietly
touched all four.

## Verification

* Feature tests: 27 passed, 0 failed.
* The one raft sequence test that fails does so identically on clean main in this environment.
