### PR TITLE
Frame the record without a second buffer

### DIFF
--- a/crates/temporalstore-rust/src/log_framing.rs
+++ b/crates/temporalstore-rust/src/log_framing.rs
@@ -163,6 +163,78 @@ pub(crate) fn encode_record_into(payload: &[u8], out: &mut Vec<u8>) {
     }
 }
 
+/// Frame a record whose length is known before it is written, with no payload buffer in between.
+///
+/// `encode_record_into` takes a payload that already exists, which means the payload was built in
+/// one buffer and copied into another. Both buffers are the size of the record. This writes the
+/// header, hands `write_payload` the same buffer to append into, and patches the checksum in
+/// afterwards -- so a write allocates nothing here and copies the payload once, into the bytes
+/// that go to the file.
+///
+/// The declared length is written BEFORE the payload, because the varint that carries it sits in
+/// front of it. That is the whole risk of this function: if `payload_len` disagrees with what
+/// `write_payload` appends, the frame declares a length the payload does not have, and every
+/// record after it in the file reads as garbage. So the disagreement is checked and returned as an
+/// error, with the buffer left cleared -- a caller cannot write the bad frame by ignoring it.
+pub(crate) fn encode_framed_into<E>(
+    payload_len: usize,
+    write_payload: impl FnOnce(&mut Vec<u8>) -> Result<(), E>,
+    out: &mut Vec<u8>,
+) -> Result<Result<(), E>, FrameLengthMismatch> {
+    out.clear();
+    if !binary_frame_enabled() {
+        // The line framing escapes the payload, so it has to see it whole first. Nothing to fuse.
+        let mut payload = Vec::with_capacity(payload_len);
+        if let Err(err) = write_payload(&mut payload) {
+            return Ok(Err(err));
+        }
+        out.extend_from_slice(&encode_line(&payload));
+        return Ok(Ok(()));
+    }
+    out.reserve(payload_len + 10);
+    out.push(FRAME_MAGIC_V3);
+    write_varint(payload_len as u64, out);
+    let checksum_at = out.len();
+    out.extend_from_slice(&[0u8; 4]);
+    let payload_at = out.len();
+    if let Err(err) = write_payload(out) {
+        out.clear();
+        return Ok(Err(err));
+    }
+    let written = out.len() - payload_at;
+    if written != payload_len {
+        out.clear();
+        return Err(FrameLengthMismatch {
+            declared: payload_len,
+            written,
+        });
+    }
+    let checksum = crate::checksum::crc32c(&out[payload_at..]);
+    out[checksum_at..checksum_at + 4].copy_from_slice(&checksum.to_le_bytes());
+    Ok(Ok(()))
+}
+
+/// A record that did not write the number of bytes it said it would.
+///
+/// Never expected to happen: it means an encoder's own length arithmetic disagrees with its
+/// writing. It is returned rather than asserted because the alternative to failing this write is
+/// writing a frame that makes the rest of the log unreadable.
+#[derive(Debug)]
+pub(crate) struct FrameLengthMismatch {
+    pub(crate) declared: usize,
+    pub(crate) written: usize,
+}
+
+impl std::fmt::Display for FrameLengthMismatch {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "record declared {} bytes and wrote {}",
+            self.declared, self.written
+        )
+    }
+}
+
 /// Prefix of the reclaim-base header, the optional first line of a log file.
 ///
 /// A reclaim drops a prefix of the file, shifting every surviving record down by the number of

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -2933,11 +2933,49 @@ fn append_record_locked(
     // Frame the record with a length + SHA-256 digest so a later value-preserving bit-flip in
     // this committed line is detected on read (see `crate::log_framing`). Offsets/stats below
     // use the real byte length, so framing is transparent to the append report and replication.
-    let payload = encode_wal_payload(record)?;
     // Taken out and returned below: framing borrows the buffer while the rest of `inner` is still
     // needed, and `mem::take` is the cheap way to say that without splitting the struct.
     let mut bytes = std::mem::take(&mut inner.encode_scratch);
-    crate::log_framing::encode_record_into(&payload, &mut bytes);
+    // BOTH flags, not just the first. The fused path writes the RAW marker and unescaped
+    // protobuf, which is what the length-prefixed frame wants and what the LINE frame cannot
+    // take: a line frame has to escape the newlines out of the payload first, and carries a
+    // different marker to say so. Fusing on `binary_records` alone wrote raw bytes into a line
+    // frame, and a value containing a newline then split into two unreadable records --
+    // `what_each_frame_costs_on_disk` toggles the frame flag precisely to catch that, and did.
+    if crate::wal_proto::binary_records_enabled() && crate::log_framing::binary_frame_enabled() {
+        // The payload lands directly in the frame. Building it separately meant carrying the
+        // record twice -- once into its own buffer and once into this one -- and at a four
+        // kilobyte value the second copy was four kilobytes of pure duplication.
+        let prepared = crate::wal_proto::prepare(record).map_err(|err| {
+            WriteAheadLogError::Corruption(format!("engine wal record encode failed: {err}"))
+        })?;
+        let written = crate::log_framing::encode_framed_into(
+            prepared.payload_len(),
+            |out| prepared.put(record, out),
+            &mut bytes,
+        );
+        match written {
+            // The record wrote a different number of bytes than it measured. The frame declares
+            // its length up front, so writing it would make every record after it unreadable --
+            // fail the append instead, with the buffer already cleared.
+            Err(mismatch) => {
+                inner.encode_scratch = bytes;
+                return Err(WriteAheadLogError::Corruption(format!(
+                    "engine wal record framing failed: {mismatch}"
+                )));
+            }
+            Ok(Err(err)) => {
+                inner.encode_scratch = bytes;
+                return Err(WriteAheadLogError::Corruption(format!(
+                    "engine wal record encode failed: {err}"
+                )));
+            }
+            Ok(Ok(())) => {}
+        }
+    } else {
+        let payload = encode_wal_payload(record)?;
+        crate::log_framing::encode_record_into(&payload, &mut bytes);
+    }
     // Close the block if this record will not fit in what is left of it, and start the next.
     //
     // A record is never split across the boundary: the one that does not fit moves whole into

--- a/crates/temporalstore-rust/src/wal_proto.rs
+++ b/crates/temporalstore-rust/src/wal_proto.rs
@@ -438,6 +438,42 @@ fn staged_block_body_len(page: &crate::wal::StagedPage) -> usize {
         }
 }
 
