### PR TITLE
Pin how a key picks its shard, because two answers exist

### DIFF
--- a/crates/temporalstore-rust/src/client/routing.rs
+++ b/crates/temporalstore-rust/src/client/routing.rs
@@ -43,3 +43,59 @@ pub fn key_is_dropped_by_percent(key: &str, drop_percent: u8) -> bool {
     let drop_percent = drop_percent.min(100);
     drop_percent > 0 && (stable_key_hash(key) % 100) < u64::from(drop_percent)
 }
+
+#[cfg(test)]
+mod bucket_ownership_tests {
+    use super::*;
+
+    /// Where a key goes is decided by the bucket MODULO the shard count, not by the bucket
+    /// ranges the metaserver publishes.
+    ///
+    /// Both exist. `bucket_id_for_key` puts a key in one of `1 << 30` buckets, the same slot
+    /// space the metaserver uses, and `build_shards` gives every shard a contiguous
+    /// `start_bucket..=end_bucket` slice of it (`bucket_count * offset / shard_count`). Nothing
+    /// routes by those ranges: this function takes the bucket modulo the count instead, so the
+    /// two describe different owners for the same key -- at four shards they disagree for about
+    /// three quarters of the bucket space.
+    ///
+    /// That is not currently a fault, because the ranges are only reported (in the client's
+    /// partition-set report, where they fall back to the same even split) and the data node
+    /// serves whatever shard it is asked for. It matters for anything built on them later: a
+    /// range split moves a contiguous slice of buckets, and this mapping would not follow it.
+    ///
+    /// This pins the mapping that is real, so that a change to range routing is a deliberate one
+    /// and not something discovered afterwards.
+    #[test]
+    fn a_key_is_routed_by_bucket_modulo_count_not_by_the_published_range() {
+        let shard_count = 4_u64;
+        let first_shard_id = 100_u64;
+        let bucket_count = 1_u64 << 30;
+
+        // The range the metaserver publishes for the first shard, computed as `build_shards`
+        // does it.
+        let shard0_end = bucket_count / shard_count - 1;
+
+        // A key whose bucket falls inside that range, but which does not route there.
+        let mut found = None;
+        for candidate in 0..10_000_u64 {
+            let key = format!("k{candidate}");
+            let bucket = bucket_id_for_key(&key);
+            if bucket <= shard0_end && bucket % shard_count != 0 {
+                found = Some((key, bucket));
+                break;
+            }
+        }
+        let (key, bucket) = found.expect("some key lands in the first shard's published range");
+
+        let routed = shard_id_for_key(&key, first_shard_id, shard_count, 0);
+        assert_eq!(
+            routed,
+            first_shard_id + bucket % shard_count,
+            "routing is modulo the shard count"
+        );
+        assert_ne!(
+            routed, first_shard_id,
+            "and it is NOT the shard whose published range contains bucket {bucket} -- if this              now holds, routing became range-based and the report and this comment need updating"
+        );
+    }
+}


### PR DESCRIPTION
A key is hashed into one of `1 << 30` buckets, and there are **two** mappings from bucket to shard.

The metaserver gives every shard a contiguous slice -- `build_shards` sets `start_bucket = bucket_count * offset / shard_count` with a matching `end_bucket` -- and publishes it on each shard. The client ignores that and takes `bucket % shard_count`. **At four shards they disagree for ~75% of the bucket space; at eight, ~87.5%.**

Nothing is broken today: nothing routes by the ranges (they are reported, and the partition-set report falls back to the same even split when a route is not cached), and the data node serves whatever shard it is asked for. It matters for what gets built on them -- a range split moves a contiguous slice of buckets, and a modulo mapping does not follow it.

This pins the mapping that is real and says in one place that the other is nominal, so moving to range routing becomes a decision rather than a discovery. The test fails if routing ever becomes range-based -- the moment the report and the comment need to change together.