### PR TITLE
Write the snapshot delta from the append path

### DIFF
--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -115,8 +115,24 @@ LOCAL_READ_CACHE_COPY = os.environ.get("MATRIXARK_LOCAL_READ_CACHE_COPY", "1").s
 LOCAL_DURABLE_READ_CACHE_ENABLED = os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_ENABLED", "1").strip().lower() not in {"0", "false", "no"}
 # Records the tail file may hold before the base is folded back in. Bounds both the
 # delta file and the work a load does stitching it onto the base.
+# 250 rather than 2000, because the tail is now on the COLD path: a load stitches the delta onto the
+# base and compacts the result, and the delta is parsed a line at a time where the base is a single
+# bulk decode. Medians over four interleaved rounds of 60 ingest-then-read cycles:
+#
+#     cap      cold      read     ingest     delta
+#     main    77 ms     87 ms    319 ms         0
+#      250   119 ms     28 ms     97 ms       152
+#     2000   228 ms     26 ms     82 ms     1,386
+#
+# Past a couple of hundred the cap buys nothing a read or an ingest can feel and charges the cold
+# start for it. Raising it trades cold start for base rewrites; lowering it does the reverse.
+#
+# The cold start IS slower than it was -- about 42 ms here, and it does not go away by shrinking the
+# cap further, because most of it is the load-time compaction rather than the delta parse (at a cap
+# of 50, where the delta empties, cold still measured ~86 ms against main's ~64). It is paid once
+# per process, and one read plus one ingest already returns ~281 ms of it.
 LOCAL_DURABLE_READ_CACHE_MAX_DELTA = max(
-    1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "2000"))
+    1, int(os.environ.get("MATRIXARK_LOCAL_DURABLE_READ_CACHE_MAX_DELTA", "250"))
 )
 # No floor by default. One was added because the fallback rewrote the WHOLE record set as JSON
 # whenever the append-only path could not apply, which was almost every append -- so a delay
@@ -4841,9 +4857,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             return None
         # Compact what was stitched. The base is a checkpoint and the delta is what has been
         # appended since, so together they can hold rows the base recorded and a later append
-        # superseded. Compaction is what makes that correct, and it is what lets the writer
-        # stop caring whether the persisted prefix is still a prefix. Measured at 3.1 ms over
-        # 1,178 records against the 114 ms rewrite it removes.
+        # superseded. Compaction is what makes that correct, and it is what lets the writer stop
+        # caring whether the persisted prefix is still a prefix.
         return compact_and_apply_tombstones(expand_interned_records(records))
 
     def _durable_read_cache_tail_fingerprint(self) -> str:

--- a/tools/matrixark_mcp_local_adapter.py
+++ b/tools/matrixark_mcp_local_adapter.py
@@ -4839,7 +4839,12 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         recorded = head.get("tail_fingerprint")
         if recorded and records and _snapshot_prefix_fingerprint(records[-1]) != recorded:
             return None
-        return expand_interned_records(records)
+        # Compact what was stitched. The base is a checkpoint and the delta is what has been
+        # appended since, so together they can hold rows the base recorded and a later append
+        # superseded. Compaction is what makes that correct, and it is what lets the writer
+        # stop caring whether the persisted prefix is still a prefix. Measured at 3.1 ms over
+        # 1,178 records against the 114 ms rewrite it removes.
+        return compact_and_apply_tombstones(expand_interned_records(records))
 
     def _durable_read_cache_tail_fingerprint(self) -> str:
         """The fingerprint the head recorded, or "" when there is none to trust."""
@@ -4910,6 +4915,8 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
         force: bool = False,
         epoch: int | None = None,
         tail_only: bool = False,
