### PR TITLE
Send the headers an admin portal is supposed to send

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1083,6 +1083,49 @@ _ACCEPT_ENCODING: "contextvars.ContextVar[str]" = contextvars.ContextVar(
 _JSON_PACK_FLOOR = 1024
 
 
+# What an admin page is allowed to do, and who is allowed to embed it.
+#
+# The pages need very little: nothing is fetched cross-origin except by explicit configuration,
+# there are no inline event handlers, and there is no eval or new Function anywhere -- so
+# 'unsafe-eval' is not needed and default-src can be 'self'.
+#
+# 'unsafe-inline' IS needed: every page carries its stylesheet and scripts inline. So this policy
+# does NOT stop injected inline script, and saying otherwise would be the more dangerous mistake.
+# What it does stop is the page being framed, script being pulled from another origin, a <base>
+# tag redirecting every relative URL, and a form posting somewhere else.
+#
+# connect-src is open on purpose. The key portal lets a customer point at a management host and a
+# gateway host of their own; a policy that forbade that would break a documented feature to close
+# a hole this deployment does not have.
+_CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "connect-src *; "
+    "object-src 'none'; "
+    "base-uri 'none'; "
+    "form-action 'none'; "
+    "frame-ancestors 'none'"
+)
+
+# Sent with every response, HTML or JSON. nosniff because a response read as a different type is
+# how a JSON body becomes executable; no-referrer because an admin URL names the deployment and
+# there is nowhere it needs to travel to.
+_SAFETY_HEADERS = [
+    (b"x-content-type-options", b"nosniff"),
+    (b"referrer-policy", b"no-referrer"),
+]
+
+# frame-ancestors is the modern spelling and X-Frame-Options the one older intermediaries honour.
+# The portal has destructive controls one click behind a confirm box; being framed is the attack
+# that turns a confirm box into a decoration.
+_HTML_SAFETY_HEADERS = _SAFETY_HEADERS + [
+    (b"content-security-policy", _CONTENT_SECURITY_POLICY.encode("ascii")),
+    (b"x-frame-options", b"DENY"),
+]
+
+
 async def _json(send: Callable, status: int, payload: Json,
                 extra_headers: Optional[list[Tuple[bytes, bytes]]] = None) -> None:
     data = json.dumps(payload).encode("utf-8")
