### PR TITLE
Let the session being talked in keep its place

### DIFF
--- a/tools/matrixark_local_adapter_retrieve.py
+++ b/tools/matrixark_local_adapter_retrieve.py
@@ -1537,6 +1537,10 @@ class _LocalAdapterRetrieveMixin:
             node_scores,
             top_k_per_layer=top_k_per_layer,
             max_children_scored_per_parent=max_children_scored_per_parent,
+            # The session being talked in should not have to out-rank its own history. If it was
+            # never scored into node_scores this is a no-op, so the guarantee can only ever add
+            # the current session, never move anything else.
+            guaranteed_path=tuple(self.default_session_node_path(scope)),
         )
         finish_retrieval_stage("node_traversal", stage_started_perf)
         stage_started_perf = time.perf_counter()

--- a/tools/matrixark_mcp_core_node_tree.py
+++ b/tools/matrixark_mcp_core_node_tree.py
@@ -76,6 +76,7 @@ def tree_first_traversal(
     *,
     top_k_per_layer: int,
     max_children_scored_per_parent: int,
+    guaranteed_path=None,
 ) -> Json:
     """Traverse ContextNode summaries layer by layer and return selected subtrees.
 
@@ -96,6 +97,29 @@ def tree_first_traversal(
         parent = path[:-1]
         children_by_parent.setdefault(parent, []).append(node)
 
+    guaranteed = node_path_tuple(list(guaranteed_path)) if guaranteed_path else ()
+    if guaranteed and guaranteed not in node_by_path:
+        # A path this store does not have must change nothing at all.
+        guaranteed = ()
+
+    def admit_guaranteed(parent: tuple[str, ...], picked: list[Json]) -> list[Json]:
+        """Add the guaranteed path's child under this parent without displacing a ranked pick.
+
+        top_k_per_layer is applied per parent, so every session under a user competes for the same
+        places, and the current session -- newest and least summarised -- is the likeliest to lose
+        to its own history. Losing it means asking about something said minutes ago and being
+        handed a much older session instead. So it is admitted alongside the ranking rather than
+        competing in it, and it is looked up directly rather than through the
+        max_children_scored_per_parent slice, so the guarantee does not depend on the scoring cap.
+        """
+        if not guaranteed or len(guaranteed) <= len(parent) or guaranteed[:len(parent)] != parent:
+            return picked
+        wanted = guaranteed[:len(parent) + 1]
+        if any(node_path_tuple(entry.get("node_path", [])) == wanted for entry in picked):
+            return picked
+        node = node_by_path.get(wanted)
+        return picked + [node] if node is not None else picked
+
     roots = children_by_parent.get((), [])
     if not roots:
         return {
@@ -106,7 +130,8 @@ def tree_first_traversal(
             "fallback_to_flat": True,
         }
 
-    frontier = top_scored_nodes(roots[:max_children_scored_per_parent], top_k_per_layer)
+    frontier = admit_guaranteed(
+        (), top_scored_nodes(roots[:max_children_scored_per_parent], top_k_per_layer))
     selected_paths: set[tuple[str, ...]] = set()
     selected_node_hashes: set[int] = set()
     leaf_paths: set[tuple[str, ...]] = set()
@@ -124,7 +149,8 @@ def tree_first_traversal(
             except (TypeError, ValueError):
                 pass
             children = children_by_parent.get(path, [])[:max_children_scored_per_parent]
-            picked_children = top_scored_nodes(children, top_k_per_layer) if children else []
+            picked_children = admit_guaranteed(
+                path, top_scored_nodes(children, top_k_per_layer) if children else [])
             trace.append(
                 {
                     "node_hash": node.get("node_hash"),


### PR DESCRIPTION
`top_k_per_layer` is applied per parent, so every session under a user competes
for the same places. The current session is the newest and least summarised,
which makes it the likeliest to lose -- and losing it means asking about
something said minutes ago and being handed a much older session instead.

`tools/test_current_session_guarantee.py` already specified the remedy, in four
tests and a docstring: the current session is admitted outside the ranking and
does not consume a ranked slot. The feature was never built. `guaranteed_path`
appeared in zero product files, so three of the four tests errored with
`TypeError: tree_first_traversal() got an unexpected keyword argument`.

So this implements the specification rather than adjusting it.

`tree_first_traversal` now takes an optional `guaranteed_path`. At each layer the
guaranteed path's child is admitted alongside the ranked picks instead of
competing with them -- appended, never substituted, so nothing that earned a
place loses one. It is looked up directly in the path index rather than through
the `max_children_scored_per_parent` slice, so the guarantee does not quietly
depend on the scoring cap. A path the store does not have is dropped up front and
changes nothing.

Wired at the one live call site, `MatrixArkLocalAdapter.retrieve`, from
`default_session_node_path(scope)` -- the same construction the ingest path uses
for a session node. There are two copies of `tree_first_traversal` in the tree
and they are not identical; the live one was resolved by object identity through
the caller's own binding (`matrixark_mcp_core_node_tree`), which is also the copy
the tests import.

The wiring is safe in one direction only: if the current session was never scored
into `node_scores`, the guarantee is a no-op. It can add the current session; it
cannot move anything else.

Two things worth recording.

The first implementation was inert. `node_path_tuple` returns `()` for anything
that is not a `list`, tuples included, and both the test and the call site pass a
tuple -- so the guaranteed path normalised to empty and the guarantee never fired.
Normalising with `list(...)` at the point of use fixes it. The shared helper is
left alone deliberately: its `Any` signature is defensive for JSON-sourced record
fields, and widening it would change behaviour for callers this change has no
business touching.

The second is why that inert version looked healthy: it passed three of the four
tests. "Admitting it does not displace a ranked node" and "an unknown path
changes nothing" are both satisfied trivially by doing nothing at all. Only
`test_worst_scoring_current_session_is_still_admitted` discriminates. The
guard-rail tests are worth keeping, but they cannot be the evidence that the
feature works.

Verified end to end as well as in unit: with the traversal spied on, a real
ingest-then-retrieve through the server passes
`('tenant:t', 'user:u', 'session:sess-live')` -- the live scope's own session --
rather than the argument merely existing.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
