### PR TITLE
Make the flag inventory complete, and remove three config keys that do nothing

### DIFF
--- a/config/temporalstore.toml
+++ b/config/temporalstore.toml
@@ -86,7 +86,6 @@ index_dump_oplog_gap_bytes = 1048576   # TS_INDEX_DUMP_OPLOG_GAP_BYTES  undumped
 # multi-barrier write path + delta-fold recovery without a rebuild.
 # -----------------------------------------------------------------------------
 [wal]
-group_commit = 1                       # TS_GROUP_COMMIT        1 = coalesce concurrent WAL fsyncs into shared barriers (sub-ms/write under load); also coalesces the shared-store object-store SYNC publish onto one durable barrier per group. DEFAULT.
 commit_delay_us = 0                     # TS_WAL_COMMIT_DELAY_US  group-commit batch-widening delay in microseconds. 0 = pure timer-less (batch = whatever accrues during one barrier's in-flight duration); >0 deliberately widens batches under extreme load.
 wal_legacy_recovery = 0                # TS_WAL_LEGACY_RECOVERY  1 = emergency fallback to the legacy multi-barrier write path + delta-fold recovery.
 # raft_wal_dir = ""                    # TS_RAFT_WAL_DIR        raft WAL directory (raft/replicated modes)
@@ -117,8 +116,6 @@ meta_auto_rebalance = 0                # TS_META_AUTO_REBALANCE 1 = enable the a
 [recovery]
 bulk_ingest = 0                        # MATRIXARK_BULK_INGEST  1 = bulk-ingest fast path (fsync deferral + linear promote); reload optimizations
 eager_cache_warm_on_load = 0           # MATRIXARK_EAGER_CACHE_WARM_ON_LOAD  1 = warm the record cache eagerly on shard load
-delta_served_index = 0                 # MATRIXARK_DELTA_SERVED_INDEX  1 = use the delta served-index cost path
-# enable_indexlog = 0                  # MATRIXARK_ENABLE_INDEXLOG  1 = enable the index-log subsystem
 # bulk_ingest_replay_from_sequence = 0 # MATRIXARK_BULK_INGEST_REPLAY_FROM_SEQUENCE  anchor sequence for bulk replay
 
 

--- a/crates/temporalstore-rust/src/bin/server.rs
+++ b/crates/temporalstore-rust/src/bin/server.rs
@@ -1855,9 +1855,8 @@ fn wire_matrixobject_durability(
         }
     };
 
-    // `TS_MATRIXOBJECT_SYNC_FLUSH=1` forces every write durable before ack; group commit (the
-    // `[wal] group_commit` / `TS_GROUP_COMMIT` gate, default ON) then coalesces concurrent sync
-    // writers onto a shared durable barrier. Coalescing requires the single-appendable-log
+    // `TS_MATRIXOBJECT_SYNC_FLUSH=1` forces every write durable before ack; group commit, which
+    // is unconditional, then coalesces concurrent sync writers onto a shared durable barrier. Coalescing requires the single-appendable-log
     // (ProtobufAppendBlob) WAL layout, so select it here when group commit is active on the sync
     // path. `latest_persisted_wal_index` / replay read BOTH layouts (union by WAL index), so a shard
     // that previously wrote the per-key layout continues monotonically with no migration.