@@ -1095,6 +1138,10 @@ async def _json(send: Callable, status: int, payload: Json,
     # Whether this response is compressed depends on the request, and a shared cache that ignored
     # that would hand a gzip body to a client that asked for none.
     headers.append((b"vary", b"accept-encoding"))
+    # Configuration, audit records and per-key usage all come through here. Nothing between the
+    # gateway and the browser should be keeping any of it.
+    headers.append((b"cache-control", b"no-store"))
+    headers.extend(_SAFETY_HEADERS)
     headers.append((b"content-length", str(len(data)).encode()))
     if extra_headers:
         headers.extend(extra_headers)
@@ -1232,6 +1279,7 @@ async def _html(send: Callable, status: int, body: bytes,
                 extra_headers: Optional[list[Tuple[bytes, bytes]]] = None) -> None:
     headers = [(b"content-type", b"text/html; charset=utf-8"),
                (b"content-length", str(len(body)).encode())]
+    headers.extend(_HTML_SAFETY_HEADERS)
     if extra_headers:
         headers.extend(extra_headers)
     await send({"type": "http.response.start", "status": status, "headers": headers})

--- a/tools/test_matrixark_the_portal_says_who_may_embed_it.py
+++ b/tools/test_matrixark_the_portal_says_who_may_embed_it.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The portal sends the headers an admin interface is supposed to send.
+
+It holds a bearer key in ``sessionStorage`` and drives operations that delete memory, revoke keys
+and rewrite configuration. It was served with none of the headers that constrain what a page may do
+or who may embed it -- no ``Content-Security-Policy``, no ``X-Frame-Options``, no
+``X-Content-Type-Options``, no ``Referrer-Policy`` -- and its JSON reads carried no ``Cache-Control``
+at all, so anything between the gateway and the browser was free to keep configuration, audit
+records and per-key usage.
+
+**Framing is the one that matters most.** Nothing stopped another site putting this portal in an
+invisible frame over its own buttons, and Explore's forget, delete and reset are one click each
+behind a confirm box -- as is revoking a key. Being framed is what turns a confirm box into a
+decoration.
+
+What makes a real policy possible here is how little the pages need: nothing is loaded
+cross-origin, there are no inline event handlers, and there is no ``eval`` or ``new Function``
+anywhere. Those three properties are asserted below, because the policy is only as tight as they
+allow and a page that grew any of them would be broken by it -- silently, since a blocked script
+does not announce itself.
+
+``'unsafe-inline'`` is needed and is stated rather than implied: every page carries its stylesheet
+and scripts inline, so this policy does **not** stop injected inline script. It stops the page being
+framed, script being pulled from another origin, a ``<base>`` tag redirecting every relative URL,
+and a form posting somewhere else.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+PAGES = ["/v1/admin", "/v1/admin/portal", "/v1/admin/setup", "/v1/admin/catalog",
+         "/v1/admin/explore", "/v1/admin/api", "/v1/admin/ingestion"]
+
+
+def _drive(*args, **kwargs):
+    from test_matrixark_v1_gateway import drive
+    return drive(*args, **kwargs)
+
+
+def _get(path):
+    from test_matrixark_v1_gateway import _FakeServer, _cfg
+    app = gw.make_v1_app(_FakeServer(), _cfg(require_auth=False))
+    return _drive(app, method="GET", path=path)
+
+
+def pages() -> dict:
+    return {name: io.open(os.path.join(PORTAL, name), encoding="utf-8").read()
+            for name in sorted(os.listdir(PORTAL)) if name.endswith(".html")}
+
+
+class EveryPageSaysWhoMayEmbedItTest(unittest.TestCase):
+
+    def test_every_page_route_answers(self) -> None:
+        self.assertGreaterEqual(len(PAGES), 7)
+        for path in PAGES:
+            with self.subTest(path=path):
+                status, _h, _b = _get(path)
+                self.assertEqual(200, status)
+
+    def test_nobody_may_frame_it(self) -> None:
+        """Explore's forget, delete and reset are one click each behind a confirm box, and so is
+        revoking a key. A frame over someone else's buttons is what makes that click theirs."""
+        for path in PAGES:
+            with self.subTest(path=path):
+                _st, headers, _b = _get(path)
+                self.assertIn("frame-ancestors 'none'", headers.get("content-security-policy", ""))
+                self.assertEqual("DENY", headers.get("x-frame-options"),
+                                 "older intermediaries honour this one and not the other")
+
+    def test_a_response_cannot_be_sniffed_into_something_else(self) -> None:
+        for path in PAGES:
+            with self.subTest(path=path):
+                _st, headers, _b = _get(path)
+                self.assertEqual("nosniff", headers.get("x-content-type-options"))
+
+    def test_the_admin_url_does_not_travel(self) -> None:
+        _st, headers, _b = _get("/v1/admin/setup")
+        self.assertEqual("no-referrer", headers.get("referrer-policy"))
+
+    def test_the_policy_does_not_allow_eval(self) -> None:
+        """Nothing in the portal needs it, and allowing it would give back most of what the rest
+        of the policy buys."""
+        _st, headers, _b = _get("/v1/admin/setup")
+        self.assertNotIn("unsafe-eval", headers.get("content-security-policy", ""))
+
+    def test_script_cannot_come_from_another_origin(self) -> None:
+        _st, headers, _b = _get("/v1/admin/setup")
+        policy = headers.get("content-security-policy", "")
+        self.assertIn("default-src 'self'", policy)
+        self.assertIn("base-uri 'none'", policy)
+        self.assertIn("form-action 'none'", policy)
+
+
+class TheAdminDataIsNotKeptTest(unittest.TestCase):
+
+    def test_json_is_not_stored_anywhere(self) -> None:
+        """Configuration names the endpoints this deployment calls; the audit route returns who
+        reached for what. Neither should sit in an intermediary."""
+        for path in ("/v1/admin/config", "/v1/admin/overview", "/v1/admin/audit"):
+            with self.subTest(path=path):
+                _st, headers, _b = _get(path)
+                self.assertEqual("no-store", headers.get("cache-control"))
+
+    def test_json_cannot_be_sniffed_either(self) -> None:
+        _st, headers, _b = _get("/v1/admin/config")
+        self.assertEqual("nosniff", headers.get("x-content-type-options"))
+        self.assertEqual("no-referrer", headers.get("referrer-policy"))
+
+
+class ThePagesStayInsideThePolicyTest(unittest.TestCase):
+    """The policy is exactly as tight as the pages allow. A page that grew any of these would be
+    broken by it, and a blocked script does not announce itself."""
+
+    def test_nothing_is_loaded_cross_origin(self) -> None:
+        external = {}
+        for name, text in pages().items():
+            found = re.findall(r'(?:src|href)="(?:https?:)?//[^"]+"', text)
+            if found:
+                external[name] = found[:3]
+        self.assertEqual({}, external, "these would be blocked by default-src 'self': %r" % external)
+
+    def test_there_are_no_inline_event_handlers(self) -> None:
+        """`onclick=` and friends are blocked by a policy without 'unsafe-hashes'. The portal wires
+        events in script instead, and this keeps it that way."""
+        offenders = {}
+        for name, text in pages().items():
+            found = re.findall(r"\son(?:click|change|input|submit|load|error)=", text)
+            if found:
+                offenders[name] = len(found)
+        self.assertEqual({}, offenders, offenders)
+
+    def test_nothing_evaluates_a_string(self) -> None:
+        offenders = sorted(name for name, text in pages().items()
+                           if re.search(r"\beval\(|new Function\(", text))
+        self.assertEqual([], offenders,
+                         "these would need 'unsafe-eval', which the policy does not grant: %r"
+                         % offenders)
+
+    def test_the_sweep_sees_the_pages(self) -> None:
+        self.assertGreaterEqual(len(pages()), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The portal holds a bearer key in `sessionStorage` and drives operations that delete memory, revoke
keys and rewrite configuration. It was served with **none** of the headers that constrain what a
page may do or who may embed it:

```
content-security-policy   absent
x-frame-options           absent
x-content-type-options    absent
referrer-policy           absent
```

and its JSON reads — configuration, audit records, per-key usage — carried **no `Cache-Control` at
all**, so anything between the gateway and the browser was free to keep them.

### Framing is the one that matters

Nothing stopped another site putting this portal in an invisible frame over its own buttons.
Explore's **forget, delete and reset** are one click each behind a confirm box, and so is revoking a
key. Being framed is what turns a confirm box into a decoration.

### What makes a real policy possible here

The pages need very little, and all three properties are asserted so they stay true:

- nothing is loaded cross-origin — no external script, style, font or image
- **no inline event handlers at all**
- no `eval`, no `new Function`

so `'unsafe-eval'` is not needed and `default-src` can be `'self'`. A page that grew any of those
would be broken by the policy **silently** — a blocked script does not announce itself — which is
why they are guarded rather than assumed.

### What this does not do

`'unsafe-inline'` **is** needed: every page carries its stylesheet and scripts inline. So this policy
does not stop injected inline script, and saying otherwise would be the more dangerous mistake. It
stops the page being framed, script being pulled from another origin, a `<base>` tag redirecting
every relative URL, and a form posting somewhere else.

`connect-src` stays open on purpose — the key portal lets a customer point at a management host and
a gateway host of their own, and forbidding that would break a documented feature to close a hole
this deployment does not have.

Against main the same test fails **twenty** ways. 12 tests here; neighbours: v1_gateway 97,
gateway_portal 60, page compression 21, json compression 12, deployment routes 23, dashboards 20,
gateway_events 12, embedding status 16, api_traffic 15, audit log 18, portal_pages 4, readiness 13.
