### PR TITLE
Show the audit trail on the page that manages the keys it is about

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -208,6 +208,8 @@
             data-pane="policy" aria-selected="false" tabindex="-1">Policy</button>
     <button type="button" role="tab" id="tab-usage" aria-controls="pane-usage"
             data-pane="usage" aria-selected="false" tabindex="-1">Usage</button>
+    <button type="button" role="tab" id="tab-audit" aria-controls="pane-audit"
+            data-pane="audit" aria-selected="false" tabindex="-1">Audit</button>
   </div>
 
   <section class="pane" role="tabpanel" aria-labelledby="tab-keys" id="pane-keys">
@@ -345,11 +347,40 @@
 
   </section>
 
+  <section class="pane" role="tabpanel" aria-labelledby="tab-audit" id="pane-audit" hidden>
+
+  <!-- ============================ Audit ============================ -->
+  <!-- Here rather than on its own page: every record is about one of the keys listed two tabs
+       away, and the question "who tried this" is asked while looking at them. -->
+  <section class="card">
+    <h2>Audit trail</h2>
+    <p class="hint">Calls <code>GET /v1/admin/audit</code> — key management and refusals for your
+      tenant, newest first. Needs a key carrying <code>admin:audit</code>. Loaded when you ask for
+      it and never on a timer: the read walks the record log, and a panel refreshing itself would
+      put that walk on a schedule for as long as this tab stayed open.</p>
+    <div class="actions">
+      <button id="auditBtn" class="secondary">Load audit records</button>
+    </div>
+    <div id="auditRecording" class="msg" role="status" aria-live="polite"></div>
+    <div id="auditMsg" class="msg" role="status" aria-live="polite"></div>
+    <div class="tablewrap">
+      <table id="auditTable" style="display:none">
+        <thead><tr>
+          <th>when</th><th>action</th><th>status</th><th>key</th><th>asked for</th>
+        </tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  </section>
+
   <footer>
     MatrixArk API Key Portal · served at <code>GET /v1/admin/portal</code>. Endpoints used:
     <code>/api/admin/create_api_key</code>, <code>/api/admin/list_api_keys</code>,
     <code>/api/admin/rotate_api_key</code>, <code>/api/admin/revoke_api_key</code>,
-    <code>/v1/admin/api_key_usage</code>. Key crypto and the usage meter are unchanged backend primitives.
+    <code>/v1/admin/api_key_usage</code>, <code>/v1/admin/audit</code>. Key crypto and the usage
+    meter are unchanged backend primitives.
   </footer>
 </main>
 
@@ -727,6 +758,62 @@
   }
 
   // ---- usage -----------------------------------------------------------------------------------
+  /* What the deployment is doing with audit records right now.
+   *
+   * An empty table means two entirely different things -- nothing happened, or nothing was kept --
+   * and the default is the second. Without this the panel would reassure somebody who is recording
+   * nothing, which is the failure the endpoint's `recording` field exists to prevent. */
+  function sayRecording(mode) {
+    var el = $("auditRecording");
+    if (mode === "off" || !mode) {
+      el.innerHTML = '<div class="msg warn">Nothing is being recorded. Audit records are ' +
+        'discarded before they reach storage, including every refusal — so an empty list below ' +
+        'is not evidence that nothing happened. Turn it on under <strong>Audit trail</strong> on ' +
+        'the <a href="/v1/admin/setup">Setup</a> page; it needs a restart to take effect ' +
+        'everywhere.</div>';
+      return;
+    }
+    el.innerHTML = '<div class="msg ok">Recording: <span class="mono">' + escapeHtml(mode) +
+      "</span>.</div>";
+  }
+
+  function auditDetail(row) {
+    var d = row.details || {};
+    var asked = [];
+    if (d.requested_tenant_id) { asked.push("tenant " + d.requested_tenant_id); }
+    if (d.requested_account_id) { asked.push("account " + d.requested_account_id); }
+    if (!asked.length && d.count !== undefined) { asked.push(d.count + " records"); }
+    return asked.join(", ");
+  }
+
+  function loadAudit() {
+    hideMsg("auditMsg");
+    apiFetch(gwBase(), "/v1/admin/audit", "GET")
+      .then(function (data) {
+        var rows = (data && data.audit_logs) || [];
+        sayRecording(data && data.recording);
+        var tb = $("auditTable").querySelector("tbody");
+        tb.innerHTML = "";
+        rows.forEach(function (r) {
+          var tr = document.createElement("tr");
+          var denied = r.status === "denied";
+          tr.innerHTML =
+            "<td>" + fmtTime(r.created_at_ms) + "</td>" +
+            "<td class='mono'>" + escapeHtml(r.action || "") + "</td>" +
+            '<td><span class="pill ' + (denied ? "failed" : "completed") + '">' +
+              escapeHtml(r.status || "") + "</span></td>" +
+            "<td class='mono'>" + escapeHtml(r.api_key_id || "") + "</td>" +
+            "<td>" + escapeHtml(auditDetail(r)) + "</td>";
+          tb.appendChild(tr);
+        });
+        $("auditTable").style.display = rows.length ? "" : "none";
+        if (!rows.length && data && data.recording && data.recording !== "off") {
+          showMsg("auditMsg", "ok", "Nothing recorded yet.");
+        }
+      })
+      .catch(function (e) { showMsg("auditMsg", "err", "Audit read failed: " + e.message); });
+  }
+
   function loadUsage() {
     hideMsg("usageMsg");
     apiFetch(gwBase(), "/v1/admin/api_key_usage", "GET")
@@ -774,6 +861,7 @@
   $("listBtn").onclick = listKeys;
   $("inclRevoked").onchange = listKeys;
   $("usageBtn").onclick = loadUsage;
+  $("auditBtn").onclick = loadAudit;
   loadConn();
 })();
 

