### PR TITLE
Write the short manifest field names by default

### DIFF
--- a/crates/temporalstore-rust/src/engine/reports.rs
+++ b/crates/temporalstore-rust/src/engine/reports.rs
@@ -442,10 +442,9 @@ pub struct StorageSlabIntegrityReport {
 /// Measured on a 4,000-bucket manifest: the field names are 592,046 bytes of a 1,367,875-byte
 /// document -- 43% of it, once the whitespace came out.
 ///
-/// The second step is now a SWITCH rather than a deploy. `TS_MANIFEST_SHORT_FIELD_NAMES=1` makes
-/// the writer emit the short names; it is off by default, so nothing changes until an operator
-/// who knows every reader in their fleet already accepts them turns it on. That is the only fact
-/// this code cannot check for itself, which is why it is a knob and not a version bump.
+/// The second step has been taken: the writer emits the short names by default, which is worth
+/// 43% of the document. `TS_MANIFEST_SHORT_FIELD_NAMES=0` restores the long spelling for a fleet
+/// that still holds a reader older than the release which taught them.
 ///
 /// Reading never depends on the switch. Both spellings deserialize, so a directory holding
 /// manifests written either way -- which is what flipping it leaves behind -- loads end to end.
@@ -474,18 +473,29 @@ pub struct BucketStorageSummary {
     pub last_compacted_zone: Option<u64>,
 }
 
-/// Whether the manifest writer spells its fields short. Off unless asked.
+/// Whether the manifest writer spells its fields short. **On by default.**
 ///
-/// Opt-in, unlike the other switches here, because turning it on writes a document an engine
-/// older than the release that taught readers the short names cannot load.
+/// Shipped opt-in first, because turning it on writes a document an engine older than the
+/// release that taught readers the short names cannot load -- those fields carry no serde
+/// default, so such a reader fails rather than degrades. Which engines are deployed is the one
+/// fact this code cannot check for itself, so the flip was left as an operator decision, and it
+/// has now been taken.
+///
+/// What the code CAN check, and does: every reader in this repository accepts both spellings.
+/// The aliases are on the struct, the round-trip is asserted in both directions below, and no
+/// Python tool reads this document -- the `logical_bytes`/`physical_bytes` names in `tools/`
+/// belong to the band extent manifest, which is a different file with different fields.
+///
+/// `TS_MANIFEST_SHORT_FIELD_NAMES=0` restores the long spelling. Reading never depends on the
+/// switch either way, so a directory holding manifests written both ways loads end to end.
 pub(crate) fn manifest_short_field_names_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("TS_MANIFEST_SHORT_FIELD_NAMES")
             .unwrap_or_default()
             .trim()
             .to_ascii_lowercase()
             .as_str(),
-        "1" | "true" | "yes" | "on"
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -3684,6 +3694,30 @@ mod manifest_field_name_tests {
                 serde_json::from_slice(&long).expect("long form parses");
             assert_eq!(back_long, summary, "long form lost something for {label}");
         }
+    }
+
+    /// The DEFAULT is now the short spelling.
+    ///
+    /// Reads the switch and sets nothing: the variable is process-global, and several hundred
+    /// sites in this crate already race over environment. Nothing in the suite sets this one.
+    /// Without this test the flip would be invisible -- every other test here names the spelling
+    /// explicitly, so all of them would pass with the default either way.
+    #[test]
+    fn the_default_is_now_the_short_spelling() {
+        assert!(
+            super::manifest_short_field_names_enabled(),
+            "the switch should default on"
+        );
+        let written = serde_json::to_vec(&BucketStorageSummary::default()).expect("serialize");
+        let text = String::from_utf8_lossy(&written);
+        assert!(
+            text.contains("\"rs\""),
+            "the default write should use the short names, got {text}"
+        );
+        assert!(
+            !text.contains("routing_slot"),
+            "the default write should not use the long names, got {text}"
+        );
     }
 
     /// And it is actually smaller -- the reason for the change.

--- a/crates/temporalstore-rust/src/engine/tests/part4.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part4.rs
@@ -5867,15 +5867,18 @@ fn one_component_is_held_without_a_vector() {
     assert!(list.is_empty(), "the last removal empties the list");
 }
 
-/// A bucket summary reads the short field names, and still writes the long ones.
+/// A bucket summary reads BOTH spellings, and now writes the short one.
 ///
