### PR TITLE
One traffic table, whichever source drew it

### DIFF
--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2117,31 +2117,63 @@ SETUP_JS = r"""
     return series;
   }
 
+  /* One table, whichever source drew it.
+   *
+   * This panel is drawn twice: once at load from the /v1/metrics text, which needs no key and so
+   * works before the reader has authenticated, and again from every live frame. They used to build
+   * DIFFERENT tables -- four columns and then six -- so the panel changed shape under the reader on
+   * every load, and a deployment whose stream never connects stayed on the four-column one with
+   * nothing to say that a tail statistic existed.
+   *
+   * Callers normalise into {name, requests, statuses, errors, avg_ms, p95_ms} and this builds it.
+   * A column neither source can fill is a dash, not a missing column. */
+  function trafficTable(rows) {
+    if (!rows.length) {
+      return '<div class="empty">No requests recorded yet on this worker.</div>';
+    }
+    rows.sort(function (a, b) { return b.requests - a.requests; });
+    return "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
+      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" +
+      rows.map(function (row) {
+        return "<tr><td><span class='mono'>" + esc(row.name) + "</span></td><td class='num'>" +
+          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
+          (row.errors || 0) + "</td><td class='num'>" +
+          (row.avg_ms == null ? "—" : row.avg_ms + " ms") + "</td><td class='num'>" +
+          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
+      }).join("") + "</tbody></table>";
+  }
+
   function renderTraffic(series) {
     var byRoute = {};
+    function row(name) {
+      if (!byRoute[name]) {
+        byRoute[name] = { name: name, requests: 0, errors: 0, statuses: {},
+                          avg_ms: null, p95_ms: null };
+      }
+      return byRoute[name];
+    }
     (series.matrixark_gateway_requests_total || []).forEach(function (s) {
-      var r = byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 };
-      r.n += s.value;
-      if (parseInt(s.labels.status, 10) >= 400) { r.err += s.value; }
+      var r = row(s.labels.route);
+      r.requests += s.value;
+      /* The status is a label on this series and was being summed away into one "errors" number.
+         A route answering 401 to somebody with the wrong key read the same as one answering 500. */
+      r.statuses[s.labels.status] = (r.statuses[s.labels.status] || 0) + s.value;
+      if (parseInt(s.labels.status, 10) >= 400) { r.errors += s.value; }
     });
     (series.matrixark_gateway_request_duration_seconds_sum || []).forEach(function (s) {
-      (byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 }).sum = s.value;
+      row(s.labels.route).sum = s.value;
     });
     (series.matrixark_gateway_request_duration_seconds_count || []).forEach(function (s) {
-      (byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 }).cnt = s.value;
+      row(s.labels.route).cnt = s.value;
     });
-    var routes = Object.keys(byRoute).sort(function (a, b) { return byRoute[b].n - byRoute[a].n; });
-    if (!routes.length) {
-      $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
-      return;
-    }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Errors</th>" +
-      "<th>Mean latency</th></tr></thead><tbody>" + routes.map(function (r) {
-        var v = byRoute[r];
-        var mean = v.cnt ? (v.sum / v.cnt * 1000).toFixed(1) + " ms" : "—";
-        return "<tr><td><span class='mono'>" + esc(r) + "</span></td><td class='num'>" +
-          v.n + "</td><td class='num'>" + (v.err || 0) + "</td><td class='num'>" + mean + "</td></tr>";
-      }).join("") + "</tbody></table>";
+    $("traffic").innerHTML = trafficTable(Object.keys(byRoute).map(function (name) {
+      var r = byRoute[name];
+      r.avg_ms = r.cnt ? Math.round(r.sum / r.cnt * 100000) / 100 : null;
+      /* p95 stays empty here. The text carries the buckets, but walking them in JS beside the walk
+         the gateway already does in Python is two implementations of one quantile, which is how
+         they come to disagree. The first frame fills the column in. */
+      return r;
+    }));
   }
 
   function loadTraffic() {
@@ -2619,22 +2651,12 @@ SETUP_JS = r"""
   /* The same table the scrape used to draw, from the frame instead of a /v1/metrics parse. */
   function renderLiveTraffic(traffic) {
     var routes = (traffic || {}).routes || {};
-    var names = Object.keys(routes).sort(function (a, b) {
-      return routes[b].requests - routes[a].requests;
-    });
-    if (!names.length) {
-      $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
-      return;
-    }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
-      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" + names.map(function (name) {
-        var row = routes[name];
-        return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
-          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
-          (row.errors || 0) + "</td><td class='num'>" +
-          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td><td class='num'>" +
-          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
-      }).join("") + "</tbody></table>";
+    $("traffic").innerHTML = trafficTable(Object.keys(routes).map(function (name) {
+      var row = routes[name];
+      return { name: name, requests: row.requests, statuses: row.statuses,
+               errors: row.errors, avg_ms: row.avg_ms == null ? null : row.avg_ms,
+               p95_ms: row.p95_ms };
+    }));
   }
 
   /* What a route actually answered, in order. One "errors" count cannot tell a customer holding the

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -1862,31 +1862,63 @@ function liveStream(options) {
     return series;
   }
 
+  /* One table, whichever source drew it.
+   *
+   * This panel is drawn twice: once at load from the /v1/metrics text, which needs no key and so
+   * works before the reader has authenticated, and again from every live frame. They used to build
+   * DIFFERENT tables -- four columns and then six -- so the panel changed shape under the reader on
+   * every load, and a deployment whose stream never connects stayed on the four-column one with
+   * nothing to say that a tail statistic existed.
+   *
+   * Callers normalise into {name, requests, statuses, errors, avg_ms, p95_ms} and this builds it.
+   * A column neither source can fill is a dash, not a missing column. */
+  function trafficTable(rows) {
+    if (!rows.length) {
+      return '<div class="empty">No requests recorded yet on this worker.</div>';
+    }
+    rows.sort(function (a, b) { return b.requests - a.requests; });
+    return "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
+      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" +
+      rows.map(function (row) {
+        return "<tr><td><span class='mono'>" + esc(row.name) + "</span></td><td class='num'>" +
+          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
+          (row.errors || 0) + "</td><td class='num'>" +
+          (row.avg_ms == null ? "—" : row.avg_ms + " ms") + "</td><td class='num'>" +
+          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
+      }).join("") + "</tbody></table>";
+  }
+
   function renderTraffic(series) {
     var byRoute = {};
+    function row(name) {
+      if (!byRoute[name]) {
+        byRoute[name] = { name: name, requests: 0, errors: 0, statuses: {},
+                          avg_ms: null, p95_ms: null };
+      }
+      return byRoute[name];
+    }
     (series.matrixark_gateway_requests_total || []).forEach(function (s) {
-      var r = byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 };
-      r.n += s.value;
-      if (parseInt(s.labels.status, 10) >= 400) { r.err += s.value; }
+      var r = row(s.labels.route);
+      r.requests += s.value;
+      /* The status is a label on this series and was being summed away into one "errors" number.
+         A route answering 401 to somebody with the wrong key read the same as one answering 500. */
+      r.statuses[s.labels.status] = (r.statuses[s.labels.status] || 0) + s.value;
+      if (parseInt(s.labels.status, 10) >= 400) { r.errors += s.value; }
     });
     (series.matrixark_gateway_request_duration_seconds_sum || []).forEach(function (s) {
-      (byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 }).sum = s.value;
+      row(s.labels.route).sum = s.value;
     });
     (series.matrixark_gateway_request_duration_seconds_count || []).forEach(function (s) {
-      (byRoute[s.labels.route] = byRoute[s.labels.route] || { n: 0, err: 0 }).cnt = s.value;
+      row(s.labels.route).cnt = s.value;
     });