+        appended_records: list[Json] | None = None,
+        pre_size: int | None = None,
     ) -> None:
         """Persist the read snapshot.
 
@@ -4953,7 +4960,11 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
             if recorded and recorded == _snapshot_prefix_fingerprint(records[persisted - 1]):
                 contiguous = True
 
-        def write_head(record_count: int, deltas: int) -> None:
+        def write_head(record_count: int, deltas: int, last_record: Json | None = None) -> None:
+            # The record this snapshot really ends on. It is records[-1] for a full rewrite, but
+            # the append path hands over what it wrote, which is not a slice of `records`.
+            persisted_last = last_record if last_record is not None else (
+                records[-1] if records else None)
             tmp = head_path.with_name(f"{head_path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
             with tmp.open("w", encoding="utf-8") as handle:
                 json.dump({
@@ -4964,10 +4975,64 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     "delta_count": deltas,
                     # The last record this snapshot holds, so another adapter over the same log
                     # can prove the file is a prefix of its own list -- see the contiguity check.
-                    "tail_fingerprint": _snapshot_prefix_fingerprint(records[-1]) if records else "",
+                    "tail_fingerprint": (
+                        _snapshot_prefix_fingerprint(persisted_last)
+                        if persisted_last is not None else ""
+                    ),
                 }, handle, separators=(",", ":"))
                 handle.write("\n")
             tmp.replace(head_path)
+
+        # The append path writes exactly the records it was handed, and asks nothing about
+        # whether the persisted prefix is still a prefix.
+        #
+        # That question is what forced the rewrite: ingest compacts, compaction removes rows
+        # from the middle, so the live list is usually NOT an extension of what is on disk and
+        # the slice below cannot apply. The load path compacts what it stitches instead, so a
+        # base holding rows that have since been superseded is reconciled rather than wrong.
+        #
+        # Safe because the append path never writes a record twice: what base+delta can contain
+        # is SUPERSEDED rows, and those are keyed, so compaction removes them. Duplicates would
+        # not be -- 56% of records have no latest-value key -- which is why the delta must carry
+        # what was appended and never a slice.
+        #
+        # Writing the head with the current signature is also what stops the READ path
+        # rewriting: `_refresh_durable_read_cache_if_behind` returns early when the recorded
+        # signature already matches.
+        #
+        # The one thing it must still establish is that the snapshot on disk describes the log as
+        # it stood BEFORE this write. Another writer -- in this process or another -- can have
+        # appended records that never passed through this instance, and extending the delta over
+        # them would publish a view that silently drops them: 55 records where the log holds 75.
+        # The head records the log it was stamped for, so requiring that to equal `pre_size` is
+        # exactly the question 'was I already behind?', and a no sends this write down the
+        # rewrite path where the full record set is reconciled.
+        head_signature = self._durable_read_cache_signature() or {}
+        covers_log_before_this_write = (
+            pre_size is not None
+            and int(head_signature.get("total_size", -1)) == int(pre_size)
+        )
+        if (
+            appended_records
+            and base_count > 0
+            and path.exists()
+            and covers_log_before_this_write
+            and delta_count + len(appended_records) <= LOCAL_DURABLE_READ_CACHE_MAX_DELTA
+        ):
+            try:
+                with delta_path.open("a", encoding="utf-8") as handle:
+                    for record in appended_records:
+                        handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+                write_head(base_count, delta_count + len(appended_records),
+                           appended_records[-1])
+                self._durable_read_cache_state = (
+                    self._cache_key_str(), base_count,
+                    delta_count + len(appended_records), epoch
+                )
+                self._durable_read_cache_last_write_ms = now
+                return
+            except (OSError, TypeError, ValueError):
+                pass   # fall through; a full rewrite also clears the partial tail
 
         # Append-only fast path. The base holds the whole record set, so rewriting it costs
         # O(corpus) JSON on every append -- and retrieval appends recall-reinforcement markers,
@@ -5395,9 +5460,10 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                     self._read_cache_size, self._read_cache_mtime_ns,
                     list(cached_records) + list(records))
                 _LOCAL_READ_CACHE_DIRTY.add(cache_key)
-                # No snapshot is taken from here while the entry is uncompacted: a cold reader
-                # is served the snapshot as-is, so writing this list would serve superseded and
-                # tombstoned records after a restart. The next read compacts and refreshes it.
+                # This entry is uncompacted, so no BASE may be written from it -- a cold reader
+                # would be served superseded and tombstoned records. The appended records are
+                # still handed to the snapshot below: they go to the delta, which is compacted
+                # at load, so they carry no such claim.
             elif self._read_cache_records is not None:
                 with self._read_cache_lock:
                     self._compact_read_cache_if_dirty_locked()
@@ -5407,20 +5473,29 @@ class MatrixArkLocalAdapter(_LocalAdapterRetrieveMixin, _LocalAdapterIngestMixin
                         list(self._read_cache_records),
                     )
                 _LOCAL_READ_CACHE_DIRTY.discard(cache_key)
-        if durable_records is not None:
-            # Only continue the tail here; never rewrite the whole base from a write.
-            #
-            # Ingest does not just append: compaction rewrites earlier records, so the list is
-            # usually not an extension of what is persisted and the tail cannot apply. Measured over
-            # 40 ingests, 173 snapshot writes, 146 of them full rewrites of the entire record set,
-            # which came to two thirds of the time an ingest took.
-            #
-            # The snapshot is derived state -- _load_durable_read_cache checks it against the log's
-            # signature and returns None on any mismatch, and the caller re-derives. Skipping a
-            # rewrite here costs a slower cold start until the next read, and the read path installs
-            # the records and writes the snapshot anyway.
-            self._write_durable_read_cache(
-                durable_records, signature, epoch=durable_epoch, tail_only=True)
+        # Only continue the tail here; never rewrite the whole base from a write.
+        #
+        # Ingest does not just append: compaction rewrites earlier records, so the list is
+        # usually not an extension of what is persisted and the tail cannot apply. Measured over
+        # 40 ingests, 173 snapshot writes, 146 of them full rewrites of the entire record set,
+        # which came to two thirds of the time an ingest took.
+        #
+        # The snapshot is derived state -- _load_durable_read_cache checks it against the log's
+        # signature and returns None on any mismatch, and the caller re-derives. Skipping a
+        # rewrite here costs a slower cold start until the next read, and the read path installs
+        # the records and writes the snapshot anyway.
+        #
+        # The appended records are handed over whether or not this instance holds a compact list.
+        # They were gated on one because the delta was replayed onto the base as-is; it is now
+        # compacted at load, so a delta carrying a since-superseded row is reconciled rather than
+        # wrong. That gate is what left the snapshot behind on every append made while the shared
+        # entry was dirty -- and a snapshot that is behind is rebuilt whole by the next read.
+        #
+        # `durable_records` remains the base-rewrite argument and stays empty when this instance
+        # cannot vouch for a compact list. With tail_only set, an empty list writes no base.
+        self._write_durable_read_cache(
+            list(durable_records or []), signature, epoch=durable_epoch, tail_only=True,
+            appended_records=list(records), pre_size=pre_size)
         if any(str(record.get("record_type") or "") in RETRIEVAL_HOT_RECORD_TYPES for record in records):
             with self._retrieval_records_cache_lock:
                 self._retrieval_records_cache_generation += 1

--- a/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
+++ b/tools/test_matrixark_the_snapshot_does_not_need_a_prefix.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MatrixArkAI
+"""The snapshot no longer needs the persisted prefix to still be a prefix.
+
+The tail could only ever be appended when the live list was an EXTENSION of what was on disk.
+Ingest compacts, and compaction removes records from the middle, so it usually was not -- and the
+fallback rewrote the entire record set as JSON on the read that followed every ingest.
+
+The delta is written by the APPEND path instead, carrying the records it was actually handed, and
+the load path compacts what it stitches. A base holding a row a later append superseded is then
+reconciled rather than wrong, so the writer can stop asking the question that forced the rewrite.
+
+What each test here guards, and how to check it still guards it:
+
+  * compacting at load          -- drop it and test_a_delete_survives_the_base_delta_seam fails
+  * the pre_size guard          -- drop it and the interloper test in test_incremental_read_cache
+                                   fails, serving 55 records where the log holds 75
+  * writing the delta on append -- drop it and test_a_read_leaves_a_current_snapshot_alone fails
+"""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.matrixark_mcp_local_adapter import (
+    MatrixArkLocalAdapter,
+    _LOCAL_READ_CACHE,
+    _LOCAL_READ_CACHE_LOCK,
+)
+
+SCOPE = {"tenant_id": "acme", "user_id": "dana", "session_id": "skills"}
+
+
+def _clear_process_read_cache() -> None:
+    with _LOCAL_READ_CACHE_LOCK:
+        _LOCAL_READ_CACHE.clear()
+
+
+def _body(tag: str) -> str:
+    return "\n".join(["# %s" % tag, ""] + ["Step %d for %s." % (i, tag) for i in range(12)])
+
+
+class SnapshotDoesNotNeedAPrefixTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.store = Path(self._dir.name)
+        self.log = self.store / "events.jsonl"
+        self.base = self.store / "events.jsonl.read-cache.json"
+        self.delta = self.store / ".events.jsonl.read-cache-delta.jsonl"
+        _clear_process_read_cache()
+        self.addCleanup(_clear_process_read_cache)
+
+    # -- helpers ---------------------------------------------------------------------------
+    def _ingest(self, tag, uri=None):
+        adapter = MatrixArkLocalAdapter(self.log)
+        result = adapter.ingest({
+            "kind": "skill",
+            "scope": SCOPE,
+            "text": _body(tag),
+            "metadata": {"raw_uri": uri or ("file:///s/%s.md" % tag), "title": tag},
+        })
+        adapter.close(timeout_s=3600)
+        return result
+
+    def _stamp(self):
+        if not self.base.exists():
+            return None
+        stat = self.base.stat()
+        return (stat.st_size, stat.st_mtime_ns)
+
+    def _delta_lines(self):
+        if not self.delta.exists():
+            return 0
+        with self.delta.open("r", encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+
+    def _snapshot_view(self):
+        """The view a cold reader is served, with the source it came from."""
+        _clear_process_read_cache()
+        reader = MatrixArkLocalAdapter(self.log)
+        return reader.read_all(), getattr(reader, "_read_cache_source", "?")
+
+    def _log_view(self):
+        """The same store rebuilt from the log alone, then restored exactly as it was."""
+        names = (
+            "events.jsonl.read-cache.json",
+            ".events.jsonl.read-cache-delta.jsonl",
+            ".events.jsonl.read-cache-head.json",
+        )
+        saved = {n: (self.store / n).read_bytes() for n in names if (self.store / n).exists()}
+        for name in saved:
+            (self.store / name).unlink()
+        _clear_process_read_cache()
+        try:
+            return MatrixArkLocalAdapter(self.log).read_all()
+        finally:
+            for name in names:
+                if (self.store / name).exists():
+                    (self.store / name).unlink()
+            for name, blob in saved.items():
+                (self.store / name).write_bytes(blob)
+            _clear_process_read_cache()
+
+    def _mentions(self, view, tag):
+        return sum(1 for record in view if tag in json.dumps(record, default=str))
+
+    def _delete(self, result):
+        memory_id = str((result or {}).get("event_id_hash") or (result or {}).get("id") or "")
+        self.assertTrue(memory_id, "ingest returned no id to delete")
+        adapter = MatrixArkLocalAdapter(self.log)
+        matched = len(adapter.records_for_delete(memory_id))
+        self.assertGreater(matched, 0, "the delete matched nothing, so it tombstones nothing")
+        adapter.delete_memory({"memory_id": memory_id})
+        adapter.close(timeout_s=3600)
+
+    # -- tests -----------------------------------------------------------------------------
+    def test_a_read_leaves_a_current_snapshot_alone(self):
+        """The read that follows an ingest used to rewrite the whole base.
+
+        The append writes its own records to the delta and stamps the head with the signature
+        they produced, so the read that follows finds the snapshot already describing this log
+        and has nothing to do. Asserted on the FILE, because that is where the cost was.
+        """
+        self._ingest("first")
+        MatrixArkLocalAdapter(self.log).read_all()          # checkpoint a base to extend
+        self.assertTrue(self.base.exists(), "no base was written, so this test cannot bind")
+        before, delta_before = self._stamp(), self._delta_lines()
+
+        self._ingest("second")
+        self.assertGreater(self._delta_lines(), delta_before,
+                           "the append wrote nothing to the delta")
+        self.assertEqual(before, self._stamp(),
+                         "the append rewrote the base instead of extending the delta")
+
+        _clear_process_read_cache()
+        MatrixArkLocalAdapter(self.log).read_all()
+        self.assertEqual(before, self._stamp(),
+                         "the read rewrote a base that already described this log")
+
+    def test_a_cold_reader_is_served_the_log_view(self):
+        """Base plus delta, compacted, is the view the log gives -- and it really came from the
+        snapshot, or every other assertion here passes emptily."""
+        self._ingest("alpha")
+        MatrixArkLocalAdapter(self.log).read_all()
+        for tag in ("beta", "gamma", "epsilon"):
+            self._ingest(tag)
+
+        view, source = self._snapshot_view()
+        self.assertEqual(source, "durable", "the snapshot did not serve the read")
+        self.assertGreater(self._delta_lines(), 0, "nothing was stitched, so the seam is untested")
+        self.assertEqual(self._log_view(), view)
+        for tag in ("alpha", "beta", "gamma", "epsilon"):
+            self.assertTrue(self._mentions(view, tag), "%s is missing from the cold view" % tag)
+
+    def test_a_delete_survives_the_base_delta_seam(self):
+        """A tombstone in the DELTA must remove a record held in the BASE.
+
+        Tombstones only remove records appearing before them, and compaction strips the markers,
+        so a delete has to stay visible across the seam. Without compacting at load, the deleted
+        document comes back after a restart.
+        """
+        result = self._ingest("doomed")
+        MatrixArkLocalAdapter(self.log).read_all()          # doomed is now IN the base
+        view, _ = self._snapshot_view()
+        self.assertTrue(self._mentions(view, "doomed"),
+                        "the document never reached the base, so the delete proves nothing")
+
+        self._delete(result)
+
+        view, _ = self._snapshot_view()
+        from_log = self._log_view()
+        self.assertEqual(from_log, view)
+        self.assertEqual(self._mentions(view, "doomed"), self._mentions(from_log, "doomed"),
+                         "the snapshot and the log disagree about a deleted document")
+
+    def test_a_record_written_after_a_tombstone_survives(self):
+        """The reverse ordering: a tombstone folded into the base must not remove a record
+        appended after it, even when that record reuses the deleted document's uri."""
+        result = self._ingest("condemned", uri="file:///s/reused.md")
+        MatrixArkLocalAdapter(self.log).read_all()
+        self._delete(result)
+        MatrixArkLocalAdapter(self.log).read_all()          # fold the tombstone into the base
+
+        self._ingest("survivor", uri="file:///s/reused.md")
+        view, _ = self._snapshot_view()
+        self.assertEqual(self._log_view(), view)
+        self.assertTrue(self._mentions(view, "survivor"),
+                        "a tombstone in the base removed a record appended after it")
+
+    def test_the_delta_stays_within_its_cap(self):
+        """The delta is bounded: past the cap the base is folded forward again, so a long-lived
+        store does not accumulate an unbounded tail for every load to stitch."""
+        from tools.matrixark_mcp_local_adapter import LOCAL_DURABLE_READ_CACHE_MAX_DELTA
+
+        self._ingest("seed")
+        MatrixArkLocalAdapter(self.log).read_all()
+        peak = 0
+        for index in range(12):
+            self._ingest("doc-%d" % index)
+            MatrixArkLocalAdapter(self.log).read_all()
+            peak = max(peak, self._delta_lines())
+        self.assertGreater(peak, 0, "the delta was never used, so the bound is untested")
+        self.assertLessEqual(peak, LOCAL_DURABLE_READ_CACHE_MAX_DELTA)
+
+        view, source = self._snapshot_view()
+        self.assertEqual(source, "durable")
+        self.assertEqual(self._log_view(), view)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The snapshot no longer needs the persisted prefix to still be a prefix.

