### PR TITLE
A record kept a table sized for twice the keys it holds

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -982,6 +982,24 @@ def _shared_container(field, value, table, depth):
     return value
 
 
+#: What a dict BUILT to a given key count costs on this interpreter, memoised by key count.
+#:
+#: Measured rather than tabulated, because the growth policy is CPython's and a table written here
+#: would silently stop matching. Only a handful of key counts occur, so the cache stays tiny.
+_RIGHT_SIZED_BYTES: dict[int, int] = {}
+
+
+def _right_sized_bytes(key_count: int) -> int:
+    cached = _RIGHT_SIZED_BYTES.get(key_count)
+    if cached is None:
+        probe: dict = {}
+        for index in range(key_count):
+            probe[index] = None
+        cached = _sys.getsizeof(probe)
+        _RIGHT_SIZED_BYTES[key_count] = cached
+    return cached
+
+
 def share_repeated_values(records: list[Json], table: dict, already: set | None = None) -> list[Json]:
     """Give every record that carries the same flat dict value the SAME object.
 
@@ -1027,10 +1045,33 @@ def share_repeated_values(records: list[Json], table: dict, already: set | None 
                 if replacements is None:
                     replacements = {}
                 replacements[field] = shared
+        # Right-size the table on the way in, whichever branch takes it.
+        #
+        # CPython grows a dict's table on insert and never shrinks it, and the table a dict ends on
+        # depends on HOW it was built rather than on what it holds. Both paths that reach the cache
+        # build records the expensive way -- expansion copies the encoded record, drops the intern
+        # token and puts the bundle's six fields back; the append path assembles field by field --
+        # and a dict that arrives at 21 keys that way keeps a 64-slot table costing 1,176 B where
+        # one BUILT to the same 21 keys gets 32 slots and costs 640.
+        #
+        # 536 B on every cached record, for identical keys and identical values. Rebuilding by
+        # ITEMS is what reclaims it: `dict(record)` and `{**record}` both presize from the source's
+        # capacity and copy the oversize faithfully.
+        #
+        # This is the right site because it is the one both paths pass through. Doing it in
+        # `expand_interned_records` instead fixed the cold load and left the warm cache -- the one a
+        # long-running box actually serves from -- still paying, which is how the shortfall came to light.
+        #
+        # Measured on a 1 MB skill corpus, where skill_section and resource_chunk are 99.2% of rows:
+        # the container falls 1,173 -> 641 B/record, the whole cache 2,759 -> 2,227 B/record
+        # (-19.3%), for about 3% on a cold load.
+        oversized = _sys.getsizeof(record) > _right_sized_bytes(len(record))
         if replacements is None:
-            shared_out.append(record)
+            shared_out.append(dict(record.items()) if oversized else record)
         else:
-            copied = dict(record)
+            # `update` here only replaces values under keys the record already has, so it cannot
+            # grow the table it was just given.
+            copied = dict(record.items()) if oversized else dict(record)
             copied.update(replacements)
             shared_out.append(copied)
     return shared_out

--- a/tools/test_matrixark_a_cached_record_is_right_sized.py
+++ b/tools/test_matrixark_a_cached_record_is_right_sized.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""A cached record should not carry a dict table sized for twice the keys it holds.
+
+CPython grows a dict's table on insert and never shrinks it, and the table a dict ends on depends on
+HOW it was built rather than on what it holds. Expansion builds one the expensive way: copy the
+encoded record, drop the intern token, then put the bundle's fields back. A record that reaches 21
+keys that way keeps a 64-slot table and costs 1,176 B, where one built straight to the same 21 keys
+gets 32 slots and costs 640.
+
+That is 536 B on every cached record, for identical keys and identical values -- about 20% of the
+whole read cache on a 1 MB skill corpus, where skill_section and resource_chunk are 99.2% of rows.
+
+These tests pin the record as right-sized, and pin the reason, because the fix is one that a later
+refactor could undo without changing any behaviour a normal test would see.
+"""
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:  # package path
+    from tools.matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+except ImportError:
+    from matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def right_sized_bytes(key_count: int) -> int:
+    """What a dict BUILT to this many keys costs on this interpreter."""
+    probe = {}
+    for index in range(key_count):
+        probe["k%06d" % index] = index
+    return sys.getsizeof(probe)
+
+
+def skill_text(index: int, sections: int = 60) -> str:
+    lines = ["# Runbook %d" % index, "", "Draining a queue for case %d." % index, ""]
+    for step in range(sections):
+        lines += ["## Step %d" % step, "",
+                  "Check the queue depth for case %d step %d and drain the oldest partition."
+                  % (index, step), ""]
+    return "\n".join(lines)
+
+
+class CachedRecordIsRightSizedTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = Path(tempfile.mkdtemp(prefix="right_sized_"))
+        log = cls.root / "events.jsonl"
+        writer = MatrixArkLocalAdapter(log)
+        for index in range(2):
+            writer.ingest({
+                "kind": "skill", "scope": SCOPE, "text": skill_text(index),
+                "metadata": {"raw_uri": "file:///s/r-%d.md" % index, "title": "r-%d" % index},
+            })
+        writer.close(timeout_s=1800)
+        cls.records = MatrixArkLocalAdapter(log).read_all()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def test_the_interpreter_still_sizes_tables_by_how_they_were_built(self):
+        # The control for everything below. If a future CPython shrank tables on delete, or sized
+        # them purely by occupancy, this whole file would be pinning something that no longer
+        # exists -- and every assertion would pass while measuring nothing.
+        grown = {}
+        for index in range(40):
+            grown["field_%02d" % index] = index
+        for index in range(19):
+            del grown["field_%02d" % (39 - index)]
+        self.assertEqual(len(grown), 21)
+        self.assertGreater(
+            sys.getsizeof(grown), right_sized_bytes(21),
+            "this interpreter no longer over-allocates a grown-then-pruned dict, so the saving "
+            "these tests pin does not exist here")
+
+    def test_the_bulk_records_carry_no_spare_table(self):
+        for record_type in ("skill_section", "resource_chunk"):
+            rows = [r for r in self.records
+                    if str(r.get("record_type") or "") == record_type]
+            # Named before it is bounded: an assertion about every row passes hardest over none.
+            self.assertGreater(len(rows), 8, "no %s rows to check" % record_type)
+            for row in rows[:40]:
+                self.assertEqual(
+                    sys.getsizeof(row), right_sized_bytes(len(row)),
+                    "%s holds %d keys in a table sized for more: %d B against %d B right-sized"
+                    % (record_type, len(row), sys.getsizeof(row), right_sized_bytes(len(row))))
+
+    def test_right_sizing_changed_no_content(self):
+        # The saving must come from the table, never from the contents. A rebuild of a right-sized
+        # record is equal to it AND the same size.
+        rows = [r for r in self.records
+                if str(r.get("record_type") or "") == "skill_section"]
+        self.assertGreater(len(rows), 8)
+        for row in rows[:20]:
+            rebuilt = dict(row.items())
+            self.assertEqual(rebuilt, row, "a rebuild changed the record's contents")
+            self.assertEqual(sys.getsizeof(rebuilt), sys.getsizeof(row),
+                             "the served record is not already right-sized")
+
+    def test_the_interned_fields_really_are_present(self):
+        # The oversize came from putting the bundle back after the copy. If the bundle were no
+        # longer expanded onto the record, these rows would be right-sized for a different and
+        # much worse reason -- the fields would simply be missing.
+        rows = [r for r in self.records
+                if str(r.get("record_type") or "") == "skill_section"]
+        self.assertGreater(len(rows), 8)
+        carrying = [r for r in rows if r.get("storage_route")]
+        self.assertGreater(len(carrying), 0,
+                           "no skill_section carries storage_route, so the record is small "
+                           "because expansion stopped, not because the table was right-sized")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CPython grows a dict's table on insert and **never shrinks it**, and the table a dict ends on depends
on *how it was built* rather than on what it holds. Reproduced exactly:

