### PR TITLE
The idle-commit scan walked the whole store, twice, per query

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4546,6 +4546,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         # dirty_hash -> the newest summary-dirty or refresh-audit row, so the outstanding set
         # can be answered without reading everything. None until first use.
         self._summary_dirty_index: dict[Any, Json] | None = None
+        #: Pipeline-task rows, kept for the same reason the summary-dirty rows are: the
+        #: pre-retrieval idle-commit flush was scanning the WHOLE live view twice per query
+        #: to find them, and they are a handful of rows in a store of millions.
+        self._pipeline_task_index: list[Json] | None = None
         # model_ref -> {node_hash}, so 'is this node already embedded' does not read the
         # store. None until first use; see _existing_node_embedding_refs.
         self._node_embedding_refs_index: dict[str, set[int]] | None = None
@@ -5051,6 +5055,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None
+            self._pipeline_task_index = None
             self._node_embedding_refs_index = None
             self._read_cache_size = -1
             self._read_cache_mtime_ns = -1
@@ -5300,6 +5305,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._pipeline_task_index = None
                 self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
@@ -5339,6 +5345,12 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 if self._summary_dirty_index is not None:
                     for record in records:
                         self._note_summary_dirty_row(self._summary_dirty_index, record)
+                if self._pipeline_task_index is not None:
+                    for record in records:
+                        if (isinstance(record, dict)
+                                and str(record.get("record_type") or "")
+                                == "matrixark_async_pipeline_task"):
+                            self._pipeline_task_index.append(record)
                 if self._node_embedding_refs_index is not None:
                     for record in records:
                         self._note_node_embedding_ref(self._node_embedding_refs_index, record)
@@ -5363,6 +5375,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._pipeline_task_index = None
                 self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
@@ -5526,6 +5539,38 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._note_summary_dirty_row(index, record)
             self._summary_dirty_index = index
         return list(index.values())
+
+    def idle_commit_task_records(self, scope: Json) -> list[Json]:
+        """Only the pipeline-task rows, without walking the store.
+
+        `pre_retrieval_idle_commit_flush` looks for scheduled idle-commit tasks before every
+        retrieve. It prefers this method and falls back to `read_all()`, and the local adapter did
+        not offer it -- so the fallback ran, scanning the entire live view TWICE per query to find
+        rows that number in the handful. Profiled on a 1 MB corpus at 8,548 records, that flush was
+        68% of a settled retrieve.
+
+        The native reader has offered this since it was written; this is the same contract for the
+        python one. Scope is accepted and not filtered on here: the caller already applies
+        `scope_matches` to every row it considers, and narrowing twice would mean rebuilding this
+        index per scope rather than per cache generation.
+
+        Kept the way `_summary_dirty_rows` is kept -- built from one read the first time, folded
+        forward on append, and dropped whenever the cache it describes is.
+        """
+        index = self._pipeline_task_index
+        if index is None:
+            index = []
+            try:
+                live = self.read_all()
+            except (OSError, ValueError):
+                live = []
+            for record in live:
+                if (isinstance(record, dict)
+                        and str(record.get("record_type") or "")
+                        == "matrixark_async_pipeline_task"):
+                    index.append(record)
+            self._pipeline_task_index = index
+        return list(index)
 
     @staticmethod
     def _note_summary_dirty_row(index: dict[Any, Json], record: Json) -> None:
@@ -6137,6 +6182,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._pipeline_task_index = None
                 self._node_embedding_refs_index = None
                 self._read_cache_size = -1
                 self._read_cache_mtime_ns = -1
@@ -6210,6 +6256,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                 self._read_cache_value_keys = None
                 self._read_cache_state_keys = None
                 self._summary_dirty_index = None
+                self._pipeline_task_index = None
                 self._node_embedding_refs_index = None
                 self._read_cache_size = size
                 self._read_cache_mtime_ns = mtime_ns
@@ -6246,6 +6293,7 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             self._read_cache_value_keys = None
             self._read_cache_state_keys = None
             self._summary_dirty_index = None
+            self._pipeline_task_index = None
             self._node_embedding_refs_index = None
             self._read_cache_size = size
             self._read_cache_mtime_ns = mtime_ns

