### PR TITLE
Make the raw half of the dual write reachable again

### DIFF
--- a/tools/matrixark_dual_write_ingestion_benchmark.py
+++ b/tools/matrixark_dual_write_ingestion_benchmark.py
@@ -144,6 +144,9 @@ def make_direct_adapter(args: argparse.Namespace, client: Any | None = None) -> 
     adapter._raw_count_key = f"{adapter._raw_ingestion_prefix}:record_count"
     adapter._raw_storage_backend = args.raw_backend
     adapter._raw_entry_count_cache = None
+    # This benchmark exists to measure both writes, and its reported return policy
+    # claims append_many waits for both, so the raw half has to be on here.
+    adapter._direct_raw_ingestion_enabled = True
     adapter._shard_size = args.shard_size
     adapter._index_cache = None
     adapter._records_cache = None

--- a/tools/matrixark_mcp_temporal_adapters.py
+++ b/tools/matrixark_mcp_temporal_adapters.py
@@ -2571,6 +2571,15 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         # every append batch. It only removes redundant pending markers -- a size
         # optimization, not correctness -- and paying an O(store) read per ingest to get it
         # is the wrong trade on this path.
+        # The raw half of the dual write. _TemporalDirectBackendMixin.append_many performs it,
+        # but this override wins the MRO and did not, so on the default backend the raw records
+        # were written NOWHERE: the only other caller, _flush_direct_write_items, runs on the
+        # queue path, and queuing is off by default. Gated rather than simply restored, because
+        # this adapter is the default backend and _append_raw_ingestion_records has no gate of
+        # its own -- calling it unconditionally would add a second store write to every ingest.
+        # Default off keeps today's behaviour byte for byte; turning it on is one flag.
+        if bool(getattr(self, "_direct_raw_ingestion_enabled", False)):
+            self._append_raw_ingestion_records(records)
         materialized = self._stamp_ingest_fields(materialize_serving_record_batch(records))
         if not materialized:
             return
@@ -2859,6 +2868,7 @@ class MatrixArkTemporalStoreDirectAdapter(MatrixArkLocalAdapter, _TemporalDirect
         self._direct_write_queue_autostart = os.environ.get("MATRIXARK_DIRECT_WRITE_QUEUE_AUTOSTART", "1").strip().lower() not in {"0", "false", "no"}
         self._native_side_index_assume_fresh = os.environ.get("MATRIXARK_NATIVE_SIDE_INDEX_ASSUME_FRESH", "0").strip().lower() in {"1", "true", "yes"}
         self._direct_raw_ingestion_queue_enabled = os.environ.get("MATRIXARK_DIRECT_RAW_INGESTION_QUEUE", "0").strip().lower() in {"1", "true", "yes"}
+        self._direct_raw_ingestion_enabled = os.environ.get("MATRIXARK_DIRECT_RAW_INGESTION", "0").strip().lower() in {"1", "true", "yes"}
         self._direct_write_queue_key = f"{self._storage_prefix}:direct_write_queue"
         self._direct_write_queue_done_key = f"{self._storage_prefix}:direct_write_queue_done"
         self._direct_write_queue_dead_key = f"{self._storage_prefix}:direct_write_queue_dead"


### PR DESCRIPTION
Six tests in test_matrixark_dual_write_ingestion_benchmark asserted
`dual_write_counts_validated` and got False. The flag was telling the truth: on
the default backend the raw write was not happening at all.

Two of its five conditions failed. `raw_record_count_observed` was None rather
than the record count, and `calls_by_raw_backend` held only `{'serving': 4}` --
InMemoryDualWriteClient labels a call by `append_options["raw_storage_backend"]`
and falls back to "serving" when it is absent, so "serving" alone means no raw
write ever reached the client.

The cause is method resolution, not the benchmark. MatrixArkTemporalStoreDirectAdapter
is declared `(MatrixArkLocalAdapter, _TemporalDirectBackendMixin, ...)`, three
classes in that MRO define `append_many`, and the one that wins is the class's own
override here. It runs `_stamp_ingest_fields` -> `_index_memory_subjects` ->
`_append_many_materialized` and never calls `_append_raw_ingestion_records`, which
the shadowed `_TemporalDirectBackendMixin.append_many` does call. A spy on that
method records it being entered zero times for an `append_many` batch.

Its only other caller, `_flush_direct_write_items`, runs on the queue path, and
queuing is off by default (MATRIXARK_DIRECT_WRITE_QUEUE defaults "0", and the raw
queue needs MATRIXARK_DIRECT_RAW_INGESTION_QUEUE as well). So the raw records were
written nowhere.

The override itself was needed and its reasoning is sound: MatrixArkLocalAdapter is
first in the MRO and its no-op writers were silently dropping every serving record.
Routing around them also dropped the raw half, and the comment explaining the
override never mentions raw ingestion, which reads as an oversight rather than a
decision.

Gated rather than simply restored. `default_mcp_backend()` returns
"temporalstore-direct" and local JSONL serving backends are refused outright, so
this adapter is the production path, and `_append_raw_ingestion_records` has no
gate of its own -- calling it unconditionally would add a second store write to
every ingest, roughly doubling ingest write volume. MATRIXARK_DIRECT_RAW_INGESTION
defaults off, so today's behaviour is unchanged; whether to turn it on is a
separate decision with a measurable cost, and it is now one flag rather than a
rewrite.

The benchmark turns it on for its own adapter, because measuring both writes is
what it is for, and it reports a return policy that claims append_many waits for
both.

Verified in both positions. Off: zero raw appends, count cache None, no
raw-backend call -- identical to what the adapter did before this change. On: the
raw append runs, `raw_record_count_observed` is 16 and equals the records written,
and `calls_by_raw_backend` gains its `temporalstore` entry.

test_matrixark_dual_write_ingestion_benchmark: 6 failing to 13 of 13 passing.

This does NOT fix the three test_validate_matrixark_context_backfill_readiness
failures, which share the symptom but not the cause: with counts now validated
they fail on `manual_exists`, because docs/matrixark_context_backfill.md was
removed by 4abcca675 and the gate still requires it. Filed separately rather than
papered over here.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