+/// A record measured but not yet written.
+///
+/// `encode` below builds the payload into its own buffer and the framing layer then copies it
+/// into a second one, so a write carries the record twice. Handing the framing layer a length and
+/// a writer instead lets it reserve once and have the payload land in the bytes that go to disk.
+///
+/// The length has to be exact, which is the whole reason this can exist: `RecordParts::len` is
+/// asserted equal to the bytes written, for every arm, by
+/// `the_borrowing_encoder_writes_the_same_bytes`.
+pub(crate) struct PreparedRecord<'a> {
+    parts: RecordParts<'a>,
+}
+
+impl PreparedRecord<'_> {
+    /// Bytes the payload will occupy: the marker, then the record.
+    pub(crate) fn payload_len(&self) -> usize {
+        self.parts.len + 1
+    }
+
+    pub(crate) fn put(
+        &self,
+        record: &WriteAheadLogRecord,
+        out: &mut Vec<u8>,
+    ) -> Result<(), String> {
+        out.push(RAW_PAYLOAD_MARKER);
+        self.parts.put(record, out)
+    }
+}
+
+/// Measure a record so it can be framed without an intermediate buffer.
+pub(crate) fn prepare(record: &WriteAheadLogRecord) -> Result<PreparedRecord<'_>, String> {
+    Ok(PreparedRecord {
+        parts: record_parts(record)?,
+    })
+}
+
 /// Encode a record as protobuf, marker byte first.
 pub(crate) fn encode(record: &WriteAheadLogRecord) -> Result<Vec<u8>, String> {
     let parts = record_parts(record)?;


### PR DESCRIPTION
An append built the record's payload into its own buffer, and the framing layer then copied that
buffer into the one that goes to disk. Both are the size of the record, so a write carried the
record twice — at a four kilobyte value, four kilobytes of pure duplication.

The frame declares its own length before the payload, so it can be reserved first and the payload
written straight into it. `encode_framed_into` writes the magic and the length, hands the encoder
that same buffer to append into, and patches the checksum in afterwards.

### Measured

Paired in one tree, alternating legs, both deterministic across two rounds:

| value | before | after | bytes saved |
|------:|-------:|------:|------------:|
| 64 B | 9.0 allocs, 320 B | 8.0 allocs, **225 B** | −29.7% |
| 256 B | 9.0, 516 B | 8.0, **225 B** | −56.4% |
| 1 KiB | 9.0, 1,288 B | 8.0, **230 B** | −82.1% |
| 4 KiB | 9.2, 4,384 B | 8.2, **253 B** | **−94.2%** |

Allocation amplification over the append falls from 1.07x to **0.06x** at 4 KiB. The payload stops
allocating per append at all — it lands in the scratch buffer the log already reuses — so what
remains is a flat ~225 B of fixed overhead that no longer grows with the value.

### The format does not move

This is a buffering change and must not alter a byte on disk.
`what_a_record_actually_costs_on_disk` reports **113.0 / 1077.0 / 4149.0 B/record** at 64 B, 1 KiB
and 4 KiB — identical to `main`.

### Why the length can be trusted

The frame commits to a length before the payload exists, so a length that disagreed with what was
written would make every record after it unreadable. Two things make that safe:

- `RecordParts::len` is asserted equal to the bytes written, for every arm, by
  `the_borrowing_encoder_writes_the_same_bytes` (#773). That assertion was added as a capacity
  check; it is what lets this exist.
- A disagreement is returned as an error with the buffer cleared, so a wrong length fails the
  append instead of writing a frame that corrupts the log.

### One defect worth naming

The first version guarded on `binary_records_enabled()` alone. The fused path writes the RAW
marker and unescaped protobuf, which is what a length-prefixed frame wants and what a LINE frame
cannot take — a line frame has to escape newlines out of the payload and carries a different
marker to say so. A value containing a newline then split into two unreadable records.

`what_each_frame_costs_on_disk` toggles the frame flag precisely to exercise that path, and caught
it. The guard now requires BOTH flags, with the reason written next to it.