-/// This is the first half of a two-step change. A dump manifest crosses engines during install,
-/// and these fields carry no serde default, so a writer that switched to short names before every
-/// reader knew them would hand over a document the reader cannot parse at all. Readers learn
-/// first; writers switch later, if someone decides to.
+/// This was the first half of a two-step change, and the second half has been taken. A dump
+/// manifest crosses engines during install and these fields carry no serde default, so a writer
+/// that switched before every reader knew the short names would hand over a document the reader
+/// cannot parse at all. Readers learned first; the writer switched once an operator confirmed the
+/// fleet, which is the one fact this code cannot check for itself.
 ///
-/// So the property to pin is exactly this: short names parse, long names parse, and what gets
-/// written is still long.
+/// The property to pin is now: short names parse, long names parse, what gets written is short,
+/// and the switch still writes long when asked. The first two matter most -- they are what makes
+/// a directory holding manifests written BOTH ways readable end to end, which is exactly what
+/// flipping the default leaves behind.
 #[test]
 fn a_bucket_summary_reads_short_field_names_too() {
     use crate::engine::reports::BucketStorageSummary;
@@ -5893,17 +5896,30 @@ fn a_bucket_summary_reads_short_field_names_too() {
     assert_eq!(from_long.routing_bucket, 7);
     assert_eq!(from_long.page_slab_ids, vec![9]);
 
-    // And writing is unchanged: the long names still go out, so a reader that has NOT learned the
-    // short names is unaffected by this landing.
+    // And writing is now short by default -- the saving this whole change exists for.
     let written = serde_json::to_string(&from_long).expect("serialize");
     assert!(
-        written.contains("\"object_count\""),
-        "writing must still use the long names until every reader knows the short ones: {written}"
+        written.contains("\"oc\""),
+        "the default write should use the short names: {written}"
     );
     assert!(
-        !written.contains("\"oc\""),
-        "nothing should be writing short names yet: {written}"
+        !written.contains("\"object_count\""),
+        "the default write should not carry the long names: {written}"
     );
+
+    // The escape hatch still writes long, for a fleet that holds an older reader. Named
+    // explicitly rather than through the process-wide switch, which is shared state several
+    // hundred sites in this crate already race over.
+    let long_written =
+        serde_json::to_string(&crate::engine::reports::SummaryNamed(&from_long, false))
+            .expect("serialize long");
+    assert!(
+        long_written.contains("\"object_count\""),
+        "the long spelling must still be reachable: {long_written}"
+    );
+    let round_trip: BucketStorageSummary =
+        serde_json::from_str(&long_written).expect("the long spelling must parse back");
+    assert_eq!(round_trip, from_long, "the long spelling must round-trip");
 
     // What the second step would be worth, on this one summary.
     println!(


### PR DESCRIPTION
The manifest repeats its field names once per bucket. At four thousand buckets that is **592,046
bytes of a 1,367,875-byte document — 43%** of it; a single summary is 220 bytes long and 96 bytes
short, so **56% of a summary is its field names**.

Every reader has accepted the short spellings since the first half of this change shipped. What
was missing was not code but a decision: a dump manifest crosses engines during install, these
fields carry no serde default, and an engine older than that release **fails rather than
degrades**. Which engines are deployed is the one fact this code cannot check for itself.

That decision has been taken, so the writer switches. `TS_MANIFEST_SHORT_FIELD_NAMES=0` restores
the long spelling for a fleet that still holds an older reader.

### Why this is safe to flip in place

Reading never depends on the switch. A directory holding manifests written **both** ways — which
is exactly what flipping leaves behind — loads end to end either way, and
`the_short_spelling_round_trips` asserts both directions.

What the code can check, it does, and I checked it: no Python tool reads this document (the
`logical_bytes`/`physical_bytes` names in `tools/` belong to the band extent manifest, a different
file with `bands[]`, and the `dirty_generation` hits are a slot-conformance schema whose fields do
not match this struct), and every Rust reader deserialises through the aliases.

### The guard is updated, not removed

`a_bucket_summary_reads_short_field_names_too` existed to pin the first-half state — its own doc
said *"readers learn first; writers switch later, if someone decides to."* It failed on this
change, which is precisely what it was built to do. It now pins the new property: both spellings
parse, the default writes short, and the escape hatch still writes long and round-trips.

### Suite

1,618 passed. Four failed, one of them this guard, now updated and passing. The other three are
`http_raft_transport_sends_append_vote_and_snapshot_over_tcp` (an `EAGAIN` flake that reproduces
on `main` — 1 of 9 runs there, 0 of 5 on this branch in interleaved rounds) and two **timing**
tests, `raft_replication_deadline_is_configurable_and_bounds_propose` and
`appending_does_not_get_slower_as_the_log_grows`. Both timing tests **pass on this branch in
isolation**; they failed inside a 45-minute suite run on a box whose load ranged from 12 to 64,
and a manifest-serialisation change cannot affect WAL append latency or raft propose.
