### PR TITLE
A backend failure goes to the log, and the caller gets a token for it

### DIFF
--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -42,6 +42,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from collections.abc import Mapping
 from typing import Any, Awaitable, Callable, Optional, Tuple
 from urllib.parse import parse_qs, unquote, urlparse
@@ -1124,6 +1125,49 @@ _HTML_SAFETY_HEADERS = _SAFETY_HEADERS + [
     (b"content-security-policy", _CONTENT_SECURITY_POLICY.encode("ascii")),
     (b"x-frame-options", b"DENY"),
 ]
+
+
+# A backend failure goes to the log; the caller gets a token that names it.
+#
+# `except Exception` catches whatever the backend raised -- an OSError naming a store directory, a
+# connection error naming an internal host and port, a driver message quoting the statement it
+# choked on. That text was returned to whoever made the call, including a service-key holder who is
+# not an operator here, and it was recorded nowhere: sanitising it alone would have closed the leak
+# by destroying the only copy, so both halves are done together.
+_GATEWAY_LOG = logging.getLogger("matrixark.gateway")
+
+# What the caller is told instead. Deliberately about the call and not about the deployment: which
+# storage this runs on and where it lives is not the caller's business.
+_FAILURE_DETAIL = {
+    "backend_error": "The backend could not complete this call.",
+    "backend_unavailable": "The backend could not be reached.",
+    "storage_quota_exceeded": "The storage quota for this deployment is exhausted.",
+    "settings_unavailable": "The settings registry could not be read.",
+    "extraction_failed": "Extraction did not finish; the write itself is durable.",
+}
+
+
+def _incident(scope: Json, code: str, exc: BaseException) -> str:
+    """Record one failure and return the token that names it.
+
+    ERROR level, so it is visible without configuring anything: with no handler installed Python
+    writes WARNING and above to stderr through its last-resort handler, which is where a container's
+    logs already go. A deployment that wants them elsewhere configures the `matrixark.gateway`
+    logger and this keeps working.
+    """
+    token = uuid.uuid4().hex[:12]
+    _GATEWAY_LOG.error("%s %s -> %s [incident %s]", scope.get("method", "?"),
+                       scope.get("path", "?"), code, token, exc_info=exc)
+    return token
+
+
+def _failure(scope: Json, code: str, exc: BaseException) -> Json:
+    """The body for a failure the caller must not be told the inside of."""
+    return {
+        "error": code,
+        "detail": _FAILURE_DETAIL.get(code, _FAILURE_DETAIL["backend_error"]),
+        "incident": _incident(scope, code, exc),
+    }
 
 
 async def _json(send: Callable, status: int, payload: Json,
@@ -3801,7 +3845,7 @@ async def _dispatch_direct(client: "DirectBackendClient", cfg: GatewayConfig, to
                            "detail": f"backend did not respond within {cfg.backend_timeout}s"}, rl_headers)
     except Exception as exc:
         return await _json(send, _classify_backend_error(exc),
-                           {"error": "backend_error", "detail": str(exc)}, rl_headers)
+                           _failure(scope, "backend_error", exc), rl_headers)
 
     if status >= 400:
         return await _json(send, status if status in (429, 507) else 502,
@@ -3988,7 +4032,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                     cfg.backend_timeout)
             except Exception as exc:
                 return await _json(send, 502,
-                                   {"error": "backend_unavailable", "detail": str(exc)})
+                                   _failure(scope, "backend_unavailable", exc))
             rows = (result or {}).get("audit_logs") if isinstance(result, dict) else None
             rows = rows if isinstance(rows, list) else []
             return await _json(send, 200, {
@@ -4017,7 +4061,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
             try:
                 snapshot["settings"] = _gwconfig.snapshot()
             except Exception as exc:  # never let the write-side registry break the read
-                snapshot["settings"] = {"status": "unavailable", "detail": str(exc)}
+                snapshot["settings"] = dict(_failure(scope, "settings_unavailable", exc),
+                                                    status="unavailable")
             return await _json(send, 200, snapshot)
 
         # ---- the deployment chooser (auth + admin scope) --------------------------------------
@@ -4505,7 +4550,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                 # A backend that cannot answer this must not read as "nothing is pending" -- the
                 # honest answer is that the state is unknown.
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             body = _ok_body(result)
             body["encoder"] = _encoder_summary()
             return await _json(send, 200, body)
@@ -4801,7 +4846,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             return await _json(send, 200, _ok_body(result))
 
         # ---- who holds memories: GET /v1/users (auth + context:retrieve) ---------------------
@@ -4837,7 +4882,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             return await _json(send, 200, _ok_body(result))
 
         # ---- skill / resource catalog (auth + resource:read / skill:read) --------------------
@@ -4888,7 +4933,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             return await _json(send, 200, _ok_body(result))
 
         # ---- enable / disable a skill (auth + skill:manage) ----------------------------------
@@ -4929,7 +4974,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             return await _json(send, 200, _ok_body(result))
 
         # ---- keyed recall via GET /v1/memory/by-key?identity_key=... (auth + context:retrieve) --
@@ -4969,7 +5014,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             if result.get("found") is False:
                 return await _json(send, 404, _ok_body(result))
             return await _json(send, 200, _ok_body(result))
@@ -5005,7 +5050,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"})
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)})
+                                   _failure(scope, "backend_error", exc))
             if tool == "matrixark_get_memory" and result.get("found") is False:
                 return await _json(send, 404, _ok_body(result))
             return await _json(send, 200, _ok_body(result))
