### PR TITLE
The failures panel names the log entry for each failure

### DIFF
--- a/tools/matrixark_gateway_metrics.py
+++ b/tools/matrixark_gateway_metrics.py
@@ -148,7 +148,8 @@ class GatewayMetrics:
         # Route label, method, status, time. Nothing that identifies who made the request: the
         # portal shows this to anyone who can read it, and identity added here would be invisible
         # in the panel and permanent in the process.
-        self._failures: Deque[Tuple[float, str, str, int]] = deque(maxlen=RECENT_FAILURES)
+        self._failures: Deque[Tuple[float, str, str, int, str]] = deque(
+            maxlen=RECENT_FAILURES)
 
         # The last datanode probe: (state, when). Set by the readiness route, published on scrape.
         # Not probed here -- a metrics endpoint that opens an outbound connection is one that can
@@ -167,7 +168,7 @@ class GatewayMetrics:
                 self._in_flight -= 1
 
     def record(self, path: str, method: str, status: int, duration_s: float,
-               request_bytes: int = 0, response_bytes: int = 0) -> None:
+               request_bytes: int = 0, response_bytes: int = 0, incident: str = "") -> None:
         route = route_label(path)
         # A long-lived stream is one request that lasts minutes. Its duration is not a latency and
         # putting it in the histogram poisons every quantile drawn across routes -- a p99 of ten
@@ -204,7 +205,7 @@ class GatewayMetrics:
             if response_bytes:
                 self._resp_bytes[route] = self._resp_bytes.get(route, 0) + int(response_bytes)
             if status >= 400:
-                self._failures.append((time.time(), route, method, status))
+                self._failures.append((time.time(), route, method, status, incident))
 
     def note_datanode(self, state: str) -> None:
         """Record what the readiness probe just found."""
@@ -250,8 +251,11 @@ class GatewayMetrics:
                 # Newest first, because a panel reads top-down and the useful one is the last thing
                 # that happened.
                 "recent_failures": [
-                    {"at": round(at, 3), "route": route, "method": method, "status": status}
-                    for at, route, method, status in reversed(self._failures)
+                    # The token only where there is one: a refusal mints none, and an empty field
+                    # on every row would be weight on a frame that goes to every open panel.
+                    dict({"at": round(at, 3), "route": route, "method": method, "status": status},
+                         **({"incident": incident} if incident else {}))
+                    for at, route, method, status, incident in reversed(self._failures)
                 ],
             }
 