## The problem

The durable read snapshot could only ever have its tail appended when the live record list was an
EXTENSION of what was on disk. Ingest does not just append -- it compacts, and compaction removes
records from the middle -- so the live list usually was not an extension, the slice could not apply,
and the fallback rewrote the entire record set as JSON.

That rewrite was paid on the read following every ingest, and it grows with the corpus.

## The change

    base  = a compacted checkpoint, rewritten only when the delta outgrows its cap
    delta = the records the APPEND path hands over, written on every append
    load  = compact_and_apply_tombstones(base + delta)

Because the load path compacts what it stitches, a base holding a row that a later append superseded
is reconciled rather than wrong -- so the writer can stop asking the question that forced the
rewrite. The appended records are handed over whether or not the instance holds a compact list; they
go to the delta, which carries no claim to be compact, rather than to the base, which does.

Two things keep it honest:

* **Duplicates would not survive compaction, so the delta carries what was appended and never a
  slice.** 56% of records have no latest-value key, so a doubled list survives compaction intact.
  The append path never writes a record twice; what base+delta can hold is SUPERSEDED rows, and
  those are keyed, so compaction removes them.
* **A write may only extend a snapshot that already describes the log as it stood before it.**
  Another writer can have appended records that never passed through this instance, and extending
  the delta over them would publish a view that silently drops them -- 55 records where the log
  holds 75. The head records the log it was stamped for, so requiring that to equal `pre_size` is
  exactly the question "was I already behind?", and a no falls through to the rewrite.

