### PR TITLE
The ingestion panel notices the configuration changing under it

### DIFF
--- a/tools/portal/config_watch_harness.js
+++ b/tools/portal/config_watch_harness.js
@@ -1,0 +1,107 @@
+/* Does the ingestion panel notice the configuration changing under it?
+ *
+ * That panel renders what an import will actually use -- embedding provider and model, the encoder
+ * endpoint, whether a failed encoder call errors or falls back, the extraction provider and key --
+ * and all of it is set on a different page. It read that once, on load, and went on describing the
+ * old deployment for as long as the tab stayed open, under a header saying "checked 14:32:01":
+ * true about when it looked, false about what it is showing.
+ *
+ * Whether a watcher fires is behaviour, and the ways it goes wrong are all silent: registering
+ * against a function the nav has not defined yet, firing on the first frame, firing on every frame,
+ * firing for a hidden tab. So the page's own registration is executed and the callback it hands
+ * over is driven with frames.
+ *
+ * Usage: node config_watch_harness.js <ingestion_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+/* The registration statement as the page ships it, including the `var lastConfigAt` it closes
+   over. Sliced rather than reimplemented: the point is to run what is there. */
+const start = page.indexOf("  var lastConfigAt = null;");
+const end = page.indexOf("});", page.indexOf("(window.__matrixarkFrameQueue", start)) + 3;
+ok("the page registers a config watcher", start !== -1 && end > start);
+if (start === -1) { console.log("FAILED " + failures); process.exit(1); }
+const src = page.slice(start, end);
+
+ok("it registers through the queue, not by calling the register function",
+   src.includes("window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []"),
+   "this script runs before the nav defines that function; a direct call registers nothing");
+
+function run() {
+  const reloads = [];
+  const hidden = { value: false };
+  const key = { value: "k-test" };
+  const win = {};
+  const env = {
+    window: win,
+    document: { get hidden() { return hidden.value; } },
+    $: (id) => (id === "key" ? key : { value: "" }),
+    loadConfig(changedElsewhere) { reloads.push(!!changedElsewhere); },
+  };
+  new Function(...Object.keys(env), src)(...Object.values(env));
+  const queue = win.__matrixarkFrameQueue;
+  const callback = queue && queue[0];
+  return { callback, reloads, hidden, key };
+}
+
+const first = run();
+ok("the watcher is on the queue", typeof first.callback === "function");
+if (typeof first.callback !== "function") { console.log("FAILED " + failures); process.exit(1); }
+
+/* ---------- the first frame is not a change ---------- */
+first.callback({ config_changed_at: 100 });
+ok("the first frame does not trigger a re-read", first.reloads.length === 0,
+   "the configuration was read a moment ago on load");
+
+/* ---------- an unchanged frame is not a change ---------- */
+first.callback({ config_changed_at: 100 });
+ok("an unchanged value does not trigger one either", first.reloads.length === 0);
+
+/* ---------- a change is ---------- */
+first.callback({ config_changed_at: 200 });
+ok("a changed value re-reads the configuration", first.reloads.length === 1,
+   String(first.reloads.length));
+ok("and the re-read is marked as caused by a change elsewhere", first.reloads[0] === true,
+   "the header would say 'checked', which is true about when it looked and false about what "
+   + "it is showing");
+
+/* ---------- and only once per change ---------- */
+first.callback({ config_changed_at: 200 });
+ok("the same value again does not re-read", first.reloads.length === 1,
+   String(first.reloads.length));
+
+/* ---------- a frame without the field ---------- */
+first.callback({});
+ok("a frame carrying no configuration stamp is ignored", first.reloads.length === 1);
+
+/* ---------- a hidden tab ---------- */
+const hiddenRun = run();
+hiddenRun.callback({ config_changed_at: 1 });
+hiddenRun.hidden.value = true;
+hiddenRun.callback({ config_changed_at: 2 });
+ok("a hidden tab does not re-read", hiddenRun.reloads.length === 0,
+   "nobody is looking at the table it would refresh");
+hiddenRun.hidden.value = false;
+hiddenRun.callback({ config_changed_at: 3 });
+ok("and it re-reads once the tab is looked at again", hiddenRun.reloads.length === 1,
+   "the change while hidden would otherwise never be picked up");
+
+/* ---------- no key ---------- */
+const noKey = run();
+noKey.key.value = "";
+noKey.callback({ config_changed_at: 1 });
+noKey.callback({ config_changed_at: 2 });
+ok("with no key it does not ask", noKey.reloads.length === 0,
+   "the read would be refused and the panel already says to enter one");
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -349,7 +349,7 @@
   }
 
   /* ---------- deployment config ---------- */
