### PR TITLE
Measure the context surface beside the command one

### DIFF
--- a/crates/temporalstore-rust/src/proxy.rs
+++ b/crates/temporalstore-rust/src/proxy.rs
@@ -3560,6 +3560,26 @@ mod tests {
         let counts = probe.stop();
         rows.push(("GET /proxy/config", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
 
+        // The context surface, which carries a scope and a body rather than a shard id. Measured
+        // whole so it can be read against POST /execute above: same dispatcher, heavier request.
+        let ingest_body = context_ingest_body("acct", "t");
+        let _ = proxy.handle(crate::proxy::HttpRequest {
+            method: "POST".to_string(),
+            path: "/context/ingest".to_string(),
+            body: ingest_body.clone(),
+        });
+        let probe = crate::alloc_probe::Probe::start();
+        for _ in 0..ITERS {
+            let out = proxy.handle(crate::proxy::HttpRequest {
+                method: "POST".to_string(),
+                path: "/context/ingest".to_string(),
+                body: ingest_body.clone(),
+            });
+            std::hint::black_box(&out);
+        }
+        let counts = probe.stop();
+        rows.push(("POST /context/ingest", counts.allocs / ITERS as u64, counts.alloc_bytes / ITERS as u64));
+
         println!();
         println!("  path                    allocs/call   bytes/call");
         for (name, allocs, bytes) in &rows {


### PR DESCRIPTION
The probe covered admission, route lookup, resolving a table and a whole `POST /execute`. It did not cover `/context/*`, which is the surface this system is for.

| path | allocs | bytes |
|---|---|---|
| admit, one command | 1 | 1 |
| admit_context | 1 | 8 |
| cached route lookup | 1 | 11 |
| table_for_request | 3 | 11 |
| POST /execute, end to end | 16 | 1057 |
| GET /proxy/config | 6 | 1040 |
| **POST /context/ingest** | **49** | **2791** |

Admission is 1 of the 49, so 48 are parse and reply -- the same place the execute row put its fourteen, and three times as much of it.

Recorded, not optimised: the row exists to say where the next hour should go. A context request costs ~3x a command, and none of it is in the admission or routing code that has been worked on; shaving those further is shaving 2% of the cheaper request.