## Measured, and what it costs

Sixty ingest-then-read cycles, one arm per process, interleaved rounds because this box drifts.
Medians over four rounds:

|  | cold load | read | ingest | delta |
|---|---|---|---|---|
| main | 77 ms | 87 ms | 319 ms | 0 |
| this branch (cap 250) | 119 ms | 28 ms | 97 ms | 152 |
| cap 2000 | 228 ms | 26 ms | 82 ms | 1,386 |

**The cold start is genuinely slower -- about 42 ms.** Most of it is the load-time compaction rather
than parsing the delta, so it does not go away by shrinking the cap: at a cap of 50, where the delta
empties entirely, cold still measured ~86 ms against main's ~64. It is paid once per process, and
one read plus one ingest returns ~281 ms of it. The delta cap drops from 2,000 to 250, which is
where the per-operation win is intact and the cold cost is far off its 228 ms.

Structurally over ten ingest cycles: main rewrites the base 10 times out of 10 and never uses the
delta; this branch rewrites it 7 times with the delta at its 250 cap.

The two arms ended one run with different record counts -- 1492 against 1471. That is entirely
`context_index`, whose postings bucket per 60-second window: main's slower run crossed a minute
boundary and got two buckets where the branch's fit in one. Index NAME coverage is identical, 78 on
both, with none missing either way, and every document is represented in both.

## Tests

`test_matrixark_the_snapshot_does_not_need_a_prefix.py` covers the cold view, the bounded delta, and
both tombstone orderings -- a delete landing in the delta that must remove a record held in the
base, and a tombstone folded into the base that must not remove a record appended after it.

Every mechanism was mutation-tested and each is caught by the test that claims to guard it:

    the loader compacts what it stitches       -> test_a_delete_survives_the_base_delta_seam
    the pre_size guard                         -> the interloper test in test_incremental_read_cache
    the append path writes to the delta        -> test_a_read_leaves_a_current_snapshot_alone

Two further edits were written and then dropped rather than shipped, both because their mutations
survived and measuring showed they changed nothing: making the log re-derive path refresh only when
behind (the append path already keeps the head current), and skipping the load-time compaction when
the delta is empty (a read itself appends, so that state barely occurs). Both call sites match main.

The suite ratchet is red on eight `test_context_app_js_*` cases; all eight are red on main with the
same names, and main carries a ninth this branch does not.