@@ -5118,7 +5163,7 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                                    "detail": f"backend did not respond within {cfg.backend_timeout}s"}, rl_headers)
             except Exception as exc:
                 return await _json(send, _classify_backend_error(exc),
-                                   {"error": "backend_error", "detail": str(exc)}, rl_headers)
+                                   _failure(scope, "backend_error", exc), rl_headers)
             return await _json(send, 200, resp, rl_headers)
 
         args = parsed.get("arguments") if isinstance(parsed.get("arguments"), dict) else parsed
@@ -5190,8 +5235,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         except Exception as exc:
             status = _classify_backend_error(exc)
             body = {"error": "rate_limited"} if status == 429 else (
-                {"error": "storage_quota_exceeded", "detail": str(exc)} if status == 507
-                else {"error": "backend_error", "detail": str(exc)})
+                _failure(scope, "storage_quota_exceeded", exc) if status == 507
+                else _failure(scope, "backend_error", exc))
             headers = rl_headers + ([(b"retry-after", b"1")] if status == 429 else [])
             return await _json(send, status, body, headers)
 
@@ -5213,7 +5258,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                     out["extraction_error"] = "backend_timeout"
                 except Exception as exc:  # extraction failure must NOT lose the durable ingest
                     out["finalized"] = False
-                    out["extraction_error"] = str(exc)
+                    out["extraction_error"] = "extraction_failed"
+                    out["extraction_incident"] = _incident(scope, "extraction_failed", exc)
             elif args.get("idle_commit_timeout_ms"):
                 # Plain streaming ingest: register the scope so the gateway's background
                 # materializer drains its scheduled idle-commit after the debounce, making the