--- a/tools/portal/audit_panel_harness.js
+++ b/tools/portal/audit_panel_harness.js
@@ -1,0 +1,147 @@
+/* An empty audit table has to say WHICH kind of empty it is.
+ *
+ * MATRIXARK_AUDIT_MODE defaults to off, so on most deployments an empty audit log means nothing
+ * was KEPT -- not that nothing happened. A panel that renders "no records" over both is at its
+ * most reassuring exactly when it should not be: every refusal was discarded and the page implies
+ * there were none.
+ *
+ * The endpoint reports the recording mode beside the rows for this reason, and whether the panel
+ * uses it is behaviour, not markup. So the page's own three functions are sliced out and run
+ * against canned payloads: the network is stubbed because it is the boundary, and everything that
+ * decides what the reader sees comes from the page.
+ *
+ * Usage: node audit_panel_harness.js <api_key_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function slice(name) {
+  const at = page.indexOf("function " + name + "(");
+  if (at === -1) { return null; }
+  let depth = 0;
+  for (let i = page.indexOf("{", at); i < page.length; i += 1) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return page.slice(at, i + 1); }
+    }
+  }
+  return null;
+}
+
+const parts = ["sayRecording", "auditDetail", "loadAudit"].map((n) => [n, slice(n)]);
+for (const [name, body] of parts) {
+  ok("the page defines " + name, !!body);
+}
+if (parts.some(([, body]) => !body)) { console.log("FAILED " + failures); process.exit(1); }
+
+/* ---------- one run of the panel against one canned response ---------- */
+function run(payload, reject) {
+  const nodes = {};
+  function node(id) {
+    const rows = [];
+    return {
+      id,
+      innerHTML: "",
+      style: {},
+      rows,
+      appendChild(child) { rows.push(child); },
+      querySelector() { return nodes[id + ":tbody"] || (nodes[id + ":tbody"] = node(id + ":tbody")); },
+    };
+  }
+  const env = {
+    $: (id) => (nodes[id] = nodes[id] || node(id)),
+    hideMsg(id) { env.$(id).innerHTML = ""; },
+    showMsg(id, cls, text) { env.$(id).innerHTML = '<div class="msg ' + cls + '">' + text + "</div>"; },
+    escapeHtml: (s) => String(s == null ? "" : s),
+    fmtTime: (ms) => "t" + ms,
+    gwBase: () => "",
+    apiFetch: () => (reject ? Promise.reject(new Error(reject)) : Promise.resolve(payload)),
+    document: { createElement: () => node("tr") },
+  };
+
+  const src = parts.map(([, body]) => body).join("\n") + "\n; return loadAudit;";
+  const loadAudit = new Function(...Object.keys(env), src)(...Object.values(env));
+  loadAudit();
+  /* The page's loaders do not return their chain -- none of them do, and asking this one to would
+     make it the odd one out for the sake of a harness. So the queue is drained instead: the stub
+     settles immediately, and what is being waited for is the .then that writes into the panel.
+     A single tick is not enough; that is how a check of this shape passes on a panel that never
+     rendered anything. */
+  return flush().then(() => ({
+    recording: env.$("auditRecording").innerHTML,
+    message: env.$("auditMsg").innerHTML,
+    table: env.$("auditTable"),
+    body: env.$("auditTable").querySelector().rows,
+  }));
+}
+
+async function flush() {
+  for (let i = 0; i < 8; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+(async () => {
+  /* ---------- nothing kept ---------- */
+  const off = await run({ status: "ok", audit_logs: [], recording: "off" });
+  ok("an empty log with recording off says nothing is being recorded",
+     /Nothing is being recorded/.test(off.recording), off.recording);
+  ok("and warns rather than reassures", /msg warn/.test(off.recording), off.recording);
+  ok("and says an empty list is not evidence",
+     /not evidence that nothing happened/.test(off.recording), off.recording);
+  ok("and says where to change it", /\/v1\/admin\/setup/.test(off.recording), off.recording);
+  ok("it does not also claim nothing has happened yet",
+     !/Nothing recorded yet/.test(off.message), off.message);
+
+  /* ---------- nothing happened ---------- */
+  const on = await run({ status: "ok", audit_logs: [], recording: "async" });
+  ok("an empty log with recording on says nothing has happened yet",
+     /Nothing recorded yet/.test(on.message), on.message);
+  ok("and does not warn", !/msg warn/.test(on.recording), on.recording);
+  ok("and still names the mode", /async/.test(on.recording), on.recording);
+
+  /* ---------- the two are not the same message ---------- */
+  ok("the two empties do not read the same", off.recording !== on.recording);
+
+  /* ---------- records ---------- */
+  const rows = await run({
+    status: "ok", recording: "async",
+    audit_logs: [
+      { action: "admin.revoke_api_key", status: "denied", api_key_id: "ak_1",
+        created_at_ms: 2, details: { requested_tenant_id: "tenant_b" } },
+      { action: "admin.create_api_key", status: "ok", api_key_id: "ak_1", created_at_ms: 1 },
+    ],
+  });
+  ok("records are rendered", rows.body.length === 2, String(rows.body.length));
+  ok("the table is shown once there is something in it", rows.table.style.display === "");
+  const denied = rows.body[0].innerHTML;
+  ok("a refusal is marked as one", /pill failed/.test(denied) && /denied/.test(denied), denied);
+  ok("and says what was asked for", /tenant_b/.test(denied), denied);
+  ok("a success is not marked as a refusal", /pill completed/.test(rows.body[1].innerHTML),
+     rows.body[1].innerHTML);
+  ok("with records present it does not say nothing was recorded",
+     !/Nothing recorded yet/.test(rows.message), rows.message);
+
+  /* ---------- a read that fails is not an empty trail ---------- */
+  const bad = await run(null, "insufficient_scope (admin:audit)");
+  ok("a failed read says so", /Audit read failed/.test(bad.message), bad.message);
+  ok("and names what went wrong", /admin:audit/.test(bad.message), bad.message);
+  ok("a failed read leaves no table pretending to be an empty trail",
+     bad.body.length === 0 && !/Nothing recorded yet/.test(bad.message), bad.message);
+
+  /* ---------- and it never puts that read on a timer ---------- */
+  ok("the panel is not polled",
+     !/setInterval\([^)]*loadAudit/.test(page) && !/loadAudit[^)]*\)\s*,\s*[0-9]{3,}/.test(page));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+})();

