### PR TITLE
Say which value is not UTF-8, not just that one is not

### DIFF
--- a/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
+++ b/crates/temporalstore-rust/src/matrixark_rust_proxy_impl.rs
@@ -1323,8 +1323,22 @@ fn hgetall_map(engine: &RecordStore, key: String) -> Result<BTreeMap<String, Str
         CommandResponse::HashEntries { entries } => {
             let mut decoded = BTreeMap::new();
             for (field, value) in entries {
-                let value = String::from_utf8(value)
-                    .map_err(|error| format!("stored hash value is not UTF-8: {error}"))?;
+                // Name what choked. Without the key and field this error can only be guessed at,
+                // and it is fatal to context assembly -- the caller returns an empty pack.
+                let value = String::from_utf8(value).map_err(|error| {
+                    let bytes = error.as_bytes();
+                    let head: String = bytes
+                        .iter()
+                        .take(16)
+                        .map(|byte| format!("{byte:02x}"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!(
+                        "stored hash value is not UTF-8: {error} (key={key}, field={field}, \
+                         len={}, first bytes: {head})",
+                        bytes.len()
+                    )
+                })?;
                 decoded.insert(field, value);
             }
             // An empty read must stay a question, not become an answer: caching it would pin


### PR DESCRIPTION
`matrixark_retrieve_context_pack` fails a whole assembly when one stored hash value is not
UTF-8, and says only this:

```
stored hash value is not UTF-8: invalid utf-8 sequence of 1 bytes from index 0
```

That is true and unusable. It does not say which key, which field, or what the bytes were, so
the only way to find the value is to guess — and the failure is not cosmetic: the caller returns
an empty ContextPack, and a hook that gets one emits `{}` and exits 0. The turn silently loses
its context.

With the key and field named, the same failure reads:

```
stored hash value is not UTF-8: invalid utf-8 sequence of 1 bytes from index 0
  (key=matrixark:claude-hook:records:000039, field=00000000000000000143,
   len=862, first bytes: da 1e fb 49 ae 01 06 78 b1 76 02 00 00 00 00 00)
```

which located it on the first run, on a store where four earlier guesses had each cost a build
and a measurement. The byte prefix is capped at 16 bytes so a large value cannot dump itself
into a log line, and the length is reported separately so the size is still visible.

This changes the message only. It does not change what is accepted, what is rejected, or when.

## Verified

* `cargo check --release -p temporalstore-rust --bin matrixark_rust_proxy` on this branch.
* Built and run against a real 460 MB store: the error names the key, field, length and prefix
  as above, and a store with no such value is unaffected.