--- a/tools/portal/api_key_portal.html
+++ b/tools/portal/api_key_portal.html
@@ -1088,6 +1088,13 @@
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/api_portal.html
+++ b/tools/portal/api_portal.html
@@ -806,6 +806,13 @@
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -347,6 +347,13 @@ NAV_JS = r'''<script>
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/catalog_portal.html
+++ b/tools/portal/catalog_portal.html
@@ -923,6 +923,13 @@
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/explore_portal.html
+++ b/tools/portal/explore_portal.html
@@ -1880,6 +1880,13 @@
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/ingestion_portal.html
+++ b/tools/portal/ingestion_portal.html
@@ -815,6 +815,13 @@
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/overview_portal.html
+++ b/tools/portal/overview_portal.html
@@ -950,6 +950,13 @@ function liveStream(options) {
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2459,6 +2459,13 @@ function liveStream(options) {
     if (body.required && body.required.length) {
       text += " — this needs " + [].concat(body.required).join(" or ");
     }
+    /* A backend failure now answers with a sentence that deliberately says nothing about the
+       inside of the deployment, and a token naming the log entry that does. Showing the token is
+       the whole point of it: without it the reader has a polite sentence and no way to get any
+       further, and an operator has a log they cannot tie to the report. */
+    if (body.incident) {
+      text += " — incident " + body.incident;
+    }
     return text;
   };
 

--- a/tools/test_matrixark_a_backend_failure_goes_to_the_log.py
+++ b/tools/test_matrixark_a_backend_failure_goes_to_the_log.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A backend failure goes to the log, and the caller gets a token for it.
+
+Fourteen handlers caught ``Exception`` and returned ``str(exc)`` to whoever made the call. That text
+is whatever the backend raised -- an ``OSError`` naming a store directory, a connection error naming
+an internal host and port, a driver message quoting the statement it choked on. Six of those sit on
+routes reachable with a service key (``/v1/memories``, ``/v1/users``, ``/v1/skills``,
+``/v1/skills/update``, ``/v1/memory/by-key``, ``/v1/ingest_file``), so the reader is often an
+integrating application rather than an operator of the deployment.
+
+It was also recorded nowhere: the gateway had a single logging call in five thousand lines, so the
+exception text existed *only* in the response. Sanitising it on its own would have closed the leak by
+destroying the only copy, which is why both halves are one change and why the checks below assert
+both -- the text absent from the body **and** present in the log, tied together by a token.
+
+What is deliberately unchanged: every handler catching a *typed* exception. ``UnknownSetting``,
+``InvalidValue``, ``PathOutsideIngestionRoot``, ``JSONDecodeError`` and the rest carry messages
+written to be read -- "must be one of x, y" is the entire answer to a rejected setting. A change
+that made errors safer by making them useless would be the worse trade, so those are guarded here
+too.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_v1_gateway as gw  # noqa: E402
+
+PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+
+# Something a caller must never learn from an error: where this deployment keeps its pages.
+SECRET = "/srv/matrixark/store/shard-7/pages.db"
+
+# The routes whose reader is a service key, not an operator.
+SERVICE_ROUTES = [
+    ("POST", "/v1/memories"),
+    ("POST", "/v1/users"),
+    ("GET", "/v1/skills"),
+]
+
+
+def _drive(*args, **kwargs):
+    from test_matrixark_v1_gateway import drive
+    return drive(*args, **kwargs)
+
+
+class _Boom:
+    """A backend whose exception names something the caller must not learn."""
+
+    def __init__(self, message=None):
+        self.message = message or ("[Errno 13] Permission denied: '%s'" % SECRET)
+
+    def call_tool(self, name, args):
+        raise OSError(self.message)
+
+    def handle(self, body):
+        return {"jsonrpc": "2.0", "id": body.get("id"), "result": {}}
+
+
+class _Capture:
+    """Everything the gateway logger emits while this is held."""
+
+    def __enter__(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.handler.setFormatter(logging.Formatter("%(levelname)s %(name)s %(message)s"))
+        self.logger = logging.getLogger("matrixark.gateway")
+        self.previous = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.ERROR)
+        return self
+
+    def __exit__(self, *_exc):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.previous)
+        return False
+
+    @property
+    def text(self):
+        return self.stream.getvalue()
+
+
+def _call(method, path, server=None, body=None):
+    from test_matrixark_v1_gateway import _cfg
+    app = gw.make_v1_app(server or _Boom(), _cfg(require_auth=False))
+    with _Capture() as log:
+        status, _headers, payload = _drive(app, method=method, path=path,
+                                           body=body if body is not None else {"scope": {}})
+    return status, json.loads(payload), payload.decode("utf-8"), log.text
+
+
+class TheCallerIsNotToldTheInsideTest(unittest.TestCase):
+
+    def test_the_exception_text_does_not_reach_the_caller(self) -> None:
+        for method, path in SERVICE_ROUTES:
+            with self.subTest(route=path):
+                _st, _body, raw, _log = _call(method, path)
+                self.assertNotIn(SECRET, raw)
+                self.assertNotIn("Errno 13", raw)
+
+    def test_what_it_says_instead_is_about_the_call(self) -> None:
+        _st, body, _raw, _log = _call("POST", "/v1/memories")
+        self.assertEqual("backend_error", body["error"], "the machine-readable code is unchanged")
+        self.assertIn("could not complete", body["detail"])
+
+    def test_the_status_is_still_classified(self) -> None:
+        """The code and status are how a client decides what to do; only the prose changed."""
+        status, body, _raw, _log = _call("POST", "/v1/memories")
+        self.assertGreaterEqual(status, 500)
+        self.assertEqual("backend_error", body["error"])
+
+
+class TheOperatorIsTest(unittest.TestCase):
+
+    def test_the_exception_reaches_the_log(self) -> None:
+        """The half that makes the other half honest. Without it this change would close the leak
+        by throwing away the only copy of what went wrong."""
+        _st, _body, _raw, log = _call("POST", "/v1/memories")
+        self.assertIn(SECRET, log)
+
+    def test_with_a_traceback(self) -> None:
+        _st, _body, _raw, log = _call("POST", "/v1/memories")
+        self.assertIn("Traceback", log)
+
+    def test_the_log_names_the_call(self) -> None:
+        _st, _body, _raw, log = _call("POST", "/v1/users")
+        self.assertIn("POST", log)
+        self.assertIn("/v1/users", log)
+
+
+class TheTokenTiesThemTogetherTest(unittest.TestCase):
+
+    def test_the_body_carries_one(self) -> None:
+        _st, body, _raw, _log = _call("POST", "/v1/memories")
+        self.assertTrue(body.get("incident"), body)
+
+    def test_and_it_is_the_one_in_the_log(self) -> None:
+        """A token that did not match would be worse than none: it would look like an answer."""
+        _st, body, _raw, log = _call("POST", "/v1/memories")
+        self.assertIn(body["incident"], log)
+
+    def test_two_failures_are_told_apart(self) -> None:
+        _st1, first, _r1, _l1 = _call("POST", "/v1/memories")
+        _st2, second, _r2, _l2 = _call("POST", "/v1/memories")
+        self.assertNotEqual(first["incident"], second["incident"])
+
+    def test_it_is_short_enough_to_quote(self) -> None:
+        _st, body, _raw, _log = _call("POST", "/v1/memories")
+        self.assertRegex(body["incident"], r"^[0-9a-f]{8,16}$")
+
+
+class ItIsVisibleWithoutBeingConfiguredTest(unittest.TestCase):
+    """"Logged" must not mean "discarded". With no handler installed, Python writes WARNING and
+    above to stderr through its last-resort handler, which is where a container's logs go."""
+
+    def test_the_level_is_high_enough_to_survive_the_default(self) -> None:
+        logger = logging.getLogger("matrixark.gateway")
+        self.assertTrue(logger.isEnabledFor(logging.ERROR))
+
+    def test_the_last_resort_handler_would_take_it(self) -> None:
+        self.assertIsNotNone(logging.lastResort)
+        self.assertLessEqual(logging.lastResort.level, logging.ERROR)
+
+    def test_the_logger_is_named_so_a_deployment_can_redirect_it(self) -> None:
+        with io.open(gw.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn('logging.getLogger("matrixark.gateway")', source)
+
+
+class TheUsefulMessagesSurviveTest(unittest.TestCase):
+    """A change that made errors safer by making them useless would be the worse trade."""
+
+    def test_a_rejected_setting_still_says_what_is_wrong(self) -> None:
+        from test_matrixark_v1_gateway import _cfg
+        app = gw.make_v1_app(_Boom(), _cfg(require_auth=False))
+        status, _h, payload = _drive(app, method="POST", path="/v1/admin/config",
+                                     body={"settings": {"embedding.provider": "not-a-provider"}})
+        body = json.loads(payload)
+        self.assertEqual(400, status)
+        self.assertEqual("invalid_value", body["error"])
+        self.assertIn("embedding.provider", body["detail"],
+                      "the reader needs to know which setting and why")
+
+    def test_an_unknown_setting_still_names_it(self) -> None:
+        from test_matrixark_v1_gateway import _cfg
+        app = gw.make_v1_app(_Boom(), _cfg(require_auth=False))
+        _st, _h, payload = _drive(app, method="POST", path="/v1/admin/config",
+                                  body={"settings": {"no.such.setting": "1"}})
+        body = json.loads(payload)
+        self.assertEqual("unknown_setting", body["error"])
+        self.assertIn("no.such.setting", body["detail"])
+
+    def test_no_catch_all_handler_returns_the_exception_as_a_detail(self) -> None:
+        """The three routes called above are a sample; this covers the other eleven sites.
+
+        Worth having for a specific reason: the first mutation I ran against this file put the
+        exception text back on one site, and the sample passed -- the site it landed on was not one
+        of the three the sample calls. A sweep over the shapes is what makes reverting any of them
+        fail.
+        """
+        with io.open(gw.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        leaks = re.findall(
+            r'"error": "(backend_error|backend_unavailable|storage_quota_exceeded)",\s*'
+            r'"detail": str\(exc\)', source)
+        self.assertEqual([], leaks,
+                         "these hand a caught-anything exception straight to the caller: %r" % leaks)
+
+    def test_the_other_two_shapes_are_gone_too(self) -> None:
+        """The same leak wearing different clothes: one assigns into a snapshot, one into an
+        ingest response. Neither is a `detail` field, so the check above does not see them."""
+        with io.open(gw.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn('{"status": "unavailable", "detail": str(exc)}', source)
+        self.assertNotIn('out["extraction_error"] = str(exc)', source)
+
+    def test_the_typed_handlers_were_left_alone(self) -> None:
+        """Named so a later sweep cannot quietly generalise this change into them."""
+        with io.open(gw.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        for code in ("invalid_value", "unknown_setting", "unknown_preset", "invalid_plan"):
+            with self.subTest(code=code):
+                self.assertRegex(source, r'"error": "%s", "detail": str\(exc\)' % code)
+
+
+class ThePortalShowsTheTokenTest(unittest.TestCase):
+    """A polite sentence with no token leaves the reader nowhere to go and the operator with a log
+    they cannot tie to the report."""
+
+    def _why(self, page_name="api_portal.html"):
+        with io.open(os.path.join(PORTAL, page_name), encoding="utf-8") as handle:
+            page = handle.read()
+        at = page.index("window.__matrixarkWhy = function")
+        end = page.index("\n  };", at) + 5
+        return page[at:end]
+
+    def test_every_page_appends_the_incident(self) -> None:
+        missing = []
+        for name in sorted(os.listdir(PORTAL)):
+            if not name.endswith(".html"):
+                continue
+            with io.open(os.path.join(PORTAL, name), encoding="utf-8") as handle:
+                if 'incident " + body.incident' not in handle.read():
+                    missing.append(name)
+        self.assertEqual([], missing, missing)
+
+    def test_it_still_appends_the_scope_a_refusal_wanted(self) -> None:
+        """The helper had one job before this and must keep it."""
+        self.assertIn("this needs", self._why())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fourteen handlers caught `Exception` and returned `str(exc)` to whoever made the call. That text is
whatever the backend raised — an `OSError` naming a store directory, a connection error naming an
internal host and port, a driver message quoting the statement it choked on.

**Six sit on routes reachable with a service key** — `/v1/memories`, `/v1/users`, `/v1/skills`,
`/v1/skills/update`, `/v1/memory/by-key`, `/v1/ingest_file` — so the reader is often an integrating
application, not an operator of the deployment.

And it was recorded nowhere: the gateway had **one logging call in five thousand lines**, so the
exception text existed *only* in the response. Sanitising it alone would have closed the leak by
destroying the only copy. That is why both halves are one change.

### Before and after, on the same failure

```
OSError("[Errno 13] Permission denied: '/srv/matrixark/store/shard-7/pages.db'")

before  → caller: {"error":"backend_error","detail":"[Errno 13] Permission denied: '/srv/…'"}
          log:    nothing

after   → caller: {"error":"backend_error",
                   "detail":"The backend could not complete this call.",
                   "incident":"057dd6aa934b"}
          log:    ERROR matrixark.gateway POST /v1/memories -> backend_error [incident 057dd6aa934b]
                  Traceback (most recent call last): … PermissionError: … '/srv/…/pages.db'
```

The status and the error code are unchanged — they are what a client decides on. Only the prose moved.

### The token is the trade

Without it the reader has a polite sentence and nowhere to go, and an operator has a log they cannot
tie to a report. With it a support request quotes twelve hex characters and the exception is one
grep away. The portal appends it the way `__matrixarkWhy` already appends the scope a refusal
wanted:

```
insufficient_scope — this needs admin:audit
The backend could not complete this call. — incident 057dd6aa934b
extraction.provider must be one of x, y            (unchanged: a message written to be read)
```

### "Logged" must not mean "discarded"

ERROR level on a named logger. With nothing configured, Python writes WARNING and above to stderr
through its last-resort handler — where a container's logs already go — and a deployment that wants
them elsewhere configures `matrixark.gateway`. That is asserted, not assumed.

### The useful messages survive

Every handler catching a **typed** exception is untouched: `UnknownSetting`, `InvalidValue`,
`PathOutsideIngestionRoot`, `JSONDecodeError` and the rest carry messages written to be read. Making
errors safer by making them useless would be the worse trade, so those are guarded here too — a
rejected setting is driven through the real route, and the shapes that must survive are named.

### One mutation did not fail at first

```
revert one site       -> OK          ← the sample of three routes did not call that one
log at DEBUG          -> FAIL x4
token ≠ logged token  -> FAIL x4
generalise into typed -> FAIL x2
```

The first mutation put the exception text back on a route the three-route sample does not exercise,
and the sample passed. A sweep over the shapes was added for that reason; reverting **any** of the
fourteen now reddens it:

```
FAIL these hand a caught-anything exception straight to the caller: ['backend_error']
```

20 tests. Neighbours: v1_gateway 97, gateway_portal 60, json compression 12, page compression 21,
security headers 12, deployment routes 23, dashboards 20, gateway_events 12, embedding status 16,
api_traffic 15, audit log 18, portal_pages 4, scope-refusal wording 7 and 5, gateway_config 28,
ingest_file scope 6, readiness 13.
