### PR TITLE
A refused stop says so

### DIFF
--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -547,7 +547,23 @@
   function cancelJob(id) {
     fetch("/v1/admin/ingestion/jobs/" + encodeURIComponent(id) + "/cancel",
           { method: "POST", headers: auth() })
-      .then(loadJobs)
+      .then(function (r) {
+        return r.json().catch(function () { return {}; }).then(function (b) {
+          return { ok: r.ok, status: r.status, body: b };
+        });
+      })
+      .then(function (res) {
+        /* fetch resolves for a 403 as readily as for a 200, so without this the list reloaded on
+           a refusal and said nothing -- the reader saw the import still running and took the stop
+           for a slow one. Same shape as retryJob directly above, for the sibling action. */
+        if (!res.ok) {
+          say($("startMsg"), window.__matrixarkWhy(res.body, failure(res.status)), "err");
+          /* Not reloaded on purpose: loadJobs clears this message, and the table it would draw is
+             the one already on screen. */
+          return;
+        }
+        loadJobs();
+      })
       .catch(function () { say($("startMsg"), "Could not stop " + id + ".", "err"); });
   }
 

--- a/tools/portal/stop_refusal_harness.js
+++ b/tools/portal/stop_refusal_harness.js
@@ -1,0 +1,122 @@
+/* Does the ingestion page notice when a stop is refused?
+ *
+ * fetch resolves for a 403 exactly as readily as for a 200 -- only a network failure rejects. A
+ * handler that goes straight to .then(loadJobs) therefore reloads the table on a refusal and says
+ * nothing, and the reader watching an import that is still running takes the stop for a slow one.
+ *
+ * That is invisible in source: the code reads as a completed action with a refresh at the end. So
+ * the page's own cancelJob is run against canned responses and asked what it did.
+ *
+ * Usage: node stop_refusal_harness.js <ingestion_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function slice(name) {
+  const at = page.indexOf("function " + name + "(");
+  if (at === -1) { return null; }
+  let depth = 0;
+  for (let i = page.indexOf("{", at); i < page.length; i += 1) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return page.slice(at, i + 1); }
+    }
+  }
+  return null;
+}
+
+const cancel = slice("cancelJob");
+const failure = slice("failure");
+ok("the page defines cancelJob", !!cancel);
+ok("the page defines its status map", !!failure);
+if (!cancel || !failure) { console.log("FAILED " + failures); process.exit(1); }
+
+async function flush() {
+  for (let i = 0; i < 8; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+function run(status, body, reject) {
+  const said = [];
+  const reloads = [];
+  const env = {
+    $: (id) => ({ id }),
+    say(_el, text, cls) { said.push({ text: String(text), cls }); },
+    auth: () => ({}),
+    loadJobs() { reloads.push(1); },
+    encodeURIComponent: (s) => s,
+    fetch: () => (reject
+      ? Promise.reject(new Error("offline"))
+      : Promise.resolve({
+          ok: status >= 200 && status < 300,
+          status,
+          json: () => (body === undefined ? Promise.reject(new Error("no body"))
+                                          : Promise.resolve(body)),
+        })),
+    window: {
+      __matrixarkWhy(b, fallback) {
+        b = b || {};
+        let text = b.detail || b.error || fallback;
+        if (b.required && b.required.length) { text += " — this needs " + b.required.join(" or "); }
+        return text;
+      },
+      /* The shared map, if this page uses it; the page's own failure() closes over whichever. */
+      __matrixarkFailure(code, overrides) {
+        if (overrides && overrides[code]) { return overrides[code]; }
+        if (code === 403) { return "This key lacks the scope for that call."; }
+        if (code === 409) { return "That import is still running — stop it first."; }
+        return "The gateway answered " + code + ".";
+      },
+    },
+  };
+  const src = failure + "\n" + cancel + "\n; return cancelJob;";
+  const cancelJob = new Function(...Object.keys(env), src)(...Object.values(env));
+  cancelJob("job-1");
+  return flush().then(() => ({ said, reloads }));
+}
+
+(async () => {
+  /* ---------- refused ---------- */
+  const denied = await run(403, { error: "insufficient_scope", required: ["admin:api_key"] });
+  ok("a refused stop is reported", denied.said.length > 0,
+     "nothing was said; the table just reloaded");
+  ok("and reported as a failure", denied.said.some((s) => s.cls === "err"),
+     JSON.stringify(denied.said));
+  ok("and says what the gateway said",
+     denied.said.some((s) => /insufficient_scope|admin:api_key|scope/.test(s.text)),
+     JSON.stringify(denied.said));
+  ok("and does not reload the table over the explanation", denied.reloads.length === 0,
+     "loadJobs ran and clears the message area");
+
+  /* ---------- refused with no body at all ---------- */
+  const bare = await run(409, undefined);
+  ok("a refusal with no body still gets a sentence", bare.said.length > 0);
+  ok("and not a bare number",
+     bare.said.some((s) => !/^The gateway answered 409/.test(s.text)) ||
+     bare.said.some((s) => /import/i.test(s.text)), JSON.stringify(bare.said));
+
+  /* ---------- accepted ---------- */
+  const okRun = await run(200, { status: "ok" });
+  ok("a stop that worked refreshes the list", okRun.reloads.length === 1,
+     String(okRun.reloads.length));
+  ok("and does not cry failure", !okRun.said.some((s) => s.cls === "err"),
+     JSON.stringify(okRun.said));
+
+  /* ---------- offline ---------- */
+  const off = await run(0, null, true);
+  ok("a gateway that cannot be reached is reported", off.said.some((s) => s.cls === "err"),
+     JSON.stringify(off.said));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+})();

