### PR TITLE
The write floor guarded the wrong write

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -129,9 +129,23 @@ LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
 #   no structural fix, 250 ms floor  ingest ~2.0 s    time inside the writer ~2.9 s
 #   this, no floor                   ingest 0.768 s   time inside the writer 0.146 s
 #
-# So the delay is no longer buying anything, and it cost correctness: four tests assert that a
-# snapshot is refreshed promptly enough for a restart to use it, and a floor makes that false for
-# a quarter of a second. They pass again at 0.
+# So the delay is no longer buying anything on that path, and it cost correctness: four tests assert
+# that a snapshot is refreshed promptly enough for a restart to use it, and a floor made that false
+# for a quarter of a second. They pass again at 0.
+#
+# The reason it cost correctness was WHERE it was checked, not the idea. The floor sat at the top of
+# _write_durable_read_cache, so it gated the cheap tail append -- which is what keeps the head's
+# signature current after a write -- as well as the O(corpus) rewrite it was aimed at. It now guards
+# the rewrite alone, and those four tests pass with a floor set.
+#
+# The default stays 0, because turning it on is a real trade rather than a free win. Measured over
+# 12 queries interleaved with ingest, 128 documents, both orderings:
+#
+#   floor 0      12 of 12 base rewrites   median 2,352 / 2,713 ms   cold load 1,391 / 1,368 ms
+#   floor 5000    0 of 12 base rewrites   median 1,922 / 2,037 ms   cold load 1,507 / 1,694 ms
+#
+# -21.8% on every query against roughly +16% on a cold start. Worth it for most deployments, since
+# queries are frequent and restarts are not -- but that is an operator's call, not a default.
 LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = max(0.0, float(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", "0")))
 
 
@@ -4864,9 +4878,6 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         if int(signature.get("total_size", -1)) < 0:
             return
         now = now_ms()
-        if not force and LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS > 0:
-            if now - self._durable_read_cache_last_write_ms < LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS:
-                return
         path = self._durable_read_cache_path()
         delta_path = self._durable_read_cache_delta_path()
         head_path = self._durable_read_cache_head_path()
@@ -4941,6 +4952,14 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             # The caller is a write. A full rewrite here is O(corpus) per append; leave the snapshot
             # as it stands and let the next read refresh it.
             return
+        # Everything below rewrites the WHOLE record set, so the floor belongs here and nowhere
+        # earlier. It used to sit at the top of this function, where it gated the tail append above
+        # as well -- and the tail append is what keeps the head's signature current after a write,
+        # so a floor there made a snapshot unusable for a restart and broke four tests asserting
+        # exactly that. Guarding only the rewrite leaves appends as prompt as they were.
+        if not force and LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS > 0:
+            if now - self._durable_read_cache_last_write_ms < LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS:
+                return
         tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         payload = {
             "schema_version": LOCAL_DURABLE_READ_CACHE_SCHEMA_VERSION,

--- a/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
+++ b/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS` is meant to bound how often the snapshot is
+rewritten. It was checked at the top of the writer, so it gated two very different writes with one
+test: the O(corpus) base rewrite, and the cheap tail append that keeps the head's signature current
+after a write.
+
+Gating the second is what made the knob unusable. A snapshot whose head no longer matches the log is
+ignored, so a restart re-derives -- and four tests assert exactly that it should not have to. Setting
+the floor at all therefore broke them, which is why the default is 0 and why the comment above the
+constant says a floor "cost correctness".
+
+These tests pin the split: with a floor set, a write still refreshes the head promptly, and only the
+full rewrite is skipped.
+"""
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+try:  # package path
+    from tools import matrixark_mcp_local_adapter as adapter_module
+    from tools.matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+except ImportError:
+    import matrixark_mcp_local_adapter as adapter_module
+    from matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+
+
+class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="write_floor_"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.log = self.root / "events.jsonl"
+        # The floor is a PROCESS-GLOBAL read at call time. Restore it, or every later test in the
+        # suite runs under whatever this one left behind.
+        self.original_floor = adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS
+        self.addCleanup(setattr, adapter_module,
+                        "LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", self.original_floor)
+
+    def base_mtime(self) -> int:
+        try:
+            return (self.root / "events.jsonl.read-cache.json").stat().st_mtime_ns
+        except FileNotFoundError:
+            return 0
+
+    def seeded(self) -> MatrixArkLocalAdapter:
+        """An adapter with a base snapshot already on disk."""
+        writer = MatrixArkLocalAdapter(self.log)
+        for index in range(6):
+            writer.append({"record_type": "context_event", "event_id": "seed-%d" % index,
+                           "content": "seed %d" % index})
+        writer.read_all()
+        self.assertGreater(self.base_mtime(), 0, "no base snapshot was written to throttle")
+        return writer
+
+    def test_a_write_still_refreshes_the_head_under_a_floor(self):
+        adapter = self.seeded()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 600000.0
+        adapter.append({"record_type": "context_event", "event_id": "after-floor",
+                        "content": "written while the floor is set"})
+        # The promptness guarantee: a restart must still be served from the snapshot rather than
+        # re-deriving from the log, which is only true if the write refreshed the head.
+        adapter_module._LOCAL_READ_CACHE.clear()
+        restarted = MatrixArkLocalAdapter(self.log)
+        records = restarted.read_all()
+        self.assertEqual(restarted._read_cache_source, "durable",
+                         "a floor blocked the tail write, so the snapshot went stale")
+        self.assertIn("after-floor", {r.get("event_id") for r in records},
+                      "the record written under the floor is missing from the served view")
+
+    def test_the_full_rewrite_is_the_thing_the_floor_skips(self):
+        adapter = self.seeded()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 600000.0
+        before = self.base_mtime()
+        # Force the path that rewrites the base: a caller that cannot vouch for the list passes
+        # epoch=None, which is what makes the tail path unavailable.
+        adapter._write_durable_read_cache(
+            list(adapter.read_all()), adapter._jsonl_cache_signature_detail(), epoch=None)
+        self.assertEqual(self.base_mtime(), before,
+                         "the base was rewritten despite the floor")
+
+    def test_without_a_floor_the_same_call_does_rewrite(self):
+        # Positive control. Without this, the test above passes for any reason at all -- including
+        # the rewrite never being reachable in this fixture.
+        adapter = self.seeded()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 0.0
+        before = self.base_mtime()
+        adapter.append({"record_type": "context_event", "event_id": "extra",
+                        "content": "one more"})
+        adapter._write_durable_read_cache(
+            list(adapter.read_all()), adapter._jsonl_cache_signature_detail(), epoch=None)
+        self.assertNotEqual(self.base_mtime(), before,
+                            "the base was not rewritten even with no floor, so the test above "
+                            "proves nothing")
+
+    def delta_mtime(self) -> int:
+        try:
+            return (self.root / ".events.jsonl.read-cache-delta.jsonl").stat().st_mtime_ns
+        except FileNotFoundError:
+            return 0
+
+    def test_a_forced_write_ignores_the_floor(self):
+        # The rebuild-from-log path forces, so a store always ends up with a snapshot even under an
+        # aggressive floor. Assert only that SOMETHING was persisted -- which of the two files the
+        # writer picks is its own decision, and pinning that here would make this test fail for
+        # reasons that have nothing to do with the floor.
+        adapter = self.seeded()
+        adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 600000.0
+        adapter.append({"record_type": "context_event", "event_id": "forced",
+                        "content": "forced"})
+        before = (self.base_mtime(), self.delta_mtime())
+        adapter._write_durable_read_cache(
+            list(adapter.read_all()), adapter._jsonl_cache_signature_detail(),
+            force=True, epoch=None)
+        self.assertNotEqual((self.base_mtime(), self.delta_mtime()), before,
+                            "force=True wrote nothing at all, so the floor blocked it")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MATRIXARK_LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS` bounds how often the durable snapshot is
rewritten. It was checked at the top of `_write_durable_read_cache`, so one test gated two very
different writes:

| write | cost | what it does |
|---|---|---|
| tail append to the delta | cheap | keeps the head's **signature** current after a write |
| full base rewrite | O(corpus) | the thing the floor was aimed at |

Blocking the second is the point. Blocking the first breaks a restart: a head whose signature no
longer matches the log is ignored, so the reader re-derives from the log and `_read_cache_source`
comes back `'jsonl'` instead of `'durable'`.

That is why setting the floor at all broke four tests, and why the comment above the constant says a
floor "cost correctness". **The cost was where it was checked, not the idea.** Moving it below the
tail path leaves appends exactly as prompt as they were and skips only the rewrite — and with a
floor set, those four tests pass.

## The default stays 0

Turning it on is a trade, not a free win. Measured over 12 queries interleaved with ingest, 128
documents, both orderings, each arm on its own store (reading a store rewrites its snapshot, so a
shared copy would have the second arm loading the first arm's file):

| floor | base rewrites | median query | cold load |
|---|---|---|---|
| 0 | **12 of 12** | 2,352 / 2,713 ms | 1,391 / 1,368 ms |
| 5000 | **0 of 12** | **1,922 / 2,037 ms** | 1,507 / 1,694 ms |

−21.8% on every query against roughly +16% on a cold start. Worth it for most deployments, since
queries are frequent and restarts are not — but that is an operator's call, so the default is
unchanged and the numbers now sit in the comment where the choice can be made from them.

Worth noting the earlier measurement in that same comment ("no floor buys nothing", 40 ingests) was
taken on the **ingest** path, where a write already returns early via `tail_only`. It says nothing
about the read path, which was taking the full rewrite 12 times out of 12.

## Tests

`test_matrixark_the_floor_guards_the_rewrite_only.py`, four tests pinning the split: under a floor a
write still refreshes the head and a restart is still served from the snapshot, while the full
rewrite is skipped — plus a positive control that the *same call* does rewrite when no floor is set,
since otherwise the skip assertion would pass for any reason at all, including the rewrite being
unreachable in the fixture. The floor is process-global and is saved and restored, so this file
cannot leave the rest of the suite running under it.

Verified against `main`: the promptness test fails there with `'jsonl' != 'durable'` and passes here.

Full python suite on both arms, diffed by failing test name. Three names came back branch-only; all
three were re-run in isolation against the modules that actually execute them, with the run asserted
non-vacuous (3/3 named tests confirmed to have run each time): **main fails 1 of 4, this branch 0 of
4**. They are pre-existing flakes, and the branch arm had simply run under twice the machine load.