--- a/tools/matrixark_v1_gateway.py
+++ b/tools/matrixark_v1_gateway.py
@@ -1136,6 +1136,15 @@ _HTML_SAFETY_HEADERS = _SAFETY_HEADERS + [
 # by destroying the only copy, so both halves are done together.
 _GATEWAY_LOG = logging.getLogger("matrixark.gateway")
 
+# The incident minted while serving this request, if one was.
+#
+# It is minted inside a handler and the request is recorded in the wrapper's `finally`, after that
+# handler has returned, so something has to carry it the few frames up. A context variable does --
+# the same way the request's Accept-Encoding reaches the response helpers -- and asyncio copies the
+# context per task, so one request cannot read another's.
+_INCIDENT: "contextvars.ContextVar[str]" = contextvars.ContextVar(
+    "matrixark_incident", default="")
+
 # What the caller is told instead. Deliberately about the call and not about the deployment: which
 # storage this runs on and where it lives is not the caller's business.
 _FAILURE_DETAIL = {
@@ -1156,6 +1165,7 @@ def _incident(scope: Json, code: str, exc: BaseException) -> str:
     logger and this keeps working.
     """
     token = uuid.uuid4().hex[:12]
+    _INCIDENT.set(token)
     _GATEWAY_LOG.error("%s %s -> %s [incident %s]", scope.get("method", "?"),
                        scope.get("path", "?"), code, token, exc_info=exc)
     return token
@@ -3927,6 +3937,9 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
         # encoding without being handed the scope. Before the legacy branch as well: those
         # responses go through the same helpers.
         _ACCEPT_ENCODING.set(_headers_map(scope).get("accept-encoding", ""))
+        # Cleared per request: a connection can serve several, and a token left behind would
+        # attach the previous failure's log entry to this one.
+        _INCIDENT.set("")
 
         # First HTTP request on this loop/worker installs the sized threadpool (if configured).
         if not executor_state["installed"]:
@@ -5314,7 +5327,8 @@ def make_v1_app(server: Any, config: Any = None) -> Callable[..., Awaitable[None
                     scope.get("path", ""), scope.get("method", ""), observed["status"],
                     time.time() - started,
                     request_bytes=observed["request_bytes"],
-                    response_bytes=observed["response_bytes"])
+                    response_bytes=observed["response_bytes"],
+                    incident=_INCIDENT.get(""))
             except Exception:  # pragma: no cover - metrics must never break a response
                 pass
 

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -2694,11 +2694,16 @@ SETUP_JS = r"""
       return;
     }
     $("failures").innerHTML =
-      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th></tr></thead>" +
+      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th>" +
+      "<th>Incident</th></tr></thead>" +
       "<tbody>" + rows.map(function (row) {
+        /* Always a column, a dash where there is none. Most rows here are refusals -- a 401 for a
+           wrong key mints no incident, because nothing went wrong inside -- and a column that came
+           and went with the data would shift the table under whoever is reading it. */
         return "<tr><td>" + esc(agoText(row.at)) + "</td><td><span class='status-chip bad'>" +
           esc(String(row.status)) + "</span></td><td class='mono'>" + esc(row.method || "") +
-          "</td><td class='mono'>" + esc(row.route || "") + "</td></tr>";
+          "</td><td class='mono'>" + esc(row.route || "") + "</td><td class='mono'>" +
+          (row.incident ? esc(row.incident) : "—") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
   /* Leaving with unsaved edits loses them silently otherwise; on a form this long that is a

--- a/tools/portal/failures_panel_harness.js
+++ b/tools/portal/failures_panel_harness.js
@@ -30,7 +30,10 @@ const FRAME = {
                         statuses: { "200": 1, "401": 1, "503": 1 } }
     },
     recent_failures: [
-      { at: NOW - 5, route: "/v1/retrieve", method: "POST", status: 503 },
+      /* A backend failure carries the token its exception was logged under; a refusal does not,
+         because nothing went wrong inside to log. Both shapes are here on purpose. */
+      { at: NOW - 5, route: "/v1/retrieve", method: "POST", status: 503,
+        incident: "9f2c41ab77de" },
       { at: NOW - 400, route: "/v1/retrieve", method: "POST", status: 401 },
       { at: NOW - 7200, route: "/v1/memories", method: "GET", status: 404 }
     ]
@@ -138,6 +141,16 @@ setTimeout(function () {
   ok("minutes read as minutes", /\b7m ago\b/.test(fails), fails.slice(0, 300));
   ok("hours read as hours", /\b2h ago\b/.test(fails), fails.slice(0, 400));
   ok("newest is first", fails.indexOf("503") < fails.indexOf("401"), fails.slice(0, 300));
+  /* Every backend failure now mints an incident token: the caller is told it and the exception is
+     logged under it. Without it here, an operator reading "503 on /v1/retrieve, 5 seconds ago" has
+     to guess at timestamps in a log that may hold many. */
+  ok("a failure that carries a token shows it", /9f2c41ab77de/.test(fails), fails.slice(0, 500));
+  ok("the column is there even for the rows without one", /<th>Incident<\/th>/.test(fails),
+     "most rows here are refusals, which mint none; a column that came and went with the data "
+     + "would shift the table under whoever is reading it");
+  ok("a row without one shows a dash rather than an empty cell", /—/.test(fails),
+     fails.slice(0, 700));
+
   ok("no identity is rendered",
      !/tenant|api[_-]?key|user_id|acme/i.test(fails), fails.slice(0, 300));
 

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -2432,11 +2432,16 @@ function liveStream(options) {
       return;
     }
     $("failures").innerHTML =
-      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th></tr></thead>" +
+      "<table><thead><tr><th>When</th><th>Status</th><th>Method</th><th>Route</th>" +
+      "<th>Incident</th></tr></thead>" +
       "<tbody>" + rows.map(function (row) {
+        /* Always a column, a dash where there is none. Most rows here are refusals -- a 401 for a
+           wrong key mints no incident, because nothing went wrong inside -- and a column that came
+           and went with the data would shift the table under whoever is reading it. */
         return "<tr><td>" + esc(agoText(row.at)) + "</td><td><span class='status-chip bad'>" +
           esc(String(row.status)) + "</span></td><td class='mono'>" + esc(row.method || "") +
-          "</td><td class='mono'>" + esc(row.route || "") + "</td></tr>";
+          "</td><td class='mono'>" + esc(row.route || "") + "</td><td class='mono'>" +
+          (row.incident ? esc(row.incident) : "—") + "</td></tr>";
       }).join("") + "</tbody></table>";
   }
   /* Leaving with unsaved edits loses them silently otherwise; on a form this long that is a

--- a/tools/test_matrixark_the_failure_panel_names_the_log_entry.py
+++ b/tools/test_matrixark_the_failure_panel_names_the_log_entry.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A recorded failure names the log entry that explains it.
+
+Every backend failure mints an incident token: the caller is told it, and the exception is logged
+under it. The panel listing recent failures did not carry it, so an operator reading *"500 on
+/v1/memories, 40 seconds ago"* had to guess at timestamps in a log that may hold many.
+
+The token exists by the time the failure is recorded -- it is minted inside the handler, and the
+request is recorded in the wrapper's ``finally`` after that handler returns -- but nothing carried it
+the few frames up the stack. A context variable does, the same way the request's ``Accept-Encoding``
+reaches the response helpers, and it is cleared at the top of every request: a connection serves
+several, and a token left behind would attach one failure's log entry to another's row. That is
+asserted, not assumed.
+
+The column is always present, with a dash where there is none. Most rows in this ring are refusals
+-- a 401 for a wrong key mints no incident, because nothing went wrong inside -- and a column that
+came and went with the data would be the shape-shifting table its neighbour was just fixed for.
+
+This file also gives ``failures_panel_harness.js`` an owner. It had none: every other harness in
+that directory is run by a test named after it, and this one sat with fifteen assertions that never
+executed. It passes against the current pages, so it was not stale -- just unreachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import matrixark_gateway_metrics as gwm  # noqa: E402
+import matrixark_v1_gateway as gw  # noqa: E402
+
+PORTAL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "portal")
+HARNESS = os.path.join(PORTAL, "failures_panel_harness.js")
+PAGE = os.path.join(PORTAL, "setup_portal.html")
+
+SECRET = "/srv/matrixark/store/shard-7/pages.db"
+
+
+class _Boom:
+    """A backend that fails the way a real one does: with something in the message."""
+
+    def call_tool(self, name, args):
+        raise OSError("[Errno 13] Permission denied: '%s'" % SECRET)
+
+    def handle(self, body):
+        return {"jsonrpc": "2.0", "id": body.get("id"), "result": {}}
+
+
+class _Quiet:
+    def call_tool(self, name, args):
+        return {"ok": name}
+
+    def handle(self, body):
+        return {"jsonrpc": "2.0", "id": body.get("id"), "result": {}}
+
+
+def _drive(*args, **kwargs):
+    from test_matrixark_v1_gateway import drive
+    return drive(*args, **kwargs)
+
+
+def _two_requests_in_one_task(app, first, second):
+    """Serve two requests without a fresh context between them.
+
+    `drive` uses asyncio.run per call, so every request it makes starts from a clean context. That
+    is the wrong shape for asking whether something is left behind BETWEEN requests, so these two
+    are awaited in one task -- which is what a server reusing a task for a keep-alive connection
+    gives you.
+    """
+    bodies = []
+
+    async def once(method, path, payload):
+        sent = []
+
+        async def receive():
+            return {"type": "http.request", "body": json.dumps(payload).encode(),
+                    "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        await app({"type": "http", "method": method, "path": path,
+                   "query_string": b"", "headers": []}, receive, send)
+        bodies.append(b"".join(m.get("body", b"") for m in sent
+                               if m["type"] == "http.response.body"))
+
+    async def both():
+        await once(*first)
+        await once(*second)
+
+    asyncio.run(both())
+    return bodies
+
+
+def _app(server):
+    from test_matrixark_v1_gateway import _cfg
+    return gw.make_v1_app(server, _cfg(require_auth=False))
+
+
+class _CaptureLog:
+    def __enter__(self):
+        self.stream = io.StringIO()
+        self.handler = logging.StreamHandler(self.stream)
+        self.logger = logging.getLogger("matrixark.gateway")
+        self.previous = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.ERROR)
+        return self
+
+    def __exit__(self, *_exc):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.previous)
+        return False
+
+    @property
+    def text(self):
+        return self.stream.getvalue()
+
+
+def _failure_rows():
+    return gwm.METRICS.snapshot().get("recent_failures", [])
+
+
+class TheRecordedFailureCarriesTheTokenTest(unittest.TestCase):
+
+    def test_the_caller_the_panel_and_the_log_agree(self) -> None:
+        """Three copies of one token. Any two disagreeing would be worse than none, because a
+        mismatched token looks like an answer."""
+        with _CaptureLog() as log:
+            _st, _h, payload = _drive(_app(_Boom()), method="POST", path="/v1/memories",
+                                      body={"scope": {}})
+        told = json.loads(payload)["incident"]
+        rows = [r for r in _failure_rows() if r.get("incident") == told]
+        self.assertTrue(rows, "no recorded failure carries the token the caller was given")
+        self.assertIn(told, log.text)
+        self.assertEqual("/v1/memories", rows[0]["route"])
+
+    def test_a_refusal_carries_none(self) -> None:
+        """Nothing went wrong inside, so there is no log entry to name. An empty token here would
+        point at nothing."""
+        _st, _h, _b = _drive(_app(_Quiet()), method="GET", path="/v1/nope")
+        for row in _failure_rows():
+            if row.get("status") == 404 and row.get("route") not in ("", None):
+                self.assertNotIn("incident", row,
+                                 "a refusal was given a token that names no log entry")
+
+    def test_one_request_does_not_inherit_anothers(self) -> None:
+        """A connection serves several requests. A token left in place would attach the previous
+        failure's log entry to this row, and an operator following it would find the wrong thing.
+
+        Driven through one task on purpose. The suite's own `drive` calls asyncio.run per request,
+        which hands each one a fresh context -- so it cannot show a token surviving into the next
+        request, which is exactly what the reset prevents. Two awaits in one task share a context,
+        the way a server reusing a task for a keep-alive connection would.
+        """
+        app = _app(_Boom())
+        with _CaptureLog():
+            first, second = _two_requests_in_one_task(
+                app,
+                ("POST", "/v1/memories", {"scope": {}}),
+                ("GET", "/v1/nope", {}))
+        told = json.loads(first)["incident"]
+        self.assertTrue(told, "the first request did not mint one, so this proves nothing")
+        stale = [r for r in _failure_rows()
+                 if r.get("status") == 404 and r.get("incident") == told]
+        self.assertEqual([], stale, "a later failure inherited an earlier request's token")
+
+
+class TheRecorderStillWorksWithoutOneTest(unittest.TestCase):
+
+    def test_record_takes_it_optionally(self) -> None:
+        """Anything already calling record() keeps working; the argument is new and defaults."""
+        gwm.METRICS.record("/v1/retrieve", "POST", 500, 0.01)
+        self.assertTrue(any(r["status"] == 500 for r in _failure_rows()))
+
+    def test_a_failure_recorded_without_one_has_no_token(self) -> None:
+        gwm.METRICS.record("/v1/retrieve", "POST", 502, 0.01)
+        rows = [r for r in _failure_rows() if r["status"] == 502]
+        self.assertTrue(rows)
+        self.assertNotIn("incident", rows[0])
+
+
+@unittest.skipUnless(shutil.which("node"), "node is not installed; the page JS cannot be run")
+class ThePanelShowsItTest(unittest.TestCase):
+    """Also the owner this harness never had: it carried fifteen assertions and no test ran it."""
+
+    def _run(self):
+        return subprocess.run(["node", HARNESS, PAGE], capture_output=True, text=True, timeout=300)
+
+    def test_the_harness_passes(self) -> None:
+        proc = self._run()
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+    def test_a_failure_that_carries_a_token_shows_it(self) -> None:
+        self.assertIn("ok   a failure that carries a token shows it", self._run().stdout)
+
+    def test_the_column_does_not_come_and_go(self) -> None:
+        out = self._run().stdout
+        self.assertIn("ok   the column is there even for the rows without one", out)
+        self.assertIn("ok   a row without one shows a dash rather than an empty cell", out)
+
+    def test_the_assertions_it_already_had_still_run(self) -> None:
+        """The point of giving it an owner: these were never executed before."""
+        out = self._run().stdout
+        for line in ("ok   the failures panel drew the failures",
+                     "ok   newest is first",
+                     "ok   the tail is shown, not just the mean",
+                     "ok   no identity is rendered"):
+            with self.subTest(line=line):
+                self.assertIn(line, out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every backend failure now mints an incident token: the caller is told it, and the exception is logged
under it (#867). The panel listing **recent failures** did not carry it — so an operator reading
*"500 on /v1/memories, 40 seconds ago"* had to guess at timestamps in a log that may hold many.

The token exists by the time the failure is recorded — it is minted inside the handler, and the
request is recorded in the wrapper's `finally` after that handler returns — but nothing carried it
the few frames up the stack. A context variable does, the same way the request's `Accept-Encoding`
reaches the response helpers.

```
caller  {"error":"backend_error", … ,"incident":"38d19767f9ed"}
panel   POST /v1/memories  500  40s ago   38d19767f9ed
log     ERROR matrixark.gateway POST /v1/memories -> backend_error [incident 38d19767f9ed]
```

### The column does not come and go

Always present, with a dash where there is none. Most rows in this ring are **refusals** — a 401 for
a wrong key mints no incident, because nothing went wrong inside — and a column that appeared and
disappeared with the data would be the shape-shifting table #868 was just fixed for.

### A harness that nothing ran

`failures_panel_harness.js` had no owner. Every other harness in that directory is run by a test
named after it; this one sat with **fifteen assertions that never executed**. It passes against the
current pages, so it was not stale — just unreachable. This gives it one, and the new assertions go
in it rather than beside it.

### One mutation did not fail at first

```
record the failure without the token -> FAIL caller / panel / log agree
drop the column when a row lacks one -> FAIL the column does not come and go (+1)
stop clearing the token per request  -> OK      ← wrong
```

The suite's `drive` calls `asyncio.run` per request, so every request starts from a **fresh
context** — it cannot show a token surviving into the next one, which is exactly what the reset
prevents. The check now drives two requests through **one task**, the way a server reusing a task
for a keep-alive connection would, and the mutation fails properly:

```
FAIL a later failure inherited an earlier request's token
     [{'route': '/v1/nope', 'status': 404, 'incident': '38d19767f9ed'}]
```

9 tests, 18 harness assertions (15 of them running for the first time). Neighbours: v1_gateway 97,
gateway_portal 60, api_traffic 15, failure logging 20, traffic table 11, dashboards 20, portal_pages
4, live_strip 38, failure_log 15, readiness 13, json compression 12.
