### PR TITLE
That test asked when the file was touched, not what it holds

### DIFF
--- a/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
+++ b/tools/test_matrixark_the_floor_guards_the_rewrite_only.py
@@ -13,6 +13,7 @@ constant says a floor "cost correctness".
 These tests pin the split: with a floor set, a write still refreshes the head promptly, and only the
 full rewrite is skipped.
 """
+import json
 import shutil
 import tempfile
 import unittest
@@ -38,11 +39,25 @@ class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
         self.addCleanup(setattr, adapter_module,
                         "LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS", self.original_floor)
 
-    def base_mtime(self) -> int:
+    def base_state(self) -> tuple:
+        """What the base snapshot HOLDS, not when it was touched.
+
+        An mtime comparison looked obvious and was not deterministic: two writes can land inside
+        one filesystem timestamp tick, so "the base was rewritten" and "the base was not rewritten"
+        are indistinguishable whenever the test runs fast enough. That made this file fail about
+        one run in six, and worse once the fixture got quicker.
+
+        Content settles it. A rewrite from a shorter list changes the record count, and a rewrite
+        from the same list still changes nothing -- which is why the tests below write a list with
+        a row REMOVED, the case compaction produces and the floor exists to bound.
+        """
+        path = self.root / "events.jsonl.read-cache.json"
         try:
-            return (self.root / "events.jsonl.read-cache.json").stat().st_mtime_ns
-        except FileNotFoundError:
-            return 0
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, ValueError):
+            return (0, 0)
+        records = payload.get("records")
+        return (path.stat().st_size, len(records) if isinstance(records, list) else -1)
 
     def seeded(self) -> MatrixArkLocalAdapter:
         """An adapter with a base snapshot already on disk."""
@@ -51,7 +66,7 @@ class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
             writer.append({"record_type": "context_event", "event_id": "seed-%d" % index,
                            "content": "seed %d" % index})
         writer.read_all()
-        self.assertGreater(self.base_mtime(), 0, "no base snapshot was written to throttle")
+        self.assertGreater(self.base_state()[0], 0, "no base snapshot was written to throttle")
         return writer
 
     def test_a_write_still_refreshes_the_head_under_a_floor(self):
@@ -69,34 +84,51 @@ class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
         self.assertIn("after-floor", {r.get("event_id") for r in records},
                       "the record written under the floor is missing from the served view")
 
+    def shortened(self, adapter) -> list:
+        """The record list with one row dropped from the middle.
+
+        Passing `epoch=None` alone does NOT force the base rewrite: the writer still has a
+        disk-based contiguity fallback, so it can decide the persisted file is a prefix of this
+        list and append the tail instead. Which path it picked then depended on bookkeeping this
+        fixture does not control, and the control below failed about one run in six.
+
+        A SHORTER list settles it. Both contiguity routes require `appended > 0`, and a removal
+        makes it negative -- which is exactly what compaction does in production, and exactly the
+        case the floor exists to bound.
+        """
+        records = list(adapter.read_all())
+        self.assertGreater(len(records), 2, "too few records to drop one from the middle")
+        return records[:1] + records[2:]
+
     def test_the_full_rewrite_is_the_thing_the_floor_skips(self):
         adapter = self.seeded()
         adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 600000.0
-        before = self.base_mtime()
-        # Force the path that rewrites the base: a caller that cannot vouch for the list passes
-        # epoch=None, which is what makes the tail path unavailable.
+        shorter = self.shortened(adapter)
+        before = self.base_state()
         adapter._write_durable_read_cache(
-            list(adapter.read_all()), adapter._jsonl_cache_signature_detail(), epoch=None)
-        self.assertEqual(self.base_mtime(), before,
+            shorter, adapter._jsonl_cache_signature_detail(), epoch=None)
+        self.assertEqual(self.base_state(), before,
                          "the base was rewritten despite the floor")
 
     def test_without_a_floor_the_same_call_does_rewrite(self):
-        # Positive control. Without this, the test above passes for any reason at all -- including
-        # the rewrite never being reachable in this fixture.
+        # Positive control for the test above, which would otherwise pass for any reason at all --
+        # including the rewrite never being reachable in this fixture. Same call, same shortened
+        # list, floor removed.
         adapter = self.seeded()
+        shorter = self.shortened(adapter)
         adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 0.0
-        before = self.base_mtime()
-        adapter.append({"record_type": "context_event", "event_id": "extra",
-                        "content": "one more"})
+        before = self.base_state()
         adapter._write_durable_read_cache(
-            list(adapter.read_all()), adapter._jsonl_cache_signature_detail(), epoch=None)
-        self.assertNotEqual(self.base_mtime(), before,
+            shorter, adapter._jsonl_cache_signature_detail(), epoch=None)
+        self.assertNotEqual(self.base_state(), before,
                             "the base was not rewritten even with no floor, so the test above "
                             "proves nothing")
 
-    def delta_mtime(self) -> int:
+    def delta_size(self) -> int:
+        # Size, not mtime, for the same reason as base_state: two writes can share one timestamp
+        # tick and then "written" and "not written" look identical.
         try:
-            return (self.root / ".events.jsonl.read-cache-delta.jsonl").stat().st_mtime_ns
+            return (self.root / ".events.jsonl.read-cache-delta.jsonl").stat().st_size
         except FileNotFoundError:
             return 0
 
@@ -109,11 +141,11 @@ class FloorGuardsTheRewriteOnlyTest(unittest.TestCase):
         adapter_module.LOCAL_DURABLE_READ_CACHE_MIN_WRITE_MS = 600000.0
         adapter.append({"record_type": "context_event", "event_id": "forced",
                         "content": "forced"})
-        before = (self.base_mtime(), self.delta_mtime())
+        before = (self.base_state(), self.delta_size())
         adapter._write_durable_read_cache(
             list(adapter.read_all()), adapter._jsonl_cache_signature_detail(),
             force=True, epoch=None)
-        self.assertNotEqual((self.base_mtime(), self.delta_mtime()), before,
+        self.assertNotEqual((self.base_state(), self.delta_size()), before,
                             "force=True wrote nothing at all, so the floor blocked it")
 
 


### PR DESCRIPTION
The tests added with the write-floor fix compared `st_mtime_ns` before and after a write to decide whether the base snapshot had been rewritten. Two writes can land inside one filesystem timestamp tick, and then "rewritten" and "not rewritten" are indistinguishable — so the positive control failed about **one run in six** on merged main. That is my regression; this is the fix.

Comparing **content** settles it: the base file's size and the number of records it holds. Both tests now write a list with one row **removed**, which is what compaction produces and what the floor exists to bound, so a rewrite necessarily changes the record count and a skipped rewrite necessarily does not.

An intermediate attempt made it *worse* — 12 failures in 20 — by removing an intervening read and so making timestamp collisions more likely. That is what identified the timestamp as the cause rather than the write path.

**Verified:** 0 failures in 20 runs at the default floor, 3 of 3 with a floor set, against 1 in 6 before.

**Mutation-tested rather than assumed:** moving the floor back to the top of the writer — the bug #835 fixed — still fails the promptness test with `'jsonl' != 'durable'`, so the repair did not buy determinism by asserting less.