### PR TITLE
Give every panel a main region, and the one unnamed control a name

### DIFF
--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -154,6 +154,12 @@
   table.failures td{vertical-align:top;overflow-wrap:anywhere}
   table.failures td.mono{font-family:"IBM Plex Mono",monospace;font-size:12px}
   details ul li{list-style:none;margin-left:-18px}
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -407,7 +413,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>API</h1>
@@ -435,6 +441,7 @@
 
   <section>
     <h2>Filter</h2>
+    <label class="sr-only" for="filter">Filter routes</label>
     <input id="filter" type="search" placeholder="path, method, scope or description" spellcheck="false" autocomplete="off">
     <div class="hint">Reading this page needs nothing. Each route enforces its own access — the
       scope column is what a key must carry.</div>
@@ -447,7 +454,7 @@
   <div id="crossGroup"></div>
   <div id="routes"><div class="empty">Loading…</div></div>
 
-</div>
+</main>
 <script>
 /* Tabs, for every portal page whose body declares a tablist.
  *

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -32,6 +32,12 @@ if not match:
 BASE_CSS = match.group(1)
 
 NAV_CSS = """
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -693,7 +699,7 @@ HEAD = """<!doctype html>
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 """
 
 # ================================================================================================
@@ -4789,6 +4795,7 @@ API_BODY = """
 
   <section>
     <h2>Filter</h2>
+    <label class="sr-only" for="filter">Filter routes</label>
     <input id="filter" type="search" placeholder="path, method, scope or description" spellcheck="false" autocomplete="off">
     <div class="hint">Reading this page needs nothing. Each route enforces its own access — the
       scope column is what a key must carry.</div>
@@ -5031,7 +5038,7 @@ API_JS = r"""
 
 
 TAIL = """
-</div>
+</main>
 %(js)s
 %(navjs)s
 </body>

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -154,6 +154,12 @@
   table.failures td{vertical-align:top;overflow-wrap:anywhere}
   table.failures td.mono{font-family:"IBM Plex Mono",monospace;font-size:12px}
   details ul li{list-style:none;margin-left:-18px}
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -407,7 +413,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>Skills &amp; resources</h1>
@@ -502,7 +508,7 @@
     <pre id="content">Nothing selected.</pre>
   </section>
 
-</div>
+</main>
 <script>
 /* Tabs, for every portal page whose body declares a tablist.
  *

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -154,6 +154,12 @@
   table.failures td{vertical-align:top;overflow-wrap:anywhere}
   table.failures td.mono{font-family:"IBM Plex Mono",monospace;font-size:12px}
   details ul li{list-style:none;margin-left:-18px}
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -407,7 +413,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>Explore</h1>
@@ -589,7 +595,7 @@
     <pre id="detail">Select a memory to see its stored record and change history.</pre>
   </section>
 
-</div>
+</main>
 <script>
 /* Tabs, for every portal page whose body declares a tablist.
  *

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -157,7 +157,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>Ingestion</h1>
@@ -251,7 +251,7 @@
     <pre id="metrics">Loading…</pre>
   </section>
 
-</div>
+</main>
 
 <script>
 (function () {

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -154,6 +154,12 @@
   table.failures td{vertical-align:top;overflow-wrap:anywhere}
   table.failures td.mono{font-family:"IBM Plex Mono",monospace;font-size:12px}
   details ul li{list-style:none;margin-left:-18px}
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -407,7 +413,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>MatrixArk</h1>
@@ -482,7 +488,7 @@
     </div>
   </section>
 
-</div>
+</main>
 <script>
 (function () {
   "use strict";

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -154,6 +154,12 @@
   table.failures td{vertical-align:top;overflow-wrap:anywhere}
   table.failures td.mono{font-family:"IBM Plex Mono",monospace;font-size:12px}
   details ul li{list-style:none;margin-left:-18px}
+  /* Named for a screen reader, absent for everyone else. The heading beside a control can
+     already say what it is for, in which case a second visible copy is noise -- but a
+     heading is not a name, and announced on its own the control has none. Clipped rather
+     than display:none, which would take it out of the accessibility tree as well. */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+           clip:rect(0 0 0 0);white-space:nowrap;border:0}
   /* shared portal nav (same markup on every page; both portal stylesheets define these vars) */
   .portalnav{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 20px;padding-bottom:2px;
              border-bottom:1px solid var(--line)}
@@ -407,7 +413,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<main class="wrap">
 
   <header>
     <h1>Setup &amp; metrics</h1>