-    var routes = Object.keys(byRoute).sort(function (a, b) { return byRoute[b].n - byRoute[a].n; });
-    if (!routes.length) {
-      $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
-      return;
-    }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Errors</th>" +
-      "<th>Mean latency</th></tr></thead><tbody>" + routes.map(function (r) {
-        var v = byRoute[r];
-        var mean = v.cnt ? (v.sum / v.cnt * 1000).toFixed(1) + " ms" : "—";
-        return "<tr><td><span class='mono'>" + esc(r) + "</span></td><td class='num'>" +
-          v.n + "</td><td class='num'>" + (v.err || 0) + "</td><td class='num'>" + mean + "</td></tr>";
-      }).join("") + "</tbody></table>";
+    $("traffic").innerHTML = trafficTable(Object.keys(byRoute).map(function (name) {
+      var r = byRoute[name];
+      r.avg_ms = r.cnt ? Math.round(r.sum / r.cnt * 100000) / 100 : null;
+      /* p95 stays empty here. The text carries the buckets, but walking them in JS beside the walk
+         the gateway already does in Python is two implementations of one quantile, which is how
+         they come to disagree. The first frame fills the column in. */
+      return r;
+    }));
   }
 
   function loadTraffic() {
@@ -2364,22 +2396,12 @@ function liveStream(options) {
   /* The same table the scrape used to draw, from the frame instead of a /v1/metrics parse. */
   function renderLiveTraffic(traffic) {
     var routes = (traffic || {}).routes || {};
-    var names = Object.keys(routes).sort(function (a, b) {
-      return routes[b].requests - routes[a].requests;
-    });
-    if (!names.length) {
-      $("traffic").innerHTML = '<div class="empty">No requests recorded yet on this worker.</div>';
-      return;
-    }
-    $("traffic").innerHTML = "<table><thead><tr><th>Route</th><th>Requests</th><th>Answers</th>" +
-      "<th>Errors</th><th>Mean</th><th>95% within</th></tr></thead><tbody>" + names.map(function (name) {
-        var row = routes[name];
-        return "<tr><td><span class='mono'>" + esc(name) + "</span></td><td class='num'>" +
-          row.requests + "</td><td>" + statusChips(row.statuses) + "</td><td class='num'>" +
-          (row.errors || 0) + "</td><td class='num'>" +
-          (row.avg_ms ? row.avg_ms + " ms" : "—") + "</td><td class='num'>" +
-          (row.p95_ms == null ? "—" : "~" + row.p95_ms + " ms") + "</td></tr>";
-      }).join("") + "</tbody></table>";
+    $("traffic").innerHTML = trafficTable(Object.keys(routes).map(function (name) {
+      var row = routes[name];
+      return { name: name, requests: row.requests, statuses: row.statuses,
+               errors: row.errors, avg_ms: row.avg_ms == null ? null : row.avg_ms,
+               p95_ms: row.p95_ms };
+    }));
   }
 
   /* What a route actually answered, in order. One "errors" count cannot tell a customer holding the

--- a/tools/portal/traffic_table_harness.js
+++ b/tools/portal/traffic_table_harness.js
@@ -1,0 +1,133 @@
+/* The traffic panel is drawn from two sources. They must draw the same table.
+ *
+ * At load the Setup page reads /v1/metrics and parses the Prometheus text -- that needs no key, so
+ * it works before the reader has authenticated. A second later the first live frame arrives and
+ * redraws the same element from the metrics snapshot.
+ *
+ * They used to build different tables: four columns from the scrape, six from the frame. The panel
+ * changed shape under the reader on every load, and a deployment whose stream never connects stayed
+ * on the four-column one -- with no way to tell that a tail statistic existed at all.
+ *
+ * Two builders producing "the same" table is not something source reading settles, so both are run
+ * over equivalent inputs and their output compared.
+ *
+ * Usage: node traffic_table_harness.js <setup_portal.html>
+ */
+"use strict";
+const fs = require("fs");
+
+const page = fs.readFileSync(process.argv[2], "utf8");
+
+let failures = 0;
+function ok(what, condition, detail) {
+  if (condition) { console.log("ok   " + what); }
+  else { console.log("FAIL " + what + (detail ? "\n     " + detail : "")); failures += 1; }
+}
+
+function slice(name) {
+  const at = page.indexOf("function " + name + "(");
+  if (at === -1) { return null; }
+  let depth = 0;
+  for (let i = page.indexOf("{", at); i < page.length; i += 1) {
+    if (page[i] === "{") { depth += 1; }
+    else if (page[i] === "}") {
+      depth -= 1;
+      if (depth === 0) { return page.slice(at, i + 1); }
+    }
+  }
+  return null;
+}
+
+const parts = ["statusChips", "trafficTable", "renderTraffic", "renderLiveTraffic"];
+const sliced = {};
+for (const name of parts) {
+  sliced[name] = slice(name);
+  ok("the page defines " + name, !!sliced[name]);
+}
+if (parts.some((n) => !sliced[n])) { console.log("FAILED " + failures); process.exit(1); }
+
+ok("both renderers go through one builder",
+   /trafficTable\(/.test(sliced.renderTraffic) && /trafficTable\(/.test(sliced.renderLiveTraffic),
+   "two builders is how the two views came to disagree");
+
+function run(which, argument) {
+  const written = { html: "" };
+  const env = {
+    $: () => ({ set innerHTML(v) { written.html = v; }, get innerHTML() { return written.html; } }),
+    esc: (s) => String(s == null ? "" : s),
+  };
+  const src = sliced.statusChips + "\n" + sliced.trafficTable + "\n" + sliced[which]
+    + "\n; return " + which + ";";
+  new Function(...Object.keys(env), src)(...Object.values(env))(argument);
+  return written.html;
+}
+
+function headers(html) {
+  const row = /<thead><tr>([\s\S]*?)<\/tr>/.exec(html);
+  return row ? row[1].match(/<th>([^<]*)<\/th>/g).map((h) => h.replace(/<\/?th>/g, "")) : null;
+}
+
+/* ---------- the same deployment, described by each source ---------- */
+const scrape = run("renderTraffic", {
+  matrixark_gateway_requests_total: [
+    { labels: { route: "/v1/retrieve", method: "POST", status: "200" }, value: 90 },
+    { labels: { route: "/v1/retrieve", method: "POST", status: "401" }, value: 10 },
+    { labels: { route: "/v1/ingest", method: "POST", status: "202" }, value: 5 },
+  ],
+  matrixark_gateway_request_duration_seconds_sum: [
+    { labels: { route: "/v1/retrieve" }, value: 2.0 },
+  ],
+  matrixark_gateway_request_duration_seconds_count: [
+    { labels: { route: "/v1/retrieve" }, value: 100 },
+  ],
+});
+
+const frame = run("renderLiveTraffic", {
+  routes: {
+    "/v1/retrieve": { requests: 100, errors: 10, statuses: { "200": 90, "401": 10 },
+                      avg_ms: 20, p95_ms: 250 },
+    "/v1/ingest": { requests: 5, errors: 0, statuses: { "202": 5 }, avg_ms: null, p95_ms: null },
+  },
+});
+
+ok("the scrape draws a table", /<table>/.test(scrape));
+ok("the frame draws a table", /<table>/.test(frame));
+ok("both draw the same columns",
+   JSON.stringify(headers(scrape)) === JSON.stringify(headers(frame)),
+   JSON.stringify(headers(scrape)) + " vs " + JSON.stringify(headers(frame)));
+ok("and the columns are the six the frame can fill",
+   JSON.stringify(headers(frame)) ===
+     JSON.stringify(["Route", "Requests", "Answers", "Errors", "Mean", "95% within"]),
+   JSON.stringify(headers(frame)));
+
+/* ---------- what each source can actually say ---------- */
+ok("the scrape shows the status breakdown it was throwing away",
+   /200×90/.test(scrape) && /401×10/.test(scrape),
+   "a route answering 401 read the same as one answering 500");
+ok("the scrape marks a 4xx as bad", /status-chip bad/.test(scrape));
+ok("the scrape computes the mean it can", /20 ms/.test(scrape), scrape.slice(0, 200));
+ok("the scrape leaves the tail column empty rather than guessing",
+   !/~\d+ ms/.test(scrape),
+   "computing it here would be a second implementation of the gateway's bucket walk");
+ok("the frame fills the tail column", /~250 ms/.test(frame));
+
+/* ---------- ordering and emptiness ---------- */
+ok("the busiest route is first in both",
+   scrape.indexOf("/v1/retrieve") < scrape.indexOf("/v1/ingest")
+   && frame.indexOf("/v1/retrieve") < frame.indexOf("/v1/ingest"));
+
+const emptyScrape = run("renderTraffic", {});
+const emptyFrame = run("renderLiveTraffic", { routes: {} });
+ok("an empty deployment reads the same either way", emptyScrape === emptyFrame,
+   emptyScrape + " vs " + emptyFrame);
+ok("and says so rather than drawing an empty table", /No requests recorded/.test(emptyFrame));
+
+/* ---------- a column nobody can fill is a dash, not a missing column ---------- */
+ok("a route with no timing keeps its row", /\/v1\/ingest/.test(frame));
+const ingestRow = /<tr>(?:(?!<\/tr>)[\s\S])*\/v1\/ingest[\s\S]*?<\/tr>/.exec(frame);
+ok("and shows a dash where the number is unknown",
+   ingestRow && (ingestRow[0].match(/—/g) || []).length >= 2,
+   ingestRow && ingestRow[0]);
+
+console.log(failures === 0 ? "PASS" : "FAILED " + failures);
+process.exit(failures === 0 ? 0 : 1);

--- a/tools/test_matrixark_one_traffic_table.py
+++ b/tools/test_matrixark_one_traffic_table.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The traffic panel draws the same table whichever source drew it.
+
+Setup draws that panel from two places. At load it reads ``/v1/metrics`` and parses the Prometheus
+text -- which needs no key, so it works before the reader has authenticated to anything. A moment
+later the first live frame arrives and redraws the same element from the metrics snapshot.
+
+They built different tables::
+
+    scrape   Route | Requests | Errors | Mean latency
+    frame    Route | Requests | Answers | Errors | Mean | 95% within
+
+So the panel changed shape under the reader on every load. Worse, a deployment whose stream never
+connects -- an enforced one with no key in the box -- stayed on the four-column table, with nothing
+to say that a tail statistic existed. The mean is the one the metrics module itself dismisses:
+*"fifty requests at 3 ms and one at nine seconds average out to something describing neither"*.
+
+One builder now, two callers normalising into it. The scrape fills five of the six columns: the
+status breakdown was in the ``status`` label all along and was being summed away, so a route
+answering 401 to somebody with the wrong key read the same as one answering 500.
+
+It leaves *95% within* empty. The text carries the buckets, but walking them in JS beside the walk
+the gateway already does in Python is two implementations of one quantile, which is how they come to
+disagree -- and the first frame fills the column in a second later.
+
+Two builders producing "the same" table is not something reading the source settles, so both are run
+over equivalent inputs and their output compared.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+import shutil
+import subprocess
+import unittest
+
+TOOLS = os.path.dirname(os.path.abspath(__file__))
+PORTAL = os.path.join(TOOLS, "portal")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+HARNESS = os.path.join(PORTAL, "traffic_table_harness.js")
+
+
+def page() -> str:
+    with io.open(PAGE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class ThereIsOneBuilderTest(unittest.TestCase):
+
+    def test_the_page_defines_it_once(self) -> None:
+        self.assertEqual(1, page().count("function trafficTable("))
+
+    def test_both_renderers_use_it(self) -> None:
+        source = page()
+        for name in ("renderTraffic", "renderLiveTraffic"):
+            with self.subTest(renderer=name):
+                start = source.index("function %s(" % name)
+                body = source[start:source.index("\n  }", start)]
+                self.assertIn("trafficTable(", body)
+
+    def test_no_second_traffic_table_is_built_by_hand(self) -> None:
+        """The header row is the tell: two of them meant two tables that could differ."""
+        self.assertEqual(1, page().count("<th>Requests</th>"))
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class BothSourcesDrawTheSameTableTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_the_columns_match(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   both draw the same columns", out)
+        self.assertIn("ok   and the columns are the six the frame can fill", out)
+
+    def test_an_empty_deployment_reads_the_same_either_way(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   an empty deployment reads the same either way", out)
+        self.assertIn("ok   and says so rather than drawing an empty table", out)
+
+    def test_the_busiest_route_is_first_in_both(self) -> None:
+        self.assertIn("ok   the busiest route is first in both", self._run().stdout)
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class WhatEachSourceCanSayTest(unittest.TestCase):
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_scrape_shows_the_answers_it_was_discarding(self) -> None:
+        """The status is a label on the counter series. Summed away, a route answering 401 to
+        somebody with the wrong key was indistinguishable from one answering 500."""
+        out = self._run().stdout
+        self.assertIn("ok   the scrape shows the status breakdown it was throwing away", out)
+        self.assertIn("ok   the scrape marks a 4xx as bad", out)
+
+    def test_the_scrape_does_not_guess_the_tail(self) -> None:
+        """Computing it here would be a second implementation of the gateway's bucket walk, and the
+        first frame fills the column in a second later."""
+        self.assertIn("ok   the scrape leaves the tail column empty rather than guessing",
+                      self._run().stdout)
+
+    def test_the_frame_fills_the_tail(self) -> None:
+        self.assertIn("ok   the frame fills the tail column", self._run().stdout)
+
+    def test_an_unknown_number_is_a_dash_not_a_missing_row(self) -> None:
+        """A route with no timing yet still has requests worth showing."""
+        out = self._run().stdout
+        self.assertIn("ok   a route with no timing keeps its row", out)
+        self.assertIn("ok   and shows a dash where the number is unknown", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Setup page draws its traffic panel from two places. At load it reads `/v1/metrics` and parses the
Prometheus text — that needs no key, so it works before the reader has authenticated to anything. A
moment later the first live frame arrives and redraws **the same element** from the metrics snapshot.

They built different tables:

```
scrape   Route | Requests | Errors | Mean latency
frame    Route | Requests | Answers | Errors | Mean | 95% within
```

So the panel **changed shape under the reader on every load**. Worse: a deployment whose stream never
connects — an enforced one with no key in the box — stayed on the four-column table, with nothing to
say that a tail statistic existed at all.

And the column it did show is the one the metrics module itself dismisses, in its own comment beside
`p95_ms`:

> fifty requests at 3 ms and one at nine seconds average out to something describing neither

### One builder, two callers

Callers normalise into `{name, requests, statuses, errors, avg_ms, p95_ms}` and one function builds
the table. A column neither source can fill is a dash, not a missing column.

The scrape now fills **five of the six**. The status breakdown was in the `status` label all along
and was being summed away into a single "errors" number — so a route answering 401 to somebody with
the wrong key read exactly like one answering 500. It now shows `200×90` `401×10`, with 4xx and 5xx
marked.

It leaves **95% within** empty. The text carries the buckets, but walking them in JS beside the walk
the gateway already does in Python is two implementations of one quantile, which is how they come to
disagree — and the first frame fills the column in a second later.

### Run, not read

Two builders producing "the same" table is not something reading the source settles, so both are run
over equivalent inputs and their output compared.

```
give the scrape its own table again -> FAIL both draw the same columns (+2)
throw the status labels away again  -> FAIL the scrape shows the status breakdown (+1)
let the scrape guess a tail number  -> FAIL the scrape leaves the tail column empty rather than guessing
```

11 tests, 19 harness assertions. Neighbours: portal_pages 4, api_traffic 15, live_strip 38,
navigable panels 8, portal_tabs 19, config-change 13, hidden tabs 8, shared stylesheet 6, warning
styling 4, dashboards 20.