-  function renderConfig(d) {
+  function renderConfig(d, changedElsewhere) {
     var rows = [
       ["Embedding", d.embedding.provider + (d.embedding.model ? " · " + d.embedding.model : "")],
       ["Encoder endpoint", d.embedding.api_base || "not set"],
@@ -386,13 +386,17 @@
       return "<tr><th>" + esc(r[0]) + "</th><td>" + esc(r[1]) + "</td></tr>";
     }).join("") + "</table>";
     $("config").innerHTML = html;
-    $("cfgTime").textContent = "checked " + new Date().toLocaleTimeString();
+    /* "checked" is about when this looked, not about what it found. When the re-read happened
+       because somebody changed the configuration elsewhere, say that instead -- otherwise the
+       table silently becomes a different table. */
+    $("cfgTime").textContent = (changedElsewhere ? "changed elsewhere — re-read " : "checked ")
+      + new Date().toLocaleTimeString();
   }
 
-  function loadConfig() {
+  function loadConfig(changedElsewhere) {
     fetch("/v1/admin/config", { headers: auth() })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
-      .then(function (d) { conn("live", "connected"); renderConfig(d); })
+      .then(function (d) { conn("live", "connected"); renderConfig(d, changedElsewhere); })
       .catch(function (e) {
         if (e === 401 || e === 403) {
           conn("live", "connected");
@@ -716,6 +720,32 @@
       else { sessionStorage.removeItem("matrixark_admin_key"); }
     } catch (e) { /* storage unavailable */ }
   }
+  /* What this panel shows IS the configuration -- the provider an import will call, the endpoint
+     it will call it at, whether a failed encoder call errors or quietly falls back. Somebody
+     changes that on the Setup page and this table described the old deployment until the tab was
+     reloaded.
+
+     Through the queue, not by calling the register function: this script runs before the nav block
+     defines it, and a direct call registers nothing at all. The catalog page lost its watcher to
+     exactly that and carries the comment.
+
+     No throttle here, unlike the catalog's watcher on the stored count. config_changed_at moves
+     only when somebody writes configuration, which is rare and deliberate; a record count moves
+     with every import. */
+  var lastConfigAt = null;
+  (window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push(
+    function (frame) {
+      var at = frame.config_changed_at;
+      if (at == null) { return; }
+      /* The first frame records only: the configuration was read a moment ago on load, and
+         treating the first sighting as a change would re-read it for nothing. */
+      if (lastConfigAt === null) { lastConfigAt = at; return; }
+      if (at === lastConfigAt) { return; }
+      lastConfigAt = at;
+      if (document.hidden || !$("key").value.trim()) { return; }
+      loadConfig(true);
+    });
+
   $("key").addEventListener("change", function () { persistKey(); loadConfig(); loadJobs(); });
   $("remember").addEventListener("change", persistKey);
 

--- a/tools/test_matrixark_the_ingestion_panel_sees_a_config_change.py
+++ b/tools/test_matrixark_the_ingestion_panel_sees_a_config_change.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The ingestion panel notices the configuration changing underneath it.
+
+That panel renders what an import will actually use: the embedding provider and model, the encoder
+endpoint, whether a failed encoder call errors or falls back to hash vectors, the extraction
+provider, and whether the extraction key is set. Every one of those is set on the Setup page.
+
+It read them once, on load, and never again -- so a provider changed on Setup left this panel
+describing the old deployment for as long as the tab stayed open, under a header reading
+"checked 14:32:01": true about when it looked, false about what it is showing.
+
+Overview and Setup already watch ``config_changed_at`` on the live frame for exactly this. Ingestion
+subscribed to no frames at all, so it had nothing to watch with.
+
+The registration goes through ``__matrixarkFrameQueue`` rather than calling the register function:
+this script runs before the nav block defines that function, and a direct call registers nothing.
+The catalog page lost its own watcher to that and carries the comment.
+
+Whether a watcher fires is behaviour, and every way it goes wrong is silent -- registering against
+nothing, firing on the first frame, firing on every frame, firing for a tab nobody is looking at --
+so the page's own registration is executed and the callback it hands over is driven with frames.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "ingestion_portal.html")
+HARNESS = os.path.join(PORTAL, "config_watch_harness.js")
+
+
+def page() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class ThePanelSubscribesTest(unittest.TestCase):
+
+    def test_it_registers_a_frame_watcher(self) -> None:
+        self.assertIn("__matrixarkFrameQueue", page())
+
+    def test_through_the_queue_rather_than_the_register_function(self) -> None:
+        """This script runs before the nav block defines the register function. Calling it
+        directly registers nothing at all, and nothing says so -- the catalog page lost a watcher
+        that way."""
+        self.assertIn("(window.__matrixarkFrameQueue = window.__matrixarkFrameQueue || []).push",
+                      page())
+
+    def test_it_watches_the_field_that_marks_a_configuration_write(self) -> None:
+        self.assertIn("config_changed_at", page())
+
+    def test_the_panel_it_refreshes_is_the_one_showing_configuration(self) -> None:
+        """Named so this cannot drift into watching for a change and refreshing something else."""
+        source = page()
+        watcher = source[source.index("var lastConfigAt = null;"):]
+        watcher = watcher[:watcher.index("});") + 3]
+        self.assertIn("loadConfig(", watcher)
+
+
+class TheStampSaysWhichItWasTest(unittest.TestCase):
+
+    def test_a_re_read_is_distinguishable_from_a_look(self) -> None:
+        """"checked" is about when the panel looked. After somebody else changes the deployment it
+        is showing a different table, and saying only when it looked is the quiet half of that."""
+        self.assertIn("changed elsewhere", page())
+
+    def test_the_ordinary_load_still_says_checked(self) -> None:
+        self.assertIn('"checked "', page())
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class WhatTheWatcherActuallyDoesTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_first_frame_is_not_treated_as_a_change(self) -> None:
+        """On load the configuration has just been read; re-reading on the first sighting would be
+        a request for nothing, on every page load."""
+        out = self._run().stdout
+        self.assertIn("ok   the first frame does not trigger a re-read", out)
+        self.assertIn("ok   an unchanged value does not trigger one either", out)
+
+    def test_a_change_is(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a changed value re-reads the configuration", out)
+        self.assertIn("ok   and the re-read is marked as caused by a change elsewhere", out)
+
+    def test_and_only_once_per_change(self) -> None:
+        """The frame repeats while nothing moves; re-reading on each would be a request every few
+        seconds for a table nobody asked to refresh."""
+        self.assertIn("ok   the same value again does not re-read", self._run().stdout)
+
+    def test_a_hidden_tab_is_left_alone_but_not_forgotten(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   a hidden tab does not re-read", out)
+        self.assertIn("ok   and it re-reads once the tab is looked at again", out)
+
+    def test_it_does_not_ask_without_a_key(self) -> None:
+        self.assertIn("ok   with no key it does not ask", self._run().stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The ingestion panel renders **what an import will actually use** — embedding provider and model, the
encoder endpoint, whether a failed encoder call errors or falls back to hash vectors, the extraction
provider, whether the extraction key is set. Every one of those is set on the **Setup** page.

It read them once, on load, and never again. Change a provider on Setup and this panel went on
describing the old deployment for as long as the tab stayed open — under a header reading
`checked 14:32:01`, which is true about when it looked and false about what it is showing.

### Who was watching what

| panel | subscribes to live frames | reacts to `config_changed_at` |
|---|---|---|
| overview, setup | own stream | yes |
| catalog, explore, api | yes | no (they watch other fields) |
| **ingestion** | **no** | **no** |
| api_key | no | n/a — its content is not frame-carried |

Ingestion had nothing to watch with. It does now, and the header says which it was: `checked` for an
ordinary load, `changed elsewhere — re-read` when somebody moved the deployment underneath it.

### Details that are the difference between working and looking like it works

- **Through the queue**, not by calling the register function: this script runs before the nav block
  defines it, and a direct call registers nothing at all. The catalog page lost its own watcher to
  exactly that and carries the comment.
- **The first frame records only.** The configuration was read a moment ago on load; treating the
  first sighting as a change would spend a request on every page load.
- **No throttle**, unlike the catalog's watcher on the stored record count — `config_changed_at`
  moves only when somebody writes configuration, which is rare and deliberate, while a record count
  moves with every import.
- Hidden tabs don't ask, and pick the change up when looked at again.

### Run, not read

```
fire on the first frame          -> FAIL the first frame does not trigger a re-read (+2)
ignore document.hidden           -> FAIL a hidden tab does not re-read (+1)
re-read without saying why       -> FAIL the re-read is marked as caused by a change elsewhere
```

12 tests, 12 harness assertions. Neighbours: portal_pages 4, live_strip 38, config-change 13,
navigable panels 8, refused stop 8, status messages 9, ingestion_retry 23, hidden tabs 8.
