### PR TITLE
The allocation probe calls the signature that exists now

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -4057,6 +4057,9 @@ fn which_write_primitive_grows_with_the_store() {
             vec![FeaturePoint { timestamp_ms: 1, value: payload.clone() }],
             0,
             false,
+            // promote_sync_writes: what execute_on_shard passes on every one of its calls. This
+            // probe exists to measure the path production takes, so it takes the same one.
+            true,
         );
         let key = format!("probe:series:{rung}");
         let probe = crate::alloc_probe::Probe::start();
@@ -4069,6 +4072,9 @@ fn which_write_primitive_grows_with_the_store() {
             vec![FeaturePoint { timestamp_ms: 1, value: payload.clone() }],
             0,
             false,
+            // promote_sync_writes: what execute_on_shard passes on every one of its calls. This
+            // probe exists to measure the path production takes, so it takes the same one.
+            true,
         );
         *series_out = probe.stop().allocs;
 


### PR DESCRIPTION
**Rust CI has failed on main for three consecutive commits**, and every open pull request is blocked
behind it:

```
error[E0061]: this function takes 9 arguments but 8 arguments were supplied
  --> crates/temporalstore-rust/src/engine/tests/part1.rs:4051:17
  --> crates/temporalstore-rust/src/engine/tests/part1.rs:4063:17
error: could not compile `temporalstore-rust` (lib test) due to 2 previous errors
```

`append_timestamped_kv_pages` gained a `promote_sync_writes` parameter. Every caller in
`execute_on_shard` was updated; **the two in this allocation probe were not**, so the lib-test
target stopped compiling.

### Why `true`

It is what `execute_on_shard` passes on all of its calls. The probe measures the allocations of the
series primitive, so it should walk the path production walks — `false` would have it measure a
branch nobody runs. If the intent was to measure the other side of that branch, this is the line to
change, and it now says so in a comment rather than being a bare positional `false`.

Test code only; no behaviour changes outside the probe.

I did not write the change that moved the signature and I have not touched it. This is the smallest
edit that makes the target compile again — if the author of that change wants a different value
here, it is one word.

**Not verified locally.** Compiling this crate on the machine I am working from measurably degrades
a live deployment sharing it, so I am letting CI be the verifier: the parameter is a `bool` and
`true` is type-correct, and the only open question was which value, which is argued above.
