### PR TITLE
A ratio cannot say what caused it

### DIFF
--- a/crates/temporalstore-rust/src/engine/tests/part1.rs
+++ b/crates/temporalstore-rust/src/engine/tests/part1.rs
@@ -8069,6 +8069,6 @@ fn emptied_buckets_are_dropped_without_walking_the_map() {
     // under 2x is not the walk coming back; timing on a shared machine is not tighter than this.
     assert!(
         growth < 2.0,
-        "per-write cost grew {growth:.2}x from a 2k to a 20k corpus -- the whole-map walk is back"
+        "per-write cost grew {growth:.2}x from a 2k to a 20k corpus. This asserts a RATIO and \n         cannot say what caused it: the by-name drop this test was written for is intact \n         (storage_bucket_internals.rs, `Drop buckets this call emptied -- BY NAME`), and \n         the growth reproduces at load 5 and at load 15 alike, so it is neither that walk \n         nor machine noise. Look for other per-write work that scales with the corpus."
     );
 }


### PR DESCRIPTION
`emptied_buckets_are_dropped_without_walking_the_map` fails on main reporting "the whole-map walk is back". **It is not back** -- the drop still runs over `touched_buckets` alone, exactly as its comment says. I read the code before believing the message.

What it measures is real and is not the machine: per-write cost grows **4.67x** from a 2k to a 20k corpus at load 5, and **4.68x** at load 15. Absolute numbers halve on a quiet box; the ratio does not move. Something on the write path scales with the corpus -- just not what the message names.

The assertion stays, because it is catching something. The message now states what was measured and what has been ruled out, so the next person does not start at the one mechanism already checked.

Context for whoever picks it up: the test was added by the change that removed the walk, so it passed then; two commits have touched the write path since, and a clean bisect between them needs care because the earlier one does not compile its own tests (repaired later by #848).