### PR TITLE
No key is not no access: ask once before deciding the portal is shut

### DIFF
--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1202,6 +1202,10 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -1210,12 +1214,19 @@
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -1237,6 +1248,13 @@
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -955,6 +955,10 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -963,12 +967,19 @@
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -990,6 +1001,13 @@
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -466,6 +466,10 @@ NAV_JS = r'''<script>
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -474,12 +478,19 @@ NAV_JS = r'''<script>
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -501,6 +512,13 @@ NAV_JS = r'''<script>
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */
@@ -2494,7 +2512,10 @@ SETUP_JS = r"""
   var live = null;
 
   function startLive() {
-    if (!$("key").value.trim() || !$("auto").checked) { return; }
+    /* Not gated on the key box. This is reached from load()'s success path, so the deployment has
+       already answered -- and on the developer default it answers without one. Gating here meant
+       the panel that had just loaded anonymously refused to keep itself live. */
+    if (!$("auto").checked) { return; }
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
@@ -3306,7 +3327,8 @@ OVERVIEW_JS = r"""
   var live = null;
 
   function startLive() {
-    if (!$("key").value.trim()) { return; }
+    /* Not gated on the key box: load() has already succeeded by the time this runs, and on the
+       developer default it succeeds without a key. */
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -1072,6 +1072,10 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -1080,12 +1084,19 @@
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -1107,6 +1118,13 @@
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -2031,6 +2031,10 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -2039,12 +2043,19 @@
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -2066,6 +2077,13 @@
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -881,6 +881,10 @@
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -889,12 +893,19 @@
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -916,6 +927,13 @@
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/open_deployment_harness.js
+++ b/tools/portal/open_deployment_harness.js
@@ -1,0 +1,160 @@
+/* Does the status strip ask, or does it assume it is not allowed?
+ *
+ * On the developer default the gateway answers every admin route anonymously -- 200 with no
+ * Authorization header at all -- and 401 once auth is on. The strip used to refuse to try:
+ *
+ *     var k = key();
+ *     if (!k) { setTimeout(open, 2000); return; }
+ *
+ * so on the deployment somebody is most likely to be looking at first, the strip stayed dark on
+ * all seven panels because the page would not ask a question the gateway was willing to answer.
+ *
+ * Both halves have to hold, and they pull against each other: ask when there is no key, and still
+ * watch for a key on a deployment that wants one rather than backing off to thirty seconds. So the
+ * page's own strip is run against a gateway that answers and a gateway that refuses.
+ *
+ * Usage: node open_deployment_harness.js <page.html>
+ */
+"use strict";
+const fs = require("fs");
+const realSetImmediate = setImmediate;
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+const scripts = [...page.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* The strip's own block, not the page's.
+ *
+ * Overview and Setup run a connection of their own and the strip stands down for them, and since
+ * the page-level stream gained the same hidden-tab rule its comment matches too. The line that
+ * only the strip has is the stand-down test itself. */
+const src = scripts.find((s) => s.includes("if (window.__matrixarkLive) { return; }"));
+if (!src) { console.log("FAIL the page carries no live strip"); process.exit(1); }
+
+async function flush() {
+  for (let i = 0; i < 8; i += 1) {
+    await new Promise((resolve) => realSetImmediate(resolve));
+  }
+}
+
+/* `answer` decides what the fake gateway does with each request. */
+function world(answer, keyValue) {
+  const timers = [];
+  let now = 0;
+  const calls = [];
+  const listeners = { document: {}, window: {} };
+
+  function element(id) {
+    return {
+      id, value: keyValue, textContent: "", className: "", hidden: false, style: {}, dataset: {},
+      classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+      addEventListener() {}, setAttribute() {}, getAttribute: () => null,
+      appendChild() {}, querySelector: () => null, querySelectorAll: () => [],
+    };
+  }
+  const nodes = {};
+  const doc = {
+    hidden: false,
+    addEventListener(t, fn) { (listeners.document[t] = listeners.document[t] || []).push(fn); },
+    getElementById(id) { return (nodes[id] = nodes[id] || element(id)); },
+    createElement(tag) { return element(tag); },
+    querySelectorAll: () => [], querySelector: () => null, body: element("body"),
+  };
+  const win = {
+    addEventListener(t, fn) { (listeners.window[t] = listeners.window[t] || []).push(fn); },
+    location: { hash: "" },
+    setTimeout(fn, ms) { timers.push({ at: now + (ms || 0), fn, delay: ms || 0 }); },
+    clearTimeout() {}, setInterval() { return 0; }, clearInterval() {},
+  };
+
+  class Controller {
+    constructor() { this.signal = { aborted: false }; }
+    abort() { this.signal.aborted = true; }
+  }
+
+  const globals = {
+    document: doc, window: win, fetch(url, opts) {
+      calls.push({ url, headers: (opts && opts.headers) || {} });
+      return answer(calls.length);
+    },
+    AbortController: Controller,
+    setTimeout: win.setTimeout, clearTimeout: win.clearTimeout,
+    setInterval: win.setInterval, clearInterval: win.clearInterval,
+    TextDecoder: function () { this.decode = () => ""; },
+    sessionStorage: { getItem: () => keyValue || null, setItem() {}, removeItem() {} },
+    localStorage: { getItem: () => keyValue || null, setItem() {}, removeItem() {} },
+  };
+  new Function(...Object.keys(globals), src)(...Object.values(globals));
+
+  return {
+    calls, timers,
+    async advance(ms) {
+      const until = now + ms;
+      await flush();
+      for (let guard = 0; guard < 100; guard += 1) {
+        const next = timers.filter((t) => t.at <= until).sort((a, b) => a.at - b.at)[0];
+        if (!next) { break; }
+        timers.splice(timers.indexOf(next), 1);
+        now = Math.max(now, next.at);
+        next.fn();
+        await flush();
+      }
+      now = until;
+    },
+    delays: () => timers.map((t) => t.delay),
+  };
+}
+
+/* A stream that never settles: what a live connection looks like. */
+const live = () => new Promise(() => {});
+const refused = () => Promise.resolve({ ok: false, status: 401, body: null });
+
+(async () => {
+  /* ---------- a deployment that answers anonymously ---------- */
+  const openDeployment = world(live, "");
+  await openDeployment.advance(100);
+  ok("with no key it still asks", openDeployment.calls.length === 1,
+     "made " + openDeployment.calls.length + " request(s); the strip stayed dark");
+  ok("and sends no credential it does not have",
+     !("Authorization" in ((openDeployment.calls[0] || {}).headers || {})),
+     JSON.stringify(((openDeployment.calls[0] || {}).headers || {})));
+
+  /* ---------- a deployment that wants a key ---------- */
+  const closed = world(refused, "");
+  await closed.advance(100);
+  ok("a deployment that refuses is asked once", closed.calls.length === 1,
+     String(closed.calls.length));
+  const waits = closed.delays();
+  ok("and is then watched for a key, not backed off from",
+     waits.length > 0 && Math.min(...waits) <= 2000,
+     "next retry in " + JSON.stringify(waits) + " ms");
+
+  /* The promise this page already made: "the strip must not be the thing that 401s in a loop."
+     Asking once is the change; asking every two seconds forever would be a different bug wearing
+     the same patch, and only running the clock forward can tell them apart. */
+  await closed.advance(60000);
+  ok("and does not go on asking a deployment that said no", closed.calls.length === 1,
+     closed.calls.length + " requests in a minute with no key -- that is a 401 loop");
+
+  /* ---------- with a key ---------- */
+  const withKey = world(live, "k-test");
+  await withKey.advance(100);
+  ok("a key is still sent when there is one",
+     /Bearer k-test/.test(JSON.stringify(((withKey.calls[0] || {}).headers || {}))),
+     JSON.stringify(((withKey.calls[0] || {}).headers || {})));
+
+  /* ---------- the hidden-tab rule still holds ---------- */
+  const hidden = world(live, "k-test");
+  await hidden.advance(100);
+  const before = hidden.calls.length;
+  hidden.timers.length = 0;
+  ok("a connection is open before hiding", before === 1, String(before));
+
+  console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+  process.exit(failures === 0 ? 0 : 1);
+})();

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -827,7 +827,8 @@ function liveStream(options) {
   var live = null;
 
   function startLive() {
-    if (!$("key").value.trim()) { return; }
+    /* Not gated on the key box: load() has already succeeded by the time this runs, and on the
+       developer default it succeeds without a key. */
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
@@ -1098,6 +1099,10 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -1106,12 +1111,19 @@ function liveStream(options) {
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -1133,6 +1145,13 @@ function liveStream(options) {
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2313,7 +2313,10 @@ function liveStream(options) {
   var live = null;
 
   function startLive() {
-    if (!$("key").value.trim() || !$("auto").checked) { return; }
+    /* Not gated on the key box. This is reached from load()'s success path, so the deployment has
+       already answered -- and on the developer default it answers without one. Gating here meant
+       the panel that had just loaded anonymously refused to keep itself live. */
+    if (!$("auto").checked) { return; }
     if (live) { live.restart(); return; }
     live = liveStream({
       headers: auth,
@@ -2610,6 +2613,10 @@ function liveStream(options) {
   }
 
   var controller = null, backoff = 1000, buffer = "";
+  /* Set the first time this deployment refuses an anonymous read. Until then there is
+     no reason to assume a key is needed; afterwards there is no reason to ask again
+     without one. */
+  var wantsKey = false;
 
   function open() {
     /* The drop below aborts the request; the abort rejects the fetch; the catch schedules another
@@ -2618,12 +2625,19 @@ function liveStream(options) {
        visibility handler's `!controller` test is what brings it back. */
     if (document.hidden) { controller = null; return; }
     var k = key();
-    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+    /* No key is not the same as no access: on the developer default the gateway answers every
+       admin route anonymously, and refusing to ask left the strip dark on the deployment somebody
+       is most likely to be looking at first. So the first attempt goes out without one.
+
+       Once a deployment has refused, this is the old behaviour exactly -- watch for a key and
+       make no request until there is one. One 401 per page load, never a loop. */
+    if (!k && wantsKey) { setTimeout(open, 2000); return; }
     controller = new AbortController();
     fetch("/v1/admin/events", {
-      headers: { Authorization: "Bearer " + k },
+      headers: k ? { Authorization: "Bearer " + k } : {},
       signal: controller.signal
     }).then(function (r) {
+      if (r.status === 401 || r.status === 403) { wantsKey = true; }
       if (!r.ok || !r.body) { throw new Error("stream " + r.status); }
       dot.className = "live-dot";
       backoff = 1000;
@@ -2645,6 +2659,13 @@ function liveStream(options) {
       }
       return pump();
     }).catch(function () {
+      /* Refused for want of a key: not stale. Stale means a gateway that was answering has
+         stopped, and a deployment waiting for somebody to paste a key is not in trouble. */
+      if (wantsKey && !key()) {
+        controller = null;
+        setTimeout(open, 2000);
+        return;
+      }
       dot.className = "live-dot stale";
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 30000);  /* a gateway that is down must not be hammered */

--- a/tools/test_matrixark_live_strip.py
+++ b/tools/test_matrixark_live_strip.py
@@ -136,8 +136,18 @@ class StripHonestyTest(unittest.TestCase):
         self.assertIn("Math.min(backoff * 2, 30000)", self.script)
 
     def test_it_stays_quiet_without_a_key(self) -> None:
-        # Every page is inert without one; the strip must not be the thing that 401s in a loop.
-        self.assertIn("if (!k) { setTimeout(open, 2000); return; }", self.script)
+        # The strip must not be the thing that 401s in a loop.
+        #
+        # It used to keep that promise by never asking at all, which was too strong: on the
+        # developer default the gateway answers anonymously, so the strip stayed dark on the
+        # deployment most likely to be somebody's first. It now asks ONCE and, if refused, reverts
+        # to exactly this -- watching for a key and making no request until there is one.
+        #
+        # Asserted on the shape rather than the old literal, and asserted for real by running it:
+        # test_matrixark_no_key_is_not_no_access advances a fake minute against a refusing gateway
+        # and counts the requests, which is the only way to tell "asks once" from "asks forever".
+        self.assertIn("if (!k && wantsKey) { setTimeout(open, 2000); return; }", self.script)
+        self.assertIn("var wantsKey = false;", self.script)
 
 
 class StripLinksTest(unittest.TestCase):

--- a/tools/test_matrixark_no_key_is_not_no_access.py
+++ b/tools/test_matrixark_no_key_is_not_no_access.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A deployment that answers without a key gets a live portal.
+
+The status strip refused to connect until somebody typed one::
+
+    var k = key();
+    if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
+
+On the developer default -- ``MATRIXARK_REQUIRE_AUTH`` unset -- the gateway answers every admin
+route anonymously. Measured against the app rather than assumed: ``/v1/admin/overview``, ``/config``,
+``/scopes``, ``/api_key_usage``, ``/models`` and ``/deployment`` all return 200 with no
+``Authorization`` header, and 401 once auth is on.
+
+So on the deployment somebody is most likely to be looking at first, the strip stayed dark on all
+seven panels -- and Overview and Setup, which run a connection of their own, stayed dark twice over
+-- because the page would not ask a question the gateway was willing to answer.
+
+Both halves have to hold and they pull against each other: ask when there is no key, and still watch
+for a key on a deployment that wants one rather than backing off to thirty seconds. So the strip is
+run against a gateway that answers and a gateway that refuses.
+
+``startLive`` on the two pages with their own stream loses its key gate as well. It is reached from
+``load()``'s success path, so by the time it runs the deployment has already answered -- the gate
+meant a panel that had just loaded anonymously refused to keep itself live.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+HARNESS = os.path.join(PORTAL, "open_deployment_harness.js")
+HIDDEN = os.path.join(PORTAL, "hidden_tab_harness.js")
+
+
+def pages() -> dict:
+    return {name: io.open(os.path.join(PORTAL, name), encoding="utf-8").read()
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+class NoPageRefusesToAskTest(unittest.TestCase):
+
+    def test_the_old_refusal_is_gone_everywhere(self) -> None:
+        """One comment, on seven pages, saying the thing that was wrong."""
+        left = sorted(name for name, text in pages().items()
+                      if "inert without a key, like every page" in text)
+        self.assertEqual([], left, left)
+
+    def test_the_page_streams_do_not_gate_on_the_key_box_either(self) -> None:
+        """startLive runs only after load() succeeded, so a key check there refuses on behalf of a
+        gateway that has already answered."""
+        gated = []
+        for name, text in pages().items():
+            match = re.search(r"function startLive\(\) \{[\s\S]{0,200}", text)
+            if match and '$("key").value.trim()' in match.group(0):
+                gated.append(name)
+        self.assertEqual([], gated, "panels still refusing to go live without a key: %r" % gated)
+
+    def test_the_pages_that_run_their_own_stream_are_covered(self) -> None:
+        """Without this the check above passes on a portal where nothing defines startLive."""
+        own = [name for name, text in pages().items() if "function startLive()" in text]
+        self.assertGreaterEqual(len(own), 2, own)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheStripAsksFirstTest(unittest.TestCase):
+
+    def _run(self, page_name):
+        return subprocess.run(["node", HARNESS, os.path.join(PORTAL, page_name)],
+                              capture_output=True, text=True, timeout=300)
+
+    def test_every_panel_connects_without_a_key(self) -> None:
+        for name in sorted(pages()):
+            with self.subTest(page=name):
+                proc = self._run(name)
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+                self.assertIn("ok   with no key it still asks", proc.stdout)
+
+    def test_it_does_not_invent_a_credential(self) -> None:
+        for name in sorted(pages()):
+            with self.subTest(page=name):
+                self.assertIn("ok   and sends no credential it does not have", self._run(name).stdout)
+
+    def test_a_deployment_that_wants_a_key_is_still_watched_for_one(self) -> None:
+        """The half that pulls the other way. Backing off to thirty seconds here would mean a key
+        typed into the box takes half a minute to do anything."""
+        for name in sorted(pages()):
+            with self.subTest(page=name):
+                out = self._run(name).stdout
+                self.assertIn("ok   a deployment that refuses is asked once", out)
+                self.assertIn("ok   and is then watched for a key, not backed off from", out)
+
+    def test_a_key_is_still_sent_when_there_is_one(self) -> None:
+        for name in sorted(pages()):
+            with self.subTest(page=name):
+                self.assertIn("ok   a key is still sent when there is one", self._run(name).stdout)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class TheHiddenTabRuleSurvivesTest(unittest.TestCase):
+    """This change rewrites the same function that lets go of a hidden tab's connection."""
+
+    def _run(self, page_name, mode):
+        return subprocess.run(["node", HIDDEN, os.path.join(PORTAL, page_name), mode],
+                              capture_output=True, text=True, timeout=300)
+
+    def test_the_strip_still_lets_go(self) -> None:
+        for name, text in sorted(pages().items()):
+            if '__matrixarkLive = "page"' in text:
+                continue
+            with self.subTest(page=name):
+                proc = self._run(name, "strip")
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_page_streams_still_let_go(self) -> None:
+        for name, text in sorted(pages().items()):
+            if '__matrixarkLive = "page"' not in text:
+                continue
+            with self.subTest(page=name):
+                proc = self._run(name, "page")
+                self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The status strip refused to connect until somebody typed a key, and the two pages that run a
connection of their own refused to start it for the same reason:

```js
var k = key();
if (!k) { setTimeout(open, 2000); return; }   /* inert without a key, like every page */
```

On the developer default — `MATRIXARK_REQUIRE_AUTH` unset — **the gateway answers every admin route
anonymously.** Measured against the app, not assumed:

```
auth OFF (the developer default)      auth ON, no key presented
  /v1/admin/overview      -> 200        -> 401
  /v1/admin/config        -> 200        -> 401
  /v1/admin/scopes        -> 200        -> 401
  /v1/admin/api_key_usage -> 200        -> 401
  /v1/admin/models        -> 200        -> 401
  /v1/admin/deployment    -> 200        -> 401
```

So on the deployment somebody is most likely to be looking at first, the strip stayed dark on all
seven panels — and Overview and Setup stayed dark twice over — because the page would not ask a
question the gateway was willing to answer.

### It asks once, and the old promise is kept

`test_matrixark_live_strip` already guaranteed *"the strip must not be the thing that 401s in a
loop."* That still holds: once a deployment refuses an anonymous read, the strip reverts to watching
for a key and makes **no further request** until there is one. One 401 per page load.

**I nearly shipped the version that 401s every two seconds.** The existing guard caught it. The
check that now holds it is behavioural rather than a literal — a fake minute is advanced against a
refusing gateway and the requests are counted, which is the only way to tell "asks once" from "asks
forever":

```
remove the new early return -> FAIL and does not go on asking a deployment that said no
                                    31 requests in a minute with no key -- that is a 401 loop
```

That guard's assertion moved off the old literal for the same reason, and now names the shape plus
points at the run.

### Two smaller things

A refusal for want of a key no longer marks the dot **stale**. Stale means a gateway that was
answering has stopped; a deployment waiting for someone to paste a key is not in trouble, and
colouring it as though it were is the same lie pointing the other way.

`startLive` on Overview and Setup loses its key gate. It is reached from `load()`'s success path, so
by the time it runs the deployment has already answered — the gate meant a panel that had just
loaded anonymously refused to keep itself live.

9 tests, 7 harness assertions per panel. Neighbours: live_strip 38, hidden tabs 8, live frames
shared 9, backend-down 15, waiting strip 12, config-change 13, navigable panels 8, portal_tabs 19,
portal_pages 4.

**Known and not addressed here**, corrected after checking rather than assuming: most panels are
*not* affected — Overview, Setup, Catalog and Ingestion call `load()` unconditionally at startup and
`auth()` omits the header when there is no key, so they already populate on a dev deployment. What
still refuses is narrower than I first wrote: the key portal's `apiFetch`, which hard-rejects every
action without a key, and Explore's two operation gates. Three sites, and they want their own change.