```
grown to 40 keys then reduced to 21 : 1,176 B   <- what every cached record measured
built straight to 21 keys           :   640 B
```

Both paths into the read cache build records the expensive way. Expansion copies the encoded record
(16 keys), drops the intern token (15), then puts the bundle's six fields back (21). The append path
assembles field by field. Either way the record arrives at 21 keys holding a 64-slot table.

**536 B on every cached record, for identical keys and identical values.**

Which rebuild reclaims it is not obvious:

| rebuild | bytes | reclaims? |
|---|---|---|
| `dict(record)`, `{**record}` | 1,176 | **no** — both presize from the *source's* capacity |
| `dict(record.items())`, a comprehension, `dict(zip(...))`, an insert loop | **640** | yes, and equal |

## Where, and why not the obvious place

`share_repeated_values` is the site, because it is the one **both** paths pass through. Fixing
`expand_interned_records` instead repaired the cold load and left the **warm** cache — the one a
long-running box actually serves from — still at 1,176 B. The first version of the test missed that
too, because it read a warm cache; it now clears the process cache so both paths are covered.

Only records that are *actually* oversized are rebuilt, against a right-sized byte count measured
from the running interpreter and memoised by key count. Without that check every record is copied on
every cache rebuild and a cold load costs 8–16% more.

## What it is worth

Measured on a 1 MB skill corpus — the shape of the real workload, where `skill_section` and
`resource_chunk` are 99.2% of rows:

| | main | this branch |
|---|---|---|
| record container | 1,172.7 B/record | **641.3** (−45.3%) |
| whole read cache | 2,758.8 B/record | **2,227.4** (−19.3%) |
| projected over 2.35M records (1,000 × 1 MB skills) | 6.48 GB | **5.23 GB** |
| cold load, best of nine per arm, both orderings | 326.3 ms | 327.4 ms — level |

## Tests

Four, and two of them exist to stop the file pinning nothing:

- The **control** grows a dict to 40 keys, prunes it to 21, and asserts this interpreter still
  over-allocates. If a future CPython shrank tables on delete, every other assertion here would pass
  while measuring something that no longer exists.
- The **bulk types** are checked against a right-sized count computed at runtime rather than a
  literal, and each bound is preceded by an assertion that the type has rows — an upper bound on key
  count passes hardest over no rows at all.
- One test asserts the rebuild changed **no content**: the saving must come from the table, never
  from a dropped key.
- One asserts the interned fields are still **present**, so a record cannot look right-sized for the
  much worse reason that expansion stopped putting the bundle back.

Verified against `main`: two of the four fail there (`1176 != 640` and `640 != 1176`) and all four
pass here.

Full python suite on both arms, built with `git archive` from a branch rebased onto current main,
diffed by failing test name: **no failure on this branch that `main` does not already have.**
