### PR TITLE
A hidden tab lets go of its live connection, and keeps letting go

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1116,6 +1116,11 @@
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -950,6 +950,11 @@
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -462,6 +462,11 @@ NAV_JS = r'''<script>
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();
@@ -572,6 +577,98 @@ def nav(active):
         current = ' aria-current="page"' if href == active else ""
         parts.append('    <a href="%s"%s>%s</a>' % (href, current, label))
     return ('  <nav class="portalnav">\n' + "\n".join(parts) + LIVE_STRIP + "\n  </nav>")
+
+
+LIVE_STREAM_JS = r"""
+/* ---------- the live stream ---------- */
+/* Read over fetch() rather than with EventSource, which cannot set an Authorization header --
+   the alternative is the key in a query string, and a credential in a URL ends up in every access
+   log and proxy trace between here and the gateway. Same wire format either way; only the
+   reconnect is ours to write. */
+function liveStream(options) {
+  var onFrame = options.onFrame || function () {};
+  var onState = options.onState || function () {};
+  var headers = options.headers || function () { return {}; };
+  var controller = null, stopped = false, backoff = 1000, buffer = "";
+
+  function schedule() {
+    if (stopped) { return; }
+    onState("retrying", Math.round(backoff / 1000));
+    setTimeout(open, backoff);
+    backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down should not be hammered */
+  }
+
+  function handle(block) {
+    var payload = null;
+    block.split("\n").forEach(function (line) {
+      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
+    });
+    if (!payload) { return; }
+    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
+  }
+
+  function open() {
+    if (stopped) { return; }
+    /* Same rule as the strip, which never reaches these two pages: they claim __matrixarkLive, so
+       the strip's script returns before registering it. */
+    if (document.hidden) { controller = null; return; }
+    controller = new AbortController();
+    onState("connecting");
+    fetch("/v1/admin/events", { headers: headers(), signal: controller.signal })
+      .then(function (response) {
+        if (!response.ok) { return Promise.reject(response.status); }
+        if (!response.body) { return Promise.reject("nostream"); }
+        onState("live");
+        backoff = 1000;
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder();
+        function pump() {
+          return reader.read().then(function (chunk) {
+            if (chunk.done) { schedule(); return; }
+            buffer += decoder.decode(chunk.value, { stream: true });
+            var blocks = buffer.split("\n\n");
+            buffer = blocks.pop();
+            blocks.forEach(handle);
+            return pump();
+          });
+        }
+        return pump();
+      })
+      .catch(function (err) {
+        if (stopped) { return; }
+        if (err === 401 || err === 403) { onState("denied"); return; }
+        schedule();
+      });
+  }
+
+  open();
+  /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
+     rule the strip follows, and until now the two pages that run their own stream followed
+     neither: the strip stands down for them, and this registered only pagehide. */
+  document.addEventListener("visibilitychange", function () {
+    if (stopped) { return; }
+    if (document.hidden) {
+      if (controller) { controller.abort(); controller = null; }
+    } else if (!controller) {
+      backoff = 1000;
+      open();
+    }
+  });
+  window.addEventListener("pagehide", function () {
+    stopped = true;
+    if (controller) { controller.abort(); }
+  });
+  return {
+    restart: function () {
+      if (controller) { controller.abort(); }
+      backoff = 1000;
+      stopped = false;
+      open();
+    },
+    stop: function () { stopped = true; if (controller) { controller.abort(); } }
+  };
+}
+"""
 
 
 TABS_JS = r"""
@@ -970,79 +1067,8 @@ SETUP_JS = r"""
      opening a second one to the same endpoint. */
   window.__matrixarkLive = "page";
 
-/* ---------- the live stream ---------- */
-/* Read over fetch() rather than with EventSource, which cannot set an Authorization header --
-   the alternative is the key in a query string, and a credential in a URL ends up in every access
-   log and proxy trace between here and the gateway. Same wire format either way; only the
-   reconnect is ours to write. */
-function liveStream(options) {
-  var onFrame = options.onFrame || function () {};
-  var onState = options.onState || function () {};
-  var headers = options.headers || function () { return {}; };
-  var controller = null, stopped = false, backoff = 1000, buffer = "";
+  /*LIVESTREAM*/
 
-  function schedule() {
-    if (stopped) { return; }
-    onState("retrying", Math.round(backoff / 1000));
-    setTimeout(open, backoff);
-    backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down should not be hammered */
-  }
-
-  function handle(block) {
-    var payload = null;
-    block.split("\n").forEach(function (line) {
-      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
-    });
-    if (!payload) { return; }
-    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
-  }
-
-  function open() {
-    if (stopped) { return; }
-    controller = new AbortController();
-    onState("connecting");
-    fetch("/v1/admin/events", { headers: headers(), signal: controller.signal })
-      .then(function (response) {
-        if (!response.ok) { return Promise.reject(response.status); }
-        if (!response.body) { return Promise.reject("nostream"); }
-        onState("live");
-        backoff = 1000;
-        var reader = response.body.getReader();
-        var decoder = new TextDecoder();
-        function pump() {
-          return reader.read().then(function (chunk) {
-            if (chunk.done) { schedule(); return; }
-            buffer += decoder.decode(chunk.value, { stream: true });
-            var blocks = buffer.split("\n\n");
-            buffer = blocks.pop();
-            blocks.forEach(handle);
-            return pump();
-          });
-        }
-        return pump();
-      })
-      .catch(function (err) {
-        if (stopped) { return; }
-        if (err === 401 || err === 403) { onState("denied"); return; }
-        schedule();
-      });
-  }
-
-  open();
-  window.addEventListener("pagehide", function () {
-    stopped = true;
-    if (controller) { controller.abort(); }
-  });
-  return {
-    restart: function () {
-      if (controller) { controller.abort(); }
-      backoff = 1000;
-      stopped = false;
-      open();
-    },
-    stop: function () { stopped = true; if (controller) { controller.abort(); } }
-  };
-}
 
   var loaded = null;      /* last GET /v1/admin/config payload */
   var fields = {};        /* setting key -> field descriptor from the server */
@@ -3032,79 +3058,8 @@ OVERVIEW_JS = r"""
      opening a second one to the same endpoint. */
   window.__matrixarkLive = "page";
 
-/* ---------- the live stream ---------- */
-/* Read over fetch() rather than with EventSource, which cannot set an Authorization header --
-   the alternative is the key in a query string, and a credential in a URL ends up in every access
-   log and proxy trace between here and the gateway. Same wire format either way; only the
-   reconnect is ours to write. */
-function liveStream(options) {
-  var onFrame = options.onFrame || function () {};
-  var onState = options.onState || function () {};
-  var headers = options.headers || function () { return {}; };
-  var controller = null, stopped = false, backoff = 1000, buffer = "";
+  /*LIVESTREAM*/
 
-  function schedule() {
-    if (stopped) { return; }
-    onState("retrying", Math.round(backoff / 1000));
-    setTimeout(open, backoff);
-    backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down should not be hammered */
-  }
-
-  function handle(block) {
-    var payload = null;
-    block.split("\n").forEach(function (line) {
-      if (line.indexOf("data: ") === 0) { payload = line.slice(6); }
-    });
-    if (!payload) { return; }
-    try { onFrame(JSON.parse(payload)); } catch (e) { /* a partial frame; the next one is whole */ }
-  }
-
-  function open() {
-    if (stopped) { return; }
-    controller = new AbortController();
-    onState("connecting");
-    fetch("/v1/admin/events", { headers: headers(), signal: controller.signal })
-      .then(function (response) {
-        if (!response.ok) { return Promise.reject(response.status); }
-        if (!response.body) { return Promise.reject("nostream"); }
-        onState("live");
-        backoff = 1000;
-        var reader = response.body.getReader();
-        var decoder = new TextDecoder();
-        function pump() {
-          return reader.read().then(function (chunk) {
-            if (chunk.done) { schedule(); return; }
-            buffer += decoder.decode(chunk.value, { stream: true });
-            var blocks = buffer.split("\n\n");
-            buffer = blocks.pop();
-            blocks.forEach(handle);
-            return pump();
-          });
-        }
-        return pump();
-      })
-      .catch(function (err) {
-        if (stopped) { return; }
-        if (err === 401 || err === 403) { onState("denied"); return; }
-        schedule();
-      });
-  }
-
-  open();
-  window.addEventListener("pagehide", function () {
-    stopped = true;
-    if (controller) { controller.abort(); }
-  });
-  return {
-    restart: function () {
-      if (controller) { controller.abort(); }
-      backoff = 1000;
-      stopped = false;
-      open();
-    },
-    stop: function () { stopped = true; if (controller) { controller.abort(); } }
-  };
-}
 
   function auth() {
     var k = $("key").value.trim();
@@ -5044,7 +4999,7 @@ def emit(filename, title, body, js, active):
     rendered = body % {"nav": nav(active)}
     # Only pages that declare a tablist carry the helper, so a page without tabs is byte for byte
     # what it was and a page that grows tabs picks it up without anyone remembering to wire it.
-    page_js = js.strip()
+    page_js = js.strip().replace("/*LIVESTREAM*/", LIVE_STREAM_JS.strip())
     if 'role="tablist"' in rendered:
         page_js = TABS_JS.strip() + "\n" + page_js
     html = (HEAD % {"title": title, "css": css}

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1068,6 +1068,11 @@
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -2027,6 +2027,11 @@
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/hidden_tab_harness.js
+++ b/tools/portal/hidden_tab_harness.js
@@ -1,0 +1,229 @@
+/* Does a portal page in a background tab actually let go of its live connection?
+ *
+ * Every page says it does. The status strip carries the rule in as many words -- "A hidden tab
+ * holds a connection open for nobody. Drop it, reconnect on return." -- and aborts the request
+ * when the tab is hidden. What it does not do is stop the reconnect: aborting rejects the fetch,
+ * the catch schedules setTimeout(open, backoff), and about a second later the page opens the
+ * stream again while the tab is still hidden.
+ *
+ * That is not visible in the source. The abort is there, the comment is there, and the line that
+ * undoes them is thirty lines away in a different function. So the page's own code is run here
+ * against a fake clock: hide the tab, fire every timer that comes due, and count the connections
+ * opened after the abort.
+ *
+ * Usage: node hidden_tab_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+/* Captured before anything in this file shadows it: the page under test is handed a fake
+   setTimeout, and the flush below must not go through it. */
+const realSetImmediate = setImmediate;
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* ---------- a fake clock, so a backoff does not cost a real second ---------- */
+function makeWorld() {
+  const timers = [];
+  let now = 0;
+  const opened = [];
+  const aborted = [];
+
+  const listeners = { document: {}, window: {} };
+  /* Enough of an element for the strip to read a key out of and to write a status into. It reads
+     `key()` before connecting and gives up quietly when there is none, so a stub returning null
+     produces a page that simply never opens a connection -- which would make every check below
+     pass for the wrong reason. */
+  function element(id) {
+    return {
+      id,
+      value: "k-test",
+      textContent: "",
+      className: "",
+      hidden: false,
+      style: {},
+      dataset: {},
+      classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+      addEventListener() {},
+      setAttribute() {},
+      getAttribute: () => null,
+      appendChild() {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    };
+  }
+  const nodes = {};
+  const doc = {
+    hidden: false,
+    addEventListener(type, fn) { (listeners.document[type] = listeners.document[type] || []).push(fn); },
+    getElementById(id) { return (nodes[id] = nodes[id] || element(id)); },
+    createElement(tag) { return element(tag); },
+    querySelectorAll() { return []; },
+    querySelector() { return null; },
+    body: element("body"),
+  };
+  const win = {
+    addEventListener(type, fn) { (listeners.window[type] = listeners.window[type] || []).push(fn); },
+    location: { hash: "" },
+    setTimeout(fn, ms) { timers.push({ at: now + (ms || 0), fn }); return timers.length; },
+    clearTimeout() {},
+    setInterval() { return 0; },
+    clearInterval() {},
+  };
+
+  class FakeController {
+    constructor() {
+      this.signal = { aborted: false };
+      this.index = opened.length;
+    }
+    abort() {
+      this.signal.aborted = true;
+      aborted.push(this.index);
+      const pending = opened[this.index];
+      if (pending && pending.reject) { pending.reject(new Error("aborted")); }
+    }
+  }
+
+  function fetchStub(url) {
+    const record = { url, reject: null };
+    opened.push(record);
+    /* A connection that never resolves: a live stream does not settle until it breaks, and that
+       is exactly the state we want the page to be holding when the tab is hidden. */
+    return new Promise((_resolve, reject) => { record.reject = reject; });
+  }
+
+  return {
+    doc, win, opened, aborted, listeners,
+    fetch: fetchStub,
+    AbortController: FakeController,
+    fire(type, where) {
+      (listeners[where][type] || []).forEach((fn) => fn({}));
+    },
+    /* Run every timer due within `ms`, including ones those timers schedule.
+     *
+     * The flush matters more than the clock. Aborting a fetch rejects it, and the reconnect is
+     * registered from the .catch at the end of that rejection's microtask chain -- so a scan for
+     * due timers that runs first finds none and reports a page that let go of its connection.
+     * That is a false pass on exactly the behaviour this file exists to check, and it is what a
+     * single `await Promise.resolve()` produced. setImmediate yields past the whole microtask
+     * queue rather than one tick of it.
+     */
+    async flush() {
+      for (let i = 0; i < 8; i += 1) {
+        await new Promise((resolve) => realSetImmediate(resolve));
+      }
+    },
+    async advance(ms) {
+      const until = now + ms;
+      await this.flush();
+      for (let guard = 0; guard < 200; guard += 1) {
+        const next = timers.filter((t) => t.at <= until).sort((a, b) => a.at - b.at)[0];
+        if (!next) { break; }
+        timers.splice(timers.indexOf(next), 1);
+        now = Math.max(now, next.at);
+        next.fn();
+        await this.flush();
+      }
+      now = until;
+    },
+  };
+}
+
+/* ---------- pick the stream this page actually runs ---------- */
+/* Two of the seven pages open their own connection and make the strip stand down for them
+   (`window.__matrixarkLive = "page"`), so "the page's live connection" is a different block of
+   code depending on which page it is. Running the strip's block on a page whose strip returns
+   immediately would check a code path that page never takes. */
+const MODE = process.argv[3] || "strip";
+
+/* Just the factory, not the block it sits in.
+ *
+ * The page's own script calls wireTabs and paints half a dozen panels as soon as it is evaluated,
+ * so running the whole block to reach one function fails on the first thing this harness has no
+ * DOM for -- and reports it as "the stream would not run", which is not what was being asked. */
+function sliceFactory(script) {
+  const at = script.indexOf("function liveStream(options)");
+  if (at === -1) { return null; }
+  let depth = 0;
+  for (let i = script.indexOf("{", at); i < script.length; i += 1) {
+    if (script[i] === "{") { depth += 1; }
+    else if (script[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return script.slice(at, i + 1); }
+    }
+  }
+  return null;
+}
+
+const src = MODE === "page"
+  ? sliceFactory(scripts.find((s) => s.includes("function liveStream(options)")) || "")
+  : scripts.find((s) => s.includes("A hidden tab holds a connection open")
+                     && s.includes("window.__matrixarkLive"));
+if (!src) {
+  console.log("FAIL the page carries no " + MODE + " stream");
+  process.exit(1);
+}
+
+(async () => {
+  const world = makeWorld();
+  const globals = {
+    document: world.doc,
+    window: world.win,
+    fetch: world.fetch,
+    AbortController: world.AbortController,
+    setTimeout: world.win.setTimeout,
+    clearTimeout: world.win.clearTimeout,
+    setInterval: world.win.setInterval,
+    clearInterval: world.win.clearInterval,
+    TextDecoder: function () { this.decode = () => ""; },
+    sessionStorage: { getItem: () => "k-test", setItem() {}, removeItem() {} },
+    localStorage: { getItem: () => "k-test", setItem() {}, removeItem() {} },
+  };
+  /* For the page stream the block only DEFINES the factory -- the page calls it from code that
+     wants far more of a DOM than this. So the factory is handed back and called here, with the
+     same options shape the page uses. */
+  const tail = MODE === "page"
+    ? "\n; return typeof liveStream === 'function' ? liveStream : null;"
+    : "";
+  let factory = null;
+  try {
+    factory = new Function(...Object.keys(globals), src + tail)(...Object.values(globals));
+  } catch (error) {
+    console.log("FAIL the " + MODE + " stream would not run: " + error.message);
+    process.exit(1);
+  }
+  if (MODE === "page") {
+    ok("the page defines its own stream", typeof factory === "function");
+    if (typeof factory !== "function") { console.log("FAILED " + failures); process.exit(1); }
+    factory({ headers: () => ({ Authorization: "Bearer k-test" }) });
+  }
+
+  await world.advance(3000);
+  const beforeHide = world.opened.length;
+  ok("the page opens a live connection", beforeHide > 0, String(beforeHide));
+
+  world.doc.hidden = true;
+  world.fire("visibilitychange", "document");
+  await world.flush();
+  ok("hiding the tab aborts the connection", world.aborted.length > 0);
+
+  const atHide = world.opened.length;
+  await world.advance(60000);
+  const whileHidden = world.opened.length - atHide;
+  ok("and it stays closed while the tab is hidden", whileHidden === 0,
+     whileHidden + " connection(s) opened while hidden -- the reconnect ignores the tab");
+
+  world.doc.hidden = false;
+  world.fire("visibilitychange", "document");
+  await world.advance(3000);
+  ok("coming back opens it again", world.opened.length > atHide + whileHidden);
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+})();

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -883,6 +883,11 @@
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -492,7 +492,7 @@
      opening a second one to the same endpoint. */
   window.__matrixarkLive = "page";
 
-/* ---------- the live stream ---------- */
+  /* ---------- the live stream ---------- */
 /* Read over fetch() rather than with EventSource, which cannot set an Authorization header --
    the alternative is the key in a query string, and a credential in a URL ends up in every access
    log and proxy trace between here and the gateway. Same wire format either way; only the
@@ -521,6 +521,9 @@ function liveStream(options) {
 
   function open() {
     if (stopped) { return; }
+    /* Same rule as the strip, which never reaches these two pages: they claim __matrixarkLive, so
+       the strip's script returns before registering it. */
+    if (document.hidden) { controller = null; return; }
     controller = new AbortController();
     onState("connecting");
     fetch("/v1/admin/events", { headers: headers(), signal: controller.signal })
@@ -551,6 +554,18 @@ function liveStream(options) {
   }
 
   open();
+  /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
+     rule the strip follows, and until now the two pages that run their own stream followed
+     neither: the strip stands down for them, and this registered only pagehide. */
+  document.addEventListener("visibilitychange", function () {
+    if (stopped) { return; }
+    if (document.hidden) {
+      if (controller) { controller.abort(); controller = null; }
+    } else if (!controller) {
+      backoff = 1000;
+      open();
+    }
+  });
   window.addEventListener("pagehide", function () {
     stopped = true;
     if (controller) { controller.abort(); }
@@ -565,6 +580,7 @@ function liveStream(options) {
     stop: function () { stopped = true; if (controller) { controller.abort(); } }
   };
 }
+
 
   function auth() {
     var k = $("key").value.trim();
@@ -1078,6 +1094,11 @@ function liveStream(options) {
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -799,7 +799,7 @@
      opening a second one to the same endpoint. */
   window.__matrixarkLive = "page";
 
-/* ---------- the live stream ---------- */
+  /* ---------- the live stream ---------- */
 /* Read over fetch() rather than with EventSource, which cannot set an Authorization header --
    the alternative is the key in a query string, and a credential in a URL ends up in every access
    log and proxy trace between here and the gateway. Same wire format either way; only the
@@ -828,6 +828,9 @@ function liveStream(options) {
 
   function open() {
     if (stopped) { return; }
+    /* Same rule as the strip, which never reaches these two pages: they claim __matrixarkLive, so
+       the strip's script returns before registering it. */
+    if (document.hidden) { controller = null; return; }
     controller = new AbortController();
     onState("connecting");
     fetch("/v1/admin/events", { headers: headers(), signal: controller.signal })
@@ -858,6 +861,18 @@ function liveStream(options) {
   }
 
   open();
+  /* A hidden tab holds a connection open for nobody. Drop it, reconnect on return -- the same
+     rule the strip follows, and until now the two pages that run their own stream followed
+     neither: the strip stands down for them, and this registered only pagehide. */
+  document.addEventListener("visibilitychange", function () {
+    if (stopped) { return; }
+    if (document.hidden) {
+      if (controller) { controller.abort(); controller = null; }
+    } else if (!controller) {
+      backoff = 1000;
+      open();
+    }
+  });
   window.addEventListener("pagehide", function () {
     stopped = true;
     if (controller) { controller.abort(); }
@@ -872,6 +887,7 @@ function liveStream(options) {
     stop: function () { stopped = true; if (controller) { controller.abort(); } }
   };
 }
+
 
   var loaded = null;      /* last GET /v1/admin/config payload */
   var fields = {};        /* setting key -> field descriptor from the server */
@@ -2590,6 +2606,11 @@ function liveStream(options) {
   var controller = null, backoff = 1000, buffer = "";
 
   function open() {
+    /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
+       open(). Without this the connection came back one backoff later with the tab still hidden,
+       so the rule this file states was true for about a second at a time. Left null so the
+       visibility handler's `!controller` test is what brings it back. */
+    if (document.hidden) { controller = null; return; }
     var k = key();
     if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
     controller = new AbortController();

--- a/tools/test_matrixark_a_hidden_tab_lets_go.py
+++ b/tools/test_matrixark_a_hidden_tab_lets_go.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A portal page in a background tab lets go of its live connection, and keeps letting go.
+
+The status strip has carried the rule in as many words -- *"A hidden tab holds a connection open
+for nobody. Drop it, reconnect on return."* -- and it did abort the request when the tab was
+hidden. What it never did was stop the reconnect. Aborting rejects the fetch, the ``catch``
+schedules ``setTimeout(open, backoff)``, and about a second later the page opened the stream again
+with the tab still hidden. The abort is on one line; the line that undoes it is thirty away in a
+different function, which is why reading the source says the rule holds.
+
+Two pages had less than that. Overview and Setup claim ``window.__matrixarkLive``, so the strip's
+script returns before it ever registers the rule, and their own ``liveStream`` registered only
+``pagehide`` -- no drop at all, on the two pages a customer is most likely to leave open in a
+background tab.
+
+Whether a connection comes back is a question about a timer inside a rejected promise, so it is
+run, not read. The harness gives the page a fake clock and a fake fetch that never settles -- which
+is what a live stream looks like -- hides the tab, and counts the connections opened afterwards.
+
+The flush in that harness is load-bearing. The reconnect is scheduled at the end of the abort's
+microtask chain, so a scan for due timers that runs first finds none and reports a page that let go
+of its connection. That is a false pass on the one behaviour this file exists to check, and it is
+what a single ``await Promise.resolve()`` produced.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "hidden_tab_harness.js")
+BUILDER = os.path.join(PORTAL, "build_portal_pages.py")
+
+
+def read(path: str) -> str:
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def pages() -> dict:
+    return {name: read(os.path.join(PORTAL, name))
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+def by_stream() -> tuple:
+    """Which pages run their own connection, and which let the strip run one.
+
+    Read off the page rather than listed: a page opts out of the strip's connection by claiming
+    ``__matrixarkLive``, and that claim is the thing that decides which code has to obey the rule.
+    """
+    own, strip = [], []
+    for name, text in pages().items():
+        (own if '__matrixarkLive = "page"' in text else strip).append(name)
+    return own, strip
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class AHiddenTabLetsGoTest(unittest.TestCase):
+
+    def _run(self, page_name, mode):
+        return subprocess.run(["node", HARNESS, os.path.join(PORTAL, page_name), mode],
+                              capture_output=True, text=True, timeout=300)
+
+    def setUp(self) -> None:
+        self.own, self.strip = by_stream()
+
+    def test_both_kinds_of_page_exist(self) -> None:
+        """The split is the point. With everything on one side, half these checks say nothing."""
+        self.assertGreaterEqual(len(self.own), 2, self.own)
+        self.assertGreaterEqual(len(self.strip), 4, self.strip)
+
+    def test_the_strip_lets_go_and_stays_gone(self) -> None:
+        for name in self.strip:
+            with self.subTest(page=name):
+                proc = self._run(name, "strip")
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                self.assertIn("ok   hiding the tab aborts the connection", proc.stdout)
+                self.assertIn("ok   and it stays closed while the tab is hidden", proc.stdout)
+
+    def test_a_page_running_its_own_stream_does_the_same(self) -> None:
+        """The strip stands down for these two, so the rule has to live in their stream as well --
+        and these are the pages most likely to be sitting in a background tab."""
+        for name in self.own:
+            with self.subTest(page=name):
+                proc = self._run(name, "page")
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                self.assertIn("ok   the page defines its own stream", proc.stdout)
+                self.assertIn("ok   hiding the tab aborts the connection", proc.stdout)
+                self.assertIn("ok   and it stays closed while the tab is hidden", proc.stdout)
+
+    def test_coming_back_reconnects(self) -> None:
+        """Dropping it is only half. A page that never reconnects is a page whose live panels
+        quietly stop being live, which is worse than the connection it saved."""
+        for name in self.strip:
+            with self.subTest(page=name, mode="strip"):
+                self.assertIn("ok   coming back opens it again", self._run(name, "strip").stdout)
+        for name in self.own:
+            with self.subTest(page=name, mode="page"):
+                self.assertIn("ok   coming back opens it again", self._run(name, "page").stdout)
+
+
+class TheHarnessCanSeeAReconnectTest(unittest.TestCase):
+    """The check above passes trivially on a harness that looks for the reconnect too early."""
+
+    def test_it_waits_for_the_microtask_queue(self) -> None:
+        source = read(HARNESS)
+        self.assertIn("realSetImmediate", source,
+                      "the harness flushes with promise ticks, which is not enough to see a "
+                      "reconnect scheduled from a rejection handler")
+        self.assertIn("await this.flush()", source)
+
+    def test_it_hands_the_page_a_key(self) -> None:
+        """The strip gives up quietly without one, so a stub with no key produces a page that
+        never connects -- and every check about letting go passes for the wrong reason."""
+        self.assertIn("value: \"k-test\"", read(HARNESS))
+
+
+class TheStreamIsWrittenOnceTest(unittest.TestCase):
+
+    def test_the_builder_holds_one_copy(self) -> None:
+        """It held two, byte for byte. Two copies of a behaviour that looks identical is how they
+        stop being identical -- and this one had a rule to keep."""
+        self.assertEqual(1, read(BUILDER).count("function liveStream(options)"))
+
+    def test_both_pages_still_get_it(self) -> None:
+        own, _strip = by_stream()
+        for name in own:
+            with self.subTest(page=name):
+                self.assertEqual(1, pages()[name].count("function liveStream(options)"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The status strip has carried this rule in as many words:

> A hidden tab holds a connection open for nobody. Drop it, reconnect on return.

And it did abort the request when the tab was hidden. **What it never did was stop the reconnect.**
Aborting rejects the fetch, the `catch` schedules `setTimeout(open, backoff)`, and about a second
later the page opened the stream again with the tab still hidden.

The abort is on one line; the line that undoes it is thirty away in a different function — which is
why reading the source says the rule holds.

### Two pages had less than that

Overview and Setup claim `window.__matrixarkLive`, so the strip's script returns before it ever
registers the rule, and their own `liveStream` registered only `pagehide` — **no drop at all**, on
the two pages a customer is most likely to leave open in a background tab.

`open()` now refuses while the tab is hidden and leaves the controller null, so the reconnect timer
lands on nothing and the visibility handler is what brings the connection back.

### The harness's flush is load-bearing

Whether a connection comes back is a question about a timer scheduled inside a rejected promise, so
it is run rather than read. The reconnect is registered at the *end* of the abort's microtask
chain — a scan for due timers that runs first finds none and reports a page that let go of its
connection.

That is a false pass on the one behaviour being checked, and it is what a single
`await Promise.resolve()` produced: the page looked correct. Flushing past the whole queue showed
the shipped defect:

```
FAIL and it stays closed while the tab is hidden
     1 connection(s) opened while hidden -- the reconnect ignores the tab
```

Three controls, all caught:

```
remove the visibility handler       -> FAIL hiding the tab aborts the connection
drop the guard, keep the handler    -> FAIL 1 connection(s) opened while hidden
revert the strip guard              -> FAIL 1 connection(s) opened while hidden
```

### One stream, not two

`liveStream` was defined **twice in the builder, byte for byte**, once in each page's script. It is
one block now, substituted by a plain marker rather than a `%` placeholder — these are JS and JS is
full of stray `%` signs, so format semantics would be a new way to break the page rather than a way
to tidy it.

Which pages are checked in which mode is read off the pages themselves (`__matrixarkLive`), not
listed, and both groups carry a floor.

8 tests. Neighbours: live_strip 38, live frames shared 9, backend-down 15, waiting strip 12,
config-change 13, portal_tabs 19, tab-link guard 9, portal_pages 4.