@@ -683,7 +689,7 @@
   </section>
   </section>
 
-</div>
+</main>
 <script>
 /* Tabs, for every portal page whose body declares a tablist.
  *

--- a/tools/test_matrixark_every_panel_is_navigable.py
+++ b/tools/test_matrixark_every_panel_is_navigable.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every panel has one main region, one title, and no control without a name.
+
+Six of the seven pages opened their content with ``<div class="wrap">``. The key portal opened with
+``<main class="wrap">``, so the intent was settled and the rest had simply never been given it.
+Without a main landmark there is nothing to skip to: a screen reader arriving on Setup walks the
+nav, the status strip and the tab list again on every visit, and a "skip to content" command has no
+target.
+
+The API page's route filter was an ``<input type="search">`` under an ``<h2>Filter</h2>`` with no
+label of any kind. A heading above a control is not its name -- announced on its own that field was
+"search edit", which is exactly what a customer gets who cannot see where it sits.
+
+Every other control on all seven pages was already named, most by a label that WRAPS it rather than
+one that points at it. Scanning only for ``for=`` reports fourteen of those as broken and hides the
+one that is, which is why the check here looks inside each label's extent as well.
+
+These are sweeps, so each carries a floor: a selector that stopped matching would otherwise leave
+every one of them quantified over nothing and passing.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+
+
+def pages() -> dict:
+    out = {}
+    for name in sorted(os.listdir(PORTAL)):
+        if not name.endswith(".html"):
+            continue
+        with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+            out[name] = handle.read()
+    return out
+
+
+def markup(text: str) -> str:
+    """The document without its scripts or stylesheet.
+
+    Pages build markup out of strings -- the API page assembles its whole route table that way --
+    so a scan of the raw file finds template fragments and counts them as structure.
+    """
+    text = re.sub(r"<script[\s\S]*?</script>", "", text)
+    return re.sub(r"<style[\s\S]*?</style>", "", text)
+
+
+def unnamed_controls(body: str) -> list:
+    """Controls nothing announces.
+
+    Three things name a control: a ``<label for=id>``, a ``<label>`` that wraps it, or an
+    ``aria-label`` on the control. The wrapping form is the one this portal mostly uses.
+    """
+    pointed = set(re.findall(r'<label[^>]*for="([^"]+)"', body))
+    wrapped = set()
+    for opening in re.finditer(r"<label\b[^>]*>", body):
+        end = body.find("</label>", opening.end())
+        if end == -1:
+            continue
+        for tag in re.findall(r"<(?:input|select|textarea)\b[^>]*>", body[opening.end():end]):
+            found = re.search(r'\sid="([^"]+)"', tag)
+            wrapped.add(found.group(1) if found else tag)
+
+    bare = []
+    for tag in re.findall(r"<(?:input|select|textarea)\b[^>]*>", body):
+        if 'type="hidden"' in tag or "aria-label" in tag:
+            continue
+        found = re.search(r'\sid="([^"]+)"', tag)
+        key = found.group(1) if found else tag
+        if key not in pointed and key not in wrapped:
+            bare.append(key)
+    return bare
+
+
+class EveryPanelIsBuiltTheSameWayTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.pages = pages()
+        self.assertGreaterEqual(len(self.pages), 7,
+                                "fewer pages than the portal has; this sweep is not seeing them")
+
+    def test_each_has_exactly_one_main_region(self) -> None:
+        """The landmark a reader skips to. Two would make "the content" ambiguous, none leaves the
+        command with no target at all."""
+        wrong = {name: len(re.findall(r"<main\b", markup(text)))
+                 for name, text in self.pages.items()}
+        self.assertEqual({}, {k: v for k, v in wrong.items() if v != 1}, wrong)
+
+    def test_the_main_region_holds_the_content(self) -> None:
+        """A landmark wrapped around nothing is worse than none: it answers "skip to content" with
+        an empty room.
+
+        Not asserted: that the ``<h1>`` is inside it. The key portal puts its title in a banner
+        header above the main region, which is a perfectly good structure -- and a check that
+        forbade it would be demanding uniformity rather than navigability.
+        """
+        for name, text in self.pages.items():
+            with self.subTest(page=name):
+                body = markup(text)
+                start = body.index("<main")
+                end = body.index("</main>", start)
+                inside = body[start:end]
+                self.assertGreater(len(inside), 2000, "the main region is nearly empty")
+                self.assertIn("<section", inside, "no content section inside the main region")
+                after = body[end:]
+                self.assertNotIn("<section", after,
+                                 "a content section sits after the main region, where skipping to "
+                                 "the content skips past it")
+
+    def test_each_has_exactly_one_title(self) -> None:
+        counts = {name: len(re.findall(r"<h1\b", markup(text)))
+                  for name, text in self.pages.items()}
+        self.assertEqual({}, {k: v for k, v in counts.items() if v != 1}, counts)
+
+    def test_no_heading_level_is_skipped(self) -> None:
+        """An h2 followed by an h4 reads as a missing section to anything navigating by heading."""
+        broken = {}
+        for name, text in self.pages.items():
+            levels = [int(m.group(1)) for m in re.finditer(r"<h([1-6])\b", markup(text))]
+            self.assertTrue(levels, "%s has no headings at all" % name)
+            previous = 0
+            for level in levels:
+                if previous and level > previous + 1:
+                    broken[name] = "h%d after h%d" % (level, previous)
+                    break
+                previous = level
+        self.assertEqual({}, broken)
+
+    def test_every_control_has_a_name(self) -> None:
+        bare = {name: unnamed_controls(markup(text)) for name, text in self.pages.items()}
+        self.assertEqual({}, {k: v for k, v in bare.items() if v},
+                         "controls nothing announces: %r" % {k: v for k, v in bare.items() if v})
+
+    def test_the_sweep_actually_sees_controls(self) -> None:
+        """Without this the check above passes on a regex that stopped matching inputs."""
+        total = sum(len(re.findall(r"<input\b", markup(text))) for text in self.pages.values())
+        self.assertGreater(total, 20, total)
+
+
+class ANameForAReaderIsNotShownTwiceTest(unittest.TestCase):
+    """Where a heading already says what a control is for, the label is for the reader who cannot
+    see the heading -- and a class that does not exist would put it on screen next to it."""
+
+    def test_every_page_using_the_class_defines_it(self) -> None:
+        used = {name for name, text in pages().items() if 'class="sr-only"' in text}
+        self.assertTrue(used, "nothing uses the class; this check is quantified over nothing")
+        undefined = sorted(name for name in used if ".sr-only{" not in pages()[name])
+        self.assertEqual([], undefined,
+                         "a visually-hidden label with no rule to hide it: %r" % undefined)
+
+    def test_it_is_clipped_rather_than_removed(self) -> None:
+        """display:none and visibility:hidden take an element out of the accessibility tree too,
+        which would hide the name from exactly the reader it was written for."""
+        for name, text in pages().items():
+            if ".sr-only{" not in text:
+                continue
+            with self.subTest(page=name):
+                rule = text[text.index(".sr-only{"):]
+                rule = rule[:rule.index("}") + 1]
+                self.assertNotIn("display:none", rule)
+                self.assertNotIn("visibility:hidden", rule)
+                self.assertIn("clip:", rule)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Six of the seven portal pages opened their content with `<div class="wrap">`. The key portal opened
with `<main class="wrap">` — so the intent was settled and the rest had simply never been given it.

Without that landmark there is nothing to skip to: a reader arriving on Setup walks the nav, the
status strip and the tab list again on every visit, and a skip-to-content command has no target at
all.

### The one control nothing announced

The API page's route filter was an `<input type="search">` under an `<h2>Filter</h2>` with no label
of any kind. A heading above a control is not its name — announced on its own, that field was
*"search edit"*, which is exactly what a customer gets who cannot see where it sits.

It is named now, **clipped rather than `display:none`**: `display:none` and `visibility:hidden` take
an element out of the accessibility tree as well, which would hide the name from the only reader it
was written for.

Every other control on all seven pages was already named — most by a label that *wraps* it rather
than one pointing at it. A scan for `for=` alone reports fourteen of those as broken and hides the
one that was, so the check here looks inside each label's extent too.

### The sweeps carry floors

One main region per page, one title per page, no heading level skipped, no control without a name —
each passes trivially on a selector that stopped matching, so each asserts it saw something first.

```
main back to a div            -> FAIL each has exactly one main region
label off the route filter    -> FAIL every control has a name (+ the class is defined)
display:none instead of clip  -> FAIL it is clipped rather than removed
```

Not asserted: that the `<h1>` sits inside `main`. The key portal puts its title in a banner header
above the main region, which is a good structure — a check forbidding it would be demanding
uniformity rather than navigability.

8 tests. Neighbours: portal_pages 4, portal_tabs 19, tab panes 7, key-pointer 13, api_traffic 15.