--- a/tools/test_matrixark_the_idle_commit_scan_is_indexed.py
+++ b/tools/test_matrixark_the_idle_commit_scan_is_indexed.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""`pre_retrieval_idle_commit_flush` runs before every retrieve to find scheduled idle-commit tasks.
+
+It prefers `idle_commit_task_records` on the target and falls back to `read_all()`. The native
+reader has offered that method since it was written; the local adapter did not, so the fallback ran
+and scanned the entire live view TWICE per query to find rows that number in the handful. Profiled
+on a 1 MB corpus at 8,548 records, that flush was 68% of a settled retrieve.
+
+These tests pin the index against the scan it replaces, in the three states where an index can go
+wrong: built cold, folded forward after an append, and rebuilt after the cache it describes is
+dropped. Task rows are APPENDED rather than hoped for -- the corpora these tests can build carry
+none of their own, and an index compared against an empty scan proves nothing. That is not
+hypothetical: it hid a real defect in the first version of this change, where the fold-forward sat
+inside another index's guard and never ran.
+"""
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+try:  # package path
+    from tools import matrixark_mcp_local_adapter as adapter_module
+    from tools.matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+except ImportError:
+    import matrixark_mcp_local_adapter as adapter_module
+    from matrixark_mcp_local_adapter import MatrixArkLocalAdapter
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+TASK_TYPE = "matrixark_async_pipeline_task"
+
+
+def task_row(index: int) -> dict:
+    return {
+        "record_type": TASK_TYPE,
+        "task_hash": 900000 + index,
+        "scheduled_task_hash": 900000 + index,
+        "status": "idle_commit_scheduled",
+        "scope": dict(SCOPE),
+        "access_scope": dict(SCOPE),
+    }
+
+
+def canonical(rows) -> str:
+    return json.dumps(rows, sort_keys=True, default=str)
+
+
+class IdleCommitScanIsIndexedTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="idle_index_"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.log = self.root / "events.jsonl"
+        writer = MatrixArkLocalAdapter(self.log)
+        for index in range(2):
+            writer.ingest({
+                "kind": "skill", "scope": SCOPE,
+                "text": "# Runbook %d\n\nDrain the queue for case %d.\n" % (index, index),
+                "metadata": {"raw_uri": "file:///s/r-%d.md" % index, "title": "r-%d" % index},
+            })
+        for index in range(4):
+            writer.append(task_row(index))
+        writer.close(timeout_s=600)
+
+    def scan(self, adapter) -> list:
+        """What the flush used to do: walk everything, keep one type."""
+        return [record for record in adapter.read_all()
+                if isinstance(record, dict)
+                and str(record.get("record_type") or "") == TASK_TYPE]
+
+    def test_the_hook_exists_at_all(self):
+        adapter = MatrixArkLocalAdapter(self.log)
+        self.assertTrue(callable(getattr(adapter, "idle_commit_task_records", None)),
+                        "without this method the flush falls back to scanning the whole store")
+
+    def test_it_returns_what_the_scan_returned(self):
+        adapter = MatrixArkLocalAdapter(self.log)
+        scanned = self.scan(adapter)
+        # The control. An index compared against an empty scan is equal for the wrong reason.
+        self.assertGreater(len(scanned), 0,
+                           "no task rows in the fixture, so the comparison below is vacuous")
+        self.assertEqual(canonical(adapter.idle_commit_task_records(SCOPE)), canonical(scanned))
+
+    def test_it_is_folded_forward_on_append(self):
+        adapter = MatrixArkLocalAdapter(self.log)
+        before = adapter.idle_commit_task_records(SCOPE)   # build it, so the append must maintain it
+        adapter.append(task_row(99))
+        scanned = self.scan(adapter)
+        self.assertGreater(len(scanned), len(before),
+                           "the append added no row, so the fold-forward is untested")
+        self.assertEqual(canonical(adapter.idle_commit_task_records(SCOPE)), canonical(scanned),
+                         "the index went stale against the cache after an append")
+
+    def test_a_fresh_reader_rebuilds_it(self):
+        adapter_module._LOCAL_READ_CACHE.clear()
+        fresh = MatrixArkLocalAdapter(self.log)
+        scanned = self.scan(fresh)
+        self.assertGreater(len(scanned), 0)
+        self.assertEqual(canonical(fresh.idle_commit_task_records(SCOPE)), canonical(scanned))
+
+    def test_the_pack_is_unchanged(self):
+        """The answer must not move. A faster retrieve that returns something else is not a saving."""
+        adapter = MatrixArkLocalAdapter(self.log)
+        query = {"scope": SCOPE, "query": "drain the queue", "limit": 8}
+        for _ in range(2):
+            adapter.retrieve(dict(query))
+        with_hook = adapter.retrieve(dict(query))
+
+        # Take the hook away so the flush uses the old fallback, on the SAME adapter and store.
+        hidden = type(adapter).idle_commit_task_records
+        try:
+            delattr(type(adapter), "idle_commit_task_records")
+            self.assertFalse(callable(getattr(adapter, "idle_commit_task_records", None)),
+                             "the hook is still reachable, so both sides are the same path")
+            for _ in range(2):
+                adapter.retrieve(dict(query))
+            without_hook = adapter.retrieve(dict(query))
+        finally:
+            type(adapter).idle_commit_task_records = hidden
+
+        self.assertEqual(canonical((with_hook or {}).get("selected_refs")),
+                         canonical((without_hook or {}).get("selected_refs")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`pre_retrieval_idle_commit_flush` runs before every retrieve to find scheduled idle-commit tasks.
It prefers `idle_commit_task_records` on the target and falls back to `read_all()`:

```python
idle_task_records = getattr(target, "idle_commit_task_records", None)
if callable(idle_task_records): records = idle_task_records(scope)
elif callable(read_all):        records = read_all()
```

The **native** reader has offered that method since it was written. The **local adapter never did**,
so the fallback ran — scanning the entire live view **twice per query** to find rows that number in
the handful.

Profiled on a 1 MB corpus at 8,548 records, that flush was **68% of a settled retrieve**.

## The change

The adapter now offers the same contract, backed by an index kept exactly the way the summary-dirty
rows are kept: built from one read the first time, folded forward on append, and dropped whenever
the cache it describes is.

Scope is accepted and not filtered on. The caller already applies `scope_matches` to every row it
considers, and narrowing here too would mean rebuilding the index per scope rather than per cache
generation.

## What it is worth

Measured on **one** store, with each arm given its own copy of it (reading a store rewrites its
snapshot, so a shared directory would have the second arm loading what the first wrote), both
orderings:

| arm | median | best |
|---|---|---|
| main | 29.33, 29.40 ms | 26.19, 26.57 |
| this branch | **10.76, 15.15 ms** | **9.51, 10.25** |

**−56% on the median, −62% on the best**, with the pack identical at 88,397 characters on both arms.

An earlier version of this comparison had each invocation ingest its own corpus. Ingest is not
deterministic — two runs of the *same* arm produced 8,545 and 8,560 records, different packs, and
10 ms against 29 ms. That variance was larger than the effect, so nothing could be read from it; the
shared-store design above is what made the result legible.

## Tests

Five, pinning the index against the scan it replaces in the three states where an index can go
wrong: built cold, folded forward after an append, and rebuilt after the cache it describes is
dropped. Plus one that the pack is unchanged — taking the hook away on the *same* adapter and store
so both sides differ only in which path the flush takes.

The fixture **appends** task rows rather than hoping the corpus carries some: the corpora buildable
here have none, and an index compared against an empty scan is equal for the wrong reason.

That is not hypothetical. It caught a real defect in the first version of this change, where the
fold-forward sat inside another index's guard *and* outside its loop — so it never ran, and only
ever saw the last record. It surfaced as scan 5 against index 4.

Verified against `main`: all five fail there (one assertion, four errors from the missing method) and
all five pass here.

Full python suite on both arms, built with `git archive` from a branch rebased onto current main,
diffed by failing test name: **101 failing names on each arm, identical sets** — nothing on this
branch that `main` does not already have.