--- a/tools/test_matrixark_a_refused_stop_says_so.py
+++ b/tools/test_matrixark_a_refused_stop_says_so.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Stopping an import that the gateway refuses to stop says so.
+
+``cancelJob`` posted to the cancel route and then, whatever came back, reloaded the job list::
+
+    fetch(...).then(loadJobs).catch(...)
+
+``fetch`` only rejects on a network failure. A 403 for want of a scope, a 409 because the job had
+already finished, a 404 for an id that is not there -- all of those *resolve*, so the list reloaded
+and nothing was said. The customer clicked Stop, watched the table refresh, saw the import still
+running, and concluded the cancel was slow.
+
+``retryJob`` sits directly above it, for the sibling action on the same page, and it checks
+``res.ok`` and reports through the shared helpers. So this was not the page's habit -- it was one
+function out of step with its own neighbour, which is why it lasted: everything around it is right.
+
+On a refusal the list is deliberately *not* reloaded. ``loadJobs`` clears the message area, so
+refreshing would replace the explanation with the same table the reader was already looking at --
+which is the original bug wearing an error handler.
+
+None of that is visible in source; the code reads as a completed action with a refresh at the end.
+So the page's own ``cancelJob`` is run against canned responses and asked what it did.
+"""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "ingestion_portal.html")
+HARNESS = os.path.join(PORTAL, "stop_refusal_harness.js")
+
+
+def page() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class ItChecksTheAnswerTest(unittest.TestCase):
+
+    def test_the_cancel_handler_looks_at_the_status(self) -> None:
+        """The single line that decides whether any of the behaviour below is possible."""
+        start = page().index("function cancelJob(")
+        body = page()[start:page().index("\n  }", start)]
+        self.assertIn("res.ok", body,
+                      "the cancel handler does not look at whether the call succeeded")
+
+    def test_it_reports_through_the_same_helpers_as_its_neighbour(self) -> None:
+        """retryJob does this for the sibling action. Two ways of explaining the same refusal on
+        one page is how they drift."""
+        start = page().index("function cancelJob(")
+        body = page()[start:page().index("\n  }", start)]
+        self.assertIn("__matrixarkWhy", body)
+        self.assertIn("failure(res.status)", body)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class WhatItActuallyDoesTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_refused_stop_is_reported(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a refused stop is reported", out)
+        self.assertIn("ok   and reported as a failure", out)
+        self.assertIn("ok   and says what the gateway said", out)
+
+    def test_the_explanation_is_not_reloaded_over(self) -> None:
+        """Reporting it and then refreshing the table on top would be the same silence, arrived at
+        by a longer route."""
+        self.assertIn("ok   and does not reload the table over the explanation", self._run().stdout)
+
+    def test_a_refusal_with_no_body_still_gets_a_sentence(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a refusal with no body still gets a sentence", out)
+        self.assertIn("ok   and not a bare number", out)
+
+    def test_a_stop_that_worked_still_refreshes(self) -> None:
+        """The check above is satisfied by a handler that never reloads at all, which would leave
+        a stopped import looking like it is still running."""
+        out = self._run().stdout
+        self.assertIn("ok   a stop that worked refreshes the list", out)
+        self.assertIn("ok   and does not cry failure", out)
+
+    def test_an_unreachable_gateway_is_still_reported(self) -> None:
+        self.assertIn("ok   a gateway that cannot be reached is reported", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`cancelJob` posted to the cancel route and then, whatever came back, reloaded the job list:

```js
fetch(...).then(loadJobs).catch(...)
```

**`fetch` only rejects on a network failure.** A 403 for want of a scope, a 409 because the job had
already finished, a 404 for an id that is not there — all of those *resolve*. So the list reloaded
and nothing was said. The customer clicked Stop, watched the table refresh, saw the import still
running, and concluded the cancel was slow.

`retryJob` sits **directly above it**, for the sibling action on the same page, and it checks
`res.ok` and reports through `__matrixarkWhy(res.body, failure(res.status))`. This was not the
page's habit — it was one function out of step with its own neighbour, which is why it lasted:
everything around it is right.

### The refusal is not reloaded over

`loadJobs` clears the message area, so refreshing after reporting would replace the explanation with
the same table the reader was already looking at — the original silence, arrived at by a longer
route. On a refusal the message stands; on success the list refreshes as before.

### Run, not read

The code reads as a completed action with a refresh at the end, so the page's own `cancelJob` is
executed against canned responses and asked what it did. Against the page as it ships:

```
FAIL a refused stop is reported
     nothing was said; the table just reloaded
FAIL and reported as a failure
FAIL and says what the gateway said
FAIL and does not reload the table over the explanation
FAIL a refusal with no body still gets a sentence
FAIL and not a bare number
```

A success case is checked alongside, because "never reload" would satisfy the refusal checks while
leaving a stopped import looking like it is still running.

8 tests, 11 harness assertions. Neighbours: ingestion_retry 23, scope-refusal wording 7, navigable
panels 8, portal_pages 4.