--- a/crates/temporalstore-rust/src/wal.rs
+++ b/crates/temporalstore-rust/src/wal.rs
@@ -856,7 +856,9 @@ pub const WRITE_AHEAD_LOG_FORMAT_VERSION: u32 = 1;
 pub struct LocalWriteAheadLogStore {
     inner: Arc<Mutex<WriteAheadLogInner>>,
     // Group-commit coordinator: serializes WAL fsyncs so many concurrent writers
-    // share one durability barrier. Consulted ONLY when TS_GROUP_COMMIT is set.
+    // share one durability barrier. Always consulted -- `group_commit_configured` returns true,
+    // and `TS_GROUP_COMMIT`, which this comment used to name as its condition, is read by
+    // nothing.
     // Writers append their bytes under the `inner` lock, RELEASE it, then coalesce
     // their fsync here -- so a burst of concurrent writes amortizes onto ~1 fsync.
     sync_coord: Arc<Mutex<HashMap<ShardId, GroupCommitState>>>,
@@ -3090,8 +3092,9 @@ fn append_record_locked(
         file.sync_data()?;
         // The parent-directory entry for the WAL file only needs a durable barrier when
         // the file is first created; appends grow the file (inode) without changing the
-        // directory. Under relaxed-sync (single-barrier default / TS_GROUP_COMMIT) skip the
-        // redundant per-append dir fsync once the file already has content (offset > 0).
+        // directory. Under relaxed-sync -- the single-barrier default, with group commit
+        // unconditional -- skip the redundant per-append dir fsync once the file already has
+        // content (offset > 0).
         // `offset == 0` is the file's first write, which is the usual reason the directory entry
         // is not yet durable. After a roll it is not zero -- the header is already there -- so the
         // debt the roll recorded is what says the entry still has to reach disk.

--- a/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
+++ b/crates/temporalstore-rust/tests/wal_single_barrier_recovery.rs
@@ -172,8 +172,10 @@ fn single_barrier_full_page_loss_no_dump_rebuilds_from_wal() {
 }
 
 fn populate_feature(root: &str) {
+    // `TS_GROUP_COMMIT=1` used to be set here. Nothing reads it -- `group_commit_configured`
+    // returns true unconditionally -- so passing it made this look like it configured the child
+    // when it configured nothing.
     let out = Command::new(bin())
-        .env("TS_GROUP_COMMIT", "1")
         .args(["--mode", "populate-feature", "--root", root])
         .output()
         .expect("populate-feature should run");

--- a/docs/ops/temporalstore-engine-flags.md
+++ b/docs/ops/temporalstore-engine-flags.md
@@ -1,172 +1,475 @@
 # Engine flags
 
-Every `TS_*` variable the engine reads, grouped by what it decides. Generated from the source
+Every environment variable the engine reads -- `TS_*`, `MATRIXARK_*` and
+`TEMPORALSTORE_*` -- grouped by what it decides. Generated from the source
 by `tools/build_engine_flag_inventory.py` and checked by
 `test_matrixark_engine_flag_inventory.py`, because a hand-kept list of this many knobs is wrong
 within a week and its staleness is silent.
 
 ## Why this exists
 
-There are 98 of them, and **none is dead**: all 55 accessor functions that read one have a
-non-test caller. So the length of this list is not a cleanup backlog -- every flag changes
-behaviour, and retiring one is a decision about behaviour rather than tidying.
+There are 325 of them, read by 121 functions.
 
-What the list gives an owner deciding that is: how many files each flag reaches (the code its
-non-default path keeps alive), whether its own documentation calls that path legacy, and
-whether a customer can set it at all.
+Deleting unreachable code is not the lever. An earlier version of this document argued that
+by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried
+forward unexamined ever since. Computing it instead named four functions as uncalled that
+plainly are: Rust reaches a function by more than one syntax (a generic definition,
+`unwrap_or_else(name)` passing it as a value, serde naming it in a string) and a name scan
+sees none of those. So the claim is neither asserted nor computed here.
+
+What shortens it is a narrower question, asked per flag: **does anything anywhere select the
+off position?** Not a test, not a config file, not a launch profile, not a portal setting. A
+flag no one can be shown to turn off is not a switch, it is a branch -- and the live side can
+be made unconditional, taking the dead side with it. That is a safe edit exactly when reads do
+not consult the flag: if the decoder already accepts both shapes, retiring the writer strands
+nothing already written.
+
+What the list gives an owner asking that is: how many files each flag reaches (the code its
+non-default path keeps alive), whether its own documentation calls that path legacy, and --
+the two columns that answer the question -- its **default**, where that can be read off the
+source, and **who sets it**: a test, the shipped config file, a launch profile, a Python
+launcher, a test harness, or the customer portal. `nothing` means no place in this
+repository gives it a value, so whatever its non-default path does, nothing here asks for it.
+
+That column is literal about WHERE, not about WHAT: it does not compare the value set against
+the default, because the default lives in Rust and this reads text. `config` is a prompt to go
+look; `nothing` is an answer.
+
+The **default** column reads two shapes: a function that reads one flag and returns a bool,
+and a single statement that does the same inline. The second was added because the first
+made the row below it -- flags defaulting on that nothing sets -- report zero while
+`MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` sat inline in the middle of a function,
+defaulting on, set by nothing. A statement is the unit rather than a window of lines because
+the `!` that inverts `!matches!(env::var(X)...)` sits above the name but inside the same
+statement: a statement always carries its own negation, a window carries it only by luck.
+Anything else is blank, and a blank means go and look.
 
 | flags | count |
 |---|---|
-| total | 98 |
-| offered on the portal | 16 |
-| documented as keeping an older path alive | 5 |
-| reaching more than two files | 3 |
-| whose doc comment is really about another flag | 0 |
+| total | 325 |
+| booleans whose default this could read off the source | 56 |
+| **defaulting on, and set by nothing** | 9 |
+| offered on the portal | 23 |
+| **that nothing in this repository sets** | 187 |
+| documented as keeping an older path alive | 7 |
+| reaching more than two files | 17 |
+| whose doc comment is really about another flag | 43 |
 
-## topology (33)
+## topology (38)
 
 Where this node is and what it talks to. Set by whoever provisions the node; not tenant-facing and not tuning.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_META_ADDR` | 3 | — | — |
-| `TS_PROXY_ADDR` | 3 | — | — |
-| `TS_SHARD_ID` | 3 | — | — |
-| `TS_META_RAFT_NODES` | 2 | — | — |
-| `TS_RAFT_NODES` | 2 | — | — |
-| `TS_RAFT_WAL_DIR` | 2 | — | — |
-| `TS_BLOB_STORE_DIR` | 1 | — | — |
-| `TS_CACHE_DIR` | 1 | — | — |
-| `TS_CLUSTER_ID` | 1 | — | — |
-| `TS_DISTRIBUTED` | 1 | — | — |
-| `TS_INDEX_DIR` | 1 | — | — |
-| `TS_MATRIXOBJECT_BUCKET` | 1 | — | — |
-| `TS_MATRIXOBJECT_ENDPOINT` | 1 | — | — |
-| `TS_MATRIXOBJECT_STORE_DIR` | 1 | — | — |
-| `TS_META_BIND_ADDR` | 1 | — | — |
-| `TS_PAGE_STORE_DIR` | 1 | — | — |
-| `TS_PROXY_ADVERTISED_ADDR` | 1 | — | — |
-| `TS_PROXY_BIND_ADDR` | 1 | — | — |
-| `TS_PROXY_LOCATION` | 1 | — | — |
-| `TS_RAFT_BIND_ADDR` | 1 | — | — |
-| `TS_REDIS_ADDR` | 1 | — | — |
-| `TS_REDIS_BIND_ADDR` | 1 | — | — |
-| `TS_SERVER_ADDR` | 1 | — | — |
-| `TS_SERVER_ADVERTISE_ADDR` | 1 | — | — |
-| `TS_SERVER_BIND_ADDR` | 1 | — | — |
-| `TS_SERVER_LOCATION` | 1 | — | — |
-| `TS_SERVER_NODE_ID` | 1 | — | — |
-| `TS_SHARD_URI` | 1 | — | — |
-| `TS_SHARED_STORE_CLUSTER_ID` | 1 | — | — |
-| `TS_SHARED_STORE_DIR` | 1 | — | — |
-| `TS_SHARED_STORE_URI` | 1 | — | — |
-| `TS_STANDALONE` | 1 | — | — |
-| `TS_STORAGE_BACKEND` | 1 | — | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_META_ADDR` | — | config, launch | 3 | — |
+| `TS_PROXY_ADDR` | — | launch, script | 3 | — |
+| `TS_RAFT_NODES` | — | harness, script | 3 | — |
+| `TS_RAFT_NODE_ID` | — | harness, script | 3 | — |
+| `TS_RAFT_SHARD_ID` | — | harness, script | 3 | — |
+| `TS_RAFT_WAL_DIR` | — | config, harness, script | 3 | — |
+| `TS_SHARD_ID` | — | config, launch | 3 | — |
+| `TS_META_RAFT_NODES` | — | config | 2 | — |
+| `TS_RAFT_BIND_ADDR` | — | harness, script | 2 | — |
+| `MATRIXARK_CONTEXT_EVENT_FANOUT_NODES` | — | nothing | 1 | — |
+| `MATRIXARK_TEMPORALSTORE_PROXY_ADDR` | — | nothing | 1 | — |
+| `TS_BLOB_STORE_DIR` | — | config, launch, script | 1 | — |
+| `TS_CACHE_DIR` | — | config, launch, script | 1 | — |
+| `TS_CLUSTER_ID` | — | launch | 1 | — |
+| `TS_DISTRIBUTED` | — | config, launch, script | 1 | — |
+| `TS_INDEX_DIR` | — | config, launch, script | 1 | — |
+| `TS_MATRIXOBJECT_BUCKET` | — | config, launch | 1 | — |
+| `TS_MATRIXOBJECT_ENDPOINT` | — | config | 1 | — |
+| `TS_MATRIXOBJECT_STORE_DIR` | — | config | 1 | — |
+| `TS_META_BIND_ADDR` | — | config | 1 | — |
+| `TS_META_RAFT_NODE_ID` | — | nothing | 1 | — |
+| `TS_PAGE_STORE_DIR` | — | config, launch, script | 1 | — |
+| `TS_PROXY_ADVERTISED_ADDR` | — | config | 1 | — |
+| `TS_PROXY_BIND_ADDR` | — | config | 1 | — |
+| `TS_PROXY_LOCATION` | — | nothing | 1 | — |
+| `TS_REDIS_ADDR` | — | launch | 1 | — |
+| `TS_REDIS_BIND_ADDR` | — | config | 1 | — |
+| `TS_SERVER_ADDR` | — | launch | 1 | — |
+| `TS_SERVER_ADVERTISE_ADDR` | — | config, launch | 1 | — |
+| `TS_SERVER_BIND_ADDR` | — | config | 1 | — |
+| `TS_SERVER_LOCATION` | — | config | 1 | — |
+| `TS_SERVER_NODE_ID` | — | config, launch | 1 | — |
+| `TS_SHARD_URI` | — | test | 1 | — |
+| `TS_SHARED_STORE_CLUSTER_ID` | — | launch | 1 | — |
+| `TS_SHARED_STORE_DIR` | — | config, script | 1 | — |
+| `TS_SHARED_STORE_URI` | — | nothing | 1 | — |
+| `TS_STANDALONE` | — | config, launch, script | 1 | — |
+| `TS_STORAGE_BACKEND` | — | config, launch, script | 1 | — |
 
-## credential (1)
+## cluster policy (39)
+
+What the metaserver does about nodes it cannot reach -- conviction, freezing, rebalancing, failover. Cluster-wide, and never per shard.
+
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_META_FORBID_SELF_CLEARING_CONVICTION` | — | nothing | 2 | — |
+| `MATRIXARK_TEMPORALSTORE_META_SYNC_DEADLINE_MS` | — | nothing | 1 | — |
+| `TS_AUTO_REBALANCE_DATA_MOVE` | — | nothing | 1 | — |
+| `TS_META_ADAPTIVE_FAILURE_DETECTOR` | — | nothing | 1 | — |
+| `TS_META_AUTO_REBALANCE` | — | config | 1 | — |
+| `TS_META_AUTO_REBALANCE_BALANCE` | — | nothing | 1 | — |
+| `TS_META_CONVICT_ENABLED` | — | nothing | 1 | — |
+| `TS_META_CONVICT_ON_REBOOT` | — | nothing | 1 | — |
+| `TS_META_CONVICT_PROXIES` | — | nothing | 1 | — |
+| `TS_META_CONVICT_SAFE_MODE` | — | nothing | 1 | — |
+| `TS_META_FD_PHI_THRESHOLD` | — | nothing | 1 | — |
+| `TS_META_FD_SAMPLE_CAPACITY` | — | nothing | 1 | — |
+| `TS_META_FORBID_ORPHANING_SHARDS` | — | nothing | 1 | — |
+| `TS_META_FREEZE_AGING` | — | nothing | 1 | — |
+| `TS_META_MUTATION_LOG` | — | nothing | 1 | — |
+| `TS_META_PLACEMENT_AWARE_REBALANCE` | — | nothing | 1 | — |
+| `TS_META_PROXY_CALIBRATION` | — | nothing | 1 | — |
+| `TS_META_PROXY_FREEZE_COOLDOWN_MS` | — | nothing | 1 | — |
+| `TS_META_PROXY_FREEZE_MS` | — | nothing | 1 | — |
+| `TS_META_PROXY_RETENTION_MS` | — | nothing | 1 | — |
+| `TS_META_RAFT` | — | config, script | 1 | — |
+| `TS_META_RAFT_ELECTION_TICK_MS` | — | nothing | 1 | — |
+| `TS_META_REBALANCE_LOCATION_SCOPED` | — | nothing | 1 | — |
+| `TS_META_REBALANCE_PER_TABLE` | — | nothing | 1 | — |
+| `TS_META_REBALANCE_SAFE_GAP` | — | nothing | 1 | — |
+| `TS_META_RETENTION_GC` | — | nothing | 1 | — |
+| `TS_META_RETENTION_MS` | — | nothing | 1 | — |
+| `TS_META_SERVER_FREEZE_COOLDOWN_MS` | — | nothing | 1 | — |
+| `TS_META_SERVER_FREEZE_MS` | — | nothing | 1 | — |
+| `TS_META_SERVER_RETENTION_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_CHECK` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_REBOOT_GRACE_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_SETTLE_GRACE_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_WINDOW_MS` | — | nothing | 1 | — |
+| `TS_META_STALE_AFTER_MS` | — | nothing | 1 | — |
+| `TS_META_TABLE_FREEZE_MS` | — | nothing | 1 | — |
+| `TS_META_TABLE_RETENTION_MS` | — | nothing | 1 | — |
+| `TS_META_TASK_SCHEDULER_BASE_POSTPONE_MS` | — | nothing | 1 | — |
+| `TS_RAFT_AUTO_FAILOVER` | — | config, script | 1 | — |
+
+## credential (5)
 
 Secrets. Never a form field, never in a launch artifact.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_META_ADMIN_TOKEN` | 1 | — | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_RAFT_AUTH_TOKEN` | — | harness, script | 2 | — |
+| `MATRIXARK_HOOK_MAX_CONTEXT_TOKENS` | — | nothing | 1 | — |
+| `MATRIXARK_MODEL_API_KEY` | — | nothing | 1 | — |
+| `TS_API_AUTH_TOKEN` | — | nothing | 1 | — |
+| `TS_META_ADMIN_TOKEN` | — | nothing | 1 | — |
 
-## durability (25)
+## durability (32)
 
 What is written, when it is flushed, and what is reclaimed. The escape hatches here trade throughput for a more conservative barrier.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_WAL_BINARY_FRAME` | 2 | — | — |
-| `TS_WAL_LEGACY_RECOVERY` | 2 | — | — |
-| `TS_BARRIER_PROFILE_WRITES` | 1 | — | — |
-| `TS_BLOCK_IN_WAL` | 1 | — | — |
-| `TS_CROSS_SHARD_RECLAIM_GUARD` | 1 | — | yes |
-| `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | 1 | — | — |
-| `TS_INDEX_DUMP_WAL_GAP_BYTES` | 1 | yes | — |
-| `TS_META_SCHEDULER_SNAPSHOT` | 1 | — | — |
-| `TS_RAFT_OVERLAP_LEADER_BARRIER` | 1 | — | — |
-| `TS_RAFT_WAL_BINARY_RECORDS` | 1 | — | — |
-| `TS_RAFT_WAL_DELTA_ENTRIES` | 1 | — | yes |
-| `TS_SHARED_STORE_FENCE` | 1 | — | — |
-| `TS_WAL_BINARY_RECORDS` | 1 | — | — |
-| `TS_WAL_COMMIT_DELAY_US` | 1 | — | — |
-| `TS_WAL_DATA_ONLY` | 1 | — | — |
-| `TS_WAL_ITEM_METADATA` | 1 | — | — |
-| `TS_WAL_OUTCOME_ITEMS` | 1 | — | — |
-| `TS_WAL_OUTCOME_STRICT` | 1 | — | — |
-| `TS_WAL_PREALLOCATE` | 1 | — | — |
-| `TS_WAL_PREALLOCATE_CHUNK` | 1 | — | — |
-| `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | 1 | — | yes |
-| `TS_WAL_RECLAIM_MIN_COPY_BYTES` | 1 | — | — |
-| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | 1 | — | — |
-| `TS_WAL_RESIDENT_PAGES` | 1 | — | — |
-| `TS_WAL_SEGMENT_BYTES` | 1 | — | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_WAL_LEGACY_RECOVERY` | on | config, harness, script | 3 | — |
+| `MATRIXARK_BULK_INGEST_EXPECTED_WAL_COMMANDS` | — | test | 2 | — |
+| `TS_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 2 | — |
+| `MATRIXARK_RUST_PROXY_LOG_RECLAIM_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_BARRIER_PROFILE_WRITES` | — | nothing | 1 | — |
+| `TS_BLOCK_IN_WAL` | on | test | 1 | yes |
+| `TS_CROSS_SHARD_RECLAIM_GUARD` | on | config | 1 | yes |
+| `TS_DATA_NODE_LIFECYCLE_SNAPSHOT` | — | nothing | 1 | — |
+| `TS_INDEX_DUMP_WAL_GAP_BYTES` | — | portal | 1 | — |
+| `TS_META_RAFT_SNAPSHOT_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_SCHEDULER_SNAPSHOT` | — | nothing | 1 | — |
+| `TS_RAFT_LEADER_READY_BARRIER` | — | test | 1 | — |
+| `TS_RAFT_OVERLAP_LEADER_BARRIER` | off | nothing | 1 | — |
+| `TS_RAFT_SNAPSHOT_STATE_IMAGE` | on | test | 1 | — |
+| `TS_RAFT_WAL_BINARY_RECORDS` | on | nothing | 1 | — |
+| `TS_RAFT_WAL_COALESCE` | on | test | 1 | — |
+| `TS_RAFT_WAL_DELTA_ENTRIES` | — | nothing | 1 | yes |
+| `TS_SHARED_STORE_FENCE` | off | test | 1 | — |
+| `TS_WAL_BINARY_FRAME` | on | launch, test | 1 | — |
+| `TS_WAL_BINARY_RECORDS` | on | launch, test | 1 | — |
+| `TS_WAL_COMMIT_DELAY_US` | — | config | 1 | — |
+| `TS_WAL_DATA_ONLY` | on | launch, test | 1 | — |
+| `TS_WAL_ITEM_METADATA` | off | test | 1 | — |
+| `TS_WAL_OUTCOME_ITEMS` | on | launch, test | 1 | — |
+| `TS_WAL_OUTCOME_STRICT` | off | nothing | 1 | — |
+| `TS_WAL_PREALLOCATE` | on | launch, test | 1 | — |
+| `TS_WAL_PREALLOCATE_CHUNK` | — | nothing | 1 | — |
+| `TS_WAL_RECLAIM_MAX_SEGMENTS_PER_PASS` | — | test | 1 | yes |
+| `TS_WAL_RECLAIM_MIN_COPY_BYTES` | — | nothing | 1 | — |
+| `TS_WAL_RECLAIM_MIN_FREED_PERCENT` | — | nothing | 1 | — |
+| `TS_WAL_RESIDENT_PAGES` | — | test | 1 | — |
+| `TS_WAL_SEGMENT_BYTES` | — | nothing | 1 | — |
 
-## format (8)
+## format (9)
 
 The shape of what is written. Readers generally accept both shapes, which is what makes these safe to flip and hard to retire.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_INDEX_CATALOG_FOLD` | 1 | — | yes |
-| `TS_INDEX_CODEC` | 1 | — | — |
-| `TS_INDEX_LOG_BINARY` | 1 | — | — |
-| `TS_NODE_SUMMARY_VECTOR` | 1 | yes | — |
-| `TS_PROXY_BINARY_VERSION` | 1 | — | — |
-| `TS_RAFT_BINARY_REPLICATION` | 1 | — | — |
-| `TS_VECTOR_INT8` | 1 | yes | — |
-| `TS_VECTOR_SCALED` | 1 | yes | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_INDEX_BINARY` | on | launch, test | 1 | — |
+| `TS_INDEX_CATALOG_FOLD` | on | config | 1 | yes |
+| `TS_INDEX_CODEC` | — | test | 1 | — |
+| `TS_INDEX_LOG_BINARY` | on | nothing | 1 | — |
+| `TS_NODE_SUMMARY_VECTOR` | on | test, portal | 1 | — |
+| `TS_PROXY_BINARY_VERSION` | — | nothing | 1 | — |
+| `TS_RAFT_BINARY_REPLICATION` | off | nothing | 1 | — |
+| `TS_VECTOR_INT8` | off | test, portal | 1 | — |
+| `TS_VECTOR_SCALED` | on | launch, script, test, portal | 1 | — |
 
-## capacity (15)
+## capacity (80)
 
 Sizes, ceilings and intervals. The tuning a deployment actually reaches for.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_BLOCK_INDEX_CACHE_BYTES` | 1 | yes | — |
-| `TS_BLOCK_SEGMENT_TARGET_BYTES` | 1 | yes | — |
-| `TS_CACHE_MEMORY_BYTES` | 1 | — | — |
-| `TS_COMPACTION_WATERMARK_BYTES` | 1 | yes | — |
-| `TS_CONTEXT_PAGE_TARGET_BYTES` | 1 | yes | — |
-| `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | 1 | — | — |
-| `TS_INDEX_DUMP_OPLOG_GAP_BYTES` | 1 | — | — |
-| `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | 1 | — | — |
-| `TS_MAX_RETAINED_FINISHED_JOBS` | 1 | yes | — |
-| `TS_METRICS_MAX_SLOT_SERIES` | 1 | yes | — |
-| `TS_PAGE_INDEX_CACHE_BYTES` | 1 | yes | — |
-| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | 1 | — | — |
-| `TS_SHARED_STORE_MAX_PENDING` | 1 | — | yes |
-| `TS_STORAGE_ZONE_SIZE` | 1 | yes | — |
-| `TS_STREAM_MAX_BLOB_SIZE` | 1 | yes | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TS_RAFT_HEARTBEAT_INTERVAL_MS` | — | harness, script | 3 | — |
+| `TS_PAGE_STORE_COMPRESSION_MIN_BYTES` | — | config, test | 2 | — |
+| `TS_PROXY_CONTEXT_IO_TIMEOUT_MS` | — | nothing | 2 | — |
+| `TS_RAFT_MAX_CATCHUP_ENTRIES_PER_HEARTBEAT` | — | nothing | 2 | — |
+| `MATRIXARK_BACKFILL_CACHE_BYTES` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_MAX_BODY` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_COMPRESSION_MAX_AGE_MS` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_COMPRESSION_MAX_RAW_EVENTS` | — | nothing | 1 | — |
+| `MATRIXARK_EMBED_DRAINER_INTERVAL_MS` | — | config, launch, portal | 1 | — |
+| `MATRIXARK_EMBED_DRAINER_MAX_EVENTS` | — | nothing | 1 | — |
+| `MATRIXARK_EMBED_DRAINER_MAX_NODES_PER_PASS` | — | nothing | 1 | — |
+| `MATRIXARK_RETRIEVAL_MAX_CANDIDATES` | — | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_CACHE_BYTES` | — | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_MIN_BYTES` | — | test | 1 | — |
+| `MATRIXARK_TEMPORALSTORE_PROXY_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
+| `MATRIXARK_TEMPORALSTORE_PROXY_IO_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_INGEST_CHUNK_SIZE` | — | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_MAX_EVENTS` | — | nothing | 1 | — |
+| `TS_BLOB_CHUNK_BYTES` | — | config | 1 | — |
+| `TS_BLOB_PEER_FETCH_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_BLOCK_INDEX_CACHE_BYTES` | — | config, portal | 1 | — |
+| `TS_BLOCK_SEGMENT_TARGET_BYTES` | — | config, portal | 1 | — |
+| `TS_CACHE_MEMORY_BYTES` | — | config, launch | 1 | — |
+| `TS_COMPACTION_WATERMARK_BYTES` | — | config, portal | 1 | — |
+| `TS_CONTEXT_PAGE_TARGET_BYTES` | — | config, portal | 1 | — |
+| `TS_DATA_RAFT_BOUNDED_STALE_MAX_INDEX_LAG` | — | nothing | 1 | — |
+| `TS_DATA_RAFT_READ_INDEX_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_DISTRIBUTED_RAFT_CATCHUP_TIMEOUT_SECS` | — | nothing | 1 | — |
+| `TS_EVICT_POOL_SIZE` | — | nothing | 1 | — |
+| `TS_INDEX_DUMP_OPLOG_GAP_BYTES` | — | config | 1 | — |
+| `TS_MATRIXOBJECT_FLUSH_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_PROBE_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_MAX_RETAINED_FINISHED_JOBS` | — | portal | 1 | — |
+| `TS_META_AUTO_REBALANCE_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_META_AUTO_REBALANCE_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_AUTO_REBALANCE_IO_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_META_CONVICT_CRITICAL_RATIO_PERCENT` | — | nothing | 1 | — |
+| `TS_META_CONVICT_MIN_ABNORMAL` | — | nothing | 1 | — |
+| `TS_META_CONVICT_WARNING_RATIO_PERCENT` | — | nothing | 1 | — |
+| `TS_META_FAILURE_DETECTOR_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_FD_INITIAL_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_FD_MAX_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_FD_MAX_ROUND_PAUSE_MS` | — | nothing | 1 | — |
+| `TS_META_FREEZE_AGING_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_FREEZE_AGING_MAX_DROPS` | — | nothing | 1 | — |
+| `TS_META_PROXY_CALIBRATION_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_PROXY_CALIBRATION_MAX_CHANGES` | — | nothing | 1 | — |
+| `TS_META_RAFT_HEARTBEAT_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_RETENTION_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_RETENTION_MAX_PURGES` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_IO_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_META_SHARD_DIVERGENCE_MAX_MOVES` | — | nothing | 1 | — |
+| `TS_META_TASK_SCHEDULER_MAX_INFLIGHT` | — | nothing | 1 | — |
+| `TS_META_TASK_SCHEDULER_MAX_POSTPONE_MS` | — | nothing | 1 | — |
+| `TS_META_TASK_SCHEDULER_MAX_RETRY_TIMES` | — | nothing | 1 | — |
+| `TS_METRICS_MAX_SLOT_SERIES` | — | portal | 1 | — |
+| `TS_PAGE_INDEX_CACHE_BYTES` | — | config, portal | 1 | — |
+| `TS_PROXY_AUTO_REGISTER_MIN_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_PROXY_CONNECT_TIMEOUT_MS` | — | config | 1 | — |
+| `TS_PROXY_DROP_PERCENT` | — | nothing | 1 | — |
+| `TS_PROXY_HEARTBEAT_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_PROXY_HEARTBEAT_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_PROXY_IO_TIMEOUT_MS` | — | config | 1 | — |
+| `TS_PROXY_MAX_INFLIGHT_REQUESTS` | — | nothing | 1 | — |
+| `TS_PROXY_MAX_INFLIGHT_WRITE_REQUESTS` | — | nothing | 1 | — |
+| `TS_PROXY_MAX_RETRIES` | — | config | 1 | — |
+| `TS_PROXY_TOPOLOGY_CHECK_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_RAFT_AUTO_FAILOVER_CONNECT_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_RAFT_AUTO_FAILOVER_INTERVAL_MS` | — | nothing | 1 | — |
+| `TS_RAFT_AUTO_FAILOVER_IO_TIMEOUT_MS` | — | nothing | 1 | — |
+| `TS_RAFT_MAX_APPLIED_LOG_BYTES` | — | nothing | 1 | — |
+| `TS_RAFT_MAX_INFLIGHTS_REPLICATE` | — | test | 1 | — |
+| `TS_SERVER_HEARTBEAT_INTERVAL_MS` | — | config | 1 | — |
+| `TS_SERVER_MAX_BACKGROUND_QUEUE_DEPTH` | — | config | 1 | — |
+| `TS_SERVER_MAX_QUEUE_DEPTH` | — | config | 1 | — |
+| `TS_SHARED_STORE_MAX_PENDING` | — | nothing | 1 | yes |
+| `TS_STORAGE_ZONE_SIZE` | — | config, portal | 1 | — |
+| `TS_STREAM_MAX_BLOB_SIZE` | — | config, portal | 1 | — |
 
-## diagnostic (1)
+## context (29)
+
+The memory pipeline: what gets extracted, embedded, drained and packed. The surface a deployment tunes for recall rather than for throughput.
+
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `MATRIXARK_CONTEXT_INGEST_GATE_L1` | off | test | 2 | — |
+| `MATRIXARK_BACKFILL_CHECKPOINT_ONLY` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_FLUSH_EVERY_ACCEPTED` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_FLUSH_EVERY_SESSION` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_GLOBAL_SESSION` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_RAW_FIRST` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_SKIP_COVERED_SESSIONS` | — | nothing | 1 | — |
+| `MATRIXARK_BACKFILL_SUB_BATCH` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_COMPRESSION_ENABLED` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_COMPRESSION_KEEP_RECENT` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_COMPRESSION_WINDOW` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_EVENT_QUERY_OVERFETCH` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_EVENT_SCAN_CAP` | — | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_HYBRID_LEXICAL` | on | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_PACK_INCLUDE_SCORES` | off | nothing | 1 | — |
+| `MATRIXARK_CONTEXT_SECONDARY_INDEX` | off | test | 1 | — |
+| `MATRIXARK_EMBEDDING_MODEL` | — | config, script, portal | 1 | — |
+| `MATRIXARK_EMBED_API_KEY_ENV` | — | nothing | 1 | — |
+| `MATRIXARK_EMBED_BASE_URL` | — | config, script | 1 | — |
+| `MATRIXARK_EMBED_DEFER_ON_FAILURE` | on | nothing | 1 | yes |
+| `MATRIXARK_EMBED_DRAINER` | — | config, launch, portal | 1 | — |
+| `MATRIXARK_EMBED_DRAINER_BATCH` | — | config, portal | 1 | — |
+| `MATRIXARK_HOOK_ADDITIONAL_CONTEXT_CHAR_LIMIT` | — | launch | 1 | — |
+| `MATRIXARK_REQUIRE_MODEL_EMBEDDINGS` | off | config, portal | 1 | — |
+| `MATRIXARK_REQUIRE_MODEL_SUMMARIES` | off | config, portal | 1 | — |
+| `MATRIXARK_RETRIEVAL_TRAVERSAL_TOP_K` | — | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_FULL_RETRIEVE_SCAN` | on | test | 1 | — |
+| `TS_PROXY_CONTEXT_FIRST_SHARD` | — | nothing | 1 | — |
+| `TS_PROXY_CONTEXT_SHARD_COUNT` | — | nothing | 1 | — |
+
+## identity (6)
+
+Who the caller is, not what the engine does. Supplied per request or per process; nothing here is a switch.
+
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `MATRIXARK_ACCOUNT_ID` | — | launch | 2 | — |
+| `MATRIXARK_AGENT_NAME` | — | launch | 2 | — |
+| `MATRIXARK_TENANT_ID` | — | launch | 2 | — |
+| `MATRIXARK_USER_ID` | — | launch, script | 2 | — |
+| `TEMPORALSTORE_AGENT_NAME` | — | launch | 2 | — |
+| `MATRIXARK_SESSION_ID` | — | nothing | 1 | — |
+
+## diagnostic (6)
 
 Extra evidence for someone investigating. Off by default.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_SCALE_STORAGE_ROOT` | 1 | — | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `MATRIXARK_CONTEXT_PACK_DEBUG_LINEAGE` | off | test | 1 | — |
+| `MATRIXARK_CONTEXT_RETRIEVE_TRACE` | off | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_SINGLE_SHOT_DEBUG` | off | script | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_REPORT_ONLY` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_TRACE` | off | nothing | 1 | — |
+| `TS_SCALE_STORAGE_ROOT` | — | nothing | 1 | — |
 
-## behaviour (15)
+## benchmark (8)
+
+Read only by the benchmark harnesses. Never consulted on a serving path.
+
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_ALL_SOURCE_REPLAY` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_COMPACT_SOURCE_REPLAY` | on | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_DIRECT_SOURCE_SCORING` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_EXTERNAL_ONLY` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_JSONL` | — | script | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_SELECTED_ID_LIMIT` | — | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_SOURCE_ORDER_RANKING` | off | nothing | 1 | — |
+| `TEMPORALSTORE_CONTEXT_BENCHMARK_STORED_RECORD_SCORING` | on | nothing | 1 | — |
+
+## behaviour (73)
 
 Everything else that changes what the engine does.
 
-| flag | files | portal | keeps an older path |
-|---|---|---|---|
-| `TS_PHASE1_FLAT` | 2 | — | — |
-| `TS_CACHE_DISK_TIER` | 1 | — | — |
-| `TS_COLD_SCAN_NO_CACHE_FILL` | 1 | yes | — |
-| `TS_DATA_RAFT_READ_MODE` | 1 | — | — |
-| `TS_HOT_PAGE_SPILL` | 1 | — | — |
-| `TS_MALLOC_TRIM` | 1 | yes | — |
-| `TS_MANIFEST_SHORT_FIELD_NAMES` | 1 | — | — |
-| `TS_META_FD_PHI_THRESHOLD` | 1 | — | — |
-| `TS_META_MUTATION_LOG` | 1 | — | — |
-| `TS_PROXY_INGESTION_ACCOUNT` | 1 | — | — |
-| `TS_PROXY_NAMESPACE` | 1 | — | — |
-| `TS_RAFT_FOLLOWER_PIPELINE` | 1 | — | — |
-| `TS_SCRATCH_SWEEP` | 1 | yes | — |
-| `TS_SERVER_RAFT_READ_MODE` | 1 | — | — |
-| `TS_TABLE_NAME` | 1 | — | — |
+| flag | default | set by | files | keeps an older path |
+|---|---|---|---|---|
+| `MATRIXARK_BULK_INGEST` | off | config, test, portal | 6 | — |
+| `MATRIXARK_EAGER_CACHE_WARM_ON_LOAD` | on | config, test | 5 | — |
+| `TS_PHASE1_FLAT` | on | test | 4 | — |
+| `TS_RAFT_ALLOW_PLAINTEXT` | — | harness, script | 4 | — |
+| `TS_RAFT_ELECTION_TICK_MS` | — | harness, script | 3 | — |
+| `TS_RAFT_ENABLE_LOCAL_ADMIN` | — | harness, script | 3 | — |
+| `TS_RAFT_RPC_DEADLINE_MS` | — | harness, script | 3 | — |
+| `TS_RAFT_RPC_RETRIES` | — | harness, script | 3 | — |
+| `MATRIXARK_BULK_INGEST_REPLAY_FROM_SEQUENCE` | — | config, test | 2 | — |
+| `TEMPORALSTORE_RUST_CODEX_HOOK_ROOT` | — | launch | 2 | — |
+| `TS_PAGE_STORE_COMPRESSION_ENABLED` | — | config, launch, test | 2 | — |
+| `TS_PAGE_STORE_COMPRESSION_LEVEL` | — | config, test | 2 | — |
+| `MATRIXARK_MONOTONIC_RECORD_COUNT` | on | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` | on | nothing | 1 | — |
+| `MATRIXARK_RUST_PROXY_ASYNC_STORAGE` | off | launch, test | 1 | — |
+| `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_ENABLED` | — | test | 1 | — |
+| `MATRIXARK_RUST_PROXY_PAGE_COMPRESSION_LEVEL` | — | test | 1 | — |
+| `MATRIXARK_RUST_SDK_MODE` | off | nothing | 1 | — |
+| `MATRIXARK_TEMPORALSTORE_RUST_ROOT` | — | launch, script, test | 1 | — |
+| `TEMPORALSTORE_RUST_CODEX_EVENT_LOG` | — | launch | 1 | — |
+| `TEMPORALSTORE_RUST_CODEX_EVENT_LOG_ENABLE` | — | nothing | 1 | — |
+| `TS_BLOB_PEER_FETCH` | — | nothing | 1 | — |
+| `TS_BLOB_RUNTIME_THREADS` | — | nothing | 1 | — |
+| `TS_CACHE_DISK_TIER` | — | test | 1 | — |
+| `TS_COLD_SCAN_NO_CACHE_FILL` | — | config, portal | 1 | — |
+| `TS_DATA_RAFT_READ_MODE` | — | config | 1 | — |
+| `TS_ENGINE_CONCURRENT_COMMIT` | on | test | 1 | — |
+| `TS_EVICT_SAMPLED_LRU` | — | test | 1 | — |
+| `TS_EVICT_SAMPLES` | — | nothing | 1 | — |
+| `TS_EVICT_SCAN_TURNS` | — | nothing | 1 | — |
+| `TS_HOT_PAGE_SPILL` | on | test | 1 | — |
+| `TS_MALLOC_TRIM` | on | test, portal | 1 | — |
+| `TS_MANIFEST_SHORT_FIELD_NAMES` | on | nothing | 1 | — |
+| `TS_MATRIXOBJECT_CHECKPOINT_ON_START` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_FLUSH_BATCH` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_NETWORKED_CHECKPOINT_ON_START` | — | nothing | 1 | — |
+| `TS_MATRIXOBJECT_SYNC_FLUSH` | — | nothing | 1 | — |
+| `TS_PROXY_BACKEND_CONTINUOUS_FAILED_TIME_MS` | — | nothing | 1 | — |
+| `TS_PROXY_CONFIG_VERSION` | — | nothing | 1 | — |
+| `TS_PROXY_ENFORCE_INGESTION_ACCOUNT` | — | nothing | 1 | — |
+| `TS_PROXY_INGESTION_ACCOUNT` | — | nothing | 1 | — |
+| `TS_PROXY_NAMESPACE` | — | nothing | 1 | — |
+| `TS_PROXY_PIN_PRIMARY_READS` | — | nothing | 1 | — |
+| `TS_PROXY_REFRESH_ROUTE_ON_BACKEND_ERROR` | — | nothing | 1 | — |
+| `TS_PROXY_ROUTE_CACHE_TTL_MS` | — | nothing | 1 | — |
+| `TS_PROXY_SERVICE_REGISTRY_TTL_MS` | — | nothing | 1 | — |
+| `TS_PROXY_SERVING_MODE` | — | nothing | 1 | — |
+| `TS_RAFT_APPLY_COALESCE` | on | test | 1 | — |
+| `TS_RAFT_CA_CERT_PATH` | — | nothing | 1 | — |
+| `TS_RAFT_CA_PATH` | — | nothing | 1 | — |
+| `TS_RAFT_CERT_PATH` | — | nothing | 1 | — |
+| `TS_RAFT_FOLLOWER_PIPELINE` | off | test | 1 | — |
+| `TS_RAFT_KEY_PATH` | — | nothing | 1 | — |
+| `TS_RAFT_PIPELINE_CONCURRENT_PROPOSE` | — | test | 1 | — |
+| `TS_RAFT_PROPOSE_SERIALIZE` | on | test | 1 | — |
+| `TS_RAFT_REPLICATION_DEADLINE_MS` | — | test | 1 | — |
+| `TS_RAFT_SECURITY_MODE` | — | nothing | 1 | — |
+| `TS_RAFT_TRANSPORT_SECURITY` | — | nothing | 1 | — |
+| `TS_SCRATCH_SWEEP` | on | portal | 1 | — |
+| `TS_SERVER_JOIN_EMPTY` | — | nothing | 1 | — |
+| `TS_SERVER_RAFT` | — | nothing | 1 | — |
+| `TS_SERVER_RAFT_READ_MODE` | — | nothing | 1 | — |
+| `TS_SERVER_READONLY` | — | nothing | 1 | — |
+| `TS_SERVER_WORKER_THREADS` | — | config | 1 | — |
+| `TS_SHARD_END_ROUTING_SLOT` | — | test | 1 | — |
+| `TS_SHARD_LOAD_VERSION` | — | test | 1 | — |
+| `TS_SHARD_READONLY` | — | test | 1 | — |
+| `TS_SHARD_READ_BURST` | — | nothing | 1 | — |
+| `TS_SHARD_READ_QPS` | — | nothing | 1 | — |
+| `TS_SHARD_START_ROUTING_SLOT` | — | test | 1 | — |
+| `TS_SHARD_WRITE_BURST` | — | nothing | 1 | — |
+| `TS_SHARD_WRITE_QPS` | — | nothing | 1 | — |
+| `TS_TABLE_NAME` | — | test | 1 | — |
+
+## outside this document (6)
+
+`sdk/rust/temporalstore` is a second Rust tree, carrying its own copy of the
+proxy implementation -- a different file, not a stale duplicate. The root
+manifest excludes it from the workspace, so `cargo check --all-targets` does not
+build it, here or in CI, and it is a client of the engine rather than part of
+it. These are the variables it reads that this document does not cover. The list
+is computed, so one more cannot appear quietly.
+
+- `MATRIXARK_RUST_FILTERED_SCAN_CACHE_ENTRIES`
+- `MATRIXARK_RUST_METRICS_PATH`
+- `MATRIXARK_RUST_PROXY_DISABLE_LEGACY_PACK_FALLBACK`
+- `MATRIXARK_RUST_PROXY_DISABLE_SDK_NATIVE_PACK`
+- `MATRIXARK_RUST_SCAN_RECORD_CACHE_ENTRIES`
+- `TEMPORALSTORE_RUST_ALLOW_NATIVE_MATRIXARK_C_API`
 

--- a/tools/build_engine_flag_inventory.py
+++ b/tools/build_engine_flag_inventory.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
-"""Generate the engine flag inventory: every TS_* knob, what it is for, and what keeping it costs.
+"""Generate the engine flag inventory: every environment variable the engine reads, what it is
+for, and what keeping it costs.
 
-Written because "there are too many flags" is true and not actionable on its own. Nothing here is
-deleted: all 55 flag accessors have a caller, so every flag changes behaviour and retiring one is a
-decision about behaviour rather than a cleanup. What was missing is the information to make those
-decisions -- how many places each flag reaches, whether its off-path is a documented legacy shape,
-and whether a customer can even set it.
+Written because "there are too many flags" is true and not actionable on its own. No accessor here
+is unreachable -- every one has a non-test caller -- so the list cannot be shortened by deleting
+code nothing calls. What shortens it is a different question, asked per flag: does anything
+anywhere select the off position? A flag whose off-path no test, config, launch profile or portal
+setting ever chooses is not a switch, it is a branch, and the live side can be made unconditional.
+The two columns that answer it are `default` and `set by`.
 
-Generated rather than written, and checked by a test, because a hand-maintained list of 98 knobs is
-wrong within a week and its staleness is silent.
+Generated rather than written, and checked by a test, because a hand-maintained list of this many
+knobs is wrong within a week and its staleness is silent. Every count is computed, including the
+accessor count: the one number that was hardcoded went stale the first time a flag was retired.
+
+Being generated is not the same as being complete, which is the harder lesson here. Regenerating
+byte-identically proves the document matches the SCAN, not the engine -- and a scan that knew one
+way of reading a flag (`env::var("TS_X")`) missed every helper-mediated read and every non-`TS_`
+prefix, listing 94 of 313. `test_matrixark_engine_flag_inventory.py` now checks the document
+against the source with a rule simpler than this one, and states how much source it read.
 """
 import io
 import pathlib
@@ -32,6 +41,14 @@ CLASS_RULES = [
     ("format", re.compile(r"BINARY|CODEC|LEGACY|ARRAY_BYTES|FRAME|RECORDS|FOLD|VECTOR")),
     ("capacity", re.compile(r"BYTES|SIZE|MAX_|MIN_|PERCENT|SERIES|JOBS|TIMEOUT|DELAY|INTERVAL")),
     ("diagnostic", re.compile(r"TRACE|DEBUG|PROFILE|SCALE|METRICS|REPORT")),
+    # Below capacity on purpose: a cap is a cap whatever subsystem it belongs to, so
+    # `MAX_SELECTED_REFS` stays under capacity rather than moving to context. These four pick up
+    # what "behaviour" was absorbing -- it held 148 of 313 flags, which is a bucket, not a group.
+    ("identity", re.compile(r"_(ACCOUNT_ID|TENANT_ID|USER_ID|SESSION_ID|AGENT_NAME)$")),
+    ("benchmark", re.compile(r"BENCHMARK")),
+    ("context", re.compile(r"CONTEXT|EMBED|RETRIEV|BACKFILL|LEXICAL|SUMMAR|CHUNK|SKILL|PACK")),
+    ("cluster policy", re.compile(r"META_|REBALANCE|CONVICT|FAILURE_DETECTOR|FAILOVER|FREEZE|"
+                                  r"RETENTION|DIVERGENCE")),
 ]
 
 # A legacy path is one the flag RESTORES. That verb is the evidence; the mood is not.
@@ -51,7 +68,75 @@ LEGACY = re.compile(
 
 NEWLINE = chr(10)
 
-FLAG_READ = re.compile(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"')
+# Every place a flag name is written down, not one way of writing it down.
+#
+# This used to match `env::var("TS_...")` only. The engine also reads flags through helpers that
+# take the name as an argument -- `env_flag_default_on("TS_X")`, `env_bool("TS_X", default)`,
+# `raft_env_flag_default_on("TS_X")` -- and a regex for one idiom cannot see the others. It listed
+# 94 of the 240 `TS_*` names the engine writes down, and missed every metaserver, proxy and
+# raft-tuning knob there is: whole subsystems absent from the one document that claims to list
+# them all, with nothing to notice, because a generator that under-counts still regenerates
+# byte-identically.
+#
+# The name in quotes is what every idiom has in common, so that is what this looks for.
+#
+# All three prefixes, because the engine reads all three. `TS_` alone left 73 `MATRIXARK_*` and
+# `TEMPORALSTORE_*` knobs -- the whole context and gateway surface, the embed drainer, the
+# retrieval caps -- in no inventory at all: this document excluded them by prefix, and the
+# Python-side inventory only reads `tools/`. A knob nobody lists is a knob nobody can decide
+# about, which is the failure this document exists to prevent.
+FLAG_READ = re.compile(r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"')
+
+
+TEST_MODULE = re.compile(r"\s*(?:pub(?:\([a-z():]+\))?\s+)?mod\s+[A-Za-z0-9_]+")
+
+
+def strip_test_modules(text):
+    """Blank out `#[cfg(test)] mod ... { }` bodies, preserving line numbers.
+
+    Excluding test PATHS is not the same as excluding test CODE: most of this engine's unit tests
+    live in an inline `mod tests` inside the file they test. Counting those, a flag named only by
+    a test would be reported as one the engine reads.
+
+    Only a `mod`. The first version of this took any `#[cfg(test)]`, scanned FORWARD for the next
+    `{` and blanked to its match -- so `#[cfg(test)]` on a single statement (which this engine
+    uses, e.g. a test-only watermark store in `lifecycle.rs`) swallowed whatever block came
+    after it. That silently removed live code from the scan: five accessors with obvious callers
+    were reported as having none, because the calls were inside the region this had erased.
+    """
+    lines = text.splitlines()
+    out = list(lines)
+    index = 0
+    while index < len(lines):
+        if lines[index].strip().startswith("#[cfg(test)]"):
+            head = index + 1
+            while head < len(lines) and (not lines[head].strip()
+                                         or lines[head].strip().startswith("#[")):
+                head += 1
+            if head < len(lines) and TEST_MODULE.match(lines[head]):
+                # `#[cfg(test)] mod tests;` declares a module in another FILE and has no body
+                # here. Hunting for its opening brace finds the next item's instead and blanks
+                # that -- which is how `propose_distributed_one` came to look uncalled: the
+                # whole of raft.rs after the declaration had been erased from the scan.
+                if lines[head].rstrip().endswith(";"):
+                    out[head] = ""
+                    index = head
+                    index += 1
+                    continue
+                depth = 0
+                started = False
+                for i in range(head, len(lines)):
+                    depth += lines[i].count("{") - lines[i].count("}")
+                    if "{" in lines[i]:
+                        started = True
+                    out[i] = ""
+                    if started and depth <= 0:
+                        index = i
+                        break
+                else:
+                    index = len(lines)
+        index += 1
+    return NEWLINE.join(out)
 
 
 def function_end(lines, fn_line):
@@ -78,11 +163,14 @@ def doc_for_flag(name, doc, lines, fn_line):
     Crediting it to all of them files words under flags they were never written about, and the
     inventory then reports those words as the reason a flag exists.
 
-    **This changes nothing today.** Nine functions read more than one flag; none of them carries a
-    doc comment, so this returns an empty shared list every time and the count it feeds is zero.
-    It is here because the failure it prevents is silent -- the first documented multi-flag
-    function would produce a confidently wrong row with nothing to notice -- and because a zero
-    that is measured is worth more than a zero that is assumed.
+    This was written when it changed nothing: nine functions read more than one flag and none of
+    them carried a doc comment, so it returned an empty shared list every time and the count it
+    feeds was zero. It was kept anyway because the failure it prevents is silent. Widening the
+    scan to every read idiom brought in the functions that read a dozen knobs at startup, several
+    of which do carry a doc comment, and the count is now in the dozens -- the words those
+    comments contain were about one flag each, and this is what stops them being reported as the
+    reason all dozen exist. A zero that is measured is worth more than a zero that is assumed,
+    and this one did not stay zero.
     """
     if not doc or name in doc or fn_line is None:
         return doc, []
@@ -90,6 +178,115 @@ def doc_for_flag(name, doc, lines, fn_line):
     if len(shared) <= 1:
         return doc, []
     return "", sorted(shared - {name})
+
+# What a boolean flag does when nobody sets it, read off the code that reads it.
+#
+# Paired with the "set by" column this is the whole retirement question in two cells: a flag
+# defaulting ON that nothing sets is one whose off-path no deployment has ever taken.
+#
+# Deliberately narrow. Only the idioms below are recognised, and anything else reports nothing at
+# all -- a wrong default here would be read as fact and acted on, while a blank is read as "go
+# look", which is what it is. Non-boolean knobs have no ON/OFF to state and are blank by
+# construction.
+DEFAULT_ON = re.compile(r"unwrap_or\(\s*true\s*\)|env_flag_default_on\(|\.is_err\(\)")
+DEFAULT_OFF = re.compile(r"unwrap_or\(\s*false\s*\)|\.is_ok\(\)")
+
+
+def _end_of_flag_chain(body: str) -> int:
+    """Where the expression that reads the flag stops, so a LATER default is not read as its own.
+
+    `matrixark_rust_sdk_mode_is_direct` reads `MATRIXARK_RUST_SDK_MODE`, compares it against four
+    mode strings, and then ORs in a second test on `env::args()` ending `.unwrap_or(false)`.
+    Searching the whole body found that `false` and reported a four-valued mode string as a
+    boolean defaulting off -- a default that is not merely unknown but wrong, because setting the
+    variable to `1` does nothing at all.
+
+    Only the END is cut. The `!` that inverts `!matches!(...)` sits several lines ABOVE the name,
+    so trimming the front would reintroduce exactly the error the caller's docstring describes.
+    """
+    first = FLAG_READ.search(body)
+    if not first:
+        return len(body)
+    later = body.find("env::", first.end())
+    return len(body) if later < 0 else later
+
+
+def default_of_statement(lines, read_line):
+    """"on", "off", or "" -- the default of a flag read INLINE, from its own statement.
+
+    `default_of` needs a one-flag function returning bool, so a read in the middle of a larger
+    function reports nothing. That is not a small gap: `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD`
+    is written inline, defaults ON, and is set by nothing anywhere -- exactly the shape the summary
+    counts, and it counted zero because it could not see it.
+
+    The unit is the STATEMENT, not a window of lines. That distinction is the whole safety
+    argument: the `!` that inverts `!matches!(env::var(X)...)` sits above the name but inside the
+    same statement, so a statement always carries its own negation, while a window of n lines
+    carries it only when n happens to be large enough.
+    """
+    start = read_line
+    while start > 0:
+        previous = lines[start - 1].strip()
+        if previous.endswith((";", "{", "}")) or not previous:
+            break
+        start -= 1
+    end = read_line
+    while end < len(lines) - 1 and not lines[end].strip().endswith(";"):
+        end += 1
+    statement = NEWLINE.join(lines[start:end + 1])
+    if len(FLAG_READ.findall(statement)) != 1:
+        return ""
+    # Boolean-shaped only. A statement reading a millisecond count has no ON/OFF to state.
+    if not any(mark in statement for mark in
+               ("matches!", "unwrap_or(true)", "unwrap_or(false)", ".is_ok()", ".is_err()")):
+        return ""
+    if DEFAULT_ON.search(statement):
+        return "on"
+    if DEFAULT_OFF.search(statement):
+        return "off"
+    index = statement.find("matches!(")
+    if index < 0:
+        return ""
+    negated = index > 0 and statement[index - 1] == "!"
+    # `unwrap_or_else(|_| "1")` supplies the default in the string itself rather than as a bool.
+    fallback_on = '"1"' in statement or '"true"' in statement
+    if negated:
+        return "on" if fallback_on or "unwrap_or_default()" in statement else ""
+    return "off" if "unwrap_or_default()" in statement else ""
+
+
+def default_of(body: str, flags_read: int) -> str:
+    """"on", "off", or "" -- the value of the boolean the function `body` returns when unset.
+
+    Read from the WHOLE accessor rather than a window around the name. A window is what a first
+    attempt used, and it reported five default-ON flags as off: they are written
+    `!matches!(env::var(X).unwrap_or_default().trim(), "0" | "false")`, where the `!` that
+    inverts the whole test sits several lines ABOVE the name and outside any window small enough
+    to be safe. A wrong default is worse than a blank one -- it is read as fact -- so this reads
+    the construct entire or says nothing.
+
+    Only for a function that reads ONE flag and returns a bool. A function reading several has
+    no single default to state, and attributing one of them to all of them is the same error in
+    another costume. The bool requirement is the other half: `TS_PROXY_CONTEXT_IO_TIMEOUT_MS` is
+    a millisecond count read inside a function that happens to contain an `.is_ok()` elsewhere,
+    and without it this reported that timeout as defaulting "off".
+    """
+    if flags_read != 1 or not re.match(r"[^\n]*\)\s*->\s*bool\b", body):
+        return ""
+    body = body[: _end_of_flag_chain(body)]
+    if DEFAULT_ON.search(body):
+        return "on"
+    if DEFAULT_OFF.search(body):
+        return "off"
+    if "unwrap_or_default()" not in body:
+        return ""
+    # `!matches!(value, "0" | "false")` is on unless switched off; the same without the `!` is
+    # off unless switched on. Which one it is, is decided by the character before `matches!`.
+    index = body.find("matches!(")
+    if index < 0:
+        return ""
+    return "on" if index > 0 and body[index - 1] == "!" else "off"
+
 
 def classify(name: str) -> str:
     for label, pattern in CLASS_RULES:
@@ -103,21 +300,36 @@ for path in SRC.rglob("*.rs"):
     rel = str(path.relative_to(SRC)).replace("\\", "/")
     sources[rel] = path.read_text(encoding="utf-8", errors="ignore")
 
-prod = {k: v for k, v in sources.items() if "/tests" not in k and not k.startswith("tests")}
+prod = {k: strip_test_modules(v) for k, v in sources.items()
+        if "/tests" not in k and not k.startswith("tests")}
 
 flags = {}
+# Distinct functions that read a flag, as (file, line) -> name. Several flags can share one, so
+# this is not len(flags).
+accessors = {}
 for rel, text in prod.items():
     lines = text.splitlines()
-    for match in re.finditer(r'(?:std::)?env::var(?:_os)?\(\s*"(TS_[A-Z0-9_]+)"', text):
+    for match in FLAG_READ.finditer(text):
         name = match.group(1)
-        entry = flags.setdefault(name, {"sites": set(), "doc": ""})
+        entry = flags.setdefault(name, {"sites": set(), "doc": "", "default": ""})
         entry["sites"].add(rel)
-        if entry["doc"]:
+        # Two things are wanted per flag and they are not found at the same site: the doc comment
+        # comes from wherever one was written, the default only from the accessor that returns a
+        # bool. Skipping the rest of a flag's sites once a doc was found also skipped its
+        # accessor -- `TS_VECTOR_INT8` is read first by a function with a doc and a moment later
+        # by `vector_int8_enabled`, and only the second one knows what unset means.
+        if entry["doc"] and entry["default"]:
             continue
         line_no = text[:match.start()].count("\n")
         fn_line = None
         for i in range(line_no, max(line_no - 40, -1), -1):
-            if re.match(r"\s*(pub(\(crate\))?\s+)?fn ", lines[i]):
+            # `pub(crate)` was the only visibility this knew about, so a `pub(super) fn`
+            # accessor -- which is what most of the per-module gates are -- did not read as a
+            # function at all: the walk continued past it to whatever function came before, and
+            # the flag was credited with that one's doc comment or none. Both `TS_BLOCK_IN_WAL`
+            # and `TS_HOT_PAGE_SPILL` say "restore the previous behaviour" in their own doc and
+            # were reported as keeping no older path alive.
+            if re.match(r"\s*(pub(\([a-z():]+\))?\s+)?(async\s+)?fn ", lines[i]):
                 fn_line = i
                 break
         doc = []
@@ -127,6 +339,19 @@ for rel, text in prod.items():
                 doc.append(lines[i].strip()[3:].strip())
                 i -= 1
             doc.reverse()
+        if fn_line is not None:
+            match_name = re.match(
+                r"\s*(?:pub(?:\([a-z():]+\))?\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)",
+                lines[fn_line])
+            if match_name:
+                accessors[(rel, fn_line)] = match_name.group(1)
+        if fn_line is not None and not entry["default"]:
+            body = NEWLINE.join(lines[fn_line:function_end(lines, fn_line)])
+            entry["default"] = default_of(body, len(set(FLAG_READ.findall(body))))
+        if not entry["default"]:
+            entry["default"] = default_of_statement(lines, line_no)
+        if entry["doc"]:
+            continue
         text_doc, shared_with = doc_for_flag(name, " ".join(doc), lines, fn_line)
         if shared_with:
             entry["doc_shared_with"] = shared_with
@@ -135,9 +360,80 @@ for rel, text in prod.items():
 # knobs named by a constant, which no env::var scan sees
 for rel, text in prod.items():
     for ident, value in re.findall(
-            r'pub const (TS_[A-Z0-9_]+)\s*:\s*&(?:\'static\s+)?str\s*=\s*"(TS_[A-Z0-9_]+)"', text):
-        entry = flags.setdefault(value, {"sites": set(), "doc": ""})
+            r'pub const ([A-Z0-9_]+)\s*:\s*&(?:\'static\s+)?str\s*=\s*'
+        r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"', text):
+        entry = flags.setdefault(value, {"sites": set(), "doc": "", "default": ""})
         entry["sites"].add(rel)
+
+# Where a flag is given a value, as opposed to read.
+#
+# This is the column the inventory was missing. "How many files does it reach" measures the code
+# its off-path keeps alive; it says nothing about whether that path is ever taken. A flag that no
+# test, config file, launch profile or portal setting ever sets is not a switch anyone throws --
+# it is a branch with one live side, and the other side can go.
+#
+# Deliberately literal: it reports WHERE a value is set, never whether that value differs from the
+# default, because the default lives in Rust and this reads text. An owner reading "config" still
+# has to look; an owner reading "nothing" does not.
+NAME = r"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"
+SETTERS = [
+    ("test", re.compile(r'(?:set_var|EnvFlagGuard::(?:set|off)|EnvGuard::(?:set|off))\(\s*"%s"'
+                        % NAME)),
+    ("launch", re.compile(r"export\s+%s=" % NAME)),
+    ("harness", re.compile(r'\.envs?\(\s*(?:&\[)?\(?\s*"%s"' % NAME)),
+    # Python launchers put a value in the environment of the process they start. Without this the
+    # column would say "nothing" for anything only the Python side configures, which is most of
+    # what an operator actually turns on.
+    ("script", re.compile(r'(?:environ(?:\.setdefault)?|env)\s*[\[(]\s*"%s"\s*[\])]?\s*(?:,|=[^=])'
+                          % NAME)),
+]
+CONFIG_NAME = re.compile(NAME)
+SET_ROOTS = [
+    (ROOT / "crates" / "temporalstore-rust" / "src", (".rs",)),
+    (ROOT / "crates" / "temporalstore-rust" / "tests", (".rs",)),
+    (ROOT / "config", (".toml",)),
+    (ROOT / "tools", (".sh", ".py")),
+    (ROOT / "deploy", (".sh", ".yml", ".yaml", ".env")),
+]
+
+
+def _setters_by_name():
+    """name -> {kinds}, in ONE pass over the corpus.
+
+    Asking "where is THIS name set" per flag re-read every file three hundred times and turned a
+    one-second generator into a minutes-long one, which is how a generated document stops being
+    regenerated. The names are matched by the same patterns, read out of the text rather than
+    substituted into it -- so nesting (`TS_META_RAFT` inside `TS_META_RAFT_NODES`) resolves by
+    what the pattern actually captured, not by a substring test that would credit the shorter
+    name with the longer one's setting.
+    """
+    found = {}
+    for root, suffixes in SET_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or path.suffix not in suffixes:
+                continue
+            body = path.read_text(encoding="utf-8", errors="ignore")
+            if path.suffix == ".toml":
+                # The shipped config names each variable in the comment beside the key it maps
+                # to, so appearing at all is appearing as a setting.
+                for name in CONFIG_NAME.findall(body):
+                    found.setdefault(name, set()).add("config")
+                continue
+            for label, pattern in SETTERS:
+                for name in pattern.findall(body):
+                    found.setdefault(name, set()).add(label)
+    return found
+
+
+SET_BY = _setters_by_name()
+
+
+def set_by(name):
+    """Sorted kinds of place that give `name` a value. Empty means nothing does."""
+    return sorted(SET_BY.get(name, ()))
+
 
 sys.path.insert(0, str(ROOT / "tools"))
 try:
@@ -151,12 +447,17 @@ for name in sorted(flags):
     entry = flags[name]
     doc = entry["doc"]
     legacy = bool(LEGACY.search(doc))
+    setters = set_by(name)
+    if name in offered:
+        setters.append("portal")
     rows.append({
         "name": name,
         "group": classify(name),
         "sites": len(entry["sites"]),
         "legacy": legacy,
+        "default": entry.get("default", ""),
         "offered": name in offered,
+        "set_by": setters,
         "doc": doc,
         "shared_with": entry.get("doc_shared_with", []),
     })
@@ -168,26 +469,61 @@ for row in rows:
 lines = [
     "# Engine flags",
     "",
-    "Every `TS_*` variable the engine reads, grouped by what it decides. Generated from the source",
+    "Every environment variable the engine reads -- `TS_*`, `MATRIXARK_*` and",
+    "`TEMPORALSTORE_*` -- grouped by what it decides. Generated from the source",
     "by `tools/build_engine_flag_inventory.py` and checked by",
     "`test_matrixark_engine_flag_inventory.py`, because a hand-kept list of this many knobs is wrong",
     "within a week and its staleness is silent.",
     "",
     "## Why this exists",
     "",
-    "There are %d of them, and **none is dead**: all 55 accessor functions that read one have a"
-    % len(rows),
-    "non-test caller. So the length of this list is not a cleanup backlog -- every flag changes",
-    "behaviour, and retiring one is a decision about behaviour rather than tidying.",
+    "There are %d of them, read by %d functions." % (len(rows), len(accessors)),
     "",
-    "What the list gives an owner deciding that is: how many files each flag reaches (the code its",
-    "non-default path keeps alive), whether its own documentation calls that path legacy, and",
-    "whether a customer can set it at all.",
+    "Deleting unreachable code is not the lever. An earlier version of this document argued that",
+    "by asserting every accessor had a caller -- true when it was hand-checked at 55, and carried",
+    "forward unexamined ever since. Computing it instead named four functions as uncalled that",
+    "plainly are: Rust reaches a function by more than one syntax (a generic definition,",
+    "`unwrap_or_else(name)` passing it as a value, serde naming it in a string) and a name scan",
+    "sees none of those. So the claim is neither asserted nor computed here.",
+    ""
+    "",
+    "What shortens it is a narrower question, asked per flag: **does anything anywhere select the",
+    "off position?** Not a test, not a config file, not a launch profile, not a portal setting. A",
+    "flag no one can be shown to turn off is not a switch, it is a branch -- and the live side can",
+    "be made unconditional, taking the dead side with it. That is a safe edit exactly when reads do",
+    "not consult the flag: if the decoder already accepts both shapes, retiring the writer strands",
+    "nothing already written.",
+    "",
+    "What the list gives an owner asking that is: how many files each flag reaches (the code its",
+    "non-default path keeps alive), whether its own documentation calls that path legacy, and --",
+    "the two columns that answer the question -- its **default**, where that can be read off the",
+    "source, and **who sets it**: a test, the shipped config file, a launch profile, a Python",
+    "launcher, a test harness, or the customer portal. `nothing` means no place in this",
+    "repository gives it a value, so whatever its non-default path does, nothing here asks for it.",
+    "",
+    "That column is literal about WHERE, not about WHAT: it does not compare the value set against",
+    "the default, because the default lives in Rust and this reads text. `config` is a prompt to go",
+    "look; `nothing` is an answer.",
+    "",
+    "The **default** column reads two shapes: a function that reads one flag and returns a bool,",
+    "and a single statement that does the same inline. The second was added because the first",
+    "made the row below it -- flags defaulting on that nothing sets -- report zero while",
+    "`MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` sat inline in the middle of a function,",
+    "defaulting on, set by nothing. A statement is the unit rather than a window of lines because",
+    "the `!` that inverts `!matches!(env::var(X)...)` sits above the name but inside the same",
+    "statement: a statement always carries its own negation, a window carries it only by luck.",
+    "Anything else is blank, and a blank means go and look.",
     "",
     "| flags | count |",
     "|---|---|",
     "| total | %d |" % len(rows),
+    "| booleans whose default this could read off the source | %d |"
+    % sum(1 for r in rows if r["default"]),
+    "| **defaulting on, and set by nothing** | %d |"
+    % sum(1 for r in rows if r["default"] == "on" and not r["set_by"]),
     "| offered on the portal | %d |" % sum(1 for r in rows if r["offered"]),
+    "| **that nothing in this repository sets** | %d |"
+    % sum(1 for r in rows if not r["set_by"]),
     "| documented as keeping an older path alive | %d |" % sum(1 for r in rows if r["legacy"]),
     "| reaching more than two files | %d |" % sum(1 for r in rows if r["sites"] > 2),
     # Zero today, and measured rather than assumed: see doc_for_flag.
@@ -196,7 +532,8 @@ lines = [
     "",
 ]
 
-ORDER = ["topology", "credential", "durability", "format", "capacity", "diagnostic", "behaviour"]
+ORDER = ["topology", "cluster policy", "credential", "durability", "format", "capacity",
+         "context", "identity", "diagnostic", "benchmark", "behaviour"]
 BLURB = {
     "topology": "Where this node is and what it talks to. Set by whoever provisions the node; not "
                 "tenant-facing and not tuning.",
@@ -207,6 +544,13 @@ BLURB = {
               "makes these safe to flip and hard to retire.",
     "capacity": "Sizes, ceilings and intervals. The tuning a deployment actually reaches for.",
     "diagnostic": "Extra evidence for someone investigating. Off by default.",
+    "identity": "Who the caller is, not what the engine does. Supplied per request or per "
+                "process; nothing here is a switch.",
+    "benchmark": "Read only by the benchmark harnesses. Never consulted on a serving path.",
+    "context": "The memory pipeline: what gets extracted, embedded, drained and packed. The "
+               "surface a deployment tunes for recall rather than for throughput.",
+    "cluster policy": "What the metaserver does about nodes it cannot reach -- conviction, "
+                      "freezing, rebalancing, failover. Cluster-wide, and never per shard.",
     "behaviour": "Everything else that changes what the engine does.",
 }
 
@@ -218,17 +562,49 @@ for group in ORDER:
     lines.append("")
     lines.append(BLURB[group])
     lines.append("")
-    lines.append("| flag | files | portal | keeps an older path |")
-    lines.append("|---|---|---|---|")
+    lines.append("| flag | default | set by | files | keeps an older path |")
+    lines.append("|---|---|---|---|---|")
     for row in sorted(members, key=lambda r: (-r["sites"], r["name"])):
-        lines.append("| `%s` | %d | %s | %s |" % (
-            row["name"], row["sites"],
-            "yes" if row["offered"] else "—",
+        lines.append("| `%s` | %s | %s | %d | %s |" % (
+            row["name"], row["default"] or "—",
+            ", ".join(row["set_by"]) if row["set_by"] else "nothing",
+            row["sites"],
             "yes" if row["legacy"] else "—"))
+    lines.append("")
+
+# --- where the engine ends ----------------------------------------------------------------------
+# `sdk/rust/temporalstore` is a SECOND Rust tree with its own copy of the proxy implementation --
+# a different file, not a stale duplicate: 121 KB against 345 KB. The root manifest carries it as
+# `exclude = ["sdk/rust/temporalstore"]`, so it is not a workspace member and `cargo check
+# --all-targets` never builds it, in CI or here.
+#
+# That makes it out of scope for a document about the engine, and it stays out of scope. What it
+# must not be is invisible: a reader who greps this file for a variable the SDK reads finds
+# nothing and concludes nothing reads it. So the boundary is stated, and the names on the far
+# side of it are computed rather than listed by hand, which is the only version that stays true.
+SDK_SRC = ROOT / "sdk" / "rust" / "temporalstore" / "src"
+sdk_names = set()
+if SDK_SRC.is_dir():
+    for path in sorted(SDK_SRC.rglob("*.rs")):
+        sdk_names.update(FLAG_READ.findall(io.open(path, encoding="utf-8").read()))
+sdk_only = sorted(sdk_names - {r["name"] for r in rows})
+if sdk_only:
+    lines.append("## outside this document (%d)" % len(sdk_only))
+    lines.append("")
+    lines.append("`sdk/rust/temporalstore` is a second Rust tree, carrying its own copy of the")
+    lines.append("proxy implementation -- a different file, not a stale duplicate. The root")
+    lines.append("manifest excludes it from the workspace, so `cargo check --all-targets` does not")
+    lines.append("build it, here or in CI, and it is a client of the engine rather than part of")
+    lines.append("it. These are the variables it reads that this document does not cover. The list")
+    lines.append("is computed, so one more cannot appear quietly.")
+    lines.append("")
+    for name in sdk_only:
+        lines.append("- `%s`" % name)
     lines.append("")
 
 OUT.parent.mkdir(parents=True, exist_ok=True)
 io.open(OUT, "w", encoding="utf-8", newline="\n").write("\n".join(lines) + "\n")
 print("  wrote %s" % OUT)
-print("  flags: %d   offered: %d   legacy-shaped: %d"
-      % (len(rows), sum(1 for r in rows if r["offered"]), sum(1 for r in rows if r["legacy"])))
+print("  flags: %d   offered: %d   legacy-shaped: %d   set by nothing: %d"
+      % (len(rows), sum(1 for r in rows if r["offered"]), sum(1 for r in rows if r["legacy"]),
+         sum(1 for r in rows if not r["set_by"])))

--- a/tools/matrixark_load_config.py
+++ b/tools/matrixark_load_config.py
@@ -92,7 +92,6 @@ ENV_MAP: Dict[str, str] = {
     "storage.cross_shard_reclaim_guard": "TS_CROSS_SHARD_RECLAIM_GUARD",
     "storage.index_dump_oplog_gap_bytes": "TS_INDEX_DUMP_OPLOG_GAP_BYTES",
     # ---- [wal] --------------------------------------------------------------
-    "wal.group_commit": "TS_GROUP_COMMIT",
     "wal.wal_legacy_recovery": "TS_WAL_LEGACY_RECOVERY",
     "wal.raft_wal_dir": "TS_RAFT_WAL_DIR",
     # ---- [replication] ------------------------------------------------------
@@ -112,8 +111,6 @@ ENV_MAP: Dict[str, str] = {
     # ---- [recovery] ---------------------------------------------------------
     "recovery.bulk_ingest": "MATRIXARK_BULK_INGEST",
     "recovery.eager_cache_warm_on_load": "MATRIXARK_EAGER_CACHE_WARM_ON_LOAD",
-    "recovery.delta_served_index": "MATRIXARK_DELTA_SERVED_INDEX",
-    "recovery.enable_indexlog": "MATRIXARK_ENABLE_INDEXLOG",
     "recovery.bulk_ingest_replay_from_sequence": "MATRIXARK_BULK_INGEST_REPLAY_FROM_SEQUENCE",
     # ---- [retrieval] --------------------------------------------------------
     "retrieval.default_max_context_tokens": "MATRIXARK_DEFAULT_MAX_CONTEXT_TOKENS",

--- a/tools/portal/build_portal_pages.py
+++ b/tools/portal/build_portal_pages.py
@@ -1256,7 +1256,13 @@ SETUP_JS = r"""
      Applies to any setting whose variable ends in _BYTES, so it covers the two quota settings
      that predate the engine group as well. */
   function byteHint(f) {
-    if (!f.env || !/_BYTES$/.test(f.env)) { return ""; }
+    /* Byte counts whose NAME does not end in _BYTES. Without these they render as bare integers:
+       1073741824 beside 268435456 look alike at a glance, which is how a zone gets sized wrong by
+       someone reading carefully. Declared INSIDE the function on purpose -- the byte-hint harness
+       extracts this function alone and calls it, so anything it needs has to travel with it.
+       test_matrixark_byte_settings_read_in_units keeps the list in step with the settings. */
+    var byteValued = { TS_STORAGE_ZONE_SIZE: 1, TS_STREAM_MAX_BLOB_SIZE: 1 };
+    if (!f.env || (!/_BYTES$/.test(f.env) && !byteValued[f.env])) { return ""; }
     var raw = (f.value === "" || f.value == null) ? f.default : f.value;
     var size = Number(raw);
     if (!isFinite(size) || size <= 0) { return ""; }

--- a/tools/portal/byte_hint_harness.js
+++ b/tools/portal/byte_hint_harness.js
@@ -45,7 +45,11 @@ const cases = [
   { env: "MATRIXARK_QUOTA_MAX_BLOB_BYTES", value: "5368709120", expect: "5 GiB" },
   { env: "MATRIXARK_QUOTA_MAX_BODY_BYTES", value: "16777216", expect: "16 MiB" },
   { env: "TS_PAGE_INDEX_CACHE_BYTES", value: "", default: "67108864", expect: "64 MiB" },
-  { env: "TS_STREAM_MAX_BLOB_SIZE_BYTES", value: "1500000", expect: "1.4 MiB" }
+  /* Both are byte counts whose names do NOT end in _BYTES. The case here used to read
+     TS_STREAM_MAX_BLOB_SIZE_BYTES, a variable that exists nowhere -- so it exercised the suffix
+     rule against a name invented to satisfy it, and said nothing about the setting it was for. */
+  { env: "TS_STREAM_MAX_BLOB_SIZE", value: "10485760", expect: "10 MiB" },
+  { env: "TS_STORAGE_ZONE_SIZE", value: "1073741824", expect: "1 GiB" }
 ];
 
 for (const c of cases) {
@@ -58,7 +62,11 @@ for (const c of cases) {
   }
 }
 
-for (const env of ["TS_VECTOR_SCALED", "TS_MAX_RETAINED_FINISHED_JOBS", "MATRIXARK_HTTP_PORT"]) {
+/* `MATRIXARK_SUMMARY_REFRESH_LIMIT` is the interesting one: an int setting whose name ends in a
+   size-ish word but which counts summaries, not bytes. It belongs here rather than above, where
+   an `expect: ""` would have asserted nothing -- `"anything".includes("")` is true. */
+for (const env of ["TS_VECTOR_SCALED", "TS_MAX_RETAINED_FINISHED_JOBS", "MATRIXARK_HTTP_PORT",
+                   "MATRIXARK_SUMMARY_REFRESH_LIMIT"]) {
   const out = byteHint({ env: env, value: "1024" });
   if (out !== "") {
     console.log("FAIL " + env + " is not a byte count and gained " + JSON.stringify(out));

--- a/tools/portal/setup_portal.html
+++ b/tools/portal/setup_portal.html
@@ -994,7 +994,13 @@ function liveStream(options) {
      Applies to any setting whose variable ends in _BYTES, so it covers the two quota settings
      that predate the engine group as well. */
   function byteHint(f) {
-    if (!f.env || !/_BYTES$/.test(f.env)) { return ""; }
+    /* Byte counts whose NAME does not end in _BYTES. Without these they render as bare integers:
+       1073741824 beside 268435456 look alike at a glance, which is how a zone gets sized wrong by
+       someone reading carefully. Declared INSIDE the function on purpose -- the byte-hint harness
+       extracts this function alone and calls it, so anything it needs has to travel with it.
+       test_matrixark_byte_settings_read_in_units keeps the list in step with the settings. */
+    var byteValued = { TS_STORAGE_ZONE_SIZE: 1, TS_STREAM_MAX_BLOB_SIZE: 1 };
+    if (!f.env || (!/_BYTES$/.test(f.env) && !byteValued[f.env])) { return ""; }
     var raw = (f.value === "" || f.value == null) ? f.default : f.value;
     var size = Number(raw);
     if (!isFinite(size) || size <= 0) { return ""; }

--- a/tools/test_matrixark_byte_settings_read_in_units.py
+++ b/tools/test_matrixark_byte_settings_read_in_units.py
@@ -14,6 +14,7 @@ function from the built page and calls it.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import unittest
@@ -44,26 +45,71 @@ class AByteSettingReadsInUnitsTest(unittest.TestCase):
 
 
 class EveryByteSettingIsCoveredTest(unittest.TestCase):
-    """The hint keys off a `_BYTES` suffix, so a byte setting named otherwise gets nothing."""
+    """Every byte-valued setting renders with a readable size -- checked by rendering it.
 
-    def test_no_byte_shaped_setting_is_missed_by_the_suffix_rule(self) -> None:
+    The hint keys off a `_BYTES` suffix plus a short list of names that lack one, so a byte
+    setting named otherwise gets a bare integer. Two did: `TS_STORAGE_ZONE_SIZE` (1 GiB) and
+    `TS_STREAM_MAX_BLOB_SIZE` (10 MiB).
+
+    This test existed to catch that and did not, because it asked whether a setting's help
+    contained the word "bytes" -- and both of them say "1 KiB". A detector that misses every
+    member of the class it guards passes exactly as loudly as one that works.
+
+    So it stops pattern-matching prose and renders instead: it finds the byte-shaped settings by
+    unit words in their help, then calls the built page's own `byteHint` on each. A name the list
+    forgets comes back empty, and empty fails.
+    """
+
+    UNIT = re.compile(r"\b(bytes?|[KMGT]iB)\b")
+
+    def _byte_shaped(self):
         import matrixark_gateway_config as cfgmod
 
-        suspicious = []
+        found = []
         for setting in cfgmod.SETTINGS:
             if setting.kind != "int" or not setting.env:
                 continue
-            if setting.env.endswith("_BYTES"):
-                continue
-            # A setting whose help talks about bytes but whose name does not end in _BYTES would
-            # render as a bare integer with no hint, and nothing else would notice.
-            help_text = (setting.help or "").lower()
-            if "bytes" in help_text and "per" not in help_text:
-                suspicious.append("%s (%s)" % (setting.key, setting.env))
+            # By NAME or by what the help calls it. Only four settings name a unit in their help,
+            # so the help alone is far too narrow a scan to rest an "everything is covered" claim
+            # on -- and the suffix alone is what missed these two in the first place.
+            if setting.env.endswith("_BYTES") or self.UNIT.search(setting.help or ""):
+                found.append(setting)
+        return found
+
+    def test_the_scan_finds_the_byte_settings(self) -> None:
+        """A scan that found none would make the check below pass over an empty list."""
+        found = self._byte_shaped()
+        self.assertGreaterEqual(
+            len(found), 8,
+            "only %d byte-shaped settings found; the scan is broken" % len(found))
+        self.assertTrue(
+            any(not s.env.endswith("_BYTES") for s in found),
+            "no byte setting outside the _BYTES suffix was found, which is the case this exists "
+            "for -- the scan has stopped seeing them")
+
+    @unittest.skipUnless(shutil.which("node"), "node is not installed; the page's own JS cannot be run")
+    def test_every_byte_shaped_setting_renders_with_a_size(self) -> None:
+        missing = []
+        for setting in self._byte_shaped():
+            value = setting.default or "1073741824"
+            script = (
+                "const fs=require('fs');"
+                "const page=fs.readFileSync(process.argv[1],'utf8');"
+                "const start=page.indexOf('function byteHint');"
+                "const end=page.indexOf('function fieldHtml');"
+                "const fn=new Function(page.slice(start,end)+'; return byteHint;')();"
+                "process.stdout.write(fn({env:process.argv[2],value:process.argv[3]}));"
+            )
+            proc = subprocess.run(["node", "-e", script, PAGE, setting.env, str(value)],
+                                  capture_output=True, text=True, timeout=120)
+            self.assertEqual(0, proc.returncode,
+                             "rendering %s failed: %s" % (setting.env, proc.stderr))
+            if not proc.stdout.strip():
+                missing.append("%s (%s = %s)" % (setting.key, setting.env, value))
         self.assertEqual(
-            [], suspicious,
-            "these look like byte counts but do not end in _BYTES, so they render without a "
-            "readable size: %s" % ", ".join(suspicious))
+            [], missing,
+            "these hold byte counts and render as bare integers, with no readable size beside "
+            "them:\n  %s" % "\n  ".join(missing))
 
 
 if __name__ == "__main__":

--- a/tools/test_matrixark_engine_flag_inventory.py
+++ b/tools/test_matrixark_engine_flag_inventory.py
@@ -2,9 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """The engine flag inventory matches the engine.
 
-98 `TS_*` variables is a lot, and the first useful thing anyone can do with that number is see the
-list grouped by what each flag decides. A hand-kept list of 98 is wrong within a week, and wrong
-quietly -- so the document is generated and this regenerates it and compares.
+Two hundred-odd `TS_*` variables is a lot, and the first useful thing anyone can do with that
+number is see the list grouped by what each flag decides. A hand-kept list that long is wrong
+within a week, and wrong quietly -- so the document is generated and this regenerates it and
+compares.
+
+Regenerating is not enough on its own, which is the lesson that added `TheInventoryIsCompleteTest`
+below. A generator that can only see one way of reading a flag regenerates byte-identically
+forever while naming half of them: this document listed 94 while the engine named 201, and every
+metaserver, proxy and raft-tuning knob was simply absent. Comparing the output to itself cannot
+catch that. So the completeness test compares the document to the SOURCE, and states how much
+source it read -- a scan that silently matched nothing would otherwise pass hardest of all.
 
 The failure message says how to fix it, because a byte-comparison failure with no instruction is
 the kind of test people delete.
@@ -13,6 +21,8 @@ from __future__ import annotations
 
 import io
 import os
+import pathlib
+import re
 import subprocess
 import sys
 import tempfile
@@ -24,21 +34,64 @@ BUILDER = os.path.join(TOOLS, "build_engine_flag_inventory.py")
 DOC = os.path.join(ROOT, "docs", "ops", "temporalstore-engine-flags.md")
 
 
+def _builder_prelude() -> dict:
+    """The builder's helpers, without running it.
+
+    The script does its work at module level -- importing it regenerates the document -- so only
+    the part above that work is executed.
+    """
+    with io.open(BUILDER, encoding="utf-8") as handle:
+        head = handle.read().split("sources = {}")[0]
+    namespace: dict = {}
+    exec(compile(head, BUILDER, "exec"), namespace)  # noqa: S102 - the builder's own prelude
+    return namespace
+
+
+# Every prefix the engine reads, which is every prefix the inventory now lists.
+FLAG_LITERAL = re.compile(r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"')
+
+
+def _engine_sources():
+    """(path, source) for the files the builder treats as engine source."""
+    strip = _builder_prelude()["strip_test_modules"]
+    source_root = os.path.join(ROOT, "crates", "temporalstore-rust", "src")
+    for directory, _, names in os.walk(source_root):
+        for name in sorted(names):
+            if not name.endswith(".rs"):
+                continue
+            path = os.path.join(directory, name)
+            relative = os.path.relpath(path, source_root).replace(os.sep, "/")
+            if "/tests" in relative or relative.startswith("tests"):
+                continue
+            with io.open(path, encoding="utf-8", errors="ignore") as handle:
+                yield relative, strip(handle.read())
+
+
 def _regenerate_into(directory: str) -> str:
     """Run the builder against a tree whose doc lives in `directory`, and return what it wrote."""
     os.makedirs(os.path.join(directory, "docs", "ops"), exist_ok=True)
-    # the builder reads the engine source from the tree it is given, so point it at the real one
-    # by symlinking rather than copying a large directory
-    link = os.path.join(directory, "crates")
-    if not os.path.exists(link):
+    # The builder reads the tree it is GIVEN -- engine source for what reads a flag, and
+    # config/tools/deploy for what sets one -- so point every one of those at the real
+    # directory by symlinking rather than copying. A missing link is not a harmless omission:
+    # the builder would report those flags as set by nothing, and the comparison would fail
+    # with a diff about flags rather than about the harness.
+    if not os.path.exists(os.path.join(directory, "crates")):
         try:
-            os.symlink(os.path.join(ROOT, "crates"), link)
+            os.symlink(os.path.join(ROOT, "crates"), os.path.join(directory, "crates"))
         except OSError:
             return ""
-    tools_link = os.path.join(directory, "tools")
-    if not os.path.exists(tools_link):
+    for name, target in (("tools", TOOLS),
+                         ("config", os.path.join(ROOT, "config")),
+                         ("deploy", os.path.join(ROOT, "deploy")),
+                         # Not a setter root: the builder reads `sdk` to say which variables are
+                         # on the far side of the engine boundary. Without the link the section
+                         # is simply absent, and the comparison below fails describing a flag.
+                         ("sdk", os.path.join(ROOT, "sdk"))):
+        link = os.path.join(directory, name)
+        if os.path.exists(link) or not os.path.exists(target):
+            continue
         try:
-            os.symlink(TOOLS, tools_link)
+            os.symlink(target, link)
         except OSError:
             pass
     subprocess.run([sys.executable, BUILDER, directory],
@@ -49,6 +102,8 @@ def _regenerate_into(directory: str) -> str:
     with io.open(written, encoding="utf-8") as handle:
         return handle.read()
 
+
+ROOT_PATH = pathlib.Path(ROOT)
 
 class TheInventoryMatchesTheEngineTest(unittest.TestCase):
 
@@ -68,30 +123,115 @@ class TheInventoryMatchesTheEngineTest(unittest.TestCase):
             "the flag inventory no longer matches the engine. A flag was added, removed or "
             "renamed. Regenerate it: python3 tools/build_engine_flag_inventory.py .")
 
+    def test_the_boundary_section_names_what_the_sdk_tree_reads(self) -> None:
+        """The document says where the engine ends; this checks it says it correctly.
+
+        `sdk/rust/temporalstore` is excluded from the workspace and carries its own copy of the
+        proxy implementation, so nothing about it is caught by building or by the comparison
+        above -- the builder would not notice a variable appearing there, and neither would CI.
+        The section exists so a reader who greps this document for such a variable is told where
+        to look instead of concluding nothing reads it, and this asserts the two agree.
+        """
+        sdk_src = os.path.join(ROOT, "sdk", "rust", "temporalstore", "src")
+        if not os.path.isdir(sdk_src):
+            self.skipTest("no sdk tree in this checkout")
+        reads = set()
+        for base, _dirs, names in os.walk(sdk_src):
+            for name in names:
+                if not name.endswith(".rs"):
+                    continue
+                with io.open(os.path.join(base, name), encoding="utf-8") as handle:
+                    reads.update(re.findall(
+                        r'"((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)"', handle.read()))
+        with io.open(DOC, encoding="utf-8") as handle:
+            text = handle.read()
+        tabled = set(re.findall(
+            r"^\| `((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)`", text, re.MULTILINE))
+        expected = sorted(reads - tabled)
+        section = text.split("## outside this document", 1)
+        listed = sorted(re.findall(
+            r"^- `((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)`", section[-1], re.MULTILINE))             if len(section) > 1 else []
+        self.assertEqual(
+            expected, listed,
+            "the boundary section no longer matches the sdk tree. Regenerate it: "
+            "python3 tools/build_engine_flag_inventory.py .")
+        # An empty expectation would make the assertion above pass while proving nothing, and
+        # that is the state this test is meant to catch drifting INTO -- so require the scan to
+        # have found the tree it is about.
+        self.assertGreater(len(reads), 3, "scanned the sdk tree and found almost no flag reads")
+
     def test_it_covers_a_plausible_number_of_flags(self) -> None:
         """A generator that produced an empty table would satisfy the comparison above."""
         with io.open(DOC, encoding="utf-8") as handle:
             text = handle.read()
-        rows = [line for line in text.splitlines() if line.startswith("| `TS_")]
+        rows = [line for line in text.splitlines()
+                if re.match(r"^\| `(TS|MATRIXARK|TEMPORALSTORE)_", line)]
         self.assertGreaterEqual(
             len(rows), 60,
             "the inventory lists only %d flags; the engine reads far more, so the generator has "
             "stopped seeing them" % len(rows))
 
     def test_every_portal_engine_setting_appears(self) -> None:
-        """The 16 a customer can set must be in the list a reader consults."""
+        """Everything a customer can set AND the engine reads must be in the list.
+
+        This was filtered on the `TS_` prefix while the document held only those. The document
+        now holds every prefix the engine reads, so that filter would quietly excuse the
+        portal's `MATRIXARK_*` settings from the check that they appear at all. The second
+        condition is the honest half: the portal also offers settings this engine never reads
+        (they are consumed on the Python side), and those have no business in an engine list.
+        """
         sys.path.insert(0, TOOLS)
         import matrixark_gateway_config as cfgmod
 
         with io.open(DOC, encoding="utf-8") as handle:
             text = handle.read()
+        named = {name for _relative, source in _engine_sources()
+                 for name in FLAG_LITERAL.findall(source)}
         missing = [s.env for s in cfgmod.SETTINGS
-                   if s.env.startswith("TS_") and ("`%s`" % s.env) not in text]
+                   if s.env in named and ("`%s`" % s.env) not in text]
         self.assertEqual(
             [], missing,
             "these are offered on the portal and absent from the flag inventory, so the one "
             "document that lists engine knobs does not list the ones a customer can change: %s"
             % ", ".join(missing))
+
+
+class TheInventoryIsCompleteTest(unittest.TestCase):
+    """Every flag name the engine source writes down appears in the document.
+
+    The pattern here is deliberately dumber than the generator's: any quoted flag name. That is
+    the property the document claims ("every TS_* variable the engine reads"), and checking it
+    with a rule *simpler* than the generator's is the point -- a guard that shares the
+    generator's blind spot is not a guard, and the blind spot was exactly a pattern that knew
+    about one way of reading a flag.
+
+    What it does share is which SOURCE counts: the same non-test paths and the same
+    `#[cfg(test)]` stripping, taken from the builder itself rather than reimplemented. "Test code
+    is not engine code" is not the property under test, and a second copy of that rule would
+    disagree with the first sooner or later.
+    """
+
+    def test_every_flag_named_in_the_engine_is_listed(self) -> None:
+        files = 0
+        named = set()
+        for _relative, source in _engine_sources():
+            files += 1
+            named.update(FLAG_LITERAL.findall(source))
+        # State the extent. An assertion over an empty scan is the easiest one in the world to
+        # pass, and a scan that stopped finding files would report "no flags missing".
+        self.assertGreater(files, 40,
+                           "read only %d engine sources; the scan is not reaching them" % files)
+        self.assertGreater(len(named), 150,
+                           "found only %d flag names in %d files; the pattern has stopped "
+                           "matching" % (len(named), files))
+        with io.open(DOC, encoding="utf-8") as handle:
+            document = handle.read()
+        missing = sorted(name for name in named if ("`%s`" % name) not in document)
+        self.assertEqual(
+            [], missing,
+            "the engine names these flags and the inventory does not list them, so the one "
+            "document that claims to list every engine knob does not: %s. Regenerate it: "
+            "python3 tools/build_engine_flag_inventory.py ." % ", ".join(missing))
 
 
 class TheDefaultRootIsThisRepositoryTest(unittest.TestCase):
@@ -125,3 +265,111 @@ class TheDefaultRootIsThisRepositoryTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheShippedConfigOffersNothingDeadTest(unittest.TestCase):
+    """Every variable `config/temporalstore.toml` names is read by something.
+
+    The config file is the document an operator trusts about what is adjustable, so a key naming
+    a variable nothing reads is worse than the key not existing: setting it produces no error and
+    no effect. Four were found this way -- `group_commit`, `delta_served_index`,
+    `enable_indexlog` and `bulk_ingest_replay_from_sequence` -- three of which had outlived their
+    gate long before anyone looked.
+
+    A reader counts: the Rust engine, the SDK tree, or any Python tool. What does not count is
+    `matrixark_load_config.py`, which merely maps the key to the variable -- if that counted, a
+    key would prove its own liveness.
+    """
+
+    def setUp(self) -> None:
+        self.config = ROOT_PATH / "config" / "temporalstore.toml"
+        if not self.config.is_file():
+            self.skipTest("no shipped config in this checkout")
+
+    def _readers(self) -> set:
+        names = set()
+        pattern = re.compile(r'["\']((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)["\']')
+        for root, suffixes in ((ROOT_PATH / "crates", (".rs",)),
+                               (ROOT_PATH / "sdk", (".rs",)),
+                               (ROOT_PATH / "tools", (".py",))):
+            if not root.is_dir():
+                continue
+            for path in root.rglob("*"):
+                if path.suffix not in suffixes or not path.is_file():
+                    continue
+                if path.name == "matrixark_load_config.py":
+                    continue
+                names.update(pattern.findall(path.read_text(encoding="utf-8", errors="ignore")))
+        return names
+
+    def test_every_config_key_names_a_variable_something_reads(self) -> None:
+        readers = self._readers()
+        self.assertGreater(len(readers), 200,
+                           "only %d variables found in the sources; the reader scan is broken"
+                           % len(readers))
+        offered, dead = 0, []
+        for line in self.config.read_text(encoding="utf-8").splitlines():
+            match = re.match(
+                r"\s*#?\s*([a-z0-9_]+)\s*=.*?#\s*((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)",
+                line)
+            if not match:
+                continue
+            offered += 1
+            if match.group(2) not in readers:
+                dead.append("%s -> %s" % (match.group(1), match.group(2)))
+        self.assertGreater(offered, 40,
+                           "only %d annotated keys found; the config scan is broken" % offered)
+        self.assertEqual(
+            [], dead,
+            "the shipped config offers %d key(s) naming a variable nothing reads, so setting "
+            "them does nothing:\n  %s" % (len(dead), "\n  ".join(dead)))
+
+
+class TheInventoryKnowsWhatTheCustomerCanSeeTest(unittest.TestCase):
+    """Every engine flag the gateway offers is marked `portal` in the inventory.
+
+    That column is what says a flag is customer-facing, and the retirement question leans on it:
+    a flag with a control on the Setup page has a setter no code search will find, because the
+    setter is a person. Undercounting it is how a live switch gets retired as unused.
+
+    Checked against `matrixark_gateway_config.SETTINGS`, which is what the portal renders, rather
+    than against the built HTML -- the page is generated from that list, so the list is the claim.
+    """
+
+    def test_every_offered_engine_flag_is_marked_portal(self) -> None:
+        sys.path.insert(0, TOOLS)
+        try:
+            import matrixark_gateway_config as cfgmod
+        except ImportError:
+            self.skipTest("the gateway config is not importable in this checkout")
+
+        text = io.open(DOC, encoding="utf-8").read()
+        listed, marked = set(), set()
+        for line in text.splitlines():
+            row = re.match(
+                r"^\| `((?:TS|MATRIXARK|TEMPORALSTORE)_[A-Z0-9_]+)` \| [^|]*\| ([^|]*)\|", line)
+            if not row:
+                continue
+            listed.add(row.group(1))
+            if "portal" in row.group(2):
+                marked.add(row.group(1))
+
+        offered = {s.env for s in cfgmod.SETTINGS if s.env}
+        self.assertGreater(len(offered), 50,
+                           "only %d settings found in the gateway config; the scan is broken"
+                           % len(offered))
+        self.assertGreater(len(listed), 200,
+                           "only %d flags read from the inventory; the scan is broken"
+                           % len(listed))
+
+        # Only flags the ENGINE reads: the gateway offers plenty that never reach it, and those
+        # are correctly absent from a document about the engine.
+        missing = sorted((offered & listed) - marked)
+        self.assertEqual(
+            [], missing,
+            "the gateway offers these on the Setup page and the inventory does not say so, so "
+            "they read as set by nothing:\n  %s" % "\n  ".join(missing))
+        self.assertGreater(
+            len(offered & listed), 10,
+            "only %d offered flags overlap the inventory; the comparison has stopped comparing"
+            % len(offered & listed))

--- a/tools/test_matrixark_engine_flag_legacy.py
+++ b/tools/test_matrixark_engine_flag_legacy.py
@@ -142,21 +142,127 @@ class TheDocMustBeAboutTheFlagTest(unittest.TestCase):
                          "sharing the doc comment of this one")
 
 
+class TheDefaultOfAnInlineReadTest(unittest.TestCase):
+    """`default_of_statement` reads a default off a flag read that has no accessor of its own.
+
+    `default_of` needs a one-flag function returning bool, so a read in the middle of a larger
+    function reported nothing -- and the summary row that matters most, flags defaulting ON that
+    nothing sets, counted zero while `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` sat inline,
+    defaulting on, set by nothing. It was not that there were none; it was that the scan could
+    only see one shape.
+
+    The unit is the STATEMENT and not a window of lines, and these pin why: the `!` that inverts
+    `!matches!(env::var(X)...)` sits above the name, so a window has to guess how far up to look
+    while a statement contains it by construction.
+    """
+
+    def setUp(self) -> None:
+        self.ns = predicates()
+
+    def _read(self, source: str) -> str:
+        lines = source.split("\n")
+        read = next(i for i, line in enumerate(lines) if "env::var(" in line)
+        return self.ns["default_of_statement"](lines, read)
+
+    def test_a_negated_matches_reads_as_on(self) -> None:
+        """The shape that a line window gets wrong: the `!` is three lines above the name."""
+        self.assertEqual("on", self._read(
+            'let warm = !matches!(\n'
+            '    env::var("TS_ONE")\n'
+            '        .unwrap_or_default()\n'
+            '        .as_str(),\n'
+            '    "0" | "false"\n'
+            ');'))
+
+    def test_a_bare_matches_reads_as_off(self) -> None:
+        self.assertEqual("off", self._read(
+            'let gate = matches!(\n'
+            '    env::var("TS_ONE").unwrap_or_default().as_str(),\n'
+            '    "1" | "true"\n'
+            ');'))
+
+    def test_an_unwrap_or_true_reads_as_on(self) -> None:
+        self.assertEqual("on", self._read(
+            'let scoring = env::var("TS_ONE")\n'
+            '    .map(|v| matches!(v.as_str(), "1"))\n'
+            '    .unwrap_or(true);'))
+
+    def test_a_string_fallback_reads_as_on(self) -> None:
+        """`unwrap_or_else(|_| "1")` states the default as the value, not as a bool."""
+        self.assertEqual("on", self._read(
+            'let warm = !matches!(\n'
+            '    env::var("TS_ONE").unwrap_or_else(|_| "1".to_string()).as_str(),\n'
+            '    "0" | "false"\n'
+            ');'))
+
+    def test_a_millisecond_count_states_no_default(self) -> None:
+        """A number has no ON/OFF, and reporting one would be read as fact."""
+        self.assertEqual("", self._read(
+            'let timeout = env::var("TS_ONE")\n'
+            '    .ok()\n'
+            '    .and_then(|v| v.parse::<u64>().ok())\n'
+            '    .unwrap_or(5_000);'))
+
+    def test_a_statement_reading_two_flags_states_no_default(self) -> None:
+        """Two flags in one statement have no single default to attribute to either."""
+        self.assertEqual("", self._read(
+            'let both = matches!(env::var("TS_ONE").unwrap_or_default().as_str(), "1")\n'
+            '    || matches!(env::var("TS_TWO").unwrap_or_default().as_str(), "1");'))
+
+    def test_it_does_not_reach_past_the_statement(self) -> None:
+        """A default belonging to the NEXT statement is not this one's.
+
+        The first statement is deliberately boolean-shaped and default-less, so that if the scan
+        ran past the `;` the `unwrap_or(true)` below would answer "on" -- which is the failure
+        this exists to catch. A non-boolean first statement would hide behind the shape check
+        instead of testing the bound.
+        """
+        self.assertEqual("", self._read(
+            'let named = matches!(env::var("TS_ONE").ok().as_deref(), Some("x"));\n'
+            'let other = std::env::args().next().is_some();\n'
+            'let third = other.then_some(false).unwrap_or(true);'))
+
+
 class TheInventoryReportsWhatItMeasuredTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.text = DOC.read_text(encoding="utf-8")
-        self.rows = [line for line in self.text.splitlines() if re.match(r"^\| `TS_", line)]
+        # All three prefixes. Matching `TS_` alone made every marked MATRIXARK_ or
+        # TEMPORALSTORE_ flag invisible here, so `test_the_count_matches_the_rows` compared the
+        # summary against a subset and reported the document as inconsistent with itself.
+        self.rows = [line for line in self.text.splitlines()
+                     if re.match(r"^\| `(TS|MATRIXARK|TEMPORALSTORE)_", line)]
+        self.legacy_column = self._column_index("keeps an older path")
+
+    def _column_index(self, heading: str) -> int:
+        """Which cell of a row holds `heading`, found by reading the header.
+
+        This used to be the literal 4, and adding a column to the table moved the legacy flag
+        under it: every assertion here then read the new column instead, and "0 rows are marked"
+        is a passing-looking answer to the wrong question in two of the three tests below.
+        """
+        for line in self.text.splitlines():
+            if line.startswith("| flag ") and heading in line:
+                cells = line.split("|")
+                for index, cell in enumerate(cells):
+                    if heading in cell:
+                        return index
+        raise AssertionError("no table header carries a %r column" % heading)
+
+    def _marked(self):
+        return [r for r in self.rows if r.split("|")[self.legacy_column].strip() == "yes"]
 
     def test_a_flag_is_not_marked_legacy_on_a_barrier_sentence(self) -> None:
+        """`TS_WAL_LEGACY_RECOVERY` is credited with block_store's doc, which says when pages are
+        fsynced and nothing else. That is a fact about ordering, not about a path kept alive."""
         row = [line for line in self.rows if line.startswith("| `TS_WAL_LEGACY_RECOVERY`")]
         self.assertTrue(row, "the flag is missing from the inventory entirely")
-        self.assertNotEqual("yes", row[0].split("|")[4].strip(),
+        self.assertNotEqual("yes", row[0].split("|")[self.legacy_column].strip(),
                             "marked as keeping an older path alive, on a doc comment that "
                             "describes when pages are fsynced and nothing else")
 
     def test_the_count_matches_the_rows(self) -> None:
-        marked = [r for r in self.rows if r.split("|")[4].strip() == "yes"]
+        marked = self._marked()
         stated = re.search(r"documented as keeping an older path alive \| (\d+) \|", self.text)
         self.assertIsNotNone(stated, "the summary no longer states the count")
         self.assertEqual(int(stated.group(1)), len(marked),
@@ -165,7 +271,7 @@ class TheInventoryReportsWhatItMeasuredTest(unittest.TestCase):
 
     def test_a_meaningful_number_of_flags_are_not_legacy(self) -> None:
         """If nearly everything is legacy-shaped the column has stopped distinguishing."""
-        marked = [r for r in self.rows if r.split("|")[4].strip() == "yes"]
+        marked = self._marked()
         self.assertLess(len(marked), len(self.rows) // 4,
                         "%d of %d flags are marked legacy-shaped, which reads as a rule matching "
                         "prose rather than a claim about code paths"


### PR DESCRIPTION
`docs/ops/temporalstore-engine-flags.md` says it lists every environment variable the engine
reads. It listed 94 of 325, and its test passed on every run: regenerating a document and
comparing it to itself checks staleness, not completeness. The scan matched `env::var("TS_...")`
and nothing else, so every flag read through a helper (`env_flag_default_on("TS_X")`,
`env_bool("TS_X", d)`) and every name not spelled `TS_` was invisible — the whole metaserver,
proxy, raft-tuning, context and gateway surface, absent from the one document that claims to say
what an operator can set.

Three changes, each with a guard that asserts its own extent.

### The inventory lists all 325, and is checked against the source

Checked by a rule deliberately simpler than the generator's — any quoted flag name — so the guard
cannot inherit the generator's blind spot, and stating how many files it read, because a scan that
stopped matching would otherwise report "nothing missing".

Two columns make it useful. **Who sets it**, from one pass over the engine, its tests, `config/`,
`tools/` and `deploy/` (per-name scanning took 124 s; one pass takes 1.8). **Its default**, in two
shapes: a one-flag `-> bool` accessor, and a single statement that reads a flag inline. The second
matters — without it the row that counts most, flags defaulting ON that nothing sets, reported
zero while `MATRIXARK_RUST_PROXY_ASYNC_CACHE_WARM_ON_LOAD` sat inline, defaulting on, set by
nothing. A statement is the unit rather than a window of lines because the `!` that inverts
`!matches!(env::var(X)...)` sits above the name but inside the same statement.

It also says **where the engine ends**: `sdk/rust/temporalstore` is a second Rust tree with its own
copy of the proxy implementation (121 KB against 345 KB), excluded from the workspace, so
`cargo check --all-targets` never builds it — here or in CI. Six variables live only there. They
are named, computed from the tree, so a seventh cannot appear quietly.

### Three config keys that set variables nothing reads

`group_commit` (`TS_GROUP_COMMIT`), `delta_served_index`, `enable_indexlog`. Setting any produced
no error and no effect. `group_commit_configured()` returns `true` and its own doc says the switch
was removed, while three comments still named the variable as a condition — so `wal.rs` told you
group commit was conditional in one place and unconditional two thousand lines later.
`wal_single_barrier_recovery` also passed `TS_GROUP_COMMIT=1` to a child process, configuring
nothing.

A test now asserts the class: every variable the config names is read by the engine, the SDK tree,
or a Python tool. `matrixark_load_config.py` does not count as a reader — it is the file that maps
key to variable, so counting it would let every key prove its own liveness. A second guard checks
that every engine flag the gateway offers on the Setup page is marked `portal` in the inventory,
because a flag with a control there has a setter no code search can find.

### Two byte settings rendered as bare integers

`byteHint` appends "= 1 GiB" beside a byte-valued setting and returns nothing unless the name ends
in `_BYTES`. `TS_STORAGE_ZONE_SIZE` and `TS_STREAM_MAX_BLOB_SIZE` are byte counts whose names do
not, so customers saw `1073741824` beside neighbours that all showed a size — the exact confusion
the hint exists for.

Three things were meant to prevent it. The guard looked for the word "bytes" in the setting's help
and both say "1 KiB". The harness had a case, and it named `TS_STREAM_MAX_BLOB_SIZE_BYTES`, a
variable that exists nowhere — so it tested the suffix rule against a name invented to satisfy it.
And the negative case I first wrote used `expect: ""` in a list checked with
`out.includes(expect)`, where `includes("")` is always true; it moved to the harness's negative
list, which asserts `out !== ""`.

The guard now **renders** every byte-shaped setting through the built page's own `byteHint` and
fails on any that comes back empty.

### Verification

`cargo check -p temporalstore-rust --all-targets` clean, no new warnings. 36 Python guards pass.
Every guard added here was mutation-tested — the change it exists to catch was made, the guard
named it, and the change was reverted.

The Rust in this PR is three comment corrections and one no-op `.env()` removed from a test.

### Not in this PR

A larger branch retires ~34 flags whose off position nothing selects. It is held back: #832 and
#866 landed on main using and building on five of those flags, and the branch deletes accessors
that main's newer code calls in three to five files each — where main added a call in a file the
branch did not touch, git would not conflict and the deletion would win silently. That work needs
rebuilding against main's current direction, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