--- a/tools/test_matrixark_the_audit_panel_says_which_empty.py
+++ b/tools/test_matrixark_the_audit_panel_says_which_empty.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The audit panel, and the difference between the two kinds of empty.
+
+The scope catalogue calls ``admin:audit`` "Read the audit log", the admin preset issues keys
+carrying it, and a route now serves one. Nothing displayed it, so the only way a customer saw who
+reached for what and was refused was to call the endpoint by hand.
+
+It sits on the key portal, beside the keys and the usage those keys generated: every record in it
+is about one of them.
+
+The panel has two jobs beyond showing rows.
+
+It never polls. The read walks the whole record log to find the audit rows, so a panel that
+refreshed itself would put that walk on a timer for as long as somebody left the tab open.
+
+And an empty list means two entirely different things. ``MATRIXARK_AUDIT_MODE`` defaults to off, so
+on most deployments an empty audit log means nothing was *kept* -- not that nothing happened. A
+panel rendering "no records" over both is at its most reassuring exactly when it should not be:
+every refusal was discarded, and the page implies there were none. The endpoint reports the
+recording mode beside the rows for this reason, and whether the panel uses it is behaviour, so it is
+run rather than read.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "api_key_portal.html")
+HARNESS = os.path.join(PORTAL, "audit_panel_harness.js")
+
+
+def page() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class ThePanelIsThereTest(unittest.TestCase):
+
+    def test_the_key_portal_has_an_audit_tab(self) -> None:
+        self.assertIn('id="tab-audit"', page())
+
+    def test_the_tab_has_a_pane(self) -> None:
+        self.assertIn('id="pane-audit"', page())
+
+    def test_it_starts_hidden_like_the_other_secondary_panes(self) -> None:
+        """A fourth pane that ships visible puts two panels on screen at once."""
+        tag = re.search(r'<section[^>]*id="pane-audit"[^>]*>', page()).group(0)
+        self.assertIn("hidden", tag)
+
+    def test_it_calls_the_route_that_serves_the_trail(self) -> None:
+        self.assertIn('"/v1/admin/audit"', page())
+
+    def test_the_footer_names_the_endpoint(self) -> None:
+        """That footer is the page's own list of what it talks to; a panel missing from it is one
+        nobody can audit from the outside."""
+        footer = page()[page().index("<footer>"):]
+        self.assertIn("/v1/admin/audit", footer)
+
+
+class ItIsNotPutOnATimerTest(unittest.TestCase):
+    """The read walks the record log. Refreshing it on a schedule is a standing cost for as long
+    as the tab is open, which is precisely the shape the other panels were careful to avoid."""
+
+    def test_nothing_polls_it(self) -> None:
+        self.assertIsNone(re.search(r"setInterval\([^)]*loadAudit", page()))
+
+    def test_it_is_wired_to_a_button(self) -> None:
+        self.assertIn('$("auditBtn")', page())
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class AnEmptyTableSaysWhichEmptyTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_nothing_kept_is_not_reported_as_nothing_happened(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   an empty log with recording off says nothing is being recorded", out)
+        self.assertIn("ok   it does not also claim nothing has happened yet", out)
+
+    def test_it_warns_rather_than_reassures_and_says_what_to_change(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   and warns rather than reassures", out)
+        self.assertIn("ok   and says an empty list is not evidence", out)
+        self.assertIn("ok   and says where to change it", out)
+
+    def test_nothing_happened_is_still_available_as_an_answer(self) -> None:
+        """The warning must not swallow the ordinary case, or a deployment that IS recording reads
+        as broken."""
+        out = self._run().stdout
+        self.assertIn("ok   an empty log with recording on says nothing has happened yet", out)
+        self.assertIn("ok   and does not warn", out)
+        self.assertIn("ok   the two empties do not read the same", out)
+
+    def test_records_render_and_a_refusal_looks_like_one(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   records are rendered", out)
+        self.assertIn("ok   a refusal is marked as one", out)
+        self.assertIn("ok   and says what was asked for", out)
+        self.assertIn("ok   a success is not marked as a refusal", out)
+
+    def test_a_failed_read_is_not_an_empty_trail(self) -> None:
+        """The worst available outcome for this panel: a read that could not run, drawn as a clean
+        audit log."""
+        out = self._run().stdout
+        self.assertIn("ok   a failed read says so", out)
+        self.assertIn("ok   and names what went wrong", out)
+        self.assertIn("ok   a failed read leaves no table pretending to be an empty trail", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The scope catalogue calls `admin:audit` "Read the audit log", the admin preset issues keys carrying
it, and #827 added a route that serves one. **Nothing displayed it** — so the only way a customer
saw who reached for what and was refused was to call the endpoint by hand.

It belongs on the key portal, beside the keys and the usage those keys generated: every record in it
is about one of them.

### It never polls

The read walks the whole record log to find the audit rows, so refreshing itself would put that walk
on a timer for as long as somebody left the tab open. The panel says so, rather than leaving the next
person to wonder why this one alone has no auto-refresh.

### The empty case is the point

`MATRIXARK_AUDIT_MODE` defaults to off, so on most deployments an empty audit log means nothing was
**kept** — not that nothing happened. A panel rendering "no records" over both is at its most
reassuring exactly when it should not be: every refusal was discarded, and the page implies there
were none.

The endpoint reports the recording mode beside the rows for this reason. The panel now says which
kind of empty it is looking at, warns rather than reassures when nothing is being kept, and names
the setting (#826) that changes it.

A read that **fails** says so. Drawing a failed read as a clean audit log is the worst answer
available to this particular panel, so it is checked separately from the empty cases.

### Run, not read

Whether any of that holds is behaviour, so the page's own `sayRecording` / `auditDetail` /
`loadAudit` are sliced out and run against canned payloads — the network is stubbed because it is
the boundary; everything deciding what the reader sees comes from the page.

```
ignore the mode, always say "nothing recorded yet" -> FAIL it does not also claim nothing has happened yet
make the off case reassure instead of warn         -> FAIL 4 checks on the off banner
swallow a failed read                              -> FAIL a failed read says so (+1)
```

The harness drains the microtask queue rather than asking the page to return its chain — none of the
page's loaders do, and a single tick is how a check of this shape passes on a panel that never
rendered anything.

13 tests. Neighbours: portal_tabs 19, tab panes 7, navigable panels 8, key copy 13, field labels 6,
rotate confirm 7, portal_pages 4, tab-link guard 9.

Verified merged with #836 on one base: audit panel 13, hidden tabs 8, portal_tabs 19, tab panes 7,
navigable 8, live_strip 38.
