### PR TITLE
One explanation per gateway status, on every panel

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -971,6 +971,32 @@
     return text;
   };
 
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -812,6 +812,32 @@
     return text;
   };
 
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -323,6 +323,32 @@ NAV_JS = r'''<script>
     return text;
   };
 
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -1101,12 +1127,7 @@ SETUP_JS = r"""
   /* One phrasing for every failure on the page. "The gateway answered 403" tells a customer
      nothing they can act on; naming the cause turns most of these into a self-service fix. */
   function failure(status) {
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks an admin scope. Issue one with admin:api_key."; }
-    if (status === 413) { return "That request was too large."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
+    return window.__matrixarkFailure(status);
   }
 
   /* ---------- summary + warnings ---------- */
@@ -3613,13 +3634,11 @@ EXPLORE_JS = r"""
     }).join("&");
   }
   function failure(status) {
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That file is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
+    /* A file, not a request: this page is sending one, and saying so is the difference between
+       a reader checking their upload and checking their gateway. */
+    return window.__matrixarkFailure(status, {
+      413: "That file is larger than this deployment accepts."
+    });
   }
   /* `detail` is a sentence when the server has something specific to say; `error` is a code word
      like "unauthorized", which is the machine's word for it and answers nothing. Prefer the

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -929,6 +929,32 @@
     return text;
   };
 
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -737,13 +737,11 @@
     }).join("&");
   }
   function failure(status) {
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks the scope for that call."; }
-    if (status === 413) { return "That file is larger than this deployment accepts."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 502) { return "The gateway could not reach the storage behind it."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
+    /* A file, not a request: this page is sending one, and saying so is the difference between
+       a reader checking their upload and checking their gateway. */
+    return window.__matrixarkFailure(status, {
+      413: "That file is larger than this deployment accepts."
+    });
   }
   /* `detail` is a sentence when the server has something specific to say; `error` is a code word
      like "unauthorized", which is the machine's word for it and answers nothing. Prefer the
@@ -1886,6 +1884,32 @@
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
     return text;
+  };
+
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
   };
 
   window.__matrixarkCopyText = function (text) {

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -274,11 +274,13 @@
   }
   /* One phrasing for a failure, so a status code never reaches a customer on its own. */
   function failure(status) {
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks an admin scope."; }
-    if (status === 409) { return "That import is still running — stop it first."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    return "The gateway answered " + status + ".";
+    /* 409 is this page's alone -- nothing else here can collide with a running import. The rest,
+       including the 413 an oversized upload gets, comes from the shared map this page did not
+       have. */
+    return window.__matrixarkFailure(status, {
+      409: "That import is still running — stop it first.",
+      413: "That file is larger than this deployment accepts."
+    });
   }
   function bytes(n) {
     if (!n) { return "0 B"; }
@@ -736,6 +738,32 @@
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
     return text;
+  };
+
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
   };
 
   window.__matrixarkCopyText = function (text) {

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -955,6 +955,32 @@ function liveStream(options) {
     return text;
   };
 
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
+  };
+
   window.__matrixarkCopyText = function (text) {
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -920,12 +920,7 @@ function liveStream(options) {
   /* One phrasing for every failure on the page. "The gateway answered 403" tells a customer
      nothing they can act on; naming the cause turns most of these into a self-service fix. */
   function failure(status) {
-    if (status === 401) { return "This key was not accepted."; }
-    if (status === 403) { return "This key lacks an admin scope. Issue one with admin:api_key."; }
-    if (status === 413) { return "That request was too large."; }
-    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
-    if (status === 504) { return "The backend did not answer in time."; }
-    return "The gateway answered " + status + ".";
+    return window.__matrixarkFailure(status);
   }
 
   /* ---------- summary + warnings ---------- */
@@ -2465,6 +2460,32 @@ function liveStream(options) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
     return text;
+  };
+
+  /* One sentence per gateway status, for every page.
+   *
+   * Three pages had a map of their own and each carried a different subset. Ingestion -- the page
+   * that uploads files -- was the one with no sentence for 413, so an upload refused for size
+   * read as "The gateway answered 413." on precisely the panel where the cause was obvious to
+   * everyone but the reader. The four pages with no map at all said that about every status.
+   *
+   * `overrides` is for what a page genuinely knows better: a file rather than a request, an
+   * import conflict only ingestion can produce. Everything else is answered once, here, so the
+   * next status added does not have to be added in four places to be true in four places.
+   *
+   * This is the FALLBACK. A refusal that carries a body is explained by __matrixarkWhy from what
+   * the gateway said; this is what the reader gets when there is nothing but a number.
+   */
+  window.__matrixarkFailure = function (status, overrides) {
+    if (overrides && overrides[status]) { return overrides[status]; }
+    if (status === 401) { return "This key was not accepted."; }
+    if (status === 403) { return "This key lacks the scope for that call."; }
+    if (status === 413) { return "That request is larger than this deployment accepts."; }
+    if (status === 429) { return "Rate limited — the edge is throttling this key."; }
+    if (status === 502) { return "The gateway could not reach the storage behind it."; }
+    if (status === 503) { return "The gateway is not ready to serve this yet."; }
+    if (status === 504) { return "The backend did not answer in time."; }
+    return "The gateway answered " + status + ".";
   };
 
   window.__matrixarkCopyText = function (text) {

--- a/tools/portal/status_message_harness.js
+++ b/tools/portal/status_message_harness.js
@@ -1,0 +1,95 @@
+/* One explanation per gateway status, and the page-specific words that survive.
+ *
+ * Three pages carried a status map of their own and each carried a different subset. Ingestion --
+ * the page that uploads files -- was the one with no sentence for 413, so an upload refused for
+ * size read as "The gateway answered 413." on the panel where the cause is obvious to everyone
+ * except the reader. Four pages had no map at all.
+ *
+ * A map is a data structure and looks fine in source whatever it omits, so the page's own helper
+ * is executed here and asked about each status.
+ *
+ * Usage: node status_message_harness.js <page.html> [...]
+ */
+"use strict";
+const fs = require("fs");
+const path = require("path");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function slice(page, header) {
+  const at = page.indexOf(header);
+  if (at === -1) { return null; }
+  let depth = 0;
+  for (let i = page.indexOf("{", at); i < page.length; i += 1) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return page.slice(at, i + 1); }
+    }
+  }
+  return null;
+}
+
+/* Statuses the edge actually answers with, and what a reader must not be left holding. */
+const EXPLAINED = [401, 403, 413, 429, 502, 503, 504];
+
+const files = process.argv.slice(2);
+ok("pages were given", files.length > 0, "none");
+
+let withOwn = 0;
+for (const file of files) {
+  const name = path.basename(file).replace("_portal.html", "");
+  const page = fs.readFileSync(file, "utf8");
+
+  const shared = slice(page, "window.__matrixarkFailure = function (status, overrides) {");
+  ok(name + ": carries the shared status map", !!shared);
+  if (!shared) { continue; }
+
+  const win = {};
+  new Function("window", shared + ";")(win);
+  const say = win.__matrixarkFailure;
+
+  const bare = EXPLAINED.filter((s) => /^The gateway answered/.test(say(s)));
+  ok(name + ": every status the edge answers with has a sentence", bare.length === 0,
+     "left as a bare number: " + bare.join(", "));
+
+  ok(name + ": an unfamiliar status still names the number", /599/.test(say(599)), say(599));
+  ok(name + ": an override wins where a page knows better",
+     say(413, { 413: "a file thing" }) === "a file thing");
+  ok(name + ": an override for another status does not leak",
+     say(429, { 413: "a file thing" }) !== "a file thing");
+
+  /* ---------- what the page itself still decides ---------- */
+  const own = slice(page, "function failure(status) {");
+  if (!own) { continue; }
+  withOwn += 1;
+
+  ok(name + ": its own failure() no longer holds a status map",
+     !/if \(status === \d/.test(own), own.slice(0, 160));
+
+  const local = new Function("window", own + "; return failure;")({ __matrixarkFailure: say });
+
+  if (name === "ingestion" || name === "explore") {
+    ok(name + ": an oversized upload is described as a file, not a request",
+       /file/i.test(local(413)), local(413));
+  }
+  if (name === "ingestion") {
+    ok(name + ": a running import is still its own answer", /import/i.test(local(409)), local(409));
+  }
+  if (name === "setup") {
+    ok(name + ": a gateway that cannot reach storage is explained here too",
+       /storage/i.test(local(502)), local(502));
+  }
+  const stillBare = EXPLAINED.filter((s) => /^The gateway answered/.test(local(s)));
+  ok(name + ": nothing it answers is left as a bare number", stillBare.length === 0,
+     stillBare.join(", "));
+}
+
+ok("at least three pages keep a failure() of their own", withOwn >= 3, String(withOwn));
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/test_matrixark_one_explanation_per_status.py
+++ b/tools/test_matrixark_one_explanation_per_status.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every panel explains a gateway status the same way, and the upload page explains 413.
+
+Three pages mapped HTTP statuses to sentences and each carried a different subset:
+
+===== ======== ========= ======
+code  explore  ingestion setup
+===== ======== ========= ======
+401   yes      yes       yes
+403   yes      yes*      yes*
+409   --       yes       --
+413   yes      **no**    yes
+429   yes      yes       yes
+502   yes      --        --
+504   yes      --        yes
+===== ======== ========= ======
+
+The 413 row is the one that cost something. Ingestion is the page that uploads files, and it was
+the page with no sentence for the refusal an upload gets when it is too big -- so a customer read
+*"The gateway answered 413."* on the one panel where the cause is obvious to everybody except them.
+The other four pages mapped nothing at all, so a 502 from a gateway that could not reach its storage
+was a bare number there too.
+
+The map now sits beside ``__matrixarkWhy`` and ``__matrixarkCopyText``, and each page keeps only
+what is genuinely its own: a *file* rather than a request where a file is being sent, and the import
+conflict only ingestion can produce.
+
+Setup's 403 loses its hardcoded *"Issue one with admin:api_key"*. That is not a downgrade: the edge
+sends ``required`` on a scope refusal and ``__matrixarkWhy`` appends it, so the scope is named by
+the process that refused rather than guessed by the page -- which is what makes it right when the
+answer is a scope the page did not predict.
+
+A map looks fine in source whatever it omits, so the pages' own helpers are executed and asked.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "status_message_harness.js")
+
+# What the edge answers with. A page leaving any of these as a bare number is a page that made a
+# reader guess at something the gateway already knew.
+EXPLAINED = (401, 403, 413, 429, 502, 503, 504)
+
+
+def pages() -> dict:
+    return {name: io.open(os.path.join(PORTAL, name), encoding="utf-8").read()
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+class TheMapIsSharedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.pages = pages()
+        self.assertGreaterEqual(len(self.pages), 7, "not every panel is being checked")
+
+    def test_every_panel_carries_it(self) -> None:
+        without = sorted(name for name, text in self.pages.items()
+                         if "__matrixarkFailure = function" not in text)
+        self.assertEqual([], without, "panels with no status map: %r" % without)
+
+    def test_no_panel_keeps_a_second_one(self) -> None:
+        """Two maps is how they came to disagree. The shared helper is the only place a status
+        literal belongs; a page's own failure() may only choose overrides."""
+        extra = {}
+        for name, text in self.pages.items():
+            own = re.search(r"function failure\(status\) \{[\s\S]*?\n  \}", text)
+            if own and re.search(r"if \(status === \d", own.group(0)):
+                extra[name] = own.group(0)[:80]
+        self.assertEqual({}, extra, "panels still holding their own map: %r" % sorted(extra))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheAnswersAreRunNotReadTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(
+            ["node", HARNESS] + [os.path.join(PORTAL, n) for n in sorted(pages())],
+            capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_no_panel_leaves_a_status_as_a_bare_number(self) -> None:
+        out = self._run().stdout
+        for name in sorted(pages()):
+            short = name.replace("_portal.html", "")
+            with self.subTest(page=short):
+                self.assertIn("ok   %s: every status the edge answers with has a sentence" % short,
+                              out)
+
+    def test_the_upload_page_explains_an_oversized_upload(self) -> None:
+        """The gap that cost something: the page sending files had no sentence for the refusal a
+        file gets for being too big."""
+        self.assertIn("ok   ingestion: an oversized upload is described as a file, not a request",
+                      self._run().stdout)
+
+    def test_a_page_keeps_what_only_it_knows(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   ingestion: a running import is still its own answer", out)
+        self.assertIn("ok   explore: an oversized upload is described as a file, not a request", out)
+
+    def test_setup_gained_the_status_it_was_missing(self) -> None:
+        self.assertIn("ok   setup: a gateway that cannot reach storage is explained here too",
+                      self._run().stdout)
+
+    def test_an_unfamiliar_status_still_names_the_number(self) -> None:
+        """Better than a wrong sentence: a reader can search for the number."""
+        out = self._run().stdout
+        self.assertIn("ok   setup: an unfamiliar status still names the number", out)
+
+    def test_an_override_applies_only_where_it_was_given(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   setup: an override wins where a page knows better", out)
+        self.assertIn("ok   setup: an override for another status does not leak", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three pages mapped HTTP statuses to sentences, and each carried a different subset:

| code | explore | ingestion | setup | other four |
|---|---|---|---|---|
| 401 | yes | yes | yes | — |
| 403 | "the scope for that call" | "an admin scope" | "…Issue one with admin:api_key" | — |
| 409 | — | yes | — | — |
| 413 | yes | **no** | yes | — |
| 429 | yes | yes | yes | — |
| 502 | yes | — | — | — |
| 504 | yes | — | yes | — |

**The 413 row is the one that cost something.** Ingestion is the page that uploads files, and it was
the page with no sentence for the refusal an upload gets when it is too big — so a customer read
*"The gateway answered 413."* on the one panel where the cause is obvious to everybody except them.
The other four pages mapped nothing at all, so a 502 from a gateway that could not reach its storage
was a bare number there too.

The map now sits beside `__matrixarkWhy` and `__matrixarkCopyText`, where the other things every
page needs already live. Each page keeps only what is genuinely its own: a **file** rather than a
request where a file is being sent, and the import conflict only ingestion can produce.

### Setup's 403 loses a hardcoded scope name, on purpose

It said *"Issue one with admin:api_key"*. The edge sends `required` on a scope refusal and
`__matrixarkWhy` appends it, so the scope is now named by the process that refused rather than
guessed by the page — which is what makes it right when the answer is a scope the page did not
predict.

### Run, not read

A map looks fine in source whatever it omits, so each page's helper is executed and asked about
every status the edge answers with.

```
restore ingestion's old map  -> FAIL its own failure() no longer holds a status map
                                FAIL an oversized upload is described as a file
                                FAIL nothing it answers is left as a bare number
drop 502 from the shared map -> FAIL api / setup: every status has a sentence
                                FAIL setup: a gateway that cannot reach storage is explained
```

9 tests, 30 harness assertions across all seven panels. Neighbours: scope-refusal wording 7 and 5,
live_strip 38, navigable panels 8, hidden tabs 8, portal_tabs 19, tab panes 7, portal_pages 4.
