### PR TITLE
A checkpoint does not carry the hash index, and the test now says so

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -3206,7 +3206,20 @@ fn binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read() {
     for (key, address) in &shard.strings {
         assert_eq!(decoded.strings.get(key), Some(address), "address changed for {key}");
     }
-    assert_eq!(decoded.hashes, shard.hashes);
+    // `hashes` is deliberately NOT in the payload: it carries `#[serde(default,
+    // skip_serializing)]` because it is rebuildable from the durable bucket/page index on load,
+    // and duplicating it in every checkpoint is what that attribute exists to avoid. So the
+    // round-trip must drop it, and this asserts the drop rather than the impossible equality it
+    // asserted before -- which is why this test was failing on main.
+    assert!(
+        decoded.hashes.is_empty(),
+        "hashes must not ride the checkpoint; it is rebuilt on load, got {:?}",
+        decoded.hashes
+    );
+    assert!(
+        !shard.hashes.is_empty(),
+        "the shard under test must actually have hashes, or the assertion above proves nothing"
+    );
     assert_eq!(decoded.applied_wal_sequence, shard.applied_wal_sequence);
     assert_eq!(decoded.index_format_version, shard.index_format_version);
 


### PR DESCRIPTION
`binary_index_payload_round_trips_and_refuses_a_shape_it_cannot_read` **fails on main, alone, every time.** It asserts the decoded checkpoint equals the shard field for field, including `hashes`.

`hashes` cannot come back: it carries `#[serde(default, skip_serializing)]`, with the reason on the line above it -- rebuildable from the durable bucket/page index on load, so not duplicated in every checkpoint. That attribute arrived with the change that compacted context recovery checkpoints; this assertion did not move with it.

Not a codec bug and not data loss -- I checked the mechanism before concluding, because `TS_INDEX_BINARY` is ON by default and a dropped index map would have been serious.

The round trip is still checked, more precisely: strings come back entry for entry, sequence and format version survive, and `hashes` must be **empty** -- plus a second assertion that the shard had hashes to begin with, so an empty-to-empty comparison cannot pass by accident.