### PR TITLE
Compress the portal pages and stop resending them

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -30,6 +30,7 @@ Routes: POST /v1/ingest (async fast-ack 202) · POST /v1/ingest_file (stream fil
 from __future__ import annotations
 
 import asyncio
+import gzip
 import hashlib
 import json
 import logging
@@ -1056,6 +1057,118 @@ async def _text(send: Callable, status: int, body: str,
         headers.extend(extra_headers)
     await send({"type": "http.response.start", "status": status, "headers": headers})
     await send({"type": "http.response.body", "body": data})
+
+
+# Compressed portal pages, keyed by the identity validator of the page they came from. Seven
+# pages, 490 KB uncompressed and 137 KB packed, so this holds ~137 KB per worker and takes 353 KB
+# off every full tour of the portal. Bounded by construction -- there are seven pages -- but a
+# ceiling anyway, because the key is content-derived and a deployment that reloads pages would
+# otherwise accumulate one entry per version.
+_HTML_PACKED: dict[str, bytes] = {}
+_HTML_PACKED_MAX = 32
+# Below this a gzip envelope is a meaningful share of the payload and the round trip dominates
+# anything it could save. The error fallbacks are the only HTML this size.
+_HTML_PACK_FLOOR = 1024
+
+
+def _validator(body: bytes) -> str:
+    """A strong ETag for these bytes. Content-derived, so it is stable across workers and across
+    restarts -- a validator that changed per process would 200 on every revalidation from a
+    deployment behind more than one worker."""
+    return '"' + hashlib.sha256(body).hexdigest()[:32] + '"'
+
+
+def _accepts_gzip(header: str) -> bool:
+    """Whether the client actually wants gzip.
+
+    ``gzip;q=0`` is a refusal, and ``identity;q=0, *`` is consent to anything. Both are lost by
+    looking for the substring, which is how a client that asked NOT to be compressed gets a
+    compressed body it will not decode.
+    """
+    for part in header.split(","):
+        token, _semi, params = part.strip().partition(";")
+        token = token.strip().lower()
+        if token not in ("gzip", "*"):
+            continue
+        quality = 1.0
+        for param in params.split(";"):
+            name, _eq, value = param.strip().partition("=")
+            if name.strip().lower() == "q":
+                try:
+                    quality = float(value)
+                except ValueError:
+                    quality = 0.0
+        if quality > 0:
+            return True
+    return False
+
+
+def _packed(body: bytes, validator: str) -> bytes:
+    packed = _HTML_PACKED.get(validator)
+    if packed is None:
+        # mtime=0: the default stamps the current time into the header, so the same page would
+        # compress to different bytes each process and anything hashing the response would see a
+        # change that is not one.
+        packed = gzip.compress(body, 6, mtime=0)
+        if len(_HTML_PACKED) >= _HTML_PACKED_MAX:
+            _HTML_PACKED.clear()
+        _HTML_PACKED[validator] = packed
+    return packed
+
+
+def _matches(header: str, validator: str) -> bool:
+    """Does the client already hold this exact representation?
+
+    ``*`` matches anything, and a weak validator (``W/"..."``) still identifies the same bytes for
+    the purpose of a conditional GET.
+    """
+    if not header:
+        return False
+    for candidate in header.split(","):
+        candidate = candidate.strip()
+        if candidate == "*":
+            return True
+        if candidate.startswith("W/"):
+            candidate = candidate[2:].strip()
+        if candidate == validator:
+            return True
+    return False
+
+
+async def _page(send: Callable, scope: Json, body: bytes) -> None:
+    """One bundled portal page: compressed if the client takes it, revalidated if they have it.
+
+    ``no-cache`` is a revalidation instruction, not a refusal to cache -- the client keeps the
+    page and asks whether it still holds, which is a 304 with no body. Serving these stale would
+    show a customer a portal that does not match the gateway they upgraded, so revalidating every
+    time and paying nothing when nothing moved is the trade that fits.
+    """
+    headers = _headers_map(scope)
+    validator = _validator(body)
+    encoding = None
+    if len(body) >= _HTML_PACK_FLOOR and _accepts_gzip(headers.get("accept-encoding", "")):
+        body = _packed(body, validator)
+        encoding = b"gzip"
+        # A different representation needs a different validator, or a client holding the
+        # identity copy revalidates with this one and is told to reuse bytes it cannot read.
+        validator = validator[:-1] + '-gzip"'
+
+    if _matches(headers.get("if-none-match", ""), validator):
+        await send({"type": "http.response.start", "status": 304, "headers": [
+            (b"etag", validator.encode()),
+            (b"cache-control", b"no-cache"),
+            (b"vary", b"accept-encoding"),
+        ]})
+        return await send({"type": "http.response.body", "body": b""})
+
+    extra = [(b"etag", validator.encode()),
+             (b"cache-control", b"no-cache"),
+             # Without this a shared cache can hand a compressed body to a client that cannot
+             # take one, having stored it under a key that ignored the difference.
+             (b"vary", b"accept-encoding")]
+    if encoding:
+        extra.append((b"content-encoding", encoding))
+    return await _html(send, 200, body, extra)
 
 
 async def _html(send: Callable, status: int, body: bytes,
@@ -3693,17 +3806,17 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         # ACTION on it calls an admin-gated JSON endpoint, so the page is inert without a valid
         # admin key. Kept before the data routes so it never touches auth/metering/quota.
         if method == "GET" and path == "/v1/admin/portal":
-            return await _html(send, 200, _portal_html_bytes())
+            return await _page(send, scope, _portal_html_bytes())
 
         # ---- setup + catalog pages (static HTML, no auth to FETCH) ---------------------------
         # Same posture as the key portal: the page is inert without an admin key, because every
         # action on it calls an admin-gated JSON endpoint.
         if method == "GET" and path in ("/v1/admin", "/v1/admin/"):
-            return await _html(send, 200, _overview_portal_html_bytes())
+            return await _page(send, scope, _overview_portal_html_bytes())
         if method == "GET" and path == "/v1/admin/explore":
-            return await _html(send, 200, _explore_portal_html_bytes())
+            return await _page(send, scope, _explore_portal_html_bytes())
         if method == "GET" and path == "/v1/admin/api":
-            return await _html(send, 200, _api_portal_html_bytes())
+            return await _page(send, scope, _api_portal_html_bytes())
 
         # ---- the API surface, as data (no auth: it is the published contract) -----------------
         # Served rather than written down separately so what a customer reads is what this process
@@ -3711,9 +3824,9 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         if method == "GET" and path == "/v1/admin/routes":
             return await _json(send, 200, {"status": "ok", "routes": documented_routes()})
         if method == "GET" and path == "/v1/admin/setup":
-            return await _html(send, 200, _setup_portal_html_bytes())
+            return await _page(send, scope, _setup_portal_html_bytes())
         if method == "GET" and path == "/v1/admin/catalog":
-            return await _html(send, 200, _catalog_portal_html_bytes())
+            return await _page(send, scope, _catalog_portal_html_bytes())
 
         # ---- per-key usage read (auth + admin scope) ----------------------------------------
         # Returns the in-process edge counters (per-key totals, ingest/retrieve split, bytes,
@@ -4275,7 +4388,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         # Same posture as the key portal: fetching the page needs nothing, every action on it calls
         # an admin-gated endpoint, so the page is inert without a valid admin key.
         if method == "GET" and path == "/v1/admin/ingestion":
-            return await _html(send, 200, _ingestion_portal_html_bytes())
+            return await _page(send, scope, _ingestion_portal_html_bytes())
 
         # ---- ingestion jobs: list (auth + admin scope) ---------------------------------------
         if method == "GET" and path == "/v1/admin/ingestion/jobs":

--- a/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
+++ b/tools/test_matrixark_a_badge_that_names_a_tab_opens_it.py
@@ -72,8 +72,11 @@ def routes_to_pages() -> dict:
     pass.
     """
     source = read(GATEWAY)
+    # Keyed on the page helper, not on the function that sends it. Which sender a route uses
+    # is an implementation detail and it has already changed once; pinning it made this map
+    # come back empty, which shows up here only because the floor below asserts it is not.
     served = re.findall(
-        r'path (?:==|in) \(?"(/v1/admin[^"]*)"[^\n]*\n\s*return await _html\(send, 200, (\w+)\(\)\)',
+        r'path (?:==|in) \(?"(/v1/admin[^"]*)"[^\n]*\n\s*return await _\w+\([^\n]*?(\w*_portal_html_bytes)\(\)\)',
         source)
     files = {}
     for helper in {name for _, name in served}:

--- a/tools/test_matrixark_the_portal_is_not_sent_twice.py
+++ b/tools/test_matrixark_the_portal_is_not_sent_twice.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A portal page is compressed if the client takes it, and not resent if the client has it.
+
+Seven pages, 490 KB, served uncompressed with no validator on any of them -- there was no
+``Content-Encoding``, no ``ETag`` and no ``Cache-Control`` anywhere in the gateway. Clicking
+between panels re-downloaded the whole page every time, and 35% of what it re-downloaded was the
+same shared stylesheet and script block the previous page already carried.
+
+gzip takes the seven from 490 KB to 137 KB. A validator turns the second visit into a 304 with no
+body at all.
+
+The two details worth testing rather than assuming are the ones that fail quietly:
+
+* ``Accept-Encoding: gzip;q=0`` is a *refusal*. Looking for the substring ``gzip`` reads it as
+  consent and sends a body the client said it would not decode.
+* the compressed and identity forms carry different validators, so a client holding one and
+  revalidating while asking for the other gets fresh bytes rather than a 304 pointing at a copy in
+  the wrong encoding.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+# Every route that serves a bundled page. A floor is asserted below so a renamed route cannot
+# leave this sweep quantified over nothing.
+PAGES = ["/v1/admin", "/v1/admin/portal", "/v1/admin/setup", "/v1/admin/catalog",
+         "/v1/admin/explore", "/v1/admin/api", "/v1/admin/ingestion"]
+GZIP = {"Accept-Encoding": "gzip, deflate"}
+
+
+def _get(path, headers=None):
+    """One request against a fresh app.
+
+    The gateway suite's fixtures are imported HERE rather than at module level. Under
+    `unittest discover` a test module is reachable as both `tools.X` and bare `X`, so importing one
+    test module from another at import time pulls a second copy into the run and shifts what every
+    later module sees -- which has previously shown up as CI failures in tests the branch never
+    touched. See test_matrixark_no_cross_test_imports, whose recorded list may only shrink.
+    """
+    from test_matrixark_v1_gateway import _FakeServer, _cfg, drive
+    app = gw.make_v1_app(_FakeServer(), _cfg())
+    return drive(app, method="GET", path=path, headers=headers)
+
+
+class TheHeaderIsParsedNotSearchedTest(unittest.TestCase):
+    """`"gzip" in header` gets three of these wrong."""
+
+    def test_a_plain_offer_is_accepted(self) -> None:
+        self.assertTrue(gw._accepts_gzip("gzip"))
+        self.assertTrue(gw._accepts_gzip("br, gzip"))
+        self.assertTrue(gw._accepts_gzip("gzip;q=0.5"))
+
+    def test_a_refusal_is_a_refusal(self) -> None:
+        self.assertFalse(gw._accepts_gzip("gzip;q=0"))
+        self.assertFalse(gw._accepts_gzip("deflate, gzip;q=0"))
+
+    def test_a_wildcard_is_consent(self) -> None:
+        self.assertTrue(gw._accepts_gzip("*"))
+        self.assertTrue(gw._accepts_gzip("identity;q=0, *"))
+
+    def test_nothing_asked_for_means_no(self) -> None:
+        self.assertFalse(gw._accepts_gzip(""))
+        self.assertFalse(gw._accepts_gzip("identity"))
+
+    def test_junk_in_the_quality_does_not_raise(self) -> None:
+        self.assertFalse(gw._accepts_gzip("gzip;q=banana"))
+
+
+class TheSamePageIsSmallerOnTheWireTest(unittest.TestCase):
+
+    def test_every_page_route_is_covered(self) -> None:
+        self.assertGreaterEqual(len(PAGES), 7)
+        for path in PAGES:
+            with self.subTest(path=path):
+                status, _h, _b = _get(path)
+                self.assertEqual(200, status)
+
+    def test_a_client_that_takes_gzip_gets_gzip(self) -> None:
+        saved = 0
+        for path in PAGES:
+            with self.subTest(path=path):
+                _st, plain_h, plain = _get(path)
+                status, headers, packed = _get(path, GZIP)
+                self.assertEqual(200, status)
+                self.assertEqual("gzip", headers.get("content-encoding"))
+                self.assertEqual(plain, gzip.decompress(packed),
+                                 "the compressed body is not the page")
+                self.assertLess(len(packed), len(plain))
+                self.assertNotIn("content-encoding", plain_h)
+                saved += len(plain) - len(packed)
+        self.assertGreater(saved, 300000, "the whole point was the bytes")
+
+    def test_the_length_describes_what_was_sent(self) -> None:
+        """A content-length taken from the uncompressed body truncates or hangs the response."""
+        for path in PAGES:
+            with self.subTest(path=path):
+                _st, headers, body = _get(path, GZIP)
+                self.assertEqual(str(len(body)), headers.get("content-length"))
+
+    def test_a_client_that_refuses_gets_the_page_itself(self) -> None:
+        _st, headers, body = _get("/v1/admin/setup", {"Accept-Encoding": "gzip;q=0"})
+        self.assertNotIn("content-encoding", headers)
+        self.assertIn(b"<!doctype html", body[:200].lower())
+
+    def test_a_cache_is_told_the_answer_depends_on_the_request(self) -> None:
+        for headers in (None, GZIP):
+            _st, got, _b = _get("/v1/admin/setup", headers)
+            self.assertEqual("accept-encoding", got.get("vary"),
+                             "a shared cache may hand a compressed body to a client that cannot "
+                             "read one")
+
+
+class TheSecondVisitCostsNothingTest(unittest.TestCase):
+
+    def _etag(self, path, headers=None):
+        _st, got, _b = _get(path, headers)
+        return got.get("etag")
+
+    def test_a_page_carries_a_validator(self) -> None:
+        for path in PAGES:
+            with self.subTest(path=path):
+                self.assertTrue(self._etag(path), "nothing to revalidate against")
+
+    def test_the_validator_is_the_same_next_time(self) -> None:
+        """Derived from the bytes, not from the process -- otherwise a deployment behind several
+        workers revalidates into a 200 whichever one answers."""
+        self.assertEqual(self._etag("/v1/admin/setup"), self._etag("/v1/admin/setup"))
+
+    def test_two_different_pages_do_not_share_one(self) -> None:
+        self.assertNotEqual(self._etag("/v1/admin/setup"), self._etag("/v1/admin/catalog"))
+
+    def test_holding_it_gets_a_304_with_no_body(self) -> None:
+        for path in PAGES:
+            with self.subTest(path=path):
+                etag = self._etag(path, GZIP)
+                headers = dict(GZIP)
+                headers["If-None-Match"] = etag
+                status, got, body = _get(path, headers)
+                self.assertEqual(304, status)
+                self.assertEqual(b"", body)
+                self.assertEqual(etag, got.get("etag"))
+
+    def test_holding_an_old_one_gets_the_page(self) -> None:
+        headers = dict(GZIP)
+        headers["If-None-Match"] = '"0000000000000000000000000000cafe"'
+        status, _got, body = _get("/v1/admin/setup", headers)
+        self.assertEqual(200, status)
+        self.assertTrue(body)
+
+    def test_a_wildcard_revalidation_is_honoured(self) -> None:
+        status, _got, _b = _get("/v1/admin/setup", {"If-None-Match": "*"})
+        self.assertEqual(304, status)
+
+
+class TheEncodingsDoNotShareAValidatorTest(unittest.TestCase):
+    """The failure this prevents is silent and total: a client reusing gzip bytes as HTML."""
+
+    def test_the_two_forms_are_labelled_differently(self) -> None:
+        _st, plain, _b = _get("/v1/admin/setup")
+        _st2, packed, _b2 = _get("/v1/admin/setup", GZIP)
+        self.assertNotEqual(plain.get("etag"), packed.get("etag"))
+
+    def test_revalidating_across_encodings_gets_fresh_bytes(self) -> None:
+        _st, packed, _b = _get("/v1/admin/setup", GZIP)
+        status, _got, body = _get("/v1/admin/setup", {"If-None-Match": packed["etag"]})
+        self.assertEqual(200, status, "a client would have reused gzip bytes as HTML")
+        self.assertIn(b"<!doctype html", body[:200].lower())
+
+
+class TheCompressionIsDoneOnceTest(unittest.TestCase):
+
+    def test_the_same_page_packs_to_the_same_bytes(self) -> None:
+        """gzip stamps the current time into its header by default, which would make every
+        response different from the last and every validator a fresh one."""
+        _st, _h, first = _get("/v1/admin/setup", GZIP)
+        _st2, _h2, second = _get("/v1/admin/setup", GZIP)
+        self.assertEqual(first, second)
+
+    def test_the_cache_is_bounded(self) -> None:
+        """Keyed by content, so a long-running process that reloads pages would otherwise keep one
+        entry per version it ever served."""
+        self.assertLessEqual(len(gw._HTML_PACKED), gw._HTML_PACKED_MAX)
+
+    def test_a_short_body_is_left_alone(self) -> None:
+        """An envelope on a few hundred bytes buys nothing and costs a decode."""
+        self.assertLess(gw._HTML_PACK_FLOOR, 4096)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Seven pages, 490 KB, and every one served uncompressed with no validator — there was no
`Content-Encoding`, no `ETag` and no `Cache-Control` anywhere in the gateway. Clicking between
panels re-downloaded the whole page each time, and **35% of what came back was the same stylesheet
and script block the previous page already carried**.

Measured over the app, a full tour of the seven panels:

| | bytes |
|---|---|
| uncompressed | 511,894 |
| gzip | 144,203 (3.5×, −367,691) |
| revisit with validators | **0** (7 × 304) |

The compressed form is built once per page and cached beside it — 144 KB per worker, for 353 KB off
every tour.

### Two things that fail quietly, so they are tested

`Accept-Encoding: gzip;q=0` is a **refusal**. Looking for the substring `gzip` reads it as consent
and sends a body the client said it would not decode; the same mistake misses `*`, which is consent
to anything.

The two encodings carry **different validators**. Sharing one lets a client that cached the identity
copy revalidate while asking for gzip, get a 304, and reuse bytes in the wrong encoding — silent and
total. `Vary: accept-encoding` is set for the same reason one layer out.

gzip stamps the current time into its header by default, so `mtime` is pinned: without it the same
page compresses differently in every process and no two workers agree on a validator.

```
search the header for "gzip"   -> FAIL a refusal is a refusal, a wildcard is consent, +2 more
one validator for both forms   -> FAIL revalidating across encodings gets fresh bytes
no Vary                        -> FAIL a cache is told the answer depends on the request
```

### One guard needed updating

The tab-link route map keyed on `_html(send, 200, ...)`, which these routes no longer call. It keys
on the page **helper** now — which sender a route uses is an implementation detail, and this is the
second time it has changed. The floor under that map is what turned a silently empty result into a
failure rather than a pass.

21 tests here. Neighbours: v1_gateway 97, gateway_portal 60, portal_tabs 19, dashboards 20,
deployment routes 23, gateway_events 12, embedding status 16.

**Not done here, measured and deliberately left:** holding only the packed copy would save the
490 KB of raw HTML per worker as well, but it needs the page-serving path rebuilt across seven
accessors and a second negotiation path that must not drift from this one. Against a datanode that
holds 27 MB per 1,000 records, that is not a trade worth making for ~0.5 MB.
