### PR TITLE
Give the on-disk cost test its attribute back

### DIFF
--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -5302,16 +5302,6 @@ mod tests {
         );
     }
 
-    /// What a record actually costs on disk AT THE DEFAULTS.
-    ///
-    /// The neighbouring size analysis builds its "today" baseline by hand, as JSON. Both encoding
-    /// flags now default ON, so that hand-built baseline is not necessarily what the log writes,
-    /// and a stale baseline overstates what is left -- which is the exact error that analysis
-    /// warns about. This one asks the store instead, with no flags set.
-    ///
-    /// Measured as the DELTA between records rather than the file size: the log preallocates in
-    /// large steps, so file size answers a different question.
-    #[test]
     /// What a batch costs on disk each way, as the batch grows.
     ///
     /// The comparison tree pays its record envelope once per COMMIT: its logger accumulates items
@@ -5385,6 +5375,16 @@ mod tests {
         }
     }
 
+    /// What a record actually costs on disk AT THE DEFAULTS.
+    ///
+    /// The neighbouring size analysis builds its "today" baseline by hand, as JSON. Both encoding
+    /// flags now default ON, so that hand-built baseline is not necessarily what the log writes,
+    /// and a stale baseline overstates what is left -- which is the exact error that analysis
+    /// warns about. This one asks the store instead, with no flags set.
+    ///
+    /// Measured as the DELTA between records rather than the file size: the log preallocates in
+    /// large steps, so file size answers a different question.
+    #[test]
     fn what_a_record_actually_costs_on_disk() {
         for value_len in [64usize, 1024, 4096] {
             let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`what_a_record_actually_costs_on_disk` has not run since #794. It compiled, and it was never a
test.

#794 inserted a probe anchored on the `fn` line of the test below it, which spliced the new
function **between the existing `#[test]` and the function it belonged to**. The result:

```
    /// What a record actually costs on disk AT THE DEFAULTS.
    #[test]                                    <- orphaned onto the new probe
    /// What a batch costs on disk each way...
    #[test]
    #[ignore]
    fn what_a_batch_costs_each_way() { ... }

    fn what_a_record_actually_costs_on_disk() {   <- no attribute, never runs
```

So the batch probe carried two `#[test]` attributes and the on-disk cost test quietly stopped
being a test. Nothing failed, because a function that is not a test cannot fail.

This puts the attribute back on the function it documents. Verified by running it: it reports
`113.0 / 1077.0 / 4149.0 B/record` at 64 B, 1 KiB and 4 KiB — the same figures it produced before
#794, so the format is unchanged and only the wiring was broken.

**The mechanism is worth naming: an insertion anchored on a `fn` line orphans the attributes above
it.** Anchor on the attribute, or assert afterwards that the test still runs. The filter reporting
`0 passed; N filtered out` is what exposed this — a test that has stopped existing looks exactly
like a typo in the filter, and both look like success if only the exit code is read.

Note: `cargo check --all-targets` on `main` is currently red for an unrelated reason —
`append_timestamped_kv_pages` grew a ninth parameter and two probe call sites in
`engine/tests/part1.rs` still pass eight. That is #848's to fix, and this branch does not touch
it; the verification above was done with that fix applied locally and discarded.